### PR TITLE
adding support for custom platforms

### DIFF
--- a/Sources/PackageDescription/SupportedPlatforms.swift
+++ b/Sources/PackageDescription/SupportedPlatforms.swift
@@ -19,6 +19,11 @@ public struct Platform: Encodable, Equatable {
         self.name = name
     }
     
+    @available(_PackageDescription, introduced: 5.6)
+    public static func custom(_ platformName: String) -> Platform {
+        return Platform(name: platformName)
+    }
+    
     /// The macOS platform.
     public static let macOS: Platform = Platform(name: "macos")
     
@@ -212,6 +217,16 @@ public struct SupportedPlatform: Encodable, Equatable {
     @available(_PackageDescription, introduced: 5.5)
     public static func driverKit(_ versionString: String) -> SupportedPlatform {
         return SupportedPlatform(platform: .driverKit, version: SupportedPlatform.DriverKitVersion(string: versionString).version)
+    }
+    
+    /// Configures the minimum deployment target version for custom platforms.
+    ///
+    /// - Since: First available in PackageDescription 5.6
+    ///
+    /// - Parameter version: The minimum deployment target that the package supports.
+    @available(_PackageDescription, introduced: 5.6)
+    public static func custom(_ platformName: String,  versionString: String) -> SupportedPlatform {
+        return SupportedPlatform(platform: .custom(platformName), version: versionString)
     }
 }
 

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -1001,7 +1001,8 @@ public final class PackageBuilder {
 
         /// Add each declared platform to the supported platforms list.
         for platform in manifest.platforms {
-            let declaredPlatform = platformRegistry.platformByName[platform.platformName]!
+            let declaredPlatform = platformRegistry.platformByName[platform.platformName]
+                ?? PackageModel.Platform.custom(name: platform.platformName, oldestSupportedVersion: platform.version)
             var version = PlatformVersion(platform.version)
 
             if let xcTestMinimumDeploymentTarget = xcTestMinimumDeploymentTargets[declaredPlatform], isTest, version < xcTestMinimumDeploymentTarget {

--- a/Sources/PackageModel/ManifestSourceGeneration.swift
+++ b/Sources/PackageModel/ManifestSourceGeneration.swift
@@ -115,7 +115,7 @@ fileprivate extension SourceCodeFragment {
         case "driverkit":
             self.init(enum: "DriverKit", string: platform.version)
         default:
-            self.init(enum: platform.platformName, string: platform.version)
+            self.init(enum: "custom", subnodes: [ .init(string: platform.platformName), .init(key: "versionString", string: platform.version) ])
         }
     }
     

--- a/Sources/PackageModel/Platform.swift
+++ b/Sources/PackageModel/Platform.swift
@@ -24,7 +24,11 @@ public struct Platform: Equatable, Hashable, Codable {
         self.name = name
         self.oldestSupportedVersion = oldestSupportedVersion
     }
-    
+
+    public static func custom(name: String, oldestSupportedVersion: String) -> Platform {
+        return Platform(name: name, oldestSupportedVersion: PlatformVersion(oldestSupportedVersion))
+    }
+
     public static let macOS: Platform = Platform(name: "macos", oldestSupportedVersion: "10.10")
     public static let macCatalyst: Platform = Platform(name: "maccatalyst", oldestSupportedVersion: "13.0")
     public static let iOS: Platform = Platform(name: "ios", oldestSupportedVersion: "9.0")

--- a/Tests/PackageLoadingTests/PD_5_6_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_6_LoadingTests.swift
@@ -112,4 +112,45 @@ class PackageDescription5_6LoadingTests: PackageDescriptionLoadingTests {
             XCTAssertEqual(manifest.targets[0].sources, ["CountMeIn.swift"])
         }
     }
+
+    func testCustomPlatforms() throws {
+        // One custom platform.
+        var stream = BufferedOutputByteStream()
+        stream <<< """
+            import PackageDescription
+            let package = Package(
+               name: "Foo",
+               platforms: [
+                   .custom("customos", versionString: "1.0"),
+               ]
+            )
+            """
+
+        loadManifest(stream.bytes) { manifest in
+            XCTAssertEqual(manifest.platforms, [
+                PlatformDescription(name: "customos", version: "1.0"),
+            ])
+        }
+
+        // Two custom platforms.
+        stream = BufferedOutputByteStream()
+        stream <<< """
+            import PackageDescription
+            let package = Package(
+               name: "Foo",
+               platforms: [
+                   .custom("customos", versionString: "1.0"),
+                   .custom("anothercustomos", versionString: "2.3"),
+               ]
+            )
+            """
+
+        loadManifest(stream.bytes) { manifest in
+            XCTAssertEqual(manifest.platforms, [
+                PlatformDescription(name: "customos", version: "1.0"),
+                PlatformDescription(name: "anothercustomos", version: "2.3"),
+            ])
+        }
+
+    }
 }

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -115,6 +115,42 @@ class ManifestSourceGenerationTests: XCTestCase {
         try testManifestWritingRoundTrip(manifestContents: manifestContents, toolsVersion: .v5_3)
     }
 
+    func testCustomPlatform() throws {
+        let manifestContents = """
+            // swift-tools-version:5.6
+            // The swift-tools-version declares the minimum version of Swift required to build this package.
+
+            import PackageDescription
+
+            let package = Package(
+                name: "MyPackage",
+                platforms: [
+                    .custom("customOS", versionString: "1.0")
+                ],
+                products: [
+                    // Products define the executables and libraries a package produces, and make them visible to other packages.
+                    .library(
+                        name: "MyPackage",
+                        targets: ["MyPackage"]),
+                ],
+                dependencies: [
+                    // Dependencies declare other packages that this package depends on.
+                    // .package(url: /* package url */, from: "1.0.0"),
+                ],
+                targets: [
+                    // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+                    // Targets can depend on other targets in this package, and on products in packages this package depends on.
+                    .target(
+                        name: "MyPackage",
+                        dependencies: []),
+                    .testTarget(
+                        name: "MyPackageTests",
+                        dependencies: ["MyPackage"]),
+                ]
+            )
+            """
+        try testManifestWritingRoundTrip(manifestContents: manifestContents, toolsVersion: .v5_6)
+    }
 
     func testAdvancedFeatures() throws {
         let manifestContents = """


### PR DESCRIPTION

Allow Package.swift specification of minimum SDK version for unknown platforms by using new "custom" platform with platform name string, and version string.

### Motivation:

Currently, platforms in SwiftPM have to always be hard-coded and we should get to a more flexible model here. As a first step, this PR adds the ability to declare custom platform deployment versions in the package manifest, which won’t be handled by SwiftPM’s own build system, but will be part of the package model, so that they can be utilized when using libSwiftPM together with another build system.

### Modifications:

Added a new API, custom() to each of Platform and SupportedPlatform.  Added fall back while reading manifest to create a custom platform where the platform is not recognized.  Tests were added for Package Loading and Building.

### Result:

From now on, anyone in the community who wishes to target a new platform for development without having to wait to add to the OSS, can do so in development by simply adding a '.custom("<new platform>", "new platform version>")' to their Package.swift, and then adding the appropriate changes in their builder to recognize their new platform.  They can then add the new platform and supported platform to the OSS for "official" support if the community needs/requires it.
