### PR TITLE
fix workspace to notify delegate on any result of manifest loading

### DIFF
--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -640,7 +640,9 @@ public final class MockWorkspace {
 
 public final class MockWorkspaceDelegate: WorkspaceDelegate {
     private let lock = Lock()
-    public var _events = [String]()
+    private var _events = [String]()
+    private var _manifest: Manifest?
+    private var _manifestLoadingDiagnostics: [Diagnostic]?
 
     public init() {}
 
@@ -697,6 +699,10 @@ public final class MockWorkspaceDelegate: WorkspaceDelegate {
 
     public func didLoadManifest(packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind, manifest: Manifest?, diagnostics: [Diagnostic]) {
         self.append("did load manifest for \(packageKind.displayName) package: \(url)")
+        self.lock.withLock {
+            self._manifest = manifest
+            self._manifestLoadingDiagnostics = diagnostics
+        }
     }
 
     public func willComputeVersion(package: PackageIdentity, location: String) {
@@ -734,6 +740,18 @@ public final class MockWorkspaceDelegate: WorkspaceDelegate {
     public func clear() {
         self.lock.withLock {
             self._events = []
+        }
+    }
+
+    public var manifest: Manifest? {
+        self.lock.withLock {
+            self._manifest
+        }
+    }
+
+    public var manifestLoadingDiagnostics: [Diagnostic]? {
+        self.lock.withLock {
+            self._manifestLoadingDiagnostics
         }
     }
 }

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1658,9 +1658,10 @@ extension Workspace {
                     switch result {
                     // Diagnostics.fatalError indicates that a more specific diagnostic has already been added.
                     case .failure(Diagnostics.fatalError):
-                        break
+                        self.delegate?.didLoadManifest(packagePath: packagePath, url: packageLocation, version: version, packageKind: packageKind, manifest: nil, diagnostics: manifestLoadingDiagnostics.diagnostics)
                     case .failure(let error):
-                        diagnostics.emit(error)
+                        manifestLoadingDiagnostics.emit(error)
+                        self.delegate?.didLoadManifest(packagePath: packagePath, url: packageLocation, version: version, packageKind: packageKind, manifest: nil, diagnostics: manifestLoadingDiagnostics.diagnostics)
                     case .success(let manifest):
                         self.delegate?.didLoadManifest(packagePath: packagePath, url: packageLocation, version: version, packageKind: packageKind, manifest: manifest, diagnostics: manifestLoadingDiagnostics.diagnostics)
                     }


### PR DESCRIPTION
motivation: bug where delegate was only notified on success but not on error

changes:
* udpate logic to notify on both error and success cases
* added unit test
