### PR TITLE
`swift build` shouldn't pass `-fmodules` when compiling C++ files

### DIFF
--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -1336,7 +1336,7 @@ final class BuildPlanTests: XCTestCase {
 
         let lib = try result.target(for: "lib").clangTarget()
     #if os(macOS)
-        XCTAssertEqual(lib.basicArguments(), ["-fobjc-arc", "-target", defaultTargetTriple, "-g", "-O0", "-DSWIFT_PACKAGE=1", "-DDEBUG=1", "-fblocks",  "-fmodules", "-fmodule-name=lib", "-I", "/Pkg/Sources/lib/include", "-fmodules-cache-path=/path/to/build/debug/ModuleCache"])
+        XCTAssertEqual(lib.basicArguments(), ["-fobjc-arc", "-target", defaultTargetTriple, "-g", "-O0", "-DSWIFT_PACKAGE=1", "-DDEBUG=1", "-fblocks", "-I", "/Pkg/Sources/lib/include"])
     #else
         XCTAssertEqual(lib.basicArguments(), ["-target", defaultTargetTriple, "-g", "-O0", "-DSWIFT_PACKAGE=1", "-DDEBUG=1", "-fblocks",  "-fmodules", "-fmodule-name=lib", "-I", "/Pkg/Sources/lib/include", "-fmodules-cache-path=/path/to/build/debug/ModuleCache"])
     #endif


### PR DESCRIPTION
Stop passing `-fmodules` to C++ compilation.

### Motivation:

Historically, `swift build` has indiscriminately passed `-fmodules` when invoking Clang on Darwin, regardless of the language being compiled for.  Also historically, Clang on Darwin has ignored the `-fmodules` option for C++ files.

In some builds of Clang on Darwin, C++ module functionality is getting activated and this can in some case cause build failures.  SwiftPM should stop passing `-fmodules` for C++ on Darwin for now, as it is already disabled altogether for Windows and Android due to SDK compatibility issues.

### Modifications:

- on Darwin, condition the passing of `-fmodules` on not building for C++ or Objective-C++
- clean up the logic to avoid repeating this condition in two places, and add an explanatory comment
- adjust unit tests

### Result:

- `-fmodules` and other module-related options are not passed on Darwin when building for C++ or Objective-C++

rdar://83431730
