### PR TITLE
Mark package plugins as being available in 5.5 again, not 5.6

### DIFF
--- a/Fixtures/Miscellaneous/Plugins/ContrivedTestPlugin/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/ContrivedTestPlugin/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 5.5
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/Miscellaneous/Plugins/MyBinaryToolPlugin/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/MyBinaryToolPlugin/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 5.5
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/Miscellaneous/Plugins/MySourceGenClient/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/MySourceGenClient/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 5.5
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/Miscellaneous/Plugins/MySourceGenPlugin/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/MySourceGenPlugin/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 5.5
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/Miscellaneous/Plugins/SandboxTesterPlugin/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/SandboxTesterPlugin/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 5.5
 import PackageDescription
 
 let package = Package(

--- a/Sources/PackageDescription/Product.swift
+++ b/Sources/PackageDescription/Product.swift
@@ -190,7 +190,7 @@ public class Product: Encodable {
     /// - Parameters:
     ///     - name: The name of the plugin product.
     ///     - targets: The plugin targets to vend as a product.
-    @available(_PackageDescription, introduced: 5.6)
+    @available(_PackageDescription, introduced: 5.5)
     public static func plugin(
         name: String,
         targets: [String]

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -119,7 +119,7 @@ public final class Target {
     public let providers: [SystemPackageProvider]?
     
     /// The capability provided by a package plugin target.
-    @available(_PackageDescription, introduced: 5.6)
+    @available(_PackageDescription, introduced: 5.5)
     public var pluginCapability: PluginCapability? {
         get { return _pluginCapability }
         set { _pluginCapability = newValue }
@@ -174,7 +174,7 @@ public final class Target {
     private var _checksum: String?
     
     /// The usages of package plugins by the target.
-    @available(_PackageDescription, introduced: 5.6)
+    @available(_PackageDescription, introduced: 5.5)
     public var plugins: [PluginUsage]? {
         get { return _pluginUsages }
         set { _pluginUsages = newValue }
@@ -394,7 +394,7 @@ public final class Target {
     ///   - cxxSettings: The C++ settings for this target.
     ///   - swiftSettings: The Swift settings for this target.
     ///   - linkerSettings: The linker settings for this target.
-    @available(_PackageDescription, introduced: 5.3, obsoleted: 5.6)
+    @available(_PackageDescription, introduced: 5.3, obsoleted: 5.5)
     public static func target(
         name: String,
         dependencies: [Dependency] = [],
@@ -448,7 +448,7 @@ public final class Target {
     ///   - swiftSettings: The Swift settings for this target.
     ///   - linkerSettings: The linker settings for this target.
     ///   - plugins: The plugins used by this target.
-    @available(_PackageDescription, introduced: 5.6)
+    @available(_PackageDescription, introduced: 5.5)
     public static func target(
         name: String,
         dependencies: [Dependency] = [],
@@ -504,7 +504,7 @@ public final class Target {
     ///   - cxxSettings: The C++ settings for this target.
     ///   - swiftSettings: The Swift settings for this target.
     ///   - linkerSettings: The linker settings for this target.
-    @available(_PackageDescription, introduced: 5.4, obsoleted: 5.6)
+    @available(_PackageDescription, introduced: 5.4, obsoleted: 5.5)
     public static func executableTarget(
         name: String,
         dependencies: [Dependency] = [],
@@ -559,7 +559,7 @@ public final class Target {
     ///   - swiftSettings: The Swift settings for this target.
     ///   - linkerSettings: The linker settings for this target.
     ///   - plugins: The plugins used by this target.
-    @available(_PackageDescription, introduced: 5.6)
+    @available(_PackageDescription, introduced: 5.5)
     public static func executableTarget(
         name: String,
         dependencies: [Dependency] = [],
@@ -694,7 +694,7 @@ public final class Target {
     ///   - cxxSettings: The C++ settings for this target.
     ///   - swiftSettings: The Swift settings for this target.
     ///   - linkerSettings: The linker settings for this target.
-    @available(_PackageDescription, introduced: 5.3, obsoleted: 5.6)
+    @available(_PackageDescription, introduced: 5.3, obsoleted: 5.5)
     public static func testTarget(
         name: String,
         dependencies: [Dependency] = [],
@@ -745,7 +745,7 @@ public final class Target {
     ///   - swiftSettings: The Swift settings for this target.
     ///   - linkerSettings: The linker settings for this target.
     ///   - plugins: The plugins used by this target.
-    @available(_PackageDescription, introduced: 5.6)
+    @available(_PackageDescription, introduced: 5.5)
     public static func testTarget(
         name: String,
         dependencies: [Dependency] = [],
@@ -896,7 +896,7 @@ public final class Target {
     /// on executables as well as binary targets. This is because of limitations
     /// in how SwiftPM constructs its build plan, and the goal is to remove this
     /// restriction in a future release.
-    @available(_PackageDescription, introduced: 5.6)
+    @available(_PackageDescription, introduced: 5.5)
     public static func plugin(
         name: String,
         capability: PluginCapability,
@@ -1006,7 +1006,7 @@ extension Target.PluginCapability {
     /// Specifies that the plugin provides a build tool capability. The plugin
     /// will be applied to each target that uses it and should create commands
     /// that will run before or during the build of the target.
-    @available(_PackageDescription, introduced: 5.6)
+    @available(_PackageDescription, introduced: 5.5)
     public static func buildTool() -> Target.PluginCapability {
         return ._buildTool
     }
@@ -1017,7 +1017,7 @@ extension Target.PluginUsage {
     ///
     /// - parameters:
     ///   - name: The name of the plugin target.
-    @available(_PackageDescription, introduced: 5.6)
+    @available(_PackageDescription, introduced: 5.5)
     public static func plugin(name: String) -> Target.PluginUsage {
         return ._pluginItem(name: name, package: nil)
     }
@@ -1027,7 +1027,7 @@ extension Target.PluginUsage {
     /// - parameters:
     ///   - name: The name of the plugin product.
     ///   - package: The name of the package in which it is defined.
-    @available(_PackageDescription, introduced: 5.6)
+    @available(_PackageDescription, introduced: 5.5)
     public static func plugin(name: String, package: String) -> Target.PluginUsage {
         return ._pluginItem(name: name, package: package)
     }

--- a/Tests/PackageLoadingTests/PD_5_4_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_4_LoadingTests.swift
@@ -39,4 +39,32 @@ class PackageDescription5_4LoadingTests: PackageDescriptionLoadingTests {
             XCTAssertEqual(manifest.targets[0].type, .executable)
         }
     }
+    
+    func testPluginsAreUnavailable() throws {
+        let stream = BufferedOutputByteStream()
+        stream <<< """
+            import PackageDescription
+            let package = Package(
+               name: "Foo",
+               targets: [
+                   .plugin(
+                       name: "Foo",
+                       capability: .buildTool()
+                   ),
+               ]
+            )
+            """
+        do {
+            try loadManifestThrowing(stream.bytes) { _ in }
+            XCTFail("expected manifest loading to fail, but it succeeded")
+        }
+        catch {
+            guard case let ManifestParseError.invalidManifestFormat(message, _) = error else {
+                return XCTFail("expected an invalidManifestFormat error, but got: \(error)")
+            }
+
+            XCTAssertMatch(message, .contains("is unavailable"))
+            XCTAssertMatch(message, .contains("was introduced in PackageDescription 5.5"))
+        }
+    }
 }

--- a/Tests/PackageLoadingTests/PD_5_5_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_5_LoadingTests.swift
@@ -65,32 +65,4 @@ class PackageDescription5_5LoadingTests: PackageDescriptionLoadingTests {
             ])
         }
     }
-    
-    func testPluginsAreUnavailable() throws {
-        let stream = BufferedOutputByteStream()
-        stream <<< """
-            import PackageDescription
-            let package = Package(
-               name: "Foo",
-               targets: [
-                   .plugin(
-                       name: "Foo",
-                       capability: .buildTool()
-                   ),
-               ]
-            )
-            """
-        do {
-            try loadManifestThrowing(stream.bytes) { _ in }
-            XCTFail("expected manifest loading to fail, but it succeeded")
-        }
-        catch {
-            guard case let ManifestParseError.invalidManifestFormat(message, _) = error else {
-                return XCTFail("expected an invalidManifestFormat error, but got: \(error)")
-            }
-
-            XCTAssertMatch(message, .contains("is unavailable"))
-            XCTAssertMatch(message, .contains("was introduced in PackageDescription 5.6"))
-        }
-    }
 }

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -282,6 +282,6 @@ class ManifestSourceGenerationTests: XCTestCase {
                 ]
             )
             """
-        try testManifestWritingRoundTrip(manifestContents: manifestContents, toolsVersion: .v5_6)
+        try testManifestWritingRoundTrip(manifestContents: manifestContents, toolsVersion: .v5_5)
     }
 }


### PR DESCRIPTION
Changes the availability annotations of manifest API related to plugins back to 5.5 again.

### Motivation:

They were originally marked as 5.5, I changed this to 5.6 when removing the feature flag.  This means that existing packages with experimental use of plugins no longer load, however, which is a problem since IDEs such as Xcode 13 actually support loading such manifests but there is no IDE that supports 5.6 yet.

SwiftPM 5.5 already has the feature flag to prevent casual use.  Supporting 5.5 again allows early adopters to write their code to work with either or both of 5.5 and/or 5.6.

### Modifications:

- changed the availability annotations back to 5.5

### Result:

Packages no longer have to upgrade their tools version to 5.6 to contain mentions of plugins.
