### PR TITLE
 convert test tool to new diagnostics apis

### DIFF
--- a/Sources/Basics/Observability.swift
+++ b/Sources/Basics/Observability.swift
@@ -83,7 +83,6 @@ public final class ObservabilityScope: DiagnosticsEmitterProtocol {
     private var diagnosticsHandler: DiagnosticsHanderWrapper
     private var metricsHandler: MetricsHandler
 
-
     fileprivate init(
         description: String,
         parent: ObservabilityScope?,

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -966,12 +966,17 @@ extension DispatchTimeInterval {
 
 // MARK: - Diagnostics
 
-private struct SwiftToolObservability: ObservabilityFactory, DiagnosticsHandler {
+private struct SwiftToolObservability: ObservabilityFactory, DiagnosticsHandler, MetricsHandler {
     var diagnosticsHandler: DiagnosticsHandler { self }
+    var metricsHandler: MetricsHandler { self }
 
     func handleDiagnostic(scope: ObservabilityScope, diagnostic: Basics.Diagnostic) {
         // TODO: do something useful with scope
         diagnostic.print()
+    }
+
+    func handleTimer(scope: ObservabilityScope, label: String, duration: DispatchTimeInterval) {
+        // TODO: do something useful with performance information
     }
 }
 

--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -33,7 +33,7 @@ final class TestToolTests: XCTestCase {
         XCTAssert(stdout.contains("Swift Package Manager"), "got stdout:\n" + stdout)
     }
 
-    func testNumWorkersParallelRequeriment() throws {
+    func testNumWorkersParallelRequirement() throws {
         // Running swift-test fixtures on linux is not yet possible.
         #if os(macOS)
         fixture(name: "Miscellaneous/EchoExecutable") { path in


### PR DESCRIPTION
motivation: adapt new diagnostics apis

changes: refactor SwiftTestTool to use new diagnostics api, including relevant scopes and timer measuring duration of tests
