### PR TITLE
Silence some warnings about potentially misleading trailing closures

### DIFF
--- a/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
+++ b/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
@@ -338,7 +338,7 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
                             var entry = result.removeValue(forKey: match.package)
                             if entry == nil {
                                 guard let package = collectionDict[match.collection].flatMap({ collection in
-                                    collection.packages.first { $0.identity == match.package }
+                                    collection.packages.first(where: { $0.identity == match.package })
                                 }) else {
                                     return
                                 }
@@ -606,7 +606,7 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
                         var packageEntry = packageCollections.removeValue(forKey: match.package)
                         if packageEntry == nil {
                             guard let package = collectionDict[match.collection].flatMap({ collection in
-                                collection.packages.first { $0.identity == match.package }
+                                collection.packages.first(where: { $0.identity == match.package })
                             }) else {
                                 return
                             }

--- a/Sources/PackageDescription/Version+StringLiteralConvertible.swift
+++ b/Sources/PackageDescription/Version+StringLiteralConvertible.swift
@@ -72,7 +72,7 @@ extension Version: LosslessStringConvertible {
         if let prereleaseDelimiterIndex = prereleaseDelimiterIndex {
             let prereleaseStartIndex = versionString.index(after: prereleaseDelimiterIndex)
             let prereleaseIdentifiers = versionString[prereleaseStartIndex..<(metadataDelimiterIndex ?? versionString.endIndex)].split(separator: ".", omittingEmptySubsequences: false)
-            guard prereleaseIdentifiers.allSatisfy( { $0.allSatisfy { $0.isLetter || $0.isNumber || $0 == "-" } } ) else { return nil }
+            guard prereleaseIdentifiers.allSatisfy({ $0.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "-" })}) else { return nil }
             self.prereleaseIdentifiers = prereleaseIdentifiers.map { String($0) }
         } else {
             self.prereleaseIdentifiers = []
@@ -81,7 +81,7 @@ extension Version: LosslessStringConvertible {
         if let metadataDelimiterIndex = metadataDelimiterIndex {
             let metadataStartIndex = versionString.index(after: metadataDelimiterIndex)
             let buildMetadataIdentifiers = versionString[metadataStartIndex...].split(separator: ".", omittingEmptySubsequences: false)
-            guard buildMetadataIdentifiers.allSatisfy( { $0.allSatisfy { $0.isLetter || $0.isNumber || $0 == "-" } } ) else { return nil }
+            guard buildMetadataIdentifiers.allSatisfy({ $0.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "-" })}) else { return nil }
             self.buildMetadataIdentifiers = buildMetadataIdentifiers.map { String($0) }
         } else {
             self.buildMetadataIdentifiers = []


### PR DESCRIPTION
Switch to parenthesized variants of the APIs.

### Motivation:

Silence some annoying warnings about potentially misleading trailing closures in conditions.

### Modifications:

Use the parenthesized form of the APIs.

### Result:

NTC