### PR TITLE
add support for local netrc file

### DIFF
--- a/Sources/Basics/FileSystem+Extensions.swift
+++ b/Sources/Basics/FileSystem+Extensions.swift
@@ -129,4 +129,8 @@ extension FileSystem {
     public func writeFileContents(_ path: AbsolutePath, string: String) throws {
         return try self.writeFileContents(path, bytes: .init(encodingAsUTF8: string))
     }
+
+    public func writeFileContents(_ path: AbsolutePath, provider: () -> String) throws {
+        return try self.writeFileContents(path, string: provider())
+    }
 }

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -385,7 +385,7 @@ public class Workspace {
             ),
             mirrors: config?.mirrors,
             authorizationProvider: netrcFilePath.map {
-                try Configuration.Netrc(path: $0, fileSystem: fileSystem).get()
+                try NetrcAuthorizationProvider(path: $0, fileSystem: fileSystem)
             },
             customToolsVersion: currentToolsVersion,
             customManifestLoader: manifestLoader,

--- a/Sources/Workspace/WorkspaceConfiguration.swift
+++ b/Sources/Workspace/WorkspaceConfiguration.swift
@@ -343,28 +343,6 @@ extension Workspace.Configuration {
     }
 }
 
-// MARK: - Authentication
-
-extension Workspace.Configuration {
-    public struct Netrc {
-        private let path: AbsolutePath
-        private let fileSystem: FileSystem
-
-        public init(path: AbsolutePath, fileSystem: FileSystem) {
-            self.path = path
-            self.fileSystem = fileSystem
-        }
-
-        public func get() throws -> AuthorizationProvider {
-            return try Self.load(self.path, fileSystem: self.fileSystem)
-        }
-
-        private static func load(_ path: AbsolutePath, fileSystem: FileSystem) throws -> AuthorizationProvider {
-            try NetrcAuthorizationProvider(path: path, fileSystem: fileSystem)
-        }
-    }
-}
-
 // MARK: - Registries
 
 extension Workspace.Configuration {

--- a/Tests/CommandsTests/SwiftToolTests.swift
+++ b/Tests/CommandsTests/SwiftToolTests.swift
@@ -1,0 +1,83 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import Basics
+@testable import Commands
+import SPMTestSupport
+import TSCBasic
+import XCTest
+
+final class SwiftToolTests: XCTestCase {
+    func testNetrcLocations() throws {
+        fixture(name: "DependencyResolution/External/XCFramework") { packageRoot in
+            let fs = localFileSystem
+
+            // custom .netrc file
+
+            do {
+                let customPath = fs.homeDirectory.appending(component: UUID().uuidString)
+                try fs.writeFileContents(customPath) {
+                    "machine mymachine.labkey.org login custom@labkey.org password custom"
+                }
+
+
+                let options = try SwiftToolOptions.parse(["--package-path", packageRoot.pathString, "--netrc-file", customPath.pathString])
+                let tool = try SwiftTool(options: options)
+                XCTAssertEqual(try tool.getNetrcConfigFile().map(resolveSymlinks), resolveSymlinks(customPath))
+                let auth = try tool.getAuthorizationProvider()?.authentication(for: URL(string: "https://mymachine.labkey.org")!)
+                XCTAssertEqual(auth?.user, "custom@labkey.org")
+                XCTAssertEqual(auth?.password, "custom")
+
+                // delete it
+                try localFileSystem.removeFileTree(customPath)
+                XCTAssertThrowsError(try tool.getNetrcConfigFile(), "error expected") { error in
+                    XCTAssertEqual(error as? StringError, StringError("Did not find .netrc file at \(customPath)."))
+                }
+            }
+
+            // local .netrc file
+
+            do {
+                let localPath = packageRoot.appending(component: ".netrc")
+                try fs.writeFileContents(localPath) {
+                    return "machine mymachine.labkey.org login local@labkey.org password local"
+                }
+
+                let options = try SwiftToolOptions.parse(["--package-path", packageRoot.pathString])
+                let tool = try SwiftTool(options: options)
+
+                XCTAssertEqual(try tool.getNetrcConfigFile().map(resolveSymlinks), resolveSymlinks(localPath))
+                let auth = try tool.getAuthorizationProvider()?.authentication(for: URL(string: "https://mymachine.labkey.org")!)
+                XCTAssertEqual(auth?.user, "local@labkey.org")
+                XCTAssertEqual(auth?.password, "local")
+            }
+
+            // user .netrc file
+
+            do {
+                // make sure there isn't a local one
+                try localFileSystem.removeFileTree(packageRoot.appending(component: ".netrc"))
+
+                let userHomePath = fs.homeDirectory.appending(component: ".netrc")
+                try fs.writeFileContents(userHomePath) {
+                    return "machine mymachine.labkey.org login user@labkey.org password user"
+                }
+
+                let options = try SwiftToolOptions.parse(["--package-path", packageRoot.pathString])
+                let tool = try SwiftTool(options: options)
+
+                XCTAssertEqual(try tool.getNetrcConfigFile().map(resolveSymlinks), resolveSymlinks(userHomePath))
+                let auth = try tool.getAuthorizationProvider()?.authentication(for: URL(string: "https://mymachine.labkey.org")!)
+                XCTAssertEqual(auth?.user, "user@labkey.org")
+                XCTAssertEqual(auth?.password, "user")
+            }
+        }
+    }
+}


### PR DESCRIPTION
motivation: SE-0292 defines that local .netrc files should be honored with priority over user home directory .netrc files

changes:
* add lookup for local .netrc file before defaulting to user home directory
* deprecate Workspace.Configuration.Netrc since it now redundant
* add tests
