### PR TITLE
cleanup test manifest creation

### DIFF
--- a/Sources/SPMTestSupport/ManifestExtensions.swift
+++ b/Sources/SPMTestSupport/ManifestExtensions.swift
@@ -15,9 +15,9 @@ import TSCUtility
 public extension Manifest {
     static func createV4Manifest(
         name: String,
-        path: String = "/",
+        path: AbsolutePath = .root,
         packageKind: PackageReference.Kind = .root,
-        packageLocation: String = "/",
+        packageLocation: String? = nil,
         version: TSCUtility.Version? = nil,
         toolsVersion: ToolsVersion = .v4,
         pkgConfig: String? = nil,
@@ -31,9 +31,9 @@ public extension Manifest {
     ) -> Manifest {
         return Manifest(
             name: name,
-            path: AbsolutePath(path).appending(component: Manifest.filename),
+            path: path.appending(component: Manifest.filename),
             packageKind: packageKind,
-            packageLocation: packageLocation,
+            packageLocation: packageLocation ?? path.pathString,
             platforms: [],
             version: version,
             toolsVersion: toolsVersion,
@@ -50,9 +50,9 @@ public extension Manifest {
 
     static func createManifest(
         name: String,
-        path: String = "/",
+        path: AbsolutePath = .root,
         packageKind: PackageReference.Kind = .root,
-        packageLocation: String = "/",
+        packageLocation: String? = nil,
         defaultLocalization: String? = nil,
         platforms: [PlatformDescription] = [],
         version: TSCUtility.Version? = nil,
@@ -68,9 +68,9 @@ public extension Manifest {
     ) -> Manifest {
         return Manifest(
             name: name,
-            path: AbsolutePath(path).appending(component: Manifest.filename),
+            path: path.appending(component: Manifest.filename),
             packageKind: packageKind,
-            packageLocation: packageLocation,
+            packageLocation: packageLocation ?? path.pathString,
             defaultLocalization: defaultLocalization,
             platforms: platforms,
             version: version,

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -109,9 +109,8 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Pkg",
-                    path: "/Pkg",
+                    path: .init("/Pkg"),
                     packageKind: .root,
-                    packageLocation: "/Pkg",
                     targets: [
                         TargetDescription(name: "exe", dependencies: ["lib"]),
                         TargetDescription(name: "lib", dependencies: []),
@@ -214,7 +213,7 @@ final class BuildPlanTests: XCTestCase {
                 manifests: [
                     Manifest.createV4Manifest(
                         name: "ExplicitTest",
-                        path: testDirPath.description,
+                        path: testDirPath,
                         packageKind: .root,
                         packageLocation: "/ExplicitTest",
                         targets: [
@@ -274,8 +273,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Pkg",
-                    path: "/Pkg",
-                    packageLocation: "/Pkg",
+                    path: .init("/Pkg"),
                     dependencies: [
                         .scm(location: "/ExtPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
@@ -296,9 +294,8 @@ final class BuildPlanTests: XCTestCase {
                 ),
                 Manifest.createV4Manifest(
                     name: "ExtPkg",
-                    path: "/ExtPkg",
+                    path: .init("/ExtPkg"),
                     packageKind: .remote,
-                    packageLocation: "/ExtPkg",
                     products: [
                         ProductDescription(name: "ExtLib", type: .library(.automatic), targets: ["ExtLib"]),
                     ],
@@ -377,9 +374,8 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "A",
-                    path: "/A",
+                    path: .init("/A"),
                     packageKind: .root,
-                    packageLocation: "/A",
                     dependencies: [
                         .scm(location: "/B", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
@@ -389,9 +385,8 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "B",
-                    path: "/B",
+                    path: .init("/B"),
                     packageKind: .local,
-                    packageLocation: "/B",
                     products: [
                         ProductDescription(name: "BLibrary", type: .library(.automatic), targets: ["BTarget"]),
                     ],
@@ -431,9 +426,8 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Pkg",
-                    path: "/Pkg",
+                    path: .init("/Pkg"),
                     packageKind: .root,
-                    packageLocation: "/Pkg",
                     targets: [
                         TargetDescription(name: "exe", dependencies: []),
                     ]),
@@ -484,9 +478,8 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Pkg",
-                    path: "/Pkg",
+                    path: .init("/Pkg"),
                     packageKind: .root,
-                    packageLocation: "/Pkg",
                     dependencies: [
                         .scm(location: "/ExtPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
@@ -496,9 +489,8 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "ExtPkg",
-                    path: "/ExtPkg",
+                    path: .init("/ExtPkg"),
                     packageKind: .local,
-                    packageLocation: "/ExtPkg",
                     products: [
                         ProductDescription(name: "ExtPkg", type: .library(.automatic), targets: ["extlib"]),
                     ],
@@ -597,8 +589,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Pkg",
-                    path: "/Pkg",
-                    packageLocation: "/Pkg",
+                    path: .init("/Pkg"),
                     dependencies: [
                         .scm(location: "/ExtPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
@@ -618,9 +609,8 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "ExtPkg",
-                    path: "/ExtPkg",
+                    path: .init("/ExtPkg"),
                     packageKind: .remote,
-                    packageLocation: "/ExtPkg",
                     products: [
                         ProductDescription(name: "ExtPkg", type: .library(.automatic), targets: ["ExtLib"]),
                     ],
@@ -683,9 +673,8 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Pkg",
-                    path: "/Pkg",
+                    path: .init("/Pkg"),
                     packageKind: .root,
-                    packageLocation: "/Pkg",
                     cLanguageStandard: "gnu99",
                     cxxLanguageStandard: "c++1z",
                     targets: [
@@ -744,9 +733,8 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Pkg",
-                    path: "/Pkg",
+                    path: .init("/Pkg"),
                     packageKind: .root,
-                    packageLocation: "/Pkg",
                     targets: [
                         TargetDescription(name: "exe", dependencies: ["lib"]),
                         TargetDescription(name: "lib", dependencies: []),
@@ -813,9 +801,8 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createManifest(
                     name: "Pkg",
-                    path: "/Pkg",
+                    path: .init("/Pkg"),
                     packageKind: .root,
-                    packageLocation: "/Pkg",
                     v: .v5,
                     targets: [
                         TargetDescription(name: "exe", dependencies: ["lib"]),
@@ -853,9 +840,8 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Pkg",
-                    path: "/Pkg",
+                    path: .init("/Pkg"),
                     packageKind: .root,
-                    packageLocation: "/Pkg",
                     dependencies: [
                         .scm(location: "/Dep", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
@@ -866,9 +852,8 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "Dep",
-                    path: "/Dep",
+                    path: .init("/Dep"),
                     packageKind: .local,
-                    packageLocation: "/Dep",
                     products: [
                         ProductDescription(name: "Dep", type: .library(.automatic), targets: ["Dep"]),
                     ],
@@ -903,9 +888,8 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Pkg",
-                    path: "/Pkg",
+                    path: .init("/Pkg"),
                     packageKind: .root,
-                    packageLocation: "/Pkg",
                     targets: [
                         TargetDescription(name: "Foo", dependencies: []),
                         TargetDescription(name: "FooTests", dependencies: ["Foo"], type: .test),
@@ -969,9 +953,8 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Pkg",
-                    path: "/Pkg",
+                    path: .init("/Pkg"),
                     packageKind: .root,
-                    packageLocation: "/Pkg",
                     toolsVersion: .v5_5,
                     targets: [
                         TargetDescription(name: "exe1", type: .executable),
@@ -1016,9 +999,8 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Pkg",
-                    path: "/Pkg",
+                    path: .init("/Pkg"),
                     packageKind: .root,
-                    packageLocation: "/Pkg",
                     dependencies: [
                         .scm(location: "/Clibgit", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
@@ -1027,9 +1009,9 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "Clibgit",
-                    path: "/Clibgit",
-                    packageKind: .local,
-                    packageLocation: "/Clibgit"),
+                    path: .init("/Clibgit"),
+                    packageKind: .local
+                ),
             ]
         )
         XCTAssertNoDiagnostics(diagnostics)
@@ -1073,9 +1055,8 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Pkg",
-                    path: "/Pkg",
+                    path: .init("/Pkg"),
                     packageKind: .root,
-                    packageLocation: "/Pkg",
                     targets: [
                         TargetDescription(name: "lib", dependencies: []),
                         TargetDescription(name: "exe", dependencies: ["lib"]),
@@ -1107,9 +1088,8 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Bar",
-                    path: "/Bar",
+                    path: .init("/Bar"),
                     packageKind: .local,
-                    packageLocation: "/Bar",
                     products: [
                         ProductDescription(name: "Bar-Baz", type: .library(.dynamic), targets: ["Bar"]),
                     ],
@@ -1118,9 +1098,8 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "Foo",
-                    path: "/Foo",
+                    path: .init("/Foo"),
                     packageKind: .root,
-                    packageLocation: "/Foo",
                     dependencies: [
                         .scm(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
@@ -1200,9 +1179,8 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Pkg",
-                    path: "/Pkg",
+                    path: .init("/Pkg"),
                     packageKind: .root,
-                    packageLocation: "/Pkg",
                     products: [
                         ProductDescription(name: "lib", type: .library(.dynamic), targets: ["lib"]),
                     ],
@@ -1264,9 +1242,8 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Pkg",
-                    path: "/Pkg",
+                    path: .init("/Pkg"),
                     packageKind: .root,
-                    packageLocation: "/Pkg",
                     products: [
                         ProductDescription(name: "lib", type: .library(.dynamic), targets: ["lib"]),
                     ],
@@ -1328,9 +1305,8 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "A",
-                    path: "/A",
+                    path: .init("/A"),
                     packageKind: .root,
-                    packageLocation: "/A",
                     dependencies: [
                         .scm(location: "/B", requirement: .upToNextMajor(from: "1.0.0")),
                         .scm(location: "/C", requirement: .upToNextMajor(from: "1.0.0")),
@@ -1343,9 +1319,8 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "B",
-                    path: "/B",
+                    path: .init("/B"),
                     packageKind: .local,
-                    packageLocation: "/B",
                     products: [
                         ProductDescription(name: "BLibrary", type: .library(.static), targets: ["BTarget1"]),
                         ProductDescription(name: "bexec", type: .executable, targets: ["BTarget2"]),
@@ -1356,9 +1331,8 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "C",
-                    path: "/C",
+                    path: .init("/C"),
                     packageKind: .local,
-                    packageLocation: "/C",
                     products: [
                         ProductDescription(name: "cexec", type: .executable, targets: ["CTarget"])
                     ],
@@ -1420,8 +1394,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "A",
-                    path: "/A",
-                    packageLocation: "/A",
+                    path: .init("/A"),
                     dependencies: [
                         .scm(location: "/B", requirement: .upToNextMajor(from: "1.0.0")),
                         .scm(location: "/C", requirement: .upToNextMajor(from: "1.0.0")),
@@ -1448,9 +1421,8 @@ final class BuildPlanTests: XCTestCase {
                 ),
                 Manifest.createV4Manifest(
                     name: "B",
-                    path: "/B",
+                    path: .init("/B"),
                     packageKind: .remote,
-                    packageLocation: "/B",
                     products: [
                         ProductDescription(name: "BLibrary1", type: .library(.static), targets: ["BTarget1"]),
                         ProductDescription(name: "BLibrary2", type: .library(.static), targets: ["BTarget2"]),
@@ -1468,9 +1440,8 @@ final class BuildPlanTests: XCTestCase {
                 ),
                 Manifest.createV4Manifest(
                     name: "C",
-                    path: "/C",
+                    path: .init("/C"),
                     packageKind: .remote,
-                    packageLocation: "/C",
                     products: [
                         ProductDescription(name: "CLibrary", type: .library(.static), targets: ["CTarget"])
                     ],
@@ -1540,10 +1511,9 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Pkg",
-                    path: "/Pkg",
-                    packageKind: .root,
-                    packageLocation: "/Pkg"
-                ),
+                    path: .init("/Pkg"),
+                    packageKind: .root
+                )
             ]
         )
         XCTAssertNoDiagnostics(diagnostics)
@@ -1566,9 +1536,8 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "A",
-                    path: "/A",
+                    path: .init("/A"),
                     packageKind: .root,
-                    packageLocation: "/A",
                     targets: [
                         TargetDescription(name: "ATarget", dependencies: ["BTarget"]),
                         TargetDescription(
@@ -1602,9 +1571,8 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "A",
-                    path: "/A",
+                    path: .init("/A"),
                     packageKind: .root,
-                    packageLocation: "/A",
                     targets: [
                         TargetDescription(name: "ATarget", dependencies: ["BTarget"]),
                         TargetDescription(
@@ -1639,9 +1607,8 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Pkg",
-                    path: "/Pkg",
+                    path: .init("/Pkg"),
                     packageKind: .root,
-                    packageLocation: "/Pkg",
                     targets: [
                     TargetDescription(name: "exe", dependencies: ["lib"]),
                     TargetDescription(name: "lib", dependencies: []),
@@ -1692,9 +1659,8 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Pkg",
-                    path: "/Pkg",
+                    path: .init("/Pkg"),
                     packageKind: .root,
-                    packageLocation: "/Pkg",
                     targets: [
                         TargetDescription(name: "app", dependencies: ["lib"]),
                         TargetDescription(name: "lib", dependencies: []),
@@ -1783,9 +1749,8 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Pkg",
-                    path: "/Pkg",
+                    path: .init("/Pkg"),
                     packageKind: .root,
-                    packageLocation: "/Pkg",
                     targets: [
                         TargetDescription(name: "exe", dependencies: ["lib"]),
                         TargetDescription(name: "lib", dependencies: []),
@@ -1826,9 +1791,8 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createManifest(
                     name: "A",
-                    path: "/A",
+                    path: .init("/A"),
                     packageKind: .root,
-                    packageLocation: "/A",
                     platforms: [
                         PlatformDescription(name: "macos", version: "10.13"),
                     ],
@@ -1841,9 +1805,8 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createManifest(
                     name: "B",
-                    path: "/B",
+                    path: .init("/B"),
                     packageKind: .local,
-                    packageLocation: "/B",
                     platforms: [
                         PlatformDescription(name: "macos", version: "10.12"),
                     ],
@@ -1888,9 +1851,8 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createManifest(
                     name: "A",
-                    path: "/A",
+                    path: .init("/A"),
                     packageKind: .root,
-                    packageLocation: "/A",
                     platforms: [
                         PlatformDescription(name: "macos", version: "10.13"),
                         PlatformDescription(name: "ios", version: "10"),
@@ -1904,9 +1866,8 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createManifest(
                     name: "B",
-                    path: "/B",
+                    path: .init("/B"),
                     packageKind: .local,
-                    packageLocation: "/B",
                     platforms: [
                         PlatformDescription(name: "macos", version: "10.14"),
                         PlatformDescription(name: "ios", version: "11"),
@@ -1954,9 +1915,8 @@ final class BuildPlanTests: XCTestCase {
 
         let aManifest = Manifest.createManifest(
             name: "A",
-            path: "/A",
+            path: .init("/A"),
             packageKind: .root,
-            packageLocation: "/A",
             v: .v5,
             dependencies: [
                 .scm(location: "/B", requirement: .upToNextMajor(from: "1.0.0")),
@@ -2001,9 +1961,8 @@ final class BuildPlanTests: XCTestCase {
 
         let bManifest = Manifest.createManifest(
             name: "B",
-            path: "/B",
+            path: .init("/B"),
             packageKind: .local,
-            packageLocation: "/B",
             v: .v5,
             products: [
                 ProductDescription(name: "Dep", type: .library(.automatic), targets: ["t1", "t2"]),
@@ -2083,9 +2042,8 @@ final class BuildPlanTests: XCTestCase {
 
         let aManifest = Manifest.createManifest(
             name: "A",
-            path: "/A",
+            path: .init("/A"),
             packageKind: .root,
-            packageLocation: "/A",
             v: .v5,
             targets: [
                 try TargetDescription(name: "exe", dependencies: []),
@@ -2122,9 +2080,8 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Pkg",
-                    path: "/Pkg",
+                    path: .init("/Pkg"),
                     packageKind: .root,
-                    packageLocation: "/Pkg",
                     targets: [
                         TargetDescription(name: "exe", dependencies: ["lib"]),
                         TargetDescription(name: "lib", dependencies: []),
@@ -2170,9 +2127,8 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "PkgA",
-                    path: "/PkgA",
+                    path: .init("/PkgA"),
                     packageKind: .local,
-                    packageLocation: "/PkgA",
                     products: [
                         ProductDescription(name: "swiftlib", type: .library(.automatic), targets: ["swiftlib"]),
                         ProductDescription(name: "exe", type: .executable, targets: ["exe"])
@@ -2183,9 +2139,8 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "PkgB",
-                    path: "/PkgB",
+                    path: .init("/PkgB"),
                     packageKind: .root,
-                    packageLocation: "/PkgB",
                     dependencies: [
                         .scm(location: "/PkgA", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
@@ -2223,9 +2178,8 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "PkgA",
-                    path: "/PkgA",
+                    path: .init("/PkgA"),
                     packageKind: .root,
-                    packageLocation: "/PkgA",
                     targets: [
                         TargetDescription(name: "Foo", dependencies: []),
                         TargetDescription(name: "Bar", dependencies: ["Foo"]),
@@ -2278,9 +2232,8 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "PkgA",
-                    path: "/PkgA",
+                    path: .init("/PkgA"),
                     packageKind: .root,
-                    packageLocation: "/PkgA",
                     dependencies: [
                         .scm(location: "/PkgB", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
@@ -2289,9 +2242,8 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "PkgB",
-                    path: "/PkgB",
+                    path: .init("/PkgB"),
                     packageKind: .local,
-                    packageLocation: "/PkgB",
                     products: [
                         ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Foo"]),
                     ],
@@ -2346,9 +2298,8 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "PkgA",
-                    path: "/PkgA",
+                    path: .init("/PkgA"),
                     packageKind: .root,
-                    packageLocation: "/PkgA",
                     dependencies: [
                         .scm(location: "/PkgB", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
@@ -2357,9 +2308,8 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "PkgB",
-                    path: "/PkgB",
+                    path: .init("/PkgB"),
                     packageKind: .local,
-                    packageLocation: "/PkgB",
                     products: [
                         ProductDescription(name: "Foo", type: .library(.dynamic), targets: ["Foo"]),
                     ],
@@ -2414,9 +2364,8 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Pkg",
-                    path: "/Pkg",
+                    path: .init("/Pkg"),
                     packageKind: .root,
-                    packageLocation: "/Pkg",
                     targets: [
                         TargetDescription(name: "exe", dependencies: ["lib"]),
                         TargetDescription(name: "lib", dependencies: []),
@@ -2476,9 +2425,8 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createManifest(
                     name: "PkgA",
-                    path: "/PkgA",
+                    path: .init("/PkgA"),
                     packageKind: .root,
-                    packageLocation: "/PkgA",
                     v: .v5_2,
                     targets: [
                         TargetDescription(
@@ -2536,9 +2484,8 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Pkg",
-                    path: "/Pkg",
+                    path: .init("/Pkg"),
                     packageKind: .root,
-                    packageLocation: "/Pkg",
                     targets: [
                         TargetDescription(name: "exe", dependencies: ["lib"]),
                         TargetDescription(name: "lib", dependencies: []),
@@ -2642,9 +2589,8 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Pkg",
-                    path: "/Pkg",
+                    path: .init("/Pkg"),
                     packageKind: .root,
-                    packageLocation: "/Pkg",
                     products: [
                         ProductDescription(name: "exe", type: .executable, targets: ["exe"]),
                         ProductDescription(name: "Library", type: .library(.dynamic), targets: ["Library"]),
@@ -2753,9 +2699,8 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Pkg",
-                    path: "/Pkg",
+                    path: .init("/Pkg"),
                     packageKind: .root,
-                    packageLocation: "/Pkg",
                     products: [
                         ProductDescription(name: "exe", type: .executable, targets: ["exe"]),
                     ],
@@ -2829,9 +2774,8 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Pkg",
-                    path: "/Pkg",
+                    path: .init("/Pkg"),
                     packageKind: .root,
-                    packageLocation: "/Pkg",
                     targets: [
                         TargetDescription(name: "exe", dependencies: ["lib", "clib"]),
                         TargetDescription(name: "lib", dependencies: []),

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -353,9 +353,8 @@ final class PackageToolTests: XCTestCase {
 
         let manifestA = Manifest.createManifest(
             name: "PackageA",
-            path: "/PackageA",
+            path: .init("/PackageA"),
             packageKind: .root,
-            packageLocation: "/PackageA",
             v: .v5_3,
             dependencies: [
                 .fileSystem(path: "/PackageB"),
@@ -371,9 +370,8 @@ final class PackageToolTests: XCTestCase {
 
         let manifestB = Manifest.createManifest(
             name: "PackageB",
-            path: "/PackageB",
+            path: .init("/PackageB"),
             packageKind: .local,
-            packageLocation: "/PackageB",
             v: .v5_3,
             dependencies: [
                 .fileSystem(path: "/PackageC"),
@@ -389,9 +387,8 @@ final class PackageToolTests: XCTestCase {
 
         let manifestC = Manifest.createManifest(
             name: "PackageC",
-            path: "/PackageC",
+            path: .init("/PackageC"),
             packageKind: .local,
-            packageLocation: "/PackageC",
             v: .v5_3,
             dependencies: [
                 .fileSystem(path: "/PackageD"),
@@ -406,9 +403,8 @@ final class PackageToolTests: XCTestCase {
 
         let manifestD = Manifest.createManifest(
             name: "PackageD",
-            path: "/PackageD",
+            path: .init("/PackageD"),
             packageKind: .local,
-            packageLocation: "/PackageD",
             v: .v5_3,
             products: [
                 .init(name: "PackageD", type: .library(.dynamic), targets: ["TargetD"])

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -32,9 +32,8 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Foo",
-                    path: "/Foo",
+                    path: .init("/Foo"),
                     packageKind: .local,
-                    packageLocation: "/Foo",
                     products: [
                         ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Foo"])
                     ],
@@ -44,9 +43,8 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "Bar",
-                    path: "/Bar",
+                    path: .init("/Bar"),
                     packageKind: .root,
-                    packageLocation: "/Bar",
                     dependencies: [
                         .scm(location: "/Foo", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
@@ -58,8 +56,7 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "Baz",
-                    path: "/Baz",
-                    packageLocation: "/Baz",
+                    path: .init("/Baz"),
                     dependencies: [
                         .scm(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
@@ -102,9 +99,8 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Foo",
-                    path: "/Foo",
+                    path: .init("/Foo"),
                     packageKind: .root,
-                    packageLocation: "/Foo",
                     dependencies: [
                         .scm(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
@@ -113,9 +109,8 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "Bar",
-                    path: "/Bar",
+                    path: .init("/Bar"),
                     packageKind: .local,
-                    packageLocation: "/Bar",
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"]),
                         ProductDescription(name: "CBar", type: .library(.automatic), targets: ["CBar"]),
@@ -148,9 +143,8 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Foo",
-                    path: "/Foo",
+                    path: .init("/Foo"),
                     packageKind: .root,
-                    packageLocation: "/Foo",
                     dependencies: [
                         .scm(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
@@ -159,9 +153,8 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "Bar",
-                    path: "/Bar",
+                    path: .init("/Bar"),
                     packageKind: .local,
-                    packageLocation: "/Bar",
                     dependencies: [
                         .scm(location: "/Baz", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
@@ -173,9 +166,8 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "Baz",
-                    path: "/Baz",
+                    path: .init("/Baz"),
                     packageKind: .local,
-                    packageLocation: "/Baz",
                     dependencies: [
                         .scm(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
@@ -205,9 +197,8 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Foo",
-                    path: "/Foo",
+                    path: .init("/Foo"),
                     packageKind: .root,
-                    packageLocation: "/Foo",
                     dependencies: [
                         .scm(location: "/Foo", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
@@ -237,9 +228,8 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Bar",
-                    path: "/Bar",
+                    path: .init("/Bar"),
                     packageKind: .root,
-                    packageLocation: "/Bar",
                     dependencies: [
                         .scm(location: "/Foo", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
@@ -249,9 +239,8 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "Foo",
-                    path: "/Foo",
+                    path: .init("/Foo"),
                     packageKind: .local,
-                    packageLocation: "/Foo",
                     products: [
                         ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Foo"]),
                     ],
@@ -281,9 +270,8 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Foo",
-                    path: "/Foo",
+                    path: .init("/Foo"),
                     packageKind: .root,
-                    packageLocation: "/Foo",
                     dependencies: [
                         .scm(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
@@ -292,9 +280,8 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "Bar",
-                    path: "/Bar",
+                    path: .init("/Bar"),
                     packageKind: .root,
-                    packageLocation: "/Bar",
                     targets: [
                         TargetDescription(name: "Bar"),
                     ]),
@@ -319,9 +306,8 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Fourth",
-                    path: "/Fourth",
+                    path: .init("/Fourth"),
                     packageKind: .local,
-                    packageLocation: "/Fourth",
                     products: [
                         ProductDescription(name: "Fourth", type: .library(.automatic), targets: ["First"])
                     ],
@@ -330,9 +316,8 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "Third",
-                    path: "/Third",
+                    path: .init("/Third"),
                     packageKind: .local,
-                    packageLocation: "/Third",
                     products: [
                         ProductDescription(name: "Third", type: .library(.automatic), targets: ["First"])
                     ],
@@ -341,9 +326,8 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "Second",
-                    path: "/Second",
+                    path: .init("/Second"),
                     packageKind: .local,
-                    packageLocation: "/Second",
                     products: [
                         ProductDescription(name: "Second", type: .library(.automatic), targets: ["First"])
                     ],
@@ -352,9 +336,8 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "First",
-                    path: "/First",
+                    path: .init("/First"),
                     packageKind: .root,
-                    packageLocation: "/First",
                     dependencies: [
                         .scm(location: "/Second", requirement: .upToNextMajor(from: "1.0.0")),
                         .scm(location: "/Third", requirement: .upToNextMajor(from: "1.0.0")),
@@ -384,9 +367,8 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Fourth",
-                    path: "/Fourth",
+                    path: .init("/Fourth"),
                     packageKind: .local,
-                    packageLocation: "/Fourth",
                     products: [
                         ProductDescription(name: "Fourth", type: .library(.automatic), targets: ["Bar"])
                     ],
@@ -395,9 +377,8 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "Third",
-                    path: "/Third",
+                    path: .init("/Third"),
                     packageKind: .local,
-                    packageLocation: "/Third",
                     products: [
                         ProductDescription(name: "Third", type: .library(.automatic), targets: ["Bar"])
                     ],
@@ -406,9 +387,8 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "Second",
-                    path: "/Second",
+                    path: .init("/Second"),
                     packageKind: .local,
-                    packageLocation: "/Second",
                     products: [
                         ProductDescription(name: "Second", type: .library(.automatic), targets: ["Foo"])
                     ],
@@ -417,9 +397,8 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "First",
-                    path: "/First",
+                    path: .init("/First"),
                     packageKind: .root,
-                    packageLocation: "/First",
                     dependencies: [
                         .scm(location: "/Second", requirement: .upToNextMajor(from: "1.0.0")),
                         .scm(location: "/Third", requirement: .upToNextMajor(from: "1.0.0")),
@@ -450,9 +429,8 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Fourth",
-                    path: "/Fourth",
+                    path: .init("/Fourth"),
                     packageKind: .local,
-                    packageLocation: "/Fourth",
                     products: [
                         ProductDescription(name: "Fourth", type: .library(.automatic), targets: ["First"])
                     ],
@@ -461,9 +439,8 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "Third",
-                    path: "/Third",
+                    path: .init("/Third"),
                     packageKind: .local,
-                    packageLocation: "/Third",
                     dependencies: [
                         .scm(location: "/Fourth", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
@@ -475,9 +452,8 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "Second",
-                    path: "/Second",
+                    path: .init("/Second"),
                     packageKind: .local,
-                    packageLocation: "/Second",
                     dependencies: [
                         .scm(location: "/Third", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
@@ -489,9 +465,8 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "First",
-                    path: "/First",
+                    path: .init("/First"),
                     packageKind: .root,
-                    packageLocation: "/First",
                     dependencies: [
                         .scm(location: "/Second", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
@@ -520,9 +495,8 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Foo",
-                    path: "/Foo",
+                    path: .init("/Foo"),
                     packageKind: .root,
-                    packageLocation: "/Foo",
                     dependencies: [
                         .scm(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
@@ -531,9 +505,8 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "Bar",
-                    path: "/Bar",
+                    path: .init("/Bar"),
                     packageKind: .local,
-                    packageLocation: "/Bar",
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
                     ],
@@ -559,9 +532,8 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Foo",
-                    path: "/Foo",
+                    path: .init("/Foo"),
                     packageKind: .root,
-                    packageLocation: "/Foo",
                     targets: [
                         TargetDescription(name: "FooTarget", dependencies: ["Barx"]),
                     ]),
@@ -584,9 +556,8 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Foo",
-                    path: "/Foo",
+                    path: .init("/Foo"),
                     packageKind: .root,
-                    packageLocation: "/Foo",
                     products: [
                         ProductDescription(name: "Foo", type: .library(.automatic), targets: ["FooTarget"]),
                     ],
@@ -613,9 +584,8 @@ class PackageGraphTests: XCTestCase {
                                  manifests: [
                     Manifest.createV4Manifest(
                         name: "XYZ",
-                        path: "/XYZ",
+                        path: .init("/XYZ"),
                         packageKind: .root,
-                        packageLocation: "/XYZ",
                         targets: [
                             TargetDescription(name: "XYZ", dependencies: [], type: .executable),
                             TargetDescription(name: "XYZTests", dependencies: ["XYZ"], type: .test),
@@ -636,9 +606,8 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Foo",
-                    path: "/Foo",
+                    path: .init("/Foo"),
                     packageKind: .root,
-                    packageLocation: "/Foo",
                     products: [
                         ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Foo"]),
                     ],
@@ -661,9 +630,8 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Foo",
-                    path: "/Foo",
+                    path: .init("/Foo"),
                     packageKind: .root,
-                    packageLocation: "/Foo",
                     toolsVersion: .v5_2,
                     targets: [
                         TargetDescription(name: "FooTarget", dependencies: [.product(name: "Barx", package: "Bar")]),
@@ -687,9 +655,8 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Foo",
-                    path: "/Foo",
+                    path: .init("/Foo"),
                     packageKind: .root,
-                    packageLocation: "/Foo",
                     toolsVersion: .v5_2,
                     targets: [
                         TargetDescription(name: "FooTarget", dependencies: [.product(name: "Barx")]),
@@ -716,9 +683,8 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createManifest(
                     name: "Foo",
-                    path: "/Foo",
+                    path: .init("/Foo"),
                     packageKind: .root,
-                    packageLocation: "/Foo",
                     v: .v5_2,
                     dependencies: [
                         .scm(location: "/Bar", requirement: .branch("master")),
@@ -730,9 +696,8 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "Bar",
-                    path: "/Bar",
+                    path:.init( "/Bar"),
                     packageKind: .remote,
-                    packageLocation: "/Bar",
                     products: [
                         ProductDescription(name: "BarLib", type: .library(.automatic), targets: ["BarLib"])
                     ],
@@ -741,9 +706,8 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "Biz",
-                    path: "/BizPath",
+                    path: .init("/BizPath"),
                     packageKind: .remote,
-                    packageLocation: "/BizPath",
                     version: "1.2.3",
                     products: [
                         ProductDescription(name: "Biz", type: .library(.automatic), targets: ["Biz"])
@@ -753,9 +717,8 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "Fiz",
-                    path: "/FizPath",
+                    path: .init("/FizPath"),
                     packageKind: .remote,
-                    packageLocation: "/FizPath",
                     version: "1.2.3",
                     products: [
                         ProductDescription(name: "FizLib", type: .library(.automatic), targets: ["FizLib"])
@@ -802,9 +765,8 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createManifest(
                     name: "Foo",
-                    path: "/Foo",
+                    path: .init("/Foo"),
                     packageKind: .root,
-                    packageLocation: "/Foo",
                     v: .v5_2,
                     dependencies: [
                         .scm(deprecatedName: "UnBar", location: "/Bar", requirement: .branch("master")),
@@ -814,9 +776,8 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "UnBar",
-                    path: "/Bar",
+                    path: .init("/Bar"),
                     packageKind: .remote,
-                    packageLocation: "/Bar",
                     products: [
                         ProductDescription(name: "BarProduct", type: .library(.automatic), targets: ["Bar"])
                     ],
@@ -843,9 +804,8 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Foo",
-                    path: "/Foo",
+                    path: .init("/Foo"),
                     packageKind: .root,
-                    packageLocation: "/Foo",
                     dependencies: [
                         .scm(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
                         .scm(location: "/Baz", requirement: .upToNextMajor(from: "1.0.0")),
@@ -856,9 +816,8 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "Biz",
-                    path: "/Biz",
+                    path: .init("/Biz"),
                     packageKind: .local,
-                    packageLocation: "/Biz",
                     products: [
                         ProductDescription(name: "biz", type: .executable, targets: ["Biz"])
                     ],
@@ -867,9 +826,8 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "Bar",
-                    path: "/Bar",
+                    path: .init("/Bar"),
                     packageKind: .local,
-                    packageLocation: "/Bar",
                     products: [
                         ProductDescription(name: "BarLibrary", type: .library(.automatic), targets: ["Bar"])
                     ],
@@ -878,9 +836,8 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "Baz",
-                    path: "/Baz",
+                    path: .init("/Baz"),
                     packageKind: .local,
-                    packageLocation: "/Baz",
                     products: [
                         ProductDescription(name: "BazLibrary", type: .library(.automatic), targets: ["Baz"])
                     ],
@@ -909,9 +866,8 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Bar",
-                    path: "/Bar",
+                    path: .init("/Bar"),
                     packageKind: .root,
-                    packageLocation: "/Bar",
                     dependencies: [
                         .scm(location: "/Foo", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
@@ -920,9 +876,9 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "Foo",
-                    path: "/Foo",
-                    packageKind: .local,
-                    packageLocation: "/Foo"),
+                    path: .init("/Foo"),
+                    packageKind: .local
+                ),
             ]
         )
 
@@ -944,9 +900,8 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Start",
-                    path: "/Start",
+                    path: .init("/Start"),
                     packageKind: .root,
-                    packageLocation: "/Start",
                     dependencies: [
                         .scm(location: "/Dep1", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
@@ -956,9 +911,8 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "Dep1",
-                    path: "/Dep1",
+                    path: .init("/Dep1"),
                     packageKind: .local,
-                    packageLocation: "/Dep1",
                     dependencies: [
                         .scm(location: "/Dep2", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
@@ -970,9 +924,8 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "Dep2",
-                    path: "/Dep2",
+                    path: .init("/Dep2"),
                     packageKind: .local,
-                    packageLocation: "/Dep2",
                     products: [
                         ProductDescription(name: "FooLibrary", type: .library(.automatic), targets: ["Foo"]),
                         ProductDescription(name: "BamLibrary", type: .library(.automatic), targets: ["Bam"]),
@@ -1001,9 +954,8 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Foo",
-                    path: "/Foo",
+                    path: .init("/Foo"),
                     packageKind: .root,
-                    packageLocation: "/Foo",
                     dependencies: [
                         .scm(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
                         .scm(location: "/Baz", requirement: .upToNextMajor(from: "1.0.0")),
@@ -1013,9 +965,8 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "Bar",
-                    path: "/Bar",
+                    path: .init("/Bar"),
                     packageKind: .local,
-                    packageLocation: "/Bar",
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
                     ],
@@ -1024,9 +975,8 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "Baz",
-                    path: "/Baz",
+                    path: .init("/Baz"),
                     packageKind: .local,
-                    packageLocation: "/Baz",
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Baz"])
                     ],
@@ -1057,9 +1007,8 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Foo",
-                    path: "/Foo",
+                    path: .init("/Foo"),
                     packageKind: .root,
-                    packageLocation: "/Foo",
                     dependencies: [
                         .scm(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
@@ -1069,9 +1018,8 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "Bar",
-                    path: "/Bar",
+                    path: .init("/Bar"),
                     packageKind: .local,
-                    packageLocation: "/Bar",
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar", "Bar2", "Bar3"]),
                         ProductDescription(name: "TransitiveBar", type: .library(.automatic), targets: ["TransitiveBar"]),
@@ -1125,8 +1073,7 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Foo",
-                    path: "/Foo",
-                    packageLocation: "/Foo",
+                    path: .init("/Foo"),
                     dependencies: [
                         .fileSystem(path: "/Biz"),
                     ],
@@ -1151,9 +1098,8 @@ class PackageGraphTests: XCTestCase {
                 ),
                 Manifest.createV4Manifest(
                     name: "Biz",
-                    path: "/Biz",
+                    path: .init("/Biz"),
                     packageKind: .remote,
-                    packageLocation: "/Biz",
                     products: [
                         ProductDescription(name: "Biz", type: .library(.automatic), targets: ["Biz"])
                     ],
@@ -1210,9 +1156,8 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createManifest(
                     name: "Root",
-                    path: "/Root",
+                    path: .init("/Root"),
                     packageKind: .root,
-                    packageLocation: "/Root",
                     v: .v5_2,
                     dependencies: [
                         .scm(location: "/Immediate", requirement: .upToNextMajor(from: "1.0.0")),
@@ -1225,9 +1170,8 @@ class PackageGraphTests: XCTestCase {
                 ),
                 Manifest.createManifest(
                     name: "Immediate",
-                    path: "/Immediate",
+                    path: .init("/Immediate"),
                     packageKind: .local,
-                    packageLocation: "/Immediate",
                     v: .v5_2,
                     dependencies: [
                         .scm(
@@ -1255,9 +1199,8 @@ class PackageGraphTests: XCTestCase {
                 ),
                 Manifest.createManifest(
                     name: "Transitive",
-                    path: "/Transitive",
+                    path: .init("/Transitive"),
                     packageKind: .local,
-                    packageLocation: "/Transitive",
                     v: .v5_2,
                     dependencies: [
                         .scm(
@@ -1327,9 +1270,8 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createManifest(
                     name: "Foo",
-                    path: "/Foo",
+                    path: .init("/Foo"),
                     packageKind: .root,
-                    packageLocation: "/Foo",
                     v: .v5,
                     dependencies: [
                         .scm(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
@@ -1339,9 +1281,8 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createManifest(
                     name: "Bar",
-                    path: "/Bar",
+                    path: .init("/Bar"),
                     packageKind: .local,
-                    packageLocation: "/Bar",
                     v: .v5,
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
@@ -1366,9 +1307,8 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createManifest(
                     name: "Foo",
-                    path: "/Foo",
+                    path: .init("/Foo"),
                     packageKind: .root,
-                    packageLocation: "/Foo",
                     v: .v5,
                     dependencies: [
                         .scm(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
@@ -1378,9 +1318,8 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createManifest(
                     name: "Bar",
-                    path: "/Bar",
+                    path: .init("/Bar"),
                     packageKind: .local,
-                    packageLocation: "/Bar",
                     v: .v5,
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
@@ -1413,9 +1352,8 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createManifest(
                     name: "Foo",
-                    path: "/Foo",
+                    path: .init("/Foo"),
                     packageKind: .root,
-                    packageLocation: "/Foo",
                     v: .v5_2,
                     dependencies: [
                         .scm(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
@@ -1425,9 +1363,8 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createManifest(
                     name: "Bar",
-                    path: "/Bar",
+                    path: .init("/Bar"),
                     packageKind: .local,
-                    packageLocation: "/Bar",
                     v: .v5_2,
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
@@ -1452,9 +1389,8 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createManifest(
                     name: "Foo",
-                    path: "/Foo",
+                    path: .init("/Foo"),
                     packageKind: .root,
-                    packageLocation: "/Foo",
                     v: .v5_2,
                     dependencies: [
                         .scm(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
@@ -1464,9 +1400,8 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createManifest(
                     name: "Bar",
-                    path: "/Bar",
+                    path: .init("/Bar"),
                     packageKind: .local,
-                    packageLocation: "/Bar",
                     v: .v5_2,
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
@@ -1497,9 +1432,8 @@ class PackageGraphTests: XCTestCase {
         let manifests = try [
             Manifest.createManifest(
                 name: "Foo",
-                path: "/Foo",
+                path: .init("/Foo"),
                 packageKind: .root,
-                packageLocation: "/Foo",
                 v: .v5_2,
                 dependencies: [
                     .scm(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
@@ -1509,9 +1443,8 @@ class PackageGraphTests: XCTestCase {
                 ]),
             Manifest.createManifest(
                 name: "Bar",
-                path: "/Bar",
+                path: .init("/Bar"),
                 packageKind: .local,
-                packageLocation: "/Bar",
                 v: .v5_2,
                 products: [
                     ProductDescription(name: "ProductBar", type: .library(.automatic), targets: ["Bar"])
@@ -1562,9 +1495,8 @@ class PackageGraphTests: XCTestCase {
         let manifests = try [
             Manifest.createManifest(
                 name: "Foo",
-                path: "/Foo",
+                path: .init("/Foo"),
                 packageKind: .root,
-                packageLocation: "/Foo",
                 v: .v5_2,
                 dependencies: [
                     .scm(deprecatedName: "Bar", location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
@@ -1574,9 +1506,8 @@ class PackageGraphTests: XCTestCase {
                 ]),
             Manifest.createManifest(
                 name: "Bar",
-                path: "/Bar",
+                path: .init("/Bar"),
                 packageKind: .local,
-                packageLocation: "/Bar",
                 v: .v5_2,
                 products: [
                     ProductDescription(name: "ProductBar", type: .library(.automatic), targets: ["Bar"])
@@ -1626,9 +1557,8 @@ class PackageGraphTests: XCTestCase {
         let manifests = try [
             Manifest.createManifest(
                 name: "Foo",
-                path: "/Foo",
+                path: .init("/Foo"),
                 packageKind: .root,
-                packageLocation: "/Foo",
                 v: .v5_2,
                 dependencies: [
                     .scm(location: "/Some-Bar", requirement: .upToNextMajor(from: "1.0.0")),
@@ -1638,9 +1568,8 @@ class PackageGraphTests: XCTestCase {
                 ]),
             Manifest.createManifest(
                 name: "Bar",
-                path: "/Some-Bar",
+                path: .init("/Some-Bar"),
                 packageKind: .local,
-                packageLocation: "/Some-Bar",
                 v: .v5_2,
                 products: [
                     ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
@@ -1689,9 +1618,8 @@ class PackageGraphTests: XCTestCase {
         let manifests = try [
             Manifest.createManifest(
                 name: "Foo",
-                path: "/Foo",
+                path: .init("/Foo"),
                 packageKind: .root,
-                packageLocation: "/Foo",
                 v: .v5_2,
                 dependencies: [
                     .scm(location: "/Some-Bar", requirement: .upToNextMajor(from: "1.0.0")),
@@ -1701,9 +1629,8 @@ class PackageGraphTests: XCTestCase {
                 ]),
             Manifest.createManifest(
                 name: "Bar",
-                path: "/Some-Bar",
+                path: .init("/Some-Bar"),
                 packageKind: .local,
-                packageLocation: "/Some-Bar",
                 v: .v5_2,
                 products: [
                     ProductDescription(name: "ProductBar", type: .library(.automatic), targets: ["Bar"])
@@ -1754,9 +1681,8 @@ class PackageGraphTests: XCTestCase {
         let manifests = try [
             Manifest.createManifest(
                 name: "Foo",
-                path: "/Foo",
+                path: .init("/Foo"),
                 packageKind: .root,
-                packageLocation: "/Foo",
                 v: .v5_2,
                 dependencies: [
                     .scm(deprecatedName: "Bar", location: "/Some-Bar", requirement: .upToNextMajor(from: "1.0.0")),
@@ -1766,9 +1692,8 @@ class PackageGraphTests: XCTestCase {
                 ]),
             Manifest.createManifest(
                 name: "Bar",
-                path: "/Some-Bar",
+                path: .init("/Some-Bar"),
                 packageKind: .local,
-                packageLocation: "/Some-Bar",
                 v: .v5_2,
                 products: [
                     ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
@@ -1794,9 +1719,8 @@ class PackageGraphTests: XCTestCase {
         let manifests = try [
             Manifest.createManifest(
                 name: "Foo",
-                path: "/Foo",
+                path: .init("/Foo"),
                 packageKind: .root,
-                packageLocation: "/Foo",
                 v: .v5_2,
                 dependencies: [
                     .scm(deprecatedName: "Bar", location: "/Some-Bar", requirement: .upToNextMajor(from: "1.0.0")),
@@ -1806,9 +1730,8 @@ class PackageGraphTests: XCTestCase {
                 ]),
             Manifest.createManifest(
                 name: "Bar",
-                path: "/Some-Bar",
+                path: .init("/Some-Bar"),
                 packageKind: .local,
-                packageLocation: "/Some-Bar",
                 v: .v5_2,
                 products: [
                     ProductDescription(name: "ProductBar", type: .library(.automatic), targets: ["Bar"])
@@ -1854,7 +1777,7 @@ extension Manifest {
     func withTargets(_ targets: [TargetDescription]) -> Manifest {
         Manifest.createManifest(
             name: self.name,
-            path: self.path.parentDirectory.pathString,
+            path: self.path.parentDirectory,
             packageKind: self.packageKind,
             packageLocation: self.packageLocation,
             v: self.toolsVersion,
@@ -1866,7 +1789,7 @@ extension Manifest {
     func withDependencies(_ dependencies: [PackageDependency]) -> Manifest {
         Manifest.createManifest(
             name: self.name,
-            path: self.path.parentDirectory.pathString,
+            path: self.path.parentDirectory,
             packageKind: self.packageKind,
             packageLocation: self.packageLocation,
             v: self.toolsVersion,

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -429,9 +429,8 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         do {
             let manifest = Manifest.createManifest(
                 name: "Foo",
-                path: "/Foo",
+                path: .init("/Foo"),
                 packageKind: .root,
-                packageLocation: "/Foo",
                 v: .v5,
                 dependencies: dependencies,
                 products: products,
@@ -453,9 +452,8 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         do {
             let manifest = Manifest.createManifest(
                 name: "Foo",
-                path: "/Foo",
+                path: .init("/Foo"),
                 packageKind: .local,
-                packageLocation: "/Foo",
                 v: .v5,
                 dependencies: dependencies,
                 products: products,
@@ -477,9 +475,8 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         do {
             let manifest = Manifest.createManifest(
                 name: "Foo",
-                path: "/Foo",
+                path: .init("/Foo"),
                 packageKind: .root,
-                packageLocation: "/Foo",
                 v: .v5_2,
                 dependencies: dependencies,
                 products: products,
@@ -501,9 +498,8 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         do {
             let manifest = Manifest.createManifest(
                 name: "Foo",
-                path: "/Foo",
+                path: .init("/Foo"),
                 packageKind: .local,
-                packageLocation: "/Foo",
                 v: .v5_2,
                 dependencies: dependencies,
                 products: products,
@@ -549,9 +545,8 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
             // Create a container provider, configured with a mock manifest loader that will return the package manifest.
             let manifest = Manifest.createV4Manifest(
                 name: packageDir.basename,
-                path: packageDir.pathString,
+                path: packageDir,
                 packageKind: .root,
-                packageLocation: packageDir.pathString,
                 targets: [
                     try TargetDescription(name: packageDir.basename, path: packageDir.pathString),
                 ]
@@ -615,9 +610,8 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
             let version = Version(1, 0, 0)
             let manifest = Manifest.createManifest(
                 name: packageDirectory.basename,
-                path: packageDirectory.pathString,
+                path: packageDirectory,
                 packageKind: .root,
-                packageLocation: packageDirectory.pathString,
                 v: .v5_2,
                 dependencies: [
                     .scm(

--- a/Tests/PackageModelTests/ManifestTests.swift
+++ b/Tests/PackageModelTests/ManifestTests.swift
@@ -29,9 +29,8 @@ class ManifestTests: XCTestCase {
         do {
             let manifest = Manifest.createManifest(
                 name: "Foo",
-                path: "/Foo",
+                path: .init("/Foo"),
                 packageKind: .root,
-                packageLocation: "/Foo",
                 v: .v5_2,
                 products: products,
                 targets: targets
@@ -48,9 +47,8 @@ class ManifestTests: XCTestCase {
         do {
             let manifest = Manifest.createManifest(
                 name: "Foo",
-                path: "/Foo",
+                path: .init("/Foo"),
                 packageKind: .local,
-                packageLocation: "/Foo",
                 v: .v5_2,
                 products: products,
                 targets: targets
@@ -86,9 +84,8 @@ class ManifestTests: XCTestCase {
         do {
             let manifest = Manifest.createManifest(
                 name: "Foo",
-                path: "/Foo",
+                path: .init("/Foo"),
                 packageKind: .root,
-                packageLocation: "/Foo",
                 v: .v5,
                 dependencies: dependencies,
                 products: products,
@@ -105,9 +102,8 @@ class ManifestTests: XCTestCase {
         do {
             let manifest = Manifest.createManifest(
                 name: "Foo",
-                path: "/Foo",
+                path: .init("/Foo"),
                 packageKind: .local,
-                packageLocation: "/Foo",
                 v: .v5,
                 dependencies: dependencies,
                 products: products,
@@ -124,9 +120,8 @@ class ManifestTests: XCTestCase {
         do {
             let manifest = Manifest.createManifest(
                 name: "Foo",
-                path: "/Foo",
+                path: .init("/Foo"),
                 packageKind: .root,
-                packageLocation: "/Foo",
                 v: .v5_2,
                 dependencies: dependencies,
                 products: products,
@@ -143,9 +138,8 @@ class ManifestTests: XCTestCase {
         do {
             let manifest = Manifest.createManifest(
                 name: "Foo",
-                path: "/Foo",
+                path: .init("/Foo"),
                 packageKind: .local,
-                packageLocation: "/Foo",
                 v: .v5_2,
                 dependencies: dependencies,
                 products: products,

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -32,9 +32,8 @@ class PluginInvocationTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Foo",
-                    path: "/Foo",
+                    path: .init("/Foo"),
                     packageKind: .root,
-                    packageLocation: "/Foo",
                     products: [
                         ProductDescription(
                             name: "Foo",

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -41,9 +41,8 @@ class PIFBuilderTests: XCTestCase {
                 manifests: [
                     Manifest.createManifest(
                         name: "B",
-                        path: "/B",
+                        path: .init("/B"),
                         packageKind: .remote,
-                        packageLocation: "/B",
                         v: .v5_2,
                         products: [
                             .init(name: "bexe", type: .executable, targets: ["B1"]),
@@ -55,9 +54,8 @@ class PIFBuilderTests: XCTestCase {
                         ]),
                     Manifest.createManifest(
                         name: "A",
-                        path: "/A",
+                        path: .init("/A"),
                         packageKind: .root,
-                        packageLocation: "/A",
                         v: .v5_2,
                         dependencies: [
                             .scm(location: "/B", requirement: .branch("master")),
@@ -113,9 +111,8 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createManifest(
                     name: "Foo",
-                    path: "/Foo",
+                    path: .init("/Foo"),
                     packageKind: .root,
-                    packageLocation: "/Foo",
                     defaultLocalization: "fr",
                     v: .v5_2,
                     dependencies: [
@@ -127,9 +124,8 @@ class PIFBuilderTests: XCTestCase {
                     ]),
                 Manifest.createManifest(
                     name: "Bar",
-                    path: "/Bar",
+                    path: .init("/Bar"),
                     packageKind: .remote,
-                    packageLocation: "/Bar",
                     platforms: [
                         PlatformDescription(name: "macos", version: "10.14"),
                         PlatformDescription(name: "ios", version: "12"),
@@ -383,9 +379,8 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createManifest(
                     name: "Foo",
-                    path: "/Foo",
+                    path: .init("/Foo"),
                     packageKind: .root,
-                    packageLocation: "/Foo",
                     v: .v5_2,
                     swiftLanguageVersions: [.v4_2, .v5],
                     dependencies: [
@@ -407,9 +402,8 @@ class PIFBuilderTests: XCTestCase {
                     ]),
                 Manifest.createManifest(
                     name: "Bar",
-                    path: "/Bar",
+                    path: .init("/Bar"),
                     packageKind: .remote,
-                    packageLocation: "/Bar",
                     v: .v4_2,
                     cLanguageStandard: "c11",
                     cxxLanguageStandard: "c++14",
@@ -709,9 +703,8 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createManifest(
                     name: "Foo",
-                    path: "/Foo",
+                    path: .init("/Foo"),
                     packageKind: .root,
-                    packageLocation: "/Foo",
                     v: .v5_2,
                     swiftLanguageVersions: [.v4_2, .v5],
                     dependencies: [
@@ -733,9 +726,8 @@ class PIFBuilderTests: XCTestCase {
                     ]),
                 Manifest.createManifest(
                     name: "Bar",
-                    path: "/Bar",
+                    path: .init("/Bar"),
                     packageKind: .remote,
-                    packageLocation: "/Bar",
                     v: .v4_2,
                     cLanguageStandard: "c11",
                     cxxLanguageStandard: "c++14",
@@ -937,9 +929,8 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createManifest(
                     name: "Foo",
-                    path: "/Foo",
+                    path: .init("/Foo"),
                     packageKind: .root,
-                    packageLocation: "/Foo",
                     v: .v5_2,
                     swiftLanguageVersions: [.v4_2, .v5],
                     dependencies: [
@@ -958,7 +949,7 @@ class PIFBuilderTests: XCTestCase {
                     ]),
                 Manifest.createManifest(
                     name: "Bar",
-                    path: "/Bar",
+                    path: .init("/Bar"),
                     packageKind: .remote,
                     packageLocation: "/Bar",
                     v: .v4_2,
@@ -1133,9 +1124,8 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createManifest(
                     name: "Foo",
-                    path: "/Foo",
+                    path: .init("/Foo"),
                     packageKind: .root,
-                    packageLocation: "/Foo",
                     v: .v5_2,
                     cxxLanguageStandard: "c++14",
                     swiftLanguageVersions: [.v4_2, .v5],
@@ -1151,9 +1141,8 @@ class PIFBuilderTests: XCTestCase {
                     ]),
                 Manifest.createManifest(
                     name: "Bar",
-                    path: "/Bar",
+                    path: .init("/Bar"),
                     packageKind: .remote,
-                    packageLocation: "/Bar",
                     v: .v4_2,
                     cLanguageStandard: "c11",
                     swiftLanguageVersions: [.v4_2],
@@ -1423,9 +1412,8 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createManifest(
                     name: "Bar",
-                    path: "/Bar",
+                    path: .init("/Bar"),
                     packageKind: .root,
-                    packageLocation: "/Bar",
                     v: .v4_2,
                     cLanguageStandard: "c11",
                     swiftLanguageVersions: [.v4_2],
@@ -1470,9 +1458,8 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createManifest(
                     name: "Bar",
-                    path: "/Bar",
+                    path: .init("/Bar"),
                     packageKind: .root,
-                    packageLocation: "/Bar",
                     v: .v4_2,
                     cLanguageStandard: "c11",
                     swiftLanguageVersions: [.v4_2],
@@ -1521,9 +1508,8 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createManifest(
                     name: "Foo",
-                    path: "/Foo",
+                    path: .init("/Foo"),
                     packageKind: .root,
-                    packageLocation: "/Foo",
                     v: .v5_2,
                     cxxLanguageStandard: "c++14",
                     swiftLanguageVersions: [.v4_2, .v5],
@@ -1634,9 +1620,8 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createManifest(
                     name: "Foo",
-                    path: "/Foo",
+                    path: .init("/Foo"),
                     packageKind: .root,
-                    packageLocation: "/Foo",
                     v: .v5_3,
                     products: [
                         .init(name: "FooLib", type: .library(.automatic), targets: ["FooLib"]),
@@ -1700,7 +1685,7 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createManifest(
                     name: "Foo",
-                    path: "/Foo",
+                    path: .init("/Foo"),
                     packageKind: .root,
                     packageLocation: "/Foo",
                     v: .v5_3,
@@ -1910,9 +1895,8 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createManifest(
                     name: "Foo",
-                    path: "/Foo",
+                    path: .init("/Foo"),
                     packageKind: .root,
-                    packageLocation: "/Foo",
                     v: .v5,
                     products: [
                         .init(name: "FooLib", type: .library(.automatic), targets: ["FooLib"]),
@@ -2130,9 +2114,8 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createManifest(
                     name: "Foo",
-                    path: "/Foo",
+                    path: .init("/Foo"),
                     packageKind: .root,
-                    packageLocation: "/Foo",
                     v: .v5_3,
                     targets: [
                         .init(name: "foo", dependencies: [
@@ -2195,7 +2178,7 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createManifest(
                     name: "Foo",
-                    path: "/Foo",
+                    path: .init("/Foo"),
                     packageKind: .root,
                     packageLocation: "/Foo",
                     platforms: [
@@ -2239,9 +2222,8 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createManifest(
                     name: "MyLib",
-                    path: "/MyLib",
+                    path: .init("/MyLib"),
                     packageKind: .root,
-                    packageLocation: "/MyLib",
                     v: .v5,
                     products: [
                         .init(name: "MyLib", type: .library(.automatic), targets: ["MyLib"]),

--- a/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
+++ b/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
@@ -39,9 +39,8 @@ class GenerateXcodeprojTests: XCTestCase {
               manifests: [
                   Manifest.createV4Manifest(
                       name: "Foo",
-                      path: packagePath.pathString,
+                      path: packagePath,
                       packageKind: .root,
-                      packageLocation: packagePath.pathString,
                       targets: [
                           TargetDescription(name: "DummyModuleName"),
                       ])
@@ -91,9 +90,8 @@ class GenerateXcodeprojTests: XCTestCase {
                 manifests: [
                     Manifest.createV4Manifest(
                         name: "Bar",
-                        path: packagePath.pathString,
+                        path: packagePath,
                         packageKind: .root,
-                        packageLocation: packagePath.pathString,
                         targets: [
                             TargetDescription(name: "Bar"),
                         ])
@@ -126,9 +124,8 @@ class GenerateXcodeprojTests: XCTestCase {
                 manifests: [
                     Manifest.createV4Manifest(
                         name: "Modules",
-                        path: packagePath.pathString,
+                        path: packagePath,
                         packageKind: .root,
-                        packageLocation: packagePath.pathString,
                         targets: [
                             TargetDescription(name: "Modules"),
                         ])
@@ -162,9 +159,8 @@ class GenerateXcodeprojTests: XCTestCase {
                 manifests: [
                     Manifest.createV4Manifest(
                         name: "Foo",
-                        path: packagePath.pathString,
+                        path: packagePath,
                         packageKind: .root,
-                        packageLocation: packagePath.pathString,
                         targets: [
                             TargetDescription(name: "DummyModule"),
                         ])
@@ -197,9 +193,8 @@ class GenerateXcodeprojTests: XCTestCase {
                 manifests: [
                     Manifest.createV4Manifest(
                         name: "Foo",
-                        path: packagePath.pathString,
+                        path: packagePath,
                         packageKind: .root,
-                        packageLocation: packagePath.pathString,
                         targets: [
                             TargetDescription(name: "DummyModule"),
                         ])
@@ -231,9 +226,8 @@ class GenerateXcodeprojTests: XCTestCase {
                 manifests: [
                     Manifest.createV4Manifest(
                         name: "Foo",
-                        path: packagePath.pathString,
+                        path: packagePath,
                         packageKind: .root,
-                        packageLocation: packagePath.pathString,
                         targets: [
                             TargetDescription(name: "DummyModule"),
                         ])
@@ -269,9 +263,8 @@ class GenerateXcodeprojTests: XCTestCase {
                 manifests: [
                     Manifest.createV4Manifest(
                         name: "Foo",
-                        path: packagePath.pathString,
+                        path: packagePath,
                         packageKind: .root,
-                        packageLocation: packagePath.pathString,
                         targets: [
                             TargetDescription(name: "DummyModule"),
                         ])
@@ -312,9 +305,8 @@ class GenerateXcodeprojTests: XCTestCase {
                 manifests: [
                     Manifest.createV4Manifest(
                         name: "Foo",
-                        path: packagePath.pathString,
+                        path: packagePath,
                         packageKind: .root,
-                        packageLocation: packagePath.pathString,
                         targets: [
                             TargetDescription(name: "DummyModule"),
                         ])
@@ -354,8 +346,7 @@ class GenerateXcodeprojTests: XCTestCase {
                 manifests: [
                     Manifest.createV4Manifest(
                         name: "Foo",
-                        path: fooPackagePath.pathString,
-                        packageLocation: fooPackagePath.pathString,
+                        path: fooPackagePath,
                         dependencies: [
                             .fileSystem(path: barPackagePath)
                         ],
@@ -366,9 +357,8 @@ class GenerateXcodeprojTests: XCTestCase {
                         ]),
                     Manifest.createV4Manifest(
                         name: "Bar",
-                        path: barPackagePath.pathString,
+                        path: barPackagePath,
                         packageKind: .remote,
-                        packageLocation: barPackagePath.pathString,
                         products: [
                             ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar1"])
                         ],

--- a/Tests/XcodeprojTests/PackageGraphTests.swift
+++ b/Tests/XcodeprojTests/PackageGraphTests.swift
@@ -38,9 +38,8 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Foo",
-                    path: "/Foo",
+                    path: .init("/Foo"),
                     packageKind: .local,
-                    packageLocation: "/Foo",
                     products: [
                         ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Foo"])
                     ],
@@ -57,9 +56,8 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createV4Manifest(
                     name: "Bar",
-                    path: "/Bar",
+                    path: .init("/Bar"),
                     packageKind: .root,
-                    packageLocation: "/Bar",
                     dependencies: [
                         .scm(location: "/Foo", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
@@ -203,9 +201,8 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Foo",
-                    path: "/Foo",
+                    path: .init("/Foo"),
                     packageKind: .root,
-                    packageLocation: "/Foo",
                     products: [
                         ProductDescription(name: "Bar", type: .library(.dynamic), targets: ["Foo"])
                     ],
@@ -244,9 +241,8 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Bar",
-                    path: "/Bar",
+                    path: .init("/Bar"),
                     packageKind: .root,
-                    packageLocation: "/Bar",
                     targets: [
                         TargetDescription(name: "Sea", dependencies: []),
                         TargetDescription(name: "Sea2", dependencies: []),
@@ -287,9 +283,8 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Pkg",
-                    path: "/Pkg",
+                    path: .init("/Pkg"),
                     packageKind: .root,
-                    packageLocation: "/Pkg",
                     targets: [
                         TargetDescription(name: "HelperTool", dependencies: []),
                         TargetDescription(name: "Library", dependencies: []),
@@ -350,9 +345,8 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createV4Manifest(
                     name: "Foo",
-                    path: "/Foo",
+                    path: .init("/Foo"),
                     packageKind: .root,
-                    packageLocation: "/Foo",
                     targets: [
                         TargetDescription(name: "a"),
                         TargetDescription(name: "b", dependencies: ["a"]),
@@ -403,9 +397,8 @@ class PackageGraphTests: XCTestCase {
                 manifests: [
                     Manifest.createV4Manifest(
                         name: "Foo",
-                        path: "/Foo",
+                        path: .init("/Foo"),
                         packageKind: .root,
-                        packageLocation: "/Foo",
                         swiftLanguageVersions: [SwiftLanguageVersion(string: swiftVersion)!],
                         targets: [
                             TargetDescription(name: "a"),


### PR DESCRIPTION
motivation: address correctness issues with tests that create in-memory manifests

changes:
* test helper function to create in-memopry manifest should take a path instead of a string representing a path
* in-memory test manifest pacageLocation is equal to the path in most test cases, remove redundancy where possible to avoid correctlness issues
* adjust tests
