### PR TITLE
update collections APIs to use package identity

### DIFF
--- a/Sources/Commands/SwiftPackageCollectionsTool.swift
+++ b/Sources/Commands/SwiftPackageCollectionsTool.swift
@@ -265,10 +265,9 @@ public struct SwiftPackageCollectionsTool: ParsableCommand {
         mutating func run() throws {
             try with { collections in
                 let identity = PackageIdentity(url: packageURL)
-                let reference = PackageReference.remote(identity: identity, location: packageURL)
 
                 do { // assume URL is for a package in an imported collection
-                    let result = try tsc_await { collections.getPackageMetadata(reference, callback: $0) }
+                    let result = try tsc_await { collections.getPackageMetadata(identity: identity, location: packageURL, callback: $0) }
 
                     if let versionString = version {
                         guard let version = TSCUtility.Version(versionString), let result = result.package.versions.first(where: { $0.version == version }), let printedResult = printVersion(result) else {

--- a/Sources/Commands/SwiftPackageCollectionsTool.swift
+++ b/Sources/Commands/SwiftPackageCollectionsTool.swift
@@ -196,7 +196,7 @@ public struct SwiftPackageCollectionsTool: ParsableCommand {
                         try JSONEncoder.makeWithDefaults().print(results.items)
                     } else {
                         results.items.forEach {
-                            print("\($0.package.repository.url): \($0.package.summary ?? "")")
+                            print("\($0.package.identity): \($0.package.summary ?? "")")
                         }
                     }
 
@@ -208,7 +208,7 @@ public struct SwiftPackageCollectionsTool: ParsableCommand {
                         try JSONEncoder.makeWithDefaults().print(packages)
                     } else {
                         packages.forEach {
-                            print("\($0.repository.url): \($0.summary ?? "")")
+                            print("\($0.identity): \($0.summary ?? "")")
                         }
                     }
                 }
@@ -314,7 +314,7 @@ public struct SwiftPackageCollectionsTool: ParsableCommand {
                         let description = optionalRow("Description", collection.overview)
                         let keywords = optionalRow("Keywords", collection.keywords?.joined(separator: ", "))
                         let createdAt = optionalRow("Created At", DateFormatter().string(from: collection.createdAt))
-                        let packages = collection.packages.map { "\($0.repository.url)" }.joined(separator: "\n\(indent(levels: 2))")
+                        let packages = collection.packages.map { "\($0.identity)" }.joined(separator: "\n\(indent(levels: 2))")
 
                         if jsonOptions.json {
                             try JSONEncoder.makeWithDefaults().print(collection)

--- a/Sources/PackageCollections/API.swift
+++ b/Sources/PackageCollections/API.swift
@@ -111,6 +111,7 @@ public protocol PackageCollectionsProtocol {
     /// - Parameters:
     ///   - reference: The package reference
     ///   - callback: The closure to invoke when result becomes available
+    @available(*, deprecated, message: "user getPackageMetadata(identity:) instead")
     func getPackageMetadata(
         _ reference: PackageReference,
         callback: @escaping (Result<PackageCollectionsModel.PackageMetadata, Error>) -> Void
@@ -126,8 +127,42 @@ public protocol PackageCollectionsProtocol {
     ///   - collections: Optional. If specified, only look for package in these collections. Data from the most recently
     ///                  processed collection will be used.
     ///   - callback: The closure to invoke when result becomes available
+    @available(*, deprecated, message: "user getPackageMetadata(identity:) instead")
     func getPackageMetadata(
         _ reference: PackageReference,
+        collections: Set<PackageCollectionsModel.CollectionIdentifier>?,
+        callback: @escaping (Result<PackageCollectionsModel.PackageMetadata, Error>) -> Void
+    )
+
+    /// Returns metadata for the package identified by the given `PackageIdentity`, along with the
+    /// identifiers of `PackageCollection`s where the package is found.
+    ///
+    /// A failure is returned if the package is not found.
+    ///
+    /// - Parameters:
+    ///   - identity: The package identity
+    ///   - location: The package location (optional for deduplication)
+    ///   - callback: The closure to invoke when result becomes available
+    func getPackageMetadata(
+        identity: PackageIdentity,
+        location: String?,
+        callback: @escaping (Result<PackageCollectionsModel.PackageMetadata, Error>) -> Void
+    )
+
+    /// Returns metadata for the package identified by the given `PackageIdentity`, along with the
+    /// identifiers of `PackageCollection`s where the package is found.
+    ///
+    /// A failure is returned if the package is not found.
+    ///
+    /// - Parameters:
+    ///   - identity: The package identity
+    ///   - location: The package location (optional for deduplication)
+    ///   - collections: Optional. If specified, only look for package in these collections. Data from the most recently
+    ///                  processed collection will be used.
+    ///   - callback: The closure to invoke when result becomes available
+    func getPackageMetadata(
+        identity: PackageIdentity,
+        location: String?,
         collections: Set<PackageCollectionsModel.CollectionIdentifier>?,
         callback: @escaping (Result<PackageCollectionsModel.PackageMetadata, Error>) -> Void
     )

--- a/Sources/PackageCollections/Model/Package.swift
+++ b/Sources/PackageCollections/Model/Package.swift
@@ -83,6 +83,16 @@ extension PackageCollectionsModel {
         /// The package's programming languages
         public let languages: Set<String>?
 
+        @available(*, deprecated, message: "use identity and location instead")
+        public var reference: PackageReference {
+            return .init(identity: self.identity, kind: .remote, location: self.location, name: nil)
+        }
+
+        @available(*, deprecated, message: "use identity and location instead")
+        public var repository: RepositorySpecifier {
+            return .init(url: self.location)
+        }
+
         /// Initializes a `Package`
         init(
             identity: PackageIdentity,

--- a/Sources/PackageCollections/Model/Package.swift
+++ b/Sources/PackageCollections/Model/Package.swift
@@ -17,11 +17,11 @@ import SourceControl
 extension PackageCollectionsModel {
     /// Package metadata
     public struct Package: Codable, Equatable {
-        /// Package reference
-        public let reference: PackageReference
+        /// Package identity
+        public let identity: PackageIdentity
 
-        /// Package's repository address
-        public let repository: RepositorySpecifier
+        /// Package location
+        public let location: String
 
         /// Package description
         public let summary: String?
@@ -85,7 +85,8 @@ extension PackageCollectionsModel {
 
         /// Initializes a `Package`
         init(
-            repository: RepositorySpecifier,
+            identity: PackageIdentity,
+            location: String,
             summary: String?,
             keywords: [String]?,
             versions: [Version],
@@ -95,8 +96,8 @@ extension PackageCollectionsModel {
             authors: [Author]?,
             languages: Set<String>?
         ) {
-            self.reference = .init(repository: repository)
-            self.repository = repository
+            self.identity = identity
+            self.location = location
             self.summary = summary
             self.keywords = keywords
             self.versions = versions
@@ -271,6 +272,6 @@ extension PackageCollectionsModel.Package.Version {
 
 extension Model.Package {
     var displayName: String {
-        self.latestVersion?.packageName ?? self.reference.identity.description
+        self.latestVersion?.packageName ?? self.identity.description
     }
 }

--- a/Sources/PackageCollections/Model/TargetListResult.swift
+++ b/Sources/PackageCollections/Model/TargetListResult.swift
@@ -47,6 +47,11 @@ extension PackageCollectionsModel.TargetListResult {
 
         /// Package collections that contain this package and at least one of the `versions`
         public let collections: [PackageCollectionsModel.CollectionIdentifier]
+
+        @available(*, deprecated, message: "use identity and location instead")
+        public var repository: RepositorySpecifier {
+            return .init(url: self.location)
+        }
     }
 }
 

--- a/Sources/PackageCollections/Model/TargetListResult.swift
+++ b/Sources/PackageCollections/Model/TargetListResult.swift
@@ -33,8 +33,11 @@ extension PackageCollectionsModel.TargetListResult {
     public struct Package: Hashable, Encodable {
         public typealias Version = PackageCollectionsModel.TargetListResult.PackageVersion
 
-        /// Package's repository address
-        public let repository: RepositorySpecifier
+        /// Package's identity
+        public let identity: PackageIdentity
+
+        /// Package's location
+        public let location: String
 
         /// Package description
         public let summary: String?

--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -314,18 +314,18 @@ public struct PackageCollections: PackageCollectionsProtocol {
             case .failure(let error):
                 callback(.failure(error))
             case .success(let collections):
-                var packageCollections = [PackageReference: (package: Model.Package, collections: Set<Model.CollectionIdentifier>)]()
+                var packageCollections = [PackageIdentity: (package: Model.Package, collections: Set<Model.CollectionIdentifier>)]()
                 // Use package data from the most recently processed collection
                 collections.sorted(by: { $0.lastProcessedAt > $1.lastProcessedAt }).forEach { collection in
                     collection.packages.forEach { package in
-                        var entry = packageCollections.removeValue(forKey: package.reference)
+                        var entry = packageCollections.removeValue(forKey: package.identity)
                         if entry == nil {
                             entry = (package, .init())
                         }
 
                         if var entry = entry {
                             entry.collections.insert(collection.identifier)
-                            packageCollections[package.reference] = entry
+                            packageCollections[package.identity] = entry
                         }
                     }
                 }
@@ -333,7 +333,7 @@ public struct PackageCollections: PackageCollectionsProtocol {
                 let result = PackageCollectionsModel.PackageSearchResult(
                     items: packageCollections.sorted { $0.value.package.displayName < $1.value.package.displayName }
                         .map { entry in
-                            .init(package: entry.value.package, collections: Array(entry.value.collections))
+                        .init(package: entry.value.package, collections: Array(entry.value.collections))
                         }
                 )
                 callback(.success(result))
@@ -343,12 +343,25 @@ public struct PackageCollections: PackageCollectionsProtocol {
 
     // MARK: - Package Metadata
 
+    @available(*, deprecated, message: "user identity based API instead")
     public func getPackageMetadata(_ reference: PackageReference,
                                    callback: @escaping (Result<PackageCollectionsModel.PackageMetadata, Error>) -> Void) {
         self.getPackageMetadata(reference, collections: nil, callback: callback)
     }
 
+    @available(*, deprecated, message: "user identity based API instead")
     public func getPackageMetadata(_ reference: PackageReference,
+                                   collections: Set<PackageCollectionsModel.CollectionIdentifier>?,
+                                   callback: @escaping (Result<PackageCollectionsModel.PackageMetadata, Error>) -> Void) {
+        self.getPackageMetadata(reference.identity, collections: nil, callback: callback)
+    }
+
+    public func getPackageMetadata(_ identity: PackageIdentity,
+                                   callback: @escaping (Result<PackageCollectionsModel.PackageMetadata, Error>) -> Void) {
+        self.getPackageMetadata(identity, collections: nil, callback: callback)
+    }
+
+    public func getPackageMetadata(_ identity: PackageIdentity,
                                    collections: Set<PackageCollectionsModel.CollectionIdentifier>?,
                                    callback: @escaping (Result<PackageCollectionsModel.PackageMetadata, Error>) -> Void) {
         guard Self.isSupportedPlatform else {
@@ -356,19 +369,20 @@ public struct PackageCollections: PackageCollectionsProtocol {
         }
 
         // first find in storage
-        self.findPackage(reference: reference, collections: collections) { result in
+        self.findPackage(identity: identity, collections: collections) { result in
             switch result {
             case .failure(let error):
                 callback(.failure(error))
             case .success(let packageSearchResult):
+
                 // then try to get more metadata from provider (optional)
-                let authTokenType = self.metadataProvider.getAuthTokenType(for: reference)
+                let authTokenType = self.metadataProvider.getAuthTokenType(for: packageSearchResult.package.location)
                 let isAuthTokenConfigured = authTokenType.flatMap { self.configuration.authTokens()?[$0] } != nil
 
-                self.metadataProvider.get(reference) { result in
+                self.metadataProvider.get(identity: packageSearchResult.package.identity, location: packageSearchResult.package.location) { result in
                     switch result {
                     case .failure(let error):
-                        self.diagnosticsEngine?.emit(warning: "Failed fetching information about \(reference) from \(self.metadataProvider.name): \(error)")
+                        self.diagnosticsEngine?.emit(warning: "Failed fetching information about \(identity) from \(self.metadataProvider.name): \(error)")
 
                         let provider: PackageMetadataProviderContext?
                         switch error {
@@ -517,7 +531,7 @@ public struct PackageCollections: PackageCollectionsProtocol {
         }
     }
 
-    func findPackage(reference: PackageReference,
+    func findPackage(identity: PackageIdentity,
                      collections: Set<PackageCollectionsModel.CollectionIdentifier>?,
                      callback: @escaping (Result<PackageCollectionsModel.PackageSearchResult.Item, Error>) -> Void) {
         self.storage.sources.list { result in
@@ -530,17 +544,17 @@ public struct PackageCollections: PackageCollectionsProtocol {
                     collectionIdentifiers = collectionIdentifiers.filter { collections.contains($0) }
                 }
                 if collectionIdentifiers.isEmpty {
-                    return callback(.failure(NotFoundError("\(reference)")))
+                    return callback(.failure(NotFoundError("\(identity)")))
                 }
-                self.storage.collections.findPackage(identifier: reference.identity, collectionIdentifiers: collectionIdentifiers) { findPackageResult in
+                self.storage.collections.findPackage(identifier: identity, collectionIdentifiers: collectionIdentifiers) { findPackageResult in
                     switch findPackageResult {
                     case .failure(let error):
                         callback(.failure(error))
                     case .success(let packagesCollections):
                         // A package identity can be associated with multiple repository URLs
-                        let matches = packagesCollections.packages.filter { $0.reference.canonicalLocation == reference.canonicalLocation }
+                        let matches = packagesCollections.packages.filter { $0.identity == identity }
                         guard let package = matches.first else {
-                            return callback(.failure(NotFoundError("\(reference)")))
+                            return callback(.failure(NotFoundError("\(identity)")))
                         }
                         callback(.success(.init(package: package, collections: packagesCollections.collections)))
                     }
@@ -550,22 +564,22 @@ public struct PackageCollections: PackageCollectionsProtocol {
     }
 
     private func targetListResultFromCollections(_ collections: [Model.Collection]) -> Model.TargetListResult {
-        var packageCollections = [PackageReference: (package: Model.Package, collections: Set<Model.CollectionIdentifier>)]()
-        var targetsPackages = [String: (target: Model.Target, packages: Set<PackageReference>)]()
+        var packageCollections = [PackageIdentity: (package: Model.Package, collections: Set<Model.CollectionIdentifier>)]()
+        var targetsPackages = [String: (target: Model.Target, packages: Set<PackageIdentity>)]()
 
         collections.forEach { collection in
             collection.packages.forEach { package in
                 // Avoid copy-on-write: remove entry from dictionary before mutating
-                var entry = packageCollections.removeValue(forKey: package.reference) ?? (package, .init())
+                var entry = packageCollections.removeValue(forKey: package.identity) ?? (package, .init())
                 entry.collections.insert(collection.identifier)
-                packageCollections[package.reference] = entry
+                packageCollections[package.identity] = entry
 
                 package.versions.forEach { version in
                     version.manifests.values.forEach { manifest in
                         manifest.targets.forEach { target in
                             // Avoid copy-on-write: remove entry from dictionary before mutating
                             var entry = targetsPackages.removeValue(forKey: target.name) ?? (target: target, packages: .init())
-                            entry.packages.insert(package.reference)
+                            entry.packages.insert(package.identity)
                             targetsPackages[target.name] = entry
                         }
                     }
@@ -586,7 +600,8 @@ public struct PackageCollections: PackageCollectionsProtocol {
                             )
                         }
                     }
-                    return .init(repository: pair.package.repository,
+                    return .init(identity: pair.package.identity,
+                                 location: pair.package.location,
                                  summary: pair.package.summary,
                                  versions: versions,
                                  collections: Array(pair.collections))
@@ -614,7 +629,8 @@ public struct PackageCollections: PackageCollectionsProtocol {
         versions.sort(by: >)
 
         return Model.Package(
-            repository: package.repository,
+            identity: package.identity,
+            location: package.location,
             summary: basicMetadata?.summary ?? package.summary,
             keywords: basicMetadata?.keywords ?? package.keywords,
             versions: versions,
@@ -632,11 +648,5 @@ private struct UnknownProvider: Error {
 
     init(_ sourceType: Model.CollectionSourceType) {
         self.sourceType = sourceType
-    }
-}
-
-private extension PackageReference {
-    var canonicalLocation: String {
-        (self.location.hasSuffix(".git") ? String(self.location.dropLast(4)) : self.location).lowercased()
     }
 }

--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -259,7 +259,8 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
                 serializationOkay = false
             }
 
-            return .init(repository: RepositorySpecifier(url: package.url.absoluteString),
+            return .init(identity: .init(url: package.url.absoluteString),
+                         location: package.url.absoluteString,
                          summary: package.summary,
                          keywords: package.keywords,
                          versions: versions,

--- a/Sources/PackageCollections/Providers/PackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/PackageMetadataProvider.swift
@@ -23,15 +23,16 @@ protocol PackageMetadataProvider: Closable {
     /// Retrieves metadata for a package at the given repository address.
     ///
     /// - Parameters:
-    ///   - reference: The package's reference
+    ///   - identity: The package's identity
+    ///   - location: The package's location
     ///   - callback: The closure to invoke when result becomes available
-    func get(_ reference: PackageReference, callback: @escaping (Result<PackageCollectionsModel.PackageBasicMetadata, Error>) -> Void)
+    func get(identity: PackageIdentity, location: String, callback: @escaping (Result<PackageCollectionsModel.PackageBasicMetadata, Error>) -> Void)
 
     /// Returns `AuthTokenType` for a package.
     ///
     /// - Parameters:
-    ///   - reference: The package's reference
-    func getAuthTokenType(for reference: PackageReference) -> AuthTokenType?
+    ///   - location: The package's location
+    func getAuthTokenType(for location: String) -> AuthTokenType?
 }
 
 extension Model {

--- a/Sources/PackageCollections/Utility.swift
+++ b/Sources/PackageCollections/Utility.swift
@@ -13,7 +13,7 @@ import SourceControl
 
 struct MultipleErrors: Error, CustomStringConvertible {
     let errors: [Error]
-
+    
     init(_ errors: [Error]) {
         self.errors = errors
     }
@@ -48,18 +48,5 @@ internal extension Result {
         case .success(let value):
             return value
         }
-    }
-}
-
-// Model Extension
-
-extension PackageReference {
-    /// Initializes a `PackageReference` from `RepositorySpecifier`
-    init(repository: RepositorySpecifier, kind: PackageReference.Kind = .remote) {
-        self.init(
-            identity: PackageIdentity(url: repository.url),
-            kind: kind,
-            location: repository.url
-        )
     }
 }

--- a/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
+++ b/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
@@ -56,7 +56,8 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             XCTAssertEqual(collection.packages.count, 2)
 
             let package = collection.packages.first!
-            XCTAssertEqual(package.repository, .init(url: "https://www.example.com/repos/RepoOne.git"))
+            XCTAssertEqual(package.identity, .init(url: "https://www.example.com/repos/RepoOne.git"))
+            XCTAssertEqual(package.location, "https://www.example.com/repos/RepoOne.git")
             XCTAssertEqual(package.summary, "Package One")
             XCTAssertEqual(package.keywords, ["sample package"])
             XCTAssertEqual(package.readmeURL, URL(string: "https://www.example.com/repos/RepoOne/README")!)
@@ -76,7 +77,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             XCTAssertEqual(version.license, .init(type: .Apache2_0, url: URL(string: "https://www.example.com/repos/RepoOne/LICENSE")!))
             XCTAssertNotNil(version.createdAt)
             XCTAssertFalse(collection.isSigned)
-
+            
             // "1.8.3" is originally "v1.8.3"
             XCTAssertEqual(["2.1.0", "1.8.3"], collection.packages[1].versions.map { $0.version.description })
         }
@@ -100,7 +101,8 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             XCTAssertEqual(collection.packages.count, 2)
 
             let package = collection.packages.first!
-            XCTAssertEqual(package.repository, .init(url: "https://www.example.com/repos/RepoOne.git"))
+            XCTAssertEqual(package.identity, .init(url: "https://www.example.com/repos/RepoOne.git"))
+            XCTAssertEqual(package.location, "https://www.example.com/repos/RepoOne.git")
             XCTAssertEqual(package.summary, "Package One")
             XCTAssertEqual(package.keywords, ["sample package"])
             XCTAssertEqual(package.readmeURL, URL(string: "https://www.example.com/repos/RepoOne/README")!)
@@ -396,7 +398,8 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             XCTAssertEqual(collection.packages.count, 2)
 
             let package = collection.packages.first!
-            XCTAssertEqual(package.repository, .init(url: "https://www.example.com/repos/RepoOne.git"))
+            XCTAssertEqual(package.identity, .init(url: "https://www.example.com/repos/RepoOne.git"))
+            XCTAssertEqual(package.location, "https://www.example.com/repos/RepoOne.git")
             XCTAssertEqual(package.summary, "Package One")
             XCTAssertEqual(package.keywords, ["sample package"])
             XCTAssertEqual(package.readmeURL, URL(string: "https://www.example.com/repos/RepoOne/README")!)
@@ -463,7 +466,8 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             XCTAssertEqual(collection.createdBy?.name, "Jane Doe")
             XCTAssertEqual(collection.packages.count, 2)
             let package = collection.packages.first!
-            XCTAssertEqual(package.repository, .init(url: "https://www.example.com/repos/RepoOne.git"))
+            XCTAssertEqual(package.identity, .init(url: "https://www.example.com/repos/RepoOne.git"))
+            XCTAssertEqual(package.location, "https://www.example.com/repos/RepoOne.git")
             XCTAssertEqual(package.summary, "Package One")
             XCTAssertEqual(package.keywords, ["sample package"])
             XCTAssertEqual(package.readmeURL, URL(string: "https://www.example.com/repos/RepoOne/README")!)
@@ -598,7 +602,8 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             XCTAssertEqual(collection.createdBy?.name, "Jane Doe")
             XCTAssertEqual(collection.packages.count, 2)
             let package = collection.packages.first!
-            XCTAssertEqual(package.repository, .init(url: "https://www.example.com/repos/RepoOne.git"))
+            XCTAssertEqual(package.identity, .init(url: "https://www.example.com/repos/RepoOne.git"))
+            XCTAssertEqual(package.location, "https://www.example.com/repos/RepoOne.git")
             XCTAssertEqual(package.summary, "Package One")
             XCTAssertEqual(package.keywords, ["sample package"])
             XCTAssertEqual(package.readmeURL, URL(string: "https://www.example.com/repos/RepoOne/README")!)
@@ -665,7 +670,8 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             XCTAssertEqual(collection.createdBy?.name, "Jane Doe")
             XCTAssertEqual(collection.packages.count, 2)
             let package = collection.packages.first!
-            XCTAssertEqual(package.repository, .init(url: "https://www.example.com/repos/RepoOne.git"))
+            XCTAssertEqual(package.identity, .init(url: "https://www.example.com/repos/RepoOne.git"))
+            XCTAssertEqual(package.location, "https://www.example.com/repos/RepoOne.git")
             XCTAssertEqual(package.summary, "Package One")
             XCTAssertEqual(package.keywords, ["sample package"])
             XCTAssertEqual(package.readmeURL, URL(string: "https://www.example.com/repos/RepoOne/README")!)
@@ -739,7 +745,8 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             XCTAssertEqual(collection.createdBy?.name, "Jane Doe")
             XCTAssertEqual(collection.packages.count, 2)
             let package = collection.packages.first!
-            XCTAssertEqual(package.repository, .init(url: "https://www.example.com/repos/RepoOne.git"))
+            XCTAssertEqual(package.identity, .init(url: "https://www.example.com/repos/RepoOne.git"))
+            XCTAssertEqual(package.location, "https://www.example.com/repos/RepoOne.git")
             XCTAssertEqual(package.summary, "Package One")
             XCTAssertEqual(package.keywords, ["sample package"])
             XCTAssertEqual(package.readmeURL, URL(string: "https://www.example.com/repos/RepoOne/README")!)

--- a/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
+++ b/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
@@ -77,7 +77,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             XCTAssertEqual(version.license, .init(type: .Apache2_0, url: URL(string: "https://www.example.com/repos/RepoOne/LICENSE")!))
             XCTAssertNotNil(version.createdAt)
             XCTAssertFalse(collection.isSigned)
-            
+
             // "1.8.3" is originally "v1.8.3"
             XCTAssertEqual(["2.1.0", "1.8.3"], collection.packages[1].versions.map { $0.version.description })
         }

--- a/Tests/PackageCollectionsTests/PackageCollectionsStorageTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsStorageTests.swift
@@ -215,7 +215,8 @@ class PackageCollectionsStorageTests: XCTestCase {
                 _ = try tsc_await { callback in storage.put(collection: collection, callback: callback) }
             }
 
-            let targetName = mockCollections.last!.packages.last!.versions.last!.defaultManifest!.targets.last!.name
+            let version = mockCollections.last!.packages.last!.versions.last!
+            let targetName = version.defaultManifest!.targets.last!.name
 
             do {
                 let searchResult = try tsc_await { callback in storage.searchTargets(query: targetName, type: .exactMatch, callback: callback) }

--- a/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
@@ -1178,7 +1178,7 @@ final class PackageCollectionsTests: XCTestCase {
             XCTAssertEqual(list.count, mockCollections.count, "list count should match")
         }
 
-        let metadata = try tsc_await { callback in packageCollections.getPackageMetadata(mockPackage.identity, callback: callback) }
+        let metadata = try tsc_await { callback in packageCollections.getPackageMetadata(identity: mockPackage.identity, location: mockPackage.location, callback: callback) }
 
         let expectedCollections = Set(mockCollections.filter { $0.packages.map { $0.identity }.contains(mockPackage.identity) }.map { $0.identifier })
         XCTAssertEqual(Set(metadata.collections), expectedCollections, "collections should match")
@@ -1216,7 +1216,7 @@ final class PackageCollectionsTests: XCTestCase {
             XCTAssertEqual(list.count, mockCollections.count, "list count should match")
         }
 
-        let metadata = try tsc_await { callback in packageCollections.getPackageMetadata(mockPackage.identity, callback: callback) }
+        let metadata = try tsc_await { callback in packageCollections.getPackageMetadata(identity: mockPackage.identity, location: mockPackage.location, callback: callback) }
 
         let expectedCollections = Set(mockCollections.filter { $0.packages.map { $0.identity }.contains(mockPackage.identity) }.map { $0.identifier })
         XCTAssertEqual(Set(metadata.collections), expectedCollections, "collections should match")
@@ -1255,7 +1255,7 @@ final class PackageCollectionsTests: XCTestCase {
         }
 
         let collectionIdentifiers: Set<Model.CollectionIdentifier> = [mockCollections.last!.identifier]
-        let metadata = try tsc_await { callback in packageCollections.getPackageMetadata(mockPackage.identity, collections: collectionIdentifiers, callback: callback) }
+        let metadata = try tsc_await { callback in packageCollections.getPackageMetadata(identity: mockPackage.identity, location: mockPackage.location, collections: collectionIdentifiers, callback: callback) }
         XCTAssertEqual(Set(metadata.collections), collectionIdentifiers, "collections should match")
 
         let expectedMetadata = PackageCollections.mergedPackageMetadata(package: mockPackage, basicMetadata: nil)
@@ -1373,7 +1373,7 @@ final class PackageCollectionsTests: XCTestCase {
             XCTAssertEqual(list.count, 0, "list should be empty")
         }
 
-        XCTAssertThrowsError(try tsc_await { callback in packageCollections.getPackageMetadata(mockPackage.identity, callback: callback) }, "expected error") { error in
+        XCTAssertThrowsError(try tsc_await { callback in packageCollections.getPackageMetadata(identity: mockPackage.identity, location: mockPackage.location, callback: callback) }, "expected error") { error in
             XCTAssert(error is NotFoundError)
         }
     }
@@ -1404,7 +1404,7 @@ final class PackageCollectionsTests: XCTestCase {
             XCTAssertEqual(list.count, mockCollections.count, "list count should match")
         }
 
-        let metadata = try tsc_await { callback in packageCollections.getPackageMetadata(mockPackage.identity, callback: callback) }
+        let metadata = try tsc_await { callback in packageCollections.getPackageMetadata(identity: mockPackage.identity, location: mockPackage.location, callback: callback) }
 
         let expectedCollections = Set(mockCollections.filter { $0.packages.map { $0.identity }.contains(mockPackage.identity) }.map { $0.identifier })
         XCTAssertEqual(Set(metadata.collections), expectedCollections, "collections should match")
@@ -1459,7 +1459,7 @@ final class PackageCollectionsTests: XCTestCase {
         }
 
         // Despite metadata provider error we should still get back data from storage
-        let metadata = try tsc_await { callback in packageCollections.getPackageMetadata(mockPackage.identity, callback: callback) }
+        let metadata = try tsc_await { callback in packageCollections.getPackageMetadata(identity: mockPackage.identity, location: mockPackage.location, callback: callback) }
         let expectedMetadata = PackageCollections.mergedPackageMetadata(package: mockPackage, basicMetadata: nil)
         XCTAssertEqual(metadata.package, expectedMetadata, "package should match")
 
@@ -1496,7 +1496,7 @@ final class PackageCollectionsTests: XCTestCase {
         sync.wait()
 
         let start = Date()
-        let metadata = try tsc_await { callback in packageCollections.getPackageMetadata(mockPackage.identity, callback: callback) }
+        let metadata = try tsc_await { callback in packageCollections.getPackageMetadata(identity: mockPackage.identity, location: mockPackage.location, callback: callback) }
         XCTAssertNotNil(metadata)
         let delta = Date().timeIntervalSince(start)
         XCTAssert(delta < 1.0, "should fetch quickly, took \(delta)")

--- a/Tests/PackageCollectionsTests/Utility.swift
+++ b/Tests/PackageCollectionsTests/Utility.swift
@@ -76,7 +76,8 @@ func makeMockCollections(count: Int = Int.random(in: 50 ... 100), maxPackages: I
                                                                createdAt: Date())
             }
 
-            return PackageCollectionsModel.Package(repository: RepositorySpecifier(url: "https://package-\(packageIndex)"),
+            return PackageCollectionsModel.Package(identity: .init(url: "https://package-\(packageIndex)"),
+                                                   location: "https://package-\(packageIndex)",
                                                    summary: "package \(packageIndex) description",
                                                    keywords: (0 ..< Int.random(in: 1 ... 3)).map { "keyword \($0)" },
                                                    versions: versions,
@@ -151,21 +152,21 @@ struct MockCollectionsProvider: PackageCollectionProvider {
 struct MockMetadataProvider: PackageMetadataProvider {
     var name: String = "MockMetadataProvider"
 
-    let packages: [PackageReference: PackageCollectionsModel.PackageBasicMetadata]
+    let packages: [PackageIdentity: PackageCollectionsModel.PackageBasicMetadata]
 
-    init(_ packages: [PackageReference: PackageCollectionsModel.PackageBasicMetadata]) {
+    init(_ packages: [PackageIdentity: PackageCollectionsModel.PackageBasicMetadata]) {
         self.packages = packages
     }
 
-    func get(_ reference: PackageReference, callback: @escaping (Result<PackageCollectionsModel.PackageBasicMetadata, Error>) -> Void) {
-        if let package = self.packages[reference] {
+    func get(identity: PackageIdentity, location: String, callback: @escaping (Result<PackageCollectionsModel.PackageBasicMetadata, Error>) -> Void) {
+        if let package = self.packages[identity] {
             callback(.success(package))
         } else {
-            callback(.failure(NotFoundError("\(reference)")))
+            callback(.failure(NotFoundError("\(identity)")))
         }
     }
 
-    func getAuthTokenType(for reference: PackageReference) -> AuthTokenType? {
+    func getAuthTokenType(for location: String) -> AuthTokenType? {
         nil
     }
 


### PR DESCRIPTION
motivation: adoption of SE-0292 package registry

chnages:
* migrate APIs that take PackageRefernec to take PackageIdentity
* adjust and update tests

rdar://83073308
rdar://82954076
