### PR TITLE
Fix the default location for diagnostics resulting from package manifest loading

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1638,7 +1638,7 @@ extension Workspace {
 
                 // Load the manifest.
                 // The delegate callback is only passed any diagnostics emitted during the parsing of the manifest, but they are also forwarded up to the caller.
-                let manifestLoadingDiagnostics = DiagnosticsEngine(handlers: [{diagnostics.emit($0)}])
+                let manifestLoadingDiagnostics = DiagnosticsEngine(handlers: [{ diagnostics.emit($0) }], defaultLocation: diagnostics.defaultLocation)
                 manifestLoader.load(at: packagePath,
                                     packageIdentity: packageIdentity,
                                     packageKind: packageKind,

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -174,6 +174,39 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
+    func testManifestParseError() throws {
+        try testWithTemporaryDirectory { path in
+            let pkgDir = path.appending(component: "MyPkg")
+            try localFileSystem.writeFileContents(pkgDir.appending(component: "Package.swift")) {
+                $0 <<<
+                    """
+                    // swift-tools-version:4.0
+                    import PackageDescription
+                    #error("An error in MyPkg")
+                    let package = Package(
+                        name: "MyPkg"
+                    )
+                    """
+            }
+            let workspace = try Workspace(
+                fileSystem: localFileSystem,
+                location: .init(forRootPackage: pkgDir, fileSystem: localFileSystem),
+                customManifestLoader: ManifestLoader(toolchain: ToolchainConfiguration.default),
+                delegate: MockWorkspaceDelegate()
+            )
+            let diagnostics = DiagnosticsEngine()
+            let rootInput = PackageGraphRootInput(packages: [pkgDir], dependencies: [])
+            let rootManifests = try tsc_await { workspace.loadRootManifests(packages: rootInput.packages, diagnostics: diagnostics, completion: $0) }
+            XCTAssert(rootManifests.count == 0, "\(rootManifests)")
+            XCTAssert(diagnostics.diagnostics.count == 1, "\(diagnostics.diagnostics)")
+            let diagnostic = try XCTUnwrap(diagnostics.diagnostics.first)
+            XCTAssert(diagnostic.message.behavior == .error, "\(diagnostic.message.behavior)")
+            XCTAssert(diagnostic.message.text.contains("An error in MyPkg"), "\(diagnostic.message.text)")
+            XCTAssert(diagnostic.location is PackageLocation.Local, "\(diagnostic.location)")
+            XCTAssertEqual((diagnostic.location as? PackageLocation.Local)?.packagePath, pkgDir)
+        }
+    }
+
     func testMultipleRootPackages() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()


### PR DESCRIPTION
An earlier change in `main` broke the default location associated with diagnostics from package manifest evaluation.

### Motivation:

- this fixes a regression

### Modifications:

- pass through the default location when creating the DiagnosticEngine for manifest loading
- add a unit test for the location

### Result:

- this restores the 5.5 behavior