### PR TITLE
swift-crypto 2.x upgrade

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -53,11 +53,12 @@ automatic linking type with `-auto` suffix appended to product's name.
 */
 let autoProducts = [swiftPMProduct, swiftPMDataModelProduct]
 
-let minimumCryptoVersion: Version = "1.1.4"
-let swiftSettings: [SwiftSetting] = [
-    // Uncomment this define when using swift-crypto 2.x
-//    .define("CRYPTO_v2"),
-]
+let useSwiftCryptoV2 = ProcessInfo.processInfo.environment["SWIFTPM_USE_SWIFT_CRYPTO_V2"] != nil
+let minimumCryptoVersion: Version = useSwiftCryptoV2 ? "2.0.0-beta.2" : "1.1.4"
+var swiftSettings: [SwiftSetting] = []
+if useSwiftCryptoV2 {
+    swiftSettings.append(.define("CRYPTO_v2"))
+}
 
 let package = Package(
     name: "SwiftPM",

--- a/Package.swift
+++ b/Package.swift
@@ -54,7 +54,7 @@ automatic linking type with `-auto` suffix appended to product's name.
 let autoProducts = [swiftPMProduct, swiftPMDataModelProduct]
 
 let useSwiftCryptoV2 = ProcessInfo.processInfo.environment["SWIFTPM_USE_SWIFT_CRYPTO_V2"] != nil
-let minimumCryptoVersion: Version = useSwiftCryptoV2 ? "2.0.0-beta.2" : "1.1.4"
+let minimumCryptoVersion: Version = useSwiftCryptoV2 ? "2.0.0" : "1.1.4"
 var swiftSettings: [SwiftSetting] = []
 if useSwiftCryptoV2 {
     swiftSettings.append(.define("CRYPTO_v2"))

--- a/Package.swift
+++ b/Package.swift
@@ -53,6 +53,12 @@ automatic linking type with `-auto` suffix appended to product's name.
 */
 let autoProducts = [swiftPMProduct, swiftPMDataModelProduct]
 
+let minimumCryptoVersion: Version = "1.1.4"
+let swiftSettings: [SwiftSetting] = [
+    // Uncomment this define when using swift-crypto 2.x
+//    .define("CRYPTO_v2"),
+]
+
 let package = Package(
     name: "SwiftPM",
     platforms: [
@@ -183,7 +189,8 @@ let package = Package(
         .target(
              /** Package collections signing */
              name: "PackageCollectionsSigning",
-             dependencies: ["PackageCollectionsModel", "PackageCollectionsSigningLibc", "Crypto", "Basics"]),
+             dependencies: ["PackageCollectionsModel", "PackageCollectionsSigningLibc", "Crypto", "Basics"],
+             swiftSettings: swiftSettings),
 
         .target(
             /** Data structures and support for package collections */
@@ -368,7 +375,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         // dependency version changes here with those projects.
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "0.4.3")),
         .package(url: "https://github.com/apple/swift-driver.git", .branch(relatedDependenciesBranch)),
-        .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: "1.1.4")),
+        .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: minimumCryptoVersion)),
     ]
 } else {
     package.dependencies += [

--- a/Sources/PackageCollectionsSigning/Certificate/Certificate.swift
+++ b/Sources/PackageCollectionsSigning/Certificate/Certificate.swift
@@ -111,7 +111,13 @@ struct CoreCertificate {
 
 #elseif os(Linux) || os(Windows) || os(Android)
 final class BoringSSLCertificate {
-    private let underlying: OpaquePointer
+    #if CRYPTO_v2
+    typealias Pointer = OpaquePointer
+    #else
+    typealias Pointer = UnsafeMutablePointer<X509>
+    #endif
+    
+    private let underlying: Pointer
 
     deinit {
         CCryptoBoringSSL_X509_free(self.underlying)
@@ -119,7 +125,7 @@ final class BoringSSLCertificate {
 
     init(derEncoded data: Data) throws {
         let bytes = data.copyBytes()
-        let x509 = try bytes.withUnsafeBufferPointer { (ptr: UnsafeBufferPointer<UInt8>) throws -> OpaquePointer in
+        let x509 = try bytes.withUnsafeBufferPointer { (ptr: UnsafeBufferPointer<UInt8>) throws -> Pointer in
             var pointer = ptr.baseAddress
             guard let x509 = CCryptoBoringSSL_d2i_X509(nil, &pointer, numericCast(ptr.count)) else {
                 throw CertificateError.initializationFailure
@@ -129,7 +135,7 @@ final class BoringSSLCertificate {
         self.underlying = x509
     }
 
-    func withUnsafeMutablePointer<R>(_ body: (OpaquePointer) throws -> R) rethrows -> R {
+    func withUnsafeMutablePointer<R>(_ body: (Pointer) throws -> R) rethrows -> R {
         return try body(self.underlying)
     }
 
@@ -195,8 +201,14 @@ final class BoringSSLCertificate {
 }
 
 private extension CertificateName {
-    init(x509Name: OpaquePointer) {
-        func getStringValue(from name: OpaquePointer, of nid: CInt) -> String? {
+    #if CRYPTO_v2
+    typealias Pointer = OpaquePointer
+    #else
+    typealias Pointer = UnsafeMutablePointer<X509_NAME>
+    #endif
+    
+    init(x509Name: Pointer) {
+        func getStringValue(from name: Pointer, of nid: CInt) -> String? {
             let index = CCryptoBoringSSL_X509_NAME_get_index_by_NID(name, nid, -1)
             guard index >= 0 else {
                 return nil

--- a/Sources/PackageCollectionsSigning/Certificate/Certificate.swift
+++ b/Sources/PackageCollectionsSigning/Certificate/Certificate.swift
@@ -111,7 +111,7 @@ struct CoreCertificate {
 
 #elseif os(Linux) || os(Windows) || os(Android)
 final class BoringSSLCertificate {
-    private let underlying: UnsafeMutablePointer<X509>
+    private let underlying: OpaquePointer
 
     deinit {
         CCryptoBoringSSL_X509_free(self.underlying)
@@ -119,7 +119,7 @@ final class BoringSSLCertificate {
 
     init(derEncoded data: Data) throws {
         let bytes = data.copyBytes()
-        let x509 = try bytes.withUnsafeBufferPointer { (ptr: UnsafeBufferPointer<UInt8>) throws -> UnsafeMutablePointer<X509> in
+        let x509 = try bytes.withUnsafeBufferPointer { (ptr: UnsafeBufferPointer<UInt8>) throws -> OpaquePointer in
             var pointer = ptr.baseAddress
             guard let x509 = CCryptoBoringSSL_d2i_X509(nil, &pointer, numericCast(ptr.count)) else {
                 throw CertificateError.initializationFailure
@@ -129,7 +129,7 @@ final class BoringSSLCertificate {
         self.underlying = x509
     }
 
-    func withUnsafeMutablePointer<R>(_ body: (UnsafeMutablePointer<X509>) throws -> R) rethrows -> R {
+    func withUnsafeMutablePointer<R>(_ body: (OpaquePointer) throws -> R) rethrows -> R {
         return try body(self.underlying)
     }
 
@@ -195,34 +195,32 @@ final class BoringSSLCertificate {
 }
 
 private extension CertificateName {
-    init(x509Name: UnsafeMutablePointer<X509_NAME>) {
-        self.userID = x509Name.getStringValue(of: NID_userId)
-        self.commonName = x509Name.getStringValue(of: NID_commonName)
-        self.organization = x509Name.getStringValue(of: NID_organizationName)
-        self.organizationalUnit = x509Name.getStringValue(of: NID_organizationalUnitName)
-    }
-}
+    init(x509Name: OpaquePointer) {
+        func getStringValue(from name: OpaquePointer, of nid: CInt) -> String? {
+            let index = CCryptoBoringSSL_X509_NAME_get_index_by_NID(name, nid, -1)
+            guard index >= 0 else {
+                return nil
+            }
 
-private extension UnsafeMutablePointer where Pointee == X509_NAME {
-    func getStringValue(of nid: CInt) -> String? {
-        let index = CCryptoBoringSSL_X509_NAME_get_index_by_NID(self, nid, -1)
-        guard index >= 0 else {
-            return nil
+            let entry = CCryptoBoringSSL_X509_NAME_get_entry(name, index)
+            guard let data = CCryptoBoringSSL_X509_NAME_ENTRY_get_data(entry) else {
+                return nil
+            }
+
+            var value: UnsafeMutablePointer<CUnsignedChar>?
+            defer { CCryptoBoringSSL_OPENSSL_free(value) }
+
+            guard CCryptoBoringSSL_ASN1_STRING_to_UTF8(&value, data) >= 0 else {
+                return nil
+            }
+
+            return String.decodeCString(value, as: UTF8.self, repairingInvalidCodeUnits: true)?.result
         }
 
-        let entry = CCryptoBoringSSL_X509_NAME_get_entry(self, index)
-        guard let data = CCryptoBoringSSL_X509_NAME_ENTRY_get_data(entry) else {
-            return nil
-        }
-
-        var value: UnsafeMutablePointer<CUnsignedChar>?
-        defer { CCryptoBoringSSL_OPENSSL_free(value) }
-
-        guard CCryptoBoringSSL_ASN1_STRING_to_UTF8(&value, data) >= 0 else {
-            return nil
-        }
-
-        return String.decodeCString(value, as: UTF8.self, repairingInvalidCodeUnits: true)?.result
+        self.userID = getStringValue(from: x509Name, of: NID_userId)
+        self.commonName = getStringValue(from: x509Name, of: NID_commonName)
+        self.organization = getStringValue(from: x509Name, of: NID_organizationName)
+        self.organizationalUnit = getStringValue(from: x509Name, of: NID_organizationalUnitName)
     }
 }
 

--- a/Sources/PackageCollectionsSigning/Certificate/CertificatePolicy.swift
+++ b/Sources/PackageCollectionsSigning/Certificate/CertificatePolicy.swift
@@ -100,7 +100,7 @@ extension CertificatePolicy {
     }
 
     #elseif os(Linux) || os(Windows) || os(Android)
-    typealias BoringSSLVerifyCallback = @convention(c) (CInt, UnsafeMutablePointer<X509_STORE_CTX>?) -> CInt
+    typealias BoringSSLVerifyCallback = @convention(c) (CInt, OpaquePointer?) -> CInt
 
     /// Verifies a certificate chain.
     ///

--- a/Sources/PackageCollectionsSigning/Certificate/CertificatePolicy.swift
+++ b/Sources/PackageCollectionsSigning/Certificate/CertificatePolicy.swift
@@ -100,7 +100,11 @@ extension CertificatePolicy {
     }
 
     #elseif os(Linux) || os(Windows) || os(Android)
+    #if CRYPTO_v2
     typealias BoringSSLVerifyCallback = @convention(c) (CInt, OpaquePointer?) -> CInt
+    #else
+    typealias BoringSSLVerifyCallback = @convention(c) (CInt, UnsafeMutablePointer<X509_STORE_CTX>?) -> CInt
+    #endif
 
     /// Verifies a certificate chain.
     ///


### PR DESCRIPTION
Motivation:
swift-crypto v2.x has breaking BoringSSL API changes. We don't want to upgrade to v2 just yet (at least until it's out of beta), but we need to be able to test v2 readily.

Modifications:
- API changes for swift-crypto v2: https://github.com/apple/swift-package-manager/commit/c1be158d24b9014cac6700cc4ade0cccbcf17096 from https://github.com/apple/swift-package-manager/pull/3731 
- `CRYPTO_v2` flag to allow coexistence of v1 and v2 code and make it easier to test v2: https://github.com/apple/swift-package-manager/commit/e8d39eae5ca3e3eae76dc8ec46e7b740a559c55a

I verified locally that package collection tests pass with swift-crypto 1.1.6 and ~~2.0.0-beta.2~~ 2.0.0 (with `CRYPTO_v2`) on macOS and Linux.
