### PR TITLE
Update PackageIdentity to be case-insensitive

### DIFF
--- a/Sources/PackageModel/PackageIdentity.swift
+++ b/Sources/PackageModel/PackageIdentity.swift
@@ -59,15 +59,21 @@ public struct PackageIdentity: CustomStringConvertible {
     }
 }
 
-extension PackageIdentity: Equatable {
-    public static func == (lhs: PackageIdentity, rhs: PackageIdentity) -> Bool {
-        return lhs.description.lowercased() == rhs.description.lowercased()
+extension PackageIdentity: Equatable, Comparable {
+    private func compare(to other: PackageIdentity) -> ComparisonResult {
+        return self.description.caseInsensitiveCompare(other.description)
     }
-}
 
-extension PackageIdentity: Comparable {
+    public static func == (lhs: PackageIdentity, rhs: PackageIdentity) -> Bool {
+        return lhs.compare(to: rhs) == .orderedSame
+    }
+
     public static func < (lhs: PackageIdentity, rhs: PackageIdentity) -> Bool {
-        return lhs.description < rhs.description
+        return lhs.compare(to: rhs) == .orderedAscending
+    }
+
+    public static func > (lhs: PackageIdentity, rhs: PackageIdentity) -> Bool {
+        return lhs.compare(to: rhs) == .orderedDescending
     }
 }
 

--- a/Sources/PackageModel/PackageIdentity.swift
+++ b/Sources/PackageModel/PackageIdentity.swift
@@ -27,7 +27,7 @@ internal protocol PackageIdentityProvider: CustomStringConvertible {
 }
 
 /// The canonical identifier for a package, based on its source location.
-public struct PackageIdentity: Hashable, CustomStringConvertible {
+public struct PackageIdentity: CustomStringConvertible {
     /// The underlying type used to create package identities.
     internal static var provider: PackageIdentityProvider.Type = LegacyPackageIdentity.self
 
@@ -59,9 +59,21 @@ public struct PackageIdentity: Hashable, CustomStringConvertible {
     }
 }
 
+extension PackageIdentity: Equatable {
+    public static func == (lhs: PackageIdentity, rhs: PackageIdentity) -> Bool {
+        return lhs.description.lowercased() == rhs.description.lowercased()
+    }
+}
+
 extension PackageIdentity: Comparable {
     public static func < (lhs: PackageIdentity, rhs: PackageIdentity) -> Bool {
         return lhs.description < rhs.description
+    }
+}
+
+extension PackageIdentity: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(description.lowercased())
     }
 }
 


### PR DESCRIPTION
This PR replaces the synthesized conformance to `Equatable` and `Hashable` and updates adoption of `Comparable` to use case-insensitive comparisons. 

### Motivation:

With [SE-0292](https://github.com/apple/swift-evolution/pull/1410), package identifiers must be case-insensitive. For example, a dependency declared as `mona.LinkedList` is equivalent to `MONA.LINKEDLIST`.

This change also makes sense for packages identified by a remote URL<sup>*</sup> or local path<sup>**</sup>.

<small>* Technically, URLs are case-sensitive. However, many if not most websites treat them as case-insensitive. This includes all of the popular code hosting services I'm aware of. I would be very surprised if any packages in the wild rely on remote packages differing only in case _not_ being equivalent.</small> 

<small>** Filesystems vary in case-sensitivity, so we should to normalize to a single case to make sure Swift packages behave the same on all platforms and don't cause [vulnerabilities](https://github.blog/2021-09-08-github-security-update-vulnerabilities-tar-npmcli-arborist/).</small>

### Modifications:

```diff
+ extension PackageIdentity: Equatable, Comparable {
+     private func compare(to other: PackageIdentity) -> ComparisonResult {
+         return self.description.caseInsensitiveCompare(other.description)
+     }
+ 
+     public static func == (lhs: PackageIdentity, rhs: PackageIdentity) -> Bool {
+         return lhs.compare(to: rhs) == .orderedSame
+     }
+ 
+     public static func < (lhs: PackageIdentity, rhs: PackageIdentity) -> Bool {
+         return lhs.compare(to: rhs) == .orderedAscending
+     }
+ 
+     public static func > (lhs: PackageIdentity, rhs: PackageIdentity) -> Bool {
+         return lhs.compare(to: rhs) == .orderedDescending
+     }
+ }
```

### Result:

This shouldn't change any existing behavior. If it causes any new failures in our test suite, we should review to see if the expected behavior is correct.
