### PR TITLE
Update `swift package archive-source` command to provide directory prefix

### DIFF
--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -523,6 +523,7 @@ public final class GitRepository: Repository, WorkingCheckout {
         try self.lock.withLock {
             try callGit("archive",
                         "--format", "zip",
+                        "--prefix", path.basenameWithoutExt,
                         "--output", path.pathString,
                         "HEAD",
                         failureMessage: "Couldn’t create an archive")


### PR DESCRIPTION
Updates `swift package archive-source` command according to the [SE-0292 amendment](https://github.com/apple/swift-evolution/pull/1410).

### Motivation:

With https://github.com/apple/swift-package-manager/pull/3624, the behavior of the `archive-source` command now adds a `--prefix` argument to the `git-archive` invocation, so that entries are prefixed by output name.

### Modifications:

```diff
  try callGit("archive",
              "--format", "zip",
+             "--prefix", path.basenameWithoutExt,
              "--output", path.pathString,
              "HEAD",
              failureMessage: "Couldn’t create an archive")
```

### Result:

Generated source archives are prefixed by output name. 

For example:

```console
$ swift package archive-source --output="LinkedList-1.2.0.zip"
$ zipinfo LinkedList-1.2.0.zip
Archive:  path/to/LinkedList-1.2.0.zip
[...]
[...] LinkedList-1.2.0/
[...] LinkedList-1.2.0/Package.swift
```