### PR TITLE
`ProductFilter` type is not `Decodable` for the `everything` case

### DIFF
--- a/Sources/PackageModel/Product.swift
+++ b/Sources/PackageModel/Product.swift
@@ -247,11 +247,10 @@ extension ProductFilter: Codable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        let optionalSet: Set<String>? = try container.decode([String]?.self).map { Set($0) }
-        if let set = optionalSet {
-            self = .specific(set)
-        } else {
+        if container.decodeNil() {
             self = .everything
+        } else {
+            self = .specific(Set(try container.decode([String].self)))
         }
     }
 }

--- a/Tests/PackageModelTests/PackageModelTests.swift
+++ b/Tests/PackageModelTests/PackageModelTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -52,5 +52,20 @@ class PackageModelTests: XCTestCase {
         checkCodable(.library(.dynamic))
         checkCodable(.executable)
         checkCodable(.test)
+    }
+    
+    func testProductFilterCodable() throws {
+        // Test ProductFilter.everything
+        try {
+            let data = try JSONEncoder().encode(ProductFilter.everything)
+            let decoded = try JSONDecoder().decode(ProductFilter.self, from: data)
+            XCTAssertEqual(decoded, ProductFilter.everything)
+        }()
+        // Test ProductFilter.specific(), including that the order is normalized
+        try {
+            let data = try JSONEncoder().encode(ProductFilter.specific(["Bar", "Foo"]))
+            let decoded = try JSONDecoder().decode(ProductFilter.self, from: data)
+            XCTAssertEqual(decoded, ProductFilter.specific(["Foo", "Bar"]))
+        }()
     }
 }


### PR DESCRIPTION
This fixes a case of not being able decode a `ProductFilter` that had been encoded.

### Motivation:

`ProductFilter` in the SwiftPM project model is declared as `Codable` and it should be possible to decode what was encoded.

### Discussion:

The `ProductFilter.everything` is encoded as the `.none` case of a `[String]?`, which gets encoded by the `SingleValueEncodingContainer` as JSON `null`.  But then `SingleValueDecodingContainer` doesn't decode that `null` as the `.none` case of `[String]?`, instead throwing an error.

This change uses `decodeNil` to check for `null`, but it seems to me that there might be a bug in `SingleValue{Encoding,Decoding}Container` here, since it doesn't seem symmetrical.  I would expect consistent handling of `[String]?` for encoding and decoding.

So there is follow-up there on a possible `SingleValueDecodingContainer` issue.

## Modifications:

- use `decodeNil()` to check for the "no specific filter" case
- add a unit test

### Result:

`ProductFilter` is properly decodable.

rdar://83647022
