### PR TITLE
refactor diagnostics

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -26,8 +26,7 @@ components that this product depends on.
 
 -------------------------------------------------------------------------------
 
-
-This dependency resolver is influenced by Dart project (pub tool).
+The dependency resolver is influenced by Dart project (pub tool).
 
   * LICENSE (BSD 3-Clause "New" or "Revised" License):
     * https://github.com/dart-lang/pub/blob/master/LICENSE
@@ -53,3 +52,32 @@ This product contains a derivation of OpenSSL's OCSP implementation, found under
     * https://www.apache.org/licenses/LICENSE-2.0
   * HOMEPAGE:
     * https://github.com/openssl/openssl
+
+---
+
+The observability system is influenced by SwiftLog project.
+
+  * LICENSE (Apache License 2.0):
+    * https://www.apache.org/licenses/LICENSE-2.0
+  * HOMEPAGE:
+    * https://github.com/apple/swift-log
+
+---
+
+The observability system is influenced by SwiftMetrics project.
+
+  * LICENSE (Apache License 2.0):
+    * https://www.apache.org/licenses/LICENSE-2.0
+  * HOMEPAGE:
+    * https://github.com/apple/swift-metrics
+
+---
+
+The observability system is influenced by SwiftDistributedTracing project.
+
+  * LICENSE (Apache License 2.0):
+    * https://www.apache.org/licenses/LICENSE-2.0
+  * HOMEPAGE:
+    * https://github.com/apple/swift-distributed-tracing-baggage
+
+---

--- a/Sources/Basics/CMakeLists.txt
+++ b/Sources/Basics/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(Basics
   HTTPClient.swift
   JSON+Extensions.swift
   JSONDecoder+Extensions.swift
+  Observability.swift
   Sandbox.swift
   SwiftVersion.swift
   SQLiteBackedCache.swift

--- a/Sources/Basics/Observability.swift
+++ b/Sources/Basics/Observability.swift
@@ -200,11 +200,6 @@ public struct DiagnosticsEmitter: DiagnosticsEmitterProtocol {
     private let scope: ObservabilityScope
     private let metadata: ObservabilityMetadata?
 
-    // uses the global Observability System
-    public init (metadata: ObservabilityMetadata? = .none) {
-        self = ObservabilitySystem.topScope.makeDiagnosticsEmitter(metadata: metadata)
-    }
-
     fileprivate init(scope: ObservabilityScope, metadata: ObservabilityMetadata?) {
         self.scope = scope
         self.metadata = metadata

--- a/Sources/Basics/Observability.swift
+++ b/Sources/Basics/Observability.swift
@@ -100,7 +100,6 @@ public struct Diagnostic: CustomStringConvertible, Equatable {
         self.underlying.message
     }
 
-
     public var data: CustomStringConvertible? {
         self.underlying.data
     }

--- a/Sources/Basics/Observability.swift
+++ b/Sources/Basics/Observability.swift
@@ -1,0 +1,293 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import TSCBasic
+import TSCUtility
+
+typealias TSCDiagnostic = TSCBasic.Diagnostic
+
+// this could become a struct when we remove the "errorsReported" pattern
+public class ObservabilitySystem {
+
+    // global
+
+    private static var _global = ObservabilitySystem(factory: NOOPFactory())
+    private static var bootstrapped = false
+    private static let lock = Lock()
+
+    public static func bootstrapGlobal(factory: ObservabilityFactory) {
+        Self.lock.withLock {
+            // FIXME: disabled for testing
+            //precondition(!Self.bootstrapped, "ObservabilitySystem can only bootstrapped once")
+            Self._global = .init(factory: factory)
+            Self.bootstrapped = true
+        }
+    }
+
+    @available(*, deprecated, message: "this pattern is deprecated, transition to error handling instead")
+    public static var errorsReported: Bool {
+        Self.lock.withLock {
+            Self._global.errorsReported
+        }
+    }
+
+    // as we transition to async/await we can take advantage of Task Local values instead of a global
+    fileprivate static var global: ObservabilitySystem {
+        Self.lock.withLock {
+            Self._global
+        }
+    }
+
+    // compatibility with DiagnosticsEngine
+
+    @available(*, deprecated, message: "temporary for transition DiagnosticsEngine -> DiagnosticsEmitter")
+    public static func makeDiagnosticsEngine() -> DiagnosticsEngine {
+        return DiagnosticsEngine(handlers: [{ Diagnostic($0).map{ self.global.diagnosticsHandler($0) } }])
+    }
+
+    // instance
+
+    public var diagnosticsHandler: DiagnosticsHandler!
+    private var _errorsReported = ThreadSafeBox<Bool>(false)
+
+    public init(factory: ObservabilityFactory) {
+        self.diagnosticsHandler = { diagnostic in
+            if diagnostic.severity == .error {
+                self._errorsReported.put(true)
+            }
+            factory.diagnosticsHandler(diagnostic)
+        }
+    }
+
+    // FIXME: we want to remove this functionality and move to more conventional error handling
+    @available(*, deprecated, message: "this pattern is deprecated, transition to error handling instead")
+    public var errorsReported: Bool {
+        self._errorsReported.get() ?? false
+    }
+
+    private struct NOOPFactory: ObservabilityFactory {
+        var diagnosticsHandler: DiagnosticsHandler = { _ in }
+    }
+}
+
+public protocol ObservabilityFactory {
+    var diagnosticsHandler: DiagnosticsHandler { get }
+}
+
+public typealias DiagnosticsHandler = (Diagnostic) -> Void
+
+public struct Diagnostic: CustomStringConvertible, Equatable {
+    public let context: DiagnosticsContext?
+    private let underlying: DiagnosticMessage
+
+    public init(context: DiagnosticsContext?, message underlying: DiagnosticMessage) {
+        self.context = context
+        self.underlying = underlying
+    }
+
+    public var severity: DiagnosticMessage.Severity {
+        self.underlying.severity
+    }
+
+    public var message: String {
+        self.underlying.message
+    }
+
+
+    public var data: CustomStringConvertible? {
+        self.underlying.data
+    }
+
+    public var description: String {
+        return "[\(self.severity)]: \(self.message)"
+    }
+
+    public static func == (lhs: Diagnostic, rhs: Diagnostic) -> Bool {
+        if lhs.context?.description != rhs.context?.description {
+            return false
+        }
+        if lhs.underlying != rhs.underlying {
+            return false
+        }
+        return true
+    }
+}
+
+// TODO: consider using @autoclosure to delay potentially expensive evaluation of data when some diagnostics may be filtered out
+public struct DiagnosticsEmitter {
+    public let context: DiagnosticsContext?
+    private let handler: DiagnosticsHandler
+
+    public init(context: DiagnosticsContext? = .none) {
+        self.context = context
+        self.handler = ObservabilitySystem.global.diagnosticsHandler
+    }
+
+    public func emit(_ diagnostic: Diagnostic) {
+        self.handler(diagnostic)
+    }
+
+    public func emit(_ message: DiagnosticMessage) {
+        self.emit(.init(context: self.context, message: message))
+    }
+
+    public func emit(severity: DiagnosticMessage.Severity, message: String, data: CustomStringConvertible? = .none) {
+        self.emit(.init(context: self.context, message: .init(severity: severity, message: message, data: data)))
+    }
+
+    public func emit(error message: String, data: CustomStringConvertible? = .none) {
+        self.emit(.error(message, data: data))
+    }
+
+    public func emit(_ error: Error, data: CustomStringConvertible? = .none) {
+        // FIXME: this brings in the TSC API still
+        if self.context == nil, let errorProvidingLocation = error as? DiagnosticLocationProviding, let diagnosticLocation = errorProvidingLocation.diagnosticLocation {
+            let context = DiagnosticLocationWrapper(diagnosticLocation)
+            return DiagnosticsEmitter(context: context).emit(error)
+        }
+        self.emit(.error(error, data: data))
+    }
+
+    public func emit(warning message: String, data: CustomStringConvertible? = .none) {
+        self.emit(.warning(message, data: data))
+    }
+
+    public func emit(info message: String, data: CustomStringConvertible? = .none) {
+        self.emit(.info(message, data: data))
+    }
+
+    public func trap<T>(_ closure: () throws -> T) -> T? {
+        do  {
+            return try closure()
+        } catch {
+            self.emit(error)
+            return nil
+        }
+    }
+}
+
+public struct DiagnosticMessage: Equatable {
+    let severity: Severity
+    let message: String
+    // 👀 TODO: not sure if this is used very much, but it we need it this could/should be changed to more structured metadata model
+    let data: CustomStringConvertible?
+
+    public static func error(_ message: String, data: CustomStringConvertible? = .none) -> Self {
+        Self(severity: .error, message: message, data: data)
+    }
+
+    public static func error(_ message: CustomStringConvertible, data: CustomStringConvertible? = .none) -> Self {
+        Self(severity: .error, message: message.description, data: data)
+    }
+
+    public static func error(_ error: Error, data: CustomStringConvertible? = .none) -> Self {
+        let message: String
+        // FIXME: this brings in the TSC API still
+        // FIXME: string interpolation seems brittle
+        if let diagnosticData = error as? DiagnosticData {
+            message = "\(diagnosticData)"
+        } else if let convertible = error as? DiagnosticDataConvertible {
+            message = "\(convertible.diagnosticData)"
+        } else {
+            message = "\(error)"
+        }
+        return Self(severity: .error, message: message, data: data)
+    }
+
+    public static func warning(_ message: String, data: CustomStringConvertible? = .none) -> Self {
+        Self(severity: .warning, message: message, data: data)
+    }
+
+    public static func warning(_ message: CustomStringConvertible, data: CustomStringConvertible? = .none) -> Self {
+        Self(severity: .warning, message: message.description, data: data)
+    }
+
+    public static func info(_ message: String, data: CustomStringConvertible? = .none) -> Self {
+        Self(severity: .info, message: message, data: data)
+    }
+
+    public static func info(_ message: CustomStringConvertible, data: CustomStringConvertible? = .none) -> Self {
+        Self(severity: .info, message: message.description, data: data)
+    }
+
+    public static func note(_ message: CustomStringConvertible, data: CustomStringConvertible? = .none) -> Self {
+        // 👀 do we need info and note?
+        Self(severity: .note, message: message.description, data: data)
+    }
+
+    public enum Severity: Equatable {
+        case error
+        case warning
+        // 👀 do we need info and note?
+        case info
+        case note
+    }
+
+    public static func == (lhs: DiagnosticMessage, rhs: DiagnosticMessage) -> Bool {
+        if lhs.severity != rhs.severity {
+            return false
+        }
+        if lhs.message != rhs.message {
+            return false
+        }
+        if lhs.data?.description != rhs.data?.description {
+            return false
+        }
+        return true
+    }
+}
+
+// 👀 TODO: this could/should be changed to more structured metadata model
+public protocol DiagnosticsContext: CustomStringConvertible {}
+
+public struct StringDiagnosticsContext: DiagnosticsContext{
+    public private (set) var description: String
+
+    public init(_ description: String) {
+        self.description = description
+    }
+}
+
+@available(*, deprecated, message: "temporary for transition DiagnosticsEngine -> DiagnosticsEmitter")
+extension Diagnostic {
+    init?(_ diagnostic: TSCDiagnostic) {
+        switch diagnostic.behavior {
+        case .error:
+            self = .init(context: DiagnosticLocationWrapper(diagnostic.location), message: .error(diagnostic.message.text, data: diagnostic.message.data))
+        case .warning:
+            self = .init(context: DiagnosticLocationWrapper(diagnostic.location), message: .warning(diagnostic.message.text, data: diagnostic.message.data))
+        case .note:
+            self = .init(context: DiagnosticLocationWrapper(diagnostic.location), message: .note(diagnostic.message.text, data: diagnostic.message.data))
+        case .remark:
+            // 👀 remark mapped to info here, do we need all these levels?
+            self = .init(context: DiagnosticLocationWrapper(diagnostic.location), message: .info(diagnostic.message.text, data: diagnostic.message.data))
+        case .ignored:
+            // 👀 is this okay?
+            return nil
+        }
+    }
+}
+
+@available(*, deprecated, message: "temporary for transition DiagnosticsEngine -> DiagnosticsEmitter")
+struct DiagnosticLocationWrapper: DiagnosticsContext {
+    let location: DiagnosticLocation
+
+    init?(_ location: DiagnosticLocation) {
+        if location is UnknownLocation {
+            return nil
+        } else {
+            self.location = location
+        }
+    }
+
+    var description: String {
+        self.location.description
+    }
+}

--- a/Sources/Basics/SQLiteBackedCache.swift
+++ b/Sources/Basics/SQLiteBackedCache.swift
@@ -97,7 +97,7 @@ public final class SQLiteBackedCache<Value: Codable>: Closable {
             if !self.configuration.truncateWhenFull {
                 throw error
             }
-            self.diagnosticsEngine?.emit(.warning("truncating \(self.tableName) cache database since it reached max size of \(self.configuration.maxSizeInBytes ?? 0) bytes"))
+            self.diagnosticsEngine?.emit(warning: "truncating \(self.tableName) cache database since it reached max size of \(self.configuration.maxSizeInBytes ?? 0) bytes")
             try self.executeStatement("DELETE FROM \(self.tableName);") { statement -> Void in
                 try statement.step()
             }

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -1977,7 +1977,7 @@ public class BuildPlan {
                 diagnostics.emit(.pkgConfigHint(pkgConfigName: result.pkgConfigName, installText: provider.installText))
             } else if let error = result.error {
                 diagnostics.emit(
-                        .warning(PkgConfigGenericDiagnostic(error: "\(error)")),
+                        .warning("\(error)"),
                         location: PkgConfigDiagnosticLocation(pcFile: result.pkgConfigName, target: target.name)
                 )
             }
@@ -2040,7 +2040,7 @@ private extension Diagnostic.Message {
     }
 
     static func pkgConfigHint(pkgConfigName: String, installText: String) -> Diagnostic.Message {
-        .warning(PkgConfigHintDiagnostic(pkgConfigName: pkgConfigName, installText: installText))
+        .warning("you may be able to install \(pkgConfigName) using your system-packager:\n\(installText)")
     }
 
     static func binaryTargetsNotSupported() -> Diagnostic.Message {

--- a/Sources/Commands/Snippets/CardStack.swift
+++ b/Sources/Commands/Snippets/CardStack.swift
@@ -8,9 +8,10 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import Basics
+import PackageGraph
 import PackageModel
 import TSCBasic
-import PackageGraph
 
 fileprivate extension TerminalController {
     func clearScreen() {
@@ -95,7 +96,7 @@ struct CardStack {
                 case let .pop(error):
                     cards.removeLast()
                     if let error = error {
-                        swiftTool.diagnostics.emit(error: error.localizedDescription)
+                        DiagnosticsEmitter().emit(error: error.localizedDescription)
                         needsToClearScreen = false
                     } else {
                         needsToClearScreen = !cards.isEmpty

--- a/Sources/Commands/Snippets/CardStack.swift
+++ b/Sources/Commands/Snippets/CardStack.swift
@@ -96,7 +96,7 @@ struct CardStack {
                 case let .pop(error):
                     cards.removeLast()
                     if let error = error {
-                        DiagnosticsEmitter().emit(error: error.localizedDescription)
+                        DiagnosticsEmitter().emit(error)
                         needsToClearScreen = false
                     } else {
                         needsToClearScreen = !cards.isEmpty

--- a/Sources/Commands/Snippets/CardStack.swift
+++ b/Sources/Commands/Snippets/CardStack.swift
@@ -96,7 +96,7 @@ struct CardStack {
                 case let .pop(error):
                     cards.removeLast()
                     if let error = error {
-                        DiagnosticsEmitter().emit(error)
+                        ObservabilitySystem.topScope.emit(error)
                         needsToClearScreen = false
                     } else {
                         needsToClearScreen = !cards.isEmpty

--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -101,7 +101,7 @@ public struct SwiftBuildTool: SwiftCommand {
         checkClangVersion()
       #endif
 
-        guard let subset = options.buildSubset(diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
+        guard let subset = options.buildSubset(diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
             else { throw ExitCode.failure }
         let buildSystem = try swiftTool.createBuildSystem(explicitProduct: options.product)
         do {

--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -101,7 +101,7 @@ public struct SwiftBuildTool: SwiftCommand {
         checkClangVersion()
       #endif
 
-        guard let subset = options.buildSubset(diagnostics: swiftTool.diagnostics)
+        guard let subset = options.buildSubset(diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
             else { throw ExitCode.failure }
         let buildSystem = try swiftTool.createBuildSystem(explicitProduct: options.product)
         do {
@@ -128,10 +128,17 @@ public struct SwiftBuildTool: SwiftCommand {
     public init() {}
 }
 
+// FIXME: remove when further cleaning DiagnosticsEngine
 extension Diagnostic.Message {
     //FIXME: Can we move this functionality into the argument parser?
     /// Diagnostic error when a command is run with several arguments that are mutually exclusive.
     static func mutuallyExclusiveArgumentsError(arguments: [String]) -> Diagnostic.Message {
         .error(arguments.map{ "'\($0)'" }.spm_localizedJoin(type: .conjunction) + " are mutually exclusive")
+    }
+}
+
+extension DiagnosticMessage {
+    static func mutuallyExclusiveArgumentsError(arguments: [String]) -> Self {
+        .error(Diagnostic.Message.mutuallyExclusiveArgumentsError(arguments: arguments).text)
     }
 }

--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -137,7 +137,7 @@ extension Diagnostic.Message {
     }
 }
 
-extension DiagnosticMessage {
+extension Basics.Diagnostic {
     static func mutuallyExclusiveArgumentsError(arguments: [String]) -> Self {
         .error(Diagnostic.Message.mutuallyExclusiveArgumentsError(arguments: arguments).text)
     }

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -1219,7 +1219,7 @@ extension SwiftPackageTool {
     }
 }
 
-private extension DiagnosticMessage {
+private extension Basics.Diagnostic {
     static var missingRequiredSubcommand: Self {
         .error("missing required subcommand; use --help to list available subcommands")
     }

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -144,7 +144,7 @@ extension SwiftPackageTool {
                 )
             }
 
-            if let pinsStore = DiagnosticsEmitter().trap({ try workspace.pinsStore.load() }), let changes = changes, dryRun {
+            if let pinsStore = ObservabilitySystem.topScope.trap({ try workspace.pinsStore.load() }), let changes = changes, dryRun {
                 logPackageChanges(changes: changes, pins: pinsStore, on: swiftTool.outputStream)
             }
 
@@ -409,7 +409,7 @@ extension SwiftPackageTool {
                 .subtracting(skippedModules)
                 .subtracting(results.map(\.moduleName))
             for failedModule in failedModules {
-                DiagnosticsEmitter().emit(error: "failed to read API digester output for \(failedModule)")
+                ObservabilitySystem.topScope.emit(error: "failed to read API digester output for \(failedModule)")
             }
 
             for result in results.get() {
@@ -834,7 +834,7 @@ extension SwiftPackageTool {
         }
 
         func run(_ swiftTool: SwiftTool) throws {
-            DiagnosticsEmitter().emit(warning: "Xcode can open and build Swift Packages directly. 'generate-xcodeproj' is no longer needed and will be deprecated soon.")
+            ObservabilitySystem.topScope.emit(warning: "Xcode can open and build Swift Packages directly. 'generate-xcodeproj' is no longer needed and will be deprecated soon.")
 
             let graph = try swiftTool.loadPackageGraph()
 
@@ -909,12 +909,12 @@ extension SwiftPackageTool.Config {
             let config = try swiftTool.getMirrorsConfig()
 
             if packageURL != nil {
-                DiagnosticsEmitter().emit(
+                ObservabilitySystem.topScope.emit(
                     warning: "'--package-url' option is deprecated; use '--original-url' instead")
             }
 
             guard let originalURL = packageURL ?? originalURL else {
-                DiagnosticsEmitter().emit(.missingRequiredArg("--original-url"))
+                ObservabilitySystem.topScope.emit(.missingRequiredArg("--original-url"))
                 throw ExitCode.failure
             }
 
@@ -944,12 +944,12 @@ extension SwiftPackageTool.Config {
             let config = try swiftTool.getMirrorsConfig()
 
             if packageURL != nil {
-                DiagnosticsEmitter().emit(
+                ObservabilitySystem.topScope.emit(
                     warning: "'--package-url' option is deprecated; use '--original-url' instead")
             }
 
             guard let originalOrMirrorURL = packageURL ?? originalURL ?? mirrorURL else {
-                DiagnosticsEmitter().emit(.missingRequiredArg("--original-url or --mirror-url"))
+                ObservabilitySystem.topScope.emit(.missingRequiredArg("--original-url or --mirror-url"))
                 throw ExitCode.failure
             }
 
@@ -976,12 +976,12 @@ extension SwiftPackageTool.Config {
             let config = try swiftTool.getMirrorsConfig()
 
             if packageURL != nil {
-                DiagnosticsEmitter().emit(
+                ObservabilitySystem.topScope.emit(
                     warning: "'--package-url' option is deprecated; use '--original-url' instead")
             }
 
             guard let originalURL = packageURL ?? originalURL else {
-                DiagnosticsEmitter().emit(.missingRequiredArg("--original-url"))
+                ObservabilitySystem.topScope.emit(.missingRequiredArg("--original-url"))
                 throw ExitCode.failure
             }
 
@@ -1052,7 +1052,7 @@ extension SwiftPackageTool {
         var resolveOptions: ResolveOptions
         
         func run(_ swiftTool: SwiftTool) throws {
-            DiagnosticsEmitter().emit(warning: "'fetch' command is deprecated; use 'resolve' instead")
+            ObservabilitySystem.topScope.emit(warning: "'fetch' command is deprecated; use 'resolve' instead")
             
             let resolveCommand = Resolve(swiftOptions: _swiftOptions, resolveOptions: _resolveOptions)
             try resolveCommand.run(swiftTool)

--- a/Sources/Commands/SwiftRunTool.swift
+++ b/Sources/Commands/SwiftRunTool.swift
@@ -271,7 +271,7 @@ public struct SwiftRunTool: SwiftCommand {
     public init() {}
 }
 
-private extension DiagnosticMessage {
+private extension Basics.Diagnostic {
     static var runFileDeprecation: Self {
         .warning("'swift run file.swift' command to interpret swift files is deprecated; use 'swift file.swift' instead")
     }

--- a/Sources/Commands/SwiftRunTool.swift
+++ b/Sources/Commands/SwiftRunTool.swift
@@ -101,7 +101,7 @@ public struct SwiftRunTool: SwiftCommand {
 
     public func run(_ swiftTool: SwiftTool) throws {
         if options.shouldBuildTests && options.shouldSkipBuild {
-            swiftTool.diagnostics.emit(
+            DiagnosticsEmitter().emit(
               .mutuallyExclusiveArgumentsError(arguments: ["--build-tests", "--skip-build"]))
             throw ExitCode.failure
         }
@@ -122,7 +122,7 @@ public struct SwiftRunTool: SwiftCommand {
                 cacheBuildManifest: false,
                 packageGraphLoader: graphLoader,
                 pluginInvoker: { _ in [:] },
-                diagnostics: swiftTool.diagnostics,
+                diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
                 outputStream: swiftTool.outputStream
             )
 
@@ -162,14 +162,14 @@ public struct SwiftRunTool: SwiftCommand {
                 let lldbPath = try swiftTool.getToolchain().getLLDB()
                 try exec(path: lldbPath.pathString, args: ["--", pathRelativeToWorkingDirectory.pathString] + options.arguments)
             } catch let error as RunError {
-                swiftTool.diagnostics.emit(error)
+                DiagnosticsEmitter().emit(error)
                 throw ExitCode.failure
             }
 
         case .run:
             // Detect deprecated uses of swift run to interpret scripts.
             if let executable = options.executable, isValidSwiftFilePath(executable) {
-                swiftTool.diagnostics.emit(.runFileDeprecation)
+                DiagnosticsEmitter().emit(.runFileDeprecation)
                 // Redirect execution to the toolchain's swift executable.
                 let swiftInterpreterPath = try swiftTool.getToolchain().swiftInterpreterPath
                 // Prepend the script to interpret to the arguments.
@@ -201,7 +201,7 @@ public struct SwiftRunTool: SwiftCommand {
             } catch Diagnostics.fatalError {
                 throw ExitCode.failure
             } catch let error as RunError {
-                swiftTool.diagnostics.emit(error)
+                DiagnosticsEmitter().emit(error)
                 throw ExitCode.failure
             }
         }
@@ -271,8 +271,8 @@ public struct SwiftRunTool: SwiftCommand {
     public init() {}
 }
 
-private extension Diagnostic.Message {
-    static var runFileDeprecation: Diagnostic.Message {
+private extension DiagnosticMessage {
+    static var runFileDeprecation: Self {
         .warning("'swift run file.swift' command to interpret swift files is deprecated; use 'swift file.swift' instead")
     }
 }

--- a/Sources/Commands/SwiftRunTool.swift
+++ b/Sources/Commands/SwiftRunTool.swift
@@ -122,7 +122,7 @@ public struct SwiftRunTool: SwiftCommand {
                 cacheBuildManifest: false,
                 packageGraphLoader: graphLoader,
                 pluginInvoker: { _ in [:] },
-                diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
                 outputStream: swiftTool.outputStream
             )
 

--- a/Sources/Commands/SwiftRunTool.swift
+++ b/Sources/Commands/SwiftRunTool.swift
@@ -101,7 +101,7 @@ public struct SwiftRunTool: SwiftCommand {
 
     public func run(_ swiftTool: SwiftTool) throws {
         if options.shouldBuildTests && options.shouldSkipBuild {
-            DiagnosticsEmitter().emit(
+            ObservabilitySystem.topScope.emit(
               .mutuallyExclusiveArgumentsError(arguments: ["--build-tests", "--skip-build"]))
             throw ExitCode.failure
         }
@@ -162,14 +162,14 @@ public struct SwiftRunTool: SwiftCommand {
                 let lldbPath = try swiftTool.getToolchain().getLLDB()
                 try exec(path: lldbPath.pathString, args: ["--", pathRelativeToWorkingDirectory.pathString] + options.arguments)
             } catch let error as RunError {
-                DiagnosticsEmitter().emit(error)
+                ObservabilitySystem.topScope.emit(error)
                 throw ExitCode.failure
             }
 
         case .run:
             // Detect deprecated uses of swift run to interpret scripts.
             if let executable = options.executable, isValidSwiftFilePath(executable) {
-                DiagnosticsEmitter().emit(.runFileDeprecation)
+                ObservabilitySystem.topScope.emit(.runFileDeprecation)
                 // Redirect execution to the toolchain's swift executable.
                 let swiftInterpreterPath = try swiftTool.getToolchain().swiftInterpreterPath
                 // Prepend the script to interpret to the arguments.
@@ -201,7 +201,7 @@ public struct SwiftRunTool: SwiftCommand {
             } catch Diagnostics.fatalError {
                 throw ExitCode.failure
             } catch let error as RunError {
-                DiagnosticsEmitter().emit(error)
+                ObservabilitySystem.topScope.emit(error)
                 throw ExitCode.failure
             }
         }

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -239,7 +239,7 @@ public struct SwiftTestTool: SwiftCommand {
             // to be removed in future releases
             // deprecation warning is emitted by validateArguments
             #if os(Linux)
-            DiagnosticsEmitter().emit(warning: "can't discover tests on Linux; please use this option on macOS instead")
+            ObservabilitySystem.topScope.emit(warning: "can't discover tests on Linux; please use this option on macOS instead")
             #endif
             let graph = try swiftTool.loadPackageGraph()
             let testProducts = try buildTestsIfNeeded(swiftTool: swiftTool)
@@ -272,7 +272,7 @@ public struct SwiftTestTool: SwiftCommand {
             case .regex, .specific, .skip:
                 // If old specifier `-s` option was used, emit deprecation notice.
                 if case .specific = options.testCaseSpecifier {
-                    DiagnosticsEmitter().emit(warning: "'--specifier' option is deprecated; use '--filter' instead")
+                    ObservabilitySystem.topScope.emit(warning: "'--specifier' option is deprecated; use '--filter' instead")
                 }
 
                 // Find the tests we need to run.
@@ -283,7 +283,7 @@ public struct SwiftTestTool: SwiftCommand {
 
                 // If there were no matches, emit a warning.
                 if tests.isEmpty {
-                    DiagnosticsEmitter().emit(.noMatchingTests)
+                    ObservabilitySystem.topScope.emit(.noMatchingTests)
                     xctestArg = "''"
                 } else {
                     xctestArg = tests.map { $0.specifier }.joined(separator: ",")
@@ -321,7 +321,7 @@ public struct SwiftTestTool: SwiftCommand {
 
             // If there were no matches, emit a warning and exit.
             if tests.isEmpty {
-                DiagnosticsEmitter().emit(.noMatchingTests)
+                ObservabilitySystem.topScope.emit(.noMatchingTests)
                 return
             }
 

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -206,7 +206,7 @@ public struct SwiftTestTool: SwiftCommand {
     
     public func run(_ swiftTool: SwiftTool) throws {
         // Validate commands arguments
-        try validateArguments(diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
+        try validateArguments(diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
 
         switch options.mode {
         case .listTests:
@@ -225,7 +225,7 @@ public struct SwiftTestTool: SwiftCommand {
             let workspace = try swiftTool.getActiveWorkspace()
             let root = try swiftTool.getWorkspaceRoot()
             let rootManifests = try temp_await {
-                workspace.loadRootManifests(packages: root.packages, diagnostics: ObservabilitySystem.makeDiagnosticsEngine(), completion: $0)
+                workspace.loadRootManifests(packages: root.packages, diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(), completion: $0)
             }
             guard let rootManifest = rootManifests.values.first else {
                 throw StringError("invalid manifests at \(root.packages)")
@@ -295,7 +295,7 @@ public struct SwiftTestTool: SwiftCommand {
                 xctestArg: xctestArg,
                 processSet: swiftTool.processSet,
                 toolchain: toolchain,
-                diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
                 options: swiftOptions,
                 buildParameters: buildParameters
             )
@@ -338,7 +338,7 @@ public struct SwiftTestTool: SwiftCommand {
                 toolchain: toolchain,
                 xUnitOutput: options.xUnitOutput,
                 numJobs: options.numberOfWorkers ?? ProcessInfo.processInfo.activeProcessorCount,
-                diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
                 options: swiftOptions,
                 buildParameters: buildParameters,
                 outputStream: swiftTool.outputStream
@@ -360,7 +360,7 @@ public struct SwiftTestTool: SwiftCommand {
         let workspace = try swiftTool.getActiveWorkspace()
         let root = try swiftTool.getWorkspaceRoot()
         let rootManifests = try temp_await {
-            workspace.loadRootManifests(packages: root.packages, diagnostics: ObservabilitySystem.makeDiagnosticsEngine(), completion: $0)
+            workspace.loadRootManifests(packages: root.packages, diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(), completion: $0)
         }
         guard let rootManifest = rootManifests.values.first else {
             throw StringError("invalid manifests at \(root.packages)")

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -1124,7 +1124,7 @@ final class XUnitGenerator {
     }
 }
 
-private extension DiagnosticMessage {
+private extension Basics.Diagnostic {
     static var noMatchingTests: Self {
         .warning("No matching test cases were run")
     }

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -239,7 +239,7 @@ public struct SwiftTestTool: SwiftCommand {
             // to be removed in future releases
             // deprecation warning is emitted by validateArguments
             #if os(Linux)
-            swiftTool.diagnostics.emit(warning: "can't discover tests on Linux; please use this option on macOS instead")
+            DiagnosticsEmitter().emit(warning: "can't discover tests on Linux; please use this option on macOS instead")
             #endif
             let graph = try swiftTool.loadPackageGraph()
             let testProducts = try buildTestsIfNeeded(swiftTool: swiftTool)

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -206,7 +206,7 @@ public struct SwiftTestTool: SwiftCommand {
     
     public func run(_ swiftTool: SwiftTool) throws {
         // Validate commands arguments
-        try validateArguments(diagnostics: swiftTool.diagnostics)
+        try validateArguments(diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
 
         switch options.mode {
         case .listTests:
@@ -225,7 +225,7 @@ public struct SwiftTestTool: SwiftCommand {
             let workspace = try swiftTool.getActiveWorkspace()
             let root = try swiftTool.getWorkspaceRoot()
             let rootManifests = try temp_await {
-                workspace.loadRootManifests(packages: root.packages, diagnostics: swiftTool.diagnostics, completion: $0)                
+                workspace.loadRootManifests(packages: root.packages, diagnostics: ObservabilitySystem.makeDiagnosticsEngine(), completion: $0)
             }
             guard let rootManifest = rootManifests.values.first else {
                 throw StringError("invalid manifests at \(root.packages)")
@@ -272,7 +272,7 @@ public struct SwiftTestTool: SwiftCommand {
             case .regex, .specific, .skip:
                 // If old specifier `-s` option was used, emit deprecation notice.
                 if case .specific = options.testCaseSpecifier {
-                    swiftTool.diagnostics.emit(warning: "'--specifier' option is deprecated; use '--filter' instead")
+                    DiagnosticsEmitter().emit(warning: "'--specifier' option is deprecated; use '--filter' instead")
                 }
 
                 // Find the tests we need to run.
@@ -283,7 +283,7 @@ public struct SwiftTestTool: SwiftCommand {
 
                 // If there were no matches, emit a warning.
                 if tests.isEmpty {
-                    swiftTool.diagnostics.emit(.noMatchingTests)
+                    DiagnosticsEmitter().emit(.noMatchingTests)
                     xctestArg = "''"
                 } else {
                     xctestArg = tests.map { $0.specifier }.joined(separator: ",")
@@ -295,7 +295,7 @@ public struct SwiftTestTool: SwiftCommand {
                 xctestArg: xctestArg,
                 processSet: swiftTool.processSet,
                 toolchain: toolchain,
-                diagnostics: swiftTool.diagnostics,
+                diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
                 options: swiftOptions,
                 buildParameters: buildParameters
             )
@@ -321,7 +321,7 @@ public struct SwiftTestTool: SwiftCommand {
 
             // If there were no matches, emit a warning and exit.
             if tests.isEmpty {
-                swiftTool.diagnostics.emit(.noMatchingTests)
+                DiagnosticsEmitter().emit(.noMatchingTests)
                 return
             }
 
@@ -338,7 +338,7 @@ public struct SwiftTestTool: SwiftCommand {
                 toolchain: toolchain,
                 xUnitOutput: options.xUnitOutput,
                 numJobs: options.numberOfWorkers ?? ProcessInfo.processInfo.activeProcessorCount,
-                diagnostics: swiftTool.diagnostics,
+                diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
                 options: swiftOptions,
                 buildParameters: buildParameters,
                 outputStream: swiftTool.outputStream
@@ -360,7 +360,7 @@ public struct SwiftTestTool: SwiftCommand {
         let workspace = try swiftTool.getActiveWorkspace()
         let root = try swiftTool.getWorkspaceRoot()
         let rootManifests = try temp_await {
-            workspace.loadRootManifests(packages: root.packages, diagnostics: swiftTool.diagnostics, completion: $0)
+            workspace.loadRootManifests(packages: root.packages, diagnostics: ObservabilitySystem.makeDiagnosticsEngine(), completion: $0)
         }
         guard let rootManifest = rootManifests.values.first else {
             throw StringError("invalid manifests at \(root.packages)")
@@ -1124,8 +1124,8 @@ final class XUnitGenerator {
     }
 }
 
-private extension Diagnostic.Message {
-    static var noMatchingTests: Diagnostic.Message {
+private extension DiagnosticMessage {
+    static var noMatchingTests: Self {
         .warning("No matching test cases were run")
     }
 }

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -323,7 +323,7 @@ public class SwiftTool {
 
         // Capture the original working directory ASAP.
         guard let cwd = localFileSystem.currentWorkingDirectory else {
-            DiagnosticsEmitter().emit(error: "couldn't determine the current working directory")
+            ObservabilitySystem.topScope.emit(error: "couldn't determine the current working directory")
             throw ExitCode.failure
         }
         originalWorkingDirectory = cwd
@@ -377,7 +377,7 @@ public class SwiftTool {
             self.buildSystemRef = buildSystemRef
 
         } catch {
-            DiagnosticsEmitter().emit(error)
+            ObservabilitySystem.topScope.emit(error)
             throw ExitCode.failure
         }
 
@@ -498,10 +498,10 @@ public class SwiftTool {
         let netrcFilePath = options.netrcFilePath ?? localFileSystem.homeDirectory.appending(component: ".netrc")
         guard localFileSystem.exists(netrcFilePath) else {
             if !options.netrcOptional {
-                DiagnosticsEmitter().emit(error: "Cannot find mandatory .netrc file at \(netrcFilePath). To make .netrc file optional, use --netrc-optional flag.")
+                ObservabilitySystem.topScope.emit(error: "Cannot find mandatory .netrc file at \(netrcFilePath). To make .netrc file optional, use --netrc-optional flag.")
                 throw ExitCode.failure
             } else {
-                DiagnosticsEmitter().emit(warning: "Did not find optional .netrc file at \(netrcFilePath).")
+                ObservabilitySystem.topScope.emit(warning: "Did not find optional .netrc file at \(netrcFilePath).")
                 return .none
             }
         }
@@ -520,7 +520,7 @@ public class SwiftTool {
         do {
             return try localFileSystem.getOrCreateSwiftPMCacheDirectory()
         } catch {
-            DiagnosticsEmitter().emit(warning: "Failed creating default cache location, \(error)")
+            ObservabilitySystem.topScope.emit(warning: "Failed creating default cache location, \(error)")
             return .none
         }
     }
@@ -537,7 +537,7 @@ public class SwiftTool {
         do {
             return try localFileSystem.getOrCreateSwiftPMConfigDirectory()
         } catch {
-            DiagnosticsEmitter().emit(warning: "Failed creating default configuration location, \(error)")
+            ObservabilitySystem.topScope.emit(warning: "Failed creating default configuration location, \(error)")
             return .none
         }
     }

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -976,25 +976,20 @@ extension Basics.Diagnostic {
     func print() {
         let writer = InteractiveWriter.stderr
 
-        if let context = self.context {
-            writer.write(context.description)
+        if let diagnosticLocation = self.metadata?.diagnosticLocation {
+            writer.write(diagnosticLocation)
             writer.write(": ")
         }
 
-        // 👀 levels
         switch self.severity {
         case .error:
             writer.write("error: ", inColor: .red, bold: true)
         case .warning:
             writer.write("warning: ", inColor: .yellow, bold: true)
-        case .note:
-            writer.write("note: ", inColor: .yellow, bold: true)
         case .info:
-            writer.write("info: ", inColor: .yellow, bold: true)
-        //case .remark:
-        //    writer.write("remark: ", inColor: .yellow, bold: true)
-        //case .ignored:
-        //    break
+            writer.write("info: ", inColor: .white, bold: true)
+        case .debug:
+            writer.write("info: ", inColor: .white, bold: true)
         }
 
         writer.write(self.message)
@@ -1033,6 +1028,18 @@ private final class InteractiveWriter {
         } else {
             stream <<< string
             stream.flush()
+        }
+    }
+}
+
+extension DiagnosticsMetadata {
+    public var diagnosticLocation: String? {
+        if let stringLocation = self.stringLocation {
+            return stringLocation
+        } else if let packageIdentity = self.packageIdentity, let packageLocation = self.packageLocation {
+            return "'\(packageIdentity)' \(packageLocation)"
+        } else {
+            return .none
         }
     }
 }

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -231,7 +231,7 @@ private class ToolWorkspaceDelegate: WorkspaceDelegate {
     }
 
     // noop
-    
+
     func willLoadManifest(packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind) {}
     func didLoadManifest(packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind, manifest: Manifest?, diagnostics: [Diagnostic]) {}
     func didCreateWorkingCopy(repository url: String, at path: AbsolutePath, error: Diagnostic?) {}
@@ -331,7 +331,7 @@ public class SwiftTool {
         do {
             try Self.postprocessArgParserResult(options: options, diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
             self.options = options
-            
+
             // Honor package-path option is provided.
             if let packagePath = options.packagePath ?? options.chdir {
                 try ProcessEnv.chdir(packagePath)
@@ -389,25 +389,25 @@ public class SwiftTool {
         self.buildPath = getEnvBuildPath(workingDir: cwd) ??
         customBuildPath ??
         (packageRoot ?? cwd).appending(component: ".build")
-        
+
         // Setup the globals.
         verbosity = Verbosity(rawValue: options.verbosity)
         Process.verbose = verbosity != .concise
     }
-    
+
     static func postprocessArgParserResult(options: SwiftToolOptions, diagnostics: DiagnosticsEngine) throws {
         if options.chdir != nil {
             diagnostics.emit(warning: "'--chdir/-C' option is deprecated; use '--package-path' instead")
         }
-        
+
         if options.multirootPackageDataFile != nil {
             diagnostics.emit(.unsupportedFlag("--multiroot-data-file"))
         }
-        
+
         if options.useExplicitModuleBuild && !options.useIntegratedSwiftDriver {
             diagnostics.emit(error: "'--experimental-explicit-module-build' option requires '--use-integrated-swift-driver'")
         }
-        
+
         if !options.archs.isEmpty && options.customCompileTriple != nil {
             diagnostics.emit(.mutuallyExclusiveArgumentsError(arguments: ["--arch", "--triple"]))
         }
@@ -635,7 +635,7 @@ public class SwiftTool {
             throw error
         }
     }
-    
+
     /// Invoke plugins for any reachable targets in the graph, and return a mapping from targets to corresponding evaluation results.
     func invokePlugins(graph: PackageGraph) throws -> [ResolvedTarget: [PluginInvocationResult]] {
         do {
@@ -646,24 +646,24 @@ public class SwiftTool {
             let buildEnvironment = try buildParameters().buildEnvironment
             let dataDir = try self.getActiveWorkspace().location.workingDirectory
             let pluginsDir = dataDir.appending(component: "plugins")
-            
+
             // The `cache` directory is in the plugins directory and is where the plugin script runner caches
             // compiled plugin binaries and any other derived information.
             let cacheDir = pluginsDir.appending(component: "cache")
             let pluginScriptRunner = try DefaultPluginScriptRunner(cacheDir: cacheDir, toolchain: self._hostToolchain.get().configuration)
-            
+
             // The `outputs` directory contains subdirectories for each combination of package, target, and plugin.
             // Each usage of a plugin has an output directory that is writable by the plugin, where it can write
             // additional files, and to which it can configure tools to write their outputs, etc.
             let outputDir = pluginsDir.appending(component: "outputs")
-            
+
             // The `tools` directory contains any command line tools (executables) that are available for any commands
             // defined by the executable.
             // FIXME: At the moment we just pass the built products directory for the host. We will need to extend this
             // with a map of the names of tools available to each plugin. In particular this would not work with any
             // binary targets.
             let builtToolsDir = dataDir.appending(components: try self._hostToolchain.get().triple.tripleString, buildEnvironment.configuration.dirname)
-            
+
             // Create the cache directory, if needed.
             try localFileSystem.createDirectory(cacheDir, recursive: true)
 
@@ -966,8 +966,10 @@ extension DispatchTimeInterval {
 
 // MARK: - Diagnostics
 
-struct SwiftToolObservability: ObservabilityFactory {
-    var diagnosticsHandler: DiagnosticsHandler = { scope, diagnostic in
+private struct SwiftToolObservability: ObservabilityFactory, DiagnosticsHandler {
+    var diagnosticsHandler: DiagnosticsHandler { self }
+
+    func handleDiagnostic(scope: ObservabilityScope, diagnostic: Basics.Diagnostic) {
         // TODO: do something useful with scope
         diagnostic.print()
     }

--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -32,7 +32,7 @@ public struct PackageCollections: PackageCollectionsProtocol {
     }
 
     // initialize with defaults
-    public init(configuration: Configuration = .init(), diagnosticsEngine: DiagnosticsEngine = ObservabilitySystem.makeDiagnosticsEngine()) {
+    public init(configuration: Configuration = .init(), diagnosticsEngine: DiagnosticsEngine = ObservabilitySystem.topScope.makeDiagnosticsEngine()) {
         let storage = Storage(sources: FilePackageCollectionsSourcesStorage(diagnosticsEngine: diagnosticsEngine),
                               collections: SQLitePackageCollectionsStorage(diagnosticsEngine: diagnosticsEngine))
 

--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -32,7 +32,7 @@ public struct PackageCollections: PackageCollectionsProtocol {
     }
 
     // initialize with defaults
-    public init(configuration: Configuration = .init(), diagnosticsEngine: DiagnosticsEngine = DiagnosticsEngine()) {
+    public init(configuration: Configuration = .init(), diagnosticsEngine: DiagnosticsEngine = ObservabilitySystem.makeDiagnosticsEngine()) {
         let storage = Storage(sources: FilePackageCollectionsSourcesStorage(diagnosticsEngine: diagnosticsEngine),
                               collections: SQLitePackageCollectionsStorage(diagnosticsEngine: diagnosticsEngine))
 

--- a/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
@@ -156,7 +156,7 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
                     do {
                         try self.cache?.put(key: identity.description, value: CacheValue(package: model, timestamp: DispatchTime.now()), replace: true)
                     } catch {
-                        self.diagnosticsEngine?.emit(.warning("Failed to save GitHub metadata for package \(identity) to cache: \(error)"))
+                        self.diagnosticsEngine?.emit(warning: "Failed to save GitHub metadata for package \(identity) to cache: \(error)")
                     }
 
                     callback(.success(model))

--- a/Sources/PackageGraph/Diagnostics.swift
+++ b/Sources/PackageGraph/Diagnostics.swift
@@ -10,7 +10,7 @@
 
 import Basics
 
-extension DiagnosticMessage {
+extension Basics.Diagnostic {
     static func unusedDependency(_ name: String) -> Self {
         .warning("dependency '\(name)' is not used by any target")
     }

--- a/Sources/PackageGraph/Diagnostics.swift
+++ b/Sources/PackageGraph/Diagnostics.swift
@@ -8,14 +8,14 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import TSCBasic
+import Basics
 
-extension Diagnostic.Message {
-    static func unusedDependency(_ name: String) -> Diagnostic.Message {
+extension DiagnosticMessage {
+    static func unusedDependency(_ name: String) -> Self {
         .warning("dependency '\(name)' is not used by any target")
     }
 
-    static func productUsesUnsafeFlags(product: String, target: String) -> Diagnostic.Message {
+    static func productUsesUnsafeFlags(product: String, target: String) -> Self {
         .error("the target '\(target)' in product '\(product)' contains unsafe build flags")
     }
 }

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -100,8 +100,7 @@ extension PackageGraph {
             //
             // FIXME: Lift this out of the manifest.
             let packagePath = manifest.path.parentDirectory
-            let diagnosticsContext = PackageDiagnosticsContext(identity: node.identity, location: node.manifest.packageLocation)
-            let diagnosticsEmitter = DiagnosticsEmitter(context: diagnosticsContext)
+            let diagnosticsEmitter = DiagnosticsEmitter(metadata: .packageMetadata(identity: node.identity, location: node.manifest.packageLocation))
             diagnosticsEmitter.trap {
                 // Create a package from the manifest and sources.
                 let builder = PackageBuilder(
@@ -237,7 +236,7 @@ private func createResolvedPackages(
                 fatalError("registry based dependencies not implemented yet")
             }
 
-            let diagnosticsEmitter = DiagnosticsEmitter(context: package.diagnosticsContext)
+            let diagnosticsEmitter = DiagnosticsEmitter(metadata: package.diagnosticsMetadata)
 
             // Otherwise, look it up by its identity.
             if let resolvedPackage = packagesByIdentity[dependency.identity] {
@@ -366,7 +365,7 @@ private func createResolvedPackages(
     // Do another pass and establish product dependencies of each target.
     for packageBuilder in packageBuilders {
         let package = packageBuilder.package
-        let diagnosticsEmitter = DiagnosticsEmitter(context: package.diagnosticsContext)
+        let diagnosticsEmitter = DiagnosticsEmitter(metadata: package.diagnosticsMetadata)
 
         // Get all implicit system library dependencies in this package.
         let implicitSystemTargetDeps = packageBuilder.dependencies

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -27,10 +27,9 @@ extension PackageGraph {
         unsafeAllowedPackages: Set<PackageReference> = [],
         binaryArtifacts: [BinaryArtifact] = [],
         xcTestMinimumDeploymentTargets: [PackageModel.Platform:PlatformVersion] = MinimumDeploymentTarget.default.xcTestMinimumDeploymentTargets,
-        diagnostics: DiagnosticsEngine,
-        fileSystem: FileSystem = localFileSystem,
         shouldCreateMultipleTestProducts: Bool = false,
-        createREPLProduct: Bool = false
+        createREPLProduct: Bool = false,
+        fileSystem: FileSystem
     ) throws -> PackageGraph {
 
         // Create a map of the manifests, keyed by their identity.
@@ -68,7 +67,7 @@ extension PackageGraph {
 
         // Detect cycles in manifest dependencies.
         if let cycle = findCycle(inputManifests, successors: successors) {
-            diagnostics.emit(PackageGraphError.cycleDetected(cycle))
+            DiagnosticsEmitter().emit(PackageGraphError.cycleDetected(cycle))
             // Break the cycle so we can build a partial package graph.
             allNodes = inputManifests.filter({ $0.manifest != cycle.cycle[0] })
         } else {
@@ -101,32 +100,30 @@ extension PackageGraph {
             //
             // FIXME: Lift this out of the manifest.
             let packagePath = manifest.path.parentDirectory
-            let diagnosticsLocation = PackageLocation.Local(name: manifest.name, packagePath: packagePath)
-            diagnostics.with(location: diagnosticsLocation) { diagnostics in
-                diagnostics.wrap {
-                    // Create a package from the manifest and sources.
-                    let builder = PackageBuilder(
-                        identity: node.identity,
-                        manifest: manifest,
-                        productFilter: node.productFilter,
-                        path: packagePath,
-                        additionalFileRules: additionalFileRules,
-                        binaryArtifacts: binaryArtifacts,
-                        xcTestMinimumDeploymentTargets: xcTestMinimumDeploymentTargets,
-                        fileSystem: fileSystem,
-                        diagnostics: diagnostics,
-                        shouldCreateMultipleTestProducts: shouldCreateMultipleTestProducts,
-                        createREPLProduct: manifest.packageKind == .root ? createREPLProduct : false
-                    )
-                    let package = try builder.construct()
-                    manifestToPackage[manifest] = package
+            let diagnosticsContext = PackageDiagnosticsContext(identity: node.identity, location: node.manifest.packageLocation)
+            let diagnosticsEmitter = DiagnosticsEmitter(context: diagnosticsContext)
+            diagnosticsEmitter.trap {
+                // Create a package from the manifest and sources.
+                let builder = PackageBuilder(
+                    identity: node.identity,
+                    manifest: manifest,
+                    productFilter: node.productFilter,
+                    path: packagePath,
+                    additionalFileRules: additionalFileRules,
+                    binaryArtifacts: binaryArtifacts,
+                    xcTestMinimumDeploymentTargets: xcTestMinimumDeploymentTargets,
+                    shouldCreateMultipleTestProducts: shouldCreateMultipleTestProducts,
+                    createREPLProduct: manifest.packageKind == .root ? createREPLProduct : false,
+                    fileSystem: fileSystem
+                )
+                let package = try builder.construct()
+                manifestToPackage[manifest] = package
 
-                    // Throw if any of the non-root package is empty.
-                    if package.targets.isEmpty // System packages have targets in the package but not the manifest.
-                        && package.manifest.targets.isEmpty // An unneeded dependency will not have loaded anything from the manifest.
-                        && manifest.packageKind != .root {
-                            throw PackageGraphError.noModules(package)
-                    }
+                // Throw if any of the non-root package is empty.
+                if package.targets.isEmpty // System packages have targets in the package but not the manifest.
+                    && package.manifest.targets.isEmpty // An unneeded dependency will not have loaded anything from the manifest.
+                    && manifest.packageKind != .root {
+                    throw PackageGraphError.noModules(package)
                 }
             }
         }
@@ -137,12 +134,11 @@ extension PackageGraph {
             identityResolver: identityResolver,
             manifestToPackage: manifestToPackage,
             rootManifestSet: rootManifestSet,
-            unsafeAllowedPackages: unsafeAllowedPackages,
-            diagnostics: diagnostics
+            unsafeAllowedPackages: unsafeAllowedPackages
         )
 
         let rootPackages = resolvedPackages.filter{ rootManifestSet.contains($0.manifest) }
-        checkAllDependenciesAreUsed(rootPackages, diagnostics)
+        checkAllDependenciesAreUsed(rootPackages)
 
         return try PackageGraph(
             rootPackages: rootPackages,
@@ -152,7 +148,7 @@ extension PackageGraph {
     }
 }
 
-private func checkAllDependenciesAreUsed(_ rootPackages: [ResolvedPackage], _ diagnostics: DiagnosticsEngine) {
+private func checkAllDependenciesAreUsed(_ rootPackages: [ResolvedPackage]) {
     for package in rootPackages {
         // List all dependency products dependent on by the package targets.
         let productDependencies: Set<ResolvedProduct> = Set(package.targets.flatMap({ target in
@@ -166,6 +162,7 @@ private func checkAllDependenciesAreUsed(_ rootPackages: [ResolvedPackage], _ di
             })
         }))
 
+        let diagnosticsEmitter =  DiagnosticsEmitter()
         for dependency in package.dependencies {
             // We continue if the dependency contains executable products to make sure we don't
             // warn on a valid use-case for a lone dependency: swift run dependency executables.
@@ -181,8 +178,8 @@ private func checkAllDependenciesAreUsed(_ rootPackages: [ResolvedPackage], _ di
             }
 
             let dependencyIsUsed = dependency.products.contains(where: productDependencies.contains)
-            if !dependencyIsUsed && !diagnostics.hasErrors {
-                diagnostics.emit(.unusedDependency(dependency.identity.description))
+            if !dependencyIsUsed && !ObservabilitySystem.errorsReported {
+                diagnosticsEmitter.emit(.unusedDependency(dependency.identity.description))
             }
         }
     }
@@ -195,8 +192,7 @@ private func createResolvedPackages(
     manifestToPackage: [Manifest: Package],
     // FIXME: This shouldn't be needed once <rdar://problem/33693433> is fixed.
     rootManifestSet: Set<Manifest>,
-    unsafeAllowedPackages: Set<PackageReference>,
-    diagnostics: DiagnosticsEngine
+    unsafeAllowedPackages: Set<PackageReference>
 ) throws -> [ResolvedPackage] {
 
     // Create package builder objects from the input manifests.
@@ -241,6 +237,8 @@ private func createResolvedPackages(
                 fatalError("registry based dependencies not implemented yet")
             }
 
+            let diagnosticsEmitter = DiagnosticsEmitter(context: package.diagnosticsContext)
+
             // Otherwise, look it up by its identity.
             if let resolvedPackage = packagesByIdentity[dependency.identity] {
                 // check if this resolved package already listed in the dependencies
@@ -252,7 +250,7 @@ private func createResolvedPackages(
                         dependencyLocation: dependencyLocation,
                         otherDependencyURL: resolvedPackage.package.manifest.packageLocation,
                         identity: dependency.identity)
-                    return diagnostics.emit(error, location: package.diagnosticLocation)
+                    return diagnosticsEmitter.emit(error)
                 }
 
                 // check if the resolved package location is the same as the dependency one
@@ -269,9 +267,9 @@ private func createResolvedPackages(
                     // we will upgrade this to an error in a few versions to tighten up the validation
                     if dependency.explicitNameForTargetDependencyResolutionOnly == .none ||
                         resolvedPackage.package.manifestName == dependency.explicitNameForTargetDependencyResolutionOnly {
-                        diagnostics.emit(.warning(error.description + ". this will be escalated to an error in future versions of SwiftPM."), location: package.diagnosticLocation)
+                        diagnosticsEmitter.emit(.warning(error.description + ". this will be escalated to an error in future versions of SwiftPM."))
                     } else {
-                        return diagnostics.emit(error, location: package.diagnosticLocation)
+                        return diagnosticsEmitter.emit(error)
                     }
                 }
 
@@ -283,7 +281,7 @@ private func createResolvedPackages(
                             dependencyLocation: dependencyLocation,
                             otherDependencyURL: previouslyResolvedPackage.package.manifest.packageLocation,
                             name: explicitDependencyName)
-                        return diagnostics.emit(error, location: package.diagnosticLocation)
+                        return diagnosticsEmitter.emit(error)
                     }
                 }
 
@@ -294,7 +292,7 @@ private func createResolvedPackages(
                         dependencyLocation: dependencyLocation,
                         otherDependencyURL: previouslyResolvedPackage.package.manifest.packageLocation,
                         name: dependency.identity.description)
-                    return diagnostics.emit(error, location: package.diagnosticLocation)
+                    return diagnosticsEmitter.emit(error)
                 }
 
                 let nameForTargetDependencyResolution = dependency.explicitNameForTargetDependencyResolutionOnly ?? dependency.identity.description
@@ -307,7 +305,7 @@ private func createResolvedPackages(
         packageBuilder.dependencies = dependencies
 
         // Create target builders for each target in the package.
-        let targetBuilders = package.targets.map({ ResolvedTargetBuilder(target: $0, diagnostics: diagnostics) })
+        let targetBuilders = package.targets.map{ ResolvedTargetBuilder(target: $0) }
         packageBuilder.targets = targetBuilders
 
         // Establish dependencies between the targets. A target can only depend on another target present in the same package.
@@ -351,7 +349,7 @@ private func createResolvedPackages(
             .map{ $0.package.identity.description }
             .sorted()
 
-        diagnostics.emit(PackageGraphError.duplicateProduct(product: productName, packages: packages))
+        DiagnosticsEmitter().emit(PackageGraphError.duplicateProduct(product: productName, packages: packages))
     }
 
     // Remove the duplicate products from the builders.
@@ -368,6 +366,7 @@ private func createResolvedPackages(
     // Do another pass and establish product dependencies of each target.
     for packageBuilder in packageBuilders {
         let package = packageBuilder.package
+        let diagnosticsEmitter = DiagnosticsEmitter(context: package.diagnosticsContext)
 
         // Get all implicit system library dependencies in this package.
         let implicitSystemTargetDeps = packageBuilder.dependencies
@@ -401,7 +400,7 @@ private func createResolvedPackages(
                     // This avoids flooding the diagnostics with product not
                     // found errors when there are more important errors to
                     // resolve (like authentication issues).
-                    if !diagnostics.hasErrors {
+                    if !ObservabilitySystem.errorsReported {
                         // Emit error if a product (not target) declared in the package is also a productRef (dependency)
                         let declProductsAsDependency = package.products.filter { product in
                             product.name == productRef.name
@@ -416,7 +415,7 @@ private func createResolvedPackages(
                             dependencyPackageName: productRef.package,
                             dependencyProductInDecl: !declProductsAsDependency.isEmpty
                         )
-                        diagnostics.emit(error, location: package.diagnosticLocation)
+                        diagnosticsEmitter.emit(error)
                     }
                     continue
                 }
@@ -439,7 +438,7 @@ private func createResolvedPackages(
                             targetName: targetBuilder.target.name,
                             packageIdentifier: referencedPackageName
                         )
-                        diagnostics.emit(error, location: package.diagnosticLocation)
+                        diagnosticsEmitter.emit(error)
                     }
                 }
 
@@ -457,7 +456,7 @@ private func createResolvedPackages(
                 .map{ $0.package.identity.description }
                 .sorted()
             if packages.count > 1 {
-                diagnostics.emit(ModuleError.duplicateModule(targetName, packages))
+                DiagnosticsEmitter().emit(ModuleError.duplicateModule(targetName, packages))
             }
         }
     }
@@ -533,12 +532,8 @@ private final class ResolvedTargetBuilder: ResolvedBuilder<ResolvedTarget> {
     /// The target dependencies of this target.
     var dependencies: [Dependency] = []
 
-    /// The diagnostics engine.
-    let diagnostics: DiagnosticsEngine
-
-    init(target: Target, diagnostics: DiagnosticsEngine) {
+    init(target: Target) {
         self.target = target
-        self.diagnostics = diagnostics
     }
 
     func diagnoseInvalidUseOfUnsafeFlags(_ product: ResolvedProduct) throws {
@@ -547,7 +542,7 @@ private final class ResolvedTargetBuilder: ResolvedBuilder<ResolvedTarget> {
             let declarations = target.underlyingTarget.buildSettings.assignments.keys
             for decl in declarations {
                 if BuildSettings.Declaration.unsafeSettings.contains(decl) {
-                    diagnostics.emit(.productUsesUnsafeFlags(product: product.name, target: target.name))
+                    DiagnosticsEmitter().emit(.productUsesUnsafeFlags(product: product.name, target: target.name))
                     break
                 }
             }

--- a/Sources/PackageLoading/Diagnostics.swift
+++ b/Sources/PackageLoading/Diagnostics.swift
@@ -8,28 +8,29 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import Basics
+import PackageModel
 import TSCBasic
 import TSCUtility
-import PackageModel
 
-extension Diagnostic.Message {
-    static func targetHasNoSources(targetPath: String, target: String) -> Diagnostic.Message {
+extension DiagnosticMessage {
+    static func targetHasNoSources(targetPath: String, target: String) -> Self {
         .warning("Source files for target \(target) should be located under \(targetPath)")
     }
 
-    static func manifestLoading(output: String, diagnosticFile: AbsolutePath?) -> Diagnostic.Message {
+    static func manifestLoading(output: String, diagnosticFile: AbsolutePath?) -> Self {
         .warning(ManifestLoadingDiagnostic(output: output, diagnosticFile: diagnosticFile))
     }
 
-    static func targetNameHasIncorrectCase(target: String) -> Diagnostic.Message {
+    static func targetNameHasIncorrectCase(target: String) -> Self {
         .warning("the target name \(target) has different case on the filesystem and the Package.swift manifest file")
     }
 
-    static func unsupportedCTestTarget(package: String, target: String) -> Diagnostic.Message {
+    static func unsupportedCTestTarget(package: String, target: String) -> Self {
         .warning("ignoring target '\(target)' in package '\(package)'; C language in tests is not yet supported")
     }
 
-    static func duplicateProduct(product: Product) -> Diagnostic.Message {
+    static func duplicateProduct(product: Product) -> Self {
         let typeString: String
         switch product.type {
         case .library(.automatic):
@@ -42,53 +43,53 @@ extension Diagnostic.Message {
         return .warning("ignoring duplicate product '\(product.name)'\(typeString)")
     }
 
-    static func duplicateTargetDependency(dependency: String, target: String, package: String) -> Diagnostic.Message {
+    static func duplicateTargetDependency(dependency: String, target: String, package: String) -> Self {
         .warning("invalid duplicate target dependency declaration '\(dependency)' in target '\(target)' from package '\(package)'")
     }
 
-    static var systemPackageDeprecation: Diagnostic.Message {
+    static var systemPackageDeprecation: Self {
         .warning("system packages are deprecated; use system library targets instead")
     }
 
-    static func systemPackageDeclaresTargets(targets: [String]) -> Diagnostic.Message {
+    static func systemPackageDeclaresTargets(targets: [String]) -> Self {
         .warning("ignoring declared target(s) '\(targets.joined(separator: ", "))' in the system package")
     }
 
-    static func systemPackageProductValidation(product: String) -> Diagnostic.Message {
+    static func systemPackageProductValidation(product: String) -> Self {
         .error("system library product \(product) shouldn't have a type and contain only one target")
     }
 
-    static func executableProductTargetNotExecutable(product: String, target: String) -> Diagnostic.Message {
+    static func executableProductTargetNotExecutable(product: String, target: String) -> Self {
         .error("""
             executable product '\(product)' expects target '\(target)' to be executable; an executable target requires \
             a 'main.swift' file
             """)
     }
 
-    static func executableProductWithoutExecutableTarget(product: String) -> Diagnostic.Message {
+    static func executableProductWithoutExecutableTarget(product: String) -> Self {
         .error("""
             executable product '\(product)' should have one executable target; an executable target requires a \
             'main.swift' file
             """)
     }
 
-    static func executableProductWithMoreThanOneExecutableTarget(product: String) -> Diagnostic.Message {
+    static func executableProductWithMoreThanOneExecutableTarget(product: String) -> Self {
         .error("executable product '\(product)' should not have more than one executable target")
     }
 
-    static func pluginProductWithNoTargets(product: String) -> Diagnostic.Message {
+    static func pluginProductWithNoTargets(product: String) -> Self {
         .error("plugin product '\(product)' should have at least one plugin target")
     }
 
-    static func pluginProductWithNonPluginTargets(product: String, otherTargets: [String]) -> Diagnostic.Message {
+    static func pluginProductWithNonPluginTargets(product: String, otherTargets: [String]) -> Self {
         .error("plugin product '\(product)' should have only plugin targets (it has \(otherTargets.map{ "'\($0)'" }.joined(separator: ", ")))")
     }
 
-    static var noLibraryTargetsForREPL: Diagnostic.Message {
+    static var noLibraryTargetsForREPL: Self {
         .error("unable to synthesize a REPL product as there are no library targets in the package")
     }
 
-    static func brokenSymlink(_ path: AbsolutePath) -> Diagnostic.Message {
+    static func brokenSymlink(_ path: AbsolutePath) -> Self {
         .warning("ignoring broken symlink \(path)")
     }
 

--- a/Sources/PackageLoading/Diagnostics.swift
+++ b/Sources/PackageLoading/Diagnostics.swift
@@ -13,13 +13,9 @@ import PackageModel
 import TSCBasic
 import TSCUtility
 
-extension DiagnosticMessage {
+extension Basics.Diagnostic {
     static func targetHasNoSources(targetPath: String, target: String) -> Self {
         .warning("Source files for target \(target) should be located under \(targetPath)")
-    }
-
-    static func manifestLoading(output: String, diagnosticFile: AbsolutePath?) -> Self {
-        .warning(ManifestLoadingDiagnostic(output: output, diagnosticFile: diagnosticFile))
     }
 
     static func targetNameHasIncorrectCase(target: String) -> Self {
@@ -98,7 +94,7 @@ extension DiagnosticMessage {
     }
 
     static func fileReference(path: RelativePath) -> Self {
-        .note("found '\(path)'")
+        .info("found '\(path)'")
     }
 
     static func infoPlistResourceConflict(
@@ -145,9 +141,17 @@ extension DiagnosticMessage {
     }
 }
 
-public struct ManifestLoadingDiagnostic: DiagnosticData {
-    public let output: String
-    public let diagnosticFile: AbsolutePath?
-
-    public var description: String { output }
+extension DiagnosticsMetadata {
+    public var manifestLoadingDiagnosticFile: AbsolutePath? {
+        get {
+            self[ManifestLoadingDiagnosticFileKey.self]
+        }
+        set {
+            self[ManifestLoadingDiagnosticFileKey.self] = newValue
+        }
+    }
+    
+    enum ManifestLoadingDiagnosticFileKey: DiagnosticsMetadataKey {
+        typealias Value = AbsolutePath
+    }
 }

--- a/Sources/PackageLoading/Diagnostics.swift
+++ b/Sources/PackageLoading/Diagnostics.swift
@@ -141,7 +141,7 @@ extension Basics.Diagnostic {
     }
 }
 
-extension DiagnosticsMetadata {
+extension ObservabilityMetadata {
     public var manifestLoadingDiagnosticFile: AbsolutePath? {
         get {
             self[ManifestLoadingDiagnosticFileKey.self]
@@ -151,7 +151,7 @@ extension DiagnosticsMetadata {
         }
     }
     
-    enum ManifestLoadingDiagnosticFileKey: DiagnosticsMetadataKey {
+    enum ManifestLoadingDiagnosticFileKey: Key {
         typealias Value = AbsolutePath
     }
 }

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -470,7 +470,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                     metadata.manifestLoadingDiagnosticFile = diagnosticFile
                     return metadata
                 }
-                DiagnosticsEmitter().emit(warning: compilerOutput, metadata: metadata)
+                ObservabilitySystem.topScope.emit(warning: compilerOutput, metadata: metadata)
             }
         }
 

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -465,7 +465,12 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         if let compilerOutput = result.compilerOutput {
             // FIXME: Temporary workaround to filter out debug output from integrated Swift driver. [rdar://73710910]
             if !(compilerOutput.hasPrefix("<unknown>:0: remark: new Swift driver at") && compilerOutput.hasSuffix("will be used")) {
-                diagnostics?.emit(.warning(ManifestLoadingDiagnostic(output: compilerOutput, diagnosticFile: result.diagnosticFile)))
+                let metadata = result.diagnosticFile.map { diagnosticFile -> DiagnosticsMetadata in
+                    var metadata = DiagnosticsMetadata()
+                    metadata.manifestLoadingDiagnosticFile = diagnosticFile
+                    return metadata
+                }
+                DiagnosticsEmitter().emit(.warning(compilerOutput, metadata: metadata))
             }
         }
 

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -465,12 +465,12 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         if let compilerOutput = result.compilerOutput {
             // FIXME: Temporary workaround to filter out debug output from integrated Swift driver. [rdar://73710910]
             if !(compilerOutput.hasPrefix("<unknown>:0: remark: new Swift driver at") && compilerOutput.hasSuffix("will be used")) {
-                let metadata = result.diagnosticFile.map { diagnosticFile -> DiagnosticsMetadata in
-                    var metadata = DiagnosticsMetadata()
+                let metadata = result.diagnosticFile.map { diagnosticFile -> ObservabilityMetadata in
+                    var metadata = ObservabilityMetadata()
                     metadata.manifestLoadingDiagnosticFile = diagnosticFile
                     return metadata
                 }
-                DiagnosticsEmitter().emit(.warning(compilerOutput, metadata: metadata))
+                DiagnosticsEmitter().emit(warning: compilerOutput, metadata: metadata)
             }
         }
 
@@ -524,7 +524,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                     diagnostics: diagnostics)
             }
         } catch {
-            diagnostics?.emit(.warning("failed loading cached manifest for '\(key.packageIdentity)': \(error)"))
+            diagnostics?.emit(warning: "failed loading cached manifest for '\(key.packageIdentity)': \(error)")
         }
 
         // shells out and compiles the manifest, finally output a JSON
@@ -546,7 +546,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         do {
             try cache?.put(key: key.sha256Checksum, value: result)
         } catch {
-            diagnostics?.emit(.warning("failed storing manifest for '\(key.packageIdentity)' in cache: \(error)"))
+            diagnostics?.emit(warning: "failed storing manifest for '\(key.packageIdentity)' in cache: \(error)")
         }
 
         return parseManifest

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -281,7 +281,7 @@ public final class PackageBuilder {
         self.shouldCreateMultipleTestProducts = shouldCreateMultipleTestProducts
         self.createREPLProduct = createREPLProduct
         self.warnAboutImplicitExecutableTargets = warnAboutImplicitExecutableTargets
-        self.diagnosticsEmitter = DiagnosticsEmitter(context: PackageDiagnosticsContext(identity: self.identity, location: self.manifest.packageLocation))
+        self.diagnosticsEmitter = DiagnosticsEmitter(metadata: .packageMetadata(identity: self.identity, location: self.manifest.packageLocation))
         self.fileSystem = fileSystem
     }
 

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -1170,8 +1170,7 @@ public final class PackageBuilder {
           #if os(Linux)
             // FIXME: Ignore C language test targets on linux for now.
             if target is ClangTarget {
-                diagnostics.emit(.unsupportedCTestTarget(
-                    package: manifest.name, target: target.name))
+                self.diagnosticsEmitter.emit(.unsupportedCTestTarget(package: manifest.name, target: target.name))
                 return false
             }
           #endif

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -1174,7 +1174,7 @@ public final class PackageBuilder {
           #if os(Linux)
             // FIXME: Ignore C language test targets on linux for now.
             if target is ClangTarget {
-                self.diagnosticsEmitter.emit(.unsupportedCTestTarget(package: manifest.name, target: target.name))
+                self.observabilityScope.emit(.unsupportedCTestTarget(package: manifest.name, target: target.name))
                 return false
             }
           #endif

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -225,12 +225,6 @@ public final class PackageBuilder {
     /// Information concerning the different downloaded binary target artifacts.
     private let binaryArtifacts: [BinaryArtifact]
 
-    /// The filesystem package builder will run on.
-    private let fileSystem: FileSystem
-
-    /// The diagnostics engine.
-    private let diagnostics: DiagnosticsEngine
-
     /// Create multiple test products.
     ///
     /// If set to true, one test product will be created for each test target.
@@ -248,6 +242,12 @@ public final class PackageBuilder {
     /// Minimum deployment target of XCTest per platform.
     private let xcTestMinimumDeploymentTargets: [PackageModel.Platform:PlatformVersion]
 
+    // helper to emit diagnostics
+    private let diagnosticsEmitter: DiagnosticsEmitter
+
+    /// The filesystem package builder will run on.
+    private let fileSystem: FileSystem
+
     /// Create a builder for the given manifest and package `path`.
     ///
     /// - Parameters:
@@ -255,10 +255,9 @@ public final class PackageBuilder {
     ///   - manifest: The manifest of this package.
     ///   - path: The root path of the package.
     ///   - artifactPaths: Paths to the downloaded binary target artifacts.
-    ///   - fileSystem: The file system on which the builder should be run.
-    ///   - diagnostics: The diagnostics engine.
     ///   - createMultipleTestProducts: If enabled, create one test product for
     ///     each test target.
+    ///   - fileSystem: The file system on which the builder should be run.///     
     public init(
         identity: PackageIdentity,
         manifest: Manifest,
@@ -267,11 +266,10 @@ public final class PackageBuilder {
         additionalFileRules: [FileRuleDescription] = [],
         binaryArtifacts: [BinaryArtifact] = [],
         xcTestMinimumDeploymentTargets: [PackageModel.Platform:PlatformVersion],
-        fileSystem: FileSystem = localFileSystem,
-        diagnostics: DiagnosticsEngine,
         shouldCreateMultipleTestProducts: Bool = false,
         warnAboutImplicitExecutableTargets: Bool = true,
-        createREPLProduct: Bool = false
+        createREPLProduct: Bool = false,
+        fileSystem: FileSystem
     ) {
         self.identity = identity
         self.manifest = manifest
@@ -280,11 +278,11 @@ public final class PackageBuilder {
         self.additionalFileRules = additionalFileRules
         self.binaryArtifacts = binaryArtifacts
         self.xcTestMinimumDeploymentTargets = xcTestMinimumDeploymentTargets
-        self.fileSystem = fileSystem
-        self.diagnostics = diagnostics
         self.shouldCreateMultipleTestProducts = shouldCreateMultipleTestProducts
         self.createREPLProduct = createREPLProduct
         self.warnAboutImplicitExecutableTargets = warnAboutImplicitExecutableTargets
+        self.diagnosticsEmitter = DiagnosticsEmitter(context: PackageDiagnosticsContext(identity: self.identity, location: self.manifest.packageLocation))
+        self.fileSystem = fileSystem
     }
 
     /// Loads a root package from a path using the resources associated with a particular `swiftc` executable.
@@ -322,7 +320,7 @@ public final class PackageBuilder {
                     productFilter: .everything,
                     path: path,
                     xcTestMinimumDeploymentTargets: xcTestMinimumDeploymentTargets,
-                    diagnostics: diagnostics)
+                    fileSystem: localFileSystem)
                 return try builder.construct()
             }
             completion(result)
@@ -345,10 +343,6 @@ public final class PackageBuilder {
             targetSearchPath: self.packagePath.appending(component: targetSpecialDirs.targetDir),
             testTargetSearchPath: self.packagePath.appending(component: targetSpecialDirs.testTargetDir)
         )
-    }
-
-    private var diagnosticLocation: DiagnosticLocation {
-        return PackageLocation.Local(name: self.manifest.name, packagePath: self.packagePath)
     }
 
     /// Computes the special directory where targets are present or should be placed in future.
@@ -395,7 +389,7 @@ public final class PackageBuilder {
 
             // Diagnose broken symlinks.
             if fileSystem.isSymlink(path) {
-                diagnostics.emit(.brokenSymlink(path), location: self.diagnosticLocation)
+                self.diagnosticsEmitter.emit(.brokenSymlink(path))
             }
 
             return false
@@ -446,15 +440,14 @@ public final class PackageBuilder {
 
             // Warn about any declared targets.
             if !manifest.targets.isEmpty {
-                diagnostics.emit(
-                    .systemPackageDeclaresTargets(targets: Array(manifest.targets.map({ $0.name }))),
-                    location: self.diagnosticLocation
+                self.diagnosticsEmitter.emit(
+                    .systemPackageDeclaresTargets(targets: Array(manifest.targets.map({ $0.name })))
                 )
             }
 
             // Emit deprecation notice.
             if manifest.toolsVersion >= .v4_2 {
-                diagnostics.emit(.systemPackageDeprecation, location: self.diagnosticLocation)
+                self.diagnosticsEmitter.emit(.systemPackageDeprecation)
             }
 
             // Package contains a modulemap at the top level, so we assuming
@@ -580,7 +573,7 @@ public final class PackageBuilder {
 
             // Otherwise, if the path "exists" then the case in manifest differs from the case on the file system.
             if fileSystem.isDirectory(path) {
-                diagnostics.emit(.targetNameHasIncorrectCase(target: target.name), location: self.diagnosticLocation)
+                self.diagnosticsEmitter.emit(.targetNameHasIncorrectCase(target: target.name))
                 return path
             }
             throw ModuleError.moduleNotFound(target.name, target.type)
@@ -732,7 +725,7 @@ public final class PackageBuilder {
                 targets[createdTarget.name] = createdTarget
             } else {
                 emptyModules.insert(potentialModule.name)
-                diagnostics.emit(.targetHasNoSources(targetPath: potentialModule.path.pathString, target: potentialModule.name))
+                self.diagnosticsEmitter.emit(.targetHasNoSources(targetPath: potentialModule.path.pathString, target: potentialModule.name))
             }
         }
 
@@ -788,7 +781,7 @@ public final class PackageBuilder {
         // Check for duplicate target dependencies by name
         let combinedDependencyNames = dependencies.map { $0.target?.name ?? $0.product!.name }
         combinedDependencyNames.spm_findDuplicates().forEach {
-            diagnostics.emit(.duplicateTargetDependency(dependency: $0, target: potentialModule.name, package: self.manifest.name))
+            self.diagnosticsEmitter.emit(.duplicateTargetDependency(dependency: $0, target: potentialModule.name, package: self.manifest.name))
         }
 
         // Create the build setting assignment table for this target.
@@ -802,15 +795,15 @@ public final class PackageBuilder {
         }
 
         let sourcesBuilder = TargetSourcesBuilder(
-            packageName: self.manifest.name,
+            packageIdentity: self.identity,
+            packageLocation: self.manifest.packageLocation,
             packagePath: self.packagePath,
             target: manifestTarget,
             path: potentialModule.path,
             defaultLocalization: self.manifest.defaultLocalization,
             additionalFileRules: self.additionalFileRules,
             toolsVersion: self.manifest.toolsVersion,
-            fs: self.fileSystem,
-            diags: self.diagnostics
+            fileSystem: self.fileSystem
         )
         let (sources, resources, headers, others) = try sourcesBuilder.run()
 
@@ -861,7 +854,7 @@ public final class PackageBuilder {
         default:
             targetType = sources.computeTargetType()
             if targetType == .executable && manifest.toolsVersion >= .v5_4 && warnAboutImplicitExecutableTargets {
-                diagnostics.emit(warning: "'\(potentialModule.name)' was identified as an executable target given the presence of a 'main.swift' file. Starting with tools version \(ToolsVersion.v5_4) executable targets should be declared as 'executableTarget()'")
+                self.diagnosticsEmitter.emit(warning: "'\(potentialModule.name)' was identified as an executable target given the presence of a 'main.swift' file. Starting with tools version \(ToolsVersion.v5_4) executable targets should be declared as 'executableTarget()'")
             }
         }
         
@@ -888,7 +881,7 @@ public final class PackageBuilder {
             
             if fileSystem.exists(publicHeadersPath) {
                 let moduleMapGenerator = ModuleMapGenerator(targetName: potentialModule.name, moduleName: potentialModule.name.spm_mangledToC99ExtendedIdentifier(), publicHeadersDir: publicHeadersPath, fileSystem: fileSystem)
-                moduleMapType = moduleMapGenerator.determineModuleMapType(diagnostics: diagnostics)
+                moduleMapType = moduleMapGenerator.determineModuleMapType(diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
             } else if targetType == .library, manifest.toolsVersion >= .v5_5 {
                 // If this clang target is a library, it must contain "include" directory.
                 throw ModuleError.invalidPublicHeadersDirectory(potentialModule.name)
@@ -1167,10 +1160,7 @@ public final class PackageBuilder {
         func append(_ product: Product) {
             let inserted = products.append(KeyedPair(product, key: product.name))
             if !inserted {
-                diagnostics.emit(
-                    .duplicateProduct(product: product),
-                    location: self.diagnosticLocation
-                )
+                self.diagnosticsEmitter.emit(.duplicateProduct(product: product))
             }
         }
 
@@ -1237,10 +1227,7 @@ public final class PackageBuilder {
             // a system library target.
             if targets.contains(where: { $0 is SystemLibraryTarget }) {
                 if product.type != .library(.automatic) || targets.count != 1 {
-                    self.diagnostics.emit(
-                        .systemPackageProductValidation(product: product.name),
-                        location: self.diagnosticLocation
-                    )
+                    self.diagnosticsEmitter.emit(.systemPackageProductValidation(product: product.name))
                     continue
                 }
             }
@@ -1289,7 +1276,7 @@ public final class PackageBuilder {
                     // If there is already a product with this name skip generating a product for it,
                     // but warn if that product is not executable
                     if product.type != .executable {
-                        self.diagnostics.emit(.warning("The target named '\(target.name)' was identified as an executable target but a non-executable product with this name already exists."))
+                        self.diagnosticsEmitter.emit(.warning("The target named '\(target.name)' was identified as an executable target but a non-executable product with this name already exists."))
                     }
                     continue
                 } else {
@@ -1305,10 +1292,7 @@ public final class PackageBuilder {
         if self.createREPLProduct {
             let libraryTargets = targets.filter{ $0.type == .library }
             if libraryTargets.isEmpty {
-                self.diagnostics.emit(
-                    .noLibraryTargetsForREPL,
-                    location: self.diagnosticLocation
-                )
+                self.diagnosticsEmitter.emit(.noLibraryTargetsForREPL)
             } else {
                 let replProduct = Product(
                     name: self.manifest.name + Product.replProductSuffix,
@@ -1333,21 +1317,12 @@ public final class PackageBuilder {
         guard executableTargetCount == 1 else {
             if executableTargetCount == 0 {
                 if let target = targets.spm_only {
-                    diagnostics.emit(
-                        .executableProductTargetNotExecutable(product: product.name, target: target.name),
-                        location: self.diagnosticLocation
-                    )
+                    self.diagnosticsEmitter.emit(.executableProductTargetNotExecutable(product: product.name, target: target.name))
                 } else {
-                    diagnostics.emit(
-                        .executableProductWithoutExecutableTarget(product: product.name),
-                        location: self.diagnosticLocation
-                    )
+                    self.diagnosticsEmitter.emit(.executableProductWithoutExecutableTarget(product: product.name))
                 }
             } else {
-                diagnostics.emit(
-                    .executableProductWithMoreThanOneExecutableTarget(product: product.name),
-                    location: self.diagnosticLocation
-                )
+                self.diagnosticsEmitter.emit(.executableProductWithMoreThanOneExecutableTarget(product: product.name))
             }
 
             return false
@@ -1359,17 +1334,11 @@ public final class PackageBuilder {
     private func validatePluginProduct(_ product: ProductDescription, with targets: [Target]) -> Bool {
         let nonPluginTargets = targets.filter{ $0.type != .plugin }
         guard nonPluginTargets.isEmpty else {
-            diagnostics.emit(
-                .pluginProductWithNonPluginTargets(product: product.name, otherTargets: nonPluginTargets.map{ $0.name }),
-                location: self.diagnosticLocation
-            )
+            self.diagnosticsEmitter.emit(.pluginProductWithNonPluginTargets(product: product.name, otherTargets: nonPluginTargets.map{ $0.name }))
             return false
         }
         guard !targets.isEmpty else {
-            diagnostics.emit(
-                .pluginProductWithNoTargets(product: product.name),
-                location: self.diagnosticLocation
-            )
+            self.diagnosticsEmitter.emit(.pluginProductWithNoTargets(product: product.name))
             return false
         }
         return true

--- a/Sources/PackageLoading/Target+PkgConfig.swift
+++ b/Sources/PackageLoading/Target+PkgConfig.swift
@@ -266,30 +266,3 @@ public struct PkgConfigDiagnosticLocation: DiagnosticLocation {
     }
 }
 
-// FIXME: Kill this.
-public struct PkgConfigGenericDiagnostic: DiagnosticData {
-    public let error: String
-
-    public init(error: String) {
-        self.error = error
-    }
-
-    public var description: String {
-        return error
-    }
-}
-
-// FIXME: Kill this.
-public struct PkgConfigHintDiagnostic: DiagnosticData {
-    public let pkgConfigName: String
-    public let installText: String
-
-    public init(pkgConfigName: String, installText: String) {
-        self.pkgConfigName = pkgConfigName
-        self.installText = installText
-    }
-
-    public var description: String {
-        return "you may be able to install \(pkgConfigName) using your system-packager:\n\(installText)"
-    }
-}

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -8,24 +8,25 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import Basics
 import Foundation
-import TSCBasic
 import PackageModel
+import TSCBasic
 import TSCUtility
 
 /// A utility to compute the source/resource files of a target.
 public struct TargetSourcesBuilder {
-    /// The target for which we're computing source/resource files.
-    public let target: TargetDescription
+    /// The identity of the package.
+    public let packageIdentity: PackageIdentity
 
-    /// The engine for emitting diagnostics.
-    let diags: DiagnosticsEngine
-
-    /// The name of the package.
-    public let packageName: String
+    /// The location of the package.
+    public let packageLocation: String
 
     /// The path of the package.
     public let packagePath: AbsolutePath
+
+    /// The target for which we're computing source/resource files.
+    public let target: TargetDescription
 
     /// The path of the target.
     public let targetPath: AbsolutePath
@@ -46,33 +47,38 @@ public struct TargetSourcesBuilder {
     public let excludedPaths: Set<AbsolutePath>
 
     /// The file system to operate on.
-    public let fs: FileSystem
+    public let fileSystem: FileSystem
+
+    private let diagnosticsEmitter: DiagnosticsEmitter
 
     /// Create a new target builder.
     public init(
-        packageName: String,
+        packageIdentity: PackageIdentity,
+        packageLocation: String,
         packagePath: AbsolutePath,
         target: TargetDescription,
         path: AbsolutePath,
         defaultLocalization: String?,
         additionalFileRules: [FileRuleDescription] = [],
         toolsVersion: ToolsVersion = .currentToolsVersion,
-        fs: FileSystem = localFileSystem,
-        diags: DiagnosticsEngine
+        fileSystem: FileSystem
     ) {
-        self.packageName = packageName
+        self.packageIdentity = packageIdentity
+        self.packageLocation = packageLocation
         self.packagePath = packagePath
         self.target = target
         self.defaultLocalization = defaultLocalization
-        self.diags = diags
         self.targetPath = path
         // In version 5.4 and earlier, SwiftPM did not support `additionalFileRules` and always implicitly included XCBuild file types.
         let actualAdditionalRules = (toolsVersion <= ToolsVersion.v5_4 ? FileRuleDescription.xcbuildFileTypes : additionalFileRules)
         self.rules = FileRuleDescription.builtinRules + actualAdditionalRules
         self.toolsVersion = toolsVersion
-        self.fs = fs
         let excludedPaths = target.exclude.map{ path.appending(RelativePath($0)) }
         self.excludedPaths = Set(excludedPaths)
+
+        self.fileSystem = fileSystem
+
+        self.diagnosticsEmitter = DiagnosticsEmitter(context: PackageDiagnosticsContext(identity: packageIdentity, location: packageLocation))
 
         let declaredSources = target.sources?.map{ path.appending(RelativePath($0)) }
         if let declaredSources = declaredSources {
@@ -80,7 +86,7 @@ public struct TargetSourcesBuilder {
             let duplicates = declaredSources.spm_findDuplicateElements()
             if !duplicates.isEmpty {
                 for duplicate in duplicates {
-                    diags.emit(warning: "found duplicate sources declaration in the package manifest: \(duplicate.map{ $0.pathString }[0])")
+                    self.diagnosticsEmitter.emit(warning: "found duplicate sources declaration in the package manifest: \(duplicate.map{ $0.pathString }[0])")
                 }
             }
         }
@@ -89,14 +95,14 @@ public struct TargetSourcesBuilder {
         self.excludedPaths.forEach { exclude in
             if let message = validTargetPath(at: exclude) {
                 let warning = "Invalid Exclude '\(exclude)': \(message)."
-                self.diags.emit(warning: warning)
+                self.diagnosticsEmitter.emit(warning: warning)
             }
         }
         
         self.declaredSources?.forEach { source in
             if let message = validTargetPath(at: source) {
                 let warning = "Invalid Source '\(source)': \(message)."
-                self.diags.emit(warning: warning)
+                self.diagnosticsEmitter.emit(warning: warning)
             }
         }
 
@@ -108,7 +114,7 @@ public struct TargetSourcesBuilder {
     @discardableResult
     private func validTargetPath(at: AbsolutePath) -> Error? {
         // Check if paths that are enumerated in targets: [] exist
-        guard self.fs.exists(at) else {
+        guard self.fileSystem.exists(at) else {
             return StringError("File not found")
         }
 
@@ -127,7 +133,7 @@ public struct TargetSourcesBuilder {
         for rule in rules {
             for ext in rule.fileTypes {
                 if let existingRule = extensionMap[ext] {
-                    diags.emit(.error("conflicting rules \(rule) and \(existingRule) for extension \(ext)"))
+                    self.diagnosticsEmitter.emit(.error("conflicting rules \(rule) and \(existingRule) for extension \(ext)"))
                 }
                 extensionMap[ext] = rule
             }
@@ -154,7 +160,7 @@ public struct TargetSourcesBuilder {
                 for (file, _) in filesWithNoRules {
                     warning += "    " + file.pathString + "\n"
                 }
-                diags.emit(.warning(warning))
+                self.diagnosticsEmitter.emit(.warning(warning))
             }
             others.append(contentsOf: filesWithNoRules.keys)
         }
@@ -193,7 +199,7 @@ public struct TargetSourcesBuilder {
             let resourcePath = self.targetPath.appending(RelativePath(declaredResource.path))
             if path.isDescendantOfOrEqual(to: resourcePath) {
                 if matchedRule.rule != .none {
-                    diags.emit(.error("duplicate resource rule '\(declaredResource.rule)' found for file at '\(path)'"))
+                    self.diagnosticsEmitter.emit(.error("duplicate resource rule '\(declaredResource.rule)' found for file at '\(path)'"))
                 }
                 matchedRule = Rule(rule: declaredResource.rule.fileRule, localization: declaredResource.localization)
             }
@@ -204,7 +210,7 @@ public struct TargetSourcesBuilder {
             for sourcePath in declaredSources {
                 if path.isDescendantOfOrEqual(to: sourcePath) {
                     if matchedRule.rule != .none {
-                        diags.emit(.error("duplicate rule found for file at '\(path)'"))
+                        self.diagnosticsEmitter.emit(.error("duplicate rule found for file at '\(path)'"))
                     }
 
                     // Check for header files as they're allowed to be mixed with sources.
@@ -272,7 +278,7 @@ public struct TargetSourcesBuilder {
             // If a resource is both inside a localization directory and has an explicit localization, it's ambiguous.
             guard implicitLocalization == nil || explicitLocalization == nil else {
                 let relativePath = path.relative(to: targetPath)
-                diags.emit(.localizationAmbiguity(path: relativePath, targetName: target.name))
+                self.diagnosticsEmitter.emit(.localizationAmbiguity(path: relativePath, targetName: target.name))
                 return nil
             }
 
@@ -285,11 +291,11 @@ public struct TargetSourcesBuilder {
     private func diagnoseConflictingResources(in resources: [Resource]) {
         let duplicateResources = resources.spm_findDuplicateElements(by: \.destination)
         for resources in duplicateResources {
-            diags.emit(.conflictingResource(path: resources[0].destination, targetName: target.name))
+            self.diagnosticsEmitter.emit(.conflictingResource(path: resources[0].destination, targetName: target.name))
 
             for resource in resources {
                 let relativePath = resource.path.relative(to: targetPath)
-                diags.emit(.fileReference(path: relativePath))
+                self.diagnosticsEmitter.emit(.fileReference(path: relativePath))
             }
         }
     }
@@ -303,7 +309,7 @@ public struct TargetSourcesBuilder {
         for resource in resources where resource.rule == .copy {
             if localizationDirectories.contains(resource.path.basename.lowercased()) {
                 let relativePath = resource.path.relative(to: targetPath)
-                diags.emit(.copyConflictWithLocalizationDirectory(path: relativePath, targetName: target.name))
+                self.diagnosticsEmitter.emit(.copyConflictWithLocalizationDirectory(path: relativePath, targetName: target.name))
             }
         }
     }
@@ -314,7 +320,7 @@ public struct TargetSourcesBuilder {
             let hasLocalizations = resources.contains(where: { $0.localization != nil })
             let hasUnlocalized = resources.contains(where: { $0.localization == nil })
             if hasLocalizations && hasUnlocalized {
-                diags.emit(.localizedAndUnlocalizedVariants(resource: basename, targetName: target.name))
+                self.diagnosticsEmitter.emit(.localizedAndUnlocalizedVariants(resource: basename, targetName: target.name))
             }
         }
     }
@@ -329,7 +335,7 @@ public struct TargetSourcesBuilder {
         let resourcesByBasename = Dictionary(grouping: localizedResources, by: { $0.path.basename })
         for (basename, resources) in resourcesByBasename {
             if !resources.contains(where: { $0.localization == defaultLocalization }) {
-                diags.emit(.missingDefaultLocalizationResource(
+                self.diagnosticsEmitter.emit(.missingDefaultLocalizationResource(
                     resource: basename,
                     targetName: target.name,
                     defaultLocalization: defaultLocalization))
@@ -340,7 +346,7 @@ public struct TargetSourcesBuilder {
     private func diagnoseInfoPlistConflicts(in resources: [Resource]) {
         for resource in resources {
             if resource.destination == RelativePath("Info.plist") {
-                diags.emit(.infoPlistResourceConflict(
+                self.diagnosticsEmitter.emit(.infoPlistResourceConflict(
                     path: resource.path.relative(to: targetPath),
                     targetName: target.name))
             }
@@ -352,7 +358,7 @@ public struct TargetSourcesBuilder {
             let resourcePath = self.targetPath.appending(RelativePath(resource.path))
             if let message = validTargetPath(at: resourcePath) {
                 let warning = "Invalid Resource '\(resource.path)': \(message)."
-                self.diags.emit(warning: warning)
+                self.diagnosticsEmitter.emit(warning: warning)
             }
         }
     }
@@ -387,7 +393,7 @@ public struct TargetSourcesBuilder {
             }
 
             // Ignore manifest files.
-            if path.parentDirectory == packagePath {
+            if path.parentDirectory == self.packagePath {
                 if path.basename == Manifest.filename { continue }
                 if path.basename == "Package.resolved" { continue }
 
@@ -400,13 +406,13 @@ public struct TargetSourcesBuilder {
             // Ignore if this is an excluded path.
             if self.excludedPaths.contains(path) { continue }
 
-            if fs.isSymlink(path) && !fs.exists(path, followSymlink: true) {
-                diags.emit(.brokenSymlink(path), location: diagnosticLocation)
+            if self.fileSystem.isSymlink(path) && !self.fileSystem.exists(path, followSymlink: true) {
+                self.diagnosticsEmitter.emit(.brokenSymlink(path))
                 continue
             }
 
             // Consider non-directories as source files.
-            if !fs.isDirectory(path) {
+            if !self.fileSystem.isDirectory(path) {
                 contents.append(path)
                 continue
             }
@@ -444,24 +450,20 @@ public struct TargetSourcesBuilder {
             // We found a directory inside a localization directory, which is forbidden.
             if path.parentDirectory.extension == Resource.localizationDirectoryExtension {
                 let relativePath = path.parentDirectory.relative(to: targetPath)
-                diags.emit(.localizationDirectoryContainsSubDirectories(
+                self.diagnosticsEmitter.emit(.localizationDirectoryContainsSubDirectories(
                     localizationDirectory: relativePath,
                     targetName: target.name))
                 continue
             }
 
             // Otherwise, add its content to the queue.
-            let dirContents = diags.wrap {
-                try fs.getDirectoryContents(path).map({ path.appending(component: $0) })
+            let dirContents = self.diagnosticsEmitter.trap {
+                try self.fileSystem.getDirectoryContents(path).map({ path.appending(component: $0) })
             }
             queue += dirContents ?? []
         }
 
         return contents
-    }
-
-    private var diagnosticLocation: DiagnosticLocation {
-        return PackageLocation.Local(name: packageName, packagePath: packagePath)
     }
 }
 
@@ -648,7 +650,7 @@ extension TargetDescription.Resource.Rule {
     }
 }
 
-extension Diagnostic.Message {
+extension DiagnosticMessage {
     static func symlinkInSources(symlink: RelativePath, targetName: String) -> Self {
         .warning("ignoring symlink at '\(symlink)' in target '\(targetName)'")
     }

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -78,7 +78,7 @@ public struct TargetSourcesBuilder {
 
         self.fileSystem = fileSystem
 
-        self.diagnosticsEmitter = DiagnosticsEmitter(context: PackageDiagnosticsContext(identity: packageIdentity, location: packageLocation))
+        self.diagnosticsEmitter = DiagnosticsEmitter(metadata: .packageMetadata(identity: packageIdentity, location: packageLocation))
 
         let declaredSources = target.sources?.map{ path.appending(RelativePath($0)) }
         if let declaredSources = declaredSources {
@@ -650,7 +650,7 @@ extension TargetDescription.Resource.Rule {
     }
 }
 
-extension DiagnosticMessage {
+extension Basics.Diagnostic {
     static func symlinkInSources(symlink: RelativePath, targetName: String) -> Self {
         .warning("ignoring symlink at '\(symlink)' in target '\(targetName)'")
     }

--- a/Sources/PackageModel/Package.swift
+++ b/Sources/PackageModel/Package.swift
@@ -13,6 +13,7 @@ import TSCUtility
 
 // Re-export Version from PackageModel, since it is a key part of the model.
 @_exported import struct TSCUtility.Version
+import Basics
 
 /// The basic package representation.
 ///
@@ -106,8 +107,15 @@ public final class Package: ObjectIdentifierProtocol, Encodable {
 }
 
 extension Package {
+    @available(*, deprecated, message: "use DiagnosticsContext instead")
     public var diagnosticLocation: DiagnosticLocation {
         return PackageLocation.Local(name: self.manifest.name, packagePath: self.path)
+    }
+}
+
+extension Package {
+    public var diagnosticsContext: DiagnosticsContext {
+        return PackageDiagnosticsContext(identity: self.identity, location: self.manifest.packageLocation)
     }
 }
 
@@ -127,5 +135,19 @@ extension Package.Error: CustomStringConvertible {
             }
             return string
         }
+    }
+}
+
+public struct PackageDiagnosticsContext: DiagnosticsContext {
+    public init(identity: PackageIdentity, location: String) {
+        self.identity = identity
+        self.location = location
+    }
+
+    public let identity: PackageIdentity
+    public let location: String
+
+    public var description: String {
+        return "'\(identity)' \(location)"
     }
 }

--- a/Sources/PackageModel/Package.swift
+++ b/Sources/PackageModel/Package.swift
@@ -114,7 +114,7 @@ extension Package {
 }
 
 extension Package {
-    public var diagnosticsMetadata: DiagnosticsMetadata {
+    public var diagnosticsMetadata: ObservabilityMetadata {
         return .packageMetadata(identity: self.identity, location: self.manifest.packageLocation)
     }
 }
@@ -138,16 +138,16 @@ extension Package.Error: CustomStringConvertible {
     }
 }
 
-extension DiagnosticsMetadata {
-    public static func packageMetadata(identity: PackageIdentity, location: String) -> DiagnosticsMetadata {
-        var metadata = DiagnosticsMetadata()
+extension ObservabilityMetadata {
+    public static func packageMetadata(identity: PackageIdentity, location: String) -> Self {
+        var metadata = ObservabilityMetadata()
         metadata.packageIdentity = identity
         metadata.packageLocation = location
         return metadata
     }
 }
 
-extension DiagnosticsMetadata {
+extension ObservabilityMetadata {
     public var packageIdentity: PackageIdentity? {
         get {
             self[PackageIdentityKey.self]
@@ -157,12 +157,12 @@ extension DiagnosticsMetadata {
         }
     }
     
-    enum PackageIdentityKey: DiagnosticsMetadataKey {
+    enum PackageIdentityKey: Key {
         typealias Value = PackageIdentity
     }
 }
 
-extension DiagnosticsMetadata {
+extension ObservabilityMetadata {
     public var packageLocation: String? {
         get {
             self[PackageLocationKey.self]
@@ -172,7 +172,7 @@ extension DiagnosticsMetadata {
         }
     }
     
-    enum PackageLocationKey: DiagnosticsMetadataKey {
+    enum PackageLocationKey: Key {
         typealias Value = String
     }
 }

--- a/Sources/PackageModel/Package.swift
+++ b/Sources/PackageModel/Package.swift
@@ -114,8 +114,8 @@ extension Package {
 }
 
 extension Package {
-    public var diagnosticsContext: DiagnosticsContext {
-        return PackageDiagnosticsContext(identity: self.identity, location: self.manifest.packageLocation)
+    public var diagnosticsMetadata: DiagnosticsMetadata {
+        return .packageMetadata(identity: self.identity, location: self.manifest.packageLocation)
     }
 }
 
@@ -138,16 +138,41 @@ extension Package.Error: CustomStringConvertible {
     }
 }
 
-public struct PackageDiagnosticsContext: DiagnosticsContext {
-    public init(identity: PackageIdentity, location: String) {
-        self.identity = identity
-        self.location = location
+extension DiagnosticsMetadata {
+    public static func packageMetadata(identity: PackageIdentity, location: String) -> DiagnosticsMetadata {
+        var metadata = DiagnosticsMetadata()
+        metadata.packageIdentity = identity
+        metadata.packageLocation = location
+        return metadata
     }
+}
 
-    public let identity: PackageIdentity
-    public let location: String
+extension DiagnosticsMetadata {
+    public var packageIdentity: PackageIdentity? {
+        get {
+            self[PackageIdentityKey.self]
+        }
+        set {
+            self[PackageIdentityKey.self] = newValue
+        }
+    }
+    
+    enum PackageIdentityKey: DiagnosticsMetadataKey {
+        typealias Value = PackageIdentity
+    }
+}
 
-    public var description: String {
-        return "'\(identity)' \(location)"
+extension DiagnosticsMetadata {
+    public var packageLocation: String? {
+        get {
+            self[PackageLocationKey.self]
+        }
+        set {
+            self[PackageLocationKey.self] = newValue
+        }
+    }
+    
+    enum PackageLocationKey: DiagnosticsMetadataKey {
+        typealias Value = String
     }
 }

--- a/Sources/SPMBuildCore/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/PluginInvocation.swift
@@ -15,6 +15,7 @@ import PackageGraph
 import TSCBasic
 import TSCUtility
 
+public typealias Diagnostic = TSCBasic.Diagnostic
 
 extension PackageGraph {
 

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -18,6 +18,8 @@ import TSCBasic
 import Workspace
 import XCTest
 
+public typealias Diagnostic = TSCBasic.Diagnostic
+
 public final class MockWorkspace {
     let sandbox: AbsolutePath
     let fs: FileSystem
@@ -221,9 +223,10 @@ public final class MockWorkspace {
         path: AbsolutePath? = nil,
         revision: Revision? = nil,
         checkoutBranch: String? = nil,
-        _ result: (DiagnosticsEngine) -> Void
+        _ result: ([Basics.Diagnostic]) -> Void
     ) {
-        let diagnostics = DiagnosticsEngine()
+        let observability = ObservabilitySystem.bootstrapForTesting()
+        let diagnostics = ObservabilitySystem.makeDiagnosticsEngine()
         diagnostics.wrap {
             let ws = try self.getOrCreateWorkspace()
             ws.edit(
@@ -234,59 +237,64 @@ public final class MockWorkspace {
                 diagnostics: diagnostics
             )
         }
-        result(diagnostics)
+        result(observability.diagnostics)
     }
 
     public func checkUnedit(
         packageName: String,
         roots: [String],
         forceRemove: Bool = false,
-        _ result: (DiagnosticsEngine) -> Void
+        _ result: ([Basics.Diagnostic]) -> Void
     ) {
-        let diagnostics = DiagnosticsEngine()
+        let observability = ObservabilitySystem.bootstrapForTesting()
+        let diagnostics = ObservabilitySystem.makeDiagnosticsEngine()
         let rootInput = PackageGraphRootInput(packages: rootPaths(for: roots))
         diagnostics.wrap {
             let ws = try self.getOrCreateWorkspace()
             try ws.unedit(packageName: packageName, forceRemove: forceRemove, root: rootInput, diagnostics: diagnostics)
         }
-        result(diagnostics)
+        result(observability.diagnostics)
     }
 
-    public func checkResolve(pkg: String, roots: [String], version: TSCUtility.Version, _ result: (DiagnosticsEngine) -> Void) {
-        let diagnostics = DiagnosticsEngine()
+    public func checkResolve(pkg: String, roots: [String], version: TSCUtility.Version, _ result: ([Basics.Diagnostic]) -> Void) {
+        let observability = ObservabilitySystem.bootstrapForTesting()
+        let diagnostics = ObservabilitySystem.makeDiagnosticsEngine()
         let rootInput = PackageGraphRootInput(packages: rootPaths(for: roots))
         diagnostics.wrap {
             let workspace = try self.getOrCreateWorkspace()
             try workspace.resolve(packageName: pkg, root: rootInput, version: version, branch: nil, revision: nil, diagnostics: diagnostics)
         }
-        result(diagnostics)
+        result(observability.diagnostics)
     }
 
-    public func checkClean(_ result: (DiagnosticsEngine) -> Void) {
-        let diagnostics = DiagnosticsEngine()
+    public func checkClean(_ result: ([Basics.Diagnostic]) -> Void) {
+        let observability = ObservabilitySystem.bootstrapForTesting()
+        let diagnostics = ObservabilitySystem.makeDiagnosticsEngine()
         diagnostics.wrap {
             let workspace = try self.getOrCreateWorkspace()
             workspace.clean(with: diagnostics)
         }
-        result(diagnostics)
+        result(observability.diagnostics)
     }
 
-    public func checkReset(_ result: (DiagnosticsEngine) -> Void) {
-        let diagnostics = DiagnosticsEngine()
+    public func checkReset(_ result: ([Basics.Diagnostic]) -> Void) {
+        let observability = ObservabilitySystem.bootstrapForTesting()
+        let diagnostics = ObservabilitySystem.makeDiagnosticsEngine()
         diagnostics.wrap {
             let workspace = try self.getOrCreateWorkspace()
             workspace.reset(with: diagnostics)
         }
-        result(diagnostics)
+        result(observability.diagnostics)
     }
 
     public func checkUpdate(
         roots: [String] = [],
         deps: [MockDependency] = [],
         packages: [String] = [],
-        _ result: (DiagnosticsEngine) -> Void
+        _ result: ([Basics.Diagnostic]) -> Void
     ) {
-        let diagnostics = DiagnosticsEngine()
+        let observability = ObservabilitySystem.bootstrapForTesting()
+        let diagnostics = ObservabilitySystem.makeDiagnosticsEngine()
         diagnostics.wrap {
             let dependencies = deps.map { $0.convert(baseURL: packagesDir, identityResolver: self.identityResolver) }
             let rootInput = PackageGraphRootInput(
@@ -295,30 +303,32 @@ public final class MockWorkspace {
             let workspace = try self.getOrCreateWorkspace()
             try workspace.updateDependencies(root: rootInput, packages: packages, diagnostics: diagnostics)
         }
-        result(diagnostics)
+        result(observability.diagnostics)
     }
 
     public func checkUpdateDryRun(
         roots: [String] = [],
         deps: [MockDependency] = [],
-        _ result: ([(PackageReference, Workspace.PackageStateChange)]?, DiagnosticsEngine) -> Void
+        _ result: ([(PackageReference, Workspace.PackageStateChange)]?, [Basics.Diagnostic]) -> Void
     ) {
         let dependencies = deps.map { $0.convert(baseURL: packagesDir, identityResolver: self.identityResolver) }
         let rootInput = PackageGraphRootInput(
             packages: rootPaths(for: roots), dependencies: dependencies
         )
-        let diagnostics = DiagnosticsEngine()
+
+        let observability = ObservabilitySystem.bootstrapForTesting()
+        let diagnostics = ObservabilitySystem.makeDiagnosticsEngine()
         let changes = diagnostics.wrap { () -> [(PackageReference, Workspace.PackageStateChange)]? in
             let workspace = try self.getOrCreateWorkspace()
             return try workspace.updateDependencies(root: rootInput, diagnostics: diagnostics, dryRun: true)
         } ?? nil
-        result(changes, diagnostics)
+        result(changes, observability.diagnostics)
     }
 
     public func checkPackageGraph(
         roots: [String] = [],
         deps: [MockDependency],
-        _ result: (PackageGraph, DiagnosticsEngine) -> Void
+        _ result: (PackageGraph, [Basics.Diagnostic]) -> Void
     ) {
         let dependencies = deps.map { $0.convert(baseURL: packagesDir, identityResolver: self.identityResolver) }
         self.checkPackageGraph(roots: roots, dependencies: dependencies, result)
@@ -328,9 +338,10 @@ public final class MockWorkspace {
         roots: [String] = [],
         dependencies: [PackageDependency] = [],
         forceResolvedVersions: Bool = false,
-        _ result: (PackageGraph, DiagnosticsEngine) -> Void
+        _ result: (PackageGraph, [Basics.Diagnostic]) -> Void
     ) {
-        let diagnostics = DiagnosticsEngine()
+        let observability = ObservabilitySystem.bootstrapForTesting()
+        let diagnostics = ObservabilitySystem.makeDiagnosticsEngine()
         let rootInput = PackageGraphRootInput(
             packages: rootPaths(for: roots), dependencies: dependencies
         )
@@ -339,7 +350,7 @@ public final class MockWorkspace {
             let graph = try workspace.loadPackageGraph(
                 rootInput: rootInput, forceResolvedVersions: forceResolvedVersions, diagnostics: diagnostics
             )
-            result(graph, diagnostics)
+            result(graph, observability.diagnostics)
         } catch {
             preconditionFailure("expected graph to load, but failed with: \(error)\n\(diagnostics)")
         }
@@ -348,7 +359,7 @@ public final class MockWorkspace {
     public func checkPackageGraphFailure(
         roots: [String] = [],
         deps: [MockDependency],
-        _ result: (DiagnosticsEngine) -> Void
+        _ result: ([Basics.Diagnostic]) -> Void
     ) {
         let dependencies = deps.map { $0.convert(baseURL: packagesDir, identityResolver: self.identityResolver) }
         self.checkPackageGraphFailure(roots: roots, dependencies: dependencies, result)
@@ -358,9 +369,10 @@ public final class MockWorkspace {
         roots: [String] = [],
         dependencies: [PackageDependency] = [],
         forceResolvedVersions: Bool = false,
-        _ result: (DiagnosticsEngine) -> Void
+        _ result: ([Basics.Diagnostic]) -> Void
     ) {
-        let diagnostics = DiagnosticsEngine()
+        let observability = ObservabilitySystem.bootstrapForTesting()
+        let diagnostics = ObservabilitySystem.makeDiagnosticsEngine()
         let rootInput = PackageGraphRootInput(
             packages: rootPaths(for: roots), dependencies: dependencies
         )
@@ -370,7 +382,7 @@ public final class MockWorkspace {
                 rootInput: rootInput, forceResolvedVersions: forceResolvedVersions, diagnostics: diagnostics
             )
         }
-        result(diagnostics)
+        result(observability.diagnostics)
     }
 
     public struct ResolutionPrecomputationResult {
@@ -379,7 +391,7 @@ public final class MockWorkspace {
     }
 
     public func checkPrecomputeResolution(_ check: (ResolutionPrecomputationResult) -> Void) throws {
-        let diagnostics = DiagnosticsEngine()
+        let diagnostics = ObservabilitySystem.makeDiagnosticsEngine()
         let workspace = try self.getOrCreateWorkspace()
         let pinsStore = try workspace.pinsStore.load()
 
@@ -545,7 +557,7 @@ public final class MockWorkspace {
         _ result: (Workspace.DependencyManifests, DiagnosticsEngine) -> Void
     ) throws {
         let dependencies = deps.map { $0.convert(baseURL: packagesDir, identityResolver: self.identityResolver) }
-        let diagnostics = DiagnosticsEngine()
+        let diagnostics = ObservabilitySystem.makeDiagnosticsEngine()
         let workspace = try self.getOrCreateWorkspace()
         let rootInput = PackageGraphRootInput(
             packages: rootPaths(for: roots), dependencies: dependencies

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -226,7 +226,7 @@ public final class MockWorkspace {
         _ result: ([Basics.Diagnostic]) -> Void
     ) {
         let observability = ObservabilitySystem.bootstrapForTesting()
-        let diagnostics = ObservabilitySystem.makeDiagnosticsEngine()
+        let diagnostics = ObservabilitySystem.topScope.makeDiagnosticsEngine()
         diagnostics.wrap {
             let ws = try self.getOrCreateWorkspace()
             ws.edit(
@@ -247,7 +247,7 @@ public final class MockWorkspace {
         _ result: ([Basics.Diagnostic]) -> Void
     ) {
         let observability = ObservabilitySystem.bootstrapForTesting()
-        let diagnostics = ObservabilitySystem.makeDiagnosticsEngine()
+        let diagnostics = ObservabilitySystem.topScope.makeDiagnosticsEngine()
         let rootInput = PackageGraphRootInput(packages: rootPaths(for: roots))
         diagnostics.wrap {
             let ws = try self.getOrCreateWorkspace()
@@ -258,7 +258,7 @@ public final class MockWorkspace {
 
     public func checkResolve(pkg: String, roots: [String], version: TSCUtility.Version, _ result: ([Basics.Diagnostic]) -> Void) {
         let observability = ObservabilitySystem.bootstrapForTesting()
-        let diagnostics = ObservabilitySystem.makeDiagnosticsEngine()
+        let diagnostics = ObservabilitySystem.topScope.makeDiagnosticsEngine()
         let rootInput = PackageGraphRootInput(packages: rootPaths(for: roots))
         diagnostics.wrap {
             let workspace = try self.getOrCreateWorkspace()
@@ -269,7 +269,7 @@ public final class MockWorkspace {
 
     public func checkClean(_ result: ([Basics.Diagnostic]) -> Void) {
         let observability = ObservabilitySystem.bootstrapForTesting()
-        let diagnostics = ObservabilitySystem.makeDiagnosticsEngine()
+        let diagnostics = ObservabilitySystem.topScope.makeDiagnosticsEngine()
         diagnostics.wrap {
             let workspace = try self.getOrCreateWorkspace()
             workspace.clean(with: diagnostics)
@@ -279,7 +279,7 @@ public final class MockWorkspace {
 
     public func checkReset(_ result: ([Basics.Diagnostic]) -> Void) {
         let observability = ObservabilitySystem.bootstrapForTesting()
-        let diagnostics = ObservabilitySystem.makeDiagnosticsEngine()
+        let diagnostics = ObservabilitySystem.topScope.makeDiagnosticsEngine()
         diagnostics.wrap {
             let workspace = try self.getOrCreateWorkspace()
             workspace.reset(with: diagnostics)
@@ -294,7 +294,7 @@ public final class MockWorkspace {
         _ result: ([Basics.Diagnostic]) -> Void
     ) {
         let observability = ObservabilitySystem.bootstrapForTesting()
-        let diagnostics = ObservabilitySystem.makeDiagnosticsEngine()
+        let diagnostics = ObservabilitySystem.topScope.makeDiagnosticsEngine()
         diagnostics.wrap {
             let dependencies = deps.map { $0.convert(baseURL: packagesDir, identityResolver: self.identityResolver) }
             let rootInput = PackageGraphRootInput(
@@ -317,7 +317,7 @@ public final class MockWorkspace {
         )
 
         let observability = ObservabilitySystem.bootstrapForTesting()
-        let diagnostics = ObservabilitySystem.makeDiagnosticsEngine()
+        let diagnostics = ObservabilitySystem.topScope.makeDiagnosticsEngine()
         let changes = diagnostics.wrap { () -> [(PackageReference, Workspace.PackageStateChange)]? in
             let workspace = try self.getOrCreateWorkspace()
             return try workspace.updateDependencies(root: rootInput, diagnostics: diagnostics, dryRun: true)
@@ -341,7 +341,7 @@ public final class MockWorkspace {
         _ result: (PackageGraph, [Basics.Diagnostic]) -> Void
     ) {
         let observability = ObservabilitySystem.bootstrapForTesting()
-        let diagnostics = ObservabilitySystem.makeDiagnosticsEngine()
+        let diagnostics = ObservabilitySystem.topScope.makeDiagnosticsEngine()
         let rootInput = PackageGraphRootInput(
             packages: rootPaths(for: roots), dependencies: dependencies
         )
@@ -372,7 +372,7 @@ public final class MockWorkspace {
         _ result: ([Basics.Diagnostic]) -> Void
     ) {
         let observability = ObservabilitySystem.bootstrapForTesting()
-        let diagnostics = ObservabilitySystem.makeDiagnosticsEngine()
+        let diagnostics = ObservabilitySystem.topScope.makeDiagnosticsEngine()
         let rootInput = PackageGraphRootInput(
             packages: rootPaths(for: roots), dependencies: dependencies
         )
@@ -391,7 +391,7 @@ public final class MockWorkspace {
     }
 
     public func checkPrecomputeResolution(_ check: (ResolutionPrecomputationResult) -> Void) throws {
-        let diagnostics = ObservabilitySystem.makeDiagnosticsEngine()
+        let diagnostics = ObservabilitySystem.topScope.makeDiagnosticsEngine()
         let workspace = try self.getOrCreateWorkspace()
         let pinsStore = try workspace.pinsStore.load()
 
@@ -557,7 +557,7 @@ public final class MockWorkspace {
         _ result: (Workspace.DependencyManifests, DiagnosticsEngine) -> Void
     ) throws {
         let dependencies = deps.map { $0.convert(baseURL: packagesDir, identityResolver: self.identityResolver) }
-        let diagnostics = ObservabilitySystem.makeDiagnosticsEngine()
+        let diagnostics = ObservabilitySystem.topScope.makeDiagnosticsEngine()
         let workspace = try self.getOrCreateWorkspace()
         let rootInput = PackageGraphRootInput(
             packages: rootPaths(for: roots), dependencies: dependencies

--- a/Sources/SPMTestSupport/Observability.swift
+++ b/Sources/SPMTestSupport/Observability.swift
@@ -1,0 +1,157 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import Basics
+import struct TSCBasic.Lock
+import func XCTest.XCTFail
+import func XCTest.XCTAssertEqual
+
+extension ObservabilitySystem {
+    public static func bootstrapForTesting() -> TestingObservability {
+        let testingObservability = TestingObservability()
+        Self.bootstrapGlobal(factory: testingObservability.factory)
+        return testingObservability
+    }
+}
+
+public struct TestingObservability {
+    fileprivate let factory = Factory()
+
+    public var diagnostics: [Basics.Diagnostic] {
+        self.factory.diagnosticsCollector.diagnostics
+    }
+
+    public var hasErrorDiagnostics: Bool {
+        self.factory.diagnosticsCollector.hasErrors
+    }
+
+    public var hasWarningDiagnostics: Bool {
+        self.factory.diagnosticsCollector.hasWarnings
+    }
+
+    struct Factory: ObservabilityFactory {
+        fileprivate let diagnosticsCollector = AccumulatingDiagnosticsCollector()
+
+        var diagnosticsHandler: DiagnosticsHandler {
+            return diagnosticsCollector.handle
+        }
+    }
+}
+
+private final class AccumulatingDiagnosticsCollector: CustomStringConvertible {
+    public private (set) var diagnostics: [Basics.Diagnostic]
+    private let lock = Lock()
+
+    public init() {
+        self.diagnostics = .init()
+    }
+
+    public func handle(_ diagnostic: Basics.Diagnostic) {
+        self.lock.withLock {
+            self.diagnostics.append(diagnostic)
+        }
+    }
+
+    public var hasErrors: Bool {
+        let diagnostics = self.lock.withLock { self.diagnostics }
+        return diagnostics.contains(where: { $0.severity == .error })
+    }
+
+    public var hasWarnings: Bool {
+        let diagnostics = self.lock.withLock { self.diagnostics }
+        return diagnostics.contains(where: { $0.severity == .warning })
+    }
+
+    public var description: String {
+        let diagnostics = self.lock.withLock { self.diagnostics }
+        return "\(diagnostics)"
+    }
+}
+
+public func XCTAssertNoDiagnostics(_ diagnostics: [Basics.Diagnostic], file: StaticString = #file, line: UInt = #line) {
+    if diagnostics.isEmpty { return }
+    let description = diagnostics.map({ "- " + $0.description }).joined(separator: "\n")
+    XCTFail("Found unexpected diagnostics: \n\(description)", file: file, line: line)
+}
+
+public func testDiagnostics(
+    _ diagnostics: [Basics.Diagnostic],
+    ignoreNotes: Bool = false,
+    file: StaticString = #file,
+    line: UInt = #line,
+    handler: (DiagnosticsTestResult) throws -> Void
+) {
+    let testResult = DiagnosticsTestResult(diagnostics, ignoreNotes: ignoreNotes)
+
+    do {
+        try handler(testResult)
+    } catch {
+        XCTFail("error \(String(describing: error))", file: file, line: line)
+    }
+
+    if !testResult.uncheckedDiagnostics.isEmpty {
+        XCTFail("unchecked diagnostics \(testResult.uncheckedDiagnostics)", file: file, line: line)
+    }
+}
+
+/// Helper to check diagnostics in the engine.
+public class DiagnosticsTestResult {
+    fileprivate var uncheckedDiagnostics: [Basics.Diagnostic]
+
+    init(_ diagnostics: [Basics.Diagnostic], ignoreNotes: Bool = false) {
+        self.uncheckedDiagnostics = diagnostics
+    }
+
+    public func check(
+        diagnostic message: StringPattern,
+        severity: DiagnosticMessage.Severity,
+        context: String? = nil,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        guard !self.uncheckedDiagnostics.isEmpty else {
+            return XCTFail("No diagnostics left to check", file: file, line: line)
+        }
+
+        let diagnostic: Basics.Diagnostic = self.uncheckedDiagnostics.removeFirst()
+
+        XCTAssertMatch(diagnostic.message, message, file: file, line: line)
+        XCTAssertEqual(diagnostic.severity, severity, file: file, line: line)
+        XCTAssertEqual(diagnostic.context?.description, context?.description, file: file, line: line)
+    }
+
+    public func checkUnordered(
+        diagnostic diagnosticPattern: StringPattern,
+        severity: DiagnosticMessage.Severity,
+        context: String? = nil,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        guard !self.uncheckedDiagnostics.isEmpty else {
+            return XCTFail("No diagnostics left to check", file: file, line: line)
+        }
+
+        let matching = self.uncheckedDiagnostics.filter { diagnosticPattern ~= $0.message }
+        if matching.isEmpty {
+            return XCTFail("No diagnostics match \(diagnosticPattern)", file: file, line: line)
+        } else if matching.count == 1, let diagnostic = matching.first, let index = self.uncheckedDiagnostics.firstIndex(where: { $0 == diagnostic }) {
+            XCTAssertEqual(diagnostic.severity, severity, file: file, line: line)
+            XCTAssertEqual(diagnostic.context?.description, context?.description, file: file, line: line)
+            self.uncheckedDiagnostics.remove(at: index)
+        } else {
+            if let index = matching.firstIndex(where: { diagnostic in
+                diagnostic.severity == severity &&
+                diagnostic.context?.description == context?.description
+            }) {
+                self.uncheckedDiagnostics.remove(at: index)
+            }
+        }
+    }
+}

--- a/Sources/SPMTestSupport/Observability.swift
+++ b/Sources/SPMTestSupport/Observability.swift
@@ -111,8 +111,8 @@ public class DiagnosticsTestResult {
 
     public func check(
         diagnostic message: StringPattern,
-        severity: DiagnosticMessage.Severity,
-        context: String? = nil,
+        severity: Basics.Diagnostic.Severity,
+        metadata: DiagnosticsMetadata? = .none,
         file: StaticString = #file,
         line: UInt = #line
     ) {
@@ -124,13 +124,13 @@ public class DiagnosticsTestResult {
 
         XCTAssertMatch(diagnostic.message, message, file: file, line: line)
         XCTAssertEqual(diagnostic.severity, severity, file: file, line: line)
-        XCTAssertEqual(diagnostic.context?.description, context?.description, file: file, line: line)
+        XCTAssertEqual(diagnostic.metadata, metadata, file: file, line: line)
     }
 
     public func checkUnordered(
         diagnostic diagnosticPattern: StringPattern,
-        severity: DiagnosticMessage.Severity,
-        context: String? = nil,
+        severity: Basics.Diagnostic.Severity,
+        metadata: DiagnosticsMetadata? = .none,
         file: StaticString = #file,
         line: UInt = #line
     ) {
@@ -143,15 +143,10 @@ public class DiagnosticsTestResult {
             return XCTFail("No diagnostics match \(diagnosticPattern)", file: file, line: line)
         } else if matching.count == 1, let diagnostic = matching.first, let index = self.uncheckedDiagnostics.firstIndex(where: { $0 == diagnostic }) {
             XCTAssertEqual(diagnostic.severity, severity, file: file, line: line)
-            XCTAssertEqual(diagnostic.context?.description, context?.description, file: file, line: line)
+            XCTAssertEqual(diagnostic.metadata, metadata, file: file, line: line)
             self.uncheckedDiagnostics.remove(at: index)
-        } else {
-            if let index = matching.firstIndex(where: { diagnostic in
-                diagnostic.severity == severity &&
-                diagnostic.context?.description == context?.description
-            }) {
-                self.uncheckedDiagnostics.remove(at: index)
-            }
+        } else if let index = self.uncheckedDiagnostics.firstIndex(where: { diagnostic in diagnostic.severity == severity && diagnostic.metadata == metadata}) {
+            self.uncheckedDiagnostics.remove(at: index)
         }
     }
 }

--- a/Sources/SPMTestSupport/Observability.swift
+++ b/Sources/SPMTestSupport/Observability.swift
@@ -37,15 +37,15 @@ public struct TestingObservability {
     }
 
     struct Factory: ObservabilityFactory {
-        fileprivate let diagnosticsCollector = AccumulatingDiagnosticsCollector()
+        fileprivate let diagnosticsCollector = DiagnosticsCollector()
 
         var diagnosticsHandler: DiagnosticsHandler {
-            return diagnosticsCollector.handle
+            return diagnosticsCollector
         }
     }
 }
 
-private final class AccumulatingDiagnosticsCollector: CustomStringConvertible {
+private final class DiagnosticsCollector: DiagnosticsHandler, CustomStringConvertible {
     public let diagnostics: ThreadSafeArrayStore<Basics.Diagnostic>
 
     public init() {
@@ -53,7 +53,7 @@ private final class AccumulatingDiagnosticsCollector: CustomStringConvertible {
     }
 
     // TODO: do something useful with scope
-    public func handle(scope: ObservabilityScope, diagnostic: Basics.Diagnostic) {
+    public func handleDiagnostic(scope: ObservabilityScope, diagnostic: Basics.Diagnostic) {
         self.diagnostics.append(diagnostic)
     }
 

--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -221,7 +221,6 @@ private func swiftArgs(
 public func loadPackageGraph(
     identityResolver: IdentityResolver = DefaultIdentityResolver(),
     fs: FileSystem,
-    diagnostics: DiagnosticsEngine = DiagnosticsEngine(),
     manifests: [Manifest],
     binaryArtifacts: [BinaryArtifact] = [],
     explicitProduct: String? = nil,
@@ -241,9 +240,8 @@ public func loadPackageGraph(
         additionalFileRules: useXCBuildFileRules ? FileRuleDescription.xcbuildFileTypes : FileRuleDescription.swiftpmFileTypes,
         externalManifests: externalManifests,
         binaryArtifacts: binaryArtifacts,
-        diagnostics: diagnostics,
-        fileSystem: fs,
         shouldCreateMultipleTestProducts: shouldCreateMultipleTestProducts,
-        createREPLProduct: createREPLProduct
+        createREPLProduct: createREPLProduct,
+        fileSystem: fs
     )
 }

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -17,6 +17,8 @@ import PackageModel
 import PackageGraph
 import SourceControl
 
+public typealias Diagnostic = TSCBasic.Diagnostic
+
 /// Enumeration of the different reasons for which the resolver needs to be run.
 public enum WorkspaceResolveReason: Equatable {
     /// Resolution was forced.
@@ -850,10 +852,9 @@ extension Workspace {
             unsafeAllowedPackages: manifests.unsafeAllowedPackages(),
             binaryArtifacts: binaryArtifacts,
             xcTestMinimumDeploymentTargets: xcTestMinimumDeploymentTargets ?? MinimumDeploymentTarget.default.xcTestMinimumDeploymentTargets,
-            diagnostics: diagnostics,
-            fileSystem: fileSystem,
             shouldCreateMultipleTestProducts: createMultipleTestProducts,
-            createREPLProduct: createREPLProduct
+            createREPLProduct: createREPLProduct,
+            fileSystem: fileSystem
         )
     }
 
@@ -959,7 +960,8 @@ extension Workspace {
                     productFilter: .everything,
                     path: path,
                     xcTestMinimumDeploymentTargets: MinimumDeploymentTarget.default.xcTestMinimumDeploymentTargets,
-                    diagnostics: diagnostics)
+                    fileSystem: self.fileSystem
+                )
                 return try builder.construct()
             }
             completion(result)
@@ -1803,7 +1805,7 @@ extension Workspace {
 
     private func download(_ artifacts: [RemoteArtifact], diagnostics: DiagnosticsEngine) throws -> [ManagedArtifact] {
         let group = DispatchGroup()
-        let tempDiagnostics = DiagnosticsEngine()
+        let tempDiagnostics = DiagnosticsEngine() // FIXME: transition to DiagnosticsEmmiter
         let result = ThreadSafeArrayStore<ManagedArtifact>()
 
         // zip files to download

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1853,7 +1853,7 @@ extension Workspace {
                             )
                         }
                     } catch {
-                        tempDiagnostics.emit(.error("failed retrieving '\(indexFile.url)': \(error)"))
+                        tempDiagnostics.emit(error: "failed retrieving '\(indexFile.url)': \(error)")
                     }
                 }
             }

--- a/Sources/Xcodeproj/pbxproj.swift
+++ b/Sources/Xcodeproj/pbxproj.swift
@@ -397,8 +397,8 @@ public func xcodeProject(
 
         // Warn if the target name is invalid.
         if target.type == .library && invalidXcodeModuleNames.contains(target.c99name) {
-            diagnostics.emit(.warning("Target '\(target.name)' conflicts with required framework filenames, rename " +
-                                      "this target to avoid conflicts."))
+            diagnostics.emit(warning: "Target '\(target.name)' conflicts with required framework filenames, rename " +
+                                      "this target to avoid conflicts.")
         }
 
         // Create a Xcode target for the target.

--- a/Tests/BasicsTests/ObservabilitySystemTests.swift
+++ b/Tests/BasicsTests/ObservabilitySystemTests.swift
@@ -1,0 +1,213 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+@testable import Basics
+import SPMTestSupport
+import TSCBasic
+import XCTest
+
+// TODO: remove when transition to new diagnostics system is complete
+typealias Diagnostic = Basics.Diagnostic
+
+final class ObservabilitySystemTest: XCTestCase {
+    func testScopes() throws {
+        let collector = Collector()
+        let observabilitySystem = ObservabilitySystem(factory: collector)
+
+        var metadata1 = ObservabilityMetadata()
+        metadata1.testKey1 = UUID().uuidString
+        metadata1.testKey2 = Int.random(in: Int.min..<Int.max)
+        metadata1.testKey3 = Int.random(in: Int.min..<Int.max) > Int.max / 2
+
+        let childScope1 = observabilitySystem.topScope.makeChildScope(description: "child 1", metadata: metadata1)
+        childScope1.emit(error: "error 1")
+
+        let emitter1 = childScope1.makeDiagnosticsEmitter()
+        emitter1.emit(error: "error 1.5")
+
+        testDiagnostics(collector.diagnostics) { result in
+            result.check(diagnostic: "error 1", severity: .error, metadata: metadata1)
+            result.check(diagnostic: "error 1.5", severity: .error, metadata: metadata1)
+        }
+
+        collector.clear()
+
+        var metadata2 = ObservabilityMetadata()
+        metadata2.testKey1 = UUID().uuidString
+        metadata2.testKey2 = Int.random(in: Int.min..<Int.max)
+
+        let mergedMetadata2 = metadata1.merging(metadata2)
+        XCTAssertEqual(mergedMetadata2.testKey1, metadata2.testKey1)
+        XCTAssertEqual(mergedMetadata2.testKey2, metadata2.testKey2)
+        XCTAssertEqual(mergedMetadata2.testKey3, metadata1.testKey3)
+
+        let childScope2 = childScope1.makeChildScope(description: "child 2", metadata: metadata2)
+        childScope2.emit(error: "error 2")
+
+        let emitter2 = childScope2.makeDiagnosticsEmitter()
+        emitter2.emit(error: "error 2.5")
+
+        testDiagnostics(collector.diagnostics) { result in
+            result.check(diagnostic: "error 2", severity: .error, metadata: mergedMetadata2)
+            result.check(diagnostic: "error 2.5", severity: .error, metadata: mergedMetadata2)
+        }
+
+        collector.clear()
+
+        var metadata3 = ObservabilityMetadata()
+        metadata3.testKey1 = UUID().uuidString
+
+        let mergedMetadata3 = metadata1.merging(metadata2).merging(metadata3)
+        XCTAssertEqual(mergedMetadata3.testKey1, metadata3.testKey1)
+        XCTAssertEqual(mergedMetadata3.testKey2, metadata2.testKey2)
+        XCTAssertEqual(mergedMetadata3.testKey3, metadata1.testKey3)
+
+        let childScope3 = childScope2.makeChildScope(description: "child 3", metadata: metadata3)
+        childScope3.emit(error: "error 3")
+
+        let emitter3 = childScope3.makeDiagnosticsEmitter()
+        emitter3.emit(error: "error 3.5")
+
+        testDiagnostics(collector.diagnostics) { result in
+            result.check(diagnostic: "error 3", severity: .error, metadata: mergedMetadata3)
+            result.check(diagnostic: "error 3.5", severity: .error, metadata: mergedMetadata3)
+        }
+    }
+
+    func testBasicDiagnostics() throws {
+        let collector = Collector()
+        let observabilitySystem = ObservabilitySystem(factory: collector)
+
+        var metadata = ObservabilityMetadata()
+        metadata.testKey1 = UUID().uuidString
+
+        let emitter = observabilitySystem.topScope.makeDiagnosticsEmitter(metadata: metadata)
+
+        emitter.emit(error: "error")
+        emitter.emit(.error("error 2"))
+        emitter.emit(StringError("error 3"))
+        emitter.emit(warning: "warning")
+        emitter.emit(.warning("warning 2"))
+        emitter.emit(info: "info")
+        emitter.emit(.info("info 2"))
+        emitter.emit(debug: "debug")
+        emitter.emit(.debug("debug 2"))
+
+        testDiagnostics(collector.diagnostics) { result in
+            result.check(diagnostic: "error", severity: .error, metadata: metadata)
+            result.check(diagnostic: "error 2", severity: .error, metadata: metadata)
+            result.check(diagnostic: "error 3", severity: .error, metadata: metadata)
+            result.check(diagnostic: "warning", severity: .warning, metadata: metadata)
+            result.check(diagnostic: "warning 2", severity: .warning, metadata: metadata)
+            result.check(diagnostic: "info", severity: .info, metadata: metadata)
+            result.check(diagnostic: "info 2", severity: .info, metadata: metadata)
+            result.check(diagnostic: "debug", severity: .debug, metadata: metadata)
+            result.check(diagnostic: "debug 2", severity: .debug, metadata: metadata)
+        }
+    }
+
+    func testDiagnosticsMetadataMerge() throws {
+        let collector = Collector()
+        let observabilitySystem = ObservabilitySystem(factory: collector)
+
+        var scopeMetadata = ObservabilityMetadata()
+        scopeMetadata.testKey1 = UUID().uuidString
+        scopeMetadata.testKey2 = Int.random(in: Int.min..<Int.max)
+        scopeMetadata.testKey3 = Int.random(in: Int.min..<Int.max) > Int.max / 2
+
+        let scope = observabilitySystem.topScope.makeChildScope(description: "child scope", metadata: scopeMetadata)
+
+        var emitterMetadata = ObservabilityMetadata()
+        emitterMetadata.testKey1 = UUID().uuidString
+        emitterMetadata.testKey2 = Int.random(in: Int.min..<Int.max)
+
+        let emitterMergedMetadata = scopeMetadata.merging(emitterMetadata)
+        XCTAssertEqual(emitterMergedMetadata.testKey1, emitterMetadata.testKey1)
+        XCTAssertEqual(emitterMergedMetadata.testKey2, emitterMetadata.testKey2)
+        XCTAssertEqual(emitterMergedMetadata.testKey3, scopeMetadata.testKey3)
+
+        let emitter = scope.makeDiagnosticsEmitter(metadata: emitterMetadata)
+        emitter.emit(error: "error")
+
+        var diagnosticMetadata = ObservabilityMetadata()
+        diagnosticMetadata.testKey1 = UUID().uuidString
+
+        let diagnosticMergedMetadata = scopeMetadata.merging(emitterMetadata).merging(diagnosticMetadata)
+        XCTAssertEqual(diagnosticMergedMetadata.testKey1, diagnosticMetadata.testKey1)
+        XCTAssertEqual(diagnosticMergedMetadata.testKey2, emitterMetadata.testKey2)
+        XCTAssertEqual(diagnosticMergedMetadata.testKey3, scopeMetadata.testKey3)
+
+        emitter.emit(warning: "warning", metadata: diagnosticMetadata)
+
+        testDiagnostics(collector.diagnostics) { result in
+            result.check(diagnostic: "error", severity: .error, metadata: emitterMergedMetadata)
+            result.check(diagnostic: "warning", severity: .warning, metadata: diagnosticMergedMetadata)
+        }
+    }
+
+    struct Collector: ObservabilityFactory {
+        let _diagnostics = ThreadSafeArrayStore<Diagnostic>()
+
+        var diagnosticsHandler: DiagnosticsHandler {
+            self.handleDiagnostic
+        }
+
+        var diagnostics: [Diagnostic] {
+            self._diagnostics.get()
+        }
+
+        func clear() {
+            self._diagnostics.clear()
+        }
+
+        private func handleDiagnostic(scope: ObservabilityScope, diagnostic: Diagnostic) {
+            self._diagnostics.append(diagnostic)
+        }
+    }
+}
+
+extension ObservabilityMetadata {
+    public var testKey1: String? {
+        get {
+            self[TestKey1.self]
+        }
+        set {
+            self[TestKey1.self] = newValue
+        }
+    }
+
+    public var testKey2: Int? {
+        get {
+            self[TestKey2.self]
+        }
+        set {
+            self[TestKey2.self] = newValue
+        }
+    }
+
+    public var testKey3: Bool? {
+        get {
+            self[TestKey3.self]
+        }
+        set {
+            self[TestKey3.self] = newValue
+        }
+    }
+
+    enum TestKey1: Key {
+        typealias Value = String
+    }
+    enum TestKey2: Key {
+        typealias Value = Int
+    }
+    enum TestKey3: Key {
+        typealias Value = Bool
+    }
+}

--- a/Tests/BasicsTests/ObservabilitySystemTests.swift
+++ b/Tests/BasicsTests/ObservabilitySystemTests.swift
@@ -72,12 +72,20 @@ final class ObservabilitySystemTest: XCTestCase {
         let childScope3 = childScope2.makeChildScope(description: "child 3", metadata: metadata3)
         childScope3.emit(error: "error 3")
 
-        let emitter3 = childScope3.makeDiagnosticsEmitter()
+        var metadata3_5 = ObservabilityMetadata()
+        metadata3_5.testKey1 = UUID().uuidString
+
+        let mergedMetadata3_5 = metadata1.merging(metadata2).merging(metadata3).merging(metadata3_5)
+        XCTAssertEqual(mergedMetadata3_5.testKey1, metadata3_5.testKey1)
+        XCTAssertEqual(mergedMetadata3_5.testKey2, metadata2.testKey2)
+        XCTAssertEqual(mergedMetadata3_5.testKey3, metadata1.testKey3)
+
+        let emitter3 = childScope3.makeDiagnosticsEmitter(metadata: metadata3_5)
         emitter3.emit(error: "error 3.5")
 
         testDiagnostics(collector.diagnostics) { result in
             result.check(diagnostic: "error 3", severity: .error, metadata: mergedMetadata3)
-            result.check(diagnostic: "error 3.5", severity: .error, metadata: mergedMetadata3)
+            result.check(diagnostic: "error 3.5", severity: .error, metadata: mergedMetadata3_5)
         }
     }
 

--- a/Tests/BasicsTests/ObservabilitySystemTests.swift
+++ b/Tests/BasicsTests/ObservabilitySystemTests.swift
@@ -160,12 +160,10 @@ final class ObservabilitySystemTest: XCTestCase {
         }
     }
 
-    struct Collector: ObservabilityFactory {
-        let _diagnostics = ThreadSafeArrayStore<Diagnostic>()
+    struct Collector: ObservabilityFactory, DiagnosticsHandler {
+        private let _diagnostics = ThreadSafeArrayStore<Diagnostic>()
 
-        var diagnosticsHandler: DiagnosticsHandler {
-            self.handleDiagnostic
-        }
+        var diagnosticsHandler: DiagnosticsHandler { self }
 
         var diagnostics: [Diagnostic] {
             self._diagnostics.get()
@@ -175,7 +173,7 @@ final class ObservabilitySystemTest: XCTestCase {
             self._diagnostics.clear()
         }
 
-        private func handleDiagnostic(scope: ObservabilityScope, diagnostic: Diagnostic) {
+        func handleDiagnostic(scope: ObservabilityScope, diagnostic: Diagnostic) {
             self._diagnostics.append(diagnostic)
         }
     }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -1624,7 +1624,11 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fileSystem
         )
 
-       XCTAssertTrue(observability.diagnostics.contains(where: { ($0.data is PkgConfigHintDiagnostic) }))
+        guard let diagnostic = observability.diagnostics.first else {
+            return XCTFail("Expected a diagnostic")
+        }
+        XCTAssertMatch(diagnostic.message, .contains("you may be able to install BTarget using your system-packager"))
+        XCTAssertEqual(diagnostic.severity, .warning)
     }
 
     func testPkgConfigGenericDiagnostic() throws {
@@ -1662,7 +1666,7 @@ final class BuildPlanTests: XCTestCase {
 
         XCTAssertEqual(diagnostic.message, "couldn't find pc file for BTarget")
         XCTAssertEqual(diagnostic.severity, .warning)
-        XCTAssertEqual(diagnostic.context?.description, "'BTarget' BTarget.pc")
+        XCTAssertEqual(diagnostic.metadata?.stringLocation, "'BTarget' BTarget.pc")
     }
 
     func testWindowsTarget() throws {

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -123,7 +123,7 @@ final class BuildPlanTests: XCTestCase {
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(shouldLinkStaticSwiftStdlib: true),
             graph: graph,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
 
@@ -237,7 +237,7 @@ final class BuildPlanTests: XCTestCase {
                         useExplicitModuleBuild: true
                     ),
                     graph: graph,
-                    diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+                    diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
                     fileSystem: fs
                 )
 
@@ -318,7 +318,7 @@ final class BuildPlanTests: XCTestCase {
                     configuration: .release
                 )),
                 graph: graph,
-                diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
                 fileSystem: fs
             )
 
@@ -344,7 +344,7 @@ final class BuildPlanTests: XCTestCase {
                     configuration: .debug
                 )),
                 graph: graph,
-                diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
                 fileSystem: fs
             )
 
@@ -404,7 +404,7 @@ final class BuildPlanTests: XCTestCase {
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
             fileSystem: fileSystem
         ))
 
@@ -443,7 +443,7 @@ final class BuildPlanTests: XCTestCase {
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(config: .release),
             graph: graph,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
 
@@ -514,7 +514,7 @@ final class BuildPlanTests: XCTestCase {
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
 
@@ -643,7 +643,7 @@ final class BuildPlanTests: XCTestCase {
                     configuration: .release
                 )),
                 graph: graph,
-                diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
                 fileSystem: fs
             ))
 
@@ -662,7 +662,7 @@ final class BuildPlanTests: XCTestCase {
                     configuration: .debug
                 )),
                 graph: graph,
-                diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
                 fileSystem: fs
             ))
 
@@ -702,7 +702,7 @@ final class BuildPlanTests: XCTestCase {
         let plan = try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         )
         let result = BuildPlanResult(plan: plan)
@@ -765,7 +765,7 @@ final class BuildPlanTests: XCTestCase {
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
         result.checkProductsCount(1)
@@ -839,7 +839,7 @@ final class BuildPlanTests: XCTestCase {
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
         result.checkProductsCount(1)
@@ -898,7 +898,7 @@ final class BuildPlanTests: XCTestCase {
         let plan = try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         )
         XCTAssertEqual(plan.createREPLArguments().sorted(), ["-I/Dep/Sources/CDep/include", "-I/path/to/build/debug", "-I/path/to/build/debug/lib.build", "-L/path/to/build/debug", "-lPkg__REPL"])
@@ -935,7 +935,7 @@ final class BuildPlanTests: XCTestCase {
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
         result.checkProductsCount(1)
@@ -1007,7 +1007,7 @@ final class BuildPlanTests: XCTestCase {
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(shouldLinkStaticSwiftStdlib: true),
             graph: graph,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
 
@@ -1060,7 +1060,7 @@ final class BuildPlanTests: XCTestCase {
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
         result.checkProductsCount(1)
@@ -1114,7 +1114,7 @@ final class BuildPlanTests: XCTestCase {
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
         result.checkProductsCount(1)
@@ -1164,7 +1164,7 @@ final class BuildPlanTests: XCTestCase {
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: g,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
         result.checkProductsCount(2)
@@ -1252,7 +1252,7 @@ final class BuildPlanTests: XCTestCase {
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
 
@@ -1318,7 +1318,7 @@ final class BuildPlanTests: XCTestCase {
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
 
@@ -1404,8 +1404,8 @@ final class BuildPlanTests: XCTestCase {
         )
 
         #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
-        XCTAssertEqual(diagnostics.diagnostics.count, 1)
-        let firstDiagnostic = diagnostics.diagnostics.first.map({ $0.message.text })
+        XCTAssertEqual(observability.diagnostics.count, 1)
+        let firstDiagnostic = observability.diagnostics.first.map({ $0.message.text })
         XCTAssert(
             firstDiagnostic == "dependency 'C' is not used by any target",
             "Unexpected diagnostic: " + (firstDiagnostic ?? "[none]")
@@ -1426,7 +1426,7 @@ final class BuildPlanTests: XCTestCase {
         let planResult = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
             fileSystem: fileSystem
         ))
 
@@ -1523,7 +1523,7 @@ final class BuildPlanTests: XCTestCase {
             let planResult = BuildPlanResult(plan: try BuildPlan(
                 buildParameters: mockBuildParameters(environment: linuxDebug),
                 graph: graph,
-                diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
                 fileSystem: fileSystem
             ))
             planResult.checkProductsCount(4)
@@ -1538,7 +1538,7 @@ final class BuildPlanTests: XCTestCase {
             let planResult = BuildPlanResult(plan: try BuildPlan(
                 buildParameters: mockBuildParameters(environment: macosDebug),
                 graph: graph,
-                diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
                 fileSystem: fileSystem
             ))
             planResult.checkProductsCount(4)
@@ -1553,7 +1553,7 @@ final class BuildPlanTests: XCTestCase {
             let planResult = BuildPlanResult(plan: try BuildPlan(
                 buildParameters: mockBuildParameters(environment: androidRelease),
                 graph: graph,
-                diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
                 fileSystem: fileSystem
             ))
             planResult.checkProductsCount(4)
@@ -1582,7 +1582,7 @@ final class BuildPlanTests: XCTestCase {
             _ = try BuildPlan(
                 buildParameters: mockBuildParameters(),
                 graph: graph,
-                diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
                 fileSystem: fs
             )
         }
@@ -1620,7 +1620,7 @@ final class BuildPlanTests: XCTestCase {
         _ = try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
             fileSystem: fileSystem
         )
 
@@ -1658,7 +1658,7 @@ final class BuildPlanTests: XCTestCase {
         _ = try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
             fileSystem: fileSystem
         )
 
@@ -1666,7 +1666,7 @@ final class BuildPlanTests: XCTestCase {
 
         XCTAssertEqual(diagnostic.message, "couldn't find pc file for BTarget")
         XCTAssertEqual(diagnostic.severity, .warning)
-        XCTAssertEqual(diagnostic.metadata?.stringLocation, "'BTarget' BTarget.pc")
+        XCTAssertEqual(diagnostic.metadata?.legacyLocation, "'BTarget' BTarget.pc")
     }
 
     func testWindowsTarget() throws {
@@ -1695,7 +1695,7 @@ final class BuildPlanTests: XCTestCase {
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(destinationTriple: .windows),
             graph: graph,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
         result.checkProductsCount(1)
@@ -1756,7 +1756,7 @@ final class BuildPlanTests: XCTestCase {
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: parameters,
             graph: graph,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
         result.checkProductsCount(2)
@@ -1841,7 +1841,7 @@ final class BuildPlanTests: XCTestCase {
             let result = BuildPlanResult(plan: try BuildPlan(
                 buildParameters: mockBuildParameters(config: config, indexStoreMode: mode),
                 graph: graph,
-                diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
                 fileSystem: fs
             ))
 
@@ -1907,7 +1907,7 @@ final class BuildPlanTests: XCTestCase {
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
             fileSystem: fileSystem
         ))
 
@@ -1972,12 +1972,12 @@ final class BuildPlanTests: XCTestCase {
             _ = try BuildPlan(
                 buildParameters: mockBuildParameters(destinationTriple: .macOS),
                 graph: graph,
-                diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
                 fileSystem: fileSystem
             )
         }
 
-        testDiagnostics(observability.diagnostics, ignoreNotes: true) { result in
+        testDiagnostics(observability.diagnostics) { result in
             let diagnosticMessage = """
             the library 'ATarget' requires macos 10.13, but depends on the product 'BLibrary' which requires macos 10.14; \
             consider changing the library 'ATarget' to require macos 10.14 or later, or the product 'BLibrary' to require \
@@ -2080,7 +2080,7 @@ final class BuildPlanTests: XCTestCase {
             return BuildPlanResult(plan: try BuildPlan(
                 buildParameters: mockBuildParameters(destinationTriple: dest),
                 graph: graph,
-                diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
                 fileSystem: fs
             ))
         }
@@ -2149,7 +2149,7 @@ final class BuildPlanTests: XCTestCase {
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(flags: flags),
             graph: graph,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
 
@@ -2189,7 +2189,7 @@ final class BuildPlanTests: XCTestCase {
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: extraBuildParameters,
             graph: graph,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
         result.checkProductsCount(1)
@@ -2249,7 +2249,7 @@ final class BuildPlanTests: XCTestCase {
         let plan = try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         )
 
@@ -2290,7 +2290,7 @@ final class BuildPlanTests: XCTestCase {
         let plan = try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         )
         let result = BuildPlanResult(plan: plan)
@@ -2361,7 +2361,7 @@ final class BuildPlanTests: XCTestCase {
         let plan = try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         )
         let result = BuildPlanResult(plan: plan)
@@ -2432,7 +2432,7 @@ final class BuildPlanTests: XCTestCase {
         let plan = try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         )
         let dynamicLibraryExtension = plan.buildParameters.triple.dynamicLibraryExtension
@@ -2492,7 +2492,7 @@ final class BuildPlanTests: XCTestCase {
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(destinationTriple: .x86_64Linux),
             graph: graph,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
 
@@ -2564,7 +2564,7 @@ final class BuildPlanTests: XCTestCase {
         let plan = try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         )
         let result = BuildPlanResult(plan: plan)
@@ -2594,7 +2594,6 @@ final class BuildPlanTests: XCTestCase {
             "/Pkg/Sources/lib/lib.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
         let graph = try loadPackageGraph(fs: fs,
             manifests: [
                 Manifest.createV4Manifest(
@@ -2613,7 +2612,7 @@ final class BuildPlanTests: XCTestCase {
             let result = BuildPlanResult(plan: try BuildPlan(
                 buildParameters: mockBuildParameters(shouldLinkStaticSwiftStdlib: true, destinationTriple: triple),
                 graph: graph,
-                diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
                 fileSystem: fs
             ))
 
@@ -2731,7 +2730,7 @@ final class BuildPlanTests: XCTestCase {
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(destinationTriple: destinationTriple),
             graph: graph,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
         XCTAssertNoDiagnostics(observability.diagnostics)
@@ -2834,7 +2833,7 @@ final class BuildPlanTests: XCTestCase {
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(destinationTriple: destinationTriple),
             graph: graph,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
         XCTAssertNoDiagnostics(observability.diagnostics)
@@ -2909,7 +2908,7 @@ final class BuildPlanTests: XCTestCase {
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: parameters,
             graph: graph,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
 

--- a/Tests/CommandsTests/MultiRootSupportTests.swift
+++ b/Tests/CommandsTests/MultiRootSupportTests.swift
@@ -39,7 +39,7 @@ final class MultiRootSupportTests: XCTestCase {
         }
 
         let observability = ObservabilitySystem.bootstrapForTesting()
-        let result = try XcodeWorkspaceLoader(diagnostics: ObservabilitySystem.makeDiagnosticsEngine(), fs: fs).load(workspace: path)
+        let result = try XcodeWorkspaceLoader(diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(), fs: fs).load(workspace: path)
 
         XCTAssertNoDiagnostics(observability.diagnostics)
         XCTAssertEqual(result.map{ $0.pathString }.sorted(), ["/tmp/test/dep", "/tmp/test/local"])

--- a/Tests/CommandsTests/MultiRootSupportTests.swift
+++ b/Tests/CommandsTests/MultiRootSupportTests.swift
@@ -8,12 +8,12 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import XCTest
-
+import Basics
+import Commands
 import SPMTestSupport
 import TSCBasic
-import Commands
 import Workspace
+import XCTest
 
 final class MultiRootSupportTests: XCTestCase {
 
@@ -38,10 +38,10 @@ final class MultiRootSupportTests: XCTestCase {
                 """
         }
 
-        let engine = DiagnosticsEngine()
-        let result = try XcodeWorkspaceLoader(diagnostics: engine, fs: fs).load(workspace: path)
+        let observability = ObservabilitySystem.bootstrapForTesting()
+        let result = try XcodeWorkspaceLoader(diagnostics: ObservabilitySystem.makeDiagnosticsEngine(), fs: fs).load(workspace: path)
 
-        XCTAssertNoDiagnostics(engine)
+        XCTAssertNoDiagnostics(observability.diagnostics)
         XCTAssertEqual(result.map{ $0.pathString }.sorted(), ["/tmp/test/dep", "/tmp/test/local"])
     }
 }

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -8,6 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import Basics
 import Commands
 import Foundation
 import PackageGraph
@@ -415,11 +416,12 @@ final class PackageToolTests: XCTestCase {
             ]
         )
 
-        let diagnostics = DiagnosticsEngine()
-        let graph = try loadPackageGraph(fs: fileSystem,
-                                         diagnostics: diagnostics,
-                                         manifests: [manifestA, manifestB, manifestC, manifestD])
-        XCTAssertNoDiagnostics(diagnostics)
+        let observability = ObservabilitySystem.bootstrapForTesting()
+        let graph = try loadPackageGraph(
+            fs: fileSystem,
+            manifests: [manifestA, manifestB, manifestC, manifestD]
+        )
+        XCTAssertNoDiagnostics(observability.diagnostics)
 
         let output = BufferedOutputByteStream()
         dumpDependenciesOf(rootPackage: graph.rootPackages[0], mode: .dot, on: output)
@@ -879,13 +881,12 @@ final class PackageToolTests: XCTestCase {
     func testWatchmanXcodeprojgen() throws {
         try testWithTemporaryDirectory { path in
             let fs = localFileSystem
-            let diagnostics = DiagnosticsEngine()
 
             let scriptsDir = path.appending(component: "scripts")
             let packageRoot = path.appending(component: "root")
 
             let helper = WatchmanHelper(
-                diagnostics: diagnostics,
+                diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
                 watchmanScriptsDir: scriptsDir,
                 packageRoot: packageRoot)
 

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -886,7 +886,7 @@ final class PackageToolTests: XCTestCase {
             let packageRoot = path.appending(component: "root")
 
             let helper = WatchmanHelper(
-                diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
                 watchmanScriptsDir: scriptsDir,
                 packageRoot: packageRoot)
 

--- a/Tests/PackageCollectionsSigningTests/CertificatePolicyTests.swift
+++ b/Tests/PackageCollectionsSigningTests/CertificatePolicyTests.swift
@@ -147,7 +147,7 @@ class CertificatePolicyTests: XCTestCase {
             try withTemporaryDirectory { tmp in
                 try localFileSystem.copy(from: rootCAPath, to: tmp.appending(components: "AppleIncRoot.cer"))
                 let policy = DefaultCertificatePolicy(trustedRootCertsDir: tmp.asURL, additionalTrustedRootCerts: nil,
-                                                      callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                                                      callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                 XCTAssertThrowsError(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) }) { error in
                     guard CertificatePolicyError.invalidCertChain == error as? CertificatePolicyError else {
                         return XCTFail("Expected CertificatePolicyError.invalidCertChain")
@@ -200,21 +200,21 @@ class CertificatePolicyTests: XCTestCase {
                 // Specify `trustedRootCertsDir`
                 do {
                     let policy = DefaultCertificatePolicy(trustedRootCertsDir: tmp.asURL, additionalTrustedRootCerts: nil,
-                                                          callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                                                          callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                     XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
                 }
 
                 // Another way is to pass in `additionalTrustedRootCerts`
                 do {
                     let policy = DefaultCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: [rootCA],
-                                                          callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                                                          callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                     XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
                 }
 
                 // What if the same cert is in both `trustedRootCertsDir` and `additionalTrustedRootCerts`?
                 do {
                     let policy = DefaultCertificatePolicy(trustedRootCertsDir: tmp.asURL, additionalTrustedRootCerts: [rootCA],
-                                                          callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                                                          callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                     XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
                 }
             }
@@ -265,21 +265,21 @@ class CertificatePolicyTests: XCTestCase {
                 // Specify `trustedRootCertsDir`
                 do {
                     let policy = AppleSwiftPackageCollectionCertificatePolicy(trustedRootCertsDir: tmp.asURL, additionalTrustedRootCerts: nil,
-                                                                              callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                                                                              callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                     XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
                 }
 
                 // Another way is to pass in `additionalTrustedRootCerts`
                 do {
                     let policy = AppleSwiftPackageCollectionCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: [rootCA],
-                                                                              callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                                                                              callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                     XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
                 }
 
                 // What if the same cert is in both `trustedRootCertsDir` and `additionalTrustedRootCerts`?
                 do {
                     let policy = AppleSwiftPackageCollectionCertificatePolicy(trustedRootCertsDir: tmp.asURL, additionalTrustedRootCerts: [rootCA],
-                                                                              callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                                                                              callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                     XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
                 }
             }
@@ -330,21 +330,21 @@ class CertificatePolicyTests: XCTestCase {
                 // Specify `trustedRootCertsDir`
                 do {
                     let policy = AppleDistributionCertificatePolicy(trustedRootCertsDir: tmp.asURL, additionalTrustedRootCerts: nil,
-                                                                    callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                                                                    callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                     XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
                 }
 
                 // Another way is to pass in `additionalTrustedRootCerts`
                 do {
                     let policy = AppleDistributionCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: [rootCA],
-                                                                    callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                                                                    callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                     XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
                 }
 
                 // What if the same cert is in both `trustedRootCertsDir` and `additionalTrustedRootCerts`?
                 do {
                     let policy = AppleDistributionCertificatePolicy(trustedRootCertsDir: tmp.asURL, additionalTrustedRootCerts: [rootCA],
-                                                                    callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                                                                    callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                     XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
                 }
             }
@@ -400,14 +400,14 @@ class CertificatePolicyTests: XCTestCase {
                 // Subject user ID matches
                 do {
                     let policy = DefaultCertificatePolicy(trustedRootCertsDir: tmp.asURL, additionalTrustedRootCerts: nil, expectedSubjectUserID: expectedSubjectUserID,
-                                                          callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                                                          callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                     XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
                 }
                 // Subject user ID does not match
                 do {
                     let mismatchSubjectUserID = "\(expectedSubjectUserID)-2"
                     let policy = DefaultCertificatePolicy(trustedRootCertsDir: tmp.asURL, additionalTrustedRootCerts: nil, expectedSubjectUserID: mismatchSubjectUserID,
-                                                          callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                                                          callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                     XCTAssertThrowsError(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) }) { error in
                         guard CertificatePolicyError.subjectUserIDMismatch == error as? CertificatePolicyError else {
                             return XCTFail("Expected CertificatePolicyError.subjectUserIDMismatch")
@@ -469,7 +469,7 @@ class CertificatePolicyTests: XCTestCase {
                 do {
                     let policy = AppleSwiftPackageCollectionCertificatePolicy(trustedRootCertsDir: tmp.asURL, additionalTrustedRootCerts: nil,
                                                                               expectedSubjectUserID: expectedSubjectUserID,
-                                                                              callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                                                                              callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                     XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
                 }
                 // Subject user ID does not match
@@ -477,7 +477,7 @@ class CertificatePolicyTests: XCTestCase {
                     let mismatchSubjectUserID = "\(expectedSubjectUserID)-2"
                     let policy = AppleSwiftPackageCollectionCertificatePolicy(trustedRootCertsDir: tmp.asURL, additionalTrustedRootCerts: nil,
                                                                               expectedSubjectUserID: mismatchSubjectUserID,
-                                                                              callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                                                                              callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                     XCTAssertThrowsError(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) }) { error in
                         guard CertificatePolicyError.subjectUserIDMismatch == error as? CertificatePolicyError else {
                             return XCTFail("Expected CertificatePolicyError.subjectUserIDMismatch")
@@ -538,14 +538,14 @@ class CertificatePolicyTests: XCTestCase {
                 // Subject user ID matches
                 do {
                     let policy = AppleDistributionCertificatePolicy(trustedRootCertsDir: tmp.asURL, additionalTrustedRootCerts: nil, expectedSubjectUserID: expectedSubjectUserID,
-                                                                    callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                                                                    callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                     XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
                 }
                 // Subject user ID does not match
                 do {
                     let mismatchSubjectUserID = "\(expectedSubjectUserID)-2"
                     let policy = AppleDistributionCertificatePolicy(trustedRootCertsDir: tmp.asURL, additionalTrustedRootCerts: nil, expectedSubjectUserID: mismatchSubjectUserID,
-                                                                    callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                                                                    callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                     XCTAssertThrowsError(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) }) { error in
                         guard CertificatePolicyError.subjectUserIDMismatch == error as? CertificatePolicyError else {
                             return XCTFail("Expected CertificatePolicyError.subjectUserIDMismatch")

--- a/Tests/PackageCollectionsSigningTests/CertificatePolicyTests.swift
+++ b/Tests/PackageCollectionsSigningTests/CertificatePolicyTests.swift
@@ -136,7 +136,7 @@ class CertificatePolicyTests: XCTestCase {
             #if os(macOS)
             // The Apple root certs come preinstalled on Apple platforms and they are automatically trusted
             let policy = DefaultCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: nil,
-                                                  callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                                                  callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
             XCTAssertThrowsError(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) }) { error in
                 guard CertificatePolicyError.invalidCertChain == error as? CertificatePolicyError else {
                     return XCTFail("Expected CertificatePolicyError.invalidCertChain")
@@ -147,7 +147,7 @@ class CertificatePolicyTests: XCTestCase {
             try withTemporaryDirectory { tmp in
                 try localFileSystem.copy(from: rootCAPath, to: tmp.appending(components: "AppleIncRoot.cer"))
                 let policy = DefaultCertificatePolicy(trustedRootCertsDir: tmp.asURL, additionalTrustedRootCerts: nil,
-                                                      callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                                                      callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                 XCTAssertThrowsError(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) }) { error in
                     guard CertificatePolicyError.invalidCertChain == error as? CertificatePolicyError else {
                         return XCTFail("Expected CertificatePolicyError.invalidCertChain")
@@ -182,14 +182,14 @@ class CertificatePolicyTests: XCTestCase {
             // The Apple root certs come preinstalled on Apple platforms and they are automatically trusted
             do {
                 let policy = DefaultCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: nil,
-                                                      callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                                                      callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                 XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
             }
 
             // What if `additionalTrustedRootCerts` has a cert that's already in the default trust store?
             do {
                 let policy = DefaultCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: [rootCA],
-                                                      callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                                                      callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                 XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
             }
             #elseif os(Linux) || os(Windows) || os(Android)
@@ -200,21 +200,21 @@ class CertificatePolicyTests: XCTestCase {
                 // Specify `trustedRootCertsDir`
                 do {
                     let policy = DefaultCertificatePolicy(trustedRootCertsDir: tmp.asURL, additionalTrustedRootCerts: nil,
-                                                          callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                                                          callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                     XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
                 }
 
                 // Another way is to pass in `additionalTrustedRootCerts`
                 do {
                     let policy = DefaultCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: [rootCA],
-                                                          callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                                                          callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                     XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
                 }
 
                 // What if the same cert is in both `trustedRootCertsDir` and `additionalTrustedRootCerts`?
                 do {
                     let policy = DefaultCertificatePolicy(trustedRootCertsDir: tmp.asURL, additionalTrustedRootCerts: [rootCA],
-                                                          callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                                                          callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                     XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
                 }
             }
@@ -247,14 +247,14 @@ class CertificatePolicyTests: XCTestCase {
             // The Apple root certs come preinstalled on Apple platforms and they are automatically trusted
             do {
                 let policy = AppleSwiftPackageCollectionCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: nil,
-                                                                          callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                                                                          callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                 XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
             }
 
             // What if `additionalTrustedRootCerts` has a cert that's already in the default trust store?
             do {
                 let policy = AppleSwiftPackageCollectionCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: [rootCA],
-                                                                          callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                                                                          callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                 XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
             }
             #elseif os(Linux) || os(Windows) || os(Android)
@@ -265,21 +265,21 @@ class CertificatePolicyTests: XCTestCase {
                 // Specify `trustedRootCertsDir`
                 do {
                     let policy = AppleSwiftPackageCollectionCertificatePolicy(trustedRootCertsDir: tmp.asURL, additionalTrustedRootCerts: nil,
-                                                                              callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                                                                              callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                     XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
                 }
 
                 // Another way is to pass in `additionalTrustedRootCerts`
                 do {
                     let policy = AppleSwiftPackageCollectionCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: [rootCA],
-                                                                              callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                                                                              callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                     XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
                 }
 
                 // What if the same cert is in both `trustedRootCertsDir` and `additionalTrustedRootCerts`?
                 do {
                     let policy = AppleSwiftPackageCollectionCertificatePolicy(trustedRootCertsDir: tmp.asURL, additionalTrustedRootCerts: [rootCA],
-                                                                              callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                                                                              callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                     XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
                 }
             }
@@ -312,14 +312,14 @@ class CertificatePolicyTests: XCTestCase {
             // The Apple root certs come preinstalled on Apple platforms and they are automatically trusted
             do {
                 let policy = AppleDistributionCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: nil,
-                                                                callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                                                                callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                 XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
             }
 
             // What if `additionalTrustedRootCerts` has a cert that's already in the default trust store?
             do {
                 let policy = AppleDistributionCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: [rootCA],
-                                                                callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                                                                callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                 XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
             }
             #elseif os(Linux) || os(Windows) || os(Android)
@@ -330,21 +330,21 @@ class CertificatePolicyTests: XCTestCase {
                 // Specify `trustedRootCertsDir`
                 do {
                     let policy = AppleDistributionCertificatePolicy(trustedRootCertsDir: tmp.asURL, additionalTrustedRootCerts: nil,
-                                                                    callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                                                                    callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                     XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
                 }
 
                 // Another way is to pass in `additionalTrustedRootCerts`
                 do {
                     let policy = AppleDistributionCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: [rootCA],
-                                                                    callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                                                                    callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                     XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
                 }
 
                 // What if the same cert is in both `trustedRootCertsDir` and `additionalTrustedRootCerts`?
                 do {
                     let policy = AppleDistributionCertificatePolicy(trustedRootCertsDir: tmp.asURL, additionalTrustedRootCerts: [rootCA],
-                                                                    callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                                                                    callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                     XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
                 }
             }
@@ -378,14 +378,14 @@ class CertificatePolicyTests: XCTestCase {
             // Subject user ID matches
             do {
                 let policy = DefaultCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: nil, expectedSubjectUserID: expectedSubjectUserID,
-                                                      callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                                                      callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                 XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
             }
             // Subject user ID does not match
             do {
                 let mismatchSubjectUserID = "\(expectedSubjectUserID)-2"
                 let policy = DefaultCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: nil, expectedSubjectUserID: mismatchSubjectUserID,
-                                                      callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                                                      callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                 XCTAssertThrowsError(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) }) { error in
                     guard CertificatePolicyError.subjectUserIDMismatch == error as? CertificatePolicyError else {
                         return XCTFail("Expected CertificatePolicyError.subjectUserIDMismatch")
@@ -400,14 +400,14 @@ class CertificatePolicyTests: XCTestCase {
                 // Subject user ID matches
                 do {
                     let policy = DefaultCertificatePolicy(trustedRootCertsDir: tmp.asURL, additionalTrustedRootCerts: nil, expectedSubjectUserID: expectedSubjectUserID,
-                                                          callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                                                          callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                     XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
                 }
                 // Subject user ID does not match
                 do {
                     let mismatchSubjectUserID = "\(expectedSubjectUserID)-2"
                     let policy = DefaultCertificatePolicy(trustedRootCertsDir: tmp.asURL, additionalTrustedRootCerts: nil, expectedSubjectUserID: mismatchSubjectUserID,
-                                                          callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                                                          callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                     XCTAssertThrowsError(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) }) { error in
                         guard CertificatePolicyError.subjectUserIDMismatch == error as? CertificatePolicyError else {
                             return XCTFail("Expected CertificatePolicyError.subjectUserIDMismatch")
@@ -446,14 +446,14 @@ class CertificatePolicyTests: XCTestCase {
             // Subject user ID matches
             do {
                 let policy = AppleSwiftPackageCollectionCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: nil, expectedSubjectUserID: expectedSubjectUserID,
-                                                                          callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                                                                          callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                 XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
             }
             // Subject user ID does not match
             do {
                 let mismatchSubjectUserID = "\(expectedSubjectUserID)-2"
                 let policy = AppleSwiftPackageCollectionCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: nil, expectedSubjectUserID: mismatchSubjectUserID,
-                                                                          callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                                                                          callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                 XCTAssertThrowsError(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) }) { error in
                     guard CertificatePolicyError.subjectUserIDMismatch == error as? CertificatePolicyError else {
                         return XCTFail("Expected CertificatePolicyError.subjectUserIDMismatch")
@@ -469,7 +469,7 @@ class CertificatePolicyTests: XCTestCase {
                 do {
                     let policy = AppleSwiftPackageCollectionCertificatePolicy(trustedRootCertsDir: tmp.asURL, additionalTrustedRootCerts: nil,
                                                                               expectedSubjectUserID: expectedSubjectUserID,
-                                                                              callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                                                                              callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                     XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
                 }
                 // Subject user ID does not match
@@ -477,7 +477,7 @@ class CertificatePolicyTests: XCTestCase {
                     let mismatchSubjectUserID = "\(expectedSubjectUserID)-2"
                     let policy = AppleSwiftPackageCollectionCertificatePolicy(trustedRootCertsDir: tmp.asURL, additionalTrustedRootCerts: nil,
                                                                               expectedSubjectUserID: mismatchSubjectUserID,
-                                                                              callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                                                                              callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                     XCTAssertThrowsError(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) }) { error in
                         guard CertificatePolicyError.subjectUserIDMismatch == error as? CertificatePolicyError else {
                             return XCTFail("Expected CertificatePolicyError.subjectUserIDMismatch")
@@ -516,14 +516,14 @@ class CertificatePolicyTests: XCTestCase {
             // Subject user ID matches
             do {
                 let policy = AppleDistributionCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: nil, expectedSubjectUserID: expectedSubjectUserID,
-                                                                callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                                                                callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                 XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
             }
             // Subject user ID does not match
             do {
                 let mismatchSubjectUserID = "\(expectedSubjectUserID)-2"
                 let policy = AppleDistributionCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: nil, expectedSubjectUserID: mismatchSubjectUserID,
-                                                                callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                                                                callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                 XCTAssertThrowsError(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) }) { error in
                     guard CertificatePolicyError.subjectUserIDMismatch == error as? CertificatePolicyError else {
                         return XCTFail("Expected CertificatePolicyError.subjectUserIDMismatch")
@@ -538,14 +538,14 @@ class CertificatePolicyTests: XCTestCase {
                 // Subject user ID matches
                 do {
                     let policy = AppleDistributionCertificatePolicy(trustedRootCertsDir: tmp.asURL, additionalTrustedRootCerts: nil, expectedSubjectUserID: expectedSubjectUserID,
-                                                                    callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                                                                    callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                     XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
                 }
                 // Subject user ID does not match
                 do {
                     let mismatchSubjectUserID = "\(expectedSubjectUserID)-2"
                     let policy = AppleDistributionCertificatePolicy(trustedRootCertsDir: tmp.asURL, additionalTrustedRootCerts: nil, expectedSubjectUserID: mismatchSubjectUserID,
-                                                                    callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                                                                    callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                     XCTAssertThrowsError(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) }) { error in
                         guard CertificatePolicyError.subjectUserIDMismatch == error as? CertificatePolicyError else {
                             return XCTFail("Expected CertificatePolicyError.subjectUserIDMismatch")

--- a/Tests/PackageCollectionsSigningTests/CertificatePolicyTests.swift
+++ b/Tests/PackageCollectionsSigningTests/CertificatePolicyTests.swift
@@ -8,13 +8,13 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
+import Basics
 import Dispatch
 import Foundation
-import XCTest
-
 @testable import PackageCollectionsSigning
 import SPMTestSupport
 import TSCBasic
+import XCTest
 
 class CertificatePolicyTests: XCTestCase {
     func test_RSA_validate_happyCase() throws {
@@ -136,7 +136,7 @@ class CertificatePolicyTests: XCTestCase {
             #if os(macOS)
             // The Apple root certs come preinstalled on Apple platforms and they are automatically trusted
             let policy = DefaultCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: nil,
-                                                  callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                                                  callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
             XCTAssertThrowsError(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) }) { error in
                 guard CertificatePolicyError.invalidCertChain == error as? CertificatePolicyError else {
                     return XCTFail("Expected CertificatePolicyError.invalidCertChain")
@@ -182,14 +182,14 @@ class CertificatePolicyTests: XCTestCase {
             // The Apple root certs come preinstalled on Apple platforms and they are automatically trusted
             do {
                 let policy = DefaultCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: nil,
-                                                      callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                                                      callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                 XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
             }
 
             // What if `additionalTrustedRootCerts` has a cert that's already in the default trust store?
             do {
                 let policy = DefaultCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: [rootCA],
-                                                      callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                                                      callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                 XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
             }
             #elseif os(Linux) || os(Windows) || os(Android)
@@ -247,14 +247,14 @@ class CertificatePolicyTests: XCTestCase {
             // The Apple root certs come preinstalled on Apple platforms and they are automatically trusted
             do {
                 let policy = AppleSwiftPackageCollectionCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: nil,
-                                                                          callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                                                                          callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                 XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
             }
 
             // What if `additionalTrustedRootCerts` has a cert that's already in the default trust store?
             do {
                 let policy = AppleSwiftPackageCollectionCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: [rootCA],
-                                                                          callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                                                                          callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                 XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
             }
             #elseif os(Linux) || os(Windows) || os(Android)
@@ -312,14 +312,14 @@ class CertificatePolicyTests: XCTestCase {
             // The Apple root certs come preinstalled on Apple platforms and they are automatically trusted
             do {
                 let policy = AppleDistributionCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: nil,
-                                                                callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                                                                callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                 XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
             }
 
             // What if `additionalTrustedRootCerts` has a cert that's already in the default trust store?
             do {
                 let policy = AppleDistributionCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: [rootCA],
-                                                                callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                                                                callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                 XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
             }
             #elseif os(Linux) || os(Windows) || os(Android)
@@ -378,14 +378,14 @@ class CertificatePolicyTests: XCTestCase {
             // Subject user ID matches
             do {
                 let policy = DefaultCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: nil, expectedSubjectUserID: expectedSubjectUserID,
-                                                      callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                                                      callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                 XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
             }
             // Subject user ID does not match
             do {
                 let mismatchSubjectUserID = "\(expectedSubjectUserID)-2"
                 let policy = DefaultCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: nil, expectedSubjectUserID: mismatchSubjectUserID,
-                                                      callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                                                      callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                 XCTAssertThrowsError(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) }) { error in
                     guard CertificatePolicyError.subjectUserIDMismatch == error as? CertificatePolicyError else {
                         return XCTFail("Expected CertificatePolicyError.subjectUserIDMismatch")
@@ -446,14 +446,14 @@ class CertificatePolicyTests: XCTestCase {
             // Subject user ID matches
             do {
                 let policy = AppleSwiftPackageCollectionCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: nil, expectedSubjectUserID: expectedSubjectUserID,
-                                                                          callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                                                                          callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                 XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
             }
             // Subject user ID does not match
             do {
                 let mismatchSubjectUserID = "\(expectedSubjectUserID)-2"
                 let policy = AppleSwiftPackageCollectionCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: nil, expectedSubjectUserID: mismatchSubjectUserID,
-                                                                          callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                                                                          callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                 XCTAssertThrowsError(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) }) { error in
                     guard CertificatePolicyError.subjectUserIDMismatch == error as? CertificatePolicyError else {
                         return XCTFail("Expected CertificatePolicyError.subjectUserIDMismatch")
@@ -516,14 +516,14 @@ class CertificatePolicyTests: XCTestCase {
             // Subject user ID matches
             do {
                 let policy = AppleDistributionCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: nil, expectedSubjectUserID: expectedSubjectUserID,
-                                                                callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                                                                callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                 XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
             }
             // Subject user ID does not match
             do {
                 let mismatchSubjectUserID = "\(expectedSubjectUserID)-2"
                 let policy = AppleDistributionCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: nil, expectedSubjectUserID: mismatchSubjectUserID,
-                                                                callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                                                                callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                 XCTAssertThrowsError(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) }) { error in
                     guard CertificatePolicyError.subjectUserIDMismatch == error as? CertificatePolicyError else {
                         return XCTFail("Expected CertificatePolicyError.subjectUserIDMismatch")

--- a/Tests/PackageCollectionsSigningTests/PackageCollectionSigningTest.swift
+++ b/Tests/PackageCollectionsSigningTests/PackageCollectionSigningTest.swift
@@ -254,7 +254,7 @@ class PackageCollectionSigningTests: XCTestCase {
 
                 // Specify `trustedRootCertsDir`
                 do {
-                    let signing = PackageCollectionSigning(trustedRootCertsDir: tmp.asURL, callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                    let signing = PackageCollectionSigning(trustedRootCertsDir: tmp.asURL, callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                     // Sign the collection
                     let signedCollection = try tsc_await { callback in
                         signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)
@@ -269,7 +269,7 @@ class PackageCollectionSigningTests: XCTestCase {
                 // Another way is to pass in `additionalTrustedRootCerts`
                 do {
                     let signing = PackageCollectionSigning(additionalTrustedRootCerts: [rootCAData.base64EncodedString()],
-                                                           callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                                                           callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                     // Sign the collection
                     let signedCollection = try tsc_await { callback in
                         signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)
@@ -346,7 +346,7 @@ class PackageCollectionSigningTests: XCTestCase {
 
                 // Specify `trustedRootCertsDir`
                 do {
-                    let signing = PackageCollectionSigning(trustedRootCertsDir: tmp.asURL, callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                    let signing = PackageCollectionSigning(trustedRootCertsDir: tmp.asURL, callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                     // Sign the collection
                     let signedCollection = try tsc_await { callback in
                         signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)
@@ -361,7 +361,7 @@ class PackageCollectionSigningTests: XCTestCase {
                 // Another way is to pass in `additionalTrustedRootCerts`
                 do {
                     let signing = PackageCollectionSigning(additionalTrustedRootCerts: [rootCAData.base64EncodedString()],
-                                                           callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                                                           callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                     // Sign the collection
                     let signedCollection = try tsc_await { callback in
                         signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)
@@ -438,7 +438,7 @@ class PackageCollectionSigningTests: XCTestCase {
 
                 // Specify `trustedRootCertsDir`
                 do {
-                    let signing = PackageCollectionSigning(trustedRootCertsDir: tmp.asURL, callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                    let signing = PackageCollectionSigning(trustedRootCertsDir: tmp.asURL, callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                     // Sign the collection
                     let signedCollection = try tsc_await { callback in
                         signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)
@@ -453,7 +453,7 @@ class PackageCollectionSigningTests: XCTestCase {
                 // Another way is to pass in `additionalTrustedRootCerts`
                 do {
                     let signing = PackageCollectionSigning(additionalTrustedRootCerts: [rootCAData.base64EncodedString()],
-                                                           callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                                                           callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                     // Sign the collection
                     let signedCollection = try tsc_await { callback in
                         signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)
@@ -508,7 +508,7 @@ class PackageCollectionSigningTests: XCTestCase {
             // On other platforms we have to specify `trustedRootCertsDir` so the Apple root cert is trusted
             try withTemporaryDirectory { tmp in
                 try localFileSystem.copy(from: rootCAPath, to: tmp.appending(components: "AppleIncRoot.cer"))
-                let signing = PackageCollectionSigning(trustedRootCertsDir: tmp.asURL, callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                let signing = PackageCollectionSigning(trustedRootCertsDir: tmp.asURL, callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                 // Sign the collection
                 let signedCollection = try tsc_await { callback in
                     signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)
@@ -563,7 +563,7 @@ class PackageCollectionSigningTests: XCTestCase {
             // On other platforms we have to specify `trustedRootCertsDir` so the Apple root cert is trusted
             try withTemporaryDirectory { tmp in
                 try localFileSystem.copy(from: rootCAPath, to: tmp.appending(components: "AppleIncRoot.cer"))
-                let signing = PackageCollectionSigning(trustedRootCertsDir: tmp.asURL, callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                let signing = PackageCollectionSigning(trustedRootCertsDir: tmp.asURL, callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                 // Sign the collection
                 let signedCollection = try tsc_await { callback in
                     signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)
@@ -618,7 +618,7 @@ class PackageCollectionSigningTests: XCTestCase {
             // On other platforms we have to specify `trustedRootCertsDir` so the Apple root cert is trusted
             try withTemporaryDirectory { tmp in
                 try localFileSystem.copy(from: rootCAPath, to: tmp.appending(components: "AppleIncRoot.cer"))
-                let signing = PackageCollectionSigning(trustedRootCertsDir: tmp.asURL, callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                let signing = PackageCollectionSigning(trustedRootCertsDir: tmp.asURL, callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                 // Sign the collection
                 let signedCollection = try tsc_await { callback in
                     signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)

--- a/Tests/PackageCollectionsSigningTests/PackageCollectionSigningTest.swift
+++ b/Tests/PackageCollectionsSigningTests/PackageCollectionSigningTest.swift
@@ -8,14 +8,14 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
+import Basics
 import Dispatch
 import Foundation
-import XCTest
-
 import PackageCollectionsModel
 @testable import PackageCollectionsSigning
 import SPMTestSupport
 import TSCBasic
+import XCTest
 
 class PackageCollectionSigningTests: XCTestCase {
     func test_RSA_signAndValidate_happyCase() throws {
@@ -38,7 +38,7 @@ class PackageCollectionSigningTests: XCTestCase {
             let rootCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(rootCAPath).contents))
             // Trust the self-signed root cert
             let certPolicy = TestCertificatePolicy(anchorCerts: [rootCA])
-            let signing = PackageCollectionSigning(certPolicy: certPolicy, callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+            let signing = PackageCollectionSigning(certPolicy: certPolicy, callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
 
             // Sign the collection
             let signedCollection = try tsc_await { callback in
@@ -85,7 +85,7 @@ class PackageCollectionSigningTests: XCTestCase {
             let rootCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(rootCAPath).contents))
             // Trust the self-signed root cert
             let certPolicy = TestCertificatePolicy(anchorCerts: [rootCA])
-            let signing = PackageCollectionSigning(certPolicy: certPolicy, callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+            let signing = PackageCollectionSigning(certPolicy: certPolicy, callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
 
             // Sign collection1
             let signedCollection = try tsc_await { callback in
@@ -126,7 +126,7 @@ class PackageCollectionSigningTests: XCTestCase {
             let rootCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(rootCAPath).contents))
             // Trust the self-signed root cert
             let certPolicy = TestCertificatePolicy(anchorCerts: [rootCA])
-            let signing = PackageCollectionSigning(certPolicy: certPolicy, callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+            let signing = PackageCollectionSigning(certPolicy: certPolicy, callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
 
             // Sign the collection
             let signedCollection = try tsc_await { callback in
@@ -173,7 +173,7 @@ class PackageCollectionSigningTests: XCTestCase {
             let rootCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(rootCAPath).contents))
             // Trust the self-signed root cert
             let certPolicy = TestCertificatePolicy(anchorCerts: [rootCA])
-            let signing = PackageCollectionSigning(certPolicy: certPolicy, callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+            let signing = PackageCollectionSigning(certPolicy: certPolicy, callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
 
             // Sign collection1
             let signedCollection = try tsc_await { callback in
@@ -221,7 +221,7 @@ class PackageCollectionSigningTests: XCTestCase {
             #if os(macOS)
             // The Apple root certs come preinstalled on Apple platforms and they are automatically trusted
             do {
-                let signing = PackageCollectionSigning(callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                let signing = PackageCollectionSigning(callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                 // Sign the collection
                 let signedCollection = try tsc_await { callback in
                     signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)
@@ -236,7 +236,7 @@ class PackageCollectionSigningTests: XCTestCase {
             // Try passing in the cert with `additionalTrustedRootCerts` even though it's already in the default trust store
             do {
                 let signing = PackageCollectionSigning(additionalTrustedRootCerts: [rootCAData.base64EncodedString()],
-                                                       callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                                                       callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                 // Sign the collection
                 let signedCollection = try tsc_await { callback in
                     signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)
@@ -313,7 +313,7 @@ class PackageCollectionSigningTests: XCTestCase {
             #if os(macOS)
             // The Apple root certs come preinstalled on Apple platforms and they are automatically trusted
             do {
-                let signing = PackageCollectionSigning(callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                let signing = PackageCollectionSigning(callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                 // Sign the collection
                 let signedCollection = try tsc_await { callback in
                     signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)
@@ -328,7 +328,7 @@ class PackageCollectionSigningTests: XCTestCase {
             // Try passing in the cert with `additionalTrustedRootCerts` even though it's already in the default trust store
             do {
                 let signing = PackageCollectionSigning(additionalTrustedRootCerts: [rootCAData.base64EncodedString()],
-                                                       callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                                                       callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                 // Sign the collection
                 let signedCollection = try tsc_await { callback in
                     signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)
@@ -405,7 +405,7 @@ class PackageCollectionSigningTests: XCTestCase {
             #if os(macOS)
             // The Apple root certs come preinstalled on Apple platforms and they are automatically trusted
             do {
-                let signing = PackageCollectionSigning(callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                let signing = PackageCollectionSigning(callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                 // Sign the collection
                 let signedCollection = try tsc_await { callback in
                     signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)
@@ -420,7 +420,7 @@ class PackageCollectionSigningTests: XCTestCase {
             // Try passing in the cert with `additionalTrustedRootCerts` even though it's already in the default trust store
             do {
                 let signing = PackageCollectionSigning(additionalTrustedRootCerts: [rootCAData.base64EncodedString()],
-                                                       callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+                                                       callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
                 // Sign the collection
                 let signedCollection = try tsc_await { callback in
                     signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)
@@ -494,7 +494,7 @@ class PackageCollectionSigningTests: XCTestCase {
 
             #if os(macOS)
             // The Apple root certs come preinstalled on Apple platforms and they are automatically trusted
-            let signing = PackageCollectionSigning(callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+            let signing = PackageCollectionSigning(callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
             // Sign the collection
             let signedCollection = try tsc_await { callback in
                 signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)
@@ -549,7 +549,7 @@ class PackageCollectionSigningTests: XCTestCase {
 
             #if os(macOS)
             // The Apple root certs come preinstalled on Apple platforms and they are automatically trusted
-            let signing = PackageCollectionSigning(callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+            let signing = PackageCollectionSigning(callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
             // Sign the collection
             let signedCollection = try tsc_await { callback in
                 signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)
@@ -604,7 +604,7 @@ class PackageCollectionSigningTests: XCTestCase {
 
             #if os(macOS)
             // The Apple root certs come preinstalled on Apple platforms and they are automatically trusted
-            let signing = PackageCollectionSigning(callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
+            let signing = PackageCollectionSigning(callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
             // Sign the collection
             let signedCollection = try tsc_await { callback in
                 signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)

--- a/Tests/PackageCollectionsSigningTests/PackageCollectionSigningTest.swift
+++ b/Tests/PackageCollectionsSigningTests/PackageCollectionSigningTest.swift
@@ -254,7 +254,7 @@ class PackageCollectionSigningTests: XCTestCase {
 
                 // Specify `trustedRootCertsDir`
                 do {
-                    let signing = PackageCollectionSigning(trustedRootCertsDir: tmp.asURL, callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                    let signing = PackageCollectionSigning(trustedRootCertsDir: tmp.asURL, callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                     // Sign the collection
                     let signedCollection = try tsc_await { callback in
                         signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)
@@ -269,7 +269,7 @@ class PackageCollectionSigningTests: XCTestCase {
                 // Another way is to pass in `additionalTrustedRootCerts`
                 do {
                     let signing = PackageCollectionSigning(additionalTrustedRootCerts: [rootCAData.base64EncodedString()],
-                                                           callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                                                           callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                     // Sign the collection
                     let signedCollection = try tsc_await { callback in
                         signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)
@@ -346,7 +346,7 @@ class PackageCollectionSigningTests: XCTestCase {
 
                 // Specify `trustedRootCertsDir`
                 do {
-                    let signing = PackageCollectionSigning(trustedRootCertsDir: tmp.asURL, callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                    let signing = PackageCollectionSigning(trustedRootCertsDir: tmp.asURL, callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                     // Sign the collection
                     let signedCollection = try tsc_await { callback in
                         signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)
@@ -361,7 +361,7 @@ class PackageCollectionSigningTests: XCTestCase {
                 // Another way is to pass in `additionalTrustedRootCerts`
                 do {
                     let signing = PackageCollectionSigning(additionalTrustedRootCerts: [rootCAData.base64EncodedString()],
-                                                           callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                                                           callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                     // Sign the collection
                     let signedCollection = try tsc_await { callback in
                         signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)
@@ -438,7 +438,7 @@ class PackageCollectionSigningTests: XCTestCase {
 
                 // Specify `trustedRootCertsDir`
                 do {
-                    let signing = PackageCollectionSigning(trustedRootCertsDir: tmp.asURL, callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                    let signing = PackageCollectionSigning(trustedRootCertsDir: tmp.asURL, callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                     // Sign the collection
                     let signedCollection = try tsc_await { callback in
                         signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)
@@ -453,7 +453,7 @@ class PackageCollectionSigningTests: XCTestCase {
                 // Another way is to pass in `additionalTrustedRootCerts`
                 do {
                     let signing = PackageCollectionSigning(additionalTrustedRootCerts: [rootCAData.base64EncodedString()],
-                                                           callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                                                           callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                     // Sign the collection
                     let signedCollection = try tsc_await { callback in
                         signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)
@@ -508,7 +508,7 @@ class PackageCollectionSigningTests: XCTestCase {
             // On other platforms we have to specify `trustedRootCertsDir` so the Apple root cert is trusted
             try withTemporaryDirectory { tmp in
                 try localFileSystem.copy(from: rootCAPath, to: tmp.appending(components: "AppleIncRoot.cer"))
-                let signing = PackageCollectionSigning(trustedRootCertsDir: tmp.asURL, callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                let signing = PackageCollectionSigning(trustedRootCertsDir: tmp.asURL, callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                 // Sign the collection
                 let signedCollection = try tsc_await { callback in
                     signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)
@@ -563,7 +563,7 @@ class PackageCollectionSigningTests: XCTestCase {
             // On other platforms we have to specify `trustedRootCertsDir` so the Apple root cert is trusted
             try withTemporaryDirectory { tmp in
                 try localFileSystem.copy(from: rootCAPath, to: tmp.appending(components: "AppleIncRoot.cer"))
-                let signing = PackageCollectionSigning(trustedRootCertsDir: tmp.asURL, callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                let signing = PackageCollectionSigning(trustedRootCertsDir: tmp.asURL, callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                 // Sign the collection
                 let signedCollection = try tsc_await { callback in
                     signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)
@@ -618,7 +618,7 @@ class PackageCollectionSigningTests: XCTestCase {
             // On other platforms we have to specify `trustedRootCertsDir` so the Apple root cert is trusted
             try withTemporaryDirectory { tmp in
                 try localFileSystem.copy(from: rootCAPath, to: tmp.appending(components: "AppleIncRoot.cer"))
-                let signing = PackageCollectionSigning(trustedRootCertsDir: tmp.asURL, callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                let signing = PackageCollectionSigning(trustedRootCertsDir: tmp.asURL, callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                 // Sign the collection
                 let signedCollection = try tsc_await { callback in
                     signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)

--- a/Tests/PackageCollectionsSigningTests/PackageCollectionSigningTest.swift
+++ b/Tests/PackageCollectionsSigningTests/PackageCollectionSigningTest.swift
@@ -38,7 +38,7 @@ class PackageCollectionSigningTests: XCTestCase {
             let rootCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(rootCAPath).contents))
             // Trust the self-signed root cert
             let certPolicy = TestCertificatePolicy(anchorCerts: [rootCA])
-            let signing = PackageCollectionSigning(certPolicy: certPolicy, callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+            let signing = PackageCollectionSigning(certPolicy: certPolicy, callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
 
             // Sign the collection
             let signedCollection = try tsc_await { callback in
@@ -85,7 +85,7 @@ class PackageCollectionSigningTests: XCTestCase {
             let rootCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(rootCAPath).contents))
             // Trust the self-signed root cert
             let certPolicy = TestCertificatePolicy(anchorCerts: [rootCA])
-            let signing = PackageCollectionSigning(certPolicy: certPolicy, callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+            let signing = PackageCollectionSigning(certPolicy: certPolicy, callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
 
             // Sign collection1
             let signedCollection = try tsc_await { callback in
@@ -126,7 +126,7 @@ class PackageCollectionSigningTests: XCTestCase {
             let rootCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(rootCAPath).contents))
             // Trust the self-signed root cert
             let certPolicy = TestCertificatePolicy(anchorCerts: [rootCA])
-            let signing = PackageCollectionSigning(certPolicy: certPolicy, callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+            let signing = PackageCollectionSigning(certPolicy: certPolicy, callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
 
             // Sign the collection
             let signedCollection = try tsc_await { callback in
@@ -173,7 +173,7 @@ class PackageCollectionSigningTests: XCTestCase {
             let rootCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(rootCAPath).contents))
             // Trust the self-signed root cert
             let certPolicy = TestCertificatePolicy(anchorCerts: [rootCA])
-            let signing = PackageCollectionSigning(certPolicy: certPolicy, callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+            let signing = PackageCollectionSigning(certPolicy: certPolicy, callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
 
             // Sign collection1
             let signedCollection = try tsc_await { callback in
@@ -221,7 +221,7 @@ class PackageCollectionSigningTests: XCTestCase {
             #if os(macOS)
             // The Apple root certs come preinstalled on Apple platforms and they are automatically trusted
             do {
-                let signing = PackageCollectionSigning(callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                let signing = PackageCollectionSigning(callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                 // Sign the collection
                 let signedCollection = try tsc_await { callback in
                     signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)
@@ -236,7 +236,7 @@ class PackageCollectionSigningTests: XCTestCase {
             // Try passing in the cert with `additionalTrustedRootCerts` even though it's already in the default trust store
             do {
                 let signing = PackageCollectionSigning(additionalTrustedRootCerts: [rootCAData.base64EncodedString()],
-                                                       callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                                                       callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                 // Sign the collection
                 let signedCollection = try tsc_await { callback in
                     signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)
@@ -313,7 +313,7 @@ class PackageCollectionSigningTests: XCTestCase {
             #if os(macOS)
             // The Apple root certs come preinstalled on Apple platforms and they are automatically trusted
             do {
-                let signing = PackageCollectionSigning(callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                let signing = PackageCollectionSigning(callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                 // Sign the collection
                 let signedCollection = try tsc_await { callback in
                     signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)
@@ -328,7 +328,7 @@ class PackageCollectionSigningTests: XCTestCase {
             // Try passing in the cert with `additionalTrustedRootCerts` even though it's already in the default trust store
             do {
                 let signing = PackageCollectionSigning(additionalTrustedRootCerts: [rootCAData.base64EncodedString()],
-                                                       callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                                                       callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                 // Sign the collection
                 let signedCollection = try tsc_await { callback in
                     signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)
@@ -405,7 +405,7 @@ class PackageCollectionSigningTests: XCTestCase {
             #if os(macOS)
             // The Apple root certs come preinstalled on Apple platforms and they are automatically trusted
             do {
-                let signing = PackageCollectionSigning(callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                let signing = PackageCollectionSigning(callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                 // Sign the collection
                 let signedCollection = try tsc_await { callback in
                     signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)
@@ -420,7 +420,7 @@ class PackageCollectionSigningTests: XCTestCase {
             // Try passing in the cert with `additionalTrustedRootCerts` even though it's already in the default trust store
             do {
                 let signing = PackageCollectionSigning(additionalTrustedRootCerts: [rootCAData.base64EncodedString()],
-                                                       callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+                                                       callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
                 // Sign the collection
                 let signedCollection = try tsc_await { callback in
                     signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)
@@ -494,7 +494,7 @@ class PackageCollectionSigningTests: XCTestCase {
 
             #if os(macOS)
             // The Apple root certs come preinstalled on Apple platforms and they are automatically trusted
-            let signing = PackageCollectionSigning(callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+            let signing = PackageCollectionSigning(callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
             // Sign the collection
             let signedCollection = try tsc_await { callback in
                 signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)
@@ -549,7 +549,7 @@ class PackageCollectionSigningTests: XCTestCase {
 
             #if os(macOS)
             // The Apple root certs come preinstalled on Apple platforms and they are automatically trusted
-            let signing = PackageCollectionSigning(callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+            let signing = PackageCollectionSigning(callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
             // Sign the collection
             let signedCollection = try tsc_await { callback in
                 signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)
@@ -604,7 +604,7 @@ class PackageCollectionSigningTests: XCTestCase {
 
             #if os(macOS)
             // The Apple root certs come preinstalled on Apple platforms and they are automatically trusted
-            let signing = PackageCollectionSigning(callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine())
+            let signing = PackageCollectionSigning(callbackQueue: callbackQueue, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
             // Sign the collection
             let signedCollection = try tsc_await { callback in
                 signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)

--- a/Tests/PackageCollectionsSigningTests/Utilities.swift
+++ b/Tests/PackageCollectionsSigningTests/Utilities.swift
@@ -62,7 +62,7 @@ struct TestCertificatePolicy: CertificatePolicy {
                         diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine(), callbackQueue: callbackQueue, callback: callback)
             #else
             self.verify(certChain: certChain, anchorCerts: self.anchorCerts, verifyDate: self.verifyDate, httpClient: nil,
-                        diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine(), callbackQueue: callbackQueue, callback: callback)
+                        diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine(), callbackQueue: callbackQueue, callback: callback)
             #endif
         } catch {
             return callbackQueue.async { callback(.failure(error)) }

--- a/Tests/PackageCollectionsSigningTests/Utilities.swift
+++ b/Tests/PackageCollectionsSigningTests/Utilities.swift
@@ -8,18 +8,17 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
+import Basics
 import Dispatch
 import Foundation
-import XCTest
-
 @testable import PackageCollectionsSigning
 import TSCBasic
+import XCTest
 
 // Set `REAL_CERT_USER_ID` env var when running ENABLE_REAL_CERT_TEST tests
 let expectedSubjectUserID = ProcessInfo.processInfo.environment["REAL_CERT_USER_ID"] ?? "<USER ID>"
 
 let callbackQueue = DispatchQueue(label: "org.swift.swiftpm.PackageCollectionsSigningTests", attributes: .concurrent)
-let diagnosticsEngine = DiagnosticsEngine()
 
 // MARK: - CertificatePolicy for test certs
 
@@ -60,10 +59,10 @@ struct TestCertificatePolicy: CertificatePolicy {
 
             #if os(macOS)
             self.verify(certChain: certChain, anchorCerts: self.anchorCerts, verifyDate: self.verifyDate,
-                        diagnosticsEngine: diagnosticsEngine, callbackQueue: callbackQueue, callback: callback)
+                        diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine(), callbackQueue: callbackQueue, callback: callback)
             #else
             self.verify(certChain: certChain, anchorCerts: self.anchorCerts, verifyDate: self.verifyDate, httpClient: nil,
-                        diagnosticsEngine: diagnosticsEngine, callbackQueue: callbackQueue, callback: callback)
+                        diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine(), callbackQueue: callbackQueue, callback: callback)
             #endif
         } catch {
             return callbackQueue.async { callback(.failure(error)) }

--- a/Tests/PackageCollectionsSigningTests/Utilities.swift
+++ b/Tests/PackageCollectionsSigningTests/Utilities.swift
@@ -59,7 +59,7 @@ struct TestCertificatePolicy: CertificatePolicy {
 
             #if os(macOS)
             self.verify(certChain: certChain, anchorCerts: self.anchorCerts, verifyDate: self.verifyDate,
-                        diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine(), callbackQueue: callbackQueue, callback: callback)
+                        diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine(), callbackQueue: callbackQueue, callback: callback)
             #else
             self.verify(certChain: certChain, anchorCerts: self.anchorCerts, verifyDate: self.verifyDate, httpClient: nil,
                         diagnosticsEngine: ObservabilitySystem.makeDiagnosticsEngine(), callbackQueue: callbackQueue, callback: callback)

--- a/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
@@ -8,13 +8,13 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import XCTest
-
-import TSCBasic
+import Basics
 import PackageGraph
-import PackageModel
 import PackageLoading
+import PackageModel
 import SPMTestSupport
+import TSCBasic
+import XCTest
 
 class PackageGraphPerfTests: XCTestCasePerf {
 
@@ -68,15 +68,15 @@ class PackageGraphPerfTests: XCTestCasePerf {
         let identityResolver = DefaultIdentityResolver()
 
         measure {
-            let diagnostics = DiagnosticsEngine()
+            let observability = ObservabilitySystem.bootstrapForTesting()
             let g = try! PackageGraph.load(
                 root: PackageGraphRoot(input: PackageGraphRootInput(packages: [rootManifest.path]), manifests: [rootManifest.path: rootManifest]),
                 identityResolver: identityResolver,
                 externalManifests: externalManifests,
-                diagnostics: diagnostics,
-                fileSystem: fs)
+                fileSystem: fs
+            )
             XCTAssertEqual(g.packages.count, N)
-            XCTAssertNoDiagnostics(diagnostics)
+            XCTAssertNoDiagnostics(observability.diagnostics)
         }
       #endif
     }

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -517,8 +517,16 @@ class PackageGraphTests: XCTestCase {
         )
 
         testDiagnostics(observability.diagnostics) { result in
-            result.check(diagnostic: "Source files for target Bar should be located under /Bar/Sources/Bar", severity: .warning, context: "'bar' /Bar")
-            result.check(diagnostic: "target 'Bar' referenced in product 'Bar' is empty", severity: .error, context: "'bar' /Bar")
+            result.check(
+                diagnostic: "Source files for target Bar should be located under /Bar/Sources/Bar",
+                severity: .warning,
+                metadata: .packageMetadata(identity: .plain("bar"), location: "/Bar")
+            )
+            result.check(
+                diagnostic: "target 'Bar' referenced in product 'Bar' is empty",
+                severity: .error,
+                metadata: .packageMetadata(identity: .plain("bar"), location: "/Bar")
+            )
         }
     }
 
@@ -541,7 +549,11 @@ class PackageGraphTests: XCTestCase {
         )
 
         testDiagnostics(observability.diagnostics) { result in
-            result.check(diagnostic: "product 'Barx' required by package 'foo' target 'FooTarget' not found.", severity: .error, context: "'foo' /Foo")
+            result.check(
+                diagnostic: "product 'Barx' required by package 'foo' target 'FooTarget' not found.",
+                severity: .error,
+                metadata: .packageMetadata(identity: .plain("foo"), location: "/Foo")
+            )
         }
     }
 
@@ -569,7 +581,11 @@ class PackageGraphTests: XCTestCase {
         )
 
         testDiagnostics(observability.diagnostics) { result in
-            result.check(diagnostic: "product 'Foo' is declared in the same package 'foo' and can't be used as a dependency for target 'FooTests'.", severity: .error, context: "'foo' /Foo")
+            result.check(
+                diagnostic: "product 'Foo' is declared in the same package 'foo' and can't be used as a dependency for target 'FooTests'.",
+                severity: .error,
+                metadata: .packageMetadata(identity: .plain("foo"), location: "/Foo")
+            )
         }
     }
 
@@ -640,7 +656,11 @@ class PackageGraphTests: XCTestCase {
         )
 
         testDiagnostics(observability.diagnostics) { result in
-            result.check(diagnostic: "product 'Barx' required by package 'foo' target 'FooTarget' not found in package 'Bar'.", severity: .error, context: "'foo' /Foo")
+            result.check(
+                diagnostic: "product 'Barx' required by package 'foo' target 'FooTarget' not found in package 'Bar'.",
+                severity: .error,
+                metadata: .packageMetadata(identity: .plain("foo"), location: "/Foo")
+            )
         }
     }
 
@@ -665,7 +685,11 @@ class PackageGraphTests: XCTestCase {
         )
 
         testDiagnostics(observability.diagnostics) { result in
-            result.check(diagnostic: "product 'Barx' required by package 'foo' target 'FooTarget' not found.", severity: .error, context: "'foo' /Foo")
+            result.check(
+                diagnostic: "product 'Barx' required by package 'foo' target 'FooTarget' not found.",
+                severity: .error,
+                metadata: .packageMetadata(identity: .plain("foo"), location: "/Foo")
+            )
         }
     }
 
@@ -734,21 +758,21 @@ class PackageGraphTests: XCTestCase {
                 dependency 'BarLib' in target 'Foo' requires explicit declaration; reference the package in the target dependency with '.product(name: "BarLib", package: "Bar")'
                 """,
                 severity: .error,
-                context: "'foo' /Foo"
+                metadata: .packageMetadata(identity: .plain("foo"), location: "/Foo")
             )
             result.checkUnordered(
                 diagnostic: """
                 dependency 'Biz' in target 'Foo' requires explicit declaration; reference the package in the target dependency with '.product(name: "Biz", package: "BizPath")'
                 """,
                 severity: .error,
-                context: "'foo' /Foo"
+                metadata: .packageMetadata(identity: .plain("foo"), location: "/Foo")
             )
             result.checkUnordered(
                 diagnostic: """
                 dependency 'FizLib' in target 'Foo' requires explicit declaration; reference the package in the target dependency with '.product(name: "FizLib", package: "FizPath")'
                 """,
                 severity: .error,
-                context: "'foo' /Foo"
+                metadata: .packageMetadata(identity: .plain("foo"), location: "/Foo")
             )
         }
     }
@@ -1333,7 +1357,7 @@ class PackageGraphTests: XCTestCase {
                     product 'Unknown' required by package 'foo' target 'Foo' not found.
                     """,
                 severity: .error,
-                context: "'foo' /Foo"
+                metadata: .packageMetadata(identity: .plain("foo"), location: "/Foo")
             )
         }
     }
@@ -1415,7 +1439,7 @@ class PackageGraphTests: XCTestCase {
                     product 'Unknown' required by package 'foo' target 'Foo' not found.
                     """,
                 severity: .error,
-                context: "'foo' /Foo"
+                metadata: .packageMetadata(identity: .plain("foo"), location: "/Foo")
             )
         }
     }
@@ -1460,7 +1484,7 @@ class PackageGraphTests: XCTestCase {
                         dependency 'ProductBar' in target 'Foo' requires explicit declaration; reference the package in the target dependency with '.product(name: "ProductBar", package: "Bar")'
                         """,
                     severity: .error,
-                    context: "'foo' /Foo"
+                    metadata: .packageMetadata(identity: .plain("foo"), location: "/Foo")
                 )
             }
         }
@@ -1523,7 +1547,7 @@ class PackageGraphTests: XCTestCase {
                         dependency 'ProductBar' in target 'Foo' requires explicit declaration; reference the package in the target dependency with '.product(name: "ProductBar", package: "Bar")'
                         """,
                     severity: .error,
-                    context: "'foo' /Foo"
+                    metadata: .packageMetadata(identity: .plain("foo"), location: "/Foo")
                 )
             }
         }
@@ -1585,7 +1609,7 @@ class PackageGraphTests: XCTestCase {
                         dependency 'Bar' in target 'Foo' requires explicit declaration; reference the package in the target dependency with '.product(name: "Bar", package: "Some-Bar")'
                         """,
                     severity: .error,
-                    context: "'foo' /Foo"
+                    metadata: .packageMetadata(identity: .plain("foo"), location: "/Foo")
                 )
             }
         }
@@ -1646,7 +1670,7 @@ class PackageGraphTests: XCTestCase {
                         dependency 'ProductBar' in target 'Foo' requires explicit declaration; reference the package in the target dependency with '.product(name: "ProductBar", package: "Some-Bar")'
                         """,
                     severity: .error,
-                    context: "'foo' /Foo"
+                    metadata: .packageMetadata(identity: .plain("foo"), location: "/Foo")
                 )
             }
         }
@@ -1747,7 +1771,7 @@ class PackageGraphTests: XCTestCase {
                         dependency 'ProductBar' in target 'Foo' requires explicit declaration; reference the package in the target dependency with '.product(name: "ProductBar", package: "Bar")'
                         """,
                     severity: .error,
-                    context: "'foo' /Foo"
+                    metadata: .packageMetadata(identity: .plain("foo"), location: "/Foo")
                 )
             }
         }

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -1009,7 +1009,7 @@ class PackageGraphTests: XCTestCase {
             ]
         )
 
-        testDiagnostics(observability.diagnostics, ignoreNotes: true) { result in
+        testDiagnostics(observability.diagnostics) { result in
             result.check(diagnostic: "multiple products named 'Bar' in: 'bar', 'baz'", severity: .error)
         }
     }
@@ -1074,7 +1074,7 @@ class PackageGraphTests: XCTestCase {
         )
 
         XCTAssertEqual(observability.diagnostics.count, 3)
-        testDiagnostics(observability.diagnostics, ignoreNotes: true) { result in
+        testDiagnostics(observability.diagnostics) { result in
             result.checkUnordered(diagnostic: .contains("the target 'Bar2' in product 'TransitiveBar' contains unsafe build flags"), severity: .error)
             result.checkUnordered(diagnostic: .contains("the target 'Bar' in product 'Bar' contains unsafe build flags"), severity: .error)
             result.checkUnordered(diagnostic: .contains("the target 'Bar2' in product 'Bar' contains unsafe build flags"), severity: .error)
@@ -1351,7 +1351,7 @@ class PackageGraphTests: XCTestCase {
             ]
         )
 
-        testDiagnostics(observability.diagnostics, ignoreNotes: true) { result in
+        testDiagnostics(observability.diagnostics) { result in
             result.check(
                 diagnostic: """
                     product 'Unknown' required by package 'foo' target 'Foo' not found.
@@ -1433,7 +1433,7 @@ class PackageGraphTests: XCTestCase {
             ]
         )
 
-        testDiagnostics(observability.diagnostics, ignoreNotes: true) { result in
+        testDiagnostics(observability.diagnostics) { result in
             result.check(
                 diagnostic: """
                     product 'Unknown' required by package 'foo' target 'Foo' not found.
@@ -1478,7 +1478,7 @@ class PackageGraphTests: XCTestCase {
         do {
             let observability = ObservabilitySystem.bootstrapForTesting()
             _ = try loadPackageGraph(fs: fs, manifests: manifests)
-            testDiagnostics(observability.diagnostics, ignoreNotes: true) { result in
+            testDiagnostics(observability.diagnostics) { result in
                 result.check(
                     diagnostic: """
                         dependency 'ProductBar' in target 'Foo' requires explicit declaration; reference the package in the target dependency with '.product(name: "ProductBar", package: "Bar")'
@@ -1541,7 +1541,7 @@ class PackageGraphTests: XCTestCase {
         do {
             let observability = ObservabilitySystem.bootstrapForTesting()
             _ = try loadPackageGraph(fs: fs, manifests: manifests)
-            testDiagnostics(observability.diagnostics, ignoreNotes: true) { result in
+            testDiagnostics(observability.diagnostics) { result in
                 result.check(
                     diagnostic: """
                         dependency 'ProductBar' in target 'Foo' requires explicit declaration; reference the package in the target dependency with '.product(name: "ProductBar", package: "Bar")'
@@ -1603,7 +1603,7 @@ class PackageGraphTests: XCTestCase {
         do {
             let observability = ObservabilitySystem.bootstrapForTesting()
             _ = try loadPackageGraph(fs: fs, manifests: manifests)
-            testDiagnostics(observability.diagnostics, ignoreNotes: true) { result in
+            testDiagnostics(observability.diagnostics) { result in
                 result.check(
                     diagnostic: """
                         dependency 'Bar' in target 'Foo' requires explicit declaration; reference the package in the target dependency with '.product(name: "Bar", package: "Some-Bar")'
@@ -1664,7 +1664,7 @@ class PackageGraphTests: XCTestCase {
         do {
             let observability = ObservabilitySystem.bootstrapForTesting()
             _ = try loadPackageGraph(fs: fs, manifests: manifests)
-            testDiagnostics(observability.diagnostics, ignoreNotes: true) { result in
+            testDiagnostics(observability.diagnostics) { result in
                 result.check(
                     diagnostic: """
                         dependency 'ProductBar' in target 'Foo' requires explicit declaration; reference the package in the target dependency with '.product(name: "ProductBar", package: "Some-Bar")'
@@ -1765,7 +1765,7 @@ class PackageGraphTests: XCTestCase {
         do {
             let observability = ObservabilitySystem.bootstrapForTesting()
             _ = try loadPackageGraph(fs: fs, manifests: manifests)
-            testDiagnostics(observability.diagnostics, ignoreNotes: true) { result in
+            testDiagnostics(observability.diagnostics) { result in
                 result.check(
                     diagnostic: """
                         dependency 'ProductBar' in target 'Foo' requires explicit declaration; reference the package in the target dependency with '.product(name: "ProductBar", package: "Bar")'

--- a/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
+++ b/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
@@ -8,12 +8,12 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import XCTest
-
-import TSCBasic
-import SPMTestSupport
-import PackageModel
+import Basics
 import PackageLoading
+import PackageModel
+import SPMTestSupport
+import TSCBasic
+import XCTest
 
 class ModuleMapGeneration: XCTestCase {
 
@@ -98,7 +98,7 @@ class ModuleMapGeneration: XCTestCase {
         ModuleMapTester("Foo", in: fs) { result in
             result.checkNotCreated()
             result.checkDiagnostics { result in
-                result.check(diagnostic: "no include directory found for target \'Foo\'; libraries cannot be imported without public headers", behavior: .warning)
+                result.check(diagnostic: "no include directory found for target \'Foo\'; libraries cannot be imported without public headers", severity: .warning)
             }
         }
 
@@ -114,7 +114,7 @@ class ModuleMapGeneration: XCTestCase {
 
                 """)
             result.checkDiagnostics { result in
-                result.check(diagnostic: "/include/F-o-o.h should be renamed to /include/F_o_o.h to be used as an umbrella header", behavior: .warning)
+                result.check(diagnostic: "/include/F-o-o.h should be renamed to /include/F_o_o.h to be used as an umbrella header", severity: .warning)
             }
         }
     }
@@ -128,7 +128,7 @@ class ModuleMapGeneration: XCTestCase {
         ModuleMapTester("Foo", in: fs) { result in
             result.checkNotCreated()
             result.checkDiagnostics { result in
-                result.check(diagnostic: "target 'Foo' has invalid header layout: umbrella header found at '/include/Foo/Foo.h', but more than one directory exists next to its parent directory: /include/Bar; consider reducing them to one", behavior: .error)
+                result.check(diagnostic: "target 'Foo' has invalid header layout: umbrella header found at '/include/Foo/Foo.h', but more than one directory exists next to its parent directory: /include/Bar; consider reducing them to one", severity: .error)
             }
         }
 
@@ -138,7 +138,7 @@ class ModuleMapGeneration: XCTestCase {
         ModuleMapTester("Foo", in: fs) { result in
             result.checkNotCreated()
             result.checkDiagnostics { result in
-                result.check(diagnostic: "target 'Foo' has invalid header layout: umbrella header found at '/include/Foo.h', but directories exist next to it: /include/Bar; consider removing them", behavior: .error)
+                result.check(diagnostic: "target 'Foo' has invalid header layout: umbrella header found at '/include/Foo.h', but directories exist next to it: /include/Bar; consider removing them", severity: .error)
             }
         }
     }
@@ -146,21 +146,21 @@ class ModuleMapGeneration: XCTestCase {
 
 /// Helper function to test module map generation.  Given a target name and optionally the name of a public-headers directory, this function determines the module map type of the public-headers directory by examining the contents of a file system and invokes a given block to check the module result (including any diagnostics).
 func ModuleMapTester(_ targetName: String, includeDir: String = "include", in fileSystem: FileSystem, _ body: (ModuleMapResult) -> Void) {
+    let observability = ObservabilitySystem.bootstrapForTesting()
     // Create a module map generator, and determine the type of module map to use for the header directory.  This may emit diagnostics.
-    let diagnostics = DiagnosticsEngine()
     let moduleMapGenerator = ModuleMapGenerator(targetName: targetName, moduleName: targetName.spm_mangledToC99ExtendedIdentifier(), publicHeadersDir: AbsolutePath.root.appending(component: includeDir), fileSystem: fileSystem)
-    let moduleMapType = moduleMapGenerator.determineModuleMapType(diagnostics: diagnostics)
+    let moduleMapType = moduleMapGenerator.determineModuleMapType(diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
     
     // Generate a module map and capture any emitted diagnostics.
     let generatedModuleMapPath = AbsolutePath.root.appending(components: "module.modulemap")
-    diagnostics.wrap {
+    DiagnosticsEmitter().trap {
         if let generatedModuleMapType = moduleMapType.generatedModuleMapType {
             try moduleMapGenerator.generateModuleMap(type: generatedModuleMapType, at: generatedModuleMapPath)
         }
     }
     
     // Invoke the closure to check the results.
-    let result = ModuleMapResult(diagnostics: diagnostics, path: generatedModuleMapPath, fs: fileSystem)
+    let result = ModuleMapResult(diagnostics: observability.diagnostics, path: generatedModuleMapPath, fs: fileSystem)
     body(result)
     
     // Check for any unexpected diagnostics (the ones the closure didn't check for).
@@ -168,26 +168,25 @@ func ModuleMapTester(_ targetName: String, includeDir: String = "include", in fi
 }
 
 final class ModuleMapResult {
-
-    private var diags: DiagnosticsEngine
+    private var diagnostics: [Basics.Diagnostic]
     private var diagsChecked: Bool
     private let path: AbsolutePath
     private let fs: FileSystem
 
-    init(diagnostics: DiagnosticsEngine, path: AbsolutePath, fs: FileSystem) {
-        self.diags = diagnostics
+    init(diagnostics: [Basics.Diagnostic], path: AbsolutePath, fs: FileSystem) {
+        self.diagnostics = diagnostics
         self.diagsChecked = false
         self.path = path
         self.fs = fs
     }
 
     func validateDiagnostics(file: StaticString = #file, line: UInt = #line) {
-        if diagsChecked || diags.diagnostics.isEmpty { return }
-        XCTFail("Unchecked diagnostics: \(diags)", file: (file), line: line)
+        if diagsChecked || diagnostics.isEmpty { return }
+        XCTFail("Unchecked diagnostics: \(diagnostics)", file: (file), line: line)
     }
 
-    func checkDiagnostics(_ result: (DiagnosticsEngineResult) throws -> Void) {
-        DiagnosticsEngineTester(diags, result: result)
+    func checkDiagnostics(_ handler: (DiagnosticsTestResult) throws -> Void) {
+        testDiagnostics(diagnostics, handler: handler)
         diagsChecked = true
     }
 

--- a/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
+++ b/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
@@ -153,7 +153,7 @@ func ModuleMapTester(_ targetName: String, includeDir: String = "include", in fi
     
     // Generate a module map and capture any emitted diagnostics.
     let generatedModuleMapPath = AbsolutePath.root.appending(components: "module.modulemap")
-    DiagnosticsEmitter().trap {
+    ObservabilitySystem.topScope.trap {
         if let generatedModuleMapType = moduleMapType.generatedModuleMapType {
             try moduleMapGenerator.generateModuleMap(type: generatedModuleMapType, at: generatedModuleMapPath)
         }

--- a/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
+++ b/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
@@ -149,7 +149,7 @@ func ModuleMapTester(_ targetName: String, includeDir: String = "include", in fi
     let observability = ObservabilitySystem.bootstrapForTesting()
     // Create a module map generator, and determine the type of module map to use for the header directory.  This may emit diagnostics.
     let moduleMapGenerator = ModuleMapGenerator(targetName: targetName, moduleName: targetName.spm_mangledToC99ExtendedIdentifier(), publicHeadersDir: AbsolutePath.root.appending(component: includeDir), fileSystem: fileSystem)
-    let moduleMapType = moduleMapGenerator.determineModuleMapType(diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
+    let moduleMapType = moduleMapGenerator.determineModuleMapType(diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
     
     // Generate a module map and capture any emitted diagnostics.
     let generatedModuleMapPath = AbsolutePath.root.appending(components: "module.modulemap")

--- a/Tests/PackageLoadingTests/PDLoadingTests.swift
+++ b/Tests/PackageLoadingTests/PDLoadingTests.swift
@@ -118,7 +118,7 @@ class PackageDescriptionLoadingTests: XCTestCase {
                 contents,
                 toolsVersion: toolsVersion ?? self.toolsVersion,
                 packageKind: packageKind,
-                diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
                 file: file,
                 line: line)
             
@@ -147,7 +147,7 @@ class PackageDescriptionLoadingTests: XCTestCase {
                 contents,
                 toolsVersion: toolsVersion ?? self.toolsVersion,
                 packageKind: packageKind,
-                diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
                 file: file,
                 line: line)
             

--- a/Tests/PackageLoadingTests/PD_4_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_0_LoadingTests.swift
@@ -8,13 +8,13 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import XCTest
-
-import TSCBasic
-import TSCUtility
+import Basics
+import PackageLoading
 import PackageModel
 import SPMTestSupport
-import PackageLoading
+import TSCBasic
+import TSCUtility
+import XCTest
 
 class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
     override var toolsVersion: ToolsVersion {
@@ -311,14 +311,14 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
 
         try fs.writeFileContents(manifestPath, bytes: stream.bytes)
 
-        let diagnostics = DiagnosticsEngine()
+        let observability = ObservabilitySystem.bootstrapForTesting()
         let manifest = try manifestLoader.load(
             at: .root,
             packageKind: .root,
             packageLocation: "/foo",
             toolsVersion: .v4,
             fileSystem: fs,
-            diagnostics: diagnostics
+            diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
         )
 
         XCTAssertEqual(manifest.name, "Trivial")
@@ -326,8 +326,8 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
         XCTAssertEqual(manifest.targets, [])
         XCTAssertEqual(manifest.dependencies, [])
 
-        DiagnosticsEngineTester(diagnostics) { result in
-            result.check(diagnostic: .contains("initialization of immutable value 'a' was never used"), behavior: .warning)
+        testDiagnostics(observability.diagnostics) { result in
+            result.check(diagnostic: .contains("initialization of immutable value 'a' was never used"), severity: .warning)
         }
     }
 
@@ -347,8 +347,8 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
             """
 
         XCTAssertManifestLoadThrows(manifest) { _, diagnotics in
-            diagnotics.checkUnordered(diagnostic: "duplicate target named 'A'", behavior: .error)
-            diagnotics.checkUnordered(diagnostic: "duplicate target named 'B'", behavior: .error)
+            diagnotics.checkUnordered(diagnostic: "duplicate target named 'A'", severity: .error)
+            diagnotics.checkUnordered(diagnostic: "duplicate target named 'B'", severity: .error)
         }
     }
 
@@ -368,7 +368,7 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
             """
 
         XCTAssertManifestLoadThrows(manifest) { _, diagnostics in
-            diagnostics.check(diagnostic: "product 'Product' doesn't reference any targets", behavior: .error)
+            diagnostics.check(diagnostic: "product 'Product' doesn't reference any targets", severity: .error)
         }
     }
 
@@ -388,7 +388,7 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
             """
 
         XCTAssertManifestLoadThrows(manifest) { _, diagnostics in
-            diagnostics.check(diagnostic: "target 'B' referenced in product 'Product' could not be found; valid targets are: 'A'", behavior: .error)
+            diagnostics.check(diagnostic: "target 'B' referenced in product 'Product' could not be found; valid targets are: 'A'", severity: .error)
         }
     }
 }

--- a/Tests/PackageLoadingTests/PD_4_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_0_LoadingTests.swift
@@ -318,7 +318,7 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
             packageLocation: "/foo",
             toolsVersion: .v4,
             fileSystem: fs,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
         )
 
         XCTAssertEqual(manifest.name, "Trivial")

--- a/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
@@ -826,7 +826,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                                     toolsVersion: .v4_2,
                                     identityResolver: identityResolver,
                                     fileSystem: localFileSystem,
-                                    diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+                                    diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
                                     on: .global()) { result in
                     defer { sync.leave() }
 
@@ -890,7 +890,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                                     toolsVersion: .v4_2,
                                     identityResolver: identityResolver,
                                     fileSystem: localFileSystem,
-                                    diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+                                    diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
                                     on: .global()) { result in
                     defer { sync.leave() }
 

--- a/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
@@ -9,8 +9,8 @@
 */
 
 import Basics
-import PackageModel
 import PackageLoading
+import PackageModel
 import SPMTestSupport
 import TSCBasic
 import TSCUtility
@@ -466,8 +466,8 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             """
 
         XCTAssertManifestLoadThrows(manifest) { _, diagnostics in
-            diagnostics.check(diagnostic: .regex("duplicate dependency 'foo(1|2)'"), behavior: .error)
-            diagnostics.check(diagnostic: .regex("duplicate dependency 'foo(1|2)'"), behavior: .error)
+            diagnostics.check(diagnostic: .regex("duplicate dependency 'foo(1|2)'"), severity: .error)
+            diagnostics.check(diagnostic: .regex("duplicate dependency 'foo(1|2)'"), severity: .error)
         }
     }
 
@@ -740,7 +740,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             """
 
         XCTAssertManifestLoadThrows(manifest) { _, diagnostics in
-            diagnostics.check(diagnostic: "target 'B' referenced in product 'Product' could not be found; valid targets are: 'A', 'C', 'b'", behavior: .error)
+            diagnostics.check(diagnostic: "target 'B' referenced in product 'Product' could not be found; valid targets are: 'A', 'C', 'b'", severity: .error)
         }
     }
 
@@ -793,7 +793,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                     """
             }
 
-            let diagnostics = DiagnosticsEngine()
+            let observability = ObservabilitySystem.bootstrapForTesting()
             let delegate = ManifestTestDelegate()
             let manifestLoader = ManifestLoader(toolchain: ToolchainConfiguration.default, cacheDir: path, delegate: delegate)
             let identityResolver = DefaultIdentityResolver()
@@ -826,7 +826,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                                     toolsVersion: .v4_2,
                                     identityResolver: identityResolver,
                                     fileSystem: localFileSystem,
-                                    diagnostics: diagnostics,
+                                    diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
                                     on: .global()) { result in
                     defer { sync.leave() }
 
@@ -845,8 +845,8 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             }
 
             XCTAssertEqual(delegate.loaded.count, total+1)
-            XCTAssertFalse(diagnostics.hasWarnings, diagnostics.description)
-            XCTAssertFalse(diagnostics.hasErrors, diagnostics.description)
+            XCTAssertFalse(observability.hasWarningDiagnostics, observability.diagnostics.description)
+            XCTAssertFalse(observability.hasErrorDiagnostics, observability.diagnostics.description)
         }
     }
 
@@ -855,7 +855,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
         let total = 1000
         try testWithTemporaryDirectory { path in
 
-            let diagnostics = DiagnosticsEngine()
+            let observability = ObservabilitySystem.bootstrapForTesting()
             let delegate = ManifestTestDelegate()
             let manifestLoader = ManifestLoader(toolchain: ToolchainConfiguration.default, cacheDir: path, delegate: delegate)
             let identityResolver = DefaultIdentityResolver()
@@ -890,7 +890,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                                     toolsVersion: .v4_2,
                                     identityResolver: identityResolver,
                                     fileSystem: localFileSystem,
-                                    diagnostics: diagnostics,
+                                    diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
                                     on: .global()) { result in
                     defer { sync.leave() }
 
@@ -909,8 +909,8 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             }
 
             XCTAssertEqual(delegate.loaded.count, total)
-            XCTAssertFalse(diagnostics.hasWarnings, diagnostics.description)
-            XCTAssertFalse(diagnostics.hasErrors, diagnostics.description)
+            XCTAssertFalse(observability.hasWarningDiagnostics, observability.diagnostics.description)
+            XCTAssertFalse(observability.hasErrorDiagnostics, observability.diagnostics.description)
         }
     }
 

--- a/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
@@ -407,11 +407,12 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
                 diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
             )
 
-            guard let diag = observability.diagnostics.first?.data as? ManifestLoadingDiagnostic else {
+            guard let diagnostic = observability.diagnostics.first else {
                 return XCTFail("Expected a diagnostic")
             }
-            XCTAssertMatch(diag.output, .contains("warning: initialization of immutable value"))
-            let contents = try localFileSystem.readFileContents(diag.diagnosticFile!)
+            XCTAssertMatch(diagnostic.message, .contains("warning: initialization of immutable value"))
+            XCTAssertEqual(diagnostic.severity, .warning)
+            let contents = try diagnostic.metadata?.manifestLoadingDiagnosticFile.map { try localFileSystem.readFileContents($0) }
             XCTAssertNotNil(contents)
         }
     }

--- a/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
@@ -404,7 +404,7 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
                 packageLocation: manifestPath.pathString,
                 toolsVersion: .v5,
                 fileSystem: fs,
-                diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
+                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
             )
 
             guard let diagnostic = observability.diagnostics.first else {
@@ -587,7 +587,7 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
                 packageLocation: manifestPath.pathString,
                 toolsVersion: .v5,
                 fileSystem: fs,
-                diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
+                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
             )
 
             XCTAssertNoDiagnostics(observability.diagnostics)

--- a/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
@@ -8,13 +8,13 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import XCTest
-
+import Basics
+import PackageLoading
+import PackageModel
+import SPMTestSupport
 import TSCBasic
 import TSCUtility
-import SPMTestSupport
-import PackageModel
-import PackageLoading
+import XCTest
 
 class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
     override var toolsVersion: ToolsVersion {
@@ -397,17 +397,17 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
                 """
             }
 
-            let diagnostics = DiagnosticsEngine()
+            let observability = ObservabilitySystem.bootstrapForTesting()
             _ = try loader.load(
                 at: manifestPath.parentDirectory,
                 packageKind: .local,
                 packageLocation: manifestPath.pathString,
                 toolsVersion: .v5,
                 fileSystem: fs,
-                diagnostics: diagnostics
+                diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
             )
 
-            guard let diag = diagnostics.diagnostics.first?.message.data as? ManifestLoadingDiagnostic else {
+            guard let diag = observability.diagnostics.first?.data as? ManifestLoadingDiagnostic else {
                 return XCTFail("Expected a diagnostic")
             }
             XCTAssertMatch(diag.output, .contains("warning: initialization of immutable value"))
@@ -579,17 +579,17 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
                 isManifestSandboxEnabled: false,
                 cacheDir: nil)
 
-            let diagnostics = DiagnosticsEngine()
+            let observability = ObservabilitySystem.bootstrapForTesting()
             let manifest = try manifestLoader.load(
                 at: manifestPath.parentDirectory,
                 packageKind: .local,
                 packageLocation: manifestPath.pathString,
                 toolsVersion: .v5,
                 fileSystem: fs,
-                diagnostics: diagnostics
+                diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
             )
 
-            XCTAssertNoDiagnostics(diagnostics)
+            XCTAssertNoDiagnostics(observability.diagnostics)
             XCTAssertEqual(manifest.name, "Trivial")
 
             let moduleTraceJSON = try XCTUnwrap(try localFileSystem.readFileContents(moduleTraceFilePath).validDescription)

--- a/Tests/PackageLoadingTests/PD_5_2_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_2_LoadingTests.swift
@@ -121,8 +121,8 @@ class PackageDescription5_2LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             XCTAssertManifestLoadThrows(manifest, packageKind: .remote) { _, diagnostics in
-                diagnostics.checkUnordered(diagnostic: "unknown package 'foo1' in dependencies of target 'Target1'; valid packages are: 'Foo', 'Bar'", behavior: .error)
-                diagnostics.checkUnordered(diagnostic: "unknown dependency 'foos' in target 'Target2'; valid dependencies are: 'Foo', 'Bar'", behavior: .error)
+                diagnostics.checkUnordered(diagnostic: "unknown package 'foo1' in dependencies of target 'Target1'; valid packages are: 'Foo', 'Bar'", severity: .error)
+                diagnostics.checkUnordered(diagnostic: "unknown dependency 'foos' in target 'Target2'; valid dependencies are: 'Foo', 'Bar'", severity: .error)
             }
         }
 
@@ -147,7 +147,7 @@ class PackageDescription5_2LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             XCTAssertManifestLoadThrows(manifest, packageKind: .root) { _, diagnostics in
-                diagnostics.checkUnordered(diagnostic: "unknown package 'foo1' in dependencies of target 'Target1'; valid packages are: 'Foo'", behavior: .error)
+                diagnostics.checkUnordered(diagnostic: "unknown package 'foo1' in dependencies of target 'Target1'; valid packages are: 'Foo'", severity: .error)
             }
         }
         
@@ -172,7 +172,7 @@ class PackageDescription5_2LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             XCTAssertManifestLoadThrows(manifest, packageKind: .root) { _, diagnostics in
-                diagnostics.checkUnordered(diagnostic: "unknown package 'foo1' in dependencies of target 'Target1'; valid packages are: 'foo2'", behavior: .error)
+                diagnostics.checkUnordered(diagnostic: "unknown package 'foo1' in dependencies of target 'Target1'; valid packages are: 'foo2'", severity: .error)
             }
         }
 
@@ -198,7 +198,7 @@ class PackageDescription5_2LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             XCTAssertManifestLoadThrows(manifest, packageKind: .root) { _, diagnostics in
-                diagnostics.checkUnordered(diagnostic: "unknown package 'foo3' in dependencies of target 'Target1'; valid packages are: 'foo1', 'foo2'", behavior: .error)
+                diagnostics.checkUnordered(diagnostic: "unknown package 'foo3' in dependencies of target 'Target1'; valid packages are: 'foo1', 'foo2'", severity: .error)
             }
         }
     }
@@ -261,8 +261,8 @@ class PackageDescription5_2LoadingTests: PackageDescriptionLoadingTests {
             """
 
         XCTAssertManifestLoadThrows(manifest) { _, diagnostics in
-            diagnostics.checkUnordered(diagnostic: "duplicate dependency named 'Bar'; consider differentiating them using the 'name' argument", behavior: .error)
-            diagnostics.checkUnordered(diagnostic: "duplicate dependency named 'Biz'; consider differentiating them using the 'name' argument", behavior: .error)
+            diagnostics.checkUnordered(diagnostic: "duplicate dependency named 'Bar'; consider differentiating them using the 'name' argument", severity: .error)
+            diagnostics.checkUnordered(diagnostic: "duplicate dependency named 'Biz'; consider differentiating them using the 'name' argument", severity: .error)
         }
     }
 

--- a/Tests/PackageLoadingTests/PD_5_3_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_3_LoadingTests.swift
@@ -149,7 +149,7 @@ class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             XCTAssertManifestLoadThrows(manifest) { _, diagnostics in
-                diagnostics.check(diagnostic: "invalid type for binary product 'FooLibrary'; products referencing only binary targets must have a type of 'library'", behavior: .error)
+                diagnostics.check(diagnostic: "invalid type for binary product 'FooLibrary'; products referencing only binary targets must have a type of 'library'", severity: .error)
             }
         }
 
@@ -168,7 +168,7 @@ class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             XCTAssertManifestLoadThrows(manifest) { _, diagnostics in
-                diagnostics.check(diagnostic: "invalid type for binary product 'FooLibrary'; products referencing only binary targets must have a type of 'library'", behavior: .error)
+                diagnostics.check(diagnostic: "invalid type for binary product 'FooLibrary'; products referencing only binary targets must have a type of 'library'", severity: .error)
             }
         }
 
@@ -205,7 +205,7 @@ class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             XCTAssertManifestLoadThrows(manifest) { _, diagnostics in
-                diagnostics.check(diagnostic: "invalid location for binary target 'Foo'", behavior: .error)
+                diagnostics.check(diagnostic: "invalid location for binary target 'Foo'", severity: .error)
             }
         }
 
@@ -224,7 +224,7 @@ class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             XCTAssertManifestLoadThrows(manifest) { _, diagnostics in
-                diagnostics.check(diagnostic: "invalid URL scheme for binary target 'Foo'; valid schemes are: 'https'", behavior: .error)
+                diagnostics.check(diagnostic: "invalid URL scheme for binary target 'Foo'; valid schemes are: 'https'", severity: .error)
             }
         }
 
@@ -243,7 +243,7 @@ class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             XCTAssertManifestLoadThrows(manifest) { _, diagnostics in
-                diagnostics.check(diagnostic: "unsupported extension for binary target 'Foo'; valid extensions are: 'xcframework', 'artifactbundle'", behavior: .error)
+                diagnostics.check(diagnostic: "unsupported extension for binary target 'Foo'; valid extensions are: 'xcframework', 'artifactbundle'", severity: .error)
             }
         }
 
@@ -265,7 +265,7 @@ class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             XCTAssertManifestLoadThrows(manifest) { _, diagnostics in
-                diagnostics.check(diagnostic: "unsupported extension for binary target 'Foo'; valid extensions are: 'zip'", behavior: .error)
+                diagnostics.check(diagnostic: "unsupported extension for binary target 'Foo'; valid extensions are: 'zip'", severity: .error)
             }
         }
 
@@ -284,7 +284,7 @@ class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             XCTAssertManifestLoadThrows(manifest) { _, diagnostics in
-                diagnostics.check(diagnostic: "unsupported extension for binary target 'Foo'; valid extensions are: 'xcframework', 'artifactbundle'", behavior: .error)
+                diagnostics.check(diagnostic: "unsupported extension for binary target 'Foo'; valid extensions are: 'xcframework', 'artifactbundle'", severity: .error)
             }
         }
 
@@ -306,7 +306,7 @@ class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             XCTAssertManifestLoadThrows(manifest) { _, diagnostics in
-                diagnostics.check(diagnostic: "unsupported extension for binary target 'Foo'; valid extensions are: 'zip'", behavior: .error)
+                diagnostics.check(diagnostic: "unsupported extension for binary target 'Foo'; valid extensions are: 'zip'", severity: .error)
             }
         }
     }

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -138,7 +138,7 @@ class PackageBuilderTests: XCTestCase {
             package.checkProduct("MyPackage") { _ in }
 
           #if os(Linux)
-            diagnostics.check(diagnostic: "ignoring target 'MyPackageTests' in package 'MyPackage'; C language in tests is not yet supported", severity: .warning)
+            diagnostics.check(diagnostic: "ignoring target 'MyPackageTests' in package 'MyPackage'; C language in tests is not yet supported", severity: .warning, context: "'' /")
           #elseif os(macOS) || os(Android)
             package.checkProduct("MyPackagePackageTests") { _ in }
           #endif

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -2399,7 +2399,7 @@ final class PackageBuilderTester {
         } catch {
             let errorString = String(describing: error)
             result = .error(errorString)
-            DiagnosticsEmitter().emit(error: errorString)
+            ObservabilitySystem.topScope.emit(error)
         }
 
         testDiagnostics(observability.diagnostics) { diagnostics in

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -77,10 +77,12 @@ class PackageBuilderTests: XCTestCase {
             )
 
             PackageBuilderTester(manifest, path: path, in: fs) { package, diagnostics in
+                var expectedMetadata = ObservabilityMetadata.packageMetadata(identity: .init(url: manifest.packageLocation), location: manifest.packageLocation)
+                expectedMetadata.targetName = manifest.targets.first!.name
                 diagnostics.check(
                     diagnostic: "ignoring broken symlink \(linkPath)",
                     severity: .warning,
-                    metadata: .packageMetadata(identity: .init(url: manifest.packageLocation), location: manifest.packageLocation)
+                    metadata: expectedMetadata
                 )
                 package.checkModule("foo")
             }
@@ -243,10 +245,12 @@ class PackageBuilderTests: XCTestCase {
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, diags in
+            var expectedMetadata = ObservabilityMetadata.packageMetadata(identity: .init(url: manifest.packageLocation), location: manifest.packageLocation)
+            expectedMetadata.targetName = manifest.targets.first!.name
             diags.check(
                 diagnostic: "found duplicate sources declaration in the package manifest: /Sources/clib",
                 severity: .warning,
-                metadata: .packageMetadata(identity: .init(url: manifest.packageLocation), location: manifest.packageLocation)
+                metadata: expectedMetadata
             )
             package.checkModule("clib") { module in
                 module.check(c99name: "clib", type: .library)

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -80,7 +80,8 @@ class PackageBuilderTests: XCTestCase {
                 diagnostics.check(
                     diagnostic: "ignoring broken symlink \(linkPath)",
                     severity: .warning,
-                    context: "'' /")
+                    metadata: .packageMetadata(identity: .init(url: manifest.packageLocation), location: manifest.packageLocation)
+                )
                 package.checkModule("foo")
             }
         }
@@ -138,7 +139,11 @@ class PackageBuilderTests: XCTestCase {
             package.checkProduct("MyPackage") { _ in }
 
           #if os(Linux)
-            diagnostics.check(diagnostic: "ignoring target 'MyPackageTests' in package 'MyPackage'; C language in tests is not yet supported", severity: .warning, context: "'' /")
+            diagnostics.check(
+                diagnostic: "ignoring target 'MyPackageTests' in package 'MyPackage'; C language in tests is not yet supported",
+                severity: .warning,
+                metadata: .packageMetadata(identity: .init(url: manifest.packageLocation), location: manifest.packageLocation)
+            )
           #elseif os(macOS) || os(Android)
             package.checkProduct("MyPackagePackageTests") { _ in }
           #endif
@@ -238,7 +243,11 @@ class PackageBuilderTests: XCTestCase {
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, diags in
-            diags.check(diagnostic: "found duplicate sources declaration in the package manifest: /Sources/clib", severity: .warning, context: "'' /")
+            diags.check(
+                diagnostic: "found duplicate sources declaration in the package manifest: /Sources/clib",
+                severity: .warning,
+                metadata: .packageMetadata(identity: .init(url: manifest.packageLocation), location: manifest.packageLocation)
+            )
             package.checkModule("clib") { module in
                 module.check(c99name: "clib", type: .library)
                 module.checkSources(root: "/Sources", paths: "clib/clib.c", "clib/clib2.c", "clib/nested/nested.c")
@@ -484,7 +493,7 @@ class PackageBuilderTests: XCTestCase {
             diagnostics.check(
                 diagnostic: "'exec2' was identified as an executable target given the presence of a 'main.swift' file. Starting with tools version 5.4.0 executable targets should be declared as 'executableTarget()'",
                 severity: .warning,
-                context: "'' /"
+                metadata: .packageMetadata(identity: .init(url: manifest.packageLocation), location: manifest.packageLocation)
             )
             package.checkModule("lib") { _ in }
             package.checkModule("exec2") { _ in }
@@ -1086,7 +1095,11 @@ class PackageBuilderTests: XCTestCase {
                 ]
             )
             PackageBuilderTester(manifest, in: fs) { package, diagnostics in
-                diagnostics.check(diagnostic: "Source files for target pkg2 should be located under /Sources/pkg2", severity: .warning, context: "'' /")
+                diagnostics.check(
+                    diagnostic: "Source files for target pkg2 should be located under /Sources/pkg2",
+                    severity: .warning,
+                    metadata: .packageMetadata(identity: .init(url: manifest.packageLocation), location: manifest.packageLocation)
+                )
                 package.checkModule("pkg1") { module in
                     module.check(c99name: "pkg1", type: .library)
                     module.checkSources(root: "/Sources/pkg1", paths: "Foo.swift")
@@ -1459,11 +1472,13 @@ class PackageBuilderTests: XCTestCase {
             diagnostics.check(
                 diagnostic: "ignoring duplicate product 'foo' (static)",
                 severity: .warning,
-                context: "'' /")
+                metadata: .packageMetadata(identity: .init(url: manifest.packageLocation), location: manifest.packageLocation)
+            )
             diagnostics.check(
                 diagnostic: "ignoring duplicate product 'foo' (dynamic)",
                 severity: .warning,
-                context: "'' /")
+                metadata: .packageMetadata(identity: .init(url: manifest.packageLocation), location: manifest.packageLocation)
+            )
         }
     }
 
@@ -1489,7 +1504,8 @@ class PackageBuilderTests: XCTestCase {
             diagnostics.check(
                 diagnostic: "ignoring declared target(s) 'foo, bar' in the system package",
                 severity: .warning,
-                context: "'' /")
+                metadata: .packageMetadata(identity: .init(url: manifest.packageLocation), location: manifest.packageLocation)
+            )
         }
     }
 
@@ -1547,7 +1563,8 @@ class PackageBuilderTests: XCTestCase {
             diagnostics.check(
                 diagnostic: "system library product foo shouldn't have a type and contain only one target",
                 severity: .error,
-                context: "'' /")
+                metadata: .packageMetadata(identity: .init(url: manifest.packageLocation), location: manifest.packageLocation)
+            )
         }
 
         manifest = Manifest.createV4Manifest(
@@ -1566,7 +1583,8 @@ class PackageBuilderTests: XCTestCase {
             diagnostics.check(
                 diagnostic: "system library product foo shouldn't have a type and contain only one target",
                 severity: .error,
-                context: "'' /")
+                metadata: .packageMetadata(identity: .init(url: manifest.packageLocation), location: manifest.packageLocation)
+            )
         }
         
         manifest = Manifest.createV4Manifest(
@@ -1619,18 +1637,21 @@ class PackageBuilderTests: XCTestCase {
                     a 'main.swift' file
                     """,
                 severity: .error,
-                context: "'' /")
+                metadata: .packageMetadata(identity: .init(url: manifest.packageLocation), location: manifest.packageLocation)
+            )
             diagnostics.check(
                 diagnostic: """
                     executable product 'foo2' should have one executable target; an executable target requires a \
                     'main.swift' file
                     """,
                 severity: .error,
-                context: "'' /")
+                metadata: .packageMetadata(identity: .init(url: manifest.packageLocation), location: manifest.packageLocation)
+            )
             diagnostics.check(
                 diagnostic: "executable product 'foo3' should not have more than one executable target",
                 severity: .error,
-                context: "'' /")
+                metadata: .packageMetadata(identity: .init(url: manifest.packageLocation), location: manifest.packageLocation)
+            )
         }
     }
 
@@ -1652,7 +1673,8 @@ class PackageBuilderTests: XCTestCase {
             diagnostics.check(
                 diagnostic: "unable to synthesize a REPL product as there are no library targets in the package",
                 severity: .error,
-                context: "'' /")
+                metadata: .packageMetadata(identity: .init(url: manifest.packageLocation), location: manifest.packageLocation)
+            )
         }
     }
 
@@ -2163,7 +2185,7 @@ class PackageBuilderTests: XCTestCase {
             "/Bar/Sources/Bar/bar.swift"
         )
 
-        let manifest1 = Manifest.createManifest(
+        let manifest = Manifest.createManifest(
             name: "Foo",
             v: .v5,
             dependencies: [
@@ -2182,11 +2204,19 @@ class PackageBuilderTests: XCTestCase {
             ]
         )
 
-        PackageBuilderTester(manifest1, path: AbsolutePath("/Foo"), in: fs) { package, diagnostics in
+        PackageBuilderTester(manifest, path: AbsolutePath("/Foo"), in: fs) { package, diagnostics in
             package.checkModule("Foo")
             package.checkModule("Foo2")
-            diagnostics.checkUnordered(diagnostic: "invalid duplicate target dependency declaration 'Bar' in target 'Foo' from package 'Foo'", severity: .warning, context: "'' /")
-            diagnostics.checkUnordered(diagnostic: "invalid duplicate target dependency declaration 'Foo2' in target 'Foo' from package 'Foo'", severity: .warning, context: "'' /")
+            diagnostics.checkUnordered(
+                diagnostic: "invalid duplicate target dependency declaration 'Bar' in target 'Foo' from package 'Foo'",
+                severity: .warning,
+                metadata: .packageMetadata(identity: .init(url: manifest.packageLocation), location: manifest.packageLocation)
+            )
+            diagnostics.checkUnordered(
+                diagnostic: "invalid duplicate target dependency declaration 'Foo2' in target 'Foo' from package 'Foo'",
+                severity: .warning,
+                metadata: .packageMetadata(identity: .init(url: manifest.packageLocation), location: manifest.packageLocation)
+            )
         }
     }
 

--- a/Tests/PackageLoadingTests/PkgConfigTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigTests.swift
@@ -32,7 +32,7 @@ class PkgConfigTests: XCTestCase {
     func testBasics() throws {
         // No pkgConfig name.
         do {
-            let result = pkgConfigArgs(for: SystemLibraryTarget(pkgConfig: ""), diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
+            let result = pkgConfigArgs(for: SystemLibraryTarget(pkgConfig: ""), diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
             XCTAssertTrue(result.isEmpty)
         }
 
@@ -46,7 +46,7 @@ class PkgConfigTests: XCTestCase {
                     .yum(["libFoo-devel"])
                 ]
             )
-            for result in pkgConfigArgs(for: target, diagnostics: ObservabilitySystem.makeDiagnosticsEngine()) {
+            for result in pkgConfigArgs(for: target, diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()) {
                 XCTAssertEqual(result.pkgConfigName, "Foo")
                 XCTAssertEqual(result.cFlags, [])
                 XCTAssertEqual(result.libs, [])
@@ -71,7 +71,7 @@ class PkgConfigTests: XCTestCase {
 
         // Pc file.
         try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
-            for result in pkgConfigArgs(for: SystemLibraryTarget(pkgConfig: "Foo"), diagnostics: ObservabilitySystem.makeDiagnosticsEngine()) {
+            for result in pkgConfigArgs(for: SystemLibraryTarget(pkgConfig: "Foo"), diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()) {
                 XCTAssertEqual(result.pkgConfigName, "Foo")
                 XCTAssertEqual(result.cFlags, ["-I/path/to/inc", "-I\(inputsDir.pathString)"])
                 XCTAssertEqual(result.libs, ["-L/usr/da/lib", "-lSystemModule", "-lok"])
@@ -83,7 +83,7 @@ class PkgConfigTests: XCTestCase {
 
         // Pc file with prohibited flags.
         try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
-            for result in pkgConfigArgs(for: SystemLibraryTarget(pkgConfig: "Bar"), diagnostics: ObservabilitySystem.makeDiagnosticsEngine()) {
+            for result in pkgConfigArgs(for: SystemLibraryTarget(pkgConfig: "Bar"), diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()) {
                 XCTAssertEqual(result.pkgConfigName, "Bar")
                 XCTAssertEqual(result.cFlags, ["-I/path/to/inc"])
                 XCTAssertEqual(result.libs, ["-L/usr/da/lib", "-lSystemModule", "-lok"])
@@ -102,7 +102,7 @@ class PkgConfigTests: XCTestCase {
     func testDependencies() throws {
         // Use additionalSearchPaths instead of pkgConfigArgs to test handling
         // of search paths when loading dependencies.
-        let result = try PkgConfig(name: "Dependent", additionalSearchPaths: [inputsDir], diagnostics: ObservabilitySystem.makeDiagnosticsEngine(), brewPrefix: nil)
+        let result = try PkgConfig(name: "Dependent", additionalSearchPaths: [inputsDir], diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(), brewPrefix: nil)
 
         XCTAssertEqual(result.name, "Dependent")
         XCTAssertEqual(result.cFlags, ["-I/path/to/dependent/include", "-I/path/to/dependency/include"])

--- a/Tests/PackageLoadingTests/PkgConfigTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigTests.swift
@@ -8,13 +8,13 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import XCTest
-
-import TSCBasic
-import PackageModel
+import Basics
 import PackageLoading
-import TSCUtility
+import PackageModel
 import SPMTestSupport
+import TSCBasic
+import TSCUtility
+import XCTest
 
 extension SystemLibraryTarget {
     convenience init(pkgConfig: String, providers: [SystemPackageProviderDescription] = []) {
@@ -27,14 +27,12 @@ extension SystemLibraryTarget {
 }
 
 class PkgConfigTests: XCTestCase {
-
     let inputsDir = AbsolutePath(#file).parentDirectory.appending(components: "Inputs")
-    let diagnostics = DiagnosticsEngine()
 
     func testBasics() throws {
         // No pkgConfig name.
         do {
-            let result = pkgConfigArgs(for: SystemLibraryTarget(pkgConfig: ""), diagnostics: diagnostics)
+            let result = pkgConfigArgs(for: SystemLibraryTarget(pkgConfig: ""), diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
             XCTAssertTrue(result.isEmpty)
         }
 
@@ -48,7 +46,7 @@ class PkgConfigTests: XCTestCase {
                     .yum(["libFoo-devel"])
                 ]
             )
-            for result in pkgConfigArgs(for: target, diagnostics: diagnostics) {
+            for result in pkgConfigArgs(for: target, diagnostics: ObservabilitySystem.makeDiagnosticsEngine()) {
                 XCTAssertEqual(result.pkgConfigName, "Foo")
                 XCTAssertEqual(result.cFlags, [])
                 XCTAssertEqual(result.libs, [])
@@ -73,7 +71,7 @@ class PkgConfigTests: XCTestCase {
 
         // Pc file.
         try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
-            for result in pkgConfigArgs(for: SystemLibraryTarget(pkgConfig: "Foo"), diagnostics: diagnostics) {
+            for result in pkgConfigArgs(for: SystemLibraryTarget(pkgConfig: "Foo"), diagnostics: ObservabilitySystem.makeDiagnosticsEngine()) {
                 XCTAssertEqual(result.pkgConfigName, "Foo")
                 XCTAssertEqual(result.cFlags, ["-I/path/to/inc", "-I\(inputsDir.pathString)"])
                 XCTAssertEqual(result.libs, ["-L/usr/da/lib", "-lSystemModule", "-lok"])
@@ -85,7 +83,7 @@ class PkgConfigTests: XCTestCase {
 
         // Pc file with prohibited flags.
         try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
-            for result in pkgConfigArgs(for: SystemLibraryTarget(pkgConfig: "Bar"), diagnostics: diagnostics) {
+            for result in pkgConfigArgs(for: SystemLibraryTarget(pkgConfig: "Bar"), diagnostics: ObservabilitySystem.makeDiagnosticsEngine()) {
                 XCTAssertEqual(result.pkgConfigName, "Bar")
                 XCTAssertEqual(result.cFlags, ["-I/path/to/inc"])
                 XCTAssertEqual(result.libs, ["-L/usr/da/lib", "-lSystemModule", "-lok"])
@@ -104,7 +102,7 @@ class PkgConfigTests: XCTestCase {
     func testDependencies() throws {
         // Use additionalSearchPaths instead of pkgConfigArgs to test handling
         // of search paths when loading dependencies.
-        let result = try PkgConfig(name: "Dependent", additionalSearchPaths: [inputsDir], diagnostics: diagnostics, brewPrefix: nil)
+        let result = try PkgConfig(name: "Dependent", additionalSearchPaths: [inputsDir], diagnostics: ObservabilitySystem.makeDiagnosticsEngine(), brewPrefix: nil)
 
         XCTAssertEqual(result.name, "Dependent")
         XCTAssertEqual(result.cFlags, ["-I/path/to/dependent/include", "-I/path/to/dependency/include"])

--- a/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
+++ b/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
@@ -53,7 +53,8 @@ class TargetSourcesBuilderTests: XCTestCase {
             path: .root,
             defaultLocalization: nil,
             toolsVersion: .v5,
-            fileSystem: fs
+            fileSystem: fs,
+            observabilityScope: ObservabilitySystem.topScope
         )
 
         let contents = builder.computeContents().map{ $0.pathString }.sorted()
@@ -97,7 +98,8 @@ class TargetSourcesBuilderTests: XCTestCase {
             path: .root,
             defaultLocalization: nil,
             toolsVersion: .v5_3,
-            fileSystem: fs
+            fileSystem: fs,
+            observabilityScope: ObservabilitySystem.topScope
         )
 
         let contents = builder.computeContents().map{ $0.pathString }.sorted()
@@ -196,10 +198,11 @@ class TargetSourcesBuilderTests: XCTestCase {
             )
 
             build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, location, diagnostics in
-                let metadata = DiagnosticsMetadata.packageMetadata(identity: identity, location: location)
-                diagnostics.check(diagnostic: "multiple resources named 'foo.txt' in target 'Foo'", severity: .error, metadata: metadata)
-                diagnostics.checkUnordered(diagnostic: "found 'Resources/foo.txt'", severity: .info, metadata: metadata)
-                diagnostics.checkUnordered(diagnostic: "found 'Resources/Sub/foo.txt'", severity: .info, metadata: metadata)
+                var expectedMetadata = ObservabilityMetadata.packageMetadata(identity: identity, location: location)
+                expectedMetadata.targetName = target.name
+                diagnostics.check(diagnostic: "multiple resources named 'foo.txt' in target 'Foo'", severity: .error, metadata: expectedMetadata)
+                diagnostics.checkUnordered(diagnostic: "found 'Resources/foo.txt'", severity: .info, metadata: expectedMetadata)
+                diagnostics.checkUnordered(diagnostic: "found 'Resources/Sub/foo.txt'", severity: .info, metadata: expectedMetadata)
             }
         }
 
@@ -217,10 +220,11 @@ class TargetSourcesBuilderTests: XCTestCase {
             )
 
             build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, location, diagnostics in
-                let metadata = DiagnosticsMetadata.packageMetadata(identity: identity, location: location)
-                diagnostics.check(diagnostic: "multiple resources named 'foo.txt' in target 'Foo'", severity: .error, metadata: metadata)
-                diagnostics.checkUnordered(diagnostic: "found 'Processed/foo.txt'", severity: .info, metadata: metadata)
-                diagnostics.checkUnordered(diagnostic: "found 'Copied/foo.txt'", severity: .info, metadata: metadata)
+                var expectedMetadata = ObservabilityMetadata.packageMetadata(identity: identity, location: location)
+                expectedMetadata.targetName = target.name
+                diagnostics.check(diagnostic: "multiple resources named 'foo.txt' in target 'Foo'", severity: .error, metadata: expectedMetadata)
+                diagnostics.checkUnordered(diagnostic: "found 'Processed/foo.txt'", severity: .info, metadata: expectedMetadata)
+                diagnostics.checkUnordered(diagnostic: "found 'Copied/foo.txt'", severity: .info, metadata: expectedMetadata)
             }
         }
 
@@ -256,10 +260,11 @@ class TargetSourcesBuilderTests: XCTestCase {
             )
 
             build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, location, diagnostics in
-                let metadata = DiagnosticsMetadata.packageMetadata(identity: identity, location: location)
-                diagnostics.check(diagnostic: "multiple resources named 'Copy' in target 'Foo'", severity: .error, metadata: metadata)
-                diagnostics.checkUnordered(diagnostic: "found 'A/Copy'", severity: .info, metadata: metadata)
-                diagnostics.checkUnordered(diagnostic: "found 'B/Copy'", severity: .info, metadata: metadata)
+                var expectedMetadata = ObservabilityMetadata.packageMetadata(identity: identity, location: location)
+                expectedMetadata.targetName = target.name
+                diagnostics.check(diagnostic: "multiple resources named 'Copy' in target 'Foo'", severity: .error, metadata: expectedMetadata)
+                diagnostics.checkUnordered(diagnostic: "found 'A/Copy'", severity: .info, metadata: expectedMetadata)
+                diagnostics.checkUnordered(diagnostic: "found 'B/Copy'", severity: .info, metadata: expectedMetadata)
             }
         }
 
@@ -277,10 +282,11 @@ class TargetSourcesBuilderTests: XCTestCase {
             )
 
             build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, location, diagnostics in
-                let metadata = DiagnosticsMetadata.packageMetadata(identity: identity, location: location)
-                diagnostics.check(diagnostic: "multiple resources named 'en.lproj/foo.txt' in target 'Foo'", severity: .error, metadata: metadata)
-                diagnostics.checkUnordered(diagnostic: "found 'A/en.lproj/foo.txt'", severity: .info, metadata: metadata)
-                diagnostics.checkUnordered(diagnostic: "found 'B/EN.lproj/foo.txt'", severity: .info, metadata: metadata)
+                var expectedMetadata = ObservabilityMetadata.packageMetadata(identity: identity, location: location)
+                expectedMetadata.targetName = target.name
+                diagnostics.check(diagnostic: "multiple resources named 'en.lproj/foo.txt' in target 'Foo'", severity: .error, metadata: expectedMetadata)
+                diagnostics.checkUnordered(diagnostic: "found 'A/en.lproj/foo.txt'", severity: .info, metadata: expectedMetadata)
+                diagnostics.checkUnordered(diagnostic: "found 'B/EN.lproj/foo.txt'", severity: .info, metadata: expectedMetadata)
             }
         }
 
@@ -298,10 +304,12 @@ class TargetSourcesBuilderTests: XCTestCase {
             )
 
             build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, location, diagnostics in
+                var expectedMetadata = ObservabilityMetadata.packageMetadata(identity: identity, location: location)
+                expectedMetadata.targetName = target.name
                 diagnostics.check(
                     diagnostic: "resource 'B/en.lproj' in target 'Foo' conflicts with other localization directories",
                     severity: .error,
-                    metadata: .packageMetadata(identity: identity, location: location)
+                    metadata: expectedMetadata
                 )
             }
         }
@@ -332,10 +340,12 @@ class TargetSourcesBuilderTests: XCTestCase {
         )
 
         build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, location, diagnostics in
+            var expectedMetadata = ObservabilityMetadata.packageMetadata(identity: identity, location: location)
+            expectedMetadata.targetName = target.name
             diagnostics.check(
                 diagnostic: "localization directory 'Processed/en.lproj' in target 'Foo' contains sub-directories, which is forbidden",
                 severity: .error,
-                metadata: .packageMetadata(identity: identity, location: location)
+                metadata: expectedMetadata
             )
         }
     }
@@ -350,13 +360,15 @@ class TargetSourcesBuilderTests: XCTestCase {
         )
 
         build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, location, diagnostics in
+            var expectedMetadata = ObservabilityMetadata.packageMetadata(identity: identity, location: location)
+            expectedMetadata.targetName = target.name
             diagnostics.check(
                 diagnostic: .contains("""
                     resource 'Resources/en.lproj/Localizable.strings' in target 'Foo' is in a localization directory \
                     and has an explicit localization declaration
                     """),
                 severity: .error,
-                metadata: .packageMetadata(identity: identity, location: location)
+                metadata: expectedMetadata
             )
         }
     }
@@ -379,10 +391,12 @@ class TargetSourcesBuilderTests: XCTestCase {
         )
 
         build(target: target, defaultLocalization: "fr", toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, location, diagnostics in
+            var expectedMetadata = ObservabilityMetadata.packageMetadata(identity: identity, location: location)
+            expectedMetadata.targetName = target.name
             diagnostics.check(
                 diagnostic: .contains("resource 'Icon.png' in target 'Foo' is missing the default localization 'fr'"),
                 severity: .warning,
-                metadata: .packageMetadata(identity: identity, location: location)
+                metadata: expectedMetadata
             )
         }
     }
@@ -406,26 +420,27 @@ class TargetSourcesBuilderTests: XCTestCase {
         )
 
         build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, location, diagnostics in
-            let metadata = DiagnosticsMetadata.packageMetadata(identity: identity, location: location)
+            var expectedMetadata = ObservabilityMetadata.packageMetadata(identity: identity, location: location)
+            expectedMetadata.targetName = target.name
             diagnostics.checkUnordered(
                 diagnostic: .contains("resource 'Localizable.strings' in target 'Foo' has both localized and un-localized variants"),
                 severity: .warning,
-                metadata: metadata
+                metadata: expectedMetadata
             )
             diagnostics.checkUnordered(
                 diagnostic: .contains("resource 'Storyboard.storyboard' in target 'Foo' has both localized and un-localized variants"),
                 severity: .warning,
-                metadata: metadata
+                metadata: expectedMetadata
             )
             diagnostics.checkUnordered(
                 diagnostic: .contains("resource 'Image.png' in target 'Foo' has both localized and un-localized variants"),
                 severity: .warning,
-                metadata: metadata
+                metadata: expectedMetadata
             )
             diagnostics.checkUnordered(
                 diagnostic: .contains("resource 'Icon.png' in target 'Foo' has both localized and un-localized variants"),
                 severity: .warning,
-                metadata: metadata
+                metadata: expectedMetadata
             )
         }
     }
@@ -490,10 +505,12 @@ class TargetSourcesBuilderTests: XCTestCase {
             )
 
             build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, location, diagnostics in
+                var expectedMetadata = ObservabilityMetadata.packageMetadata(identity: identity, location: location)
+                expectedMetadata.targetName = target.name
                 diagnostics.check(
                     diagnostic: .contains("resource 'Resources/Processed/Info.plist' in target 'Foo' is forbidden"),
                     severity: .error,
-                    metadata: .packageMetadata(identity: .plain("test"), location: "/test")
+                    metadata: expectedMetadata
                 )
             }
         }
@@ -508,10 +525,12 @@ class TargetSourcesBuilderTests: XCTestCase {
             )
 
             build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, location, diagnostics in
+                var expectedMetadata = ObservabilityMetadata.packageMetadata(identity: identity, location: location)
+                expectedMetadata.targetName = target.name
                 diagnostics.check(
                     diagnostic: .contains("resource 'Resources/Copied/Info.plist' in target 'Foo' is forbidden"),
                     severity: .error,
-                    metadata: .packageMetadata(identity: identity, location: location)
+                    metadata: expectedMetadata
                 )
             }
         }
@@ -537,7 +556,8 @@ class TargetSourcesBuilderTests: XCTestCase {
             defaultLocalization: defaultLocalization,
             additionalFileRules: additionalFileRules,
             toolsVersion: toolsVersion,
-            fileSystem: fs
+            fileSystem: fs,
+            observabilityScope: ObservabilitySystem.topScope
         )
 
         do {
@@ -578,13 +598,15 @@ class TargetSourcesBuilderTests: XCTestCase {
             path: .root,
             defaultLocalization: nil,
             toolsVersion: .v5,
-            fileSystem: fs
+            fileSystem: fs,
+            observabilityScope: ObservabilitySystem.topScope
         )
 
         testDiagnostics(observability.diagnostics) { result in
-            let metadata = DiagnosticsMetadata.packageMetadata(identity: builder.packageIdentity, location: builder.packageLocation)
-            result.checkUnordered(diagnostic: "Invalid Exclude '/fileOutsideRoot.py': File not found.", severity: .warning, metadata: metadata)
-            result.checkUnordered(diagnostic: "Invalid Exclude '/fakeDir': File not found.", severity: .warning, metadata: metadata)
+            var expectedMetadata = ObservabilityMetadata.packageMetadata(identity: builder.packageIdentity, location: builder.packageLocation)
+            expectedMetadata.targetName = target.name
+            result.checkUnordered(diagnostic: "Invalid Exclude '/fileOutsideRoot.py': File not found.", severity: .warning, metadata: expectedMetadata)
+            result.checkUnordered(diagnostic: "Invalid Exclude '/fakeDir': File not found.", severity: .warning, metadata: expectedMetadata)
         }
     }
     
@@ -616,14 +638,16 @@ class TargetSourcesBuilderTests: XCTestCase {
             path: .root,
             defaultLocalization: nil,
             toolsVersion: .v5,
-            fileSystem: fs
+            fileSystem: fs,
+            observabilityScope: ObservabilitySystem.topScope
         )
         _ = try builder.run()
 
         testDiagnostics(observability.diagnostics) { result in
-            let metadata = DiagnosticsMetadata.packageMetadata(identity: builder.packageIdentity, location: builder.packageLocation)
-            result.checkUnordered(diagnostic: "Invalid Resource '../../../Fake.txt': File not found.", severity: .warning, metadata: metadata)
-            result.checkUnordered(diagnostic: "Invalid Resource 'NotReal': File not found.", severity: .warning, metadata: metadata)
+            var expectedMetadata = ObservabilityMetadata.packageMetadata(identity: builder.packageIdentity, location: builder.packageLocation)
+            expectedMetadata.targetName = target.name
+            result.checkUnordered(diagnostic: "Invalid Resource '../../../Fake.txt': File not found.", severity: .warning, metadata: expectedMetadata)
+            result.checkUnordered(diagnostic: "Invalid Resource 'NotReal': File not found.", severity: .warning, metadata: expectedMetadata)
         }
     }
     
@@ -656,14 +680,16 @@ class TargetSourcesBuilderTests: XCTestCase {
             path: .root,
             defaultLocalization: nil,
             toolsVersion: .v5,
-            fileSystem: fs
+            fileSystem: fs,
+            observabilityScope: ObservabilitySystem.topScope
         )
 
         testDiagnostics(observability.diagnostics) { result in
-            let metadata = DiagnosticsMetadata.packageMetadata(identity: builder.packageIdentity, location: builder.packageLocation)
-            result.checkUnordered(diagnostic: "Invalid Source '/InvalidPackage.swift': File not found.", severity: .warning, metadata: metadata)
-            result.checkUnordered(diagnostic: "Invalid Source '/DoesNotExist.swift': File not found.", severity: .warning, metadata: metadata)
-            result.checkUnordered(diagnostic: "Invalid Source '/Tests/InvalidPackageTests/InvalidPackageTests.swift': File not found.", severity: .warning, metadata: metadata)
+            var expectedMetadata = ObservabilityMetadata.packageMetadata(identity: builder.packageIdentity, location: builder.packageLocation)
+            expectedMetadata.targetName = target.name
+            result.checkUnordered(diagnostic: "Invalid Source '/InvalidPackage.swift': File not found.", severity: .warning, metadata: expectedMetadata)
+            result.checkUnordered(diagnostic: "Invalid Source '/DoesNotExist.swift': File not found.", severity: .warning, metadata: expectedMetadata)
+            result.checkUnordered(diagnostic: "Invalid Source '/Tests/InvalidPackageTests/InvalidPackageTests.swift': File not found.", severity: .warning, metadata: expectedMetadata)
         }
     }
 
@@ -694,13 +720,15 @@ class TargetSourcesBuilderTests: XCTestCase {
             path: .root,
             defaultLocalization: nil,
             toolsVersion: .v5_5,
-            fileSystem: fs
+            fileSystem: fs,
+            observabilityScope: ObservabilitySystem.topScope
         )
         _ = try builder.run()
 
         testDiagnostics(observability.diagnostics) { result in
-            let metadata = DiagnosticsMetadata.packageMetadata(identity: builder.packageIdentity, location: builder.packageLocation)
-            result.check(diagnostic: "found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target\n    /Foo.xcdatamodel\n", severity: .warning, metadata: metadata)
+            var expectedMetadata = ObservabilityMetadata.packageMetadata(identity: builder.packageIdentity, location: builder.packageLocation)
+            expectedMetadata.targetName = target.name
+            result.check(diagnostic: "found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target\n    /Foo.xcdatamodel\n", severity: .warning, metadata: expectedMetadata)
         }
     }
 
@@ -732,7 +760,8 @@ class TargetSourcesBuilderTests: XCTestCase {
             defaultLocalization: nil,
             additionalFileRules: FileRuleDescription.swiftpmFileTypes,
             toolsVersion: .v5_5,
-            fileSystem: fs
+            fileSystem: fs,
+            observabilityScope: ObservabilitySystem.topScope
         )
         _ = try builder.run()
 

--- a/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
+++ b/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
@@ -143,7 +143,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             toolsVersion: .minimumRequired,
             fileTypes: ["something"])
 
-        build(target: target, additionalFileRules: [somethingRule], toolsVersion: .v5, fs: fs) { _, _, _, _,_  in
+        build(target: target, additionalFileRules: [somethingRule], toolsVersion: .v5, fs: fs) { _, _, _, _, _, _, _  in
             // No diagnostics
         }
     }
@@ -174,7 +174,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             fileTypes: ["something"]
         )
 
-        build(target: target, additionalFileRules: [somethingRule], toolsVersion: .v5_5, fs: fs) { sources, _, _, _,_  in
+        build(target: target, additionalFileRules: [somethingRule], toolsVersion: .v5_5, fs: fs) { sources, _, _, _, _, _, _  in
             XCTAssertEqual(
                 sources.paths.map(\.pathString).sorted(),
                 files.sorted()
@@ -195,10 +195,11 @@ class TargetSourcesBuilderTests: XCTestCase {
                 "/Resources/Sub/foo.txt"
             )
 
-            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, diagnostics in
-                diagnostics.check(diagnostic: "multiple resources named 'foo.txt' in target 'Foo'", severity: .error, context: "'test' /test")
-                diagnostics.checkUnordered(diagnostic: "found 'Resources/foo.txt'", severity: .note, context: "'test' /test")
-                diagnostics.checkUnordered(diagnostic: "found 'Resources/Sub/foo.txt'", severity: .note, context: "'test' /test")
+            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, location, diagnostics in
+                let metadata = DiagnosticsMetadata.packageMetadata(identity: identity, location: location)
+                diagnostics.check(diagnostic: "multiple resources named 'foo.txt' in target 'Foo'", severity: .error, metadata: metadata)
+                diagnostics.checkUnordered(diagnostic: "found 'Resources/foo.txt'", severity: .info, metadata: metadata)
+                diagnostics.checkUnordered(diagnostic: "found 'Resources/Sub/foo.txt'", severity: .info, metadata: metadata)
             }
         }
 
@@ -215,10 +216,11 @@ class TargetSourcesBuilderTests: XCTestCase {
                 "/Copied/foo.txt"
             )
 
-            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, diagnostics in
-                diagnostics.check(diagnostic: "multiple resources named 'foo.txt' in target 'Foo'", severity: .error, context: "'test' /test")
-                diagnostics.checkUnordered(diagnostic: "found 'Processed/foo.txt'", severity: .note, context: "'test' /test")
-                diagnostics.checkUnordered(diagnostic: "found 'Copied/foo.txt'", severity: .note, context: "'test' /test")
+            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, location, diagnostics in
+                let metadata = DiagnosticsMetadata.packageMetadata(identity: identity, location: location)
+                diagnostics.check(diagnostic: "multiple resources named 'foo.txt' in target 'Foo'", severity: .error, metadata: metadata)
+                diagnostics.checkUnordered(diagnostic: "found 'Processed/foo.txt'", severity: .info, metadata: metadata)
+                diagnostics.checkUnordered(diagnostic: "found 'Copied/foo.txt'", severity: .info, metadata: metadata)
             }
         }
 
@@ -235,7 +237,7 @@ class TargetSourcesBuilderTests: XCTestCase {
                 "/Copied/foo.txt"
             )
 
-            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, diagnostics in
+            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, _, _, diagnostics in
                 // No diagnostics
             }
         }
@@ -253,10 +255,11 @@ class TargetSourcesBuilderTests: XCTestCase {
                 "/B/Copy/foo.txt"
             )
 
-            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, diagnostics in
-                diagnostics.check(diagnostic: "multiple resources named 'Copy' in target 'Foo'", severity: .error, context: "'test' /test")
-                diagnostics.checkUnordered(diagnostic: "found 'A/Copy'", severity: .note, context: "'test' /test")
-                diagnostics.checkUnordered(diagnostic: "found 'B/Copy'", severity: .note, context: "'test' /test")
+            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, location, diagnostics in
+                let metadata = DiagnosticsMetadata.packageMetadata(identity: identity, location: location)
+                diagnostics.check(diagnostic: "multiple resources named 'Copy' in target 'Foo'", severity: .error, metadata: metadata)
+                diagnostics.checkUnordered(diagnostic: "found 'A/Copy'", severity: .info, metadata: metadata)
+                diagnostics.checkUnordered(diagnostic: "found 'B/Copy'", severity: .info, metadata: metadata)
             }
         }
 
@@ -273,10 +276,11 @@ class TargetSourcesBuilderTests: XCTestCase {
                 "/B/EN.lproj/foo.txt"
             )
 
-            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, diagnostics in
-                diagnostics.check(diagnostic: "multiple resources named 'en.lproj/foo.txt' in target 'Foo'", severity: .error, context: "'test' /test")
-                diagnostics.checkUnordered(diagnostic: "found 'A/en.lproj/foo.txt'", severity: .note, context: "'test' /test")
-                diagnostics.checkUnordered(diagnostic: "found 'B/EN.lproj/foo.txt'", severity: .note, context: "'test' /test")
+            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, location, diagnostics in
+                let metadata = DiagnosticsMetadata.packageMetadata(identity: identity, location: location)
+                diagnostics.check(diagnostic: "multiple resources named 'en.lproj/foo.txt' in target 'Foo'", severity: .error, metadata: metadata)
+                diagnostics.checkUnordered(diagnostic: "found 'A/en.lproj/foo.txt'", severity: .info, metadata: metadata)
+                diagnostics.checkUnordered(diagnostic: "found 'B/EN.lproj/foo.txt'", severity: .info, metadata: metadata)
             }
         }
 
@@ -293,8 +297,12 @@ class TargetSourcesBuilderTests: XCTestCase {
                 "/B/en.lproj/foo.txt"
             )
 
-            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, diagnostics in
-                diagnostics.check(diagnostic: "resource 'B/en.lproj' in target 'Foo' conflicts with other localization directories", severity: .error, context: "'test' /test")
+            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, location, diagnostics in
+                diagnostics.check(
+                    diagnostic: "resource 'B/en.lproj' in target 'Foo' conflicts with other localization directories",
+                    severity: .error,
+                    metadata: .packageMetadata(identity: identity, location: location)
+                )
             }
         }
     }
@@ -306,7 +314,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             "/en.lproj/Localizable.strings"
         )
 
-        build(target: target, toolsVersion: .v5_2, fs: fs) { _, resources, _, _, _ in
+        build(target: target, toolsVersion: .v5_2, fs: fs) { _, resources, _, _, _, _, _ in
             XCTAssert(resources.isEmpty)
             // No diagnostics
         }
@@ -323,8 +331,12 @@ class TargetSourcesBuilderTests: XCTestCase {
             "/Copied/en.lproj/sub/Localizable.strings"
         )
 
-        build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, diagnostics in
-            diagnostics.check(diagnostic: "localization directory 'Processed/en.lproj' in target 'Foo' contains sub-directories, which is forbidden", severity: .error, context: "'test' /test")
+        build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, location, diagnostics in
+            diagnostics.check(
+                diagnostic: "localization directory 'Processed/en.lproj' in target 'Foo' contains sub-directories, which is forbidden",
+                severity: .error,
+                metadata: .packageMetadata(identity: identity, location: location)
+            )
         }
     }
 
@@ -337,14 +349,14 @@ class TargetSourcesBuilderTests: XCTestCase {
             "/Resources/en.lproj/Localizable.strings"
         )
 
-        build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, diagnostics in
+        build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, location, diagnostics in
             diagnostics.check(
                 diagnostic: .contains("""
                     resource 'Resources/en.lproj/Localizable.strings' in target 'Foo' is in a localization directory \
                     and has an explicit localization declaration
                     """),
                 severity: .error,
-                context: "'test' /test"
+                metadata: .packageMetadata(identity: identity, location: location)
             )
         }
     }
@@ -366,11 +378,11 @@ class TargetSourcesBuilderTests: XCTestCase {
             "/Icon.png"
         )
 
-        build(target: target, defaultLocalization: "fr", toolsVersion: .v5_3, fs: fs) { _, _, _, _, diagnostics in
+        build(target: target, defaultLocalization: "fr", toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, location, diagnostics in
             diagnostics.check(
                 diagnostic: .contains("resource 'Icon.png' in target 'Foo' is missing the default localization 'fr'"),
                 severity: .warning,
-                context: "'test' /test"
+                metadata: .packageMetadata(identity: identity, location: location)
             )
         }
     }
@@ -393,23 +405,28 @@ class TargetSourcesBuilderTests: XCTestCase {
             "/Icon.png"
         )
 
-        build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, diagnostics in
+        build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, location, diagnostics in
+            let metadata = DiagnosticsMetadata.packageMetadata(identity: identity, location: location)
             diagnostics.checkUnordered(
                 diagnostic: .contains("resource 'Localizable.strings' in target 'Foo' has both localized and un-localized variants"),
                 severity: .warning,
-                context: "'test' /test")
+                metadata: metadata
+            )
             diagnostics.checkUnordered(
                 diagnostic: .contains("resource 'Storyboard.storyboard' in target 'Foo' has both localized and un-localized variants"),
                 severity: .warning,
-                context: "'test' /test")
+                metadata: metadata
+            )
             diagnostics.checkUnordered(
                 diagnostic: .contains("resource 'Image.png' in target 'Foo' has both localized and un-localized variants"),
                 severity: .warning,
-                context: "'test' /test")
+                metadata: metadata
+            )
             diagnostics.checkUnordered(
                 diagnostic: .contains("resource 'Icon.png' in target 'Foo' has both localized and un-localized variants"),
                 severity: .warning,
-                context: "'test' /test")
+                metadata: metadata
+            )
         }
     }
 
@@ -433,7 +450,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             "/Other/Image.png"
         )
 
-        build(target: target, defaultLocalization: "fr", toolsVersion: .v5_3, fs: fs) { _, resources, _,  _, diagnostics in
+        build(target: target, defaultLocalization: "fr", toolsVersion: .v5_3, fs: fs) { _, resources, _,  _, identity, location, diagnostics in
             XCTAssertEqual(Set(resources), [
                 Resource(rule: .process, path: AbsolutePath("/Processed/foo.txt"), localization: nil),
                 Resource(rule: .process, path: AbsolutePath("/Processed/En-uS.lproj/Localizable.stringsdict"), localization: "en-us"),
@@ -454,7 +471,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             "/Foo/es.lproj/Image.png"
         )
 
-        build(target: try TargetDescription(name: "Foo"), defaultLocalization: "fr", toolsVersion: .v5_3, fs: fs) { _, resources, _, _, diagnostics in
+        build(target: try TargetDescription(name: "Foo"), defaultLocalization: "fr", toolsVersion: .v5_3, fs: fs) { _, resources, _, _, identity, location, diagnostics in
             XCTAssertEqual(Set(resources), [
                 Resource(rule: .process, path: AbsolutePath("/Foo/fr.lproj/Image.png"), localization: "fr"),
                 Resource(rule: .process, path: AbsolutePath("/Foo/es.lproj/Image.png"), localization: "es"),
@@ -472,11 +489,11 @@ class TargetSourcesBuilderTests: XCTestCase {
                 "/Resources/Processed/Info.plist"
             )
 
-            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, diagnostics in
+            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, location, diagnostics in
                 diagnostics.check(
                     diagnostic: .contains("resource 'Resources/Processed/Info.plist' in target 'Foo' is forbidden"),
                     severity: .error,
-                    context: "'test' /test"
+                    metadata: .packageMetadata(identity: .plain("test"), location: "/test")
                 )
             }
         }
@@ -490,11 +507,11 @@ class TargetSourcesBuilderTests: XCTestCase {
                 "/Resources/Copied/Info.plist"
             )
 
-            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, diagnostics in
+            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, location, diagnostics in
                 diagnostics.check(
                     diagnostic: .contains("resource 'Resources/Copied/Info.plist' in target 'Foo' is forbidden"),
                     severity: .error,
-                    context: "'test' /test"
+                    metadata: .packageMetadata(identity: identity, location: location)
                 )
             }
         }
@@ -508,7 +525,7 @@ class TargetSourcesBuilderTests: XCTestCase {
         fs: FileSystem,
         file: StaticString = #file,
         line: UInt = #line,
-        checker: (Sources, [Resource], [AbsolutePath], [AbsolutePath], DiagnosticsTestResult) -> ()
+        checker: (Sources, [Resource], [AbsolutePath], [AbsolutePath], PackageIdentity, String, DiagnosticsTestResult) -> ()
     ) {
         let observability = ObservabilitySystem.bootstrapForTesting()
         let builder = TargetSourcesBuilder(
@@ -527,7 +544,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             let (sources, resources, headers, others) = try builder.run()
 
             testDiagnostics(observability.diagnostics, file: file, line: line) { diagnostics in
-                checker(sources, resources, headers, others, diagnostics)
+                checker(sources, resources, headers, others, builder.packageIdentity, builder.packageLocation, diagnostics)
             }
         } catch {
             XCTFail(error.localizedDescription, file: file, line: line)
@@ -553,7 +570,7 @@ class TargetSourcesBuilderTests: XCTestCase {
 
         let observability = ObservabilitySystem.bootstrapForTesting()
 
-        let _ = TargetSourcesBuilder(
+        let builder = TargetSourcesBuilder(
             packageIdentity: .plain("test"),
             packageLocation: "/test",
             packagePath: .root,
@@ -565,8 +582,9 @@ class TargetSourcesBuilderTests: XCTestCase {
         )
 
         testDiagnostics(observability.diagnostics) { result in
-            result.checkUnordered(diagnostic: "Invalid Exclude '/fileOutsideRoot.py': File not found.", severity: .warning, context: "'test' /test")
-            result.checkUnordered(diagnostic: "Invalid Exclude '/fakeDir': File not found.", severity: .warning, context: "'test' /test")
+            let metadata = DiagnosticsMetadata.packageMetadata(identity: builder.packageIdentity, location: builder.packageLocation)
+            result.checkUnordered(diagnostic: "Invalid Exclude '/fileOutsideRoot.py': File not found.", severity: .warning, metadata: metadata)
+            result.checkUnordered(diagnostic: "Invalid Exclude '/fakeDir': File not found.", severity: .warning, metadata: metadata)
         }
     }
     
@@ -603,8 +621,9 @@ class TargetSourcesBuilderTests: XCTestCase {
         _ = try builder.run()
 
         testDiagnostics(observability.diagnostics) { result in
-            result.checkUnordered(diagnostic: "Invalid Resource '../../../Fake.txt': File not found.", severity: .warning, context: "'test' /test")
-            result.checkUnordered(diagnostic: "Invalid Resource 'NotReal': File not found.", severity: .warning, context: "'test' /test")
+            let metadata = DiagnosticsMetadata.packageMetadata(identity: builder.packageIdentity, location: builder.packageLocation)
+            result.checkUnordered(diagnostic: "Invalid Resource '../../../Fake.txt': File not found.", severity: .warning, metadata: metadata)
+            result.checkUnordered(diagnostic: "Invalid Resource 'NotReal': File not found.", severity: .warning, metadata: metadata)
         }
     }
     
@@ -629,7 +648,7 @@ class TargetSourcesBuilderTests: XCTestCase {
 
         let observability = ObservabilitySystem.bootstrapForTesting()
 
-        let _ = TargetSourcesBuilder(
+        let builder = TargetSourcesBuilder(
             packageIdentity: .plain("test"),
             packageLocation: "/test",
             packagePath: .root,
@@ -641,9 +660,10 @@ class TargetSourcesBuilderTests: XCTestCase {
         )
 
         testDiagnostics(observability.diagnostics) { result in
-            result.checkUnordered(diagnostic: "Invalid Source '/InvalidPackage.swift': File not found.", severity: .warning, context: "'test' /test")
-            result.checkUnordered(diagnostic: "Invalid Source '/DoesNotExist.swift': File not found.", severity: .warning, context: "'test' /test")
-            result.checkUnordered(diagnostic: "Invalid Source '/Tests/InvalidPackageTests/InvalidPackageTests.swift': File not found.", severity: .warning, context: "'test' /test")
+            let metadata = DiagnosticsMetadata.packageMetadata(identity: builder.packageIdentity, location: builder.packageLocation)
+            result.checkUnordered(diagnostic: "Invalid Source '/InvalidPackage.swift': File not found.", severity: .warning, metadata: metadata)
+            result.checkUnordered(diagnostic: "Invalid Source '/DoesNotExist.swift': File not found.", severity: .warning, metadata: metadata)
+            result.checkUnordered(diagnostic: "Invalid Source '/Tests/InvalidPackageTests/InvalidPackageTests.swift': File not found.", severity: .warning, metadata: metadata)
         }
     }
 
@@ -679,7 +699,8 @@ class TargetSourcesBuilderTests: XCTestCase {
         _ = try builder.run()
 
         testDiagnostics(observability.diagnostics) { result in
-            result.check(diagnostic: "found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target\n    /Foo.xcdatamodel\n", severity: .warning, context: "'test' /test")
+            let metadata = DiagnosticsMetadata.packageMetadata(identity: builder.packageIdentity, location: builder.packageLocation)
+            result.check(diagnostic: "found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target\n    /Foo.xcdatamodel\n", severity: .warning, metadata: metadata)
         }
     }
 

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -144,7 +144,7 @@ class PluginInvocationTests: XCTestCase {
             outputDir: outputDir,
             builtToolsDir: builtToolsDir,
             pluginScriptRunner: pluginRunner,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
             fileSystem: fileSystem
         )
         

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -8,6 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import Basics
 import PackageGraph
 import PackageModel
 @testable import SPMBuildCore
@@ -27,8 +28,8 @@ class PluginInvocationTests: XCTestCase {
             "/Foo/Sources/Foo/source.swift",
             "/Foo/Sources/Foo/SomeFile.abc"
         )
-        let diagnostics = DiagnosticsEngine()
-        let graph = try loadPackageGraph(fs: fileSystem, diagnostics: diagnostics,
+        let observability = ObservabilitySystem.bootstrapForTesting()
+        let graph = try loadPackageGraph(fs: fileSystem,
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Foo",
@@ -64,7 +65,7 @@ class PluginInvocationTests: XCTestCase {
         )
         
         // Check the basic integrity before running plugins.
-        XCTAssertNoDiagnostics(diagnostics)
+        XCTAssertNoDiagnostics(observability.diagnostics)
         PackageGraphTester(graph) { graph in
             graph.check(packages: "Foo")
             graph.check(targets: "Foo", "FooPlugin", "FooTool")
@@ -139,10 +140,16 @@ class PluginInvocationTests: XCTestCase {
         let outputDir = AbsolutePath("/Foo/.build")
         let builtToolsDir = AbsolutePath("/Foo/.build/debug")
         let pluginRunner = MockPluginScriptRunner()
-        let results = try graph.invokePlugins(outputDir: outputDir, builtToolsDir: builtToolsDir, pluginScriptRunner: pluginRunner, diagnostics: diagnostics, fileSystem: fileSystem)
+        let results = try graph.invokePlugins(
+            outputDir: outputDir,
+            builtToolsDir: builtToolsDir,
+            pluginScriptRunner: pluginRunner,
+            diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
+            fileSystem: fileSystem
+        )
         
         // Check the canned output to make sure nothing was lost in transport.
-        XCTAssertNoDiagnostics(diagnostics)
+        XCTAssertNoDiagnostics(observability.diagnostics)
         XCTAssertEqual(results.count, 1)
         let (evalTarget, evalResults) = try XCTUnwrap(results.first)
         XCTAssertEqual(evalTarget.name, "Foo")

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -356,8 +356,8 @@ final class WorkspaceTests: XCTestCase {
         )
 
         workspace.checkPackageGraphFailure(roots: ["Foo", "Nested/Foo"]) { diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: .equal("found multiple top-level packages named 'Foo'"), behavior: .error)
+            testDiagnostics(diagnostics) { result in
+                result.check(diagnostic: .equal("found multiple top-level packages named 'Foo'"), severity: .error)
             }
         }
     }
@@ -772,8 +772,8 @@ final class WorkspaceTests: XCTestCase {
             .scm(path: "./B", requirement: .exact("1.0.0"), products: .specific(["B"])),
         ]
         workspace.checkPackageGraph(deps: deps) { _, diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: .contains("Dependencies could not be resolved"), behavior: .error)
+            testDiagnostics(diagnostics) { result in
+                result.check(diagnostic: .contains("Dependencies could not be resolved"), severity: .error)
             }
         }
         // There should be no extra fetches.
@@ -1947,8 +1947,8 @@ final class WorkspaceTests: XCTestCase {
 
         // Check failure.
         workspace.checkResolve(pkg: "Foo", roots: ["Root"], version: "1.3.0") { diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: .contains("'Foo' 1.3.0"), behavior: .error)
+            testDiagnostics(diagnostics) { result in
+                result.check(diagnostic: .contains("'Foo' 1.3.0"), severity: .error)
             }
         }
         workspace.checkManagedDependencies { result in
@@ -1999,8 +1999,8 @@ final class WorkspaceTests: XCTestCase {
                 result.check(roots: "Root")
                 result.check(packages: "Foo", "Root")
             }
-            DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: .contains("dependency 'Foo' is missing; cloning again"), behavior: .warning)
+            testDiagnostics(diagnostics) { result in
+                result.check(diagnostic: .contains("dependency 'Foo' is missing; cloning again"), severity: .warning)
             }
         }
     }
@@ -2041,8 +2041,8 @@ final class WorkspaceTests: XCTestCase {
 
         #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
         workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: .contains("Foo[Foo] 1.0.0..<2.0.0"), behavior: .error)
+            testDiagnostics(diagnostics) { result in
+                result.check(diagnostic: .contains("Foo[Foo] 1.0.0..<2.0.0"), severity: .error)
             }
         }
         #endif
@@ -2092,18 +2092,30 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkPackageGraphFailure(roots: ["Bar"]) { diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: .equal("package 'bar' is using Swift tools version 4.1.0 but the installed version is 4.0.0"), behavior: .error, location: "/tmp/ws/roots/Bar")
+            testDiagnostics(diagnostics) { result in
+                result.check(
+                    diagnostic: .equal("package 'bar' is using Swift tools version 4.1.0 but the installed version is 4.0.0"),
+                    severity: .error,
+                    context: "/tmp/ws/roots/Bar"
+                )
             }
         }
         workspace.checkPackageGraphFailure(roots: ["Foo", "Bar"]) { diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: .equal("package 'bar' is using Swift tools version 4.1.0 but the installed version is 4.0.0"), behavior: .error, location: "/tmp/ws/roots/Bar")
+            testDiagnostics(diagnostics) { result in
+                result.check(
+                    diagnostic: .equal("package 'bar' is using Swift tools version 4.1.0 but the installed version is 4.0.0"),
+                    severity: .error,
+                    context: "/tmp/ws/roots/Bar"
+                )
             }
         }
         workspace.checkPackageGraphFailure(roots: ["Baz"]) { diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: .equal("package 'baz' is using Swift tools version 3.1.0 which is no longer supported; consider using '// swift-tools-version:4.0' to specify the current tools version"), behavior: .error, location: "/tmp/ws/roots/Baz")
+            testDiagnostics(diagnostics) { result in
+                result.check(
+                    diagnostic: .equal("package 'baz' is using Swift tools version 3.1.0 which is no longer supported; consider using '// swift-tools-version:4.0' to specify the current tools version"),
+                    severity: .error,
+                    context: "/tmp/ws/roots/Baz"
+                )
             }
         }
     }
@@ -2179,8 +2191,8 @@ final class WorkspaceTests: XCTestCase {
 
         // Try re-editing foo.
         workspace.checkEdit(packageName: "Foo") { diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: .equal("dependency 'Foo' already in edit mode"), behavior: .error)
+            testDiagnostics(diagnostics) { result in
+                result.check(diagnostic: .equal("dependency 'Foo' already in edit mode"), severity: .error)
             }
         }
         workspace.checkManagedDependencies { result in
@@ -2189,8 +2201,8 @@ final class WorkspaceTests: XCTestCase {
 
         // Try editing bar at bad revision.
         workspace.checkEdit(packageName: "Bar", revision: Revision(identifier: "dev")) { diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: .equal("revision 'dev' does not exist"), behavior: .error)
+            testDiagnostics(diagnostics) { result in
+                result.check(diagnostic: .equal("revision 'dev' does not exist"), severity: .error)
             }
         }
 
@@ -2265,8 +2277,8 @@ final class WorkspaceTests: XCTestCase {
         // Remove the edited package.
         try fs.removeFileTree(fooPath)
         workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: .equal("dependency 'Foo' was being edited but is missing; falling back to original checkout"), behavior: .warning)
+            testDiagnostics(diagnostics) { result in
+                result.check(diagnostic: .equal("dependency 'Foo' was being edited but is missing; falling back to original checkout"), severity: .warning)
             }
         }
         workspace.checkManagedDependencies { result in
@@ -2705,8 +2717,8 @@ final class WorkspaceTests: XCTestCase {
             .scm(path: "./Bar", requirement: .exact("1.1.0"), products: .specific(["Bar"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: .contains("'Bar' 1.1.0"), behavior: .error)
+            testDiagnostics(diagnostics) { result in
+                result.check(diagnostic: .contains("'Bar' 1.1.0"), severity: .error)
             }
         }
     }
@@ -2827,13 +2839,13 @@ final class WorkspaceTests: XCTestCase {
 
         // Test that its not possible to edit or resolve this package.
         workspace.checkEdit(packageName: "Bar") { diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: .contains("local dependency 'Bar' can't be edited"), behavior: .error)
+            testDiagnostics(diagnostics) { result in
+                result.check(diagnostic: .contains("local dependency 'Bar' can't be edited"), severity: .error)
             }
         }
         workspace.checkResolve(pkg: "Bar", roots: ["Foo"], version: "1.0.0") { diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: .contains("local dependency 'Bar' can't be edited"), behavior: .error)
+            testDiagnostics(diagnostics) { result in
+                result.check(diagnostic: .contains("local dependency 'Bar' can't be edited"), severity: .error)
             }
         }
     }
@@ -2892,8 +2904,8 @@ final class WorkspaceTests: XCTestCase {
                 result.check(targets: "Foo")
             }
             #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
-            DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: .contains("Bar[Bar] {1.0.0..<1.5.0, 1.5.1..<2.0.0} is forbidden"), behavior: .error)
+            testDiagnostics(diagnostics) { result in
+                result.check(diagnostic: .contains("Bar[Bar] {1.0.0..<1.5.0, 1.5.1..<2.0.0} is forbidden"), severity: .error)
             }
             #endif
         }
@@ -2992,8 +3004,8 @@ final class WorkspaceTests: XCTestCase {
                 result.check(packages: "Foo")
                 result.check(targets: "Foo")
             }
-            DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: .contains("the package at '/tmp/ws/pkgs/Bar' cannot be accessed (/tmp/ws/pkgs/Bar doesn't exist in file system"), behavior: .error)
+            testDiagnostics(diagnostics) { result in
+                result.check(diagnostic: .contains("the package at '/tmp/ws/pkgs/Bar' cannot be accessed (/tmp/ws/pkgs/Bar doesn't exist in file system"), severity: .error)
             }
         }
     }
@@ -3639,8 +3651,8 @@ final class WorkspaceTests: XCTestCase {
 
         // Check force resolve. This should produce an error because the resolved file is out-of-date.
         workspace.checkPackageGraphFailure(roots: ["Root"], forceResolvedVersions: true) { diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: "an out-of-date resolved file was detected at /tmp/ws/Package.resolved, which is not allowed when automatic dependency resolution is disabled; please make sure to update the file to reflect the changes in dependencies. Running resolver because  requirements have changed.", checkContains: true, behavior: .error)
+            testDiagnostics(diagnostics) { result in
+                result.check(diagnostic: "an out-of-date resolved file was detected at /tmp/ws/Package.resolved, which is not allowed when automatic dependency resolution is disabled; please make sure to update the file to reflect the changes in dependencies. Running resolver because  requirements have changed.", severity: .error)
             }
         }
         workspace.checkManagedDependencies { result in
@@ -3724,9 +3736,9 @@ final class WorkspaceTests: XCTestCase {
         )
 
         workspace.checkPackageGraphFailure(roots: ["Root"], forceResolvedVersions: true) { diagnostics in
-            guard let diagnostic = diagnostics.diagnostics.first else { return XCTFail("unexpectedly got no diagnostics") }
+            guard let diagnostic = diagnostics.first else { return XCTFail("unexpectedly got no diagnostics") }
             // rdar://82544922 (`WorkspaceResolveReason` is non-deterministic)
-            XCTAssertTrue(diagnostic.message.text.hasPrefix("a resolved file is required when automatic dependency resolution is disabled and should be placed at /tmp/ws/Package.resolved. Running resolver because the following dependencies were added:"), "unexpected diagnostic message")
+            XCTAssertTrue(diagnostic.message.hasPrefix("a resolved file is required when automatic dependency resolution is disabled and should be placed at /tmp/ws/Package.resolved. Running resolver because the following dependencies were added:"), "unexpected diagnostic message")
         }
     }
 
@@ -3776,33 +3788,33 @@ final class WorkspaceTests: XCTestCase {
         // This checkout of the SwiftPM package.
         let packagePath = AbsolutePath(#file).parentDirectory.parentDirectory.parentDirectory
 
-        let diagnostics = DiagnosticsEngine()
+        let observability = ObservabilitySystem.bootstrapForTesting()
         let workspace = try Workspace(forRootPackage: packagePath, customToolchain: UserToolchain.default)
 
         // From here the API should be simple and straightforward:
         let manifest = try tsc_await {
             workspace.loadRootManifest(
                 at: packagePath,
-                diagnostics: diagnostics,
+                diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
                 completion: $0
             )
         }
-        XCTAssertFalse(diagnostics.hasErrors)
+        XCTAssertFalse(observability.hasErrorDiagnostics)
 
         let package = try tsc_await {
             workspace.loadRootPackage(
                 at: packagePath,
-                diagnostics: diagnostics,
+                diagnostics: ObservabilitySystem.makeDiagnosticsEngine(),
                 completion: $0
             )
         }
-        XCTAssertFalse(diagnostics.hasErrors)
+        XCTAssertFalse(observability.hasErrorDiagnostics)
 
         let graph = try workspace.loadPackageGraph(
             rootPath: packagePath,
-            diagnostics: diagnostics
+            diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
         )
-        XCTAssertFalse(diagnostics.hasErrors)
+        XCTAssertFalse(observability.hasErrorDiagnostics)
 
         XCTAssertEqual(manifest.name, "SwiftPM")
         XCTAssertEqual(package.manifestName, manifest.name)
@@ -3856,8 +3868,8 @@ final class WorkspaceTests: XCTestCase {
         )
 
         workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: .equal("package 'Foo' is required using a revision-based requirement and it depends on local package 'Local', which is not supported"), behavior: .error)
+            testDiagnostics(diagnostics) { result in
+                result.check(diagnostic: .equal("package 'Foo' is required using a revision-based requirement and it depends on local package 'Local', which is not supported"), severity: .error)
             }
         }
     }
@@ -3901,8 +3913,8 @@ final class WorkspaceTests: XCTestCase {
         ]
 
         workspace.checkPackageGraphFailure(roots: ["Overridden/bazzz-master"], deps: deps) { diagnostics in
-            DiagnosticsEngineTester(diagnostics, ignoreNotes: true) { result in
-                result.check(diagnostic: .equal("unable to override package 'Baz' because its identity 'bazzz' doesn't match override's identity (directory name) 'bazzz-master'"), behavior: .error)
+            testDiagnostics(diagnostics, ignoreNotes: true) { result in
+                result.check(diagnostic: .equal("unable to override package 'Baz' because its identity 'bazzz' doesn't match override's identity (directory name) 'bazzz-master'"), severity: .error)
             }
         }
     }
@@ -3966,9 +3978,9 @@ final class WorkspaceTests: XCTestCase {
 
         // We should only see errors about use of unsafe flag in the version-based dependency.
         workspace.checkPackageGraph(roots: ["Foo", "Bar"]) { _, diagnostics in
-            DiagnosticsEngineTester(diagnostics, ignoreNotes: true) { result in
-                result.checkUnordered(diagnostic: .equal("the target 'Baz' in product 'Baz' contains unsafe build flags"), behavior: .error)
-                result.checkUnordered(diagnostic: .equal("the target 'Bar' in product 'Baz' contains unsafe build flags"), behavior: .error)
+            testDiagnostics(diagnostics, ignoreNotes: true) { result in
+                result.checkUnordered(diagnostic: .equal("the target 'Baz' in product 'Baz' contains unsafe build flags"), severity: .error)
+                result.checkUnordered(diagnostic: .equal("the target 'Bar' in product 'Baz' contains unsafe build flags"), severity: .error)
             }
         }
     }
@@ -4204,9 +4216,9 @@ final class WorkspaceTests: XCTestCase {
             let binaryPath = sandbox.appending(component: "binary.zip")
             try fs.writeFileContents(binaryPath, bytes: ByteString([0xAA, 0xBB, 0xCC]))
 
-            let diagnostics = DiagnosticsEngine()
-            let checksum = ws.checksum(forBinaryArtifactAt: binaryPath, diagnostics: diagnostics)
-            XCTAssertTrue(!diagnostics.hasErrors, diagnostics.description)
+            let observability = ObservabilitySystem.bootstrapForTesting()
+            let checksum = ws.checksum(forBinaryArtifactAt: binaryPath, diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
+            XCTAssertTrue(!observability.hasErrorDiagnostics, observability.diagnostics.description)
             XCTAssertEqual(workspace.checksumAlgorithm.hashes.map { $0.contents }, [[0xAA, 0xBB, 0xCC]])
             XCTAssertEqual(checksum, "ccbbaa")
         }
@@ -4214,24 +4226,24 @@ final class WorkspaceTests: XCTestCase {
         // Checks an unsupported extension.
         do {
             let unknownPath = sandbox.appending(component: "unknown")
-            let diagnostics = DiagnosticsEngine()
-            let checksum = ws.checksum(forBinaryArtifactAt: unknownPath, diagnostics: diagnostics)
+            let observability = ObservabilitySystem.bootstrapForTesting()
+            let checksum = ws.checksum(forBinaryArtifactAt: unknownPath, diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
             XCTAssertEqual(checksum, "")
-            DiagnosticsEngineTester(diagnostics) { result in
+            testDiagnostics(observability.diagnostics) { result in
                 let expectedDiagnostic = "unexpected file type; supported extensions are: zip"
-                result.check(diagnostic: .contains(expectedDiagnostic), behavior: .error)
+                result.check(diagnostic: .contains(expectedDiagnostic), severity: .error)
             }
         }
 
         // Checks a supported extension that is not a file (does not exist).
         do {
             let unknownPath = sandbox.appending(component: "missingFile.zip")
-            let diagnostics = DiagnosticsEngine()
-            let checksum = ws.checksum(forBinaryArtifactAt: unknownPath, diagnostics: diagnostics)
+            let observability = ObservabilitySystem.bootstrapForTesting()
+            let checksum = ws.checksum(forBinaryArtifactAt: unknownPath, diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
             XCTAssertEqual(checksum, "")
-            DiagnosticsEngineTester(diagnostics) { result in
+            testDiagnostics(observability.diagnostics) { result in
                 result.check(diagnostic: .contains("file not found at path: /tmp/ws/missingFile.zip"),
-                             behavior: .error)
+                             severity: .error)
             }
         }
 
@@ -4240,12 +4252,12 @@ final class WorkspaceTests: XCTestCase {
             let unknownPath = sandbox.appending(component: "aDirectory.zip")
             try fs.createDirectory(unknownPath)
 
-            let diagnostics = DiagnosticsEngine()
-            let checksum = ws.checksum(forBinaryArtifactAt: unknownPath, diagnostics: diagnostics)
+            let observability = ObservabilitySystem.bootstrapForTesting()
+            let checksum = ws.checksum(forBinaryArtifactAt: unknownPath, diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
             XCTAssertEqual(checksum, "")
-            DiagnosticsEngineTester(diagnostics) { result in
+            testDiagnostics(observability.diagnostics) { result in
                 result.check(diagnostic: .contains("file not found at path: /tmp/ws/aDirectory.zip"),
-                             behavior: .error)
+                             severity: .error)
             }
         }
     }
@@ -4626,7 +4638,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         workspace.checkPackageGraphFailure(roots: ["Foo"]) { diagnostics in
-            XCTAssertEqual(diagnostics.diagnostics.map { $0.message.text },
+            XCTAssertEqual(diagnostics.map { $0.message },
                            ["downloaded archive of binary target 'A3' does not contain expected binary artifact 'A3'"])
             XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/B")))
             XCTAssert(!fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/A/A3.xcframework")))
@@ -4916,11 +4928,11 @@ final class WorkspaceTests: XCTestCase {
         )
 
         workspace.checkPackageGraphFailure(roots: ["Foo"]) { diagnostics in
-            print(diagnostics.diagnostics)
-            DiagnosticsEngineTester(diagnostics) { result in
-                result.checkUnordered(diagnostic: .contains("failed downloading 'https://a.com/a1.zip' which is required by binary target 'A1': badResponseStatusCode(500)"), behavior: .error)
-                result.checkUnordered(diagnostic: .contains("failed extracting 'https://a.com/a2.zip' which is required by binary target 'A2': dummy error"), behavior: .error)
-                result.checkUnordered(diagnostic: .contains("checksum of downloaded artifact of binary target 'A3' (6d75736b6365686320746e65726566666964203d2073746e65746e6f6320746e65726566666964) does not match checksum specified by the manifest (a3)"), behavior: .error)
+            print(diagnostics)
+            testDiagnostics(diagnostics) { result in
+                result.checkUnordered(diagnostic: .contains("failed downloading 'https://a.com/a1.zip' which is required by binary target 'A1': badResponseStatusCode(500)"), severity: .error)
+                result.checkUnordered(diagnostic: .contains("failed extracting 'https://a.com/a2.zip' which is required by binary target 'A2': dummy error"), severity: .error)
+                result.checkUnordered(diagnostic: .contains("checksum of downloaded artifact of binary target 'A3' (6d75736b6365686320746e65726566666964203d2073746e65746e6f6320746e65726566666964) does not match checksum specified by the manifest (a3)"), severity: .error)
             }
         }
     }
@@ -4988,8 +5000,8 @@ final class WorkspaceTests: XCTestCase {
         )
 
         workspace.checkPackageGraphFailure(roots: ["Foo"]) { diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: .contains("artifact of binary target 'A' has changed checksum"), behavior: .error)
+            testDiagnostics(diagnostics) { result in
+                result.check(diagnostic: .contains("artifact of binary target 'A' has changed checksum"), severity: .error)
             }
         }
     }
@@ -5261,8 +5273,8 @@ final class WorkspaceTests: XCTestCase {
         )
 
         workspace.checkPackageGraphFailure(roots: ["Foo"]) { diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: .contains("failed retrieving 'https://a.com/a.artifactbundleindex': badResponseStatusCode(500)"), behavior: .error)
+            testDiagnostics(diagnostics) { result in
+                result.check(diagnostic: .contains("failed retrieving 'https://a.com/a.artifactbundleindex': badResponseStatusCode(500)"), severity: .error)
             }
         }
     }
@@ -5334,8 +5346,8 @@ final class WorkspaceTests: XCTestCase {
         )
 
         workspace.checkPackageGraphFailure(roots: ["Foo"]) { diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: .contains("failed retrieving 'https://a.com/a.artifactbundleindex': checksum of downloaded artifact of binary target 'A' (\(ariChecksums)) does not match checksum specified by the manifest (incorrect)"), behavior: .error)
+            testDiagnostics(diagnostics) { result in
+                result.check(diagnostic: .contains("failed retrieving 'https://a.com/a.artifactbundleindex': checksum of downloaded artifact of binary target 'A' (\(ariChecksums)) does not match checksum specified by the manifest (incorrect)"), severity: .error)
             }
         }
     }
@@ -5398,8 +5410,8 @@ final class WorkspaceTests: XCTestCase {
         )
 
         workspace.checkPackageGraphFailure(roots: ["Foo"]) { diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: .contains("artifact of binary target 'A' has changed checksum"), behavior: .error)
+            testDiagnostics(diagnostics) { result in
+                result.check(diagnostic: .contains("artifact of binary target 'A' has changed checksum"), severity: .error)
             }
         }
     }
@@ -5514,8 +5526,8 @@ final class WorkspaceTests: XCTestCase {
         )
 
         workspace.checkPackageGraphFailure(roots: ["Foo"]) { diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: .contains("checksum of downloaded artifact of binary target 'A' (42) does not match checksum specified by the manifest (a)"), behavior: .error)
+            testDiagnostics(diagnostics) { result in
+                result.check(diagnostic: .contains("checksum of downloaded artifact of binary target 'A' (42) does not match checksum specified by the manifest (a)"), severity: .error)
             }
         }
     }
@@ -5592,8 +5604,8 @@ final class WorkspaceTests: XCTestCase {
         )
 
         workspace.checkPackageGraphFailure(roots: ["Foo"]) { diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: .contains("failed downloading 'https://a.com/not-found.zip' which is required by binary target 'A': badResponseStatusCode(404)"), behavior: .error)
+            testDiagnostics(diagnostics) { result in
+                result.check(diagnostic: .contains("failed downloading 'https://a.com/not-found.zip' which is required by binary target 'A': badResponseStatusCode(404)"), severity: .error)
             }
         }
     }
@@ -5668,8 +5680,8 @@ final class WorkspaceTests: XCTestCase {
         )
 
         workspace.checkPackageGraphFailure(roots: ["Foo"]) { diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: .contains("failed retrieving 'https://a.com/a.artifactbundleindex': No supported archive was found for '\(hostToolchain.triple.tripleString)'"), behavior: .error)
+            testDiagnostics(diagnostics) { result in
+                result.check(diagnostic: .contains("failed retrieving 'https://a.com/a.artifactbundleindex': No supported archive was found for '\(hostToolchain.triple.tripleString)'"), severity: .error)
             }
         }
     }
@@ -5743,11 +5755,11 @@ final class WorkspaceTests: XCTestCase {
         )
 
         workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
+            testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: "'root' dependency on '/tmp/ws/pkgs/bar/utility' conflicts with dependency on '/tmp/ws/pkgs/foo/utility' which has the same identity 'utility'",
-                    behavior: .error,
-                    location: "'Root' /tmp/ws/roots/Root"
+                    severity: .error,
+                    context: "'root' /tmp/ws/roots/Root"
                 )
             }
         }
@@ -5805,11 +5817,11 @@ final class WorkspaceTests: XCTestCase {
         )
 
         workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
+            testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: "'root' dependency on '/tmp/ws/pkgs/bar/utility' conflicts with dependency on '/tmp/ws/pkgs/foo/utility' which has the same identity 'utility'",
-                    behavior: .error,
-                    location: "'Root' /tmp/ws/roots/Root"
+                    severity: .error,
+                    context: "'root' /tmp/ws/roots/Root"
                 )
             }
         }
@@ -5867,11 +5879,11 @@ final class WorkspaceTests: XCTestCase {
         )
 
         workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
+            testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: "'root' dependency on '/tmp/ws/pkgs/bar' conflicts with dependency on '/tmp/ws/pkgs/foo' which has the same explicit name 'FooPackage'",
-                    behavior: .error,
-                    location: "'Root' /tmp/ws/roots/Root"
+                    severity: .error,
+                    context: "'root' /tmp/ws/roots/Root"
                 )
             }
         }
@@ -6093,16 +6105,16 @@ final class WorkspaceTests: XCTestCase {
         )
 
         workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
+            testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: "dependency 'FooProduct' in target 'RootTarget' requires explicit declaration; reference the package in the target dependency with '.product(name: \"FooProduct\", package: \"foo\")'",
-                    behavior: .error,
-                    location: "'Root' /tmp/ws/roots/Root"
+                    severity: .error,
+                    context: "'root' /tmp/ws/roots/Root"
                 )
                 result.check(
                     diagnostic: "dependency 'BarProduct' in target 'RootTarget' requires explicit declaration; reference the package in the target dependency with '.product(name: \"BarProduct\", package: \"bar\")'",
-                    behavior: .error,
-                    location: "'Root' /tmp/ws/roots/Root"
+                    severity: .error,
+                    context: "'root' /tmp/ws/roots/Root"
                 )
             }
         }
@@ -6214,11 +6226,11 @@ final class WorkspaceTests: XCTestCase {
         )
 
         workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
+            testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: "'root' dependency on '/tmp/ws/pkgs/bar' conflicts with dependency on '/tmp/ws/pkgs/foo' which has the same explicit name 'foo'",
-                    behavior: .error,
-                    location: "'Root' /tmp/ws/roots/Root"
+                    severity: .error,
+                    context: "'root' /tmp/ws/roots/Root"
                 )
             }
         }
@@ -6275,11 +6287,11 @@ final class WorkspaceTests: XCTestCase {
         )
 
         workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
+            testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: "'root' dependency on '/tmp/ws/pkgs/bar' conflicts with dependency on '/tmp/ws/pkgs/foo' which has the same explicit name 'foo'",
-                    behavior: .error,
-                    location: "'Root' /tmp/ws/roots/Root"
+                    severity: .error,
+                    context: "'root' /tmp/ws/roots/Root"
                 )
             }
         }
@@ -6353,11 +6365,11 @@ final class WorkspaceTests: XCTestCase {
         )
 
         workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
+            testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: "'bar' dependency on '/tmp/ws/pkgs/other/utility' conflicts with dependency on '/tmp/ws/pkgs/foo/utility' which has the same identity 'utility'",
-                    behavior: .error,
-                    location: "'BarPackage' /tmp/ws/pkgs/bar"
+                    severity: .error,
+                    context: "'bar' /tmp/ws/pkgs/bar"
                 )
             }
         }
@@ -6433,18 +6445,18 @@ final class WorkspaceTests: XCTestCase {
         // 9/2021 this is currently emitting a warning only to support backwards compatibility
         // we will escalate this to an error in a few versions to tighten up the validation
         workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
+            testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: "'bar' dependency on '/tmp/ws/pkgs/other-foo/utility' conflicts with dependency on '/tmp/ws/pkgs/foo/utility' which has the same identity 'utility'. this will be escalated to an error in future versions of SwiftPM.",
-                    behavior: .warning,
-                    location: "'BarPackage' /tmp/ws/pkgs/bar"
+                    severity: .warning,
+                    context: "'bar' /tmp/ws/pkgs/bar"
                 )
                 // FIXME: rdar://72940946
                 // we need to improve this situation or diagnostics when working on identity
                 result.check(
                     diagnostic: "product 'OtherUtilityProduct' required by package 'bar' target 'BarTarget' not found in package 'utility'.",
-                    behavior: .error,
-                    location: "'BarPackage' /tmp/ws/pkgs/bar"
+                    severity: .error,
+                    context: "'bar' /tmp/ws/pkgs/bar"
                 )
             }
         }
@@ -6808,11 +6820,11 @@ final class WorkspaceTests: XCTestCase {
         // 9/2021 this is currently emitting a warning only to support backwards compatibility
         // we will escalate this to an error in a few versions to tighten up the validation
         workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
+            testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: "'bar' dependency on 'https://github.com/foo-moved/foo.git' conflicts with dependency on 'https://github.com/foo/foo.git' which has the same identity 'foo'. this will be escalated to an error in future versions of SwiftPM.",
-                    behavior: .warning,
-                    location: "'BarPackage' /tmp/ws/pkgs/bar"
+                    severity: .warning,
+                    context: "'bar' /tmp/ws/pkgs/bar"
                 )
             }
         }
@@ -6889,13 +6901,12 @@ final class WorkspaceTests: XCTestCase {
         )
 
         workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
+            testDiagnostics(diagnostics) { result in
                 // FIXME: rdar://72940946
                 // we need to improve this situation or diagnostics when working on identity
                 result.check(
                     diagnostic: "cyclic dependency declaration found: Root -> FooUtilityPackage -> BarPackage -> FooUtilityPackage",
-                    behavior: .error,
-                    location: "<unknown>"
+                    severity: .error
                 )
             }
         }
@@ -6974,13 +6985,12 @@ final class WorkspaceTests: XCTestCase {
         )
 
         workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
+            testDiagnostics(diagnostics) { result in
                 // FIXME: rdar://72940946
                 // we need to improve this situation or diagnostics when working on identity
                 result.check(
                     diagnostic: "cyclic dependency declaration found: Root -> FooUtilityPackage -> BarPackage -> FooUtilityPackage",
-                    behavior: .error,
-                    location: "<unknown>"
+                    severity: .error
                 )
             }
         }
@@ -7042,13 +7052,12 @@ final class WorkspaceTests: XCTestCase {
         )
 
         workspace.checkPackageGraph(roots: ["foo"]) { graph, diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
+            testDiagnostics(diagnostics) { result in
                 // FIXME: rdar://72940946
                 // we need to improve this situation or diagnostics when working on identity
                 result.check(
                     diagnostic: "cyclic dependency declaration found: Root -> BarPackage -> Root",
-                    behavior: .error,
-                    location: "<unknown>"
+                    severity: .error
                 )
             }
         }

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -8,16 +8,16 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import XCTest
+import Basics
+import PackageGraph
+@testable import PackageLoading
+import PackageModel
+import SPMBuildCore
+import SPMTestSupport
 import TSCBasic
 import TSCUtility
-import PackageModel
-import PackageGraph
-import SPMBuildCore
 import XCBuildSupport
-import SPMTestSupport
-
-@testable import PackageLoading
+import XCTest
 
 class PIFBuilderTests: XCTestCase {
     let inputsDir = AbsolutePath(#file).parentDirectory.appending(components: "Inputs")
@@ -34,10 +34,9 @@ class PIFBuilderTests: XCTestCase {
                 "/B/Sources/B2/lib.swift"
             )
 
-            let diagnostics = DiagnosticsEngine()
+            let observability = ObservabilitySystem.bootstrapForTesting()
             let graph = try loadPackageGraph(
                 fs: fs,
-                diagnostics: diagnostics,
                 manifests: [
                     Manifest.createManifest(
                         name: "B",
@@ -72,10 +71,10 @@ class PIFBuilderTests: XCTestCase {
                 ]
             )
 
-            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: diagnostics)
+            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
             let pif = try builder.construct()
 
-            XCTAssertNoDiagnostics(diagnostics)
+            XCTAssertNoDiagnostics(observability.diagnostics)
 
             let projectNames = pif.workspace.projects.map({ $0.name })
             XCTAssertEqual(projectNames, ["A", "B", "Aggregate"])
@@ -104,10 +103,9 @@ class PIFBuilderTests: XCTestCase {
             "/Bar/Sources/BarLib/lib.swift"
         )
 
-        let diagnostics = DiagnosticsEngine()
+        let observability = ObservabilitySystem.bootstrapForTesting()
         let graph = try loadPackageGraph(
             fs: fs,
-            diagnostics: diagnostics,
             manifests: [
                 Manifest.createManifest(
                     name: "Foo",
@@ -144,10 +142,10 @@ class PIFBuilderTests: XCTestCase {
             shouldCreateMultipleTestProducts: true
         )
 
-        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: diagnostics)
+        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
         let pif = try builder.construct()
 
-        XCTAssertNoDiagnostics(diagnostics)
+        XCTAssertNoDiagnostics(observability.diagnostics)
 
         PIFTester(pif) { workspace in
             workspace.checkProject("PACKAGE:/Foo") { project in
@@ -372,10 +370,9 @@ class PIFBuilderTests: XCTestCase {
             "/Bar/Sources/BarLib/lib.swift"
         )
 
-        let diagnostics = DiagnosticsEngine()
+        let observability = ObservabilitySystem.bootstrapForTesting()
         let graph = try loadPackageGraph(
             fs: fs,
-            diagnostics: diagnostics,
             manifests: [
                 Manifest.createManifest(
                     name: "Foo",
@@ -423,11 +420,11 @@ class PIFBuilderTests: XCTestCase {
 
         var pif: PIF.TopLevelObject!
         try! withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
-            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: diagnostics)
+            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
             pif = try builder.construct()
         }
 
-        XCTAssertNoDiagnostics(diagnostics)
+        XCTAssertNoDiagnostics(observability.diagnostics)
 
         PIFTester(pif) { workspace in
             workspace.checkProject("PACKAGE:/Foo") { project in
@@ -704,10 +701,9 @@ class PIFBuilderTests: XCTestCase {
             "/Bar/Sources/BarLib/lib.swift"
         )
 
-        let diagnostics = DiagnosticsEngine()
+        let observability = ObservabilitySystem.bootstrapForTesting()
         let graph = try loadPackageGraph(
             fs: fs,
-            diagnostics: diagnostics,
             manifests: [
                 Manifest.createManifest(
                     name: "Foo",
@@ -756,11 +752,11 @@ class PIFBuilderTests: XCTestCase {
 
         var pif: PIF.TopLevelObject!
         try! withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
-            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: diagnostics)
+            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
             pif = try builder.construct()
         }
 
-        XCTAssertNoDiagnostics(diagnostics)
+        XCTAssertNoDiagnostics(observability.diagnostics)
 
         PIFTester(pif) { workspace in
             workspace.checkProject("PACKAGE:/Foo") { project in
@@ -930,10 +926,9 @@ class PIFBuilderTests: XCTestCase {
             "/Bar/Sources/BarLib/lib.swift"
         )
 
-        let diagnostics = DiagnosticsEngine()
+        let observability = ObservabilitySystem.bootstrapForTesting()
         let graph = try loadPackageGraph(
             fs: fs,
-            diagnostics: diagnostics,
             manifests: [
                 Manifest.createManifest(
                     name: "Foo",
@@ -975,11 +970,11 @@ class PIFBuilderTests: XCTestCase {
 
         var pif: PIF.TopLevelObject!
         try! withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
-            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: diagnostics)
+            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
             pif = try builder.construct()
         }
 
-        XCTAssertNoDiagnostics(diagnostics)
+        XCTAssertNoDiagnostics(observability.diagnostics)
 
         PIFTester(pif) { workspace in
             workspace.checkProject("PACKAGE:/Foo") { project in
@@ -1127,10 +1122,9 @@ class PIFBuilderTests: XCTestCase {
             "/Bar/Sources/BarLib/lib.c"
         )
 
-        let diagnostics = DiagnosticsEngine()
+        let observability = ObservabilitySystem.bootstrapForTesting()
         let graph = try loadPackageGraph(
             fs: fs,
-            diagnostics: diagnostics,
             manifests: [
                 Manifest.createManifest(
                     name: "Foo",
@@ -1167,11 +1161,11 @@ class PIFBuilderTests: XCTestCase {
 
         var pif: PIF.TopLevelObject!
         try! withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
-            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: diagnostics)
+            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
             pif = try builder.construct()
         }
 
-        XCTAssertNoDiagnostics(diagnostics)
+        XCTAssertNoDiagnostics(observability.diagnostics)
 
         PIFTester(pif) { workspace in
             workspace.checkProject("PACKAGE:/Foo") { project in
@@ -1415,10 +1409,9 @@ class PIFBuilderTests: XCTestCase {
             "/Bar/Sources/BarLib/lib.c"
         )
 
-        let diagnostics = DiagnosticsEngine()
+        let observability = ObservabilitySystem.bootstrapForTesting()
         let graph = try loadPackageGraph(
             fs: fs,
-            diagnostics: diagnostics,
             manifests: [
                 Manifest.createManifest(
                     name: "Bar",
@@ -1438,11 +1431,11 @@ class PIFBuilderTests: XCTestCase {
 
         var pif: PIF.TopLevelObject!
         try! withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
-            let builder = PIFBuilder(graph: graph, parameters: .mock(shouldCreateDylibForDynamicProducts: true), diagnostics: diagnostics)
+            let builder = PIFBuilder(graph: graph, parameters: .mock(shouldCreateDylibForDynamicProducts: true), diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
             pif = try builder.construct()
         }
 
-        XCTAssertNoDiagnostics(diagnostics)
+        XCTAssertNoDiagnostics(observability.diagnostics)
 
         PIFTester(pif) { workspace in
             workspace.checkProject("PACKAGE:/Bar") { project in
@@ -1461,10 +1454,9 @@ class PIFBuilderTests: XCTestCase {
             "/Bar/Sources/BarLib/module.modulemap"
         )
         
-        let diagnostics = DiagnosticsEngine()
+        let observability = ObservabilitySystem.bootstrapForTesting()
         let graph = try loadPackageGraph(
             fs: fs,
-            diagnostics: diagnostics,
             manifests: [
                 Manifest.createManifest(
                     name: "Bar",
@@ -1484,11 +1476,11 @@ class PIFBuilderTests: XCTestCase {
         
         var pif: PIF.TopLevelObject!
         try! withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
-            let builder = PIFBuilder(graph: graph, parameters: .mock(shouldCreateDylibForDynamicProducts: true), diagnostics: diagnostics)
+            let builder = PIFBuilder(graph: graph, parameters: .mock(shouldCreateDylibForDynamicProducts: true), diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
             pif = try builder.construct()
         }
         
-        XCTAssertNoDiagnostics(diagnostics)
+        XCTAssertNoDiagnostics(observability.diagnostics)
         
         PIFTester(pif) { workspace in
             workspace.checkProject("PACKAGE:/Bar") { project in
@@ -1511,10 +1503,9 @@ class PIFBuilderTests: XCTestCase {
             "/Foo/Sources/SystemLib2/module.modulemap"
         )
 
-        let diagnostics = DiagnosticsEngine()
+        let observability = ObservabilitySystem.bootstrapForTesting()
         let graph = try loadPackageGraph(
             fs: fs,
-            diagnostics: diagnostics,
             manifests: [
                 Manifest.createManifest(
                     name: "Foo",
@@ -1532,11 +1523,11 @@ class PIFBuilderTests: XCTestCase {
 
         var pif: PIF.TopLevelObject!
         try! withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
-            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: diagnostics)
+            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
             pif = try builder.construct()
         }
 
-        XCTAssertNoDiagnostics(diagnostics)
+        XCTAssertNoDiagnostics(observability.diagnostics)
 
         PIFTester(pif) { workspace in
             workspace.checkProject("PACKAGE:/Foo") { project in
@@ -1623,10 +1614,9 @@ class PIFBuilderTests: XCTestCase {
             "/Foo/BinaryLibrary.xcframework/Info.plist"
         )
 
-        let diagnostics = DiagnosticsEngine()
+        let observability = ObservabilitySystem.bootstrapForTesting()
         let graph = try loadPackageGraph(
             fs: fs,
-            diagnostics: diagnostics,
             manifests: [
                 Manifest.createManifest(
                     name: "Foo",
@@ -1649,10 +1639,10 @@ class PIFBuilderTests: XCTestCase {
             shouldCreateMultipleTestProducts: true
         )
 
-        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: diagnostics)
+        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
         let pif = try builder.construct()
 
-        XCTAssertNoDiagnostics(diagnostics)
+        XCTAssertNoDiagnostics(observability.diagnostics)
 
         PIFTester(pif) { workspace in
             workspace.checkProject("PACKAGE:/Foo") { project in
@@ -1688,10 +1678,9 @@ class PIFBuilderTests: XCTestCase {
             "/Foo/Sources/FooTests/Resources/Database.xcdatamodel"
         )
 
-        let diagnostics = DiagnosticsEngine()
+        let observability = ObservabilitySystem.bootstrapForTesting()
         let graph = try loadPackageGraph(
             fs: fs,
-            diagnostics: diagnostics,
             manifests: [
                 Manifest.createManifest(
                     name: "Foo",
@@ -1719,10 +1708,10 @@ class PIFBuilderTests: XCTestCase {
             useXCBuildFileRules: true
         )
 
-        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: diagnostics)
+        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
         let pif = try builder.construct()
 
-        XCTAssertNoDiagnostics(diagnostics)
+        XCTAssertNoDiagnostics(observability.diagnostics)
 
         PIFTester(pif) { workspace in
             workspace.checkProject("PACKAGE:/Foo") { project in
@@ -1898,10 +1887,9 @@ class PIFBuilderTests: XCTestCase {
             "/Foo/Sources/FooTests/FooTests.swift"
         )
 
-        let diagnostics = DiagnosticsEngine()
+        let observability = ObservabilitySystem.bootstrapForTesting()
         let graph = try loadPackageGraph(
             fs: fs,
-            diagnostics: diagnostics,
             manifests: [
                 Manifest.createManifest(
                     name: "Foo",
@@ -1980,10 +1968,10 @@ class PIFBuilderTests: XCTestCase {
             shouldCreateMultipleTestProducts: true
         )
 
-        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: diagnostics)
+        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
         let pif = try builder.construct()
 
-        XCTAssertNoDiagnostics(diagnostics)
+        XCTAssertNoDiagnostics(observability.diagnostics)
 
         PIFTester(pif) { workspace in
             workspace.checkProject("PACKAGE:/Foo") { project in
@@ -2117,10 +2105,9 @@ class PIFBuilderTests: XCTestCase {
             "/Foo/Sources/FooTests/FooTests.swift"
         )
 
-        let diagnostics = DiagnosticsEngine()
+        let observability = ObservabilitySystem.bootstrapForTesting()
         let graph = try loadPackageGraph(
             fs: fs,
-            diagnostics: diagnostics,
             manifests: [
                 Manifest.createManifest(
                     name: "Foo",
@@ -2139,12 +2126,13 @@ class PIFBuilderTests: XCTestCase {
             shouldCreateMultipleTestProducts: true
         )
 
-        XCTAssertNoDiagnostics(diagnostics)
+        XCTAssertNoDiagnostics(observability.diagnostics)
 
         let builder = PIFBuilder(
             graph: graph,
             parameters: .mock(),
-            diagnostics: diagnostics)
+            diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
+        )
         let pif = try builder.construct()
 
         let expectedFilters: [PIF.GUID: [PIF.PlatformFilter]] = [
@@ -2181,10 +2169,9 @@ class PIFBuilderTests: XCTestCase {
             "/Foo/Sources/foo/main.swift"
         )
 
-        let diagnostics = DiagnosticsEngine()
+        let observability = ObservabilitySystem.bootstrapForTesting()
         let graph = try loadPackageGraph(
             fs: fs,
-            diagnostics: diagnostics,
             manifests: [
                 Manifest.createManifest(
                     name: "Foo",
@@ -2202,10 +2189,10 @@ class PIFBuilderTests: XCTestCase {
             shouldCreateMultipleTestProducts: true
         )
 
-        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: diagnostics)
+        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
         let pif = try builder.construct()
 
-        XCTAssertNoDiagnostics(diagnostics)
+        XCTAssertNoDiagnostics(observability.diagnostics)
 
         PIFTester(pif) { workspace in
             workspace.checkProject("PACKAGE:/Foo") { project in
@@ -2225,10 +2212,9 @@ class PIFBuilderTests: XCTestCase {
             "/MyLib/Sources/MyLib/Foo.swift"
         )
 
-        let diagnostics = DiagnosticsEngine()
+        let observability = ObservabilitySystem.bootstrapForTesting()
         let graph = try loadPackageGraph(
             fs: fs,
-            diagnostics: diagnostics,
             manifests: [
                 Manifest.createManifest(
                     name: "MyLib",
@@ -2251,10 +2237,10 @@ class PIFBuilderTests: XCTestCase {
             shouldCreateMultipleTestProducts: true
         )
 
-        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: diagnostics)
+        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
         let pif = try builder.construct()
 
-        XCTAssertNoDiagnostics(diagnostics)
+        XCTAssertNoDiagnostics(observability.diagnostics)
 
         PIFTester(pif) { workspace in
             workspace.checkProject("PACKAGE:/MyLib") { project in

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -71,7 +71,7 @@ class PIFBuilderTests: XCTestCase {
                 ]
             )
 
-            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
+            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
             let pif = try builder.construct()
 
             XCTAssertNoDiagnostics(observability.diagnostics)
@@ -142,7 +142,7 @@ class PIFBuilderTests: XCTestCase {
             shouldCreateMultipleTestProducts: true
         )
 
-        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
+        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
         let pif = try builder.construct()
 
         XCTAssertNoDiagnostics(observability.diagnostics)
@@ -420,7 +420,7 @@ class PIFBuilderTests: XCTestCase {
 
         var pif: PIF.TopLevelObject!
         try! withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
-            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
+            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
             pif = try builder.construct()
         }
 
@@ -752,7 +752,7 @@ class PIFBuilderTests: XCTestCase {
 
         var pif: PIF.TopLevelObject!
         try! withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
-            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
+            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
             pif = try builder.construct()
         }
 
@@ -970,7 +970,7 @@ class PIFBuilderTests: XCTestCase {
 
         var pif: PIF.TopLevelObject!
         try! withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
-            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
+            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
             pif = try builder.construct()
         }
 
@@ -1161,7 +1161,7 @@ class PIFBuilderTests: XCTestCase {
 
         var pif: PIF.TopLevelObject!
         try! withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
-            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
+            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
             pif = try builder.construct()
         }
 
@@ -1431,7 +1431,7 @@ class PIFBuilderTests: XCTestCase {
 
         var pif: PIF.TopLevelObject!
         try! withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
-            let builder = PIFBuilder(graph: graph, parameters: .mock(shouldCreateDylibForDynamicProducts: true), diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
+            let builder = PIFBuilder(graph: graph, parameters: .mock(shouldCreateDylibForDynamicProducts: true), diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
             pif = try builder.construct()
         }
 
@@ -1476,7 +1476,7 @@ class PIFBuilderTests: XCTestCase {
         
         var pif: PIF.TopLevelObject!
         try! withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
-            let builder = PIFBuilder(graph: graph, parameters: .mock(shouldCreateDylibForDynamicProducts: true), diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
+            let builder = PIFBuilder(graph: graph, parameters: .mock(shouldCreateDylibForDynamicProducts: true), diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
             pif = try builder.construct()
         }
         
@@ -1523,7 +1523,7 @@ class PIFBuilderTests: XCTestCase {
 
         var pif: PIF.TopLevelObject!
         try! withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
-            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
+            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
             pif = try builder.construct()
         }
 
@@ -1639,7 +1639,7 @@ class PIFBuilderTests: XCTestCase {
             shouldCreateMultipleTestProducts: true
         )
 
-        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
+        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
         let pif = try builder.construct()
 
         XCTAssertNoDiagnostics(observability.diagnostics)
@@ -1708,7 +1708,7 @@ class PIFBuilderTests: XCTestCase {
             useXCBuildFileRules: true
         )
 
-        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
+        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
         let pif = try builder.construct()
 
         XCTAssertNoDiagnostics(observability.diagnostics)
@@ -1968,7 +1968,7 @@ class PIFBuilderTests: XCTestCase {
             shouldCreateMultipleTestProducts: true
         )
 
-        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
+        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
         let pif = try builder.construct()
 
         XCTAssertNoDiagnostics(observability.diagnostics)
@@ -2131,7 +2131,7 @@ class PIFBuilderTests: XCTestCase {
         let builder = PIFBuilder(
             graph: graph,
             parameters: .mock(),
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
         )
         let pif = try builder.construct()
 
@@ -2189,7 +2189,7 @@ class PIFBuilderTests: XCTestCase {
             shouldCreateMultipleTestProducts: true
         )
 
-        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
+        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
         let pif = try builder.construct()
 
         XCTAssertNoDiagnostics(observability.diagnostics)
@@ -2237,7 +2237,7 @@ class PIFBuilderTests: XCTestCase {
             shouldCreateMultipleTestProducts: true
         )
 
-        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.makeDiagnosticsEngine())
+        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
         let pif = try builder.construct()
 
         XCTAssertNoDiagnostics(observability.diagnostics)

--- a/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
+++ b/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
@@ -56,7 +56,7 @@ class GenerateXcodeprojTests: XCTestCase {
             xcodeprojPath: outpath,
             graph: graph,
             options: XcodeprojOptions(),
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
           )
 
           XCTAssertDirectoryExists(outpath)
@@ -115,7 +115,7 @@ class GenerateXcodeprojTests: XCTestCase {
                     extraFiles: [],
                     options: options,
                     fileSystem: localFileSystem,
-                    diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
+                    diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
                 )
                 XCTFail("Project generation should have failed")
             } catch ProjectGenerationError.xcconfigOverrideNotFound(let path) {
@@ -151,7 +151,7 @@ class GenerateXcodeprojTests: XCTestCase {
                 xcodeprojPath: AbsolutePath.root.appending(component: "xcodeproj"),
                 graph: graph, extraDirs: [], extraFiles: [],
                 options: XcodeprojOptions(), fileSystem: localFileSystem,
-                diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
+                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
             )
 
             testDiagnostics(observability.diagnostics) { result in
@@ -193,7 +193,7 @@ class GenerateXcodeprojTests: XCTestCase {
                 xcodeprojPath: outpath,
                 graph: graph,
                 options: XcodeprojOptions(),
-                diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
+                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
             )
 
             XCTAssertFalse(project.mainGroup.subitems.contains { $0.path == "a.txt" })
@@ -233,7 +233,7 @@ class GenerateXcodeprojTests: XCTestCase {
                 xcodeprojPath: outpath,
                 graph: graph,
                 options: XcodeprojOptions(),
-                diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
+                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
             )
 
             XCTAssertFalse(project.mainGroup.subitems.contains { $0.path == ".a.txt" })
@@ -272,7 +272,7 @@ class GenerateXcodeprojTests: XCTestCase {
                 xcodeprojPath: outpath,
                 graph: graph,
                 options: XcodeprojOptions(),
-                diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
+                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
             )
 
             XCTAssertTrue(project.mainGroup.subitems.contains { $0.path == "a.txt" })
@@ -282,7 +282,7 @@ class GenerateXcodeprojTests: XCTestCase {
                 xcodeprojPath: outpath,
                 graph: graph,
                 options: XcodeprojOptions(addExtraFiles: false),
-                diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
+                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
             )
             XCTAssertFalse(projectWithoutExtraFiles.mainGroup.subitems.contains { $0.path == "a.txt" })
         }
@@ -321,7 +321,7 @@ class GenerateXcodeprojTests: XCTestCase {
                 xcodeprojPath: outpath,
                 graph: graph,
                 options: XcodeprojOptions(),
-                diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
+                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
             )
 
             let sources = project.mainGroup.subitems[1] as? Xcode.Group
@@ -369,7 +369,7 @@ class GenerateXcodeprojTests: XCTestCase {
                 xcodeprojPath: outpath,
                 graph: graph,
                 options: XcodeprojOptions(),
-                diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
+                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
             )
 
             let sources = project.mainGroup.subitems[1] as? Xcode.Group
@@ -431,7 +431,7 @@ class GenerateXcodeprojTests: XCTestCase {
                 xcodeprojPath: outpath,
                 graph: graph,
                 options: XcodeprojOptions(),
-                diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
+                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
             )
 
             testDiagnostics(observability.diagnostics) { result in

--- a/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
+++ b/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
@@ -8,13 +8,14 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import TSCBasic
-import SPMTestSupport
+import Basics
 import PackageGraph
 import PackageModel
 import SourceControl
-import Xcodeproj
+import SPMTestSupport
 import TSCUtility
+import TSCBasic
+import Xcodeproj
 import XCTest
 
 class GenerateXcodeprojTests: XCTestCase {
@@ -34,8 +35,8 @@ class GenerateXcodeprojTests: XCTestCase {
           try makeDirectories(modulePath)
           try localFileSystem.writeFileContents(modulePath.appending(component: "source.swift"), bytes: "")
 
-          let diagnostics = DiagnosticsEngine()
-          let graph = try loadPackageGraph(fs: localFileSystem, diagnostics: diagnostics,
+          let observability = ObservabilitySystem.bootstrapForTesting()
+          let graph = try loadPackageGraph(fs: localFileSystem,
               manifests: [
                   Manifest.createV4Manifest(
                       name: "Foo",
@@ -46,11 +47,17 @@ class GenerateXcodeprojTests: XCTestCase {
                       ])
               ]
           )
-          XCTAssertNoDiagnostics(diagnostics)
+          XCTAssertNoDiagnostics(observability.diagnostics)
 
           let projectName = "DummyProjectName"
           let outpath = Xcodeproj.buildXcodeprojPath(outputDir: dstdir, projectName: projectName)
-          try Xcodeproj.generate(projectName: projectName, xcodeprojPath: outpath, graph: graph, options: XcodeprojOptions(), diagnostics: diagnostics)
+          try Xcodeproj.generate(
+            projectName: projectName,
+            xcodeprojPath: outpath,
+            graph: graph,
+            options: XcodeprojOptions(),
+            diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
+          )
 
           XCTAssertDirectoryExists(outpath)
           XCTAssertEqual(outpath, dstdir.appending(component: projectName + ".xcodeproj"))
@@ -85,8 +92,8 @@ class GenerateXcodeprojTests: XCTestCase {
             try makeDirectories(modulePath)
             try localFileSystem.writeFileContents(modulePath.appending(component: "bar.swift"), bytes: "")
 
-            let diagnostics = DiagnosticsEngine()
-            let graph = try loadPackageGraph(fs: localFileSystem, diagnostics: diagnostics,
+            let observability = ObservabilitySystem.bootstrapForTesting()
+            let graph = try loadPackageGraph(fs: localFileSystem,
                 manifests: [
                     Manifest.createV4Manifest(
                         name: "Bar",
@@ -97,12 +104,19 @@ class GenerateXcodeprojTests: XCTestCase {
                         ])
                 ]
             )
-            XCTAssertNoDiagnostics(diagnostics)
+            XCTAssertNoDiagnostics(observability.diagnostics)
 
             let options = XcodeprojOptions(xcconfigOverrides: AbsolutePath("/doesntexist"))
             do {
-                _ = try xcodeProject(xcodeprojPath: AbsolutePath.root.appending(component: "xcodeproj"),
-                                     graph: graph, extraDirs: [], extraFiles: [], options: options, fileSystem: localFileSystem, diagnostics: diagnostics)
+                _ = try xcodeProject(
+                    xcodeprojPath: AbsolutePath.root.appending(component: "xcodeproj"),
+                    graph: graph,
+                    extraDirs: [],
+                    extraFiles: [],
+                    options: options,
+                    fileSystem: localFileSystem,
+                    diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
+                )
                 XCTFail("Project generation should have failed")
             } catch ProjectGenerationError.xcconfigOverrideNotFound(let path) {
                 XCTAssertEqual(options.xcconfigOverrides, path)
@@ -119,8 +133,8 @@ class GenerateXcodeprojTests: XCTestCase {
             try makeDirectories(modulePath)
             try localFileSystem.writeFileContents(modulePath.appending(component: "example.swift"), bytes: "")
 
-            let diagnostics = DiagnosticsEngine()
-            let graph = try loadPackageGraph(fs: localFileSystem, diagnostics: diagnostics,
+            let observability = ObservabilitySystem.bootstrapForTesting()
+            let graph = try loadPackageGraph(fs: localFileSystem,
                 manifests: [
                     Manifest.createV4Manifest(
                         name: "Modules",
@@ -131,19 +145,20 @@ class GenerateXcodeprojTests: XCTestCase {
                         ])
                 ]
             )
-            XCTAssertNoDiagnostics(diagnostics)
+            XCTAssertNoDiagnostics(observability.diagnostics)
 
             _ = try xcodeProject(
                 xcodeprojPath: AbsolutePath.root.appending(component: "xcodeproj"),
                 graph: graph, extraDirs: [], extraFiles: [],
                 options: XcodeprojOptions(), fileSystem: localFileSystem,
-                diagnostics: diagnostics
+                diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
             )
 
-            DiagnosticsEngineTester(diagnostics) { result in
+            testDiagnostics(observability.diagnostics) { result in
                 result.check(
                     diagnostic: .contains("Target 'Modules' conflicts with required framework filenames, rename this target to avoid conflicts."),
-                    behavior: .warning)
+                    severity: .warning
+                )
             }
         }
     }
@@ -156,9 +171,9 @@ class GenerateXcodeprojTests: XCTestCase {
             try localFileSystem.writeFileContents(modulePath.appending(component: "dummy.swift"), bytes: "dummy_data")
             try localFileSystem.writeFileContents(packagePath.appending(component: "a.txt"), bytes: "dummy_data")
 
-            let diagnostics = DiagnosticsEngine()
+            let observability = ObservabilitySystem.bootstrapForTesting()
             let graph = try loadPackageGraph(
-                fs: localFileSystem, diagnostics: diagnostics,
+                fs: localFileSystem,
                 manifests: [
                     Manifest.createV4Manifest(
                         name: "Foo",
@@ -169,11 +184,17 @@ class GenerateXcodeprojTests: XCTestCase {
                         ])
                 ]
             )
-            XCTAssertNoDiagnostics(diagnostics)
+            XCTAssertNoDiagnostics(observability.diagnostics)
 
             let projectName = "DummyProjectName"
             let outpath = Xcodeproj.buildXcodeprojPath(outputDir: dstdir, projectName: projectName)
-            let project = try Xcodeproj.generate(projectName: projectName, xcodeprojPath: outpath, graph: graph, options: XcodeprojOptions(), diagnostics: diagnostics)
+            let project = try Xcodeproj.generate(
+                projectName: projectName,
+                xcodeprojPath: outpath,
+                graph: graph,
+                options: XcodeprojOptions(),
+                diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
+            )
 
             XCTAssertFalse(project.mainGroup.subitems.contains { $0.path == "a.txt" })
         }
@@ -190,9 +211,9 @@ class GenerateXcodeprojTests: XCTestCase {
 
             initGitRepo(packagePath, addFile: false)
 
-            let diagnostics = DiagnosticsEngine()
+            let observability = ObservabilitySystem.bootstrapForTesting()
             let graph = try loadPackageGraph(
-                fs: localFileSystem, diagnostics: diagnostics,
+                fs: localFileSystem,
                 manifests: [
                     Manifest.createV4Manifest(
                         name: "Foo",
@@ -203,11 +224,17 @@ class GenerateXcodeprojTests: XCTestCase {
                         ])
                 ]
             )
-            XCTAssertNoDiagnostics(diagnostics)
+            XCTAssertNoDiagnostics(observability.diagnostics)
 
             let projectName = "DummyProjectName"
             let outpath = Xcodeproj.buildXcodeprojPath(outputDir: dstdir, projectName: projectName)
-            let project = try Xcodeproj.generate(projectName: projectName, xcodeprojPath: outpath, graph: graph, options: XcodeprojOptions(), diagnostics: diagnostics)
+            let project = try Xcodeproj.generate(
+                projectName: projectName,
+                xcodeprojPath: outpath,
+                graph: graph,
+                options: XcodeprojOptions(),
+                diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
+            )
 
             XCTAssertFalse(project.mainGroup.subitems.contains { $0.path == ".a.txt" })
         }
@@ -223,9 +250,9 @@ class GenerateXcodeprojTests: XCTestCase {
 
             initGitRepo(packagePath, addFile: false)
 
-            let diagnostics = DiagnosticsEngine()
+            let observability = ObservabilitySystem.bootstrapForTesting()
             let graph = try loadPackageGraph(
-                fs: localFileSystem, diagnostics: diagnostics,
+                fs: localFileSystem,
                 manifests: [
                     Manifest.createV4Manifest(
                         name: "Foo",
@@ -236,15 +263,27 @@ class GenerateXcodeprojTests: XCTestCase {
                         ])
                 ]
             )
-            XCTAssertNoDiagnostics(diagnostics)
+            XCTAssertNoDiagnostics(observability.diagnostics)
 
             let projectName = "DummyProjectName"
             let outpath = Xcodeproj.buildXcodeprojPath(outputDir: dstdir, projectName: projectName)
-            let project = try Xcodeproj.generate(projectName: projectName, xcodeprojPath: outpath, graph: graph, options: XcodeprojOptions(), diagnostics: diagnostics)
+            let project = try Xcodeproj.generate(
+                projectName: projectName,
+                xcodeprojPath: outpath,
+                graph: graph,
+                options: XcodeprojOptions(),
+                diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
+            )
 
             XCTAssertTrue(project.mainGroup.subitems.contains { $0.path == "a.txt" })
 
-            let projectWithoutExtraFiles = try Xcodeproj.generate(projectName: projectName, xcodeprojPath: outpath, graph: graph, options: XcodeprojOptions(addExtraFiles: false), diagnostics: diagnostics)
+            let projectWithoutExtraFiles = try Xcodeproj.generate(
+                projectName: projectName,
+                xcodeprojPath: outpath,
+                graph: graph,
+                options: XcodeprojOptions(addExtraFiles: false),
+                diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
+            )
             XCTAssertFalse(projectWithoutExtraFiles.mainGroup.subitems.contains { $0.path == "a.txt" })
         }
     }
@@ -260,9 +299,9 @@ class GenerateXcodeprojTests: XCTestCase {
 
             initGitRepo(packagePath, addFile: false)
 
-            let diagnostics = DiagnosticsEngine()
+            let observability = ObservabilitySystem.bootstrapForTesting()
             let graph = try loadPackageGraph(
-                fs: localFileSystem, diagnostics: diagnostics,
+                fs: localFileSystem,
                 manifests: [
                     Manifest.createV4Manifest(
                         name: "Foo",
@@ -273,11 +312,17 @@ class GenerateXcodeprojTests: XCTestCase {
                         ])
                 ]
             )
-            XCTAssertNoDiagnostics(diagnostics)
+            XCTAssertNoDiagnostics(observability.diagnostics)
 
             let projectName = "DummyProjectName"
             let outpath = Xcodeproj.buildXcodeprojPath(outputDir: tmpdir, projectName: projectName)
-            let project = try Xcodeproj.generate(projectName: projectName, xcodeprojPath: outpath, graph: graph, options: XcodeprojOptions(), diagnostics: diagnostics)
+            let project = try Xcodeproj.generate(
+                projectName: projectName,
+                xcodeprojPath: outpath,
+                graph: graph,
+                options: XcodeprojOptions(),
+                diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
+            )
 
             let sources = project.mainGroup.subitems[1] as? Xcode.Group
             let dummyModule = sources?.subitems[0] as? Xcode.Group
@@ -302,9 +347,9 @@ class GenerateXcodeprojTests: XCTestCase {
             try localFileSystem.writeFileContents(modulePath.appending(component: "ignored_file"), bytes: "dummy_data")
             try localFileSystem.writeFileContents(packagePath.appending(component: "ignored_file"), bytes: "dummy_data")
 
-            let diagnostics = DiagnosticsEngine()
+            let observability = ObservabilitySystem.bootstrapForTesting()
             let graph = try loadPackageGraph(
-                fs: localFileSystem, diagnostics: diagnostics,
+                fs: localFileSystem,
                 manifests: [
                     Manifest.createV4Manifest(
                         name: "Foo",
@@ -315,11 +360,17 @@ class GenerateXcodeprojTests: XCTestCase {
                         ])
                 ]
             )
-            XCTAssertNoDiagnostics(diagnostics)
+            XCTAssertNoDiagnostics(observability.diagnostics)
 
             let projectName = "DummyProjectName"
             let outpath = Xcodeproj.buildXcodeprojPath(outputDir: dstdir, projectName: projectName)
-            let project = try Xcodeproj.generate(projectName: projectName, xcodeprojPath: outpath, graph: graph, options: XcodeprojOptions(), diagnostics: diagnostics)
+            let project = try Xcodeproj.generate(
+                projectName: projectName,
+                xcodeprojPath: outpath,
+                graph: graph,
+                options: XcodeprojOptions(),
+                diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
+            )
 
             let sources = project.mainGroup.subitems[1] as? Xcode.Group
             let dummyModule = sources?.subitems[0] as? Xcode.Group
@@ -344,8 +395,8 @@ class GenerateXcodeprojTests: XCTestCase {
             try makeDirectories(bar2TargetPath)
             try localFileSystem.writeFileContents(bar2TargetPath.appending(component: "Sources.swift"), bytes: "")
 
-            let diagnostics = DiagnosticsEngine()
-            let graph = try loadPackageGraph(fs: localFileSystem, diagnostics: diagnostics,
+            let observability = ObservabilitySystem.bootstrapForTesting()
+            let graph = try loadPackageGraph(fs: localFileSystem,
                 manifests: [
                     Manifest.createV4Manifest(
                         name: "Foo",
@@ -380,15 +431,16 @@ class GenerateXcodeprojTests: XCTestCase {
                 xcodeprojPath: outpath,
                 graph: graph,
                 options: XcodeprojOptions(),
-                diagnostics: diagnostics)
+                diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
+            )
 
-            DiagnosticsEngineTester(diagnostics) { result in
+            testDiagnostics(observability.diagnostics) { result in
                 result.check(
                     diagnostic: .regex("""
                         Xcode project generation does not support conditional target dependencies, so the generated \
                         project might not build successfully. The offending targets are: (Foo, Bar1|Bar1, Foo).
                         """),
-                    behavior: .warning)
+                    severity: .warning)
             }
         }
     }

--- a/Tests/XcodeprojTests/PackageGraphTests.swift
+++ b/Tests/XcodeprojTests/PackageGraphTests.swift
@@ -8,13 +8,13 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import XCTest
-
-import TSCBasic
+import Basics
 import PackageGraph
-import SPMTestSupport
 import PackageModel
+import SPMTestSupport
+import TSCBasic
 import Xcodeproj
+import XCTest
 
 class PackageGraphTests: XCTestCase {
     func testBasics() throws {
@@ -33,8 +33,8 @@ class PackageGraphTests: XCTestCase {
             "/Overrides.xcconfig"
         )
 
-        let diagnostics = DiagnosticsEngine()
-        let g = try loadPackageGraph(fs: fs, diagnostics: diagnostics,
+        let observability = ObservabilitySystem.bootstrapForTesting()
+        let g = try loadPackageGraph(fs: fs,
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Foo",
@@ -70,11 +70,19 @@ class PackageGraphTests: XCTestCase {
                     ]),
             ]
         )
-        XCTAssertNoDiagnostics(diagnostics)
+        XCTAssertNoDiagnostics(observability.diagnostics)
 
         let options = XcodeprojOptions(xcconfigOverrides: AbsolutePath("/Overrides.xcconfig"))
 
-        let project = try xcodeProject(xcodeprojPath: AbsolutePath.root.appending(component: "xcodeproj"), graph: g, extraDirs: [], extraFiles: [], options: options, fileSystem: fs, diagnostics: diagnostics)
+        let project = try xcodeProject(
+            xcodeprojPath: AbsolutePath.root.appending(component: "xcodeproj"),
+            graph: g,
+            extraDirs: [],
+            extraFiles: [],
+            options: options,
+            fileSystem: fs,
+            diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
+        )
 
         XcodeProjectTester(project) { result in
             result.check(projectDir: "Bar")
@@ -196,8 +204,8 @@ class PackageGraphTests: XCTestCase {
             "/Foo/Sources/Foo/source.swift"
         )
 
-        let diagnostics = DiagnosticsEngine()
-        let g = try loadPackageGraph(fs: fs, diagnostics: diagnostics,
+        let observability = ObservabilitySystem.bootstrapForTesting()
+        let g = try loadPackageGraph(fs: fs,
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Foo",
@@ -211,9 +219,17 @@ class PackageGraphTests: XCTestCase {
                     ]),
             ]
         )
-        XCTAssertNoDiagnostics(diagnostics)
+        XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let project = try xcodeProject(xcodeprojPath: AbsolutePath("/Foo/build").appending(component: "xcodeproj"), graph: g, extraDirs: [], extraFiles: [], options: XcodeprojOptions(), fileSystem: fs, diagnostics: diagnostics)
+        let project = try xcodeProject(
+            xcodeprojPath: AbsolutePath("/Foo/build").appending(component: "xcodeproj"),
+            graph: g,
+            extraDirs: [],
+            extraFiles: [],
+            options: XcodeprojOptions(),
+            fileSystem: fs,
+            diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
+        )
         XcodeProjectTester(project) { result in
             result.check(target: "Foo") { targetResult in
                 targetResult.check(productType: .framework)
@@ -236,8 +252,8 @@ class PackageGraphTests: XCTestCase {
             "/Bar/Sources/swift/main.swift"
         )
 
-        let diagnostics = DiagnosticsEngine()
-        let g = try loadPackageGraph(fs: fs, diagnostics: diagnostics,
+        let observability = ObservabilitySystem.bootstrapForTesting()
+        let g = try loadPackageGraph(fs: fs,
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Bar",
@@ -250,9 +266,17 @@ class PackageGraphTests: XCTestCase {
                     ]),
             ]
         )
-        XCTAssertNoDiagnostics(diagnostics)
+        XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let project = try xcodeProject(xcodeprojPath: AbsolutePath("/Bar/build").appending(component: "xcodeproj"), graph: g, extraDirs: [], extraFiles: [], options: XcodeprojOptions(), fileSystem: fs, diagnostics: diagnostics)
+        let project = try xcodeProject(
+            xcodeprojPath: AbsolutePath("/Bar/build").appending(component: "xcodeproj"),
+            graph: g,
+            extraDirs: [],
+            extraFiles: [],
+            options: XcodeprojOptions(),
+            fileSystem: fs,
+            diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
+        )
         XcodeProjectTester(project) { result in
             result.check(target: "swift") { targetResult in
                 XCTAssertEqual(targetResult.target.buildSettings.common.OTHER_SWIFT_FLAGS ?? [], [
@@ -278,8 +302,8 @@ class PackageGraphTests: XCTestCase {
             "/Pkg/Tests/LibraryTests/aTest.swift"
         )
 
-        let diagnostics = DiagnosticsEngine()
-        let g = try loadPackageGraph(fs: fs, diagnostics: diagnostics,
+        let observability = ObservabilitySystem.bootstrapForTesting()
+        let g = try loadPackageGraph(fs: fs,
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Pkg",
@@ -292,9 +316,17 @@ class PackageGraphTests: XCTestCase {
                     ]),
             ]
         )
-        XCTAssertNoDiagnostics(diagnostics)
+        XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let project = try xcodeProject(xcodeprojPath: AbsolutePath.root.appending(component: "xcodeproj"), graph: g, extraDirs: [], extraFiles: [], options: XcodeprojOptions(), fileSystem: fs, diagnostics: diagnostics)
+        let project = try xcodeProject(
+            xcodeprojPath: AbsolutePath.root.appending(component: "xcodeproj"),
+            graph: g,
+            extraDirs: [],
+            extraFiles: [],
+            options: XcodeprojOptions(),
+            fileSystem: fs,
+            diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
+        )
 
         XcodeProjectTester(project) { result in
             result.check(projectDir: "Pkg")
@@ -340,8 +372,8 @@ class PackageGraphTests: XCTestCase {
             "/end"
         )
 
-        let diagnostics = DiagnosticsEngine()
-        let graph = try loadPackageGraph(fs: fs, diagnostics: diagnostics,
+        let observability = ObservabilitySystem.bootstrapForTesting()
+        let graph = try loadPackageGraph(fs: fs,
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Foo",
@@ -361,7 +393,7 @@ class PackageGraphTests: XCTestCase {
                     ]),
             ]
         )
-        XCTAssertNoDiagnostics(diagnostics)
+        XCTAssertNoDiagnostics(observability.diagnostics)
 
         let generatedSchemes = try SchemesGenerator(
             graph: graph,
@@ -392,8 +424,8 @@ class PackageGraphTests: XCTestCase {
                 "/end"
             )
 
-            let diagnostics = DiagnosticsEngine()
-            let graph = try loadPackageGraph(fs: fs, diagnostics: diagnostics,
+            let observability = ObservabilitySystem.bootstrapForTesting()
+            let graph = try loadPackageGraph(fs: fs,
                 manifests: [
                     Manifest.createV4Manifest(
                         name: "Foo",
@@ -405,10 +437,18 @@ class PackageGraphTests: XCTestCase {
                         ]),
                 ]
             )
-            XCTAssertNoDiagnostics(diagnostics)
+            XCTAssertNoDiagnostics(observability.diagnostics)
 
-            let project = try xcodeProject(xcodeprojPath: AbsolutePath("/Foo").appending(component: "xcodeproj"), graph: graph, extraDirs: [], extraFiles: [], options: XcodeprojOptions(), fileSystem: fs, diagnostics: diagnostics)
-            XCTAssertNoDiagnostics(diagnostics)
+            let project = try xcodeProject(
+                xcodeprojPath: AbsolutePath("/Foo").appending(component: "xcodeproj"),
+                graph: graph,
+                extraDirs: [],
+                extraFiles: [],
+                options: XcodeprojOptions(),
+                fileSystem: fs,
+                diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
 
             XcodeProjectTester(project) { result in
                 result.check(target: "a") { targetResult in

--- a/Tests/XcodeprojTests/PackageGraphTests.swift
+++ b/Tests/XcodeprojTests/PackageGraphTests.swift
@@ -81,7 +81,7 @@ class PackageGraphTests: XCTestCase {
             extraFiles: [],
             options: options,
             fileSystem: fs,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
         )
 
         XcodeProjectTester(project) { result in
@@ -228,7 +228,7 @@ class PackageGraphTests: XCTestCase {
             extraFiles: [],
             options: XcodeprojOptions(),
             fileSystem: fs,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
         )
         XcodeProjectTester(project) { result in
             result.check(target: "Foo") { targetResult in
@@ -275,7 +275,7 @@ class PackageGraphTests: XCTestCase {
             extraFiles: [],
             options: XcodeprojOptions(),
             fileSystem: fs,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
         )
         XcodeProjectTester(project) { result in
             result.check(target: "swift") { targetResult in
@@ -325,7 +325,7 @@ class PackageGraphTests: XCTestCase {
             extraFiles: [],
             options: XcodeprojOptions(),
             fileSystem: fs,
-            diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
+            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
         )
 
         XcodeProjectTester(project) { result in
@@ -446,7 +446,7 @@ class PackageGraphTests: XCTestCase {
                 extraFiles: [],
                 options: XcodeprojOptions(),
                 fileSystem: fs,
-                diagnostics: ObservabilitySystem.makeDiagnosticsEngine()
+                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
             )
             XCTAssertNoDiagnostics(observability.diagnostics)
 


### PR DESCRIPTION
motivation: refactor the diagnostics frameworks to seperate between emitting diagnostics and collecting/handling them, this helps creating an API to allow emitting diagnostics from any point at the code without having to pass in a DiagnosticsEngine everywhere

changes:
* add newe ObservabilitySystem API to abstract features like diagnostics, metrics and tracing
* add new DiagnosticsEmitter API design to [only] emit diagnostics
* adjust callsites to always create DiagnosticsEngine using the ObservabilitySystem so that the system are bridged
* convert GraphLoading subsystem to use DiagnosticsEmitter instead of DiagnosticsEngine
* move the Diagnostic printing code closer the Diganostic handling code in SwiftTool and clean it up
* adjust all tests and test utilities to use ObservabilitySystem

note: the code includes several API to allow bridging between the DiagnosticsEngine using the ObservabilitySystem APIs so that we can transition in steps and control the scope of the cahnges. The APIs are marked as deprecated to help trasnition, but are fairly noisy until we make more progress.

