### PR TITLE
Consolidate pkgConfig diagnostics

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -1978,16 +1978,6 @@ public class BuildPlan {
         let results = pkgConfigArgs(for: target, diagnostics: diagnostics)
         var ret: [(cFlags: [String], libs: [String])] = []
         for result in results {
-            // If there is no pc file on system and we have an available provider, emit a warning.
-            if let provider = result.provider, result.couldNotFindConfigFile {
-                diagnostics.emit(.pkgConfigHint(pkgConfigName: result.pkgConfigName, installText: provider.installText))
-            } else if let error = result.error {
-                diagnostics.emit(
-                        .warning("\(error)"),
-                        location: PkgConfigDiagnosticLocation(pcFile: result.pkgConfigName, target: target.name)
-                )
-            }
-
             ret.append((result.cFlags, result.libs))
         }
 
@@ -2043,10 +2033,6 @@ private extension Diagnostic.Message {
             or the product '\(product)' to require \
             \(targetPlatform.platform.name) \(targetPlatform.version.versionString) or earlier.
             """)
-    }
-
-    static func pkgConfigHint(pkgConfigName: String, installText: String) -> Diagnostic.Message {
-        .warning("you may be able to install \(pkgConfigName) using your system-packager:\n\(installText)")
     }
 
     static func binaryTargetsNotSupported() -> Diagnostic.Message {

--- a/Sources/PackageLoading/Target+PkgConfig.swift
+++ b/Sources/PackageLoading/Target+PkgConfig.swift
@@ -67,6 +67,7 @@ public func pkgConfigArgs(for target: SystemLibraryTarget, diagnostics: Diagnost
    var ret: [PkgConfigResult] = []
     // Get the pkg config flags.
     for pkgConfigName in pkgConfigNames.components(separatedBy: " ") {
+        let result: PkgConfigResult
         do {
             let pkgConfig = try PkgConfig(
                     name: pkgConfigName,
@@ -87,16 +88,28 @@ public func pkgConfigArgs(for target: SystemLibraryTarget, diagnostics: Diagnost
                 error = PkgConfigError.prohibitedFlags(filtered.unallowed.joined(separator: ", "))
             }
 
-            ret.append(PkgConfigResult(
+            result = PkgConfigResult(
                     pkgConfigName: pkgConfigName,
                     cFlags: cFlags,
                     libs: libs,
                     error: error,
                     provider: provider
-            ))
+            )
         } catch {
-            ret.append(PkgConfigResult(pkgConfigName: pkgConfigName, error: error, provider: provider))
+            result = PkgConfigResult(pkgConfigName: pkgConfigName, error: error, provider: provider)
         }
+
+        // If there is no pc file on system and we have an available provider, emit a warning.
+        if let provider = result.provider, result.couldNotFindConfigFile {
+            diagnostics.emit(.warning("you may be able to install \(result.pkgConfigName) using your system-packager:\n\(provider.installText)"))
+        } else if let error = result.error {
+            diagnostics.emit(
+                    .warning("\(error)"),
+                    location: PkgConfigDiagnosticLocation(pcFile: result.pkgConfigName, target: target.name)
+            )
+        }
+
+        ret.append(result)
     }
     return ret
 }


### PR DESCRIPTION
It makes more sense to emit all pkgConfig related diagnostics as part of `pkgConfigArgs(for:)` so that clients of libSwiftPM won't have to duplicate them.
