### PR TITLE
make error message more specific when failing to create build system with LLBuild

### DIFF
--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -219,7 +219,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
 
         // Build the package structure target which will re-generate the llbuild manifest, if necessary.
         if !buildSystem.build(target: "PackageStructure") {
-            throw Diagnostics.fatalError
+            throw StringError("LLBuild::build failed building package structure")
         }
     }
 


### PR DESCRIPTION
motivation: clearer error message to help diagnose when LLBuild fails

changes: instead of throwing a generic error, throw a more detailed one
