### PR TITLE
refactor workspace repository handling

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -154,6 +154,7 @@ let package = Package(
             /** Primitive Package model objects */
             name: "PackageModel",
             dependencies: ["SwiftToolsSupport-auto", "Basics"]),
+
         .target(
             /** Package model conventions and loading support */
             name: "PackageLoading",

--- a/Sources/PackageGraph/CMakeLists.txt
+++ b/Sources/PackageGraph/CMakeLists.txt
@@ -14,7 +14,6 @@ add_library(PackageGraph
   DependencyResolver.swift
   Diagnostics.swift
   GraphLoadingNode.swift
-  LocalPackageContainer.swift
   PackageContainer.swift
   PackageGraph.swift
   PackageGraph+Loading.swift
@@ -27,7 +26,6 @@ add_library(PackageGraph
   Pubgrub/PartialSolution.swift
   Pubgrub/PubgrubDependencyResolver.swift
   Pubgrub/Term.swift
-  RepositoryPackageContainer.swift
   ResolvedPackage.swift
   ResolvedProduct.swift
   ResolvedTarget.swift

--- a/Sources/PackageGraph/CheckoutState.swift
+++ b/Sources/PackageGraph/CheckoutState.swift
@@ -8,9 +8,8 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
-import TSCBasic
-import SourceControl
-import TSCUtility
+import struct SourceControl.Revision // FIXME: remove this dependency
+import struct TSCUtility.Version
 
 /// A checkout state represents the current state of a repository.
 ///

--- a/Sources/PackageGraph/DependencyMirrors.swift
+++ b/Sources/PackageGraph/DependencyMirrors.swift
@@ -9,9 +9,7 @@
 */
 
 import Foundation
-
 import TSCBasic
-import TSCUtility
 
 /// A collection of dependency mirrors.
 public final class DependencyMirrors: Equatable {

--- a/Sources/PackageGraph/GraphLoadingNode.swift
+++ b/Sources/PackageGraph/GraphLoadingNode.swift
@@ -8,10 +8,9 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
-import TSCBasic
 import PackageLoading
 import PackageModel
-import TSCUtility
+import TSCBasic
 
 /// A node used while loading the packages in a resolved graph.
 ///

--- a/Sources/PackageGraph/PackageContainer.swift
+++ b/Sources/PackageGraph/PackageContainer.swift
@@ -9,9 +9,7 @@
  */
 
 import Dispatch
-import PackageLoading
 import PackageModel
-import SourceControl
 import struct TSCUtility.Version
 
 /// A container of packages.
@@ -104,7 +102,7 @@ extension PackageContainer {
     }
 }
 
-// MARK: -
+// MARK: - PackageContainerConstraint
 
 /// An individual constraint onto a container.
 public struct PackageContainerConstraint: Equatable, Hashable {
@@ -139,7 +137,7 @@ extension PackageContainerConstraint: CustomStringConvertible {
     }
 }
 
-// MARK: -
+// MARK: - PackageContainerProvider
 
 /// An interface for resolving package containers.
 public protocol PackageContainerProvider {

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -11,9 +11,7 @@
 import Basics
 import PackageLoading
 import PackageModel
-import SourceControl
 import TSCBasic
-import TSCUtility
 
 extension PackageGraph {
 

--- a/Sources/PackageGraph/PackageGraph.swift
+++ b/Sources/PackageGraph/PackageGraph.swift
@@ -8,8 +8,8 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
-import TSCBasic
 import PackageModel
+import TSCBasic
 
 enum PackageGraphError: Swift.Error {
     /// Indicates a non-root package with no targets.

--- a/Sources/PackageGraph/PackageGraphRoot.swift
+++ b/Sources/PackageGraph/PackageGraphRoot.swift
@@ -10,9 +10,8 @@
 
 import Basics
 import PackageModel
-import SourceControl
 import TSCBasic
-import TSCUtility
+import enum TSCUtility.Git
 
 /// Represents the input to the package graph root.
 public struct PackageGraphRootInput {

--- a/Sources/PackageGraph/PackageModel+Extensions.swift
+++ b/Sources/PackageGraph/PackageModel+Extensions.swift
@@ -9,7 +9,6 @@
 */
 
 import PackageModel
-import SourceControl
 
 extension PackageDependency {
     /// Create the package reference object for the dependency.

--- a/Sources/PackageGraph/PinsStore.swift
+++ b/Sources/PackageGraph/PinsStore.swift
@@ -11,7 +11,7 @@
 import Basics
 import Foundation
 import PackageModel
-import SourceControl
+import struct SourceControl.Revision // FIXME: remove this dependency
 import TSCBasic
 
 public final class PinsStore {

--- a/Sources/PackageGraph/Version+Extensions.swift
+++ b/Sources/PackageGraph/Version+Extensions.swift
@@ -8,7 +8,7 @@ See http://swift.org/LICENSE.txt for license information
 See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import TSCUtility
+import struct TSCUtility.Version
 
 extension Version {
     func nextPatch() -> Version {

--- a/Sources/PackageGraph/VersionSetSpecifier.swift
+++ b/Sources/PackageGraph/VersionSetSpecifier.swift
@@ -8,7 +8,7 @@ See http://swift.org/LICENSE.txt for license information
 See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import TSCUtility
+import struct TSCUtility.Version
 
 /// An abstract definition for a set of versions.
 public enum VersionSetSpecifier: Hashable {

--- a/Sources/PackageLoading/Diagnostics.swift
+++ b/Sources/PackageLoading/Diagnostics.swift
@@ -11,7 +11,6 @@
 import Basics
 import PackageModel
 import TSCBasic
-import TSCUtility
 
 extension Basics.Diagnostic {
     static func targetHasNoSources(targetPath: String, target: String) -> Self {

--- a/Sources/PackageLoading/IdentityResolver.swift
+++ b/Sources/PackageLoading/IdentityResolver.swift
@@ -47,6 +47,8 @@ public struct DefaultIdentityResolver: IdentityResolver {
             return try self.resolveIdentity(for: path)
         case .remoteSourceControl(let url):
             return try self.resolveIdentity(for: url)
+        case .registry(let identity):
+            return identity
         }
     }
 

--- a/Sources/PackageLoading/ManifestJSONParser.swift
+++ b/Sources/PackageLoading/ManifestJSONParser.swift
@@ -11,7 +11,7 @@
 import Basics
 import Foundation
 import PackageModel
-import SourceControl
+import SourceControl // FIXME: remove this dependency
 import TSCBasic
 import TSCUtility
 
@@ -231,6 +231,9 @@ enum ManifestJSONParser {
         case .localSourceControl(let path):
             packagePath = path
         case .remoteSourceControl:
+            // nothing to fix
+            return dependencyLocation
+        case .registry:
             // nothing to fix
             return dependencyLocation
         }

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -9,11 +9,12 @@
 */
 
 import Basics
-import TSCBasic
-import PackageModel
-import TSCUtility
 import Foundation
-public typealias FileSystem = TSCBasic.FileSystem
+import PackageModel
+import TSCBasic
+import struct TSCUtility.Triple
+import enum TSCUtility.Diagnostics
+import var TSCUtility.verbosity
 
 public enum ManifestParseError: Swift.Error, Equatable {
     /// The manifest contains invalid format.

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -12,7 +12,7 @@ import Basics
 import Dispatch
 import PackageModel
 import TSCBasic
-import TSCUtility
+//import TSCUtility
 
 /// An error in the structure or layout of a package.
 public enum ModuleError: Swift.Error {

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -12,7 +12,6 @@ import Basics
 import Dispatch
 import PackageModel
 import TSCBasic
-//import TSCUtility
 
 /// An error in the structure or layout of a package.
 public enum ModuleError: Swift.Error {

--- a/Sources/PackageLoading/Target+PkgConfig.swift
+++ b/Sources/PackageLoading/Target+PkgConfig.swift
@@ -9,8 +9,8 @@
 */
 
 import Basics
-import TSCBasic
 import PackageModel
+import TSCBasic
 import TSCUtility
 
 /// Wrapper struct containing result of a pkgConfig query.

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -12,7 +12,6 @@ import Basics
 import Foundation
 import PackageModel
 import TSCBasic
-//import TSCUtility
 
 /// A utility to compute the source/resource files of a target.
 public struct TargetSourcesBuilder {

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -12,7 +12,7 @@ import Basics
 import Foundation
 import PackageModel
 import TSCBasic
-import TSCUtility
+//import TSCUtility
 
 /// A utility to compute the source/resource files of a target.
 public struct TargetSourcesBuilder {

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -12,7 +12,6 @@ import Basics
 import Foundation
 import PackageModel
 import TSCBasic
-//import TSCUtility
 
 /// Protocol for the manifest loader interface.
 public protocol ToolsVersionLoaderProtocol {

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -12,7 +12,7 @@ import Basics
 import Foundation
 import PackageModel
 import TSCBasic
-import TSCUtility
+//import TSCUtility
 
 /// Protocol for the manifest loader interface.
 public protocol ToolsVersionLoaderProtocol {

--- a/Sources/PackageModel/PackageReference.swift
+++ b/Sources/PackageModel/PackageReference.swift
@@ -16,7 +16,7 @@ import TSCUtility
 /// A package reference.
 ///
 /// This represents a reference to a package containing its identity and location.
-public struct PackageReference: Encodable {
+public struct PackageReference {
     /// The kind of package reference.
     public enum Kind: Equatable {
         /// A root package.
@@ -31,6 +31,9 @@ public struct PackageReference: Encodable {
         /// A remote source package.
         case remoteSourceControl(Foundation.URL)
 
+        /// A package from  a registry.
+        case registry(PackageIdentity)
+
         // FIXME: we should not need this
         //@available(*, deprecated)
         public var locationString: String {
@@ -43,6 +46,9 @@ public struct PackageReference: Encodable {
                 return path.pathString
             case .remoteSourceControl(let url):
                 return url.absoluteString
+            case .registry(let identity):
+                // FIXME: this is a placeholder
+                return identity.description
             }
         }
 
@@ -75,7 +81,7 @@ public struct PackageReference: Encodable {
     /// The kind of package: root, local, or remote.
     public let kind: Kind
 
-    /// Create a package reference given its identity and repository.
+    /// Create a package reference given its identity and kind.
     public init(identity: PackageIdentity, kind: Kind, name: String? = nil) {
         self.identity = identity
         self.kind = kind
@@ -88,6 +94,9 @@ public struct PackageReference: Encodable {
             self.name = name ?? LegacyPackageIdentity.computeDefaultName(fromPath: path)
         case .remoteSourceControl(let url):
             self.name = name ?? LegacyPackageIdentity.computeDefaultName(fromURL: url)
+        case .registry(let identity):
+            // FIXME: this is a placeholder
+            self.name = name ?? identity.description
         }
     }
 
@@ -104,13 +113,16 @@ public struct PackageReference: Encodable {
         PackageReference(identity: identity, kind: .fileSystem(path))
     }
 
-
     public static func localSourceControl(identity: PackageIdentity, path: AbsolutePath) -> PackageReference {
         PackageReference(identity: identity, kind: .localSourceControl(path))
     }
 
     public static func remoteSourceControl(identity: PackageIdentity, url: Foundation.URL) -> PackageReference {
         PackageReference(identity: identity, kind: .remoteSourceControl(url))
+    }
+
+    public static func registry(identity: PackageIdentity) -> PackageReference {
+        PackageReference(identity: identity, kind: .registry(identity))
     }
 }
 
@@ -136,7 +148,7 @@ extension PackageReference: CustomStringConvertible {
 
 extension PackageReference.Kind: Encodable {
     private enum CodingKeys: String, CodingKey {
-        case root, fileSystem, localSourceControl, remoteSourceControl
+        case root, fileSystem, localSourceControl, remoteSourceControl,registry
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -154,6 +166,9 @@ extension PackageReference.Kind: Encodable {
         case .remoteSourceControl(let url):
             var unkeyedContainer = container.nestedUnkeyedContainer(forKey: .remoteSourceControl)
             try unkeyedContainer.encode(url)
+        case .registry:
+            var unkeyedContainer = container.nestedUnkeyedContainer(forKey: .registry)
+            try unkeyedContainer.encode(self.isRoot)
         }
     }
 }

--- a/Sources/PackageModel/PackageReference.swift
+++ b/Sources/PackageModel/PackageReference.swift
@@ -6,7 +6,7 @@
 
  See http://swift.org/LICENSE.txt for license information
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
-*/
+ */
 
 import Basics
 import Foundation
@@ -148,7 +148,7 @@ extension PackageReference: CustomStringConvertible {
 
 extension PackageReference.Kind: Encodable {
     private enum CodingKeys: String, CodingKey {
-        case root, fileSystem, localSourceControl, remoteSourceControl,registry
+        case root, fileSystem, localSourceControl, remoteSourceControl, registry
     }
 
     public func encode(to encoder: Encoder) throws {

--- a/Sources/SPMTestSupport/MockManifestLoader.swift
+++ b/Sources/SPMTestSupport/MockManifestLoader.swift
@@ -8,15 +8,14 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import func XCTest.XCTFail
-import Dispatch
-
 import Basics
-import TSCBasic
+import Dispatch
 import PackageModel
 import PackageLoading
 import PackageGraph
+import TSCBasic
 import TSCUtility
+import func XCTest.XCTFail
 
 public enum MockManifestLoaderError: Swift.Error {
     case unknownRequest(String)
@@ -82,7 +81,7 @@ extension ManifestLoader {
         packageKind: PackageModel.PackageReference.Kind,
         toolsVersion: PackageModel.ToolsVersion,
         identityResolver: IdentityResolver = DefaultIdentityResolver(),
-        fileSystem: PackageLoading.FileSystem,
+        fileSystem: TSCBasic.FileSystem,
         diagnostics: TSCBasic.DiagnosticsEngine? = nil
     ) throws -> Manifest{
         let packageIdentity: PackageIdentity
@@ -100,6 +99,10 @@ extension ManifestLoader {
         case .remoteSourceControl(let url):
             packageIdentity = try identityResolver.resolveIdentity(for: url)
             packageLocation = url.absoluteString
+        case .registry(let identity):
+            packageIdentity = identity
+            // FIXME: placeholder
+            packageLocation = identity.description
         }
         return try tsc_await {
             self.load(at: path,

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -777,6 +777,8 @@ extension PackageReference.Kind {
             return "localSourceControl"
         case .remoteSourceControl:
             return "remoteSourceControl"
+        case .registry:
+            return "registry"
         }
     }
 }

--- a/Sources/Workspace/CMakeLists.txt
+++ b/Sources/Workspace/CMakeLists.txt
@@ -10,11 +10,13 @@ add_library(Workspace
   DefaultPluginScriptRunner.swift
   Destination.swift
   Diagnostics.swift
+  FileSystemPackageContainer.swift
   InitPackage.swift
   ManagedArtifact.swift
   ManagedDependency.swift
   ResolvedFileWatcher.swift
   ResolverPrecomputationProvider.swift
+  SourceControlPackageContainer.swift
   ToolsVersionSpecificationRewriter.swift
   UserToolchain.swift
   Workspace.swift

--- a/Sources/Workspace/FileSystemPackageContainer.swift
+++ b/Sources/Workspace/FileSystemPackageContainer.swift
@@ -8,22 +8,20 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Dispatch
-
 import Basics
-import TSCBasic
+import Dispatch
+import PackageGraph
 import PackageLoading
 import PackageModel
-import SourceControl
-import TSCUtility
+import TSCBasic
 
-/// Local package container.
+/// Local file system package container.
 ///
 /// This class represent packages that are referenced locally in the file system.
 /// There is no need to perform any git operations on such packages and they
 /// should be used as-is. In fact, they might not even have a git repository.
 /// Examples: Root packages, local dependencies, edited packages.
-public final class LocalPackageContainer: PackageContainer {
+internal struct FileSystemPackageContainer: PackageContainer {
     public let package: PackageReference
     private let identityResolver: IdentityResolver
     private let manifestLoader: ManifestLoaderProtocol
@@ -129,8 +127,8 @@ public final class LocalPackageContainer: PackageContainer {
     }
 }
 
-extension LocalPackageContainer: CustomStringConvertible  {
+extension FileSystemPackageContainer: CustomStringConvertible  {
     public var description: String {
-        return "LocalPackageContainer(\(self.package.identity))"
+        return "FileSystemPackageContainer(\(self.package.identity))"
     }
 }

--- a/Sources/Workspace/SourceControlPackageContainer.swift
+++ b/Sources/Workspace/SourceControlPackageContainer.swift
@@ -71,7 +71,7 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
     /// valid or not.
     internal var validToolsVersionsCache = ThreadSafeKeyValueStore<Version, Bool>()
 
-    public init(
+    init(
         package: PackageReference,
         identityResolver: IdentityResolver,
         repositorySpecifier: RepositorySpecifier,
@@ -376,19 +376,6 @@ fileprivate extension Git {
             return versionSpecificKnownVersions
         } else {
             return knownVersions
-        }
-    }
-}
-
-fileprivate extension PackageReference {
-    func makeRepositorySpecifier() throws -> RepositorySpecifier {
-        switch self.kind {
-        case .localSourceControl(let path):
-            return .init(path: path)
-        case .remoteSourceControl(let url):
-            return .init(url: url)
-        default:
-            throw StringError("invalid dependency kind \(self.kind)")
         }
     }
 }

--- a/Sources/Workspace/SourceControlPackageContainer.swift
+++ b/Sources/Workspace/SourceControlPackageContainer.swift
@@ -8,21 +8,17 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Dispatch
 import Basics
-import TSCBasic
+import Dispatch
+import PackageGraph
 import PackageLoading
 import PackageModel
 import SourceControl
+import TSCBasic
 import TSCUtility
 
-enum RepositoryPackageResolutionError: Swift.Error {
-    /// A requested repository could not be cloned.
-    case unavailableRepository
-}
-
 /// Adaptor to expose an individual repository as a package container.
-public class RepositoryPackageContainer: PackageContainer, CustomStringConvertible {
+internal final class SourceControlPackageContainer: PackageContainer, CustomStringConvertible {
     public typealias Constraint = PackageContainerConstraint
 
     // A wrapper for getDependencies() errors. This adds additional information
@@ -37,14 +33,14 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
 
         /// The actual error that occurred.
         public let underlyingError: Error
-        
+
         /// Optional suggestion for how to resolve the error.
         public let suggestion: String?
-        
+
         public var diagnosticLocation: DiagnosticLocation? {
             return PackageLocation.Remote(url: self.url, reference: self.reference)
         }
-        
+
         /// Description shown for errors of this kind.
         public var description: String {
             var desc = "\(underlyingError) in \(self.url)"
@@ -75,9 +71,10 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
     /// valid or not.
     internal var validToolsVersionsCache = ThreadSafeKeyValueStore<Version, Bool>()
 
-    init(
+    public init(
         package: PackageReference,
         identityResolver: IdentityResolver,
+        repositorySpecifier: RepositorySpecifier,
         repository: Repository,
         manifestLoader: ManifestLoaderProtocol,
         toolsVersionLoader: ToolsVersionLoaderProtocol,
@@ -85,16 +82,13 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
     ) throws {
         self.package = package
         self.identityResolver = identityResolver
-        guard let repositorySpecifier = package.repositorySpecifier else {
-            throw InternalError("invalid package type \(package.kind)")
-        }
         self.repositorySpecifier = repositorySpecifier
         self.repository = repository
         self.manifestLoader = manifestLoader
         self.toolsVersionLoader = toolsVersionLoader
         self.currentToolsVersion = currentToolsVersion
     }
-    
+
     // Compute the map of known versions.
     private func knownVersions() throws -> [Version: String] {
         try self.knownVersionsCache.memoize() {
@@ -103,7 +97,7 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
             return knownVersionsWithDuplicates.mapValues({ tags -> String in
                 if tags.count > 1 {
                     // FIXME: Warn if the two tags point to different git references.
-                    
+
                     // If multiple tags are present with the same semantic version (e.g. v1.0.0, 1.0.0, 1.0) reconcile which one we prefer.
                     // Prefer the most specific tag, e.g. 1.0.0 is preferred over 1.0.
                     // Sort the tags so the most specific tag is first, order is ascending so the most specific tag will be last
@@ -128,7 +122,7 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
     public func versionsAscending() throws -> [Version] {
         [Version](try self.knownVersions().keys).sorted()
     }
-    
+
     /// The available version list (in reverse order).
     public func toolsVersionsAppropriateVersionsDescending() throws -> [Version] {
         let reversedVersions = try self.versionsDescending()
@@ -350,97 +344,11 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
     }
 
     public var description: String {
-        return "RepositoryPackageContainer(\(self.package.location))"
+        return "SourceControlPackageContainer(\(self.package.location))"
     }
 }
 
-/// Adaptor for exposing repositories as PackageContainerProvider instances.
-///
-/// This is the root class for bridging the manifest & SCM systems into the
-/// interfaces used by the `DependencyResolver` algorithm.
-public class RepositoryPackageContainerProvider: PackageContainerProvider {
-    let fileSystem: FileSystem
-    let repositoryManager: RepositoryManager
-    let manifestLoader: ManifestLoaderProtocol
-    let identityResolver: IdentityResolver
-
-    /// The tools version currently in use. Only the container versions less than and equal to this will be provided by
-    /// the container.
-    let currentToolsVersion: ToolsVersion
-
-    /// The tools version loader.
-    let toolsVersionLoader: ToolsVersionLoaderProtocol
-
-    /// Create a repository-based package provider.
-    ///
-    /// - Parameters:
-    ///   - repositoryManager: The repository manager responsible for providing repositories.
-    ///   - manifestLoader: The manifest loader instance.
-    ///   - currentToolsVersion: The current tools version in use.
-    ///   - toolsVersionLoader: The tools version loader.
-    public init(
-        fileSystem: FileSystem,
-        repositoryManager: RepositoryManager,
-        identityResolver: IdentityResolver,
-        manifestLoader: ManifestLoaderProtocol,
-        currentToolsVersion: ToolsVersion = ToolsVersion.currentToolsVersion,
-        toolsVersionLoader: ToolsVersionLoaderProtocol = ToolsVersionLoader()
-    ) {
-        self.fileSystem = fileSystem
-        self.repositoryManager = repositoryManager
-        self.identityResolver = identityResolver
-        self.manifestLoader = manifestLoader
-        self.currentToolsVersion = currentToolsVersion
-        self.toolsVersionLoader = toolsVersionLoader
-    }
-
-    public func getContainer(
-        for package: PackageReference,
-        skipUpdate: Bool,
-        on queue: DispatchQueue,
-        completion: @escaping (Result<PackageContainer, Swift.Error>) -> Void
-    ) {
-        if let repositorySpecifier = package.repositorySpecifier {
-            // Resolve the container using the repository manager.
-            repositoryManager.lookup(repository: repositorySpecifier, skipUpdate: skipUpdate, on: queue) { result in
-                queue.async {
-                    // Create the container wrapper.
-                    let result = result.tryMap { handle -> PackageContainer in
-                        // Open the repository.
-                        //
-                        // FIXME: Do we care about holding this open for the lifetime of the container.
-                        let repository = try handle.open()
-                        return try RepositoryPackageContainer(
-                            package: package,
-                            identityResolver: self.identityResolver,
-                            repository: repository,
-                            manifestLoader: self.manifestLoader,
-                            toolsVersionLoader: self.toolsVersionLoader,
-                            currentToolsVersion: self.currentToolsVersion
-                        )
-                    }
-                    completion(result)
-                }
-            }
-        } else  {
-            // If the container is local, just create and return a local package container.
-            do {
-                let container = try LocalPackageContainer(
-                    package: package,
-                    identityResolver: self.identityResolver,
-                    manifestLoader: self.manifestLoader,
-                    toolsVersionLoader: self.toolsVersionLoader,
-                    currentToolsVersion: self.currentToolsVersion,
-                    fileSystem: self.fileSystem)
-                completion(.success(container))
-            } catch {
-                completion(.failure(error))
-            }
-        }
-    }
-}
-
-extension Git {
+fileprivate extension Git {
     static func convertTagsToVersionMap(_ tags: [String]) -> [Version: [String]] {
         // First, check if we need to restrict the tag set to version-specific tags.
         var knownVersions: [Version: [String]] = [:]
@@ -472,17 +380,15 @@ extension Git {
     }
 }
 
-private extension PackageReference {
-    var repositorySpecifier: RepositorySpecifier? {
+fileprivate extension PackageReference {
+    func makeRepositorySpecifier() throws -> RepositorySpecifier {
         switch self.kind {
-        case .root:
-            return .none
-        case .fileSystem:
-            return .none
         case .localSourceControl(let path):
             return .init(path: path)
         case .remoteSourceControl(let url):
             return .init(url: url)
+        default:
+            throw StringError("invalid dependency kind \(self.kind)")
         }
     }
 }

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -2819,7 +2819,7 @@ extension Workspace: PackageContainerProvider {
         case .localSourceControl, .remoteSourceControl:
             return try self.checkoutRepository(package: package, at: checkoutState)
         case .registry:
-            fatalError("registry dependencies are supported at this point")
+            fatalError("registry dependencies are not supported at this point")
         }
     }
 
@@ -2868,11 +2868,13 @@ extension Workspace: PackageContainerProvider {
 
         switch package.kind {
         case .root, .fileSystem:
-            fatalError("local dependencies are supported")
-        case .localSourceControl, .remoteSourceControl:
+            break // NOOP
+        case .localSourceControl:
+            break // NOOP
+        case .remoteSourceControl:
             try self.removeRepository(dependency: dependencyToRemove)
         case .registry:
-            fatalError("registry dependencies are supported at this point")
+            fatalError("registry dependencies are not supported at this point")
         }
 
         // Save the state.

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -2802,7 +2802,7 @@ extension Workspace: PackageContainerProvider {
                 }
             }
         case .registry:
-            fatalError("registry dependencies are supported at this point")
+            fatalError("registry dependencies are not supported at this point")
         }
     }
 

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -3045,7 +3045,7 @@ fileprivate extension DiagnosticsEngine {
     }
 }
 
-fileprivate extension PackageReference {
+internal extension PackageReference {
     func makeRepositorySpecifier() throws -> RepositorySpecifier {
         switch self.kind {
         case .localSourceControl(let path):

--- a/Sources/Workspace/WorkspaceState.swift
+++ b/Sources/Workspace/WorkspaceState.swift
@@ -354,6 +354,10 @@ fileprivate struct WorkspaceStateStorage {
                 case .remoteSourceControl(let url):
                     self.kind = .remoteSourceControl
                     self.location = url.absoluteString
+                case .registry:
+                    self.kind = .registry
+                    // FIXME: placeholder
+                    self.location = self.identity.description
                 }
                 self.name = reference.name
             }
@@ -363,6 +367,7 @@ fileprivate struct WorkspaceStateStorage {
                 case fileSystem
                 case localSourceControl
                 case remoteSourceControl
+                case registry
             }
         }
     }
@@ -391,6 +396,7 @@ extension Workspace.ManagedArtifact {
 
 extension PackageModel.PackageReference {
     fileprivate init(_ reference: WorkspaceStateStorage.V4.PackageReference) throws {
+        let identity = PackageIdentity.plain(reference.identity)
         let kind: PackageModel.PackageReference.Kind
         switch reference.kind {
         case .root:
@@ -404,10 +410,12 @@ extension PackageModel.PackageReference {
                 throw StringError("invalid url \(reference.location)")
             }
             kind = .remoteSourceControl(url)
+        case .registry:
+            kind = .registry(identity)
         }
 
         self.init(
-            identity: .plain(reference.identity),
+            identity: identity,
             kind: kind,
             name: reference.name
         )

--- a/Tests/PackageLoadingTests/PDLoadingTests.swift
+++ b/Tests/PackageLoadingTests/PDLoadingTests.swift
@@ -57,7 +57,7 @@ class PackageDescriptionLoadingTests: XCTestCase {
             packagePath = path
         case .localSourceControl(let path):
             packagePath = path
-        case .remoteSourceControl:
+        case .remoteSourceControl, .registry:
             throw InternalError("invalid package kind \(packageKind)")
         }
 
@@ -210,7 +210,7 @@ class PackageDescriptionLoadingTests: XCTestCase {
             packagePath = path
         case .localSourceControl(let path):
             packagePath = path
-        case .remoteSourceControl:
+        case .remoteSourceControl, .registry:
             throw InternalError("invalid package kind \(packageKind)")
         }
 


### PR DESCRIPTION
motivation: make supporting registry depedencies easier

changes:
* rename LocalPackageContainer to FileSystemPackageContainer and move it to workspace module as internal struct
* rename RepositoryPackageContainer to SourceControlPackageContainer and move it to the workspace module as internal class
* remove RepositoryPackageContainerProvider and move its logic to workspace itself, including the logic to switch over dependecy type (local/remote) and providing the correct container type
* conform workspace to PackageContainerProvider and change getContiner call-sites to use it
* reorgnize repository related methods in a consistent manner so its easier to read the code that deals with repositories
* adjust call sites and tests

rdar://81621441