### PR TITLE
Handle undeclared sources for a target

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -48,6 +48,9 @@ public enum ModuleError: Swift.Error {
     /// The public headers directory is at an invalid path.
     case invalidPublicHeadersDirectory(String)
 
+    /// The path is not declared as sources for a given target when it should be.
+    case sourceNotDeclared(path: AbsolutePath, target: String)
+
     /// The sources of a target are overlapping with another target.
     case overlappingSources(target: String, sources: [AbsolutePath])
 
@@ -94,6 +97,8 @@ extension ModuleError: CustomStringConvertible {
                 " -> " + cycle.cycle[0]
         case .invalidPublicHeadersDirectory(let name):
             return "public headers (\"include\") directory path for '\(name)' is invalid or not contained in the target"
+        case .sourceNotDeclared(let path, let target):
+            return "\(path.pathString) is not part of declared sources for target '\(target)'. If it shouldn't be, make sure target directories do not overlap."
         case .overlappingSources(let target, let sources):
             return "target '\(target)' has sources overlapping sources: " +
                 sources.map({ $0.description }).joined(separator: ", ")

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -396,6 +396,29 @@ class PackageBuilderTests: XCTestCase {
         }
     }
 
+    func testMissingSourceDeclaration() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/Sources/foo.swift",
+            "/Sources/bar/bar.swift"
+        )
+        
+        let manifest = Manifest.createV4Manifest(
+            name: "pkg",
+            toolsVersion: .v5_5,
+            targets: [
+                try TargetDescription(
+                    name: "foo",
+                    path: "Sources",
+                    sources: ["foo.swift"]),
+                try TargetDescription(
+                    name: "bar")
+            ]
+        )
+        PackageBuilderTester(manifest, in: fs) { package, diagnotics in
+            diagnotics.check(diagnostic: "/Sources/bar/bar.swift is not part of declared sources for target 'foo'. If it shouldn't be, make sure target directories do not overlap.", behavior: .error)
+        }
+    }
+    
     func testExecutableTargets() throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/Sources/exec1/exec.swift",
@@ -658,7 +681,7 @@ class PackageBuilderTests: XCTestCase {
             package.checkProduct("exe") { _ in }
         }
     }
-
+   
     func testCustomTargetPathsOverlap() throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/target/bar/bar.swift",

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -415,7 +415,7 @@ class PackageBuilderTests: XCTestCase {
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, diagnotics in
-            diagnotics.check(diagnostic: "/Sources/bar/bar.swift is not part of declared sources for target 'foo'. If it shouldn't be, make sure target directories do not overlap.", behavior: .error)
+            diagnotics.check(diagnostic: "/Sources/bar/bar.swift is not part of declared sources for target 'foo'. If it shouldn't be, make sure target directories do not overlap.", severity: .error)
         }
     }
     


### PR DESCRIPTION
This handles cases when source files are considered for rule checks for a target even though they are not declared as part of sources (due to an overlapping file structure), and get incorrect rules set. If they are explicitly declared as sources or the sources parameter itself is removed, then the existing check for overlapping sources will detect them and throw a correct error.  Resolves rdar://67093441.
 