### PR TITLE
Fix crash with absolute path to binary artifact

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1777,8 +1777,7 @@ extension Workspace {
             for target in manifest.targets where target.type == .binary {
                 if let path = target.path {
                     // TODO: find a better way to get the base path (not via the manifest)
-                    // the target path is validated earlier to be within the package directory
-                    let absolutePath = manifest.path.parentDirectory.appending(RelativePath(path))
+                    let absolutePath = try manifest.path.parentDirectory.appending(RelativePath(validating: path))
                     localArtifacts.append(
                         .local(
                             packageRef: packageReference,

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -6811,6 +6811,45 @@ final class WorkspaceTests: XCTestCase {
             }
         }
     }
+
+    func testBinaryArtifactsInvalidPath() throws {
+        let fs = localFileSystem
+        try testWithTemporaryDirectory { path in
+            let foo = path.appending(component: "foo")
+
+            try fs.writeFileContents(foo.appending(component: "Package.swift")) {
+                $0 <<<
+                    """
+                    // swift-tools-version:5.3
+                    import PackageDescription
+                    let package = Package(
+                        name: "Best",
+                        targets: [
+                            .binaryTarget(name: "best", path: "/best.xcframework")
+                        ]
+                    )
+                    """
+            }
+
+            let manifestLoader = ManifestLoader(toolchain: ToolchainConfiguration.default)
+            let sandbox = path.appending(component: "ws")
+            let workspace = try Workspace(
+                fileSystem: fs,
+                location: .init(forRootPackage: sandbox, fileSystem: fs),
+                customManifestLoader: manifestLoader,
+                delegate: MockWorkspaceDelegate()
+            )
+
+            do {
+                let diagnostics = DiagnosticsEngine()
+                try workspace.resolve(root: .init(packages: [foo]), diagnostics: diagnostics)
+            } catch {
+                XCTAssertEqual(error.localizedDescription, "invalid relative path '/best.xcframework'; relative path should not begin with '/' or '~'")
+                return
+            }
+            XCTFail("unexpected success")
+        }
+    }
 }
 
 struct DummyError: LocalizedError, Equatable {


### PR DESCRIPTION
The code in `Workspace.parseArtifacts()` assumes prior validation of paths even though it is running before any such validation.

rdar://83059393
