### PR TITLE
Revert JSON format change and fix bug introduced by #3696

### DIFF
--- a/Sources/Workspace/Destination.swift
+++ b/Sources/Workspace/Destination.swift
@@ -225,7 +225,7 @@ extension Destination {
             binDir: destination.binDir,
             extraCCFlags: destination.extraCCFlags,
             extraSwiftCFlags: destination.extraSwiftCFlags,
-            extraCPPFlags: destination.extraCCFlags
+            extraCPPFlags: destination.extraCPPFlags
         )
     }
 }
@@ -241,4 +241,13 @@ fileprivate struct DestinationInfo: Codable {
     let extraCCFlags: [String]
     let extraSwiftCFlags: [String]
     let extraCPPFlags: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case target
+        case sdk
+        case binDir = "toolchain-bin-dir"
+        case extraCCFlags = "extra-cc-flags"
+        case extraSwiftCFlags = "extra-swiftc-flags"
+        case extraCPPFlags = "extra-cpp-flags"
+    }
 }


### PR DESCRIPTION
Motivation: The larger refactoring changed the destination JSON format and introduced a bug in passing flags.

Changes: Use a CodingKeys enum to go back to the old format and correct the flag error.

[I had to modify the destination JSON format that I use on my Android CI](https://github.com/buttaface/swift-android-sdk/blob/6e6343faf9d6b6997b86b2f28834bd1be04e5877/.github/workflows/sdks.yml#L138) because of this format change, and [the flag bug broke using trunk SPM with a destination JSON for NIO SSL, so I had to roll back to 5.5 SPM instead](https://github.com/buttaface/swift-android-sdk/blob/6e6343faf9d6b6997b86b2f28834bd1be04e5877/.github/workflows/sdks.yml#L218).

There is currently no test that would catch these JSON issues, so I will submit one separately in a subsequent pull, but I'd like to quickly get these fixes in in the meantime. It will take longer for me to learn the testing infrastructure enough to add that test.