### PR TITLE
Add keychain auth provider

### DIFF
--- a/Sources/Basics/AuthorizationProvider.swift
+++ b/Sources/Basics/AuthorizationProvider.swift
@@ -67,7 +67,7 @@ public struct NetrcAuthorizationProvider: AuthorizationProvider {
     public init(path: AbsolutePath, fileSystem: FileSystem) throws {
         self.path = path
         self.fileSystem = fileSystem
-        self.underlying = try Self.loadFromDisk(path: path)
+        self.underlying = try Self.load(from: path)
     }
     
     public mutating func addOrUpdate(for url: Foundation.URL, user: String, password: String, callback: @escaping (Result<Void, Error>) -> Void) {
@@ -97,7 +97,7 @@ public struct NetrcAuthorizationProvider: AuthorizationProvider {
         do {
             try self.saveToDisk(machines: machines)
             // At this point the netrc file should exist and non-empty
-            guard let netrc = try Self.loadFromDisk(path: self.path) else {
+            guard let netrc = try Self.load(from: self.path) else {
                 throw AuthorizationProviderError.other("Failed to update netrc file at \(self.path)")
             }
             self.underlying = netrc
@@ -135,7 +135,7 @@ public struct NetrcAuthorizationProvider: AuthorizationProvider {
         }
     }
     
-    private static func loadFromDisk(path: AbsolutePath) throws -> TSCUtility.Netrc? {
+    private static func load(from path: AbsolutePath) throws -> TSCUtility.Netrc? {
         do {
             return try TSCUtility.Netrc.load(fromFileAtPath: path).get()
         } catch {

--- a/Sources/Basics/AuthorizationProvider.swift
+++ b/Sources/Basics/AuthorizationProvider.swift
@@ -269,8 +269,10 @@ public struct CompositeAuthorizationProvider: AuthorizationProvider {
                 switch provider {
                 case let provider as NetrcAuthorizationProvider:
                     ObservabilitySystem.topScope.emit(info: "Credentials for \(url) found in netrc file at \(provider.path)")
+#if canImport(Security)
                 case is KeychainAuthorizationProvider:
                     ObservabilitySystem.topScope.emit(info: "Credentials for \(url) found in keychain")
+#endif
                 default:
                     ObservabilitySystem.topScope.emit(info: "Credentials for \(url) found in \(provider)")
                 }

--- a/Sources/Basics/AuthorizationProvider.swift
+++ b/Sources/Basics/AuthorizationProvider.swift
@@ -1,19 +1,37 @@
 /*
  This source file is part of the Swift.org open source project
+
  Copyright (c) 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
+
  See http://swift.org/LICENSE.txt for license information
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
-import Foundation
+import struct Foundation.Data
+import struct Foundation.URL
+#if os(macOS)
+import Security
+#endif
+
+import TSCBasic
+import TSCUtility
 
 public protocol AuthorizationProvider {
-    func authentication(for url: URL) -> (user: String, password: String)?
+    mutating func addOrUpdate(for url: Foundation.URL, user: String, password: String, callback: @escaping (Result<Void, Error>) -> Void)
+    
+    func authentication(for url: Foundation.URL) -> (user: String, password: String)?
+}
+
+public enum AuthorizationProviderError: Error {
+    case noURLHost
+    case notFound
+    case unexpectedPasswordData
+    case unexpectedError(String)
 }
 
 extension AuthorizationProvider {
-    public func httpAuthorizationHeader(for url: URL) -> String? {
+    public func httpAuthorizationHeader(for url: Foundation.URL) -> String? {
         guard let (user, password) = self.authentication(for: url) else {
             return nil
         }
@@ -24,3 +42,224 @@ extension AuthorizationProvider {
         return "Basic \(authData.base64EncodedString())"
     }
 }
+
+// MARK: - netrc
+
+public struct NetrcAuthorizationProvider: AuthorizationProvider {
+    private let path: AbsolutePath
+    private let fileSystem: FileSystem
+    
+    private var underlying: TSCUtility.Netrc?
+    
+    private var machines: [TSCUtility.Netrc.Machine] {
+        self.underlying?.machines ?? []
+    }
+
+    public init(path: AbsolutePath, fileSystem: FileSystem) throws {
+        self.path = path
+        self.fileSystem = fileSystem
+        self.underlying = try Self.loadFromDisk(path: path)
+    }
+    
+    public mutating func addOrUpdate(for url: Foundation.URL, user: String, password: String, callback: @escaping (Result<Void, Error>) -> Void) {
+        guard let machineName = self.machineName(for: url) else {
+            return callback(.failure(AuthorizationProviderError.noURLHost))
+        }
+        let machine = TSCUtility.Netrc.Machine(name: machineName, login: user, password: password)
+        
+        var machines = [TSCUtility.Netrc.Machine]()
+        var hasExisting = false
+        
+        self.machines.forEach {
+            if $0.name.lowercased() != machineName {
+                machines.append($0)
+            } else if !hasExisting {
+                // Update existing entry and retain one copy only
+                machines.append(machine)
+                hasExisting = true
+            }
+        }
+        
+        // New entry
+        if !hasExisting {
+            machines.append(machine)
+        }
+        
+        do {
+            try self.saveToDisk(machines: machines)
+            // At this point the netrc file should exist and non-empty
+            guard let netrc = try Self.loadFromDisk(path: self.path) else {
+                throw AuthorizationProviderError.unexpectedError("Failed to update netrc file at \(self.path)")
+            }
+            self.underlying = netrc
+            callback(.success(()))
+        } catch {
+            callback(.failure(AuthorizationProviderError.unexpectedError("Failed to update netrc file at \(self.path): \(error)")))
+        }
+    }
+
+    public func authentication(for url: Foundation.URL) -> (user: String, password: String)? {
+        self.machine(for: url).map { (user: $0.login, password: $0.password) }
+    }
+    
+    private func machineName(for url: Foundation.URL) -> String? {
+        url.host?.lowercased()
+    }
+
+    private func machine(for url: Foundation.URL) -> TSCUtility.Netrc.Machine? {
+        if let machineName = self.machineName(for: url), let machine = self.machines.first(where: { $0.name.lowercased() == machineName }) {
+            return machine
+        }
+        if let machine = self.machines.first(where: { $0.isDefault }) {
+            return machine
+        }
+        return .none
+    }
+    
+    private func saveToDisk(machines: [TSCUtility.Netrc.Machine]) throws {
+        try self.fileSystem.withLock(on: self.path, type: .exclusive) {
+            try self.fileSystem.writeFileContents(self.path) { stream in
+                machines.forEach {
+                    stream.write("machine \($0.name) login \($0.login) password \($0.password)\n")
+                }
+            }
+        }
+    }
+    
+    private static func loadFromDisk(path: AbsolutePath) throws -> TSCUtility.Netrc? {
+        do {
+            return try TSCUtility.Netrc.load(fromFileAtPath: path).get()
+        } catch {
+            switch error {
+            case Netrc.Error.fileNotFound, Netrc.Error.machineNotFound:
+                // These are recoverable errors. We will just create the file and append entry to it.
+                return nil
+            default:
+                throw error
+            }
+        }
+    }
+}
+
+// MARK: - Keychain
+
+#if os(macOS)
+public struct KeychainAuthorizationProvider: AuthorizationProvider {
+    public init() {}
+    
+    public func addOrUpdate(for url: Foundation.URL, user: String, password: String, callback: @escaping (Result<Void, Error>) -> Void) {
+        guard let server = self.server(for: url) else {
+            return callback(.failure(AuthorizationProviderError.noURLHost))
+        }
+        guard let passwordData = password.data(using: .utf8) else {
+            return callback(.failure(AuthorizationProviderError.unexpectedPasswordData))
+        }
+        let `protocol` = self.`protocol`(for: url)
+        
+        do {
+            try self.update(server: server, protocol: `protocol`, account: user, password: passwordData)
+            callback(.success(()))
+        } catch AuthorizationProviderError.notFound {
+            do {
+                try self.create(server: server, protocol: `protocol`, account: user, password: passwordData)
+                callback(.success(()))
+            } catch {
+                callback(.failure(error))
+            }
+        } catch {
+            callback(.failure(error))
+        }
+    }
+    
+    public func authentication(for url: Foundation.URL) -> (user: String, password: String)? {
+        guard let server = self.server(for: url) else {
+            return nil
+        }
+        
+        do {
+            guard let existingItem = try self.search(server: server, protocol: self.`protocol`(for: url)) as? [String : Any],
+                  let passwordData = existingItem[kSecValueData as String] as? Data,
+                  let password = String(data: passwordData, encoding: String.Encoding.utf8),
+                  let account = existingItem[kSecAttrAccount as String] as? String else {
+                throw AuthorizationProviderError.unexpectedError("Failed to extract credentials for server \(server) from keychain")
+            }
+            return (user: account, password: password)
+        } catch {
+            switch error {
+            case AuthorizationProviderError.notFound:
+                ObservabilitySystem.topScope.emit(info: "No credentials found for server \(server) in keychain")
+            case AuthorizationProviderError.unexpectedError(let detail):
+                ObservabilitySystem.topScope.emit(error: detail)
+            default:
+                ObservabilitySystem.topScope.emit(error: "Failed to find credentials for server \(server) in keychain: \(error)")
+            }
+            return nil
+        }
+    }
+    
+    private func create(server: String, `protocol`: CFString, account: String, password: Data) throws {
+        let query: [String: Any] = [kSecClass as String: kSecClassInternetPassword,
+                                    kSecAttrServer as String: server,
+                                    kSecAttrProtocol as String: `protocol`,
+                                    kSecAttrAccount as String: account,
+                                    kSecValueData as String: password]
+        
+        let status = SecItemAdd(query as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            throw AuthorizationProviderError.unexpectedError("Failed to save credentials for server \(server) to keychain: status \(status)")
+        }
+    }
+    
+    private func update(server: String, `protocol`: CFString, account: String, password: Data) throws {
+        let query: [String: Any] = [kSecClass as String: kSecClassInternetPassword,
+                                    kSecAttrServer as String: server,
+                                    kSecAttrProtocol as String: `protocol`]
+        let attributes: [String: Any] = [kSecAttrAccount as String: account,
+                                         kSecValueData as String: password]
+        
+        let status = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+        guard status != errSecItemNotFound else {
+            throw AuthorizationProviderError.notFound
+        }
+        guard status == errSecSuccess else {
+            throw AuthorizationProviderError.unexpectedError("Failed to update credentials for server \(server) in keychain: status \(status)")
+        }
+    }
+    
+    private func search(server: String, `protocol`: CFString) throws -> CFTypeRef? {
+        let query: [String: Any] = [kSecClass as String: kSecClassInternetPassword,
+                                    kSecAttrServer as String: server,
+                                    kSecAttrProtocol as String: `protocol`,
+                                    kSecMatchLimit as String: kSecMatchLimitOne,
+                                    kSecReturnAttributes as String: true,
+                                    kSecReturnData as String: true]
+        
+        var item: CFTypeRef?
+        // Search keychain for server's username and password, if any.
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status != errSecItemNotFound else {
+            throw AuthorizationProviderError.notFound
+        }
+        guard status == errSecSuccess else {
+            throw AuthorizationProviderError.unexpectedError("Failed to find credentials for server \(server) in keychain: status \(status)")
+        }
+        
+        return item
+    }
+    
+    private func server(for url: Foundation.URL) -> String? {
+        url.host?.lowercased()
+    }
+    
+    private func `protocol`(for url: Foundation.URL) -> CFString {
+        // See https://developer.apple.com/documentation/security/keychain_services/keychain_items/item_attribute_keys_and_values?language=swift
+        // for a list of possible values for the `kSecAttrProtocol` attribute.
+        switch url.scheme?.lowercased() {
+        case "https":
+            return kSecAttrProtocolHTTPS
+        default:
+            return kSecAttrProtocolHTTPS
+        }
+    }
+}
+#endif

--- a/Sources/Basics/AuthorizationProvider.swift
+++ b/Sources/Basics/AuthorizationProvider.swift
@@ -10,7 +10,7 @@
 
 import struct Foundation.Data
 import struct Foundation.URL
-#if os(macOS)
+#if canImport(Security)
 import Security
 #endif
 
@@ -143,7 +143,7 @@ public struct NetrcAuthorizationProvider: AuthorizationProvider {
 
 // MARK: - Keychain
 
-#if os(macOS)
+#if canImport(Security)
 public struct KeychainAuthorizationProvider: AuthorizationProvider {
     public init() {}
     

--- a/Sources/Basics/AuthorizationProvider.swift
+++ b/Sources/Basics/AuthorizationProvider.swift
@@ -43,6 +43,15 @@ extension AuthorizationProvider {
     }
 }
 
+extension Foundation.URL {
+    var authenticationID: String? {
+        guard let host = host?.lowercased() else {
+            return nil
+        }
+        return host.isEmpty ? nil : host
+    }
+}
+
 // MARK: - netrc
 
 public struct NetrcAuthorizationProvider: AuthorizationProvider {
@@ -103,7 +112,7 @@ public struct NetrcAuthorizationProvider: AuthorizationProvider {
     }
     
     private func machineName(for url: Foundation.URL) -> String? {
-        url.host?.lowercased()
+        url.authenticationID
     }
 
     private func machine(for url: Foundation.URL) -> TSCUtility.Netrc.Machine? {
@@ -248,7 +257,7 @@ public struct KeychainAuthorizationProvider: AuthorizationProvider {
     }
     
     private func server(for url: Foundation.URL) -> String? {
-        url.host?.lowercased()
+        url.authenticationID
     }
     
     private func `protocol`(for url: Foundation.URL) -> CFString {

--- a/Sources/Basics/CMakeLists.txt
+++ b/Sources/Basics/CMakeLists.txt
@@ -32,6 +32,8 @@ target_link_libraries(Basics PRIVATE
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(Basics PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+target_link_options(Basics PRIVATE
+    "$<$<PLATFORM_ID:Darwin>:SHELL:-Xlinker -framework -Xlinker Security>")
 
 if(USE_CMAKE_INSTALL)
 install(TARGETS Basics

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -501,9 +501,12 @@ public class SwiftTool {
         if let workspaceNetrc = try self.getNetrcConfig()?.get() {
             providers.append(workspaceNetrc)
         }
-#if canImport(Security)
-        providers.append(KeychainAuthorizationProvider())
-#endif
+        
+        // TODO: add --no-keychain option to allow opt-out
+//#if canImport(Security)
+//        providers.append(KeychainAuthorizationProvider())
+//#endif
+        
         return providers.isEmpty ? nil : CompositeAuthorizationProvider(providers)
     }
 

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -504,8 +504,7 @@ public class SwiftTool {
 #if canImport(Security)
         providers.append(KeychainAuthorizationProvider())
 #endif
-        return CompositeAuthorizationProvider(providers)
-
+        return providers.isEmpty ? nil : CompositeAuthorizationProvider(providers)
     }
 
     func getNetrcConfig() -> Workspace.Configuration.Netrc? {

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -504,10 +504,10 @@ public class SwiftTool {
         
         // TODO: add --no-keychain option to allow opt-out
 //#if canImport(Security)
-//        providers.append(KeychainAuthorizationProvider())
+//        providers.append(KeychainAuthorizationProvider(observabilityScope: self.observabilityScope))
 //#endif
         
-        return providers.isEmpty ? nil : CompositeAuthorizationProvider(providers)
+        return providers.isEmpty ? nil : CompositeAuthorizationProvider(providers, observabilityScope: self.observabilityScope)
     }
 
     func getNetrcConfig() -> Workspace.Configuration.Netrc? {

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -496,8 +496,16 @@ public class SwiftTool {
     }
 
     func getAuthorizationProvider() throws -> AuthorizationProvider? {
-        // currently only single provider: netrc
-        return try self.getNetrcConfig()?.get()
+        var providers = [AuthorizationProvider]()
+        // netrc file has higher specificity than keychain so use it first
+        if let workspaceNetrc = try self.getNetrcConfig()?.get() {
+            providers.append(workspaceNetrc)
+        }
+#if canImport(Security)
+        providers.append(KeychainAuthorizationProvider())
+#endif
+        return CompositeAuthorizationProvider(providers)
+
     }
 
     func getNetrcConfig() -> Workspace.Configuration.Netrc? {

--- a/Sources/Workspace/WorkspaceConfiguration.swift
+++ b/Sources/Workspace/WorkspaceConfiguration.swift
@@ -350,13 +350,7 @@ extension Workspace.Configuration {
         }
 
         private static func load(_ path: AbsolutePath, fileSystem: FileSystem) throws -> AuthorizationProvider {
-            var providers = [AuthorizationProvider]()
-            // netrc file has higher specificity than keychain so use it first
-            providers.append(try NetrcAuthorizationProvider(path: path, fileSystem: fileSystem))
-#if canImport(Security)
-            providers.append(KeychainAuthorizationProvider())
-#endif
-            return CompositeAuthorizationProvider(providers)
+            try NetrcAuthorizationProvider(path: path, fileSystem: fileSystem)
         }
     }
 }

--- a/Sources/Workspace/WorkspaceConfiguration.swift
+++ b/Sources/Workspace/WorkspaceConfiguration.swift
@@ -350,7 +350,13 @@ extension Workspace.Configuration {
         }
 
         private static func load(_ path: AbsolutePath, fileSystem: FileSystem) throws -> AuthorizationProvider {
-            return try NetrcAuthorizationProvider(path: path, fileSystem: fileSystem)
+            var providers = [AuthorizationProvider]()
+            // netrc file has higher specificity than keychain so use it first
+            providers.append(try NetrcAuthorizationProvider(path: path, fileSystem: fileSystem))
+#if canImport(Security)
+            providers.append(KeychainAuthorizationProvider())
+#endif
+            return CompositeAuthorizationProvider(providers)
         }
     }
 }

--- a/Sources/Workspace/WorkspaceConfiguration.swift
+++ b/Sources/Workspace/WorkspaceConfiguration.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2018 Apple Inc. and the Swift project authors
+ Copyright (c) 2018-2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -350,30 +350,7 @@ extension Workspace.Configuration {
         }
 
         private static func load(_ path: AbsolutePath, fileSystem: FileSystem) throws -> AuthorizationProvider {
-            let netrc = try TSCUtility.Netrc.load(fromFileAtPath: path).get()
-            return NetrcAuthorizationProvider(netrc)
-        }
-
-        struct NetrcAuthorizationProvider: AuthorizationProvider {
-            private let underlying: TSCUtility.Netrc
-
-            init(_ underlying: TSCUtility.Netrc) {
-                self.underlying = underlying
-            }
-
-            func authentication(for url: Foundation.URL) -> (user: String, password: String)? {
-                return self.machine(for: url).map { (user: $0.login, password: $0.password) }
-            }
-
-            private func machine(for url: Foundation.URL) -> TSCUtility.Netrc.Machine? {
-                if let machine = self.underlying.machines.first(where: { $0.name.lowercased() == url.host?.lowercased() }) {
-                    return machine
-                }
-                if let machine = self.underlying.machines.first(where: { $0.isDefault }) {
-                    return machine
-                }
-                return .none
-            }
+            return try NetrcAuthorizationProvider(path: path, fileSystem: fileSystem)
         }
     }
 }

--- a/Tests/BasicsTests/AuthorizationProviderTests.swift
+++ b/Tests/BasicsTests/AuthorizationProviderTests.swift
@@ -63,7 +63,7 @@ final class AuthorizationProviderTests: XCTestCase {
         #if !canImport(Security) || !ENABLE_KEYCHAIN_TEST
         try XCTSkipIf(true)
         #else
-        let provider = KeychainAuthorizationProvider()
+        let provider = KeychainAuthorizationProvider(observabilityScope: ObservabilitySystem.NOOP)
 
         let user = UUID().uuidString
 
@@ -101,20 +101,20 @@ final class AuthorizationProviderTests: XCTestCase {
 
         do {
             // providerOne's password is returned first
-            let provider = CompositeAuthorizationProvider(providerOne, providerTwo)
+            let provider = CompositeAuthorizationProvider(providerOne, providerTwo, observabilityScope: ObservabilitySystem.NOOP)
             self.assertAuthentication(provider, for: url, expected: (user, passwordOne))
         }
 
         do {
             // providerTwo's password is returned first
-            let provider = CompositeAuthorizationProvider(providerTwo, providerOne)
+            let provider = CompositeAuthorizationProvider(providerTwo, providerOne, observabilityScope: ObservabilitySystem.NOOP)
             self.assertAuthentication(provider, for: url, expected: (user, passwordTwo))
         }
 
         do {
             // Neither has password
             let unknownURL = URL(string: "http://\(UUID().uuidString)")!
-            let provider = CompositeAuthorizationProvider(providerOne, providerTwo)
+            let provider = CompositeAuthorizationProvider(providerOne, providerTwo, observabilityScope: ObservabilitySystem.NOOP)
             XCTAssertNil(provider.authentication(for: unknownURL))
         }
     }

--- a/Tests/BasicsTests/AuthorizationProviderTests.swift
+++ b/Tests/BasicsTests/AuthorizationProviderTests.swift
@@ -8,28 +8,79 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
+import XCTest
+
 import Basics
 import TSCBasic
-import XCTest
+import TSCTestSupport
 
 final class AuthorizationProviderTests: XCTestCase {
     func testBasicAPIs() {
         struct TestProvider: AuthorizationProvider {
-            let map: [URL: (user: String, password: String)]
+            private var map = [URL: (user: String, password: String)]()
+            
+            mutating func addOrUpdate(for url: Foundation.URL, user: String, password: String, callback: @escaping (Result<Void, Error>) -> Void) {
+                self.map[url] = (user, password)
+                callback(.success(()))
+            }
 
             func authentication(for url: URL) -> (user: String, password: String)? {
                 return self.map[url]
             }
         }
 
-        let url = URL(string: "http://\(UUID().uuidString)")!
+        var provider = TestProvider()
+        self.run(for: &provider)
+    }
+    
+    func testNetrc() throws {
+        try testWithTemporaryDirectory { tmpPath in
+            let netrcPath = tmpPath.appending(component: ".netrc")
+            
+            var provider = try NetrcAuthorizationProvider(path: netrcPath, fileSystem: localFileSystem)
+            self.run(for: &provider)
+        }
+    }
+    
+    func testKeychain() throws {
+        #if os(macOS) && ENABLE_KEYCHAIN_TEST
+        #else
+        try XCTSkipIf(true)
+        #endif
+        
+        var provider = KeychainAuthorizationProvider()
+        self.run(for: &provider)
+    }
+    
+    private func run<Provider>(for provider: inout Provider) where Provider: AuthorizationProvider {
         let user = UUID().uuidString
+        
+        let url = URL(string: "http://\(UUID().uuidString)")!
         let password = UUID().uuidString
-        let provider = TestProvider(map: [url: (user: user, password: password)])
+        
+        let otherURL = URL(string: "https://\(UUID().uuidString)")!
+        let otherPassword = UUID().uuidString
+        
+        // Add
+        XCTAssertNoThrow(try tsc_await { callback in provider.addOrUpdate(for: url, user: user, password: password, callback: callback) })
+        XCTAssertNoThrow(try tsc_await { callback in provider.addOrUpdate(for: otherURL, user: user, password: otherPassword, callback: callback) })
 
         let auth = provider.authentication(for: url)
         XCTAssertEqual(auth?.user, user)
         XCTAssertEqual(auth?.password, password)
         XCTAssertEqual(provider.httpAuthorizationHeader(for: url), "Basic " + "\(user):\(password)".data(using: .utf8)!.base64EncodedString())
+        
+        // Update
+        let newPassword = UUID().uuidString
+        XCTAssertNoThrow(try tsc_await { callback in provider.addOrUpdate(for: url, user: user, password: newPassword, callback: callback) })
+        
+        let updatedAuth = provider.authentication(for: url)
+        XCTAssertEqual(updatedAuth?.user, user)
+        XCTAssertEqual(updatedAuth?.password, newPassword)
+        XCTAssertEqual(provider.httpAuthorizationHeader(for: url), "Basic " + "\(user):\(newPassword)".data(using: .utf8)!.base64EncodedString())
+        
+        let otherAuth = provider.authentication(for: otherURL)
+        XCTAssertEqual(otherAuth?.user, user)
+        XCTAssertEqual(otherAuth?.password, otherPassword)
     }
 }

--- a/Tests/BasicsTests/AuthorizationProviderTests.swift
+++ b/Tests/BasicsTests/AuthorizationProviderTests.swift
@@ -43,13 +43,12 @@ final class AuthorizationProviderTests: XCTestCase {
     }
     
     func testKeychain() throws {
-        #if os(macOS) && ENABLE_KEYCHAIN_TEST
-        #else
+        #if !os(macOS) || !ENABLE_KEYCHAIN_TEST
         try XCTSkipIf(true)
-        #endif
-        
+        #else
         var provider = KeychainAuthorizationProvider()
         self.run(for: &provider)
+        #endif
     }
     
     private func run<Provider>(for provider: inout Provider) where Provider: AuthorizationProvider {

--- a/Tests/BasicsTests/AuthorizationProviderTests.swift
+++ b/Tests/BasicsTests/AuthorizationProviderTests.swift
@@ -43,7 +43,7 @@ final class AuthorizationProviderTests: XCTestCase {
     }
     
     func testKeychain() throws {
-        #if !os(macOS) || !ENABLE_KEYCHAIN_TEST
+        #if !canImport(Security) || !ENABLE_KEYCHAIN_TEST
         try XCTSkipIf(true)
         #else
         var provider = KeychainAuthorizationProvider()

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -7195,7 +7195,7 @@ final class WorkspaceTests: XCTestCase {
                 customManifestLoader: TestLoader(error: .none),
                 delegate: delegate
             )
-            try workspace.loadPackageGraph(rootPath: .root, diagnostics: DiagnosticsEngine())
+            try workspace.loadPackageGraph(rootPath: .root, observabilityScope: ObservabilitySystem.NOOP)
 
             XCTAssertNotNil(delegate.manifest)
             XCTAssertEqual(delegate.manifestLoadingDiagnostics?.count, 0)
@@ -7210,7 +7210,7 @@ final class WorkspaceTests: XCTestCase {
                 customManifestLoader: TestLoader(error: Diagnostics.fatalError),
                 delegate: delegate
             )
-            try workspace.loadPackageGraph(rootPath: .root, diagnostics: DiagnosticsEngine())
+            try workspace.loadPackageGraph(rootPath: .root, observabilityScope: ObservabilitySystem.NOOP)
 
             XCTAssertNil(delegate.manifest)
             XCTAssertEqual(delegate.manifestLoadingDiagnostics?.count, 0)
@@ -7225,7 +7225,7 @@ final class WorkspaceTests: XCTestCase {
                 customManifestLoader: TestLoader(error: StringError("boom")),
                 delegate: delegate
             )
-            try workspace.loadPackageGraph(rootPath: .root, diagnostics: DiagnosticsEngine())
+            try workspace.loadPackageGraph(rootPath: .root, observabilityScope: ObservabilitySystem.NOOP)
 
             XCTAssertNil(delegate.manifest)
             XCTAssertEqual(delegate.manifestLoadingDiagnostics?.count, 1)


### PR DESCRIPTION
Motivation:
Support keychain auth on macOS.

Modifications:
- Add `addOrUpdate` API to `AuthorizationProvider` protocol
- Implement `KeychainAuthorizationProvider`
- Move `NetrcAuthorizationProvider` to `Basics` and update conformance
- Add tests

rdar://83682028
