### PR TITLE
convert the build modules to the new diagnostics apis

### DIFF
--- a/Sources/Commands/APIDigester.swift
+++ b/Sources/Commands/APIDigester.swift
@@ -125,8 +125,9 @@ struct APIDigesterBaselineDumper {
             cacheBuildManifest: false,
             packageGraphLoader: { graph },
             pluginInvoker: { _ in [:] },
-            diagnostics: observabilityScope.makeDiagnosticsEngine(),
-            outputStream: outputStream
+            outputStream: outputStream,
+            fileSystem: localFileSystem,
+            observabilityScope: observabilityScope
         )
 
         try buildOp.build()

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -40,7 +40,7 @@ public struct SwiftPackageTool: ParsableCommand {
             Describe.self,
             Init.self,
             Format.self,
-            
+
             APIDiff.self,
             DeprecatedAPIDiff.self,
             DumpSymbolGraph.self,
@@ -591,7 +591,8 @@ extension SwiftPackageTool {
             let builder = PIFBuilder(
                 graph: graph,
                 parameters: parameters,
-                diagnostics: swiftTool.observabilityScope.makeDiagnosticsEngine()
+                fileSystem: localFileSystem,
+                observabilityScope: swiftTool.observabilityScope
             )
             let pif = try builder.generatePIF(preservePIFModelStructure: preserveStructure)
             print(pif)
@@ -880,7 +881,8 @@ extension SwiftPackageTool {
                 xcodeprojPath: xcodeprojPath,
                 graph: graph,
                 options: genOptions,
-                diagnostics: swiftTool.observabilityScope.makeDiagnosticsEngine()
+                fileSystem: localFileSystem,
+                observabilityScope: swiftTool.observabilityScope
             )
 
             print("generated:", xcodeprojPath.prettyPath(cwd: swiftTool.originalWorkingDirectory))
@@ -888,9 +890,10 @@ extension SwiftPackageTool {
             // Run the file watcher if requested.
             if options.enableAutogeneration {
                 try WatchmanHelper(
-                    diagnostics: swiftTool.observabilityScope.makeDiagnosticsEngine(),
                     watchmanScriptsDir: swiftTool.buildPath.appending(component: "watchman"),
-                    packageRoot: swiftTool.packageRoot!
+                    packageRoot: swiftTool.packageRoot!,
+                    fileSystem: localFileSystem,
+                    observabilityScope: swiftTool.observabilityScope
                 ).runXcodeprojWatcher(xcodeprojOptions())
             }
         }

--- a/Sources/Commands/SwiftRunTool.swift
+++ b/Sources/Commands/SwiftRunTool.swift
@@ -66,7 +66,7 @@ struct RunToolOptions: ParsableArguments {
     /// If the executable product should be built before running.
     @Flag(name: .customLong("skip-build"), help: "Skip building the executable product")
     var shouldSkipBuild: Bool = false
-    
+
     var shouldBuild: Bool { !shouldSkipBuild }
 
     /// If the test should be built.
@@ -123,8 +123,9 @@ public struct SwiftRunTool: SwiftCommand {
                 cacheBuildManifest: false,
                 packageGraphLoader: graphLoader,
                 pluginInvoker: { _ in [:] },
-                diagnostics: swiftTool.observabilityScope.makeDiagnosticsEngine(),
-                outputStream: swiftTool.outputStream
+                outputStream: swiftTool.outputStream,
+                fileSystem: localFileSystem,
+                observabilityScope: swiftTool.observabilityScope
             )
 
             // Save the instance so it can be cancelled from the int handler.
@@ -185,7 +186,7 @@ public struct SwiftRunTool: SwiftCommand {
             // Redirect stdout to stderr because swift-run clients usually want
             // to ignore swiftpm's output and only care about the tool's output.
             swiftTool.redirectStdoutToStderr()
-            
+
             do {
                 let buildSystem = try swiftTool.createBuildSystem(explicitProduct: options.executable)
                 let productName = try findProductName(in: buildSystem.getPackageGraph())
@@ -194,7 +195,7 @@ public struct SwiftRunTool: SwiftCommand {
                 } else if options.shouldBuild {
                     try buildSystem.build(subset: .product(productName))
                 }
-            
+
                 let executablePath = try swiftTool.buildParameters().buildPath.appending(component: productName)
                 try run(executablePath,
                         originalWorkingDirectory: swiftTool.originalWorkingDirectory,
@@ -268,7 +269,7 @@ public struct SwiftRunTool: SwiftCommand {
         }
         return localFileSystem.isFile(absolutePath)
     }
-    
+
     public init() {}
 }
 

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -546,16 +546,19 @@ private final class ResolvedTargetBuilder: ResolvedBuilder<ResolvedTarget> {
     /// The target reference.
     let target: Target
 
-
-    /// scope with which to emit diagnostics
-    let observabilityScope: ObservabilityScope
+    /// DiagnosticsEmitter with which to emit diagnostics
+    let diagnosticsEmitter: DiagnosticsEmitter
 
     /// The target dependencies of this target.
     var dependencies: [Dependency] = []
 
     init(target: Target, observabilityScope: ObservabilityScope) {
         self.target = target
-        self.observabilityScope = observabilityScope
+        self.diagnosticsEmitter = observabilityScope.makeDiagnosticsEmitter() {
+            var metadata = ObservabilityMetadata()
+            metadata.targetName = target.name
+            return metadata
+        }
     }
 
     func diagnoseInvalidUseOfUnsafeFlags(_ product: ResolvedProduct) throws {
@@ -564,7 +567,7 @@ private final class ResolvedTargetBuilder: ResolvedBuilder<ResolvedTarget> {
             let declarations = target.underlyingTarget.buildSettings.assignments.keys
             for decl in declarations {
                 if BuildSettings.Declaration.unsafeSettings.contains(decl) {
-                    self.observabilityScope.emit(.productUsesUnsafeFlags(product: product.name, target: target.name))
+                    self.diagnosticsEmitter.emit(.productUsesUnsafeFlags(product: product.name, target: target.name))
                     break
                 }
             }

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -241,7 +241,7 @@ public final class PackageBuilder {
     /// Minimum deployment target of XCTest per platform.
     private let xcTestMinimumDeploymentTargets: [PackageModel.Platform:PlatformVersion]
 
-    // scope with which to emit diagnostics
+    /// ObservabilityScope with which to emit diagnostics
     private let observabilityScope: ObservabilityScope
 
     /// The filesystem package builder will run on.
@@ -256,7 +256,7 @@ public final class PackageBuilder {
     ///   - artifactPaths: Paths to the downloaded binary target artifacts.
     ///   - createMultipleTestProducts: If enabled, create one test product for
     ///     each test target.
-    ///   - fileSystem: The file system on which the builder should be run.///     
+    ///   - fileSystem: The file system on which the builder should be run.///
     public init(
         identity: PackageIdentity,
         manifest: Manifest,
@@ -489,7 +489,7 @@ public final class PackageBuilder {
 
     /// Predefined test directories, in order of preference.
     public static let predefinedTestDirectories = ["Tests", "Sources", "Source", "src", "srcs"]
-    
+
     /// Predefined plugin directories, in order of preference.
     public static let predefinedPluginDirectories = ["Plugins"]
 
@@ -702,7 +702,7 @@ public final class PackageBuilder {
                     }
                 }
             } ?? []
-            
+
             // Get dependencies from the plugin usages of this target.
             let pluginUsages: [Target.PluginUsage] = manifestTarget?.pluginUsages.map {
                 $0.compactMap{ usage in
@@ -718,7 +718,7 @@ public final class PackageBuilder {
                     }
                 }
             } ?? []
-            
+
             // Create the target, adding the inferred dependencies from plugin usages to the declared dependencies.
             let target = try createTarget(
                 potentialModule: potentialModule,
@@ -826,13 +826,13 @@ public final class PackageBuilder {
             return nil
         }
         try validateSourcesOverlapping(forTarget: potentialModule.name, sources: sources.paths)
-        
+
         // Deal with package plugin targets.
         if potentialModule.type == .plugin {
             guard let declaredCapability = manifestTarget.pluginCapability else {
                 throw ModuleError.pluginCapabilityNotDeclared(target: manifestTarget.name)
             }
-            
+
             // Translate the capability from the target description form coming in from the manifest
             // to the package model form.
             let capability: PluginCapability
@@ -840,7 +840,7 @@ public final class PackageBuilder {
             case .buildTool:
                 capability = .buildTool
             }
-            
+
             // Crate and return an PluginTarget configured with the information from the manifest.
             return PluginTarget(
                 name: potentialModule.name,
@@ -849,7 +849,7 @@ public final class PackageBuilder {
                 pluginCapability: capability,
                 dependencies: dependencies)
         }
-        
+
         /// Determine the target's type, or leave nil to check the source directory.
         let targetType: Target.Kind
         switch potentialModule.type {
@@ -863,7 +863,7 @@ public final class PackageBuilder {
                 self.observabilityScope.emit(warning: "'\(potentialModule.name)' was identified as an executable target given the presence of a 'main.swift' file. Starting with tools version \(ToolsVersion.v5_4) executable targets should be declared as 'executableTarget()'")
             }
         }
-        
+
         // Create and return the right kind of target depending on what kind of sources we found.
         if sources.hasSwiftSources {
             return SwiftTarget(
@@ -881,10 +881,10 @@ public final class PackageBuilder {
             )
         } else {
             // It's not a Swift target, so it's a Clang target (those are the only two types of source target currently supported).
-            
+
             // First determine the type of module map that will be appropriate for the target based on its header layout.
             let moduleMapType: ModuleMapType
-            
+
             if fileSystem.exists(publicHeadersPath) {
                 let moduleMapGenerator = ModuleMapGenerator(targetName: potentialModule.name, moduleName: potentialModule.name.spm_mangledToC99ExtendedIdentifier(), publicHeadersDir: publicHeadersPath, fileSystem: fileSystem)
                 moduleMapType = moduleMapGenerator.determineModuleMapType(observabilityScope: self.observabilityScope)
@@ -1417,7 +1417,7 @@ extension Sources {
     var containsMixedLanguage: Bool {
         return hasSwiftSources && hasClangSources
     }
-    
+
     /// Determine target type based on the sources.
     fileprivate func computeTargetType() -> Target.Kind {
         let isLibrary = !relativePaths.contains { path in

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -48,7 +48,7 @@ public struct TargetSourcesBuilder {
     /// The file system to operate on.
     public let fileSystem: FileSystem
 
-    // scope with which to emit diagnostics
+    /// ObservabilityScope with which to emit diagnostics
     private let observabilityScope: ObservabilityScope
 
     /// Create a new target builder.
@@ -96,14 +96,14 @@ public struct TargetSourcesBuilder {
             }
         }
         self.declaredSources = declaredSources?.spm_uniqueElements()
-        
+
         self.excludedPaths.forEach { exclude in
             if let message = validTargetPath(at: exclude) {
                 let warning = "Invalid Exclude '\(exclude)': \(message)."
                 self.observabilityScope.emit(warning: warning)
             }
         }
-        
+
         self.declaredSources?.forEach { source in
             if let message = validTargetPath(at: source) {
                 let warning = "Invalid Source '\(source)': \(message)."
@@ -128,10 +128,10 @@ public struct TargetSourcesBuilder {
         guard at.pathString.hasPrefix(self.packagePath.pathString) else {
             return StringError("File must be within the package directory structure")
         }
-        
+
         return nil
     }
-    
+
     /// Emits an error in debug mode if we have conflicting rules for any file type.
     private func validateRules(_ rules: [FileRuleDescription]) {
         var extensionMap: [String: FileRuleDescription] = [:]
@@ -357,7 +357,7 @@ public struct TargetSourcesBuilder {
             }
         }
     }
-    
+
     private func diagnoseInvalidResource(in resources: [TargetDescription.Resource]) {
         resources.forEach { resource in
             let resourcePath = self.targetPath.appending(RelativePath(resource.path))
@@ -494,7 +494,7 @@ public struct FileRuleDescription {
 
         /// A header file.
         case header
-        
+
         /// Indicates that the file should be treated as ignored, without causing an unhandled-file warning.
         case ignored
 

--- a/Tests/CommandsTests/APIDiffTests.swift
+++ b/Tests/CommandsTests/APIDiffTests.swift
@@ -30,7 +30,7 @@ final class APIDiffTests: XCTestCase {
         environment["SWIFTPM_TESTS_PACKAGECACHE"] = "1"
         return try SwiftPMProduct.SwiftPackage.execute(args, packagePath: packagePath, env: environment)
     }
-    
+
     func skipIfApiDigesterUnsupportedOrUnset() throws {
         try skipIfApiDigesterUnsupported()
         // The following is added to separate out the integration point testing of the API
@@ -39,7 +39,7 @@ final class APIDiffTests: XCTestCase {
             throw XCTSkip("Env var SWIFTPM_TEST_API_DIFF_OUTPUT must be set to test the output")
         }
     }
-    
+
     func skipIfApiDigesterUnsupported() throws {
       // swift-api-digester is required to run tests.
       guard (try? UserToolchain.default.getSwiftAPIDigester()) != nil else {
@@ -49,7 +49,7 @@ final class APIDiffTests: XCTestCase {
       // not all of which can be tested for easily. Fortunately, we can test for the
       // `-disable-fail-on-error` option, and any version which supports this flag
       // will meet the other requirements.
-      guard SwiftTargetBuildDescription.checkSupportedFrontendFlags(flags: ["disable-fail-on-error"], fs: localFileSystem) else {
+      guard SwiftTargetBuildDescription.checkSupportedFrontendFlags(flags: ["disable-fail-on-error"], fileSystem: localFileSystem) else {
         throw XCTSkip("swift-api-digester is too old")
       }
     }
@@ -71,7 +71,7 @@ final class APIDiffTests: XCTestCase {
             }
         }
     }
-    
+
     func testSimpleAPIDiff() throws {
         try skipIfApiDigesterUnsupportedOrUnset()
         fixture(name: "Miscellaneous/APIDiff/") { prefix in

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -903,9 +903,11 @@ final class PackageToolTests: XCTestCase {
             let packageRoot = path.appending(component: "root")
 
             let helper = WatchmanHelper(
-                diagnostics: observability.topScope.makeDiagnosticsEngine(),
                 watchmanScriptsDir: scriptsDir,
-                packageRoot: packageRoot)
+                packageRoot: packageRoot,
+                fileSystem: fs,
+                observabilityScope: observability.topScope
+            )
 
             let script = try helper.createXcodegenScript(
                 XcodeprojOptions(xcconfigOverrides: .init("/tmp/overrides.xcconfig")))

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -1070,9 +1070,13 @@ class PackageGraphTests: XCTestCase {
 
         XCTAssertEqual(observability.diagnostics.count, 3)
         testDiagnostics(observability.diagnostics) { result in
-            result.checkUnordered(diagnostic: .contains("the target 'Bar2' in product 'TransitiveBar' contains unsafe build flags"), severity: .error)
-            result.checkUnordered(diagnostic: .contains("the target 'Bar' in product 'Bar' contains unsafe build flags"), severity: .error)
-            result.checkUnordered(diagnostic: .contains("the target 'Bar2' in product 'Bar' contains unsafe build flags"), severity: .error)
+            var expectedMetadata = ObservabilityMetadata()
+            expectedMetadata.targetName = "Foo2"
+            result.checkUnordered(diagnostic: .contains("the target 'Bar2' in product 'TransitiveBar' contains unsafe build flags"), severity: .error, metadata: expectedMetadata)
+            expectedMetadata = ObservabilityMetadata()
+            expectedMetadata.targetName = "Foo"
+            result.checkUnordered(diagnostic: .contains("the target 'Bar' in product 'Bar' contains unsafe build flags"), severity: .error, metadata: expectedMetadata)
+            result.checkUnordered(diagnostic: .contains("the target 'Bar2' in product 'Bar' contains unsafe build flags"), severity: .error, metadata: expectedMetadata)
         }
     }
 

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -71,7 +71,12 @@ class PIFBuilderTests: XCTestCase {
                 observabilityScope: observability.topScope
             )
 
-            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: observability.topScope.makeDiagnosticsEngine())
+            let builder = PIFBuilder(
+                graph: graph,
+                parameters: .mock(),
+                fileSystem: fs,
+                observabilityScope: observability.topScope
+            )
             let pif = try builder.construct()
 
             XCTAssertNoDiagnostics(observability.diagnostics)
@@ -142,7 +147,12 @@ class PIFBuilderTests: XCTestCase {
             observabilityScope: observability.topScope
         )
 
-        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: observability.topScope.makeDiagnosticsEngine())
+        let builder = PIFBuilder(
+            graph: graph,
+            parameters: .mock(),
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
         let pif = try builder.construct()
 
         XCTAssertNoDiagnostics(observability.diagnostics)
@@ -419,7 +429,12 @@ class PIFBuilderTests: XCTestCase {
 
         var pif: PIF.TopLevelObject!
         try! withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
-            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: observability.topScope.makeDiagnosticsEngine())
+            let builder = PIFBuilder(
+                graph: graph,
+                parameters: .mock(),
+                fileSystem: localFileSystem,
+                observabilityScope: observability.topScope
+            )
             pif = try builder.construct()
         }
 
@@ -750,7 +765,12 @@ class PIFBuilderTests: XCTestCase {
 
         var pif: PIF.TopLevelObject!
         try! withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
-            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: observability.topScope.makeDiagnosticsEngine())
+            let builder = PIFBuilder(
+                graph: graph,
+                parameters: .mock(),
+                fileSystem: fs,
+                observabilityScope: observability.topScope
+            )
             pif = try builder.construct()
         }
 
@@ -966,7 +986,12 @@ class PIFBuilderTests: XCTestCase {
 
         var pif: PIF.TopLevelObject!
         try! withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
-            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: observability.topScope.makeDiagnosticsEngine())
+            let builder = PIFBuilder(
+                graph: graph,
+                parameters: .mock(),
+                fileSystem: localFileSystem,
+                observabilityScope: observability.topScope
+            )
             pif = try builder.construct()
         }
 
@@ -1156,7 +1181,12 @@ class PIFBuilderTests: XCTestCase {
 
         var pif: PIF.TopLevelObject!
         try! withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
-            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: observability.topScope.makeDiagnosticsEngine())
+            let builder = PIFBuilder(
+                graph: graph,
+                parameters: .mock(),
+                fileSystem: localFileSystem,
+                observabilityScope: observability.topScope
+            )
             pif = try builder.construct()
         }
 
@@ -1429,7 +1459,8 @@ class PIFBuilderTests: XCTestCase {
             let builder = PIFBuilder(
                 graph: graph,
                 parameters: .mock(shouldCreateDylibForDynamicProducts: true),
-                diagnostics: observability.topScope.makeDiagnosticsEngine()
+                fileSystem: fs,
+                observabilityScope: observability.topScope
             )
             pif = try builder.construct()
         }
@@ -1446,13 +1477,13 @@ class PIFBuilderTests: XCTestCase {
             }
         }
     }
-  
+
     func testLibraryTargetWithModuleMap() throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/Bar/Sources/BarLib/lib.c",
             "/Bar/Sources/BarLib/module.modulemap"
         )
-        
+
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
             fs: fs,
@@ -1473,24 +1504,25 @@ class PIFBuilderTests: XCTestCase {
             ],
             observabilityScope: observability.topScope
         )
-        
+
         var pif: PIF.TopLevelObject!
         try! withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
             let builder = PIFBuilder(
                 graph: graph,
                 parameters: .mock(shouldCreateDylibForDynamicProducts: true),
-                diagnostics: observability.topScope.makeDiagnosticsEngine()
+                fileSystem: fs,
+                observabilityScope: observability.topScope
             )
             pif = try builder.construct()
         }
-        
+
         XCTAssertNoDiagnostics(observability.diagnostics)
-        
+
         PIFTester(pif) { workspace in
             workspace.checkProject("PACKAGE:/Bar") { project in
                 project.checkTarget("PACKAGE-PRODUCT:BarLib") { target in
                     XCTAssertEqual(target.name, "BarLib_175D063FAE17B2_PackageProduct")
-                    
+
                     target.checkBuildConfiguration("Debug") { configuration in
                         configuration.checkBuildSettings { settings in
                             XCTAssertNil(settings[.MODULEMAP_FILE_CONTENTS])
@@ -1527,7 +1559,12 @@ class PIFBuilderTests: XCTestCase {
 
         var pif: PIF.TopLevelObject!
         try! withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
-            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: observability.topScope.makeDiagnosticsEngine())
+            let builder = PIFBuilder(
+                graph: graph,
+                parameters: .mock(),
+                fileSystem: localFileSystem,
+                observabilityScope: observability.topScope
+            )
             pif = try builder.construct()
         }
 
@@ -1643,7 +1680,12 @@ class PIFBuilderTests: XCTestCase {
             observabilityScope: observability.topScope
         )
 
-        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: observability.topScope.makeDiagnosticsEngine())
+        let builder = PIFBuilder(
+            graph: graph,
+            parameters: .mock(),
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
         let pif = try builder.construct()
 
         XCTAssertNoDiagnostics(observability.diagnostics)
@@ -1711,7 +1753,12 @@ class PIFBuilderTests: XCTestCase {
             observabilityScope: observability.topScope
         )
 
-        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: observability.topScope.makeDiagnosticsEngine())
+        let builder = PIFBuilder(
+            graph: graph,
+            parameters: .mock(shouldCreateDylibForDynamicProducts: true),
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
         let pif = try builder.construct()
 
         XCTAssertNoDiagnostics(observability.diagnostics)
@@ -1971,7 +2018,12 @@ class PIFBuilderTests: XCTestCase {
             observabilityScope: observability.topScope
         )
 
-        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: observability.topScope.makeDiagnosticsEngine())
+        let builder = PIFBuilder(
+            graph: graph,
+            parameters: .mock(),
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
         let pif = try builder.construct()
 
         XCTAssertNoDiagnostics(observability.diagnostics)
@@ -2132,7 +2184,12 @@ class PIFBuilderTests: XCTestCase {
 
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: observability.topScope.makeDiagnosticsEngine())
+        let builder = PIFBuilder(
+            graph: graph,
+            parameters: .mock(),
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
         let pif = try builder.construct()
 
         let expectedFilters: [PIF.GUID: [PIF.PlatformFilter]] = [
@@ -2188,7 +2245,12 @@ class PIFBuilderTests: XCTestCase {
             observabilityScope: observability.topScope
         )
 
-        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: observability.topScope.makeDiagnosticsEngine())
+        let builder = PIFBuilder(
+            graph: graph,
+            parameters: .mock(),
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
         let pif = try builder.construct()
 
         XCTAssertNoDiagnostics(observability.diagnostics)
@@ -2203,7 +2265,7 @@ class PIFBuilderTests: XCTestCase {
             }
         }
     }
-    
+
     /// Tests that the inference of XCBuild build settings based on the package manifest's declared unsafe settings
     /// works as expected.
     func testUnsafeFlagsBuildSettingInference() throws {
@@ -2236,7 +2298,12 @@ class PIFBuilderTests: XCTestCase {
             observabilityScope: observability.topScope
         )
 
-        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: observability.topScope.makeDiagnosticsEngine())
+        let builder = PIFBuilder(
+            graph: graph,
+            parameters: .mock(),
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
         let pif = try builder.construct()
 
         XCTAssertNoDiagnostics(observability.diagnostics)

--- a/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
+++ b/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
@@ -57,7 +57,8 @@ class GenerateXcodeprojTests: XCTestCase {
             xcodeprojPath: outpath,
             graph: graph,
             options: XcodeprojOptions(),
-            diagnostics: observability.topScope.makeDiagnosticsEngine()
+            fileSystem: localFileSystem,
+            observabilityScope: observability.topScope
           )
 
           XCTAssertDirectoryExists(outpath)
@@ -117,7 +118,7 @@ class GenerateXcodeprojTests: XCTestCase {
                     extraFiles: [],
                     options: options,
                     fileSystem: localFileSystem,
-                    diagnostics: observability.topScope.makeDiagnosticsEngine()
+                    observabilityScope: observability.topScope
                 )
                 XCTFail("Project generation should have failed")
             } catch ProjectGenerationError.xcconfigOverrideNotFound(let path) {
@@ -154,7 +155,7 @@ class GenerateXcodeprojTests: XCTestCase {
                 xcodeprojPath: AbsolutePath.root.appending(component: "xcodeproj"),
                 graph: graph, extraDirs: [], extraFiles: [],
                 options: XcodeprojOptions(), fileSystem: localFileSystem,
-                diagnostics: observability.topScope.makeDiagnosticsEngine()
+                observabilityScope: observability.topScope
             )
 
             testDiagnostics(observability.diagnostics) { result in
@@ -196,7 +197,8 @@ class GenerateXcodeprojTests: XCTestCase {
                 xcodeprojPath: outpath,
                 graph: graph,
                 options: XcodeprojOptions(),
-                diagnostics: observability.topScope.makeDiagnosticsEngine()
+                fileSystem: localFileSystem,
+                observabilityScope: observability.topScope
             )
 
             XCTAssertFalse(project.mainGroup.subitems.contains { $0.path == "a.txt" })
@@ -236,7 +238,8 @@ class GenerateXcodeprojTests: XCTestCase {
                 xcodeprojPath: outpath,
                 graph: graph,
                 options: XcodeprojOptions(),
-                diagnostics: observability.topScope.makeDiagnosticsEngine()
+                fileSystem: localFileSystem,
+                observabilityScope: observability.topScope
             )
 
             XCTAssertFalse(project.mainGroup.subitems.contains { $0.path == ".a.txt" })
@@ -275,7 +278,8 @@ class GenerateXcodeprojTests: XCTestCase {
                 xcodeprojPath: outpath,
                 graph: graph,
                 options: XcodeprojOptions(),
-                diagnostics: observability.topScope.makeDiagnosticsEngine()
+                fileSystem: localFileSystem,
+                observabilityScope: observability.topScope
             )
 
             XCTAssertTrue(project.mainGroup.subitems.contains { $0.path == "a.txt" })
@@ -285,7 +289,8 @@ class GenerateXcodeprojTests: XCTestCase {
                 xcodeprojPath: outpath,
                 graph: graph,
                 options: XcodeprojOptions(addExtraFiles: false),
-                diagnostics: observability.topScope.makeDiagnosticsEngine()
+                fileSystem: localFileSystem,
+                observabilityScope: observability.topScope
             )
             XCTAssertFalse(projectWithoutExtraFiles.mainGroup.subitems.contains { $0.path == "a.txt" })
         }
@@ -324,7 +329,8 @@ class GenerateXcodeprojTests: XCTestCase {
                 xcodeprojPath: outpath,
                 graph: graph,
                 options: XcodeprojOptions(),
-                diagnostics: observability.topScope.makeDiagnosticsEngine()
+                fileSystem: localFileSystem,
+                observabilityScope: observability.topScope
             )
 
             let sources = project.mainGroup.subitems[1] as? Xcode.Group
@@ -372,7 +378,8 @@ class GenerateXcodeprojTests: XCTestCase {
                 xcodeprojPath: outpath,
                 graph: graph,
                 options: XcodeprojOptions(),
-                diagnostics: observability.topScope.makeDiagnosticsEngine()
+                fileSystem: localFileSystem,
+                observabilityScope: observability.topScope
             )
 
             let sources = project.mainGroup.subitems[1] as? Xcode.Group
@@ -435,7 +442,8 @@ class GenerateXcodeprojTests: XCTestCase {
                 xcodeprojPath: outpath,
                 graph: graph,
                 options: XcodeprojOptions(),
-                diagnostics: observability.topScope.makeDiagnosticsEngine()
+                fileSystem: localFileSystem,
+                observabilityScope: observability.topScope
             )
 
             testDiagnostics(observability.diagnostics) { result in

--- a/Tests/XcodeprojTests/PackageGraphTests.swift
+++ b/Tests/XcodeprojTests/PackageGraphTests.swift
@@ -81,7 +81,7 @@ class PackageGraphTests: XCTestCase {
             extraFiles: [],
             options: options,
             fileSystem: fs,
-            diagnostics: observability.topScope.makeDiagnosticsEngine()
+            observabilityScope: observability.topScope
         )
 
         XcodeProjectTester(project) { result in
@@ -229,7 +229,7 @@ class PackageGraphTests: XCTestCase {
             extraFiles: [],
             options: XcodeprojOptions(),
             fileSystem: fs,
-            diagnostics: observability.topScope.makeDiagnosticsEngine()
+            observabilityScope: observability.topScope
         )
         XcodeProjectTester(project) { result in
             result.check(target: "Foo") { targetResult in
@@ -277,7 +277,7 @@ class PackageGraphTests: XCTestCase {
             extraFiles: [],
             options: XcodeprojOptions(),
             fileSystem: fs,
-            diagnostics: observability.topScope.makeDiagnosticsEngine()
+            observabilityScope: observability.topScope
         )
         XcodeProjectTester(project) { result in
             result.check(target: "swift") { targetResult in
@@ -328,7 +328,7 @@ class PackageGraphTests: XCTestCase {
             extraFiles: [],
             options: XcodeprojOptions(),
             fileSystem: fs,
-            diagnostics: observability.topScope.makeDiagnosticsEngine()
+            observabilityScope: observability.topScope
         )
 
         XcodeProjectTester(project) { result in
@@ -451,7 +451,7 @@ class PackageGraphTests: XCTestCase {
                 extraFiles: [],
                 options: XcodeprojOptions(),
                 fileSystem: fs,
-                diagnostics: observability.topScope.makeDiagnosticsEngine()
+                observabilityScope: observability.topScope
             )
             XCTAssertNoDiagnostics(observability.diagnostics)
 


### PR DESCRIPTION
motivation: adapt new diagnostics apis

changes:
* refactor the build  modules and relevant call sites to use new diagnostics api
* clean up assumptions about local file system as a default argument
* adjust call-sites and test
