### PR TITLE
fix warnings from API changes

### DIFF
--- a/Sources/Build/ManifestBuilder.swift
+++ b/Sources/Build/ManifestBuilder.swift
@@ -49,6 +49,7 @@ public class LLBuildManifestBuilder {
 
     // MARK:- Generate Manifest
     /// Generate manifest at the given path.
+    @discardableResult
     public func generateManifest(at path: AbsolutePath) throws -> BuildManifest {
         manifest.createTarget(TargetKind.main.targetName)
         manifest.createTarget(TargetKind.test.targetName)

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -779,7 +779,7 @@ extension SwiftPackageTool {
 
             try repository.archive(to: destination)
 
-            if destination.contains(packageRoot) {
+            if destination.isDescendantOfOrEqual(to: packageRoot) {
                 let relativePath = destination.relative(to: packageRoot)
                 swiftTool.outputStream <<< "Created \(relativePath.pathString)" <<< "\n"
             } else {

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -546,7 +546,7 @@ public final class PackageBuilder {
 
                 let path = packagePath.appending(relativeSubPath)
                 // Make sure the target is inside the package root.
-                guard path.contains(packagePath) else {
+                guard path.isDescendantOfOrEqual(to: packagePath) else {
                     throw ModuleError.targetOutsidePackage(package: self.manifest.name, target: target.name)
                 }
                 if fileSystem.isDirectory(path) {
@@ -797,7 +797,7 @@ public final class PackageBuilder {
         // Compute the path to public headers directory.
         let publicHeaderComponent = manifestTarget.publicHeadersPath ?? ClangTarget.defaultPublicHeadersComponent
         let publicHeadersPath = potentialModule.path.appending(try RelativePath(validating: publicHeaderComponent))
-        guard publicHeadersPath.contains(potentialModule.path) else {
+        guard publicHeadersPath.isDescendantOfOrEqual(to: potentialModule.path) else {
             throw ModuleError.invalidPublicHeadersDirectory(potentialModule.name)
         }
 
@@ -937,7 +937,7 @@ public final class PackageBuilder {
 
                 // Ensure that the search path is contained within the package.
                 let subpath = try RelativePath(validating: setting.value[0])
-                guard targetRoot.appending(subpath).contains(packagePath) else {
+                guard targetRoot.appending(subpath).isDescendantOfOrEqual(to: packagePath) else {
                     throw ModuleError.invalidHeaderSearchPath(subpath.pathString)
                 }
 
@@ -1127,12 +1127,12 @@ public final class PackageBuilder {
             // If the target root's parent directory is inside the package, start
             // search there. Otherwise, we start search from the target root.
             var searchPath = target.sources.root.parentDirectory
-            if !searchPath.contains(packagePath) {
+            if !searchPath.isDescendantOfOrEqual(to: packagePath) {
                 searchPath = target.sources.root
             }
 
             while true {
-                assert(searchPath.contains(packagePath), "search path \(searchPath) is outside the package \(packagePath)")
+                assert(searchPath.isDescendantOfOrEqual(to: packagePath), "search path \(searchPath) is outside the package \(packagePath)")
                 // If we have already searched this path, skip.
                 if !pathsSearched.contains(searchPath) {
                     SwiftTarget.testManifestNames.forEach { name in

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -191,7 +191,7 @@ public struct TargetSourcesBuilder {
         // First match any resources explicitly declared in the manifest file.
         for declaredResource in target.resources {
             let resourcePath = self.targetPath.appending(RelativePath(declaredResource.path))
-            if path.contains(resourcePath) {
+            if path.isDescendantOfOrEqual(to: resourcePath) {
                 if matchedRule.rule != .none {
                     diags.emit(.error("duplicate resource rule '\(declaredResource.rule)' found for file at '\(path)'"))
                 }
@@ -202,7 +202,7 @@ public struct TargetSourcesBuilder {
         // Match any sources explicitly declared in the manifest file.
         if let declaredSources = self.declaredSources {
             for sourcePath in declaredSources {
-                if path.contains(sourcePath) {
+                if path.isDescendantOfOrEqual(to: sourcePath) {
                     if matchedRule.rule != .none {
                         diags.emit(.error("duplicate rule found for file at '\(path)'"))
                     }

--- a/Sources/PackageModel/Target.swift
+++ b/Sources/PackageModel/Target.swift
@@ -428,7 +428,7 @@ public final class ClangTarget: Target {
         dependencies: [Target.Dependency] = [],
         buildSettings: BuildSettings.AssignmentTable = .init()
     ) {
-        assert(includeDir.contains(sources.root), "\(includeDir) should be contained in the source root \(sources.root)")
+        assert(includeDir.isDescendantOfOrEqual(to: sources.root), "\(includeDir) should be contained in the source root \(sources.root)")
         self.isCXX = sources.containsCXXFiles
         self.cLanguageStandard = cLanguageStandard
         self.cxxLanguageStandard = cxxLanguageStandard


### PR DESCRIPTION
motivation: no warnings

changes:
* mark generateManifest as discardableResult
* udpated call-sites of TSC Path contains to isDescendantOfOrEqual(to:)

