### PR TITLE
[5.5] Fix the default location for diagnostics resulting from package manifest loading

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1423,7 +1423,7 @@ extension Workspace {
 
                 // Load the manifest.
                 // The delegate callback is only passed any diagnostics emitted during the parsing of the manifest, but they are also forwarded up to the caller.
-                let manifestLoadingDiagnostics = DiagnosticsEngine(handlers: [{diagnostics.emit($0)}])
+                let manifestLoadingDiagnostics = DiagnosticsEngine(handlers: [{ diagnostics.emit($0) }], defaultLocation: diagnostics.defaultLocation)
                 manifestLoader.load(at: packagePath,
                                     packageIdentity: packageIdentity,
                                     packageKind: packageKind,


### PR DESCRIPTION
This is the 5.5 cherry-pick of https://github.com/apple/swift-package-manager/pull/3739.  That fix landed some time ago, but I didn’t realize that the regression was also in 5.5.

An earlier change in main broke the default location associated with diagnostics from package manifest evaluation.

### Motivation

This fixes a regression causing diagnostics involving manifests to not be properly associated with the packages whence they came.

### Modifications

- pass through the default location when creating the DiagnosticEngine for manifest loading
- add a unit test for the location

rdar://83818577