### PR TITLE
Serialize workspace state deterministically

### DIFF
--- a/Sources/Workspace/WorkspaceState.swift
+++ b/Sources/Workspace/WorkspaceState.swift
@@ -154,6 +154,11 @@ fileprivate struct WorkspaceStateStorage {
         struct Container: Codable {
             var dependencies: [Dependency]
             var artifacts: [Artifact]
+
+            init(dependencies: [Dependency], artifacts: [Artifact]) {
+                self.dependencies = dependencies.sorted { $0.packageRef.identity < $1.packageRef.identity }
+                self.artifacts = artifacts.sorted { $0.packageRef.identity < $1.packageRef.identity }
+            }
         }
 
         struct Dependency: Codable {

--- a/Sources/Workspace/WorkspaceState.swift
+++ b/Sources/Workspace/WorkspaceState.swift
@@ -146,19 +146,14 @@ fileprivate struct WorkspaceStateStorage {
         init (dependencies: Workspace.ManagedDependencies, artifacts: Workspace.ManagedArtifacts) {
             self.version = 4
             self.object = .init(
-                dependencies: dependencies.map { .init($0) },
-                artifacts: artifacts.map {.init($0) }
+                dependencies: dependencies.map { .init($0) }.sorted { $0.packageRef.identity < $1.packageRef.identity },
+                artifacts: artifacts.map { .init($0) }.sorted { $0.packageRef.identity < $1.packageRef.identity }
             )
         }
 
         struct Container: Codable {
             var dependencies: [Dependency]
             var artifacts: [Artifact]
-
-            init(dependencies: [Dependency], artifacts: [Artifact]) {
-                self.dependencies = dependencies.sorted { $0.packageRef.identity < $1.packageRef.identity }
-                self.artifacts = artifacts.sorted { $0.packageRef.identity < $1.packageRef.identity }
-            }
         }
 
         struct Dependency: Codable {


### PR DESCRIPTION
The `ManagedDependencies` and `ManagedArtifacts` collections use dictionaries as their underlying storage, so enumerating their elements is nondeterministic.

### Motivation:

In CI, we hash the contents of the workspace state, and use that as part of a cache key to avoid re-building unnecessarily, e.g. when pre-merge and post-merge sources are identical.  Thus, nondeterminism in serializing the workspace state contributed to extremely high cache invalidation rates.

### Modifications:

Sort artifacts and dependencies by package identity, which seems to be unique and Comparable.

### Result:

I ran `swift-package resolve` on SPM itself, and verified by inspection that the resulting dependencies in `.build/workspace-state.json` were sorted as expected.
