### PR TITLE
[5.5] `ProductFilter` type is not `Decodable` for the `everything` case (#3775)

### DIFF
--- a/Sources/PackageModel/Product.swift
+++ b/Sources/PackageModel/Product.swift
@@ -233,11 +233,10 @@ extension ProductFilter: Codable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        let optionalSet: Set<String>? = try container.decode([String]?.self).map { Set($0) }
-        if let set = optionalSet {
-            self = .specific(set)
-        } else {
+        if container.decodeNil() {
             self = .everything
+        } else {
+            self = .specific(Set(try container.decode([String].self)))
         }
     }
 }

--- a/Tests/PackageModelTests/PackageModelTests.swift
+++ b/Tests/PackageModelTests/PackageModelTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -52,5 +52,20 @@ class PackageModelTests: XCTestCase {
         checkCodable(.library(.dynamic))
         checkCodable(.executable)
         checkCodable(.test)
+    }
+    
+    func testProductFilterCodable() throws {
+        // Test ProductFilter.everything
+        try {
+            let data = try JSONEncoder().encode(ProductFilter.everything)
+            let decoded = try JSONDecoder().decode(ProductFilter.self, from: data)
+            XCTAssertEqual(decoded, ProductFilter.everything)
+        }()
+        // Test ProductFilter.specific(), including that the order is normalized
+        try {
+            let data = try JSONEncoder().encode(ProductFilter.specific(["Bar", "Foo"]))
+            let decoded = try JSONDecoder().decode(ProductFilter.self, from: data)
+            XCTAssertEqual(decoded, ProductFilter.specific(["Foo", "Bar"]))
+        }()
     }
 }


### PR DESCRIPTION
This is the 5.5 cherry-pick of #3775.  See that PR for the details.