### PR TITLE
remove global observability scope

### DIFF
--- a/Examples/package-info/Sources/package-info/main.swift
+++ b/Examples/package-info/Sources/package-info/main.swift
@@ -1,3 +1,4 @@
+import Basics
 import TSCBasic
 import Workspace
 
@@ -13,22 +14,16 @@ let packagePath = AbsolutePath(#file).parentDirectory.parentDirectory.parentDire
 
 // There are several levels of information available.
 // Each takes longer to load than the level above it, but provides more detail.
-let diagnostics = DiagnosticsEngine(handlers: [{ print($0)}])
+
+let observability = ObservabilitySystem({ print("\($0): \($1)") })
+
 let workspace = try Workspace(forRootPackage: packagePath)
-let manifest = try tsc_await { workspace.loadRootManifest(at: packagePath, diagnostics: diagnostics, completion: $0) }
-guard !diagnostics.hasErrors else {
-    fatalError("error loading manifest: \(diagnostics)")
-}
 
-let package = try tsc_await { workspace.loadRootPackage(at: packagePath, diagnostics: diagnostics, completion: $0) }
-guard !diagnostics.hasErrors else {
-    fatalError("error loading package: \(diagnostics)")
-}
+let manifest = try tsc_await { workspace.loadRootManifest(at: packagePath, observabilityScope: observability.topScope, completion: $0) }
 
-let graph = try workspace.loadPackageGraph(rootPath: packagePath, diagnostics: diagnostics)
-guard !diagnostics.hasErrors else {
-    fatalError("error loading graph: \(diagnostics)")
-}
+let package = try tsc_await { workspace.loadRootPackage(at: packagePath, observabilityScope: observability.topScope, completion: $0) }
+
+let graph = try workspace.loadPackageGraph(rootPath: packagePath, observabilityScope: observability.topScope)
 
 // EXAMPLES
 // ========

--- a/Sources/Basics/HTPClient+URLSession.swift
+++ b/Sources/Basics/HTPClient+URLSession.swift
@@ -27,6 +27,10 @@ public struct URLSessionHTTPClient: HTTPClientProtocol {
     }
 
     public func execute(_ request: HTTPClient.Request, progress: ProgressHandler?, completion: @escaping CompletionHandler) {
+        self.execute(request, observabilityScope: nil, progress: progress, completion: completion)
+    }
+
+    public func execute(_ request: HTTPClient.Request, observabilityScope: ObservabilityScope? = nil, progress: ProgressHandler?, completion: @escaping CompletionHandler) {
         switch request.kind {
         case .generic:
             let task = self.dataTasksManager.makeTask(request: request, progress: progress, completion: completion)

--- a/Sources/Commands/APIDigester.swift
+++ b/Sources/Commands/APIDigester.swift
@@ -36,21 +36,21 @@ struct APIDigesterBaselineDumper {
     /// The API digester tool.
     let apiDigesterTool: SwiftAPIDigester
 
-    /// The diagnostics engine for emitting errors/warnings.
-    let diags: DiagnosticsEngine
+    /// The observabilityScope for emitting errors/warnings.
+    let observabilityScope: ObservabilityScope
 
     init(
         baselineRevision: Revision,
         packageRoot: AbsolutePath,
         buildParameters: BuildParameters,
         apiDigesterTool: SwiftAPIDigester,
-        diags: DiagnosticsEngine
+        observabilityScope: ObservabilityScope
     ) {
         self.baselineRevision = baselineRevision
         self.packageRoot = packageRoot
         self.inputBuildParameters = buildParameters
         self.apiDigesterTool = apiDigesterTool
-        self.diags = diags
+        self.observabilityScope = observabilityScope
     }
 
     /// Emit the API baseline files and return the path to their directory.
@@ -103,13 +103,15 @@ struct APIDigesterBaselineDumper {
         )
 
         let graph = try workspace.loadPackageGraph(
-            rootPath: baselinePackageRoot, diagnostics: diags)
+            rootPath: baselinePackageRoot,
+            observabilityScope: observabilityScope
+        )
 
         // Don't emit a baseline for a module that didn't exist yet in this revision.
         modulesToDiff.formIntersection(graph.apiDigesterModules)
 
         // Abort if we weren't able to load the package graph.
-        if diags.hasErrors {
+        if observabilityScope.errorsReported {
             throw Diagnostics.fatalError
         }
 
@@ -123,7 +125,7 @@ struct APIDigesterBaselineDumper {
             cacheBuildManifest: false,
             packageGraphLoader: { graph },
             pluginInvoker: { _ in [:] },
-            diagnostics: diags,
+            diagnostics: observabilityScope.makeDiagnosticsEngine(),
             outputStream: outputStream
         )
 
@@ -152,9 +154,9 @@ struct APIDigesterBaselineDumper {
         group.wait()
 
         for error in errors.get() {
-            diags.emit(error)
+            observabilityScope.emit(error)
         }
-        if diags.hasErrors {
+        if observabilityScope.errorsReported {
             throw Diagnostics.fatalError
         }
 

--- a/Sources/Commands/Snippets/CardStack.swift
+++ b/Sources/Commands/Snippets/CardStack.swift
@@ -96,7 +96,7 @@ struct CardStack {
                 case let .pop(error):
                     cards.removeLast()
                     if let error = error {
-                        ObservabilitySystem.topScope.emit(error)
+                        self.swiftTool.observabilityScope.emit(error)
                         needsToClearScreen = false
                     } else {
                         needsToClearScreen = !cards.isEmpty

--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -101,7 +101,7 @@ public struct SwiftBuildTool: SwiftCommand {
         checkClangVersion()
       #endif
 
-        guard let subset = options.buildSubset(diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
+        guard let subset = options.buildSubset(diagnostics: swiftTool.observabilityScope.makeDiagnosticsEngine())
             else { throw ExitCode.failure }
         let buildSystem = try swiftTool.createBuildSystem(explicitProduct: options.product)
         do {

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -46,14 +46,14 @@ public struct SwiftPackageTool: ParsableCommand {
             DumpSymbolGraph.self,
             DumpPIF.self,
             DumpPackage.self,
-            
+
             Edit.self,
             Unedit.self,
-            
+
             Config.self,
             Resolve.self,
             Fetch.self,
-            
+
             ShowDependencies.self,
             ToolsVersionCommand.self,
             GenerateXcodeProject.self,
@@ -82,9 +82,9 @@ extension SwiftPackageTool {
 
         @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
-        
+
         func run(_ swiftTool: SwiftTool) throws {
-            try swiftTool.getActiveWorkspace().clean(with: ObservabilitySystem.topScope.makeDiagnosticsEngine())
+            try swiftTool.getActiveWorkspace().clean(with: swiftTool.observabilityScope.makeDiagnosticsEngine())
         }
     }
 
@@ -96,75 +96,75 @@ extension SwiftPackageTool {
         var swiftOptions: SwiftToolOptions
 
         func run(_ swiftTool: SwiftTool) throws {
-            try swiftTool.getActiveWorkspace().purgeCache(with: ObservabilitySystem.topScope.makeDiagnosticsEngine())
+            try swiftTool.getActiveWorkspace().purgeCache(with: swiftTool.observabilityScope.makeDiagnosticsEngine())
         }
     }
-    
+
     struct Reset: SwiftCommand {
         static let configuration = CommandConfiguration(
             abstract: "Reset the complete cache/build directory")
 
         @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
-        
+
         func run(_ swiftTool: SwiftTool) throws {
-            try swiftTool.getActiveWorkspace().reset(with: ObservabilitySystem.topScope.makeDiagnosticsEngine())
+            try swiftTool.getActiveWorkspace().reset(with: swiftTool.observabilityScope.makeDiagnosticsEngine())
         }
     }
-    
+
     struct Update: SwiftCommand {
         static let configuration = CommandConfiguration(
             abstract: "Update package dependencies")
 
         @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
-        
+
         @Flag(name: [.long, .customShort("n")],
               help: "Display the list of dependencies that can be updated")
         var dryRun: Bool = false
-        
+
         @Argument(help: "The packages to update")
         var packages: [String] = []
 
         func run(_ swiftTool: SwiftTool) throws {
             let workspace = try swiftTool.getActiveWorkspace()
-            
+
             let changes = try workspace.updateDependencies(
                 root: swiftTool.getWorkspaceRoot(),
                 packages: packages,
-                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+                diagnostics: swiftTool.observabilityScope.makeDiagnosticsEngine(),
                 dryRun: dryRun
             )
 
             // try to load the graph which will emit any errors
-            if !ObservabilitySystem.topScope.errorsReported {
+            if !swiftTool.observabilityScope.errorsReported {
                 _ = try workspace.loadPackageGraph(
                     rootInput: swiftTool.getWorkspaceRoot(),
-                    diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
+                    observabilityScope: swiftTool.observabilityScope
                 )
             }
 
-            if let pinsStore = ObservabilitySystem.topScope.trap({ try workspace.pinsStore.load() }), let changes = changes, dryRun {
+            if let pinsStore = swiftTool.observabilityScope.trap({ try workspace.pinsStore.load() }), let changes = changes, dryRun {
                 logPackageChanges(changes: changes, pins: pinsStore, on: swiftTool.outputStream)
             }
 
             if !dryRun {
                 // Throw if there were errors when loading the graph.
                 // The actual errors will be printed before exiting.
-                guard !ObservabilitySystem.topScope.errorsReported else {
+                guard !swiftTool.observabilityScope.errorsReported else {
                     throw ExitCode.failure
                 }
             }
         }
     }
-    
+
     struct Describe: SwiftCommand {
         static let configuration = CommandConfiguration(
             abstract: "Describe the current package")
 
         @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
-                
+
         @Option(help: "json | text")
         var type: DescribeMode = .text
 
@@ -173,7 +173,7 @@ extension SwiftPackageTool {
             let root = try swiftTool.getWorkspaceRoot()
 
             let rootManifests = try temp_await {
-                workspace.loadRootManifests(packages: root.packages, diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(), completion: $0)
+                workspace.loadRootManifests(packages: root.packages, diagnostics: swiftTool.observabilityScope.makeDiagnosticsEngine(), completion: $0)
             }
             guard let rootManifest = rootManifests.values.first else {
                 throw StringError("invalid manifests at \(root.packages)")
@@ -185,7 +185,8 @@ extension SwiftPackageTool {
                 productFilter: .everything,
                 path: try swiftTool.getPackageRoot(),
                 xcTestMinimumDeploymentTargets: MinimumDeploymentTarget.default.xcTestMinimumDeploymentTargets,
-                fileSystem: localFileSystem
+                fileSystem: localFileSystem,
+                observabilityScope: swiftTool.observabilityScope
             )
             let package = try builder.construct()
             describe(package, in: type, on: swiftTool.outputStream)
@@ -198,13 +199,13 @@ extension SwiftPackageTool {
 
         @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
-        
+
         @Option(name: .customLong("type"), help: "Package type: empty | library | executable | system-module | manifest")
         var initMode: InitPackage.PackageType = .library
-        
+
         @Option(name: .customLong("name"), help: "Provide custom package name")
         var packageName: String?
-        
+
         func run(_ swiftTool: SwiftTool) throws {
             guard let cwd = localFileSystem.currentWorkingDirectory else {
                 throw InternalError("Could not find the current working directory")
@@ -219,18 +220,18 @@ extension SwiftPackageTool {
             try initPackage.writePackageStructure()
         }
     }
-    
+
     struct Format: SwiftCommand {
         static let configuration = CommandConfiguration(
             commandName: "_format")
 
         @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
-        
+
         @Argument(parsing: .unconditionalRemaining,
                   help: "Pass flag through to the swift-format tool")
         var swiftFormatFlags: [String] = []
-        
+
         func run(_ swiftTool: SwiftTool) throws {
             // Look for swift-format binary.
             // FIXME: This should be moved to user toolchain.
@@ -244,7 +245,11 @@ extension SwiftPackageTool {
             let workspace = try swiftTool.getActiveWorkspace()
             let root = try swiftTool.getWorkspaceRoot()
             let rootManifests = try temp_await {
-                workspace.loadRootManifests(packages: root.packages, diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(), completion: $0)
+                workspace.loadRootManifests(
+                    packages: root.packages,
+                    diagnostics: swiftTool.observabilityScope.makeDiagnosticsEngine(),
+                    completion: $0
+                )
             }
             guard let rootManifest = rootManifests.values.first else {
                 throw StringError("invalid manifests at \(root.packages)")
@@ -256,7 +261,8 @@ extension SwiftPackageTool {
                 productFilter: .everything,
                 path: try swiftTool.getPackageRoot(),
                 xcTestMinimumDeploymentTargets: [:], // Minimum deployment target does not matter for this operation.
-                fileSystem: localFileSystem
+                fileSystem: localFileSystem,
+                observabilityScope: swiftTool.observabilityScope
             )
             let package = try builder.construct()
 
@@ -300,7 +306,7 @@ extension SwiftPackageTool {
             throw ExitCode.failure
         }
     }
-    
+
     struct APIDiff: SwiftCommand {
         static let configuration = CommandConfiguration(
             commandName: "diagnose-api-breaking-changes",
@@ -355,8 +361,10 @@ extension SwiftPackageTool {
             let buildOp = try swiftTool.createBuildOperation(cacheBuildManifest: false)
 
             let packageGraph = try buildOp.getPackageGraph()
-            let modulesToDiff = try determineModulesToDiff(packageGraph: packageGraph,
-                                                           diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
+            let modulesToDiff = try determineModulesToDiff(
+                packageGraph: packageGraph,
+                diagnostics: swiftTool.observabilityScope.makeDiagnosticsEngine()
+            )
 
             // Build the current package.
             try buildOp.build()
@@ -367,7 +375,7 @@ extension SwiftPackageTool {
                 packageRoot: swiftTool.getPackageRoot(),
                 buildParameters: buildOp.buildParameters,
                 apiDigesterTool: apiDigesterTool,
-                diags: ObservabilitySystem.topScope.makeDiagnosticsEngine()
+                observabilityScope: swiftTool.observabilityScope
             )
 
             let baselineDir = try baselineDumper.emitAPIBaseline(
@@ -409,11 +417,11 @@ extension SwiftPackageTool {
                 .subtracting(skippedModules)
                 .subtracting(results.map(\.moduleName))
             for failedModule in failedModules {
-                ObservabilitySystem.topScope.emit(error: "failed to read API digester output for \(failedModule)")
+                swiftTool.observabilityScope.emit(error: "failed to read API digester output for \(failedModule)")
             }
 
             for result in results.get() {
-                printComparisonResult(result, diagnosticsEngine: ObservabilitySystem.topScope.makeDiagnosticsEngine())
+                printComparisonResult(result, diagnosticsEngine: swiftTool.observabilityScope.makeDiagnosticsEngine())
             }
 
             guard failedModules.isEmpty && results.get().allSatisfy(\.hasNoAPIBreakingChanges) else {
@@ -494,7 +502,7 @@ extension SwiftPackageTool {
             }
         }
     }
-    
+
     struct DumpSymbolGraph: SwiftCommand {
         static let configuration = CommandConfiguration(
             abstract: "Dump Symbol Graph")
@@ -538,20 +546,24 @@ extension SwiftPackageTool {
             )
         }
     }
-    
+
     struct DumpPackage: SwiftCommand {
         static let configuration = CommandConfiguration(
             abstract: "Print parsed Package.swift as JSON")
 
         @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
-        
+
         func run(_ swiftTool: SwiftTool) throws {
             let workspace = try swiftTool.getActiveWorkspace()
             let root = try swiftTool.getWorkspaceRoot()
 
             let rootManifests = try temp_await {
-                workspace.loadRootManifests(packages: root.packages, diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(), completion: $0)
+                workspace.loadRootManifests(
+                    packages: root.packages,
+                    diagnostics: swiftTool.observabilityScope.makeDiagnosticsEngine(),
+                    completion: $0
+                )
             }
             guard let rootManifest = rootManifests.values.first else {
                 throw StringError("invalid manifests at \(root.packages)")
@@ -565,23 +577,27 @@ extension SwiftPackageTool {
             print(jsonString)
         }
     }
-    
+
     struct DumpPIF: SwiftCommand {
         @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
-        
+
         @Flag(help: "Preserve the internal structure of PIF")
         var preserveStructure: Bool = false
 
         func run(_ swiftTool: SwiftTool) throws {
             let graph = try swiftTool.loadPackageGraph(createMultipleTestProducts: true)
             let parameters = try PIFBuilderParameters(swiftTool.buildParameters())
-            let builder = PIFBuilder(graph: graph, parameters: parameters, diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
+            let builder = PIFBuilder(
+                graph: graph,
+                parameters: parameters,
+                diagnostics: swiftTool.observabilityScope.makeDiagnosticsEngine()
+            )
             let pif = try builder.generatePIF(preservePIFModelStructure: preserveStructure)
             print(pif)
         }
     }
-    
+
     struct Edit: SwiftCommand {
         static let configuration = CommandConfiguration(
             abstract: "Put a package in editable mode")
@@ -591,13 +607,13 @@ extension SwiftPackageTool {
 
         @Option(help: "The revision to edit", transform: { Revision(identifier: $0) })
         var revision: Revision?
-        
+
         @Option(name: .customLong("branch"), help: "The branch to create")
         var checkoutBranch: String?
-        
+
         @Option(help: "Create or use the checkout at this path")
         var path: AbsolutePath?
-        
+
         @Argument(help: "The name of the package to edit")
         var packageName: String
 
@@ -611,7 +627,8 @@ extension SwiftPackageTool {
                 path: path,
                 revision: revision,
                 checkoutBranch: checkoutBranch,
-                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
+                diagnostics: swiftTool.observabilityScope.makeDiagnosticsEngine()
+            )
         }
     }
 
@@ -621,11 +638,11 @@ extension SwiftPackageTool {
 
         @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
-        
+
         @Flag(name: .customLong("force"),
               help: "Unedit the package even if it has uncommited and unpushed changes")
         var shouldForceRemove: Bool = false
-        
+
         @Argument(help: "The name of the package to unedit")
         var packageName: String
 
@@ -637,22 +654,22 @@ extension SwiftPackageTool {
                 packageName: packageName,
                 forceRemove: shouldForceRemove,
                 root: swiftTool.getWorkspaceRoot(),
-                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
+                diagnostics: swiftTool.observabilityScope.makeDiagnosticsEngine()
             )
         }
     }
-    
+
     struct ShowDependencies: SwiftCommand {
         static let configuration = CommandConfiguration(
             abstract: "Print the resolved dependency graph")
 
         @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
-        
+
         @Option(help: "text | dot | json | flatlist")
         var format: ShowDependenciesMode = .text
 
-        @Option(name: [.long, .customShort("o") ], 
+        @Option(name: [.long, .customShort("o") ],
                 help: "The absolute or relative path to output the resolved dependency graph.")
         var outputPath: AbsolutePath?
 
@@ -670,22 +687,22 @@ extension SwiftPackageTool {
 
         @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
-        
+
         @Option(help: "text | dot | json | flatlist")
         var format: ShowDependenciesMode = .text
 
         @Flag(help: "Set tools version of package to the current tools version in use")
         var setCurrent: Bool = false
-        
+
         @Option(help: "Set tools version of package to the given value")
         var set: String?
-        
+
         enum ToolsVersionMode {
             case display
             case set(String)
             case setCurrent
         }
-        
+
         var toolsVersionMode: ToolsVersionMode {
             // TODO: enforce exclusivity
             if let set = set {
@@ -722,25 +739,25 @@ extension SwiftPackageTool {
             }
         }
     }
-    
+
     struct ComputeChecksum: SwiftCommand {
         static let configuration = CommandConfiguration(
             abstract: "Compute the checksum for a binary artifact.")
 
         @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
-        
+
         @Argument(help: "The absolute or relative path to the binary artifact")
         var path: AbsolutePath
-        
+
         func run(_ swiftTool: SwiftTool) throws {
             let workspace = try swiftTool.getActiveWorkspace()
             let checksum = workspace.checksum(
                 forBinaryArtifactAt: path,
-                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
+                diagnostics: swiftTool.observabilityScope.makeDiagnosticsEngine()
             )
 
-            guard !ObservabilitySystem.topScope.errorsReported else {
+            guard !swiftTool.observabilityScope.errorsReported else {
                 throw ExitCode.failure
             }
 
@@ -800,19 +817,19 @@ extension SwiftPackageTool {
         struct Options: ParsableArguments {
             @Option(help: "Path to xcconfig file", completion: .file())
             var xcconfigOverrides: AbsolutePath?
-            
+
             @Option(name: .customLong("output"),
                     help: "Path where the Xcode project should be generated")
             var outputPath: AbsolutePath?
-            
+
             @Flag(name: .customLong("legacy-scheme-generator"),
                   help: "Use the legacy scheme generator")
             var useLegacySchemeGenerator: Bool = false
-            
+
             @Flag(name: .customLong("watch"),
                   help: "Watch for changes to the Package manifest to regenerate the Xcode project")
             var enableAutogeneration: Bool = false
-            
+
             @Flag(help: "Do not add file references for extra files to the generated Xcode project")
             var skipExtraFiles: Bool = false
         }
@@ -822,7 +839,7 @@ extension SwiftPackageTool {
 
         @OptionGroup()
         var options: Options
-        
+
         func xcodeprojOptions() -> XcodeprojOptions {
             XcodeprojOptions(
                 flags: swiftOptions.buildFlags,
@@ -834,7 +851,7 @@ extension SwiftPackageTool {
         }
 
         func run(_ swiftTool: SwiftTool) throws {
-            ObservabilitySystem.topScope.emit(warning: "Xcode can open and build Swift Packages directly. 'generate-xcodeproj' is no longer needed and will be deprecated soon.")
+            swiftTool.observabilityScope.emit(warning: "Xcode can open and build Swift Packages directly. 'generate-xcodeproj' is no longer needed and will be deprecated soon.")
 
             let graph = try swiftTool.loadPackageGraph()
 
@@ -863,7 +880,7 @@ extension SwiftPackageTool {
                 xcodeprojPath: xcodeprojPath,
                 graph: graph,
                 options: genOptions,
-                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
+                diagnostics: swiftTool.observabilityScope.makeDiagnosticsEngine()
             )
 
             print("generated:", xcodeprojPath.prettyPath(cwd: swiftTool.originalWorkingDirectory))
@@ -871,7 +888,7 @@ extension SwiftPackageTool {
             // Run the file watcher if requested.
             if options.enableAutogeneration {
                 try WatchmanHelper(
-                    diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+                    diagnostics: swiftTool.observabilityScope.makeDiagnosticsEngine(),
                     watchmanScriptsDir: swiftTool.buildPath.appending(component: "watchman"),
                     packageRoot: swiftTool.packageRoot!
                 ).runXcodeprojWatcher(xcodeprojOptions())
@@ -895,26 +912,26 @@ extension SwiftPackageTool.Config {
 
         @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
-        
+
         @Option(help: "The package dependency url")
         var packageURL: String?
-        
+
         @Option(help: "The original url")
         var originalURL: String?
-        
+
         @Option(help: "The mirror url")
         var mirrorURL: String
-        
+
         func run(_ swiftTool: SwiftTool) throws {
             let config = try swiftTool.getMirrorsConfig()
 
             if packageURL != nil {
-                ObservabilitySystem.topScope.emit(
+                swiftTool.observabilityScope.emit(
                     warning: "'--package-url' option is deprecated; use '--original-url' instead")
             }
 
             guard let originalURL = packageURL ?? originalURL else {
-                ObservabilitySystem.topScope.emit(.missingRequiredArg("--original-url"))
+                swiftTool.observabilityScope.emit(.missingRequiredArg("--original-url"))
                 throw ExitCode.failure
             }
 
@@ -930,26 +947,26 @@ extension SwiftPackageTool.Config {
 
         @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
-        
+
         @Option(help: "The package dependency url")
         var packageURL: String?
-        
+
         @Option(help: "The original url")
         var originalURL: String?
-        
+
         @Option(help: "The mirror url")
         var mirrorURL: String?
-        
+
         func run(_ swiftTool: SwiftTool) throws {
             let config = try swiftTool.getMirrorsConfig()
 
             if packageURL != nil {
-                ObservabilitySystem.topScope.emit(
+                swiftTool.observabilityScope.emit(
                     warning: "'--package-url' option is deprecated; use '--original-url' instead")
             }
 
             guard let originalOrMirrorURL = packageURL ?? originalURL ?? mirrorURL else {
-                ObservabilitySystem.topScope.emit(.missingRequiredArg("--original-url or --mirror-url"))
+                swiftTool.observabilityScope.emit(.missingRequiredArg("--original-url or --mirror-url"))
                 throw ExitCode.failure
             }
 
@@ -965,10 +982,10 @@ extension SwiftPackageTool.Config {
 
         @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
-        
+
         @Option(help: "The package dependency url")
         var packageURL: String?
-        
+
         @Option(help: "The original url")
         var originalURL: String?
 
@@ -976,12 +993,12 @@ extension SwiftPackageTool.Config {
             let config = try swiftTool.getMirrorsConfig()
 
             if packageURL != nil {
-                ObservabilitySystem.topScope.emit(
+                swiftTool.observabilityScope.emit(
                     warning: "'--package-url' option is deprecated; use '--original-url' instead")
             }
 
             guard let originalURL = packageURL ?? originalURL else {
-                ObservabilitySystem.topScope.emit(.missingRequiredArg("--original-url"))
+                swiftTool.observabilityScope.emit(.missingRequiredArg("--original-url"))
                 throw ExitCode.failure
             }
 
@@ -1000,27 +1017,27 @@ extension SwiftPackageTool {
     struct ResolveOptions: ParsableArguments {
         @Option(help: "The version to resolve at", transform: { Version($0) })
         var version: Version?
-        
+
         @Option(help: "The branch to resolve at")
         var branch: String?
-        
+
         @Option(help: "The revision to resolve at")
         var revision: String?
 
         @Argument(help: "The name of the package to resolve")
         var packageName: String?
     }
-    
+
     struct Resolve: SwiftCommand {
         static let configuration = CommandConfiguration(
             abstract: "Resolve package dependencies")
-        
+
         @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
 
         @OptionGroup()
         var resolveOptions: ResolveOptions
-        
+
         func run(_ swiftTool: SwiftTool) throws {
             // If a package is provided, use that to resolve the dependencies.
             if let packageName = resolveOptions.packageName {
@@ -1031,8 +1048,9 @@ extension SwiftPackageTool {
                     version: resolveOptions.version,
                     branch: resolveOptions.branch,
                     revision: resolveOptions.revision,
-                    diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
-                if ObservabilitySystem.topScope.errorsReported {
+                    diagnostics: swiftTool.observabilityScope.makeDiagnosticsEngine()
+                )
+                if swiftTool.observabilityScope.errorsReported {
                     throw ExitCode.failure
                 }
             } else {
@@ -1041,19 +1059,19 @@ extension SwiftPackageTool {
             }
         }
     }
-    
+
     struct Fetch: SwiftCommand {
         static let configuration = CommandConfiguration(shouldDisplay: false)
-        
+
         @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
-        
+
         @OptionGroup()
         var resolveOptions: ResolveOptions
-        
+
         func run(_ swiftTool: SwiftTool) throws {
-            ObservabilitySystem.topScope.emit(warning: "'fetch' command is deprecated; use 'resolve' instead")
-            
+            swiftTool.observabilityScope.emit(warning: "'fetch' command is deprecated; use 'resolve' instead")
+
             let resolveCommand = Resolve(swiftOptions: _swiftOptions, resolveOptions: _resolveOptions)
             try resolveCommand.run(swiftTool)
         }
@@ -1089,7 +1107,7 @@ extension SwiftPackageTool {
                 ]
             )
         }
-      
+
         @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
 
@@ -1235,11 +1253,11 @@ private extension Basics.Diagnostic {
 /// - Parameter stream: Stream used for logging
 fileprivate func logPackageChanges(changes: [(PackageReference, Workspace.PackageStateChange)], pins: PinsStore, on stream: OutputByteStream) {
     let changes = changes.filter { $0.1 != .unchanged }
-    
+
     stream <<< "\n"
     stream <<< "\(changes.count) dependenc\(changes.count == 1 ? "y has" : "ies have") changed\(changes.count > 0 ? ":" : ".")"
     stream <<< "\n"
-    
+
     for (package, change) in changes {
         let currentVersion = pins.pinsMap[package.identity]?.state.description ?? ""
         switch change {

--- a/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
@@ -24,20 +24,25 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
     public var name: String = "GitHub"
 
     let configuration: Configuration
-
+    private let observabilityScope: ObservabilityScope
     private let httpClient: HTTPClient
     private let decoder: JSONDecoder
 
     private let cache: SQLiteBackedCache<CacheValue>?
 
-    init(configuration: Configuration = .init(), httpClient: HTTPClient? = nil) {
+    init(configuration: Configuration = .init(), observabilityScope: ObservabilityScope, httpClient: HTTPClient? = nil) {
         self.configuration = configuration
+        self.observabilityScope = observabilityScope
         self.httpClient = httpClient ?? Self.makeDefaultHTTPClient()
         self.decoder = JSONDecoder.makeWithDefaults()
         if configuration.cacheTTLInSeconds > 0 {
             var cacheConfig = SQLiteBackedCacheConfiguration()
             cacheConfig.maxSizeInMegabytes = configuration.cacheSizeInMegabytes
-            self.cache = SQLiteBackedCache<CacheValue>(tableName: "github_cache", path: configuration.cacheDir.appending(component: "package-metadata.db"), configuration: cacheConfig)
+            self.cache = SQLiteBackedCache<CacheValue>(
+                tableName: "github_cache",
+                path: configuration.cacheDir.appending(component: "package-metadata.db"),
+                configuration: cacheConfig
+            )
         } else {
             self.cache = nil
         }
@@ -83,7 +88,7 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
                 let apiRemaining = response.headers.get("X-RateLimit-Remaining").first.flatMap(Int.init) ?? -1
                 switch (response.statusCode, hasAuthorization, apiRemaining) {
                 case (_, _, 0):
-                    ObservabilitySystem.topScope.emit(warning: "Exceeded API limits on \(metadataURL.host ?? metadataURL.absoluteString) (\(apiRemaining)/\(apiLimit)), consider configuring an API token for this service.")
+                    self.observabilityScope.emit(warning: "Exceeded API limits on \(metadataURL.host ?? metadataURL.absoluteString) (\(apiRemaining)/\(apiLimit)), consider configuring an API token for this service.")
                     results[metadataURL] = .failure(Errors.apiLimitsExceeded(metadataURL, apiLimit))
                 case (401, true, _):
                     results[metadataURL] = .failure(Errors.invalidAuthToken(metadataURL))
@@ -95,7 +100,7 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
                     results[metadataURL] = .failure(NotFoundError("\(baseURL)"))
                 case (200, _, _):
                     if apiRemaining < self.configuration.apiLimitWarningThreshold {
-                        ObservabilitySystem.topScope.emit(warning: "Approaching API limits on \(metadataURL.host ?? metadataURL.absoluteString) (\(apiRemaining)/\(apiLimit)), consider configuring an API token for this service.")
+                        self.observabilityScope.emit(warning: "Approaching API limits on \(metadataURL.host ?? metadataURL.absoluteString) (\(apiRemaining)/\(apiLimit)), consider configuring an API token for this service.")
                     }
                     // if successful, fan out multiple API calls
                     [releasesURL, contributorsURL, readmeURL, licenseURL, languagesURL].forEach { url in
@@ -152,9 +157,14 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
                     )
 
                     do {
-                        try self.cache?.put(key: identity.description, value: CacheValue(package: model, timestamp: DispatchTime.now()), replace: true)
+                        try self.cache?.put(
+                            key: identity.description,
+                            value: CacheValue(package: model, timestamp: DispatchTime.now()),
+                            replace: true,
+                            observabilityScope: self.observabilityScope
+                        )
                     } catch {
-                        ObservabilitySystem.topScope.emit(warning: "Failed to save GitHub metadata for package \(identity) to cache: \(error)")
+                        self.observabilityScope.emit(warning: "Failed to save GitHub metadata for package \(identity) to cache: \(error)")
                     }
 
                     callback(.success(model))

--- a/Sources/PackageCollectionsSigning/Certificate/CertificatePolicy.swift
+++ b/Sources/PackageCollectionsSigning/Certificate/CertificatePolicy.swift
@@ -114,14 +114,15 @@ extension CertificatePolicy {
     ///                  On other platforms, these are the **only** root certificates to be trusted.
     ///   - verifyDate: Overrides the timestamp used for checking certificate expiry (e.g., for testing). By default the current time is used.
     ///   - httpClient: HTTP client for OCSP requests
+    ///   - observabilityScope: observabilityScope to emit diagnostics on
     ///   - callbackQueue: The `DispatchQueue` to use for callbacks
     ///   - callback: The callback to invoke when the result is available.
     func verify(certChain: [Certificate],
                 anchorCerts: [Certificate]? = nil,
                 verifyDate: Date? = nil,
                 httpClient: HTTPClient?,
-                callbackQueue: DispatchQueue,
                 observabilityScope: ObservabilityScope,
+                callbackQueue: DispatchQueue,
                 callback: @escaping (Result<Void, Error>) -> Void) {
         let wrappedCallback: (Result<Void, Error>) -> Void = { result in callbackQueue.async { callback(result) } }
 
@@ -586,6 +587,8 @@ struct DefaultCertificatePolicy: CertificatePolicy {
     private let httpClient: HTTPClient
     #endif
 
+    private let observabilityScope: ObservabilityScope
+
     /// Initializes a `DefaultCertificatePolicy`.
     /// - Parameters:
     ///   - trustedRootCertsDir: On Apple platforms, all root certificates that come preinstalled with the OS are automatically trusted.
@@ -616,6 +619,8 @@ struct DefaultCertificatePolicy: CertificatePolicy {
         self.httpClient = HTTPClient.makeDefault(callbackQueue: callbackQueue)
         #endif
         #endif
+
+        self.observabilityScope = observabilityScope
     }
 
     func validate(certChain: [Certificate], callback: @escaping (Result<Void, Error>) -> Void) {
@@ -649,7 +654,7 @@ struct DefaultCertificatePolicy: CertificatePolicy {
             #if os(macOS)
             self.verify(certChain: certChain, anchorCerts: self.trustedRoots, callbackQueue: self.callbackQueue, callback: callback)
             #elseif os(Linux) || os(Windows) || os(Android)
-            self.verify(certChain: certChain, anchorCerts: self.trustedRoots, httpClient: self.httpClient, callbackQueue: self.callbackQueue, callback: callback)
+            self.verify(certChain: certChain, anchorCerts: self.trustedRoots, httpClient: self.httpClient, observabilityScope: self.observabilityScope, callbackQueue: self.callbackQueue, callback: callback)
             #endif
         } catch {
             return wrappedCallback(.failure(error))
@@ -673,6 +678,8 @@ struct AppleSwiftPackageCollectionCertificatePolicy: CertificatePolicy {
     #if os(Linux) || os(Windows) || os(Android)
     private let httpClient: HTTPClient
     #endif
+
+    private let observabilityScope: ObservabilityScope
 
     /// Initializes a `AppleSwiftPackageCollectionCertificatePolicy`.
     /// - Parameters:
@@ -704,6 +711,8 @@ struct AppleSwiftPackageCollectionCertificatePolicy: CertificatePolicy {
         self.httpClient = HTTPClient.makeDefault(callbackQueue: callbackQueue)
         #endif
         #endif
+
+        self.observabilityScope = observabilityScope
     }
 
     func validate(certChain: [Certificate], callback: @escaping (Result<Void, Error>) -> Void) {
@@ -749,7 +758,7 @@ struct AppleSwiftPackageCollectionCertificatePolicy: CertificatePolicy {
             #if os(macOS)
             self.verify(certChain: certChain, anchorCerts: self.trustedRoots, callbackQueue: self.callbackQueue, callback: callback)
             #elseif os(Linux) || os(Windows) || os(Android)
-            self.verify(certChain: certChain, anchorCerts: self.trustedRoots, httpClient: self.httpClient, callbackQueue: self.callbackQueue, callback: callback)
+            self.verify(certChain: certChain, anchorCerts: self.trustedRoots, httpClient: self.httpClient, observabilityScope: self.observabilityScope, callbackQueue: self.callbackQueue, callback: callback)
             #endif
         } catch {
             return wrappedCallback(.failure(error))
@@ -773,6 +782,8 @@ struct AppleDistributionCertificatePolicy: CertificatePolicy {
     #if os(Linux) || os(Windows) || os(Android)
     private let httpClient: HTTPClient
     #endif
+
+    private let observabilityScope: ObservabilityScope
 
     /// Initializes a `AppleDistributionCertificatePolicy`.
     /// - Parameters:
@@ -804,6 +815,8 @@ struct AppleDistributionCertificatePolicy: CertificatePolicy {
         self.httpClient = HTTPClient.makeDefault(callbackQueue: callbackQueue)
         #endif
         #endif
+
+        self.observabilityScope = observabilityScope
     }
 
     func validate(certChain: [Certificate], callback: @escaping (Result<Void, Error>) -> Void) {
@@ -849,7 +862,7 @@ struct AppleDistributionCertificatePolicy: CertificatePolicy {
             #if os(macOS)
             self.verify(certChain: certChain, anchorCerts: self.trustedRoots, callbackQueue: self.callbackQueue, callback: callback)
             #elseif os(Linux) || os(Windows) || os(Android)
-            self.verify(certChain: certChain, anchorCerts: self.trustedRoots, httpClient: self.httpClient, callbackQueue: self.callbackQueue, callback: callback)
+            self.verify(certChain: certChain, anchorCerts: self.trustedRoots, httpClient: self.httpClient, observabilityScope: self.observabilityScope, callbackQueue: self.callbackQueue, callback: callback)
             #endif
         } catch {
             return wrappedCallback(.failure(error))

--- a/Sources/PackageLoading/Diagnostics.swift
+++ b/Sources/PackageLoading/Diagnostics.swift
@@ -149,8 +149,16 @@ extension ObservabilityMetadata {
             self[ManifestLoadingDiagnosticFileKey.self] = newValue
         }
     }
-    
+
     enum ManifestLoadingDiagnosticFileKey: Key {
         typealias Value = AbsolutePath
     }
+}
+
+// FIXME: (diagnostics) deprecate in favor of the metadata version ^^ when transitioning manifest loader to Observability APIs
+public struct ManifestLoadingDiagnostic: DiagnosticData {
+     public let output: String
+     public let diagnosticFile: AbsolutePath?
+
+     public var description: String { output }
 }

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -268,7 +268,8 @@ public final class PackageBuilder {
         shouldCreateMultipleTestProducts: Bool = false,
         warnAboutImplicitExecutableTargets: Bool = true,
         createREPLProduct: Bool = false,
-        fileSystem: FileSystem
+        fileSystem: FileSystem,
+        observabilityScope: ObservabilityScope
     ) {
         self.identity = identity
         self.manifest = manifest
@@ -280,7 +281,7 @@ public final class PackageBuilder {
         self.shouldCreateMultipleTestProducts = shouldCreateMultipleTestProducts
         self.createREPLProduct = createREPLProduct
         self.warnAboutImplicitExecutableTargets = warnAboutImplicitExecutableTargets
-        self.observabilityScope = ObservabilitySystem.topScope.makeChildScope(
+        self.observabilityScope = observabilityScope.makeChildScope(
             description: "PackageBuilder",
             metadata: .packageMetadata(identity: self.identity, location: self.manifest.packageLocation)
         )
@@ -322,7 +323,9 @@ public final class PackageBuilder {
                     productFilter: .everything,
                     path: path,
                     xcTestMinimumDeploymentTargets: xcTestMinimumDeploymentTargets,
-                    fileSystem: localFileSystem)
+                    fileSystem: localFileSystem,
+                    observabilityScope: ObservabilitySystem(diagnosticEngine: diagnostics).topScope
+                )
                 return try builder.construct()
             }
             completion(result)

--- a/Sources/PackageModel/Package.swift
+++ b/Sources/PackageModel/Package.swift
@@ -143,6 +143,8 @@ extension ObservabilityMetadata {
         var metadata = ObservabilityMetadata()
         metadata.packageIdentity = identity
         metadata.packageLocation = location
+        // FIXME: (diagnostics) remove once transition to Observability API is complete
+        metadata.legacyLocation = "'\(identity)' \(location)"
         return metadata
     }
 }
@@ -156,7 +158,7 @@ extension ObservabilityMetadata {
             self[PackageIdentityKey.self] = newValue
         }
     }
-    
+
     enum PackageIdentityKey: Key {
         typealias Value = PackageIdentity
     }
@@ -171,7 +173,7 @@ extension ObservabilityMetadata {
             self[PackageLocationKey.self] = newValue
         }
     }
-    
+
     enum PackageLocationKey: Key {
         typealias Value = String
     }

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -220,9 +220,9 @@ public final class MockWorkspace {
         checkoutBranch: String? = nil,
         _ result: ([Basics.Diagnostic]) -> Void
     ) {
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let diagnostics = ObservabilitySystem.topScope.makeDiagnosticsEngine()
-        diagnostics.wrap {
+        let observability = ObservabilitySystem.makeForTesting()
+        let diagnostics = observability.topScope.makeDiagnosticsEngine()
+        observability.topScope.trap {
             let ws = try self.getOrCreateWorkspace()
             ws.edit(
                 packageName: packageName,
@@ -241,10 +241,10 @@ public final class MockWorkspace {
         forceRemove: Bool = false,
         _ result: ([Basics.Diagnostic]) -> Void
     ) {
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let diagnostics = ObservabilitySystem.topScope.makeDiagnosticsEngine()
+        let observability = ObservabilitySystem.makeForTesting()
+        let diagnostics = observability.topScope.makeDiagnosticsEngine()
         let rootInput = PackageGraphRootInput(packages: rootPaths(for: roots))
-        diagnostics.wrap {
+        observability.topScope.trap {
             let ws = try self.getOrCreateWorkspace()
             try ws.unedit(packageName: packageName, forceRemove: forceRemove, root: rootInput, diagnostics: diagnostics)
         }
@@ -252,10 +252,10 @@ public final class MockWorkspace {
     }
 
     public func checkResolve(pkg: String, roots: [String], version: TSCUtility.Version, _ result: ([Basics.Diagnostic]) -> Void) {
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let diagnostics = ObservabilitySystem.topScope.makeDiagnosticsEngine()
+        let observability = ObservabilitySystem.makeForTesting()
+        let diagnostics = observability.topScope.makeDiagnosticsEngine()
         let rootInput = PackageGraphRootInput(packages: rootPaths(for: roots))
-        diagnostics.wrap {
+        observability.topScope.trap {
             let workspace = try self.getOrCreateWorkspace()
             try workspace.resolve(packageName: pkg, root: rootInput, version: version, branch: nil, revision: nil, diagnostics: diagnostics)
         }
@@ -263,9 +263,9 @@ public final class MockWorkspace {
     }
 
     public func checkClean(_ result: ([Basics.Diagnostic]) -> Void) {
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let diagnostics = ObservabilitySystem.topScope.makeDiagnosticsEngine()
-        diagnostics.wrap {
+        let observability = ObservabilitySystem.makeForTesting()
+        let diagnostics = observability.topScope.makeDiagnosticsEngine()
+        observability.topScope.trap {
             let workspace = try self.getOrCreateWorkspace()
             workspace.clean(with: diagnostics)
         }
@@ -273,9 +273,9 @@ public final class MockWorkspace {
     }
 
     public func checkReset(_ result: ([Basics.Diagnostic]) -> Void) {
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let diagnostics = ObservabilitySystem.topScope.makeDiagnosticsEngine()
-        diagnostics.wrap {
+        let observability = ObservabilitySystem.makeForTesting()
+        let diagnostics = observability.topScope.makeDiagnosticsEngine()
+        observability.topScope.trap {
             let workspace = try self.getOrCreateWorkspace()
             workspace.reset(with: diagnostics)
         }
@@ -290,11 +290,12 @@ public final class MockWorkspace {
     ) throws {
         let dependencies = try deps.map { try $0.convert(baseURL: packagesDir, identityResolver: self.identityResolver) }
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let diagnostics = ObservabilitySystem.topScope.makeDiagnosticsEngine()
-        diagnostics.wrap {
+        let observability = ObservabilitySystem.makeForTesting()
+        let diagnostics = observability.topScope.makeDiagnosticsEngine()
+        observability.topScope.trap {
             let rootInput = PackageGraphRootInput(
-                packages: rootPaths(for: roots), dependencies: dependencies
+                packages: rootPaths(for: roots),
+                dependencies: dependencies
             )
             let workspace = try self.getOrCreateWorkspace()
             try workspace.updateDependencies(root: rootInput, packages: packages, diagnostics: diagnostics)
@@ -309,12 +310,13 @@ public final class MockWorkspace {
     ) throws {
         let dependencies = try deps.map { try $0.convert(baseURL: packagesDir, identityResolver: self.identityResolver) }
         let rootInput = PackageGraphRootInput(
-            packages: rootPaths(for: roots), dependencies: dependencies
+            packages: rootPaths(for: roots),
+            dependencies: dependencies
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let diagnostics = ObservabilitySystem.topScope.makeDiagnosticsEngine()
-        let changes = diagnostics.wrap { () -> [(PackageReference, Workspace.PackageStateChange)]? in
+        let observability = ObservabilitySystem.makeForTesting()
+        let diagnostics = observability.topScope.makeDiagnosticsEngine()
+        let changes = observability.topScope.trap { () -> [(PackageReference, Workspace.PackageStateChange)]? in
             let workspace = try self.getOrCreateWorkspace()
             return try workspace.updateDependencies(root: rootInput, diagnostics: diagnostics, dryRun: true)
         } ?? nil
@@ -336,14 +338,15 @@ public final class MockWorkspace {
         forceResolvedVersions: Bool = false,
         _ result: (PackageGraph, [Basics.Diagnostic]) -> Void
     ) throws {
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let diagnostics = ObservabilitySystem.topScope.makeDiagnosticsEngine()
+        let observability = ObservabilitySystem.makeForTesting()
         let rootInput = PackageGraphRootInput(
             packages: rootPaths(for: roots), dependencies: dependencies
         )
         let workspace = try self.getOrCreateWorkspace()
         let graph = try workspace.loadPackageGraph(
-            rootInput: rootInput, forceResolvedVersions: forceResolvedVersions, diagnostics: diagnostics
+            rootInput: rootInput,
+            forceResolvedVersions: forceResolvedVersions,
+            observabilityScope: observability.topScope
         )
         result(graph, observability.diagnostics)
     }
@@ -363,15 +366,17 @@ public final class MockWorkspace {
         forceResolvedVersions: Bool = false,
         _ result: ([Basics.Diagnostic]) -> Void
     ) {
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let diagnostics = ObservabilitySystem.topScope.makeDiagnosticsEngine()
+        let observability = ObservabilitySystem.makeForTesting()
         let rootInput = PackageGraphRootInput(
-            packages: rootPaths(for: roots), dependencies: dependencies
+            packages: rootPaths(for: roots),
+            dependencies: dependencies
         )
-        _ = diagnostics.wrap {
+        observability.topScope.trap {
             let workspace = try self.getOrCreateWorkspace()
             try workspace.loadPackageGraph(
-                rootInput: rootInput, forceResolvedVersions: forceResolvedVersions, diagnostics: diagnostics
+                rootInput: rootInput,
+                forceResolvedVersions: forceResolvedVersions,
+                observabilityScope: observability.topScope
             )
         }
         result(observability.diagnostics)
@@ -383,7 +388,8 @@ public final class MockWorkspace {
     }
 
     public func checkPrecomputeResolution(_ check: (ResolutionPrecomputationResult) -> Void) throws {
-        let diagnostics = ObservabilitySystem.topScope.makeDiagnosticsEngine()
+        let observability = ObservabilitySystem.makeForTesting()
+        let diagnostics = observability.topScope.makeDiagnosticsEngine()
         let workspace = try self.getOrCreateWorkspace()
         let pinsStore = try workspace.pinsStore.load()
 
@@ -557,8 +563,9 @@ public final class MockWorkspace {
         deps: [MockDependency] = [],
         _ result: (Workspace.DependencyManifests, DiagnosticsEngine) -> Void
     ) throws {
+        let observability = ObservabilitySystem.makeForTesting()
+        let diagnostics = observability.topScope.makeDiagnosticsEngine()
         let dependencies = try deps.map { try $0.convert(baseURL: packagesDir, identityResolver: self.identityResolver) }
-        let diagnostics = ObservabilitySystem.topScope.makeDiagnosticsEngine()
         let workspace = try self.getOrCreateWorkspace()
         let rootInput = PackageGraphRootInput(
             packages: rootPaths(for: roots), dependencies: dependencies
@@ -662,7 +669,7 @@ public final class MockWorkspaceDelegate: WorkspaceDelegate {
 
     public func fetchingRepository(from repository: String, objectsFetched: Int, totalObjectsToFetch: Int) {
     }
-    
+
     public func fetchingDidFinish(repository: String, fetchDetails: RepositoryManager.FetchDetails?, diagnostic: Diagnostic?, duration: DispatchTimeInterval) {
         self.append("finished fetching repo: \(repository)")
     }

--- a/Sources/SPMTestSupport/Observability.swift
+++ b/Sources/SPMTestSupport/Observability.swift
@@ -14,64 +14,69 @@ import func XCTest.XCTFail
 import func XCTest.XCTAssertEqual
 
 extension ObservabilitySystem {
-    public static func bootstrapForTesting() -> TestingObservability {
-        let testingObservability = TestingObservability()
-        Self._bootstrapGlobalForTestingOnlySeriously(factory: testingObservability.factory)
-        return testingObservability
+    public static func makeForTesting() -> TestingObservability {
+        let collector = TestingObservability.Collector()
+        let observabilitySystem = ObservabilitySystem(collector)
+        return TestingObservability(collector: collector, topScope: observabilitySystem.topScope)
+    }
+
+    public static var NOOP: ObservabilityScope {
+        ObservabilitySystem({ _, _ in }).topScope
     }
 }
 
 public struct TestingObservability {
-    fileprivate let factory = Factory()
+    private let collector: Collector
+    public let topScope: ObservabilityScope
+
+    fileprivate init(collector: Collector, topScope: ObservabilityScope) {
+        self.collector = collector
+        self.topScope = topScope
+    }
 
     public var diagnostics: [Basics.Diagnostic] {
-        self.factory.diagnosticsCollector.diagnostics.get()
+        self.collector.diagnostics.get()
     }
 
     public var hasErrorDiagnostics: Bool {
-        self.factory.diagnosticsCollector.hasErrors
+        self.collector.hasErrors
     }
 
     public var hasWarningDiagnostics: Bool {
-        self.factory.diagnosticsCollector.hasWarnings
+        self.collector.hasWarnings
     }
 
-    struct Factory: ObservabilityFactory {
-        fileprivate let diagnosticsCollector = DiagnosticsCollector()
+    struct Collector: ObservabilityHandlerProvider, DiagnosticsHandler, CustomStringConvertible {
+        var diagnosticsHandler: DiagnosticsHandler { return self }
 
-        var diagnosticsHandler: DiagnosticsHandler {
-            return diagnosticsCollector
+        let diagnostics: ThreadSafeArrayStore<Basics.Diagnostic>
+
+        init() {
+            self.diagnostics = .init()
+        }
+
+        // TODO: do something useful with scope
+        func handleDiagnostic(scope: ObservabilityScope, diagnostic: Basics.Diagnostic) {
+            self.diagnostics.append(diagnostic)
+        }
+
+        var hasErrors: Bool {
+            let diagnostics = self.diagnostics.get()
+            return diagnostics.contains(where: { $0.severity == .error })
+        }
+
+        var hasWarnings: Bool {
+            let diagnostics = self.diagnostics.get()
+            return diagnostics.contains(where: { $0.severity == .warning })
+        }
+
+        var description: String {
+            let diagnostics = self.diagnostics.get()
+            return "\(diagnostics)"
         }
     }
 }
 
-private final class DiagnosticsCollector: DiagnosticsHandler, CustomStringConvertible {
-    public let diagnostics: ThreadSafeArrayStore<Basics.Diagnostic>
-
-    public init() {
-        self.diagnostics = .init()
-    }
-
-    // TODO: do something useful with scope
-    public func handleDiagnostic(scope: ObservabilityScope, diagnostic: Basics.Diagnostic) {
-        self.diagnostics.append(diagnostic)
-    }
-
-    public var hasErrors: Bool {
-        let diagnostics = self.diagnostics.get()
-        return diagnostics.contains(where: { $0.severity == .error })
-    }
-
-    public var hasWarnings: Bool {
-        let diagnostics = self.diagnostics.get()
-        return diagnostics.contains(where: { $0.severity == .warning })
-    }
-
-    public var description: String {
-        let diagnostics = self.diagnostics.get()
-        return "\(diagnostics)"
-    }
-}
 
 public func XCTAssertNoDiagnostics(_ diagnostics: [Basics.Diagnostic], file: StaticString = #file, line: UInt = #line) {
     if diagnostics.isEmpty { return }

--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -8,6 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
+import Basics
 import class Foundation.NSDate
 import class Foundation.Thread
 import PackageGraph
@@ -226,7 +227,8 @@ public func loadPackageGraph(
     explicitProduct: String? = nil,
     shouldCreateMultipleTestProducts: Bool = false,
     createREPLProduct: Bool = false,
-    useXCBuildFileRules: Bool = false
+    useXCBuildFileRules: Bool = false,
+    observabilityScope: ObservabilityScope
 ) throws -> PackageGraph {
     let rootManifests = manifests.filter { $0.packageKind.isRoot }.spm_createDictionary{ ($0.path, $0) }
     let externalManifests = try manifests.filter { !$0.packageKind.isRoot }.reduce(into: OrderedDictionary<PackageIdentity, Manifest>()) { partial, item in
@@ -245,6 +247,7 @@ public func loadPackageGraph(
         binaryArtifacts: binaryArtifacts,
         shouldCreateMultipleTestProducts: shouldCreateMultipleTestProducts,
         createREPLProduct: createREPLProduct,
-        fileSystem: fs
+        fileSystem: fs,
+        observabilityScope: observabilityScope
     )
 }

--- a/Tests/BasicsTests/ObservabilitySystemTests.swift
+++ b/Tests/BasicsTests/ObservabilitySystemTests.swift
@@ -19,7 +19,7 @@ typealias Diagnostic = Basics.Diagnostic
 final class ObservabilitySystemTest: XCTestCase {
     func testScopes() throws {
         let collector = Collector()
-        let observabilitySystem = ObservabilitySystem(factory: collector)
+        let observabilitySystem = ObservabilitySystem(collector)
 
         var metadata1 = ObservabilityMetadata()
         metadata1.testKey1 = UUID().uuidString
@@ -91,7 +91,7 @@ final class ObservabilitySystemTest: XCTestCase {
 
     func testBasicDiagnostics() throws {
         let collector = Collector()
-        let observabilitySystem = ObservabilitySystem(factory: collector)
+        let observabilitySystem = ObservabilitySystem(collector)
 
         var metadata = ObservabilityMetadata()
         metadata.testKey1 = UUID().uuidString
@@ -123,7 +123,7 @@ final class ObservabilitySystemTest: XCTestCase {
 
     func testDiagnosticsMetadataMerge() throws {
         let collector = Collector()
-        let observabilitySystem = ObservabilitySystem(factory: collector)
+        let observabilitySystem = ObservabilitySystem(collector)
 
         var scopeMetadata = ObservabilityMetadata()
         scopeMetadata.testKey1 = UUID().uuidString
@@ -160,7 +160,7 @@ final class ObservabilitySystemTest: XCTestCase {
         }
     }
 
-    struct Collector: ObservabilityFactory, DiagnosticsHandler {
+    struct Collector: ObservabilityHandlerProvider, DiagnosticsHandler {
         private let _diagnostics = ThreadSafeArrayStore<Diagnostic>()
 
         var diagnosticsHandler: DiagnosticsHandler { self }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -105,8 +105,9 @@ final class BuildPlanTests: XCTestCase {
             "/Pkg/Sources/lib/lib.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let graph = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -115,14 +116,15 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "exe", dependencies: ["lib"]),
                         TargetDescription(name: "lib", dependencies: []),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(shouldLinkStaticSwiftStdlib: true),
             graph: graph,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+            diagnostics: observability.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
 
@@ -210,8 +212,9 @@ final class BuildPlanTests: XCTestCase {
             }
 
             // Plan package build with explicit module build
-            let observability = ObservabilitySystem.bootstrapForTesting()
-            let graph = try loadPackageGraph(fs: fs,
+            let observability = ObservabilitySystem.makeForTesting()
+            let graph = try loadPackageGraph(
+                fs: fs,
                 manifests: [
                     Manifest.createRootManifest(
                         name: "ExplicitTest",
@@ -221,7 +224,8 @@ final class BuildPlanTests: XCTestCase {
                             TargetDescription(name: "B", dependencies: ["C"]),
                             TargetDescription(name: "C", dependencies: []),
                         ]),
-                ]
+                ],
+                observabilityScope: observability.topScope
             )
             XCTAssertNoDiagnostics(observability.diagnostics)
             do {
@@ -234,7 +238,7 @@ final class BuildPlanTests: XCTestCase {
                         useExplicitModuleBuild: true
                     ),
                     graph: graph,
-                    diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+                    diagnostics: observability.topScope.makeDiagnosticsEngine(),
                     fileSystem: fs
                 )
 
@@ -268,8 +272,9 @@ final class BuildPlanTests: XCTestCase {
             "/ExtPkg/Sources/ExtLib/lib.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let graph = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -302,7 +307,8 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "ExtLib", dependencies: []),
                     ]
                 ),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         XCTAssertNoDiagnostics(observability.diagnostics)
@@ -314,7 +320,7 @@ final class BuildPlanTests: XCTestCase {
                     configuration: .release
                 )),
                 graph: graph,
-                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+                diagnostics: observability.topScope.makeDiagnosticsEngine(),
                 fileSystem: fs
             )
 
@@ -340,7 +346,7 @@ final class BuildPlanTests: XCTestCase {
                     configuration: .debug
                 )),
                 graph: graph,
-                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+                diagnostics: observability.topScope.makeDiagnosticsEngine(),
                 fileSystem: fs
             )
 
@@ -368,8 +374,9 @@ final class BuildPlanTests: XCTestCase {
             "/B/Tests/BTargetTests/foo.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let graph = try loadPackageGraph(fs: fileSystem,
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fs: fileSystem,
             manifests: [
                 Manifest.createRootManifest(
                     name: "A",
@@ -391,14 +398,15 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "BTarget", dependencies: []),
                         TargetDescription(name: "BTargetTests", dependencies: ["BTarget"], type: .test),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+            diagnostics: observability.topScope.makeDiagnosticsEngine(),
             fileSystem: fileSystem
         ))
 
@@ -420,8 +428,9 @@ final class BuildPlanTests: XCTestCase {
             "/Pkg/Sources/exe/main.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let graph = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -429,14 +438,15 @@ final class BuildPlanTests: XCTestCase {
                     targets: [
                         TargetDescription(name: "exe", dependencies: []),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(config: .release),
             graph: graph,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+            diagnostics: observability.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
 
@@ -476,8 +486,9 @@ final class BuildPlanTests: XCTestCase {
             "/ExtPkg/Sources/extlib/include/ext.h"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let graph = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -498,14 +509,15 @@ final class BuildPlanTests: XCTestCase {
                     targets: [
                         TargetDescription(name: "extlib", dependencies: []),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+            diagnostics: observability.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
 
@@ -588,7 +600,7 @@ final class BuildPlanTests: XCTestCase {
             "/ExtPkg/Sources/ExtLib/include/ext.h"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
             fs: fs,
             manifests: [
@@ -621,7 +633,8 @@ final class BuildPlanTests: XCTestCase {
                     targets: [
                         TargetDescription(name: "ExtLib", dependencies: []),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         XCTAssertNoDiagnostics(observability.diagnostics)
@@ -633,7 +646,7 @@ final class BuildPlanTests: XCTestCase {
                     configuration: .release
                 )),
                 graph: graph,
-                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+                diagnostics: observability.topScope.makeDiagnosticsEngine(),
                 fileSystem: fs
             ))
 
@@ -652,7 +665,7 @@ final class BuildPlanTests: XCTestCase {
                     configuration: .debug
                 )),
                 graph: graph,
-                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+                diagnostics: observability.topScope.makeDiagnosticsEngine(),
                 fileSystem: fs
             ))
 
@@ -672,8 +685,9 @@ final class BuildPlanTests: XCTestCase {
             "/Pkg/Sources/lib/include/lib.h"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let graph = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -684,14 +698,15 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "exe", dependencies: ["lib"]),
                         TargetDescription(name: "lib", dependencies: []),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         let plan = try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+            diagnostics: observability.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         )
         let result = BuildPlanResult(plan: plan)
@@ -736,8 +751,9 @@ final class BuildPlanTests: XCTestCase {
             "/Pkg/Sources/lib/include/lib.h"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let graph = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -746,14 +762,15 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "exe", dependencies: ["lib"]),
                         TargetDescription(name: "lib", dependencies: []),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+            diagnostics: observability.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
         result.checkProductsCount(1)
@@ -807,7 +824,7 @@ final class BuildPlanTests: XCTestCase {
             "/Pkg/Sources/lib/include/lib.h"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
             fs: fs,
             manifests: [
@@ -819,14 +836,15 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "exe", dependencies: ["lib"]),
                         TargetDescription(name: "lib", dependencies: []),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+            diagnostics: observability.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
         result.checkProductsCount(1)
@@ -851,8 +869,9 @@ final class BuildPlanTests: XCTestCase {
             "/Dep/Sources/CDep/include/module.modulemap"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let graph = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -876,14 +895,15 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "CDep", dependencies: []),
                     ]),
             ],
-            createREPLProduct: true
+            createREPLProduct: true,
+                                         observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         let plan = try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+            diagnostics: observability.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         )
         XCTAssertEqual(plan.createREPLArguments().sorted(), ["-I/Dep/Sources/CDep/include", "-I/path/to/build/debug", "-I/path/to/build/debug/lib.build", "-L/path/to/build/debug", "-lPkg__REPL"])
@@ -902,8 +922,9 @@ final class BuildPlanTests: XCTestCase {
             "/Pkg/Tests/FooTests/foo.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let graph = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -912,14 +933,15 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "Foo", dependencies: []),
                         TargetDescription(name: "FooTests", dependencies: ["Foo"], type: .test),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+            diagnostics: observability.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
         result.checkProductsCount(1)
@@ -971,8 +993,9 @@ final class BuildPlanTests: XCTestCase {
             "/Pkg/Sources/exe3/main.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let graph = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -983,14 +1006,15 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "exe2", type: .executable),
                         TargetDescription(name: "exe3", type: .executable),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(shouldLinkStaticSwiftStdlib: true),
             graph: graph,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+            diagnostics: observability.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
 
@@ -1018,8 +1042,9 @@ final class BuildPlanTests: XCTestCase {
             "/Clibgit/module.modulemap"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let graph = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -1034,14 +1059,15 @@ final class BuildPlanTests: XCTestCase {
                     name: "Clibgit",
                     path: .init("/Clibgit")
                 ),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+            diagnostics: observability.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
         result.checkProductsCount(1)
@@ -1077,8 +1103,9 @@ final class BuildPlanTests: XCTestCase {
             "/Pkg/Sources/lib/include/lib.h"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let graph = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -1087,14 +1114,15 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "lib", dependencies: []),
                         TargetDescription(name: "exe", dependencies: ["lib"]),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+            diagnostics: observability.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
         result.checkProductsCount(1)
@@ -1114,8 +1142,9 @@ final class BuildPlanTests: XCTestCase {
             "/Bar/Source/Bar/source.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let g = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        let g = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "Bar",
@@ -1135,14 +1164,15 @@ final class BuildPlanTests: XCTestCase {
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Bar-Baz"]),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: g,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+            diagnostics: observability.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
         result.checkProductsCount(2)
@@ -1209,8 +1239,9 @@ final class BuildPlanTests: XCTestCase {
             "/Pkg/Sources/lib/lib.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let graph = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -1222,14 +1253,15 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "lib", dependencies: []),
                         TargetDescription(name: "exe", dependencies: ["lib"]),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+            diagnostics: observability.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
 
@@ -1274,8 +1306,9 @@ final class BuildPlanTests: XCTestCase {
             "/Pkg/Sources/lib/lib.cpp"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let graph = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -1287,14 +1320,15 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "lib", dependencies: []),
                         TargetDescription(name: "exe", dependencies: []),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+            diagnostics: observability.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
 
@@ -1337,8 +1371,9 @@ final class BuildPlanTests: XCTestCase {
             "/C/Sources/CTarget/main.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let graph = try loadPackageGraph(fs: fileSystem,
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fs: fileSystem,
             manifests: [
                 Manifest.createRootManifest(
                     name: "A",
@@ -1373,7 +1408,8 @@ final class BuildPlanTests: XCTestCase {
                     targets: [
                         TargetDescription(name: "CTarget", dependencies: []),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
@@ -1399,7 +1435,7 @@ final class BuildPlanTests: XCTestCase {
         let planResult = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+            diagnostics: observability.topScope.makeDiagnosticsEngine(),
             fileSystem: fileSystem
         ))
 
@@ -1421,7 +1457,7 @@ final class BuildPlanTests: XCTestCase {
             "/C/Sources/CTarget/source.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
             fs: fileSystem,
             manifests: [
@@ -1480,7 +1516,8 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "CTarget", dependencies: []),
                     ]
                 ),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         XCTAssertNoDiagnostics(observability.diagnostics)
@@ -1494,7 +1531,7 @@ final class BuildPlanTests: XCTestCase {
             let planResult = BuildPlanResult(plan: try BuildPlan(
                 buildParameters: mockBuildParameters(environment: linuxDebug),
                 graph: graph,
-                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+                diagnostics: observability.topScope.makeDiagnosticsEngine(),
                 fileSystem: fileSystem
             ))
             planResult.checkProductsCount(4)
@@ -1509,7 +1546,7 @@ final class BuildPlanTests: XCTestCase {
             let planResult = BuildPlanResult(plan: try BuildPlan(
                 buildParameters: mockBuildParameters(environment: macosDebug),
                 graph: graph,
-                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+                diagnostics: observability.topScope.makeDiagnosticsEngine(),
                 fileSystem: fileSystem
             ))
             planResult.checkProductsCount(4)
@@ -1524,7 +1561,7 @@ final class BuildPlanTests: XCTestCase {
             let planResult = BuildPlanResult(plan: try BuildPlan(
                 buildParameters: mockBuildParameters(environment: androidRelease),
                 graph: graph,
-                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+                diagnostics: observability.topScope.makeDiagnosticsEngine(),
                 fileSystem: fileSystem
             ))
             planResult.checkProductsCount(4)
@@ -1537,14 +1574,16 @@ final class BuildPlanTests: XCTestCase {
             "/Pkg/module.modulemap"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let graph = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
                     path: .init("/Pkg")
                 )
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
@@ -1552,7 +1591,7 @@ final class BuildPlanTests: XCTestCase {
             _ = try BuildPlan(
                 buildParameters: mockBuildParameters(),
                 graph: graph,
-                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+                diagnostics: observability.topScope.makeDiagnosticsEngine(),
                 fileSystem: fs
             )
         }
@@ -1564,8 +1603,9 @@ final class BuildPlanTests: XCTestCase {
             "/A/Sources/BTarget/module.modulemap"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let graph = try loadPackageGraph(fs: fileSystem,
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fs: fileSystem,
             manifests: [
                 Manifest.createRootManifest(
                     name: "A",
@@ -1583,13 +1623,14 @@ final class BuildPlanTests: XCTestCase {
                             ]
                         )
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         _ = try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+            diagnostics: observability.topScope.makeDiagnosticsEngine(),
             fileSystem: fileSystem
         )
 
@@ -1605,8 +1646,9 @@ final class BuildPlanTests: XCTestCase {
             "/A/Sources/BTarget/module.modulemap"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let graph = try loadPackageGraph(fs: fileSystem,
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fs: fileSystem,
             manifests: [
                 Manifest.createRootManifest(
                     name: "A",
@@ -1619,13 +1661,14 @@ final class BuildPlanTests: XCTestCase {
                             pkgConfig: "BTarget"
                         )
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         _ = try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+            diagnostics: observability.topScope.makeDiagnosticsEngine(),
             fileSystem: fileSystem
         )
 
@@ -1643,7 +1686,7 @@ final class BuildPlanTests: XCTestCase {
             "/Pkg/Sources/lib/include/lib.h"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
             fs: fs,
             manifests: [
@@ -1654,14 +1697,15 @@ final class BuildPlanTests: XCTestCase {
                     TargetDescription(name: "exe", dependencies: ["lib"]),
                     TargetDescription(name: "lib", dependencies: []),
                 ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(destinationTriple: .windows),
             graph: graph,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+            diagnostics: observability.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
         result.checkProductsCount(1)
@@ -1699,7 +1743,7 @@ final class BuildPlanTests: XCTestCase {
             "/Pkg/Tests/test/TestCase.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
             fs: fs,
             manifests: [
@@ -1712,7 +1756,8 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "test", dependencies: ["lib"], type: .test)
                     ]
                 ),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
@@ -1721,7 +1766,7 @@ final class BuildPlanTests: XCTestCase {
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: parameters,
             graph: graph,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+            diagnostics: observability.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
         result.checkProductsCount(2)
@@ -1787,8 +1832,9 @@ final class BuildPlanTests: XCTestCase {
             "/Pkg/Sources/lib/include/lib.h"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let graph = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -1797,7 +1843,8 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "exe", dependencies: ["lib"]),
                         TargetDescription(name: "lib", dependencies: []),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
@@ -1805,7 +1852,7 @@ final class BuildPlanTests: XCTestCase {
             let result = BuildPlanResult(plan: try BuildPlan(
                 buildParameters: mockBuildParameters(config: config, indexStoreMode: mode),
                 graph: graph,
-                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+                diagnostics: observability.topScope.makeDiagnosticsEngine(),
                 fileSystem: fs
             ))
 
@@ -1833,8 +1880,9 @@ final class BuildPlanTests: XCTestCase {
             "/B/Sources/BTarget/foo.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let graph = try loadPackageGraph(fs: fileSystem,
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fs: fileSystem,
             manifests: [
                 Manifest.createRootManifest(
                     name: "A",
@@ -1862,14 +1910,15 @@ final class BuildPlanTests: XCTestCase {
                     targets: [
                         TargetDescription(name: "BTarget", dependencies: []),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+            diagnostics: observability.topScope.makeDiagnosticsEngine(),
             fileSystem: fileSystem
         ))
 
@@ -1893,8 +1942,9 @@ final class BuildPlanTests: XCTestCase {
             "/B/Sources/BTarget/foo.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let graph = try loadPackageGraph(fs: fileSystem,
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fs: fileSystem,
             manifests: [
                 Manifest.createRootManifest(
                     name: "A",
@@ -1924,7 +1974,8 @@ final class BuildPlanTests: XCTestCase {
                     targets: [
                         TargetDescription(name: "BTarget", dependencies: []),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
@@ -1932,7 +1983,7 @@ final class BuildPlanTests: XCTestCase {
             _ = try BuildPlan(
                 buildParameters: mockBuildParameters(destinationTriple: .macOS),
                 graph: graph,
-                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+                diagnostics: observability.topScope.makeDiagnosticsEngine(),
                 fileSystem: fileSystem
             )
         }
@@ -2028,9 +2079,11 @@ final class BuildPlanTests: XCTestCase {
                 ),
             ])
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let graph = try loadPackageGraph(fs: fs,
-            manifests: [aManifest, bManifest]
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fs: fs,
+            manifests: [aManifest, bManifest],
+            observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
@@ -2038,7 +2091,7 @@ final class BuildPlanTests: XCTestCase {
             return BuildPlanResult(plan: try BuildPlan(
                 buildParameters: mockBuildParameters(destinationTriple: dest),
                 graph: graph,
-                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+                diagnostics: observability.topScope.makeDiagnosticsEngine(),
                 fileSystem: fs
             ))
         }
@@ -2095,9 +2148,11 @@ final class BuildPlanTests: XCTestCase {
             ]
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let graph = try loadPackageGraph(fs: fs,
-            manifests: [aManifest]
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fs: fs,
+            manifests: [aManifest],
+            observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
@@ -2106,7 +2161,7 @@ final class BuildPlanTests: XCTestCase {
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(flags: flags),
             graph: graph,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+            diagnostics: observability.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
 
@@ -2121,8 +2176,9 @@ final class BuildPlanTests: XCTestCase {
             "/Pkg/Sources/lib/include/lib.h"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let graph = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -2131,7 +2187,8 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "exe", dependencies: ["lib"]),
                         TargetDescription(name: "lib", dependencies: []),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
@@ -2145,7 +2202,7 @@ final class BuildPlanTests: XCTestCase {
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: extraBuildParameters,
             graph: graph,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+            diagnostics: observability.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
         result.checkProductsCount(1)
@@ -2172,8 +2229,9 @@ final class BuildPlanTests: XCTestCase {
             "/PkgB/Sources/PkgB/PkgB.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let graph = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "PkgA",
@@ -2196,14 +2254,15 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "PkgB", dependencies: ["swiftlib"]),
                     ]),
             ],
-            explicitProduct: "exe"
+            explicitProduct: "exe",
+            observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         let plan = try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+            diagnostics: observability.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         )
 
@@ -2226,8 +2285,9 @@ final class BuildPlanTests: XCTestCase {
             "/PkgA/Sources/Foo/Foo.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let graph = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "PkgA",
@@ -2236,14 +2296,15 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "Foo", dependencies: []),
                         TargetDescription(name: "Bar", dependencies: ["Foo"]),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         let plan = try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+            diagnostics: observability.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         )
         let result = BuildPlanResult(plan: plan)
@@ -2284,8 +2345,9 @@ final class BuildPlanTests: XCTestCase {
             "/PkgB/Sources/Foo/Foo.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let graph = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "PkgA",
@@ -2305,14 +2367,15 @@ final class BuildPlanTests: XCTestCase {
                     targets: [
                         TargetDescription(name: "Foo", dependencies: []),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         let plan = try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+            diagnostics: observability.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         )
         let result = BuildPlanResult(plan: plan)
@@ -2353,8 +2416,9 @@ final class BuildPlanTests: XCTestCase {
             "/PkgB/Sources/Foo/Foo.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let graph = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "PkgA",
@@ -2374,14 +2438,15 @@ final class BuildPlanTests: XCTestCase {
                     targets: [
                         TargetDescription(name: "Foo", dependencies: []),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         let plan = try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+            diagnostics: observability.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         )
         let dynamicLibraryExtension = plan.buildParameters.triple.dynamicLibraryExtension
@@ -2422,8 +2487,9 @@ final class BuildPlanTests: XCTestCase {
             "/Pkg/Sources/lib/lib.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let graph = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -2433,14 +2499,15 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "lib", dependencies: []),
                     ]
                 ),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(destinationTriple: .x86_64Linux),
             graph: graph,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+            diagnostics: observability.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
 
@@ -2481,7 +2548,7 @@ final class BuildPlanTests: XCTestCase {
             "/PkgA/Sources/Bar/Bar.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        let observability = ObservabilitySystem.makeForTesting()
 
         let graph = try loadPackageGraph(
             fs: fs,
@@ -2503,7 +2570,8 @@ final class BuildPlanTests: XCTestCase {
                         ),
                     ]
                 )
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         XCTAssertNoDiagnostics(observability.diagnostics)
@@ -2511,7 +2579,7 @@ final class BuildPlanTests: XCTestCase {
         let plan = try BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+            diagnostics: observability.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         )
         let result = BuildPlanResult(plan: plan)
@@ -2541,7 +2609,10 @@ final class BuildPlanTests: XCTestCase {
             "/Pkg/Sources/lib/lib.swift"
         )
 
-        let graph = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+
+        let graph = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -2550,7 +2621,8 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "exe", dependencies: ["lib"]),
                         TargetDescription(name: "lib", dependencies: []),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         let supportingTriples: [TSCUtility.Triple] = [.x86_64Linux, .arm64Linux, .wasi]
@@ -2558,7 +2630,7 @@ final class BuildPlanTests: XCTestCase {
             let result = BuildPlanResult(plan: try BuildPlan(
                 buildParameters: mockBuildParameters(shouldLinkStaticSwiftStdlib: true, destinationTriple: triple),
                 graph: graph,
-                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+                diagnostics: observability.topScope.makeDiagnosticsEngine(),
                 fileSystem: fs
             ))
 
@@ -2643,7 +2715,7 @@ final class BuildPlanTests: XCTestCase {
                 </plist>
                 """))
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        let observability = ObservabilitySystem.makeForTesting()
         
         let graph = try loadPackageGraph(
             fs: fs,
@@ -2668,14 +2740,15 @@ final class BuildPlanTests: XCTestCase {
             binaryArtifacts: [
                 .init(kind: .xcframework, originURL: nil, path: AbsolutePath("/Pkg/Framework.xcframework")),
                 .init(kind: .xcframework, originURL: nil, path: AbsolutePath("/Pkg/StaticLibrary.xcframework"))
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(destinationTriple: destinationTriple),
             graph: graph,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+            diagnostics: observability.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
         XCTAssertNoDiagnostics(observability.diagnostics)
@@ -2752,7 +2825,7 @@ final class BuildPlanTests: XCTestCase {
                 }
         """))
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
             fs: fs,
             manifests: [
@@ -2770,14 +2843,15 @@ final class BuildPlanTests: XCTestCase {
             ],
             binaryArtifacts: [
                 .init(kind: .artifactsArchive, originURL: nil, path: toolPath),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         XCTAssertNoDiagnostics(observability.diagnostics)
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(destinationTriple: destinationTriple),
             graph: graph,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+            diagnostics: observability.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
         XCTAssertNoDiagnostics(observability.diagnostics)
@@ -2827,8 +2901,9 @@ final class BuildPlanTests: XCTestCase {
             "/Pkg/Sources/clib/include/clib.h"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let graph = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -2838,7 +2913,8 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "lib", dependencies: []),
                         TargetDescription(name: "clib", dependencies: []),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
@@ -2851,7 +2927,7 @@ final class BuildPlanTests: XCTestCase {
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: parameters,
             graph: graph,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+            diagnostics: observability.topScope.makeDiagnosticsEngine(),
             fileSystem: fs
         ))
 

--- a/Tests/CommandsTests/MultiRootSupportTests.swift
+++ b/Tests/CommandsTests/MultiRootSupportTests.swift
@@ -38,8 +38,8 @@ final class MultiRootSupportTests: XCTestCase {
                 """
         }
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let result = try XcodeWorkspaceLoader(diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(), fs: fs).load(workspace: path)
+        let observability = ObservabilitySystem.makeForTesting()
+        let result = try XcodeWorkspaceLoader(diagnostics: observability.topScope.makeDiagnosticsEngine(), fs: fs).load(workspace: path)
 
         XCTAssertNoDiagnostics(observability.diagnostics)
         XCTAssertEqual(result.map{ $0.pathString }.sorted(), ["/tmp/test/dep", "/tmp/test/local"])

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -429,10 +429,11 @@ final class PackageToolTests: XCTestCase {
             ]
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
             fs: fileSystem,
-            manifests: [manifestA, manifestB, manifestC, manifestD]
+            manifests: [manifestA, manifestB, manifestC, manifestD],
+            observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
@@ -896,12 +897,13 @@ final class PackageToolTests: XCTestCase {
     func testWatchmanXcodeprojgen() throws {
         try testWithTemporaryDirectory { path in
             let fs = localFileSystem
+            let observability = ObservabilitySystem.makeForTesting()
 
             let scriptsDir = path.appending(component: "scripts")
             let packageRoot = path.appending(component: "root")
 
             let helper = WatchmanHelper(
-                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+                diagnostics: observability.topScope.makeDiagnosticsEngine(),
                 watchmanScriptsDir: scriptsDir,
                 packageRoot: packageRoot)
 

--- a/Tests/PackageCollectionsSigningTests/CertificatePolicyTests.swift
+++ b/Tests/PackageCollectionsSigningTests/CertificatePolicyTests.swift
@@ -135,8 +135,10 @@ class CertificatePolicyTests: XCTestCase {
 
             #if os(macOS)
             // The Apple root certs come preinstalled on Apple platforms and they are automatically trusted
-            let policy = DefaultCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: nil,
-                                                  callbackQueue: callbackQueue)
+            let policy = DefaultCertificatePolicy(
+                trustedRootCertsDir: nil, additionalTrustedRootCerts: nil,
+                callbackQueue: callbackQueue
+            )
             XCTAssertThrowsError(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) }) { error in
                 guard CertificatePolicyError.invalidCertChain == error as? CertificatePolicyError else {
                     return XCTFail("Expected CertificatePolicyError.invalidCertChain")
@@ -181,15 +183,19 @@ class CertificatePolicyTests: XCTestCase {
             #if os(macOS)
             // The Apple root certs come preinstalled on Apple platforms and they are automatically trusted
             do {
-                let policy = DefaultCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: nil,
-                                                      callbackQueue: callbackQueue)
+                let policy = DefaultCertificatePolicy(
+                    trustedRootCertsDir: nil, additionalTrustedRootCerts: nil,
+                    callbackQueue: callbackQueue
+                )
                 XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
             }
 
             // What if `additionalTrustedRootCerts` has a cert that's already in the default trust store?
             do {
-                let policy = DefaultCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: [rootCA],
-                                                      callbackQueue: callbackQueue)
+                let policy = DefaultCertificatePolicy(
+                    trustedRootCertsDir: nil, additionalTrustedRootCerts: [rootCA],
+                    callbackQueue: callbackQueue
+                )
                 XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
             }
             #elseif os(Linux) || os(Windows) || os(Android)
@@ -246,15 +252,19 @@ class CertificatePolicyTests: XCTestCase {
             #if os(macOS)
             // The Apple root certs come preinstalled on Apple platforms and they are automatically trusted
             do {
-                let policy = AppleSwiftPackageCollectionCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: nil,
-                                                                          callbackQueue: callbackQueue)
+                let policy = AppleSwiftPackageCollectionCertificatePolicy(
+                    trustedRootCertsDir: nil, additionalTrustedRootCerts: nil,
+                    callbackQueue: callbackQueue
+                )
                 XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
             }
 
             // What if `additionalTrustedRootCerts` has a cert that's already in the default trust store?
             do {
-                let policy = AppleSwiftPackageCollectionCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: [rootCA],
-                                                                          callbackQueue: callbackQueue)
+                let policy = AppleSwiftPackageCollectionCertificatePolicy(
+                    trustedRootCertsDir: nil, additionalTrustedRootCerts: [rootCA],
+                    callbackQueue: callbackQueue
+                )
                 XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
             }
             #elseif os(Linux) || os(Windows) || os(Android)
@@ -308,18 +318,22 @@ class CertificatePolicyTests: XCTestCase {
 
             let certChain = [certificate, intermediateCA, rootCA]
 
-            #if os(macOS)
+#if os(macOS)
             // The Apple root certs come preinstalled on Apple platforms and they are automatically trusted
             do {
-                let policy = AppleDistributionCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: nil,
-                                                                callbackQueue: callbackQueue)
+                let policy = AppleDistributionCertificatePolicy(
+                    trustedRootCertsDir: nil, additionalTrustedRootCerts: nil,
+                    callbackQueue: callbackQueue
+                )
                 XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
             }
 
             // What if `additionalTrustedRootCerts` has a cert that's already in the default trust store?
             do {
-                let policy = AppleDistributionCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: [rootCA],
-                                                                callbackQueue: callbackQueue)
+                let policy = AppleDistributionCertificatePolicy(
+                    trustedRootCertsDir: nil, additionalTrustedRootCerts: [rootCA],
+                    callbackQueue: callbackQueue
+                )
                 XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
             }
             #elseif os(Linux) || os(Windows) || os(Android)
@@ -377,15 +391,23 @@ class CertificatePolicyTests: XCTestCase {
 
             // Subject user ID matches
             do {
-                let policy = DefaultCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: nil, expectedSubjectUserID: expectedSubjectUserID,
-                                                      callbackQueue: callbackQueue)
+                let policy = DefaultCertificatePolicy(
+                    trustedRootCertsDir: nil,
+                    additionalTrustedRootCerts: nil,
+                    expectedSubjectUserID: expectedSubjectUserID,
+                    callbackQueue: callbackQueue
+                )
                 XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
             }
             // Subject user ID does not match
             do {
                 let mismatchSubjectUserID = "\(expectedSubjectUserID)-2"
-                let policy = DefaultCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: nil, expectedSubjectUserID: mismatchSubjectUserID,
-                                                      callbackQueue: callbackQueue)
+                let policy = DefaultCertificatePolicy(
+                    trustedRootCertsDir: nil,
+                    additionalTrustedRootCerts: nil,
+                    expectedSubjectUserID: mismatchSubjectUserID,
+                    callbackQueue: callbackQueue
+                )
                 XCTAssertThrowsError(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) }) { error in
                     guard CertificatePolicyError.subjectUserIDMismatch == error as? CertificatePolicyError else {
                         return XCTFail("Expected CertificatePolicyError.subjectUserIDMismatch")
@@ -445,15 +467,23 @@ class CertificatePolicyTests: XCTestCase {
 
             // Subject user ID matches
             do {
-                let policy = AppleSwiftPackageCollectionCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: nil, expectedSubjectUserID: expectedSubjectUserID,
-                                                                          callbackQueue: callbackQueue)
+                let policy = AppleSwiftPackageCollectionCertificatePolicy(
+                    trustedRootCertsDir: nil,
+                    additionalTrustedRootCerts: nil,
+                    expectedSubjectUserID: expectedSubjectUserID,
+                    callbackQueue: callbackQueue
+                )
                 XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
             }
             // Subject user ID does not match
             do {
                 let mismatchSubjectUserID = "\(expectedSubjectUserID)-2"
-                let policy = AppleSwiftPackageCollectionCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: nil, expectedSubjectUserID: mismatchSubjectUserID,
-                                                                          callbackQueue: callbackQueue)
+                let policy = AppleSwiftPackageCollectionCertificatePolicy(
+                    trustedRootCertsDir: nil,
+                    additionalTrustedRootCerts: nil,
+                    expectedSubjectUserID: mismatchSubjectUserID,
+                    callbackQueue: callbackQueue
+                )
                 XCTAssertThrowsError(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) }) { error in
                     guard CertificatePolicyError.subjectUserIDMismatch == error as? CertificatePolicyError else {
                         return XCTFail("Expected CertificatePolicyError.subjectUserIDMismatch")
@@ -515,15 +545,23 @@ class CertificatePolicyTests: XCTestCase {
 
             // Subject user ID matches
             do {
-                let policy = AppleDistributionCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: nil, expectedSubjectUserID: expectedSubjectUserID,
-                                                                callbackQueue: callbackQueue)
+                let policy = AppleDistributionCertificatePolicy(
+                    trustedRootCertsDir: nil,
+                    additionalTrustedRootCerts: nil,
+                    expectedSubjectUserID: expectedSubjectUserID,
+                    callbackQueue: callbackQueue
+                )
                 XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
             }
             // Subject user ID does not match
             do {
                 let mismatchSubjectUserID = "\(expectedSubjectUserID)-2"
-                let policy = AppleDistributionCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: nil, expectedSubjectUserID: mismatchSubjectUserID,
-                                                                callbackQueue: callbackQueue)
+                let policy = AppleDistributionCertificatePolicy(
+                    trustedRootCertsDir: nil,
+                    additionalTrustedRootCerts: nil,
+                    expectedSubjectUserID: mismatchSubjectUserID,
+                    callbackQueue: callbackQueue
+                )
                 XCTAssertThrowsError(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) }) { error in
                     guard CertificatePolicyError.subjectUserIDMismatch == error as? CertificatePolicyError else {
                         return XCTFail("Expected CertificatePolicyError.subjectUserIDMismatch")
@@ -555,5 +593,23 @@ class CertificatePolicyTests: XCTestCase {
             }
             #endif
         }
+    }
+}
+
+fileprivate extension AppleSwiftPackageCollectionCertificatePolicy {
+    init(trustedRootCertsDir: URL?, additionalTrustedRootCerts: [Certificate]?, expectedSubjectUserID: String? = nil, callbackQueue: DispatchQueue) {
+        self.init(trustedRootCertsDir: trustedRootCertsDir, additionalTrustedRootCerts: additionalTrustedRootCerts, expectedSubjectUserID: expectedSubjectUserID, observabilityScope: ObservabilitySystem.NOOP, callbackQueue: callbackQueue)
+    }
+}
+
+fileprivate extension AppleDistributionCertificatePolicy {
+    init(trustedRootCertsDir: URL?, additionalTrustedRootCerts: [Certificate]?, expectedSubjectUserID: String? = nil, callbackQueue: DispatchQueue) {
+        self.init(trustedRootCertsDir: trustedRootCertsDir, additionalTrustedRootCerts: additionalTrustedRootCerts, expectedSubjectUserID: expectedSubjectUserID, observabilityScope: ObservabilitySystem.NOOP, callbackQueue: callbackQueue)
+    }
+}
+
+fileprivate extension DefaultCertificatePolicy {
+    init(trustedRootCertsDir: URL?, additionalTrustedRootCerts: [Certificate]?, expectedSubjectUserID: String? = nil, callbackQueue: DispatchQueue) {
+        self.init(trustedRootCertsDir: trustedRootCertsDir, additionalTrustedRootCerts: additionalTrustedRootCerts, expectedSubjectUserID: expectedSubjectUserID, observabilityScope: ObservabilitySystem.NOOP, callbackQueue: callbackQueue)
     }
 }

--- a/Tests/PackageCollectionsSigningTests/PackageCollectionSigningTest.swift
+++ b/Tests/PackageCollectionsSigningTests/PackageCollectionSigningTest.swift
@@ -224,22 +224,40 @@ class PackageCollectionSigningTests: XCTestCase {
                 let signing = PackageCollectionSigning(callbackQueue: callbackQueue)
                 // Sign the collection
                 let signedCollection = try tsc_await { callback in
-                    signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)
+                    signing.sign(
+                        collection: collection,
+                        certChainPaths: certChainPaths,
+                        certPrivateKeyPath: privateKeyPath.asURL,
+                        certPolicyKey: certPolicyKey,
+                        callback: callback
+                    )
                 }
 
                 // Then validate that signature is valid
                 XCTAssertNoThrow(try tsc_await { callback in
-                    signing.validate(signedCollection: signedCollection, certPolicyKey: certPolicyKey, callback: callback)
+                    signing.validate(
+                        signedCollection: signedCollection,
+                        certPolicyKey: certPolicyKey,
+                        callback: callback
+                    )
                 })
             }
 
             // Try passing in the cert with `additionalTrustedRootCerts` even though it's already in the default trust store
             do {
-                let signing = PackageCollectionSigning(additionalTrustedRootCerts: [rootCAData.base64EncodedString()],
-                                                       callbackQueue: callbackQueue)
+                let signing = PackageCollectionSigning(
+                    additionalTrustedRootCerts: [rootCAData.base64EncodedString()],
+                    callbackQueue: callbackQueue
+                )
                 // Sign the collection
                 let signedCollection = try tsc_await { callback in
-                    signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)
+                    signing.sign(
+                        collection: collection,
+                        certChainPaths: certChainPaths,
+                        certPrivateKeyPath: privateKeyPath.asURL,
+                        certPolicyKey: certPolicyKey,
+                        callback: callback
+                    )
                 }
 
                 // Then validate that signature is valid
@@ -327,8 +345,10 @@ class PackageCollectionSigningTests: XCTestCase {
 
             // Try passing in the cert with `additionalTrustedRootCerts` even though it's already in the default trust store
             do {
-                let signing = PackageCollectionSigning(additionalTrustedRootCerts: [rootCAData.base64EncodedString()],
-                                                       callbackQueue: callbackQueue)
+                let signing = PackageCollectionSigning(
+                    additionalTrustedRootCerts: [rootCAData.base64EncodedString()],
+                    callbackQueue: callbackQueue
+                )
                 // Sign the collection
                 let signedCollection = try tsc_await { callback in
                     signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)
@@ -419,8 +439,10 @@ class PackageCollectionSigningTests: XCTestCase {
 
             // Try passing in the cert with `additionalTrustedRootCerts` even though it's already in the default trust store
             do {
-                let signing = PackageCollectionSigning(additionalTrustedRootCerts: [rootCAData.base64EncodedString()],
-                                                       callbackQueue: callbackQueue)
+                let signing = PackageCollectionSigning(
+                    additionalTrustedRootCerts: [rootCAData.base64EncodedString()],
+                    callbackQueue: callbackQueue
+                )
                 // Sign the collection
                 let signedCollection = try tsc_await { callback in
                     signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)
@@ -552,12 +574,22 @@ class PackageCollectionSigningTests: XCTestCase {
             let signing = PackageCollectionSigning(callbackQueue: callbackQueue)
             // Sign the collection
             let signedCollection = try tsc_await { callback in
-                signing.sign(collection: collection, certChainPaths: certChainPaths, certPrivateKeyPath: privateKeyPath.asURL, certPolicyKey: certPolicyKey, callback: callback)
+                signing.sign(
+                    collection: collection,
+                    certChainPaths: certChainPaths,
+                    certPrivateKeyPath: privateKeyPath.asURL,
+                    certPolicyKey: certPolicyKey,
+                    callback: callback
+                )
             }
 
             // Then validate that signature is valid
             XCTAssertNoThrow(try tsc_await { callback in
-                signing.validate(signedCollection: signedCollection, certPolicyKey: certPolicyKey, callback: callback)
+                signing.validate(
+                    signedCollection: signedCollection,
+                    certPolicyKey: certPolicyKey,
+                    callback: callback
+                )
             })
             #elseif os(Linux) || os(Windows) || os(Android)
             // On other platforms we have to specify `trustedRootCertsDir` so the Apple root cert is trusted
@@ -631,5 +663,14 @@ class PackageCollectionSigningTests: XCTestCase {
             }
             #endif
         }
+    }
+}
+
+fileprivate extension PackageCollectionSigning  {
+    init(trustedRootCertsDir: URL? = nil, additionalTrustedRootCerts: [String]? = nil, callbackQueue: DispatchQueue) {
+        self.init(trustedRootCertsDir: trustedRootCertsDir, additionalTrustedRootCerts: additionalTrustedRootCerts, observabilityScope: ObservabilitySystem.NOOP, callbackQueue: callbackQueue)
+    }
+    init(certPolicy: CertificatePolicy, callbackQueue: DispatchQueue) {
+        self.init(certPolicy: certPolicy, observabilityScope: ObservabilitySystem.NOOP, callbackQueue: callbackQueue)
     }
 }

--- a/Tests/PackageCollectionsSigningTests/Utilities.swift
+++ b/Tests/PackageCollectionsSigningTests/Utilities.swift
@@ -62,6 +62,7 @@ struct TestCertificatePolicy: CertificatePolicy {
                         callbackQueue: callbackQueue, callback: callback)
             #else
             self.verify(certChain: certChain, anchorCerts: self.anchorCerts, verifyDate: self.verifyDate, httpClient: nil,
+                        observabilityScope: ObservabilitySystem.NOOP,
                         callbackQueue: callbackQueue, callback: callback)
             #endif
         } catch {

--- a/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
+++ b/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
@@ -384,3 +384,13 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
         }
     }
 }
+
+internal extension GitHubPackageMetadataProvider {
+    init(configuration: Configuration = .init(), httpClient: HTTPClient? = nil) {
+        self.init(
+            configuration: configuration,
+            observabilityScope: ObservabilitySystem.NOOP,
+            httpClient: httpClient
+        )
+    }
+}

--- a/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
+++ b/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
@@ -827,3 +827,22 @@ private extension XCTestCase {
         }
     }
 }
+
+internal extension JSONPackageCollectionProvider {
+    init(
+        configuration: Configuration = .init(),
+        httpClient: HTTPClient? = nil,
+        signatureValidator: PackageCollectionSignatureValidator? = nil,
+        sourceCertPolicy: PackageCollectionSourceCertificatePolicy = PackageCollectionSourceCertificatePolicy(),
+        fileSystem: FileSystem = localFileSystem
+    ) {
+        self.init(
+            configuration: configuration,
+            observabilityScope: ObservabilitySystem.NOOP,
+            httpClient: httpClient,
+            signatureValidator: signatureValidator,
+            sourceCertPolicy: sourceCertPolicy,
+            fileSystem: fileSystem
+        )
+    }
+}

--- a/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
@@ -1601,6 +1601,23 @@ final class PackageCollectionsTests: XCTestCase {
     }
 }
 
+private extension PackageCollections {
+    init(
+        configuration: Configuration = .init(),
+        storage: Storage,
+        collectionProviders: [Model.CollectionSourceType: PackageCollectionProvider],
+        metadataProvider: PackageMetadataProvider
+    ) {
+        self.init(
+            configuration: configuration,
+            observabilityScope: ObservabilitySystem.NOOP,
+            storage: storage,
+            collectionProviders: collectionProviders,
+            metadataProvider: metadataProvider
+        )
+    }
+}
+
 private extension XCTestCase {
     func skipIfUnsupportedPlatform() throws {
         if !PackageCollections.isSupportedPlatform {

--- a/Tests/PackageCollectionsTests/Utility.swift
+++ b/Tests/PackageCollectionsTests/Utility.swift
@@ -8,10 +8,10 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
+import Basics
 import struct Foundation.Date
 import struct Foundation.URL
 import struct Foundation.UUID
-
 @testable import PackageCollections
 import PackageCollectionsModel
 import PackageCollectionsSigning

--- a/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
@@ -68,12 +68,13 @@ class PackageGraphPerfTests: XCTestCasePerf {
         }
 
         measure {
-            let observability = ObservabilitySystem.bootstrapForTesting()
+            let observability = ObservabilitySystem.makeForTesting()
             let g = try! PackageGraph.load(
                 root: PackageGraphRoot(input: PackageGraphRootInput(packages: [rootManifest.path]), manifests: [rootManifest.path: rootManifest]),
                 identityResolver: identityResolver,
                 externalManifests: externalManifests,
-                fileSystem: fs
+                fileSystem: fs,
+                observabilityScope: observability.topScope
             )
             XCTAssertEqual(g.packages.count, N)
             XCTAssertNoDiagnostics(observability.diagnostics)

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -27,8 +27,9 @@ class PackageGraphTests: XCTestCase {
             "/Baz/Tests/BazTests/source.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let g = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        let g = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "Foo",
@@ -62,7 +63,8 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "Baz", dependencies: ["Bar"]),
                         TargetDescription(name: "BazTests", dependencies: ["Baz"], type: .test),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         XCTAssertNoDiagnostics(observability.diagnostics)
@@ -92,8 +94,9 @@ class PackageGraphTests: XCTestCase {
             "/Bar/Source/CBar/module.modulemap"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let g = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        let g = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -115,7 +118,8 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "Bar", dependencies: ["CBar"]),
                         TargetDescription(name: "CBar", type: .system),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         XCTAssertNoDiagnostics(observability.diagnostics)
@@ -134,8 +138,9 @@ class PackageGraphTests: XCTestCase {
             "/Baz/Sources/Baz/source.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        _ = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        _ = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -170,7 +175,8 @@ class PackageGraphTests: XCTestCase {
                     targets: [
                         TargetDescription(name: "Baz", dependencies: ["Bar"]),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         testDiagnostics(observability.diagnostics) { result in
@@ -185,8 +191,9 @@ class PackageGraphTests: XCTestCase {
             "/Baz/Sources/Baz/source.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        _ = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        _ = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -197,7 +204,8 @@ class PackageGraphTests: XCTestCase {
                     targets: [
                         TargetDescription(name: "Foo"),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         testDiagnostics(observability.diagnostics) { result in
@@ -215,8 +223,9 @@ class PackageGraphTests: XCTestCase {
             "/Bar/Tests/BarTests/source.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let g = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        let g = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Bar",
@@ -238,7 +247,8 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "Foo", dependencies: []),
                         TargetDescription(name: "FooTests", dependencies: ["Foo"], type: .test),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         XCTAssertNoDiagnostics(observability.diagnostics)
@@ -255,8 +265,9 @@ class PackageGraphTests: XCTestCase {
             "/Bar/Sources/Bar/source.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        _ = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        _ = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -273,7 +284,8 @@ class PackageGraphTests: XCTestCase {
                     targets: [
                         TargetDescription(name: "Bar"),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         testDiagnostics(observability.diagnostics) { result in
@@ -289,8 +301,9 @@ class PackageGraphTests: XCTestCase {
             "/First/Sources/First/source.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        _ = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        _ = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "Fourth",
@@ -330,7 +343,8 @@ class PackageGraphTests: XCTestCase {
                     targets: [
                         TargetDescription(name: "First", dependencies: ["Second", "Third", "Fourth"]),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         testDiagnostics(observability.diagnostics) { result in
@@ -346,8 +360,9 @@ class PackageGraphTests: XCTestCase {
             "/First/Sources/Foo/source.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        _ = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        _ = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "Fourth",
@@ -387,7 +402,8 @@ class PackageGraphTests: XCTestCase {
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Second", "Third", "Fourth"]),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         testDiagnostics(observability.diagnostics) { result in
@@ -404,8 +420,9 @@ class PackageGraphTests: XCTestCase {
             "/First/Sources/First/source.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        _ = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        _ = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "Fourth",
@@ -452,7 +469,8 @@ class PackageGraphTests: XCTestCase {
                     targets: [
                         TargetDescription(name: "First", dependencies: ["Second"]),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         testDiagnostics(observability.diagnostics) { result in
@@ -466,8 +484,9 @@ class PackageGraphTests: XCTestCase {
             "/Bar/Sources/Bar/source.txt"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        _ = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        _ = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -487,7 +506,8 @@ class PackageGraphTests: XCTestCase {
                     targets: [
                         TargetDescription(name: "Bar"),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         testDiagnostics(observability.diagnostics) { result in
@@ -509,8 +529,9 @@ class PackageGraphTests: XCTestCase {
             "/Foo/Sources/FooTarget/foo.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        _ = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        _ = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -518,7 +539,8 @@ class PackageGraphTests: XCTestCase {
                     targets: [
                         TargetDescription(name: "FooTarget", dependencies: ["Barx"]),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         testDiagnostics(observability.diagnostics) { result in
@@ -536,8 +558,9 @@ class PackageGraphTests: XCTestCase {
             "/Foo/Tests/FooTests/source.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        _ = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        _ = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -549,7 +572,8 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "FooTarget", dependencies: []),
                         TargetDescription(name: "FooTests", dependencies: ["Foo"], type: .test),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         testDiagnostics(observability.diagnostics) { result in
@@ -563,20 +587,23 @@ class PackageGraphTests: XCTestCase {
 
     func testExecutableTargetDependency() throws {
         let fs = InMemoryFileSystem(emptyFiles:
-                "/XYZ/Sources/XYZ/main.swift",
-                "/XYZ/Tests/XYZTests/tests.swift"
+                                        "/XYZ/Sources/XYZ/main.swift",
+                                    "/XYZ/Tests/XYZTests/tests.swift"
         )
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        _ = try loadPackageGraph(fs: fs,
-                                 manifests: [
-                    Manifest.createRootManifest(
-                        name: "XYZ",
-                        path: .init("/XYZ"),
-                        targets: [
-                            TargetDescription(name: "XYZ", dependencies: [], type: .executable),
-                            TargetDescription(name: "XYZTests", dependencies: ["XYZ"], type: .test),
-                        ]),
+        let observability = ObservabilitySystem.makeForTesting()
+        _ = try loadPackageGraph(
+            fs: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    name: "XYZ",
+                    path: .init("/XYZ"),
+                    targets: [
+                        TargetDescription(name: "XYZ", dependencies: [], type: .executable),
+                        TargetDescription(name: "XYZTests", dependencies: ["XYZ"], type: .test),
                     ]
+                ),
+            ],
+            observabilityScope: observability.topScope
         )
         testDiagnostics(observability.diagnostics) { _ in }
     }
@@ -587,8 +614,9 @@ class PackageGraphTests: XCTestCase {
             "/Foo/Tests/FooTests/source.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        _ = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        _ = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -600,7 +628,8 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "Foo", dependencies: []),
                         TargetDescription(name: "FooTests", dependencies: ["Foo"], type: .test),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
         testDiagnostics(observability.diagnostics) { _ in }
     }
@@ -610,8 +639,9 @@ class PackageGraphTests: XCTestCase {
             "/Foo/Sources/FooTarget/foo.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        _ = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        _ = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -621,7 +651,8 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "FooTarget", dependencies: [.product(name: "Barx", package: "Bar")]),
                     ]
                 )
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         testDiagnostics(observability.diagnostics) { result in
@@ -638,8 +669,9 @@ class PackageGraphTests: XCTestCase {
             "/Foo/Sources/FooTarget/foo.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        _ = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        _ = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -649,7 +681,8 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "FooTarget", dependencies: [.product(name: "Barx")]),
                     ]
                 )
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         testDiagnostics(observability.diagnostics) { result in
@@ -669,8 +702,9 @@ class PackageGraphTests: XCTestCase {
             "/FizPath/Sources/FizLib/fiz.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        _ = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        _ = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -713,7 +747,8 @@ class PackageGraphTests: XCTestCase {
                     targets: [
                         TargetDescription(name: "FizLib"),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         testDiagnostics(observability.diagnostics) { result in
@@ -747,8 +782,9 @@ class PackageGraphTests: XCTestCase {
             "/Bar/Sources/Bar/bar.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        _ = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        _ = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -769,7 +805,8 @@ class PackageGraphTests: XCTestCase {
                     targets: [
                         TargetDescription(name: "Bar"),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         // Expect no diagnostics.
@@ -784,8 +821,9 @@ class PackageGraphTests: XCTestCase {
             "/Biz/Sources/Biz/main.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        _ = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        _ = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -825,7 +863,8 @@ class PackageGraphTests: XCTestCase {
                     targets: [
                         TargetDescription(name: "Baz"),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         testDiagnostics(observability.diagnostics) { result in
@@ -842,8 +881,9 @@ class PackageGraphTests: XCTestCase {
             "/Bar/Sources/Bar/main.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        _ = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        _ = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Bar",
@@ -858,7 +898,8 @@ class PackageGraphTests: XCTestCase {
                     name: "Foo",
                     path: .init("/Foo")
                 ),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         // We don't expect any unused dependency diagnostics from a system module package.
@@ -874,8 +915,9 @@ class PackageGraphTests: XCTestCase {
             "/Dep2/Sources/Bam/bam.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        _ = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        _ = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Start",
@@ -910,7 +952,8 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "Foo"),
                         TargetDescription(name: "Bam"),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         testDiagnostics(observability.diagnostics) { result in
@@ -925,8 +968,9 @@ class PackageGraphTests: XCTestCase {
             "/Baz/Sources/Baz/baz.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        _ = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        _ = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -956,7 +1000,8 @@ class PackageGraphTests: XCTestCase {
                     targets: [
                         TargetDescription(name: "Baz"),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         testDiagnostics(observability.diagnostics) { result in
@@ -975,8 +1020,9 @@ class PackageGraphTests: XCTestCase {
             "<end>"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        _ = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        _ = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -1018,7 +1064,8 @@ class PackageGraphTests: XCTestCase {
                             dependencies: ["Bar2"]
                         ),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         XCTAssertEqual(observability.diagnostics.count, 3)
@@ -1037,7 +1084,7 @@ class PackageGraphTests: XCTestCase {
             "/Biz/Sources/Biz/source.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
             fs: fs,
             manifests: [
@@ -1076,7 +1123,8 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "Biz"),
                     ]
                 ),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         XCTAssertNoDiagnostics(observability.diagnostics)
@@ -1118,7 +1166,7 @@ class PackageGraphTests: XCTestCase {
             "/Transitive/Sources/TransitiveUnused/TransitiveUnused.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        let observability = ObservabilitySystem.makeForTesting()
         _ = try loadPackageGraph(
             fs: fs,
             manifests: [
@@ -1182,7 +1230,8 @@ class PackageGraphTests: XCTestCase {
                             .product(name: "Nonexistent", package: "Nonexistent")
                         ])
                 ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         XCTAssertNoDiagnostics(observability.diagnostics)
@@ -1230,8 +1279,9 @@ class PackageGraphTests: XCTestCase {
             "/Bar/Sources/Bar/bar.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        _ = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        _ = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -1253,7 +1303,8 @@ class PackageGraphTests: XCTestCase {
                     targets: [
                         TargetDescription(name: "Bar"),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         XCTAssertNoDiagnostics(observability.diagnostics)
@@ -1265,8 +1316,9 @@ class PackageGraphTests: XCTestCase {
             "/Bar/Sources/Bar/bar.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        _ = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        _ = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -1288,7 +1340,8 @@ class PackageGraphTests: XCTestCase {
                     targets: [
                         TargetDescription(name: "Bar"),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         testDiagnostics(observability.diagnostics) { result in
@@ -1308,8 +1361,9 @@ class PackageGraphTests: XCTestCase {
             "/Bar/Sources/Bar/bar.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        _ = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        _ = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -1331,7 +1385,8 @@ class PackageGraphTests: XCTestCase {
                     targets: [
                         TargetDescription(name: "Bar"),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         XCTAssertNoDiagnostics(observability.diagnostics)
@@ -1343,8 +1398,9 @@ class PackageGraphTests: XCTestCase {
             "/Bar/Sources/Bar/bar.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        _ = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        _ = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -1366,7 +1422,8 @@ class PackageGraphTests: XCTestCase {
                     targets: [
                         TargetDescription(name: "Bar"),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         testDiagnostics(observability.diagnostics) { result in
@@ -1410,8 +1467,8 @@ class PackageGraphTests: XCTestCase {
         ]
 
         do {
-            let observability = ObservabilitySystem.bootstrapForTesting()
-            _ = try loadPackageGraph(fs: fs, manifests: manifests)
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadPackageGraph(fs: fs, manifests: manifests, observabilityScope: observability.topScope)
             testDiagnostics(observability.diagnostics) { result in
                 result.check(
                     diagnostic: """
@@ -1433,8 +1490,8 @@ class PackageGraphTests: XCTestCase {
                 manifests[1] // same
             ]
 
-            let observability = ObservabilitySystem.bootstrapForTesting()
-            _ = try loadPackageGraph(fs: fs, manifests: fixedManifests)
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadPackageGraph(fs: fs, manifests: fixedManifests, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
         }
     }
@@ -1471,8 +1528,8 @@ class PackageGraphTests: XCTestCase {
         ]
 
         do {
-            let observability = ObservabilitySystem.bootstrapForTesting()
-            _ = try loadPackageGraph(fs: fs, manifests: manifests)
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadPackageGraph(fs: fs, manifests: manifests, observabilityScope: observability.topScope)
             testDiagnostics(observability.diagnostics) { result in
                 result.check(
                     diagnostic: """
@@ -1495,8 +1552,8 @@ class PackageGraphTests: XCTestCase {
                 manifests[1] // same
             ]
 
-            let observability = ObservabilitySystem.bootstrapForTesting()
-            _ = try loadPackageGraph(fs: fs, manifests: fixedManifests)
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadPackageGraph(fs: fs, manifests: fixedManifests, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
         }
     }
@@ -1531,8 +1588,8 @@ class PackageGraphTests: XCTestCase {
         ]
 
         do {
-            let observability = ObservabilitySystem.bootstrapForTesting()
-            _ = try loadPackageGraph(fs: fs, manifests: manifests)
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadPackageGraph(fs: fs, manifests: manifests, observabilityScope: observability.topScope)
             testDiagnostics(observability.diagnostics) { result in
                 result.check(
                     diagnostic: """
@@ -1554,8 +1611,8 @@ class PackageGraphTests: XCTestCase {
                 manifests[1] // same
             ]
 
-            let observability = ObservabilitySystem.bootstrapForTesting()
-            _ = try loadPackageGraph(fs: fs, manifests: fixedManifests)
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadPackageGraph(fs: fs, manifests: fixedManifests, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
         }
     }
@@ -1590,8 +1647,8 @@ class PackageGraphTests: XCTestCase {
         ]
 
         do {
-            let observability = ObservabilitySystem.bootstrapForTesting()
-            _ = try loadPackageGraph(fs: fs, manifests: manifests)
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadPackageGraph(fs: fs, manifests: manifests, observabilityScope: observability.topScope)
             testDiagnostics(observability.diagnostics) { result in
                 result.check(
                     diagnostic: """
@@ -1613,8 +1670,8 @@ class PackageGraphTests: XCTestCase {
                 manifests[1] // same
             ]
 
-            let observability = ObservabilitySystem.bootstrapForTesting()
-            _ = try loadPackageGraph(fs: fs, manifests: fixedManifests)
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadPackageGraph(fs: fs, manifests: fixedManifests, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
         }
     }
@@ -1650,8 +1707,8 @@ class PackageGraphTests: XCTestCase {
                 ]),
         ]
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        _ = try loadPackageGraph(fs: fs, manifests: manifests)
+        let observability = ObservabilitySystem.makeForTesting()
+        _ = try loadPackageGraph(fs: fs, manifests: manifests, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
     }
 
@@ -1687,8 +1744,8 @@ class PackageGraphTests: XCTestCase {
         ]
 
         do {
-            let observability = ObservabilitySystem.bootstrapForTesting()
-            _ = try loadPackageGraph(fs: fs, manifests: manifests)
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadPackageGraph(fs: fs, manifests: manifests, observabilityScope: observability.topScope)
             testDiagnostics(observability.diagnostics) { result in
                 result.check(
                     diagnostic: """
@@ -1710,8 +1767,8 @@ class PackageGraphTests: XCTestCase {
                 manifests[1] // same
             ]
 
-            let observability = ObservabilitySystem.bootstrapForTesting()
-            _ = try loadPackageGraph(fs: fs, manifests: fixedManifests)
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadPackageGraph(fs: fs, manifests: fixedManifests, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
         }
     }

--- a/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
+++ b/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
@@ -167,14 +167,14 @@ class ModuleMapGeneration: XCTestCase {
 
 /// Helper function to test module map generation.  Given a target name and optionally the name of a public-headers directory, this function determines the module map type of the public-headers directory by examining the contents of a file system and invokes a given block to check the module result (including any diagnostics).
 func ModuleMapTester(_ targetName: String, includeDir: String = "include", in fileSystem: FileSystem, _ body: (ModuleMapResult) -> Void) {
-    let observability = ObservabilitySystem.bootstrapForTesting()
+    let observability = ObservabilitySystem.makeForTesting()
     // Create a module map generator, and determine the type of module map to use for the header directory.  This may emit diagnostics.
     let moduleMapGenerator = ModuleMapGenerator(targetName: targetName, moduleName: targetName.spm_mangledToC99ExtendedIdentifier(), publicHeadersDir: AbsolutePath.root.appending(component: includeDir), fileSystem: fileSystem)
-    let moduleMapType = moduleMapGenerator.determineModuleMapType(observabilityScope: ObservabilitySystem.topScope)
+    let moduleMapType = moduleMapGenerator.determineModuleMapType(observabilityScope: observability.topScope)
     
     // Generate a module map and capture any emitted diagnostics.
     let generatedModuleMapPath = AbsolutePath.root.appending(components: "module.modulemap")
-    ObservabilitySystem.topScope.trap {
+    observability.topScope.trap {
         if let generatedModuleMapType = moduleMapType.generatedModuleMapType {
             try moduleMapGenerator.generateModuleMap(type: generatedModuleMapType, at: generatedModuleMapPath)
         }

--- a/Tests/PackageLoadingTests/PDLoadingTests.swift
+++ b/Tests/PackageLoadingTests/PDLoadingTests.swift
@@ -123,14 +123,14 @@ class PackageDescriptionLoadingTests: XCTestCase {
         line: UInt = #line,
         onSuccess: ((Manifest, DiagnosticsTestResult) -> Void)? = nil
     ) {
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        let observability = ObservabilitySystem.makeForTesting()
         
         do {
             let manifest = try loadManifest(
                 contents,
                 toolsVersion: toolsVersion ?? self.toolsVersion,
                 packageKind: packageKind,
-                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+                diagnostics: observability.topScope.makeDiagnosticsEngine(),
                 file: file,
                 line: line)
             
@@ -152,14 +152,14 @@ class PackageDescriptionLoadingTests: XCTestCase {
         line: UInt = #line,
         onCatch: ((Error, DiagnosticsTestResult) -> Void)? = nil
     ) {
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        let observability = ObservabilitySystem.makeForTesting()
         
         do {
             let manifest = try loadManifest(
                 contents,
                 toolsVersion: toolsVersion ?? self.toolsVersion,
                 packageKind: packageKind,
-                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+                diagnostics: observability.topScope.makeDiagnosticsEngine(),
                 file: file,
                 line: line)
             

--- a/Tests/PackageLoadingTests/PD_4_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_0_LoadingTests.swift
@@ -311,13 +311,13 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
 
         try fs.writeFileContents(manifestPath, bytes: stream.bytes)
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        let observability = ObservabilitySystem.makeForTesting()
         let manifest = try manifestLoader.load(
             at: .root,
             packageKind: .root(.root),
             toolsVersion: .v4,
             fileSystem: fs,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
+            diagnostics: observability.topScope.makeDiagnosticsEngine()
         )
 
         XCTAssertEqual(manifest.name, "Trivial")

--- a/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
@@ -794,7 +794,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                     """
             }
 
-            let observability = ObservabilitySystem.bootstrapForTesting()
+            let observability = ObservabilitySystem.makeForTesting()
             let delegate = ManifestTestDelegate()
             let manifestLoader = ManifestLoader(toolchain: ToolchainConfiguration.default, cacheDir: path, delegate: delegate)
             let identityResolver = DefaultIdentityResolver()
@@ -827,7 +827,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                                     toolsVersion: .v4_2,
                                     identityResolver: identityResolver,
                                     fileSystem: localFileSystem,
-                                    diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+                                    diagnostics: observability.topScope.makeDiagnosticsEngine(),
                                     on: .global()) { result in
                     defer { sync.leave() }
 
@@ -856,7 +856,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
         let total = 1000
         try testWithTemporaryDirectory { path in
 
-            let observability = ObservabilitySystem.bootstrapForTesting()
+            let observability = ObservabilitySystem.makeForTesting()
             let delegate = ManifestTestDelegate()
             let manifestLoader = ManifestLoader(toolchain: ToolchainConfiguration.default, cacheDir: path, delegate: delegate)
             let identityResolver = DefaultIdentityResolver()
@@ -891,7 +891,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                                     toolsVersion: .v4_2,
                                     identityResolver: identityResolver,
                                     fileSystem: localFileSystem,
-                                    diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+                                    diagnostics: observability.topScope.makeDiagnosticsEngine(),
                                     on: .global()) { result in
                     defer { sync.leave() }
 

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -1890,7 +1890,7 @@ class PackageBuilderTests: XCTestCase {
             "/Sources/lib/include/lib.h"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        //let observability = ObservabilitySystem.makeForTesting()
         let manifest = Manifest.createRootManifest(
             name: "Pkg",
             toolsVersion: .v5,
@@ -1898,7 +1898,7 @@ class PackageBuilderTests: XCTestCase {
                 try TargetDescription(name: "lib", dependencies: []),
             ]
         )
-        XCTAssertNoDiagnostics(observability.diagnostics)
+        //XCTAssertNoDiagnostics(observability.diagnostics)
 
         PackageBuilderTester(manifest, in: fs) { package, _ in
             package.checkModule("lib") { module in
@@ -2380,7 +2380,7 @@ final class PackageBuilderTester {
         line: UInt = #line,
         _ body: (PackageBuilderTester, DiagnosticsTestResult) -> Void
     ) {
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        let observability = ObservabilitySystem.makeForTesting()
         do {
             // FIXME: We should allow customizing root package boolean.
             let builder = PackageBuilder(
@@ -2393,7 +2393,8 @@ final class PackageBuilderTester {
                 shouldCreateMultipleTestProducts: shouldCreateMultipleTestProducts,
                 warnAboutImplicitExecutableTargets: true,
                 createREPLProduct: createREPLProduct,
-                fileSystem: fs
+                fileSystem: fs,
+                observabilityScope: observability.topScope
             )
             let loadedPackage = try builder.construct()
             result = .package(loadedPackage)
@@ -2402,7 +2403,7 @@ final class PackageBuilderTester {
         } catch {
             let errorString = String(describing: error)
             result = .error(errorString)
-            ObservabilitySystem.topScope.emit(error)
+            observability.topScope.emit(error)
         }
 
         testDiagnostics(observability.diagnostics) { diagnostics in

--- a/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
+++ b/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
@@ -43,7 +43,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             "/some/path/toBeCopied/cool/hello.swift",
         ])
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        let observability = ObservabilitySystem.makeForTesting()
 
         let builder = TargetSourcesBuilder(
             packageIdentity: .plain("test"),
@@ -54,7 +54,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             defaultLocalization: nil,
             toolsVersion: .v5,
             fileSystem: fs,
-            observabilityScope: ObservabilitySystem.topScope
+            observabilityScope: observability.topScope
         )
 
         let contents = builder.computeContents().map{ $0.pathString }.sorted()
@@ -88,7 +88,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             "/Hello.something/hello.txt",
         ])
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        let observability = ObservabilitySystem.makeForTesting()
 
         let builder = TargetSourcesBuilder(
             packageIdentity: .plain("test"),
@@ -99,7 +99,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             defaultLocalization: nil,
             toolsVersion: .v5_3,
             fileSystem: fs,
-            observabilityScope: ObservabilitySystem.topScope
+            observabilityScope: observability.topScope
         )
 
         let contents = builder.computeContents().map{ $0.pathString }.sorted()
@@ -546,7 +546,7 @@ class TargetSourcesBuilderTests: XCTestCase {
         line: UInt = #line,
         checker: (Sources, [Resource], [AbsolutePath], [AbsolutePath], PackageIdentity, String, DiagnosticsTestResult) -> ()
     ) {
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        let observability = ObservabilitySystem.makeForTesting()
         let builder = TargetSourcesBuilder(
             packageIdentity: .plain("test"),
             packageLocation: "/test",
@@ -557,7 +557,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             additionalFileRules: additionalFileRules,
             toolsVersion: toolsVersion,
             fileSystem: fs,
-            observabilityScope: ObservabilitySystem.topScope
+            observabilityScope: observability.topScope
         )
 
         do {
@@ -588,7 +588,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             "/Bar.swift"
         ])
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        let observability = ObservabilitySystem.makeForTesting()
 
         let builder = TargetSourcesBuilder(
             packageIdentity: .plain("test"),
@@ -599,7 +599,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             defaultLocalization: nil,
             toolsVersion: .v5,
             fileSystem: fs,
-            observabilityScope: ObservabilitySystem.topScope
+            observabilityScope: observability.topScope
         )
 
         testDiagnostics(observability.diagnostics) { result in
@@ -628,7 +628,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             "/Bar.swift"
         ])
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        let observability = ObservabilitySystem.makeForTesting()
 
         let builder = TargetSourcesBuilder(
             packageIdentity: .plain("test"),
@@ -639,7 +639,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             defaultLocalization: nil,
             toolsVersion: .v5,
             fileSystem: fs,
-            observabilityScope: ObservabilitySystem.topScope
+            observabilityScope: observability.topScope
         )
         _ = try builder.run()
 
@@ -670,7 +670,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             "/Bar.swift"
         ])
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        let observability = ObservabilitySystem.makeForTesting()
 
         let builder = TargetSourcesBuilder(
             packageIdentity: .plain("test"),
@@ -681,7 +681,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             defaultLocalization: nil,
             toolsVersion: .v5,
             fileSystem: fs,
-            observabilityScope: ObservabilitySystem.topScope
+            observabilityScope: observability.topScope
         )
 
         testDiagnostics(observability.diagnostics) { result in
@@ -710,7 +710,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             "/Foo.xcdatamodel"
         ])
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        let observability = ObservabilitySystem.makeForTesting()
 
         let builder = TargetSourcesBuilder(
             packageIdentity: .plain("test"),
@@ -721,7 +721,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             defaultLocalization: nil,
             toolsVersion: .v5_5,
             fileSystem: fs,
-            observabilityScope: ObservabilitySystem.topScope
+            observabilityScope: observability.topScope
         )
         _ = try builder.run()
 
@@ -749,7 +749,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             "/Foo.docc"
         ])
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        let observability = ObservabilitySystem.makeForTesting()
 
         let builder = TargetSourcesBuilder(
             packageIdentity: .plain("test"),
@@ -761,7 +761,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             additionalFileRules: FileRuleDescription.swiftpmFileTypes,
             toolsVersion: .v5_5,
             fileSystem: fs,
-            observabilityScope: ObservabilitySystem.topScope
+            observabilityScope: observability.topScope
         )
         _ = try builder.run()
 

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -28,8 +28,9 @@ class PluginInvocationTests: XCTestCase {
             "/Foo/Sources/Foo/source.swift",
             "/Foo/Sources/Foo/SomeFile.abc"
         )
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let graph = try loadPackageGraph(fs: fileSystem,
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fs: fileSystem,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -60,7 +61,8 @@ class PluginInvocationTests: XCTestCase {
                         ),
                     ]
                 )
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
         
         // Check the basic integrity before running plugins.
@@ -143,7 +145,7 @@ class PluginInvocationTests: XCTestCase {
             outputDir: outputDir,
             builtToolsDir: builtToolsDir,
             pluginScriptRunner: pluginRunner,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine(),
+            diagnostics: observability.topScope.makeDiagnosticsEngine(),
             fileSystem: fileSystem
         )
         

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -35,7 +35,7 @@ class PIFBuilderTests: XCTestCase {
                 "/B/Sources/B2/lib.swift"
             )
 
-            let observability = ObservabilitySystem.bootstrapForTesting()
+            let observability = ObservabilitySystem.makeForTesting()
             let graph = try loadPackageGraph(
                 fs: fs,
                 manifests: [
@@ -67,10 +67,11 @@ class PIFBuilderTests: XCTestCase {
                             .init(name: "A2", dependencies: []),
                             .init(name: "A3", dependencies: []),
                         ]),
-                ]
+                ],
+                observabilityScope: observability.topScope
             )
 
-            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
+            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: observability.topScope.makeDiagnosticsEngine())
             let pif = try builder.construct()
 
             XCTAssertNoDiagnostics(observability.diagnostics)
@@ -102,7 +103,7 @@ class PIFBuilderTests: XCTestCase {
             "/Bar/Sources/BarLib/lib.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
             fs: fs,
             manifests: [
@@ -137,10 +138,11 @@ class PIFBuilderTests: XCTestCase {
                         .init(name: "BarTests", type: .test),
                     ]),
             ],
-            shouldCreateMultipleTestProducts: true
+            shouldCreateMultipleTestProducts: true,
+            observabilityScope: observability.topScope
         )
 
-        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
+        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: observability.topScope.makeDiagnosticsEngine())
         let pif = try builder.construct()
 
         XCTAssertNoDiagnostics(observability.diagnostics)
@@ -368,7 +370,7 @@ class PIFBuilderTests: XCTestCase {
             "/Bar/Sources/BarLib/lib.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
             fs: fs,
             manifests: [
@@ -411,12 +413,13 @@ class PIFBuilderTests: XCTestCase {
                         .init(name: "cbar"),
                         .init(name: "BarLib"),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         var pif: PIF.TopLevelObject!
         try! withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
-            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
+            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: observability.topScope.makeDiagnosticsEngine())
             pif = try builder.construct()
         }
 
@@ -697,7 +700,7 @@ class PIFBuilderTests: XCTestCase {
             "/Bar/Sources/BarLib/lib.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
             fs: fs,
             manifests: [
@@ -741,12 +744,13 @@ class PIFBuilderTests: XCTestCase {
                         .init(name: "BarLib"),
                     ]),
             ],
-            shouldCreateMultipleTestProducts: true
+            shouldCreateMultipleTestProducts: true,
+            observabilityScope: observability.topScope
         )
 
         var pif: PIF.TopLevelObject!
         try! withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
-            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
+            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: observability.topScope.makeDiagnosticsEngine())
             pif = try builder.construct()
         }
 
@@ -920,7 +924,7 @@ class PIFBuilderTests: XCTestCase {
             "/Bar/Sources/BarLib/lib.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
             fs: fs,
             manifests: [
@@ -956,12 +960,13 @@ class PIFBuilderTests: XCTestCase {
                     targets: [
                         .init(name: "BarLib"),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         var pif: PIF.TopLevelObject!
         try! withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
-            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
+            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: observability.topScope.makeDiagnosticsEngine())
             pif = try builder.construct()
         }
 
@@ -1113,7 +1118,7 @@ class PIFBuilderTests: XCTestCase {
             "/Bar/Sources/BarLib/lib.c"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
             fs: fs,
             manifests: [
@@ -1145,12 +1150,13 @@ class PIFBuilderTests: XCTestCase {
                     targets: [
                         .init(name: "BarLib"),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         var pif: PIF.TopLevelObject!
         try! withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
-            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
+            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: observability.topScope.makeDiagnosticsEngine())
             pif = try builder.construct()
         }
 
@@ -1398,7 +1404,7 @@ class PIFBuilderTests: XCTestCase {
             "/Bar/Sources/BarLib/lib.c"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
             fs: fs,
             manifests: [
@@ -1414,12 +1420,17 @@ class PIFBuilderTests: XCTestCase {
                     targets: [
                         .init(name: "BarLib"),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         var pif: PIF.TopLevelObject!
         try! withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
-            let builder = PIFBuilder(graph: graph, parameters: .mock(shouldCreateDylibForDynamicProducts: true), diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
+            let builder = PIFBuilder(
+                graph: graph,
+                parameters: .mock(shouldCreateDylibForDynamicProducts: true),
+                diagnostics: observability.topScope.makeDiagnosticsEngine()
+            )
             pif = try builder.construct()
         }
 
@@ -1442,7 +1453,7 @@ class PIFBuilderTests: XCTestCase {
             "/Bar/Sources/BarLib/module.modulemap"
         )
         
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
             fs: fs,
             manifests: [
@@ -1459,12 +1470,17 @@ class PIFBuilderTests: XCTestCase {
                     targets: [
                         .init(name: "BarLib"),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
         
         var pif: PIF.TopLevelObject!
         try! withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
-            let builder = PIFBuilder(graph: graph, parameters: .mock(shouldCreateDylibForDynamicProducts: true), diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
+            let builder = PIFBuilder(
+                graph: graph,
+                parameters: .mock(shouldCreateDylibForDynamicProducts: true),
+                diagnostics: observability.topScope.makeDiagnosticsEngine()
+            )
             pif = try builder.construct()
         }
         
@@ -1491,7 +1507,7 @@ class PIFBuilderTests: XCTestCase {
             "/Foo/Sources/SystemLib2/module.modulemap"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
             fs: fs,
             manifests: [
@@ -1505,12 +1521,13 @@ class PIFBuilderTests: XCTestCase {
                         .init(name: "SystemLib1", type: .system),
                         .init(name: "SystemLib2", type: .system, pkgConfig: "Foo"),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
 
         var pif: PIF.TopLevelObject!
         try! withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
-            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
+            let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: observability.topScope.makeDiagnosticsEngine())
             pif = try builder.construct()
         }
 
@@ -1601,7 +1618,7 @@ class PIFBuilderTests: XCTestCase {
             "/Foo/BinaryLibrary.xcframework/Info.plist"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
             fs: fs,
             manifests: [
@@ -1622,10 +1639,11 @@ class PIFBuilderTests: XCTestCase {
             binaryArtifacts: [
                 .init(kind: .xcframework, originURL: nil, path: AbsolutePath("/Foo/BinaryLibrary.xcframework"))
             ],
-            shouldCreateMultipleTestProducts: true
+            shouldCreateMultipleTestProducts: true,
+            observabilityScope: observability.topScope
         )
 
-        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
+        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: observability.topScope.makeDiagnosticsEngine())
         let pif = try builder.construct()
 
         XCTAssertNoDiagnostics(observability.diagnostics)
@@ -1664,7 +1682,7 @@ class PIFBuilderTests: XCTestCase {
             "/Foo/Sources/FooTests/Resources/Database.xcdatamodel"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
             fs: fs,
             manifests: [
@@ -1689,10 +1707,11 @@ class PIFBuilderTests: XCTestCase {
                     ]),
             ],
             shouldCreateMultipleTestProducts: true,
-            useXCBuildFileRules: true
+            useXCBuildFileRules: true,
+            observabilityScope: observability.topScope
         )
 
-        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
+        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: observability.topScope.makeDiagnosticsEngine())
         let pif = try builder.construct()
 
         XCTAssertNoDiagnostics(observability.diagnostics)
@@ -1871,7 +1890,7 @@ class PIFBuilderTests: XCTestCase {
             "/Foo/Sources/FooTests/FooTests.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
             fs: fs,
             manifests: [
@@ -1948,10 +1967,11 @@ class PIFBuilderTests: XCTestCase {
                         ]),
                     ]),
             ],
-            shouldCreateMultipleTestProducts: true
+            shouldCreateMultipleTestProducts: true,
+            observabilityScope: observability.topScope
         )
 
-        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
+        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: observability.topScope.makeDiagnosticsEngine())
         let pif = try builder.construct()
 
         XCTAssertNoDiagnostics(observability.diagnostics)
@@ -2088,7 +2108,7 @@ class PIFBuilderTests: XCTestCase {
             "/Foo/Sources/FooTests/FooTests.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
             fs: fs,
             manifests: [
@@ -2106,16 +2126,13 @@ class PIFBuilderTests: XCTestCase {
                         .init(name: "FooLib2"),
                     ]),
             ],
-            shouldCreateMultipleTestProducts: true
+            shouldCreateMultipleTestProducts: true,
+            observabilityScope: observability.topScope
         )
 
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let builder = PIFBuilder(
-            graph: graph,
-            parameters: .mock(),
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
-        )
+        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: observability.topScope.makeDiagnosticsEngine())
         let pif = try builder.construct()
 
         let expectedFilters: [PIF.GUID: [PIF.PlatformFilter]] = [
@@ -2152,7 +2169,7 @@ class PIFBuilderTests: XCTestCase {
             "/Foo/Sources/foo/main.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
             fs: fs,
             manifests: [
@@ -2167,10 +2184,11 @@ class PIFBuilderTests: XCTestCase {
                         .init(name: "foo", dependencies: []),
                     ]),
             ],
-            shouldCreateMultipleTestProducts: true
+            shouldCreateMultipleTestProducts: true,
+            observabilityScope: observability.topScope
         )
 
-        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
+        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: observability.topScope.makeDiagnosticsEngine())
         let pif = try builder.construct()
 
         XCTAssertNoDiagnostics(observability.diagnostics)
@@ -2193,7 +2211,7 @@ class PIFBuilderTests: XCTestCase {
             "/MyLib/Sources/MyLib/Foo.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
+        let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
             fs: fs,
             manifests: [
@@ -2214,10 +2232,11 @@ class PIFBuilderTests: XCTestCase {
                         ]),
                     ]),
             ],
-            shouldCreateMultipleTestProducts: true
+            shouldCreateMultipleTestProducts: true,
+            observabilityScope: observability.topScope
         )
 
-        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine())
+        let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: observability.topScope.makeDiagnosticsEngine())
         let pif = try builder.construct()
 
         XCTAssertNoDiagnostics(observability.diagnostics)

--- a/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
+++ b/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
@@ -35,16 +35,18 @@ class GenerateXcodeprojTests: XCTestCase {
           try makeDirectories(modulePath)
           try localFileSystem.writeFileContents(modulePath.appending(component: "source.swift"), bytes: "")
 
-          let observability = ObservabilitySystem.bootstrapForTesting()
-          let graph = try loadPackageGraph(fs: localFileSystem,
-              manifests: [
-                  Manifest.createRootManifest(
-                      name: "Foo",
-                      path: packagePath,
-                      targets: [
-                          TargetDescription(name: "DummyModuleName"),
-                      ])
-              ]
+          let observability = ObservabilitySystem.makeForTesting()
+          let graph = try loadPackageGraph(
+            fs: localFileSystem,
+            manifests: [
+                Manifest.createRootManifest(
+                    name: "Foo",
+                    path: packagePath,
+                    targets: [
+                        TargetDescription(name: "DummyModuleName"),
+                    ])
+            ],
+            observabilityScope: observability.topScope
           )
           XCTAssertNoDiagnostics(observability.diagnostics)
 
@@ -55,7 +57,7 @@ class GenerateXcodeprojTests: XCTestCase {
             xcodeprojPath: outpath,
             graph: graph,
             options: XcodeprojOptions(),
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
+            diagnostics: observability.topScope.makeDiagnosticsEngine()
           )
 
           XCTAssertDirectoryExists(outpath)
@@ -91,8 +93,9 @@ class GenerateXcodeprojTests: XCTestCase {
             try makeDirectories(modulePath)
             try localFileSystem.writeFileContents(modulePath.appending(component: "bar.swift"), bytes: "")
 
-            let observability = ObservabilitySystem.bootstrapForTesting()
-            let graph = try loadPackageGraph(fs: localFileSystem,
+            let observability = ObservabilitySystem.makeForTesting()
+            let graph = try loadPackageGraph(
+                fs: localFileSystem,
                 manifests: [
                     Manifest.createRootManifest(
                         name: "Bar",
@@ -100,7 +103,8 @@ class GenerateXcodeprojTests: XCTestCase {
                         targets: [
                             TargetDescription(name: "Bar"),
                         ])
-                ]
+                ],
+                observabilityScope: observability.topScope
             )
             XCTAssertNoDiagnostics(observability.diagnostics)
 
@@ -113,7 +117,7 @@ class GenerateXcodeprojTests: XCTestCase {
                     extraFiles: [],
                     options: options,
                     fileSystem: localFileSystem,
-                    diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
+                    diagnostics: observability.topScope.makeDiagnosticsEngine()
                 )
                 XCTFail("Project generation should have failed")
             } catch ProjectGenerationError.xcconfigOverrideNotFound(let path) {
@@ -131,8 +135,9 @@ class GenerateXcodeprojTests: XCTestCase {
             try makeDirectories(modulePath)
             try localFileSystem.writeFileContents(modulePath.appending(component: "example.swift"), bytes: "")
 
-            let observability = ObservabilitySystem.bootstrapForTesting()
-            let graph = try loadPackageGraph(fs: localFileSystem,
+            let observability = ObservabilitySystem.makeForTesting()
+            let graph = try loadPackageGraph(
+                fs: localFileSystem,
                 manifests: [
                     Manifest.createRootManifest(
                         name: "Modules",
@@ -140,7 +145,8 @@ class GenerateXcodeprojTests: XCTestCase {
                         targets: [
                             TargetDescription(name: "Modules"),
                         ])
-                ]
+                ],
+                observabilityScope: observability.topScope
             )
             XCTAssertNoDiagnostics(observability.diagnostics)
 
@@ -148,7 +154,7 @@ class GenerateXcodeprojTests: XCTestCase {
                 xcodeprojPath: AbsolutePath.root.appending(component: "xcodeproj"),
                 graph: graph, extraDirs: [], extraFiles: [],
                 options: XcodeprojOptions(), fileSystem: localFileSystem,
-                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
+                diagnostics: observability.topScope.makeDiagnosticsEngine()
             )
 
             testDiagnostics(observability.diagnostics) { result in
@@ -168,7 +174,7 @@ class GenerateXcodeprojTests: XCTestCase {
             try localFileSystem.writeFileContents(modulePath.appending(component: "dummy.swift"), bytes: "dummy_data")
             try localFileSystem.writeFileContents(packagePath.appending(component: "a.txt"), bytes: "dummy_data")
 
-            let observability = ObservabilitySystem.bootstrapForTesting()
+            let observability = ObservabilitySystem.makeForTesting()
             let graph = try loadPackageGraph(
                 fs: localFileSystem,
                 manifests: [
@@ -178,7 +184,8 @@ class GenerateXcodeprojTests: XCTestCase {
                         targets: [
                             TargetDescription(name: "DummyModule"),
                         ])
-                ]
+                ],
+                observabilityScope: observability.topScope
             )
             XCTAssertNoDiagnostics(observability.diagnostics)
 
@@ -189,7 +196,7 @@ class GenerateXcodeprojTests: XCTestCase {
                 xcodeprojPath: outpath,
                 graph: graph,
                 options: XcodeprojOptions(),
-                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
+                diagnostics: observability.topScope.makeDiagnosticsEngine()
             )
 
             XCTAssertFalse(project.mainGroup.subitems.contains { $0.path == "a.txt" })
@@ -207,7 +214,7 @@ class GenerateXcodeprojTests: XCTestCase {
 
             initGitRepo(packagePath, addFile: false)
 
-            let observability = ObservabilitySystem.bootstrapForTesting()
+            let observability = ObservabilitySystem.makeForTesting()
             let graph = try loadPackageGraph(
                 fs: localFileSystem,
                 manifests: [
@@ -217,7 +224,8 @@ class GenerateXcodeprojTests: XCTestCase {
                         targets: [
                             TargetDescription(name: "DummyModule"),
                         ])
-                ]
+                ],
+                observabilityScope: observability.topScope
             )
             XCTAssertNoDiagnostics(observability.diagnostics)
 
@@ -228,7 +236,7 @@ class GenerateXcodeprojTests: XCTestCase {
                 xcodeprojPath: outpath,
                 graph: graph,
                 options: XcodeprojOptions(),
-                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
+                diagnostics: observability.topScope.makeDiagnosticsEngine()
             )
 
             XCTAssertFalse(project.mainGroup.subitems.contains { $0.path == ".a.txt" })
@@ -245,7 +253,7 @@ class GenerateXcodeprojTests: XCTestCase {
 
             initGitRepo(packagePath, addFile: false)
 
-            let observability = ObservabilitySystem.bootstrapForTesting()
+            let observability = ObservabilitySystem.makeForTesting()
             let graph = try loadPackageGraph(
                 fs: localFileSystem,
                 manifests: [
@@ -255,7 +263,8 @@ class GenerateXcodeprojTests: XCTestCase {
                         targets: [
                             TargetDescription(name: "DummyModule"),
                         ])
-                ]
+                ],
+                observabilityScope: observability.topScope
             )
             XCTAssertNoDiagnostics(observability.diagnostics)
 
@@ -266,7 +275,7 @@ class GenerateXcodeprojTests: XCTestCase {
                 xcodeprojPath: outpath,
                 graph: graph,
                 options: XcodeprojOptions(),
-                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
+                diagnostics: observability.topScope.makeDiagnosticsEngine()
             )
 
             XCTAssertTrue(project.mainGroup.subitems.contains { $0.path == "a.txt" })
@@ -276,7 +285,7 @@ class GenerateXcodeprojTests: XCTestCase {
                 xcodeprojPath: outpath,
                 graph: graph,
                 options: XcodeprojOptions(addExtraFiles: false),
-                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
+                diagnostics: observability.topScope.makeDiagnosticsEngine()
             )
             XCTAssertFalse(projectWithoutExtraFiles.mainGroup.subitems.contains { $0.path == "a.txt" })
         }
@@ -293,7 +302,7 @@ class GenerateXcodeprojTests: XCTestCase {
 
             initGitRepo(packagePath, addFile: false)
 
-            let observability = ObservabilitySystem.bootstrapForTesting()
+            let observability = ObservabilitySystem.makeForTesting()
             let graph = try loadPackageGraph(
                 fs: localFileSystem,
                 manifests: [
@@ -303,7 +312,8 @@ class GenerateXcodeprojTests: XCTestCase {
                         targets: [
                             TargetDescription(name: "DummyModule"),
                         ])
-                ]
+                ],
+                observabilityScope: observability.topScope
             )
             XCTAssertNoDiagnostics(observability.diagnostics)
 
@@ -314,7 +324,7 @@ class GenerateXcodeprojTests: XCTestCase {
                 xcodeprojPath: outpath,
                 graph: graph,
                 options: XcodeprojOptions(),
-                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
+                diagnostics: observability.topScope.makeDiagnosticsEngine()
             )
 
             let sources = project.mainGroup.subitems[1] as? Xcode.Group
@@ -340,7 +350,7 @@ class GenerateXcodeprojTests: XCTestCase {
             try localFileSystem.writeFileContents(modulePath.appending(component: "ignored_file"), bytes: "dummy_data")
             try localFileSystem.writeFileContents(packagePath.appending(component: "ignored_file"), bytes: "dummy_data")
 
-            let observability = ObservabilitySystem.bootstrapForTesting()
+            let observability = ObservabilitySystem.makeForTesting()
             let graph = try loadPackageGraph(
                 fs: localFileSystem,
                 manifests: [
@@ -350,7 +360,8 @@ class GenerateXcodeprojTests: XCTestCase {
                         targets: [
                             TargetDescription(name: "DummyModule"),
                         ])
-                ]
+                ],
+                observabilityScope: observability.topScope
             )
             XCTAssertNoDiagnostics(observability.diagnostics)
 
@@ -361,7 +372,7 @@ class GenerateXcodeprojTests: XCTestCase {
                 xcodeprojPath: outpath,
                 graph: graph,
                 options: XcodeprojOptions(),
-                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
+                diagnostics: observability.topScope.makeDiagnosticsEngine()
             )
 
             let sources = project.mainGroup.subitems[1] as? Xcode.Group
@@ -387,8 +398,9 @@ class GenerateXcodeprojTests: XCTestCase {
             try makeDirectories(bar2TargetPath)
             try localFileSystem.writeFileContents(bar2TargetPath.appending(component: "Sources.swift"), bytes: "")
 
-            let observability = ObservabilitySystem.bootstrapForTesting()
-            let graph = try loadPackageGraph(fs: localFileSystem,
+            let observability = ObservabilitySystem.makeForTesting()
+            let graph = try loadPackageGraph(
+                fs: localFileSystem,
                 manifests: [
                     Manifest.createRootManifest(
                         name: "Foo",
@@ -413,7 +425,8 @@ class GenerateXcodeprojTests: XCTestCase {
                             ]),
                             TargetDescription(name: "Bar2"),
                         ])
-                ]
+                ],
+                observabilityScope: observability.topScope
             )
 
             let outpath = Xcodeproj.buildXcodeprojPath(outputDir: dstdir, projectName: "Foo")
@@ -422,7 +435,7 @@ class GenerateXcodeprojTests: XCTestCase {
                 xcodeprojPath: outpath,
                 graph: graph,
                 options: XcodeprojOptions(),
-                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
+                diagnostics: observability.topScope.makeDiagnosticsEngine()
             )
 
             testDiagnostics(observability.diagnostics) { result in

--- a/Tests/XcodeprojTests/PackageGraphTests.swift
+++ b/Tests/XcodeprojTests/PackageGraphTests.swift
@@ -33,8 +33,9 @@ class PackageGraphTests: XCTestCase {
             "/Overrides.xcconfig"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let g = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        let g = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createLocalSourceControlManifest(
                     name: "Foo",
@@ -66,7 +67,8 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "Sea2", dependencies: ["Foo"]),
                         TargetDescription(name: "Sea3", dependencies: ["Foo"]),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
@@ -79,7 +81,7 @@ class PackageGraphTests: XCTestCase {
             extraFiles: [],
             options: options,
             fileSystem: fs,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
+            diagnostics: observability.topScope.makeDiagnosticsEngine()
         )
 
         XcodeProjectTester(project) { result in
@@ -202,8 +204,9 @@ class PackageGraphTests: XCTestCase {
             "/Foo/Sources/Foo/source.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let g = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        let g = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -214,7 +217,8 @@ class PackageGraphTests: XCTestCase {
                     targets: [
                         TargetDescription(name: "Foo", dependencies: []),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
@@ -225,7 +229,7 @@ class PackageGraphTests: XCTestCase {
             extraFiles: [],
             options: XcodeprojOptions(),
             fileSystem: fs,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
+            diagnostics: observability.topScope.makeDiagnosticsEngine()
         )
         XcodeProjectTester(project) { result in
             result.check(target: "Foo") { targetResult in
@@ -249,8 +253,9 @@ class PackageGraphTests: XCTestCase {
             "/Bar/Sources/swift/main.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let g = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        let g = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Bar",
@@ -260,7 +265,8 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "Sea2", dependencies: []),
                         TargetDescription(name: "swift", dependencies: ["Sea", "Sea2"]),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
@@ -271,7 +277,7 @@ class PackageGraphTests: XCTestCase {
             extraFiles: [],
             options: XcodeprojOptions(),
             fileSystem: fs,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
+            diagnostics: observability.topScope.makeDiagnosticsEngine()
         )
         XcodeProjectTester(project) { result in
             result.check(target: "swift") { targetResult in
@@ -298,8 +304,9 @@ class PackageGraphTests: XCTestCase {
             "/Pkg/Tests/LibraryTests/aTest.swift"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let g = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        let g = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -309,7 +316,8 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "Library", dependencies: []),
                         TargetDescription(name: "LibraryTests", dependencies: ["Library", "HelperTool"], type: .test),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
@@ -320,7 +328,7 @@ class PackageGraphTests: XCTestCase {
             extraFiles: [],
             options: XcodeprojOptions(),
             fileSystem: fs,
-            diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
+            diagnostics: observability.topScope.makeDiagnosticsEngine()
         )
 
         XcodeProjectTester(project) { result in
@@ -367,8 +375,9 @@ class PackageGraphTests: XCTestCase {
             "/end"
         )
 
-        let observability = ObservabilitySystem.bootstrapForTesting()
-        let graph = try loadPackageGraph(fs: fs,
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fs: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -385,7 +394,8 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "dTests", dependencies: ["d"], type: .test),
                         TargetDescription(name: "libdTests", dependencies: ["libd"], type: .test),
                     ]),
-            ]
+            ],
+            observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
@@ -418,8 +428,9 @@ class PackageGraphTests: XCTestCase {
                 "/end"
             )
 
-            let observability = ObservabilitySystem.bootstrapForTesting()
-            let graph = try loadPackageGraph(fs: fs,
+            let observability = ObservabilitySystem.makeForTesting()
+            let graph = try loadPackageGraph(
+                fs: fs,
                 manifests: [
                     Manifest.createRootManifest(
                         name: "Foo",
@@ -428,7 +439,8 @@ class PackageGraphTests: XCTestCase {
                         targets: [
                             TargetDescription(name: "a"),
                         ]),
-                ]
+                ],
+                observabilityScope: observability.topScope
             )
             XCTAssertNoDiagnostics(observability.diagnostics)
 
@@ -439,7 +451,7 @@ class PackageGraphTests: XCTestCase {
                 extraFiles: [],
                 options: XcodeprojOptions(),
                 fileSystem: fs,
-                diagnostics: ObservabilitySystem.topScope.makeDiagnosticsEngine()
+                diagnostics: observability.topScope.makeDiagnosticsEngine()
             )
             XCTAssertNoDiagnostics(observability.diagnostics)
 


### PR DESCRIPTION
motivation: better fit with long running process likes IDEs

changes:
* remove the global bootstrap and scope
* add observabilityScope argument to functions that need to emit diagnostics
* adjust call sites and tests
