### PR TITLE
PackageCollectionsSigning: avoid peeking into `X509_STORE_CTX`

### DIFF
--- a/Sources/PackageCollectionsSigning/Certificate/CertificatePolicy.swift
+++ b/Sources/PackageCollectionsSigning/Certificate/CertificatePolicy.swift
@@ -182,7 +182,7 @@ extension CertificatePolicy {
                 // Certs could have unknown critical extensions and cause them to be rejected.
                 // Check if they are tolerable.
                 if errorCode == X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION {
-                    guard let cert = ctx?.pointee.current_cert else {
+                    guard let ctx = ctx, let cert = CCryptoBoringSSL_X509_STORE_CTX_get_current_cert(ctx) else {
                         return result
                     }
 


### PR DESCRIPTION
This uses the `CCryptoBoringSSL_X509_STORE_CTX_get_current_cert`
accessor to access the `current_cert` member.  This is purely a cleanup
change that will become important when swift-crypto is bumped as
BoringSSL has made more of the interfaces opaque.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
