### PR TITLE
Additional refactoring of ManagedDependencies

### DIFF
--- a/Sources/Workspace/ManagedDependency.swift
+++ b/Sources/Workspace/ManagedDependency.swift
@@ -19,9 +19,9 @@ extension Workspace {
     ///
     /// Each dependency will have a checkout containing the sources at a
     /// particular revision, and may have an associated version.
-    final public class ManagedDependency {
+    public struct ManagedDependency: Equatable {
         /// Represents the state of the managed dependency.
-        public enum State: Equatable {
+        public indirect enum State: Equatable {
             /// The dependency is a managed checkout.
             case checkout(CheckoutState)
 
@@ -34,19 +34,6 @@ extension Workspace {
 
             // The dependency is a local package.
             case local
-
-            public static func == (lhs: Workspace.ManagedDependency.State, rhs: Workspace.ManagedDependency.State) -> Bool {
-                switch (lhs, rhs) {
-                case (.local, .local):
-                    return true
-                case (.checkout(let lState), .checkout(let rState)):
-                    return lState == rState
-                case (.edited(let lBasedOn, let lUnmanagedPath), .edited(let rBasedOn, let rUnmanagedPath)):
-                    return lBasedOn?.packageRef == rBasedOn?.packageRef && lUnmanagedPath == rUnmanagedPath
-                default:
-                    return false
-                }
-            }
         }
 
         /// The package reference.

--- a/Sources/Workspace/ManagedDependency.swift
+++ b/Sources/Workspace/ManagedDependency.swift
@@ -57,10 +57,6 @@ extension Workspace {
         /// The checked out path of the dependency on disk, relative to the workspace checkouts path.
         public let subpath: RelativePath
 
-        public var packageIdentity: PackageIdentity {
-            self.packageRef.identity
-        }
-
         internal init(
             packageRef: PackageReference,
             state: State,

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1254,7 +1254,7 @@ extension Workspace {
         /// Returns all manifests contained in DependencyManifests.
         public func allDependencyManifests() -> OrderedDictionary<PackageIdentity, Manifest> {
             return self.dependencies.reduce(into: OrderedDictionary<PackageIdentity, Manifest>()) { partial, item in
-                partial[item.dependency.packageIdentity] = item.manifest
+                partial[item.dependency.packageRef.identity] = item.manifest
             }
         }
 
@@ -1290,7 +1290,7 @@ extension Workspace {
         func computePackageURLs() -> (required: Set<PackageReference>, missing: Set<PackageReference>) {
             let manifestsMap: [PackageIdentity: Manifest] = Dictionary(uniqueKeysWithValues:
                 self.root.packages.map { ($0.key, $0.value.manifest) } +
-                self.dependencies.map { ($0.dependency.packageIdentity, $0.manifest) }
+                self.dependencies.map { ($0.dependency.packageRef.identity, $0.manifest) }
             )
 
             var inputIdentities: Set<PackageReference> = []

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1098,7 +1098,7 @@ extension Workspace {
 
         // Remove the existing checkout.
         do {
-            let oldCheckoutPath = self.location.repositoriesCheckoutsDirectory.appending(dependency.subpath)
+            let oldCheckoutPath = self.location.repositoriesCheckoutSubdirectory(for: dependency)
             try fileSystem.chmod(.userWritable, path: oldCheckoutPath, options: [.recursive, .onlyFiles])
             try fileSystem.removeFileTree(oldCheckoutPath)
         }
@@ -1136,7 +1136,7 @@ extension Workspace {
         }
 
         // Form the edit working repo path.
-        let path = self.location.editsDirectory.appending(dependency.subpath)
+        let path = self.location.editsSubdirectory(for: dependency)
         // Check for uncommited and unpushed changes if force removal is off.
         if !forceRemove {
             let workingCopy = try repositoryManager.openWorkingCopy(at: path)
@@ -1426,9 +1426,9 @@ extension Workspace {
     public func path(to dependency: Workspace.ManagedDependency) -> AbsolutePath {
         switch dependency.state {
         case .checkout:
-            return self.location.repositoriesCheckoutsDirectory.appending(dependency.subpath)
+            return self.location.repositoriesCheckoutSubdirectory(for: dependency)
         case .edited(_, let path):
-            return path ?? self.location.editsDirectory.appending(dependency.subpath)
+            return path ?? self.location.editsSubdirectory(for: dependency)
         case .local:
             return AbsolutePath(dependency.packageRef.location)
         }
@@ -2986,7 +2986,7 @@ extension Workspace {
     /// Removes the clone and checkout of the provided specifier.
     fileprivate func removeRepository(dependency: ManagedDependency) throws {
         // Remove the checkout.
-        let dependencyPath = self.location.repositoriesCheckoutsDirectory.appending(dependency.subpath)
+        let dependencyPath = self.location.repositoriesCheckoutSubdirectory(for: dependency)
         let workingCopy = try self.repositoryManager.openWorkingCopy(at: dependencyPath)
         guard !workingCopy.hasUncommittedChanges() else {
             throw WorkspaceDiagnostics.UncommitedChanges(repositoryPath: dependencyPath)

--- a/Sources/Workspace/WorkspaceConfiguration.swift
+++ b/Sources/Workspace/WorkspaceConfiguration.swift
@@ -42,9 +42,19 @@ extension Workspace {
             self.workingDirectory.appending(component: "repositories")
         }
 
+        /// Returns the path to the repository checkout directory for a package.
+        public func editsSubdirectory(for dependency: ManagedDependency) -> AbsolutePath {
+            self.editsDirectory.appending(dependency.subpath)
+        }
+
         /// Path to the repository checkouts.
         public var repositoriesCheckoutsDirectory: AbsolutePath {
             self.workingDirectory.appending(component: "checkouts")
+        }
+
+        /// Returns the path to the repository checkout directory for a package.
+        public func repositoriesCheckoutSubdirectory(for dependency: ManagedDependency) -> AbsolutePath {
+            self.repositoriesCheckoutsDirectory.appending(dependency.subpath)
         }
 
         /// Path to the downloaded binary artifacts.

--- a/Sources/Workspace/WorkspaceState.swift
+++ b/Sources/Workspace/WorkspaceState.swift
@@ -374,7 +374,7 @@ fileprivate struct WorkspaceStateStorage {
 }
 
 extension Workspace.ManagedDependency {
-    fileprivate convenience init(_ dependency: WorkspaceStateStorage.V4.Dependency) throws {
+    fileprivate init(_ dependency: WorkspaceStateStorage.V4.Dependency) throws {
         try self.init(
             packageRef: .init(dependency.packageRef),
             state: dependency.state.underlying,


### PR DESCRIPTION
As suggested in https://github.com/apple/swift-package-manager/pull/3698#discussion_r709598802, this PR provides additional refactoring of `ManagedDependencies` by rebasing changes in #3640 against #3698.

### Motivation:

Improve convenience and correctness of `Workspace` APIs.

### Modifications:

- Converted `ManagedDependency` from class to structure and made `ManagedDependency.State` an indirect enumeration. It makes sense for this to be a value type and has the added benefit of automatic `Equatable` synthesis.
- Removed `ManagedDependency.packageIdentity` property. This was a helper for `self.packageRef.identity` and only used in a couple places.
- Consolidated dependency path determination into dedicated APIs. There are a few places where we determine the location of a repository checkout or edited package by appending to a location. To ensure consistent routing (i.e. [case normalization](https://github.com/apple/swift-package-manager/pull/3749)), these now go through a single API.
 - <del>Removed `ManagedDependency.subpath` property. The location of a managed dependency is determined by the workspace (except in the case of an unmanaged edited dependency, which stores its path separately), so we don't need to store it separately.</del> <ins>I wasn't able to get this working. To be considered for a future refactoring pass.</ins>
