### PR TITLE
[5.5] Fix crash with absolute path to binary artifact

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1562,8 +1562,7 @@ extension Workspace {
             for target in manifest.targets where target.type == .binary {
                 if let path = target.path {
                     // TODO: find a better way to get the base path (not via the manifest)
-                    // the target path is validated earlier to be within the package directory
-                    let absolutePath = manifest.path.parentDirectory.appending(RelativePath(path))
+                    let absolutePath = try manifest.path.parentDirectory.appending(RelativePath(validating: path))
                     localArtifacts.append(
                         .local(
                             packageRef: packageReference,

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -6779,14 +6779,15 @@ final class WorkspaceTests: XCTestCase {
                     """
             }
 
-            let manifestLoader = ManifestLoader(toolchain: ToolchainConfiguration.default)
+            let manifestLoader = ManifestLoader(manifestResources: Resources.default)
             let sandbox = path.appending(component: "ws")
-            let workspace = try Workspace(
-                fileSystem: fs,
-                location: .init(forRootPackage: sandbox, fileSystem: fs),
-                customManifestLoader: manifestLoader,
-                delegate: MockWorkspaceDelegate()
-            )
+            let workspace = Workspace(
+                dataPath: sandbox.appending(component: ".build"),
+                editablesPath: sandbox.appending(component: "edits"),
+                pinsFile: sandbox.appending(component: "Package.resolved"),
+                manifestLoader: manifestLoader,
+                delegate: MockWorkspaceDelegate(),
+                cachePath: fs.swiftPMCacheDirectory.appending(component: "repositories"))
 
             do {
                 let diagnostics = DiagnosticsEngine()


### PR DESCRIPTION
5.5 cherry-pick of https://github.com/apple/swift-package-manager/pull/3737