### PR TITLE
Update command-line interface for .netrc file handling

### DIFF
--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -316,8 +316,8 @@ public struct SwiftToolOptions: ParsableArguments {
     }
     
     /// Tells `Workspace` to attempt to locate .netrc file at `NSHomeDirectory`.
-    @Flag()
-    var netrc: Bool = false
+    @Flag(inversion: .prefixedNo)
+    var netrc: Bool = true
     
     /// Similar to `--netrc`, but this option makes the .netrc usage optional and not mandatory as with the `--netrc` option.
     @Flag(name: .customLong("netrc-optional"))

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -320,7 +320,8 @@ public struct SwiftToolOptions: ParsableArguments {
     var netrc: Bool = true
     
     /// Similar to `--netrc`, but this option makes the .netrc usage optional and not mandatory as with the `--netrc` option.
-    @Flag(name: .customLong("netrc-optional"))
+    @available(*, deprecated, message: ".netrc files are located by default")
+    @Flag(name: .customLong("netrc-optional"), help: .hidden)
     var netrcOptional: Bool = false
     
     /// The path to the netrc file which should be use for authentication when downloading binary target artifacts.

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -315,20 +315,20 @@ public struct SwiftToolOptions: ParsableArguments {
         archs.count > 1 ? .xcode : _buildSystem
     }
     
-    /// Tells `Workspace` to attempt to locate .netrc file at `NSHomeDirectory`.
-    @Flag(inversion: .prefixedNo)
+    /// Whether to load .netrc files for authenticating with remote servers
+    /// when downloading binary artifacts or communicating with a registry.
+    @Flag(inversion: .prefixedNo, help: "Load credentials from a .netrc file")
     var netrc: Bool = true
     
-    /// Similar to `--netrc`, but this option makes the .netrc usage optional and not mandatory as with the `--netrc` option.
     @available(*, deprecated, message: ".netrc files are located by default")
     @Flag(name: .customLong("netrc-optional"), help: .hidden)
     var netrcOptional: Bool = false
     
-    /// The path to the netrc file which should be use for authentication when downloading binary target artifacts.
-    /// Similar to `--netrc`, except that you also provide the path to the actual file to use.
-    /// This is useful when you want to provide the information in another directory or with another file name.
-    ///  - important: Respects `--netrcOptional` option.
-    @Option(name: .customLong("netrc-file"), completion: .file())
+    /// The path to the .netrc file used when `netrc` is `true`.
+    @Option(
+        name: .customLong("netrc-file"),
+        help: "Specify the .netrc file path.",
+        completion: .file())
     var netrcFilePath: AbsolutePath?
     
     public init() {}


### PR DESCRIPTION
This PR updates how `.netrc` file handling behavior is configured in `swift-package` command and its subcommands.

### Motivation:

When resolving dependencies through a registry ([SE-0292](https://github.com/apple/swift-evolution/blob/main/proposals/0292-package-registry-service.md)), users will often need to authenticate with the configured server. Because `.netrc` files are the prescribed way to store and manage credentials, it makes sense for them to be read by default, rather than being opt-in behavior.

### Modifications:

- Default / invert `--netrc` to `true`, such that users instead opt-out with `--no-netrc` 
- Deprecate and hide the `--netrc-optional` flag, such that passing it is a no-op
- Add help messages for the `--netrc` flag and `--netrc-file-path` option

### Result:

Before:

```console
$ swift package
[...]
OPTIONS:
[...]
 --netrc
  --netrc-optional
  --netrc-file <netrc-file>
```

After:

```console
$ swift package
[...]
OPTIONS:
[...]
  --netrc/--no-netrc      Load credentials from a .netrc file (default: true)
  --netrc-file <netrc-file>
                          Specify the .netrc file path. 
```


