### PR TITLE
Add accept header to download request

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -2025,7 +2025,9 @@ extension Workspace {
             let archivePath = parentDirectory.appending(component: artifact.url.lastPathComponent)
 
             group.enter()
-            var request = HTTPClient.Request.download(url: artifact.url, fileSystem: self.fileSystem, destination: archivePath)
+            var headers = HTTPClientHeaders()
+            headers.add(name: "Accept", value: "application/octet-stream")
+            var request = HTTPClient.Request.download(url: artifact.url, headers: headers, fileSystem: self.fileSystem, destination: archivePath)
             request.options.authorizationProvider = self.authorizationProvider?.httpAuthorizationHeader(for:)
             request.options.validResponseCodes = [200]
             self.httpClient.execute(


### PR DESCRIPTION
Add `Accept: application/octet-stream` header to binary download request to allow use of Github API.

### Motivation:

I want to be able to download Github release assets as binary dependencies. However the [Github API states](https://docs.github.com/en/rest/reference/repos#get-a-release-asset) that in order to download an asset a `Accept: application/octet-stream` header should be present, otherwise the API JSON response is returned.

### Modifications:

When downloading a binary artifact an `Accept: application/octet-stream` header is added to the request.

### Result:

On each download download request of an artifact the `Accept: application/octet-stream` header is added.
