### PR TITLE
Add conformance of an enum to String so that SwiftPM still builds on 5.4

### DIFF
--- a/Sources/PackagePlugin/PublicAPI/Context.swift
+++ b/Sources/PackagePlugin/PublicAPI/Context.swift
@@ -105,7 +105,7 @@ public final class TargetBuildContext: Decodable {
     /// Internal
     internal let pluginAction: PluginAction
 
-    internal enum PluginAction: Decodable {
+    internal enum PluginAction: String, Decodable {
         case createBuildToolCommands
     }
 }

--- a/Sources/SPMBuildCore/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/PluginInvocation.swift
@@ -400,7 +400,7 @@ struct PluginScriptRunnerInput: Codable {
         var path: String
     }
     var pluginAction: PluginAction
-    enum PluginAction: Codable {
+    enum PluginAction: String, Codable {
         case createBuildToolCommands
     }
 }


### PR DESCRIPTION
### Motivation:

https://github.com/apple/swift-package-manager/pull/3712 accidentally made SwiftPM no longer compile using 5.4, which lacks automatic Codable synthesis for enums.

### Modifications:

Make `PluginAction` in the PackagePlugin API conform to `String` as well as `Decodable`.

### Result:

SwiftPM can build on 5.4.