### PR TITLE
Update tests expecting a merge-module job to also accept emit-module

### DIFF
--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -729,6 +729,8 @@ fileprivate struct CommandTaskTracker {
                 return "Linking \(targetName)"
             case "merge-module":
                 return "Merging module \(targetName)"
+            case "emit-module":
+                return "Emitting module \(targetName)"
             case "generate-dsym":
                 return "Generating \(targetName) dSYM"
             case "generate-pch":

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -33,9 +33,11 @@ class MiscellaneousTestCase: XCTestCase {
             let (output, _) = try executeSwiftBuild(prefix.appending(component: "Bar"))
             XCTAssertMatch(output, .regex("Computed .* at 1\\.2\\.3"))
             XCTAssertMatch(output, .contains("Compiling Foo Foo.swift"))
-            XCTAssertMatch(output, .contains("Merging module Foo"))
+            XCTAssertMatch(output, .or(.contains("Merging module Foo"),
+                                       .contains("Emitting module Foo")))
             XCTAssertMatch(output, .contains("Compiling Bar main.swift"))
-            XCTAssertMatch(output, .contains("Merging module Bar"))
+            XCTAssertMatch(output, .or(.contains("Merging module Bar"),
+                                      .contains("Emitting module Bar")))
             XCTAssertMatch(output, .contains("Linking Bar"))
         }
     }

--- a/Tests/FunctionalTests/TestDiscoveryTests.swift
+++ b/Tests/FunctionalTests/TestDiscoveryTests.swift
@@ -18,9 +18,9 @@ class TestDiscoveryTests: XCTestCase {
         fixture(name: "Miscellaneous/TestDiscovery/Simple") { path in
             let (stdout, _) = try executeSwiftBuild(path)
             #if os(macOS)
-            XCTAssertMatch(stdout, .contains("Merging module Simple"))
+            XCTAssertMatch(stdout, .contains("module Simple"))
             #else
-            XCTAssertMatch(stdout, .contains("Merging module Simple"))
+            XCTAssertMatch(stdout, .contains("module Simple"))
             #endif
         }
     }
@@ -29,10 +29,10 @@ class TestDiscoveryTests: XCTestCase {
         fixture(name: "Miscellaneous/TestDiscovery/Simple") { path in
             let (stdout, stderr) = try executeSwiftTest(path)
             #if os(macOS)
-            XCTAssertMatch(stdout, .contains("Merging module Simple"))
+            XCTAssertMatch(stdout, .contains("module Simple"))
             XCTAssertMatch(stderr, .contains("Executed 2 tests"))
             #else
-            XCTAssertMatch(stdout, .contains("Merging module Simple"))
+            XCTAssertMatch(stdout, .contains("module Simple"))
             XCTAssertMatch(stdout, .contains("Executed 2 tests"))
             #endif
         }
@@ -42,10 +42,10 @@ class TestDiscoveryTests: XCTestCase {
         fixture(name: "Miscellaneous/TestDiscovery/hello world") { path in
             let (stdout, stderr) = try executeSwiftTest(path)
             #if os(macOS)
-            XCTAssertMatch(stdout, .contains("Merging module hello_world"))
+            XCTAssertMatch(stdout, .contains("module hello_world"))
             XCTAssertMatch(stderr, .contains("Executed 1 test"))
             #else
-            XCTAssertMatch(stdout, .contains("Merging module hello_world"))
+            XCTAssertMatch(stdout, .contains("module hello_world"))
             XCTAssertMatch(stdout, .contains("Executed 1 test"))
             #endif
         }
@@ -61,7 +61,7 @@ class TestDiscoveryTests: XCTestCase {
                 let manifestPath = path.appending(components: "Tests", name)
                 try localFileSystem.writeFileContents(manifestPath, bytes: ByteString("print(\"\(random)\")".utf8))
                 let (stdout, _) = try executeSwiftTest(path)
-                XCTAssertMatch(stdout, .contains("Merging module Simple"))
+                XCTAssertMatch(stdout, .contains("module Simple"))
                 XCTAssertNoMatch(stdout, .contains("Executed 1 test"))
                 XCTAssertMatch(stdout, .contains(random))
             }
@@ -78,7 +78,7 @@ class TestDiscoveryTests: XCTestCase {
             let manifestPath = path.appending(components: "Tests", name)
             try localFileSystem.writeFileContents(manifestPath, bytes: ByteString("fatalError(\"should not be called\")".utf8))
             let (stdout, _) = try executeSwiftTest(path, extraArgs: ["--enable-test-discovery"])
-            XCTAssertMatch(stdout, .contains("Merging module Simple"))
+            XCTAssertMatch(stdout, .contains("module Simple"))
             XCTAssertNoMatch(stdout, .contains("Executed 1 test"))
         }
         #endif
@@ -90,7 +90,7 @@ class TestDiscoveryTests: XCTestCase {
         #else
         fixture(name: "Miscellaneous/TestDiscovery/Extensions") { path in
             let (stdout, _) = try executeSwiftTest(path, extraArgs: ["--enable-test-discovery"])
-            XCTAssertMatch(stdout, .contains("Merging module Simple"))
+            XCTAssertMatch(stdout, .contains("module Simple"))
             XCTAssertMatch(stdout, .contains("SimpleTests1.testExample1"))
             XCTAssertMatch(stdout, .contains("SimpleTests1.testExample1_a"))
             XCTAssertMatch(stdout, .contains("SimpleTests2.testExample2"))


### PR DESCRIPTION
Recent Swift drivers may schedule an emit-module job to build module-wide
files instead of merging partial swiftmodules.

### Motivation:

Some tests are failing with a recent Swift driver that schedules emit-module jobs as the tests expect a merge-module job explicitly. Unblock Swift-side CI testing like: https://ci.swift.org/job/swift-PR-macos-smoke-test/31017/

### Modifications:

Updated tests to accept both merge-module and emit-module.

### Result:

Tests should pass with a recent driver, and older ones.
