### PR TITLE
use identity instead of location where possible

### DIFF
--- a/Sources/PackageGraph/LocalPackageContainer.swift
+++ b/Sources/PackageGraph/LocalPackageContainer.swift
@@ -42,7 +42,7 @@ public final class LocalPackageContainer: PackageContainer {
             let toolsVersion = try self.toolsVersionLoader.load(at: AbsolutePath(self.package.location), fileSystem: self.fileSystem)
 
             // Validate the tools version.
-            try toolsVersion.validateToolsVersion(self.currentToolsVersion, packagePath: self.package.location)
+            try toolsVersion.validateToolsVersion(self.currentToolsVersion, packageIdentity: self.package.identity)
 
             // Load the manifest.
             // FIXME: this should not block

--- a/Sources/PackageGraph/PackageModel+Extensions.swift
+++ b/Sources/PackageGraph/PackageModel+Extensions.swift
@@ -70,13 +70,3 @@ extension PackageContainerConstraint {
         }
     }
 }
-
-extension PackageReference {
-    /// The repository of the package.
-    ///
-    /// This should only be accessed when the reference is not local.
-    public var repository: RepositorySpecifier {
-        precondition(kind == .remote)
-        return RepositorySpecifier(url: self.location)
-    }
-}

--- a/Sources/PackageModel/Diagnostics.swift
+++ b/Sources/PackageModel/Diagnostics.swift
@@ -15,8 +15,8 @@ import TSCUtility
 
 /// The diagnostic triggered when the package has a newer tools version than the installed tools.
 public struct RequireNewerTools: DiagnosticData, Swift.Error {
-    /// The path of the package.
-    public let packagePath: String
+    /// The identity of the package.
+    public let packageIdentity: PackageIdentity
 
     /// The version of the package.
     public let packageVersion: String?
@@ -28,19 +28,19 @@ public struct RequireNewerTools: DiagnosticData, Swift.Error {
     public let packageToolsVersion: ToolsVersion
 
     public init(
-        packagePath: String,
+        packageIdentity: PackageIdentity,
         packageVersion: String? = nil,
         installedToolsVersion: ToolsVersion,
         packageToolsVersion: ToolsVersion
     ) {
-        self.packagePath = packagePath
+        self.packageIdentity = packageIdentity
         self.packageVersion = packageVersion
         self.installedToolsVersion = installedToolsVersion
         self.packageToolsVersion = packageToolsVersion
     }
 
     public var description: String {
-        var text = "package at '\(packagePath)'"
+        var text = "package '\(self.packageIdentity)'"
         if let version = self.packageVersion {
             text += " @ \(version)"
         }
@@ -51,8 +51,8 @@ public struct RequireNewerTools: DiagnosticData, Swift.Error {
 
 /// The diagnostic triggered when the package has an unsupported tools version.
 public struct UnsupportedToolsVersion: DiagnosticData, Swift.Error {
-    /// The path of the package.
-    public let packagePath: String
+    /// The identity of the package.
+    public let packageIdentity: PackageIdentity
 
     /// The version of the package.
     public let packageVersion: String?
@@ -68,19 +68,19 @@ public struct UnsupportedToolsVersion: DiagnosticData, Swift.Error {
     }
 
     public init(
-        packagePath: String,
+        packageIdentity: PackageIdentity,
         packageVersion: String? = nil,
         currentToolsVersion: ToolsVersion,
         packageToolsVersion: ToolsVersion
     ) {
-        self.packagePath = packagePath
+        self.packageIdentity = packageIdentity
         self.packageVersion = packageVersion
         self.currentToolsVersion = currentToolsVersion
         self.packageToolsVersion = packageToolsVersion
     }
 
     public var description: String {
-        var text = "package at '\(self.packagePath)'"
+        var text = "package '\(self.packageIdentity)'"
         if let version = self.packageVersion {
             text += " @ \(version)"
         }

--- a/Sources/PackageModel/ToolsVersion.swift
+++ b/Sources/PackageModel/ToolsVersion.swift
@@ -104,8 +104,8 @@ public struct ToolsVersion: Equatable, Hashable, Codable {
     /// version of the package manager.
     public func validateToolsVersion(
         _ currentToolsVersion: ToolsVersion,
-        packagePath: String,
-        packageVersion: String? = nil
+        packageIdentity: PackageIdentity,
+        packageVersion: String? = .none
     ) throws {
         // We don't want to throw any error when using the special vNext version.
         if SwiftVersion.currentVersion.isDevelopment && self == .vNext {
@@ -115,7 +115,7 @@ public struct ToolsVersion: Equatable, Hashable, Codable {
         // Make sure the package has the right minimum tools version.
         guard self >= .minimumRequired else {
             throw UnsupportedToolsVersion(
-                packagePath: packagePath,
+                packageIdentity: packageIdentity,
                 packageVersion: packageVersion,
                 currentToolsVersion: currentToolsVersion,
                 packageToolsVersion: self
@@ -125,7 +125,7 @@ public struct ToolsVersion: Equatable, Hashable, Codable {
         // Make sure the package isn't newer than the current tools version.
         guard currentToolsVersion >= self else {
             throw RequireNewerTools(
-                packagePath: packagePath,
+                packageIdentity: packageIdentity,
                 packageVersion: packageVersion,
                 installedToolsVersion: currentToolsVersion,
                 packageToolsVersion: self

--- a/Sources/Workspace/ResolverPrecomputationProvider.swift
+++ b/Sources/Workspace/ResolverPrecomputationProvider.swift
@@ -105,7 +105,7 @@ private struct LocalPackageContainer: PackageContainer {
 
     func isToolsVersionCompatible(at version: Version) -> Bool {
         do {
-            try manifest.toolsVersion.validateToolsVersion(currentToolsVersion, packagePath: "")
+            try manifest.toolsVersion.validateToolsVersion(currentToolsVersion, packageIdentity: .plain("unknown"))
             return true
         } catch {
             return false

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -768,7 +768,7 @@ final class PackageToolTests: XCTestCase {
                     let path = try SwiftPMProduct.packagePath(for: pkg, packageRoot: fooPath)
                     let pin = pinsStore.pinsMap[PackageIdentity(path: path)]!
                     XCTAssertEqual(pin.packageRef.identity, PackageIdentity(path: path))
-                    XCTAssert(pin.packageRef.repository.url.hasSuffix(pkg))
+                    XCTAssert(pin.packageRef.location.hasSuffix(pkg))
                     XCTAssertEqual(pin.state.version, "1.2.3")
                 }
             }

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -286,7 +286,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
                 _ = try container.getDependencies(at: revision.identifier, productFilter: .nothing)
             } catch let error as RepositoryPackageContainer.GetDependenciesError {
                 let error = error.underlyingError as! UnsupportedToolsVersion
-                XCTAssertMatch(error.description, .and(.prefix("package at '/' @"), .suffix("is using Swift tools version 3.1.0 which is no longer supported; consider using '// swift-tools-version:4.0' to specify the current tools version")))
+                XCTAssertMatch(error.description, .and(.prefix("package '\(PackageIdentity(url: specifier.url))' @"), .suffix("is using Swift tools version 3.1.0 which is no longer supported; consider using '// swift-tools-version:4.0' to specify the current tools version")))
             }
         }
     }

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -2060,17 +2060,17 @@ final class WorkspaceTests: XCTestCase {
         }
         workspace.checkPackageGraphFailure(roots: ["Bar"]) { diagnostics in
             DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: .equal("package at '/tmp/ws/roots/Bar' is using Swift tools version 4.1.0 but the installed version is 4.0.0"), behavior: .error, location: "/tmp/ws/roots/Bar")
+                result.check(diagnostic: .equal("package 'bar' is using Swift tools version 4.1.0 but the installed version is 4.0.0"), behavior: .error, location: "/tmp/ws/roots/Bar")
             }
         }
         workspace.checkPackageGraphFailure(roots: ["Foo", "Bar"]) { diagnostics in
             DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: .equal("package at '/tmp/ws/roots/Bar' is using Swift tools version 4.1.0 but the installed version is 4.0.0"), behavior: .error, location: "/tmp/ws/roots/Bar")
+                result.check(diagnostic: .equal("package 'bar' is using Swift tools version 4.1.0 but the installed version is 4.0.0"), behavior: .error, location: "/tmp/ws/roots/Bar")
             }
         }
         workspace.checkPackageGraphFailure(roots: ["Baz"]) { diagnostics in
             DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: .equal("package at '/tmp/ws/roots/Baz' is using Swift tools version 3.1.0 which is no longer supported; consider using '// swift-tools-version:4.0' to specify the current tools version"), behavior: .error, location: "/tmp/ws/roots/Baz")
+                result.check(diagnostic: .equal("package 'baz' is using Swift tools version 3.1.0 which is no longer supported; consider using '// swift-tools-version:4.0' to specify the current tools version"), behavior: .error, location: "/tmp/ws/roots/Baz")
             }
         }
     }


### PR DESCRIPTION
motivation: adoption of SE-0292 package registry

changes:
* remove assumption and runtime check about RepositorySpecifier always available for PackageRefrence
* adjust call-sites and test

rdar://82954076
