### PR TITLE
cleanup use of package location where we can avoid it

### DIFF
--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -361,7 +361,7 @@ public struct PackageCollections: PackageCollectionsProtocol {
     public func getPackageMetadata(_ reference: PackageReference,
                                    collections: Set<PackageCollectionsModel.CollectionIdentifier>?,
                                    callback: @escaping (Result<PackageCollectionsModel.PackageMetadata, Error>) -> Void) {
-        self.getPackageMetadata(identity: reference.identity, location: reference.location, collections: .none, callback: callback)
+        self.getPackageMetadata(identity: reference.identity, location: reference.locationString, collections: .none, callback: callback)
     }
 
     public func getPackageMetadata(identity: PackageIdentity,

--- a/Sources/PackageModel/PackageReference.swift
+++ b/Sources/PackageModel/PackageReference.swift
@@ -18,7 +18,7 @@ import TSCUtility
 /// This represents a reference to a package containing its identity and location.
 public struct PackageReference {
     /// The kind of package reference.
-    public enum Kind: Equatable {
+    public enum Kind: Equatable, CustomStringConvertible {
         /// A root package.
         case root(AbsolutePath)
 
@@ -52,6 +52,21 @@ public struct PackageReference {
             }
         }
 
+        public var description: String {
+            switch self {
+            case .root(let path):
+                return "root \(path)"
+            case .fileSystem(let path):
+                return "fileSystem \(path)"
+            case .localSourceControl(let path):
+                return "localSourceControl \(path)"
+            case .remoteSourceControl(let url):
+                return "remoteSourceControl \(url)"
+            case .registry(let identity):
+                return "registry \(identity)"
+            }
+        }
+
         // FIXME: ideally this would not be required and we can check on the enum directly
         public var isRoot: Bool {
             if case .root = self {
@@ -74,7 +89,7 @@ public struct PackageReference {
     /// This could be a remote repository, local repository or local package.
     // FIXME: we should not need this
     //@available(*, deprecated)
-    public var location: String {
+    public var locationString: String {
         self.kind.locationString
     }
 
@@ -131,6 +146,11 @@ extension PackageReference: Equatable {
     public static func ==(lhs: PackageReference, rhs: PackageReference) -> Bool {
         return lhs.identity == rhs.identity
     }
+
+    // TODO: consider rolling into Equatable
+    public func equalsIncludingLocation(_ other: PackageReference) -> Bool {
+        return self.identity == other.identity && self.kind.locationString == other.kind.locationString
+    }
 }
 
 extension PackageReference: Hashable {
@@ -142,7 +162,7 @@ extension PackageReference: Hashable {
 
 extension PackageReference: CustomStringConvertible {
     public var description: String {
-        return "\(self.identity)\(self.location.isEmpty ? "" : "[\(self.location)]")"
+        return "\(self.identity) \(self.kind)"
     }
 }
 

--- a/Sources/PackageRegistry/RegistryManager.swift
+++ b/Sources/PackageRegistry/RegistryManager.swift
@@ -167,7 +167,7 @@ public final class RegistryManager {
                         at: .root,
                         packageIdentity: package.identity,
                         packageKind: .registry(package.identity),
-                        packageLocation: package.location,
+                        packageLocation: package.locationString,
                         version: version,
                         revision: nil,
                         toolsVersion: .currentToolsVersion,

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -138,7 +138,7 @@ public final class MockWorkspace {
             let manifestPath = packagePath.appending(component: Manifest.filename)
             for version in versions {
                 let v = version.flatMap(Version.init(_:))
-                manifests[.init(url: specifier.url, version: v)] = try Manifest(
+                manifests[.init(url: specifier.location.description, version: v)] = try Manifest(
                     name: package.name,
                     path: manifestPath,
                     packageKind: packageKind,
@@ -497,8 +497,9 @@ public final class MockWorkspace {
                     return
                 }
             case .local:
-                if dependency.state != .local {
+                guard case .local(_) = dependency.state  else {
                     XCTFail("Expected local dependency", file: file, line: line)
+                    return
                 }
             }
         }

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -103,9 +103,9 @@ public struct GitRepositoryProvider: RepositoryProvider {
         // FIXME: Ideally we should pass `--progress` here and report status regularly.  We currently don't have callbacks for that.
         //
         // NOTE: Explicitly set `core.symlinks=true` on `git clone` to ensure that symbolic links are correctly resolved.
-        try self.callGit("clone", "-c", "core.symlinks=true", "--mirror", repository.url, path.pathString,
+        try self.callGit("clone", "-c", "core.symlinks=true", "--mirror", repository.location.description, path.pathString,
                          repository: repository,
-                         failureMessage: "Failed to clone repository \(repository.url)",
+                         failureMessage: "Failed to clone repository \(repository.location)",
                          progress: progressHandler)
     }
     
@@ -143,13 +143,13 @@ public struct GitRepositoryProvider: RepositoryProvider {
             // NOTE: Explicitly set `core.symlinks=true` on `git clone` to ensure that symbolic links are correctly resolved.
             try self.callGit("clone", "-c", "core.symlinks=true", "--no-checkout", sourcePath.pathString, destinationPath.pathString,
                              repository: repository,
-                             failureMessage: "Failed to clone repository \(repository.url)")
+                             failureMessage: "Failed to clone repository \(repository.location)")
             // The default name of the remote.
             let origin = "origin"
             // In destination repo remove the remote which will be pointing to the source repo.
             let clone = GitRepository(path: destinationPath)
             // Set the original remote to the new clone.
-            try clone.setURL(remote: origin, url: repository.url)
+            try clone.setURL(remote: origin, url: repository.location.description)
             // FIXME: This is unfortunate that we have to fetch to update remote's data.
             try clone.fetch()
         } else {
@@ -165,7 +165,7 @@ public struct GitRepositoryProvider: RepositoryProvider {
             // NOTE: Explicitly set `core.symlinks=true` on `git clone` to ensure that symbolic links are correctly resolved.
             try self.callGit("clone", "-c", "core.symlinks=true", "--shared", "--no-checkout", sourcePath.pathString, destinationPath.pathString,
                              repository: repository,
-                             failureMessage: "Failed to clone repository \(repository.url)")
+                             failureMessage: "Failed to clone repository \(repository.location)")
         }
         return try self.openWorkingCopy(at: destinationPath)
     }
@@ -949,7 +949,7 @@ public struct GitCloneError: Error, CustomStringConvertible, DiagnosticLocationP
     public struct Location: DiagnosticLocation {
         public let repository: RepositorySpecifier
         public var description: String {
-            return self.repository.url
+            return self.repository.location.description
         }
     }
 

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -103,7 +103,7 @@ public struct GitRepositoryProvider: RepositoryProvider {
         // FIXME: Ideally we should pass `--progress` here and report status regularly.  We currently don't have callbacks for that.
         //
         // NOTE: Explicitly set `core.symlinks=true` on `git clone` to ensure that symbolic links are correctly resolved.
-        try self.callGit("clone", "-c", "core.symlinks=true", "--mirror", repository.location.description, path.pathString,
+        try self.callGit("clone", "-c", "core.symlinks=true", "--mirror", repository.location.gitURL, path.pathString,
                          repository: repository,
                          failureMessage: "Failed to clone repository \(repository.location)",
                          progress: progressHandler)
@@ -149,7 +149,7 @@ public struct GitRepositoryProvider: RepositoryProvider {
             // In destination repo remove the remote which will be pointing to the source repo.
             let clone = GitRepository(path: destinationPath)
             // Set the original remote to the new clone.
-            try clone.setURL(remote: origin, url: repository.location.description)
+            try clone.setURL(remote: origin, url: repository.location.gitURL)
             // FIXME: This is unfortunate that we have to fetch to update remote's data.
             try clone.fetch()
         } else {
@@ -1111,6 +1111,17 @@ fileprivate func gitFetchStatusFilter(_ bytes: [UInt8], progress: FetchProgress.
             default:
                 continue
             }
+        }
+    }
+}
+
+extension RepositorySpecifier.Location {
+    fileprivate var gitURL: String {
+        switch self {
+        case .path(let path):
+            return path.pathString
+        case .url(let url):
+            return url.absoluteString
         }
     }
 }

--- a/Sources/SourceControl/Repository.swift
+++ b/Sources/SourceControl/Repository.swift
@@ -13,12 +13,6 @@ import TSCBasic
 
 /// Specifies a repository address.
 public struct RepositorySpecifier: Hashable {
-    /// The URL of the repository.
-    // FIXME: transition url to location
-    public var url: String {
-        self.location.description
-    }
-
     public let location: Location
 
     public init(location: Location) {
@@ -35,13 +29,20 @@ public struct RepositorySpecifier: Hashable {
         self.init(location: .url(url))
     }
 
+    /// The URL of the repository.
+    // FIXME: transition url to location
+    @available(*, deprecated, message: "user location instead")
+    public var url: String {
+        self.location.description
+    }
+
     /// A unique identifier for this specifier.
     ///
     /// This identifier is suitable for use in a file system path, and
     /// unique for each repository.
     public var fileSystemIdentifier: String {
         // Use first 8 chars of a stable hash.
-        let suffix = ByteString(encodingAsUTF8: url).sha256Checksum.prefix(8)
+        let suffix = ByteString(encodingAsUTF8: self.location.description).sha256Checksum.prefix(8)
 
         return "\(self.basename)-\(suffix)"
     }

--- a/Sources/Workspace/SourceControlPackageContainer.swift
+++ b/Sources/Workspace/SourceControlPackageContainer.swift
@@ -43,7 +43,7 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
 
         /// Description shown for errors of this kind.
         public var description: String {
-            var desc = "\(underlyingError) in \(self.repository.location.description)"
+            var desc = "\(underlyingError) in \(self.repository.location)"
             if let suggestion = suggestion {
                 desc += " (\(suggestion))"
             }

--- a/Sources/Workspace/WorkspaceState.swift
+++ b/Sources/Workspace/WorkspaceState.swift
@@ -220,7 +220,8 @@ fileprivate struct WorkspaceStateStorage {
                     let kind = try container.decode(String.self, forKey: .name)
                     switch kind {
                     case "local":
-                        return self.init(underlying: .local)
+                        let path = try container.decode(AbsolutePath.self, forKey: .path)
+                        return self.init(underlying: .local(path))
                     case "checkout":
                         let checkout = try container.decode(CheckoutInfo.self, forKey: .checkoutState)
                         return try self.init(underlying: .checkout(.init(checkout)))
@@ -235,15 +236,15 @@ fileprivate struct WorkspaceStateStorage {
                 func encode(to encoder: Encoder) throws {
                     var container = encoder.container(keyedBy: CodingKeys.self)
                     switch self.underlying {
-                    case .local:
+                    case .local(let path):
                         try container.encode("local", forKey: .name)
+                        try container.encode(path, forKey: .path)
                     case .checkout(let state):
                         try container.encode("checkout", forKey: .name)
                         try container.encode(CheckoutInfo(state), forKey: .checkoutState)
                     case .edited(_, let path):
                         try container.encode("edited", forKey: .name)
                         try container.encode(path, forKey: .path)
-
                     }
                 }
 

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -63,14 +63,14 @@ private class DummyRepositoryProvider: RepositoryProvider {
     func fetch(repository: RepositorySpecifier, to path: AbsolutePath, progressHandler: FetchProgress.Handler? = nil) throws {
         assert(!localFileSystem.exists(path))
         try localFileSystem.createDirectory(path.parentDirectory, recursive: true)
-        try localFileSystem.writeFileContents(path, bytes: ByteString(encodingAsUTF8: repository.url))
+        try localFileSystem.writeFileContents(path, bytes: ByteString(encodingAsUTF8: repository.location.description))
 
         self.lock.withLock {
             self._numClones += 1
         }
 
         // We only support one dummy URL.
-        let basename = repository.url.components(separatedBy: "/").last!
+        let basename = repository.location.description.components(separatedBy: "/").last!
         if basename != "dummy" {
             throw DummyError.invalidRepository
         }
@@ -334,7 +334,7 @@ class RepositoryManagerTests: XCTestCase {
             do {
                 let checkoutsStateFile = path.appending(component: "checkouts-state.json")
                 let jsonData = try JSON(bytes: localFileSystem.readFileContents(checkoutsStateFile))
-                XCTAssertEqual(jsonData.dictionary?["object"]?.dictionary?["repositories"]?.dictionary?[dummyRepo.url], nil)
+                XCTAssertEqual(jsonData.dictionary?["object"]?.dictionary?["repositories"]?.dictionary?[dummyRepo.location.description], nil)
             }
 
             // We should get a new handle now because we deleted the existing repository.

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -1051,7 +1051,7 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertEqual(result.diagnostics.hasErrors, false)
             XCTAssertEqual(result.result, .required(reason: .packageRequirementChange(
                 package: cRef,
-                state: .local,
+                state: .local(cPackagePath),
                 requirement: .revision("master")
             )))
         }
@@ -1735,7 +1735,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Check that we can compute missing dependencies.
         try workspace.loadDependencyManifests(roots: ["Root1", "Root2"]) { manifests, diagnostics in
-            XCTAssertEqual(manifests.missingPackageURLs().map { $0.location }.sorted(), ["/tmp/ws/pkgs/Bar", "/tmp/ws/pkgs/Foo"])
+            XCTAssertEqual(manifests.missingPackages().map { $0.locationString }.sorted(), ["/tmp/ws/pkgs/Bar", "/tmp/ws/pkgs/Foo"])
             XCTAssertNoDiagnostics(diagnostics)
         }
 
@@ -1749,7 +1749,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Check that we compute the correct missing dependencies.
         try workspace.loadDependencyManifests(roots: ["Root1", "Root2"]) { manifests, diagnostics in
-            XCTAssertEqual(manifests.missingPackageURLs().map { $0.location }.sorted(), ["/tmp/ws/pkgs/Bar"])
+            XCTAssertEqual(manifests.missingPackages().map { $0.locationString }.sorted(), ["/tmp/ws/pkgs/Bar"])
             XCTAssertNoDiagnostics(diagnostics)
         }
 
@@ -1763,7 +1763,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Check that we compute the correct missing dependencies.
         try workspace.loadDependencyManifests(roots: ["Root1", "Root2"]) { manifests, diagnostics in
-            XCTAssertEqual(manifests.missingPackageURLs().map { $0.location }.sorted(), [])
+            XCTAssertEqual(manifests.missingPackages().map { $0.locationString }.sorted(), [])
             XCTAssertNoDiagnostics(diagnostics)
         }
     }
@@ -2211,7 +2211,7 @@ final class WorkspaceTests: XCTestCase {
 
         try workspace.loadDependencyManifests(roots: ["Root"]) { manifests, diagnostics in
             let editedPackages = manifests.editedPackagesConstraints()
-            XCTAssertEqual(editedPackages.map { $0.package.location }, [fooPath.pathString])
+            XCTAssertEqual(editedPackages.map { $0.package.locationString }, [fooPath.pathString])
             XCTAssertNoDiagnostics(diagnostics)
         }
 
@@ -3309,7 +3309,7 @@ final class WorkspaceTests: XCTestCase {
         }
         do {
             let ws = try workspace.getOrCreateWorkspace()
-            XCTAssertEqual(ws.state.dependencies[.plain("foo")]?.packageRef.location, "/tmp/ws/pkgs/Foo")
+            XCTAssertEqual(ws.state.dependencies[.plain("foo")]?.packageRef.locationString, "/tmp/ws/pkgs/Foo")
         }
 
         deps = [
@@ -3323,7 +3323,7 @@ final class WorkspaceTests: XCTestCase {
         }
         do {
             let ws = try workspace.getOrCreateWorkspace()
-            XCTAssertEqual(ws.state.dependencies[.plain("foo")]?.packageRef.location, "/tmp/ws/pkgs/Nested/Foo")
+            XCTAssertEqual(ws.state.dependencies[.plain("foo")]?.packageRef.locationString, "/tmp/ws/pkgs/Nested/Foo")
         }
     }
 
@@ -3638,7 +3638,7 @@ final class WorkspaceTests: XCTestCase {
 
         do {
             let ws = try workspace.getOrCreateWorkspace()
-            XCTAssertEqual(ws.state.dependencies[.plain("foo")]?.packageRef.location, "/tmp/ws/pkgs/Foo")
+            XCTAssertEqual(ws.state.dependencies[.plain("foo")]?.packageRef.locationString, "/tmp/ws/pkgs/Foo")
         }
 
         workspace.checkReset { diagnostics in
@@ -3662,7 +3662,7 @@ final class WorkspaceTests: XCTestCase {
 
         do {
             let ws = try workspace.getOrCreateWorkspace()
-            XCTAssertEqual(ws.state.dependencies[.plain("foo")]?.packageRef.location, "/tmp/ws/pkgs/Nested/Foo")
+            XCTAssertEqual(ws.state.dependencies[.plain("foo")]?.packageRef.locationString, "/tmp/ws/pkgs/Nested/Foo")
         }
     }
 
@@ -3732,7 +3732,7 @@ final class WorkspaceTests: XCTestCase {
             let pinsStore = try ws.pinsStore.load()
             let fooPin = pinsStore.pins.first(where: { $0.packageRef.identity.description == "foo" })!
 
-            let fooRepo = workspace.repoProvider.specifierMap[RepositorySpecifier(path: AbsolutePath(fooPin.packageRef.location))]!
+            let fooRepo = workspace.repoProvider.specifierMap[RepositorySpecifier(path: AbsolutePath(fooPin.packageRef.locationString))]!
             let revision = try fooRepo.resolveRevision(tag: "1.0.0")
             let newState = CheckoutState.version("1.0.0", revision: revision)
 


### PR DESCRIPTION
motivation: use identity instead of location where possible

changes:
* abstract PackageRef comparison which need to acccount for location intoa function
* replace several places in Workspace that use location but can use identity
* rename "location" to "locatioString" to discourage the uses of the untypes / string form
* deprecate RepositorySpecifier::url in favour of RepositorySpecifier::location
* adjust call sites and tests

rdar://82954076
