### PR TITLE
migrate workspace, manifest loading and plugins to observability APIs

### DIFF
--- a/Sources/Basics/SQLiteBackedCache.swift
+++ b/Sources/Basics/SQLiteBackedCache.swift
@@ -34,7 +34,6 @@ public final class SQLiteBackedCache<Value: Codable>: Closable {
     ///   - tableName: The SQLite table name. Must follow SQLite naming rules (e.g., no spaces).
     ///   - location: SQLite.Location
     ///   - configuration: Optional. Configuration for the cache.
-    ///   - diagnosticsEngine: DiagnosticsEngine
     public init(tableName: String, location: SQLite.Location, configuration: SQLiteBackedCacheConfiguration = .init()) {
         self.tableName = tableName
         self.location = location
@@ -55,7 +54,6 @@ public final class SQLiteBackedCache<Value: Codable>: Closable {
     ///   - tableName: The SQLite table name. Must follow SQLite naming rules (e.g., no spaces).
     ///   - path: The path of the SQLite database.
     ///   - configuration: Optional. Configuration for the cache.
-    ///   - diagnosticsEngine: DiagnosticsEngine
     public convenience init(tableName: String, path: AbsolutePath, configuration: SQLiteBackedCacheConfiguration = .init()) {
         self.init(tableName: tableName, location: .path(path), configuration: configuration)
     }

--- a/Sources/Build/SPMSwiftDriverExecutor.swift
+++ b/Sources/Build/SPMSwiftDriverExecutor.swift
@@ -15,7 +15,7 @@ import Foundation
 
 final class SPMSwiftDriverExecutor: DriverExecutor {
 
-  private enum Error: Swift.Error, DiagnosticData {
+  private enum Error: Swift.Error, CustomStringConvertible {
     case inPlaceExecutionUnsupported
 
     var description: String {

--- a/Sources/Commands/APIDigester.swift
+++ b/Sources/Commands/APIDigester.swift
@@ -241,7 +241,7 @@ public struct SwiftAPIDigester {
 }
 
 extension SwiftAPIDigester {
-    public enum Error: Swift.Error, DiagnosticData {
+    public enum Error: Swift.Error, CustomStringConvertible {
         case failedToGenerateBaseline(String)
 
         public var description: String {

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -225,7 +225,7 @@ public struct SwiftTestTool: SwiftCommand {
             let rootManifests = try temp_await {
                 workspace.loadRootManifests(
                     packages: root.packages,
-                    diagnostics: swiftTool.observabilityScope.makeDiagnosticsEngine(),
+                    observabilityScope: swiftTool.observabilityScope,
                     completion: $0
                 )
             }
@@ -366,7 +366,7 @@ public struct SwiftTestTool: SwiftCommand {
         let rootManifests = try temp_await {
             workspace.loadRootManifests(
                 packages: root.packages,
-                diagnostics: swiftTool.observabilityScope.makeDiagnosticsEngine(),
+                observabilityScope: swiftTool.observabilityScope,
                 completion: $0
             )
         }

--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -36,7 +36,7 @@ public struct PackageCollections: PackageCollectionsProtocol {
     public init(configuration: Configuration = .init(), observabilityScope: ObservabilityScope) {
         let storage = Storage(
             sources: FilePackageCollectionsSourcesStorage(),
-            collections: SQLitePackageCollectionsStorage()
+            collections: SQLitePackageCollectionsStorage(observabilityScope: observabilityScope)
         )
 
         let collectionProviders = [

--- a/Sources/PackageGraph/PackageContainer.swift
+++ b/Sources/PackageGraph/PackageContainer.swift
@@ -8,6 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
+import Basics
 import Dispatch
 import PackageModel
 import struct TSCUtility.Version
@@ -41,7 +42,7 @@ public protocol PackageContainer {
 
     /// Returns the tools version for the given version
     func toolsVersion(for version: Version) throws -> ToolsVersion
-    
+
     /// Get the list of versions which are available for the package.
     ///
     /// The list will be returned in sorted order, with the latest version *first*.
@@ -145,6 +146,7 @@ public protocol PackageContainerProvider {
     func getContainer(
         for package: PackageReference,
         skipUpdate: Bool,
+        observabilityScope: ObservabilityScope,
         on queue: DispatchQueue,
         completion: @escaping (Result<PackageContainer, Swift.Error>) -> Void
     )

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -97,7 +97,7 @@ extension PackageGraph {
         for node in allNodes {
             let nodeObservabilityScope = observabilityScope.makeChildScope(
                 description: "loading package \(node.identity)",
-                metadata: .packageMetadata(identity: node.identity, location: node.manifest.packageLocation, path: node.manifest.path.parentDirectory)
+                metadata: .packageMetadata(identity: node.identity, kind: node.manifest.packageKind)
             )
 
             let manifest = node.manifest

--- a/Sources/PackageLoading/Diagnostics.swift
+++ b/Sources/PackageLoading/Diagnostics.swift
@@ -156,9 +156,12 @@ extension ObservabilityMetadata {
 }
 
 // FIXME: (diagnostics) deprecate in favor of the metadata version ^^ when transitioning manifest loader to Observability APIs
-public struct ManifestLoadingDiagnostic: DiagnosticData {
+@available(*, deprecated, message: "user metadata API instead")
+public struct ManifestLoadingDiagnostic: CustomStringConvertible {
      public let output: String
      public let diagnosticFile: AbsolutePath?
 
-     public var description: String { output }
+    public var description: String {
+        self.output
+    }
 }

--- a/Sources/PackageLoading/ManifestJSONParser.swift
+++ b/Sources/PackageLoading/ManifestJSONParser.swift
@@ -333,7 +333,7 @@ enum ManifestJSONParser {
         let providers = try? json
             .getArray("providers")
             .map(SystemPackageProviderDescription.init(v4:))
-        
+
         let pluginCapability = try? TargetDescription.PluginCapability(v4: json.getJSON("pluginCapability"))
 
         let dependencies = try json
@@ -465,7 +465,7 @@ extension PackageModel.ProductType {
             }
 
             self = .library(libraryType)
-            
+
         case "plugin":
             self = .plugin
 

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -37,8 +37,8 @@ public protocol ManifestLoaderProtocol {
     ///   - revision: Optional. The revision the manifest is from, if known
     ///   - toolsVersion: The version of the tools the manifest supports.
     ///   - identityResolver: A helper to resolve identities based on configuration
-    ///   - fileSystem: The file system to load from.
-    ///   - diagnostics: Optional.  The diagnostics engine.
+    ///   - fileSystem: File system to load from.
+    ///   - observabilityScope: Observability scope to emit diagnostics.
     ///   - on: The dispatch queue to perform asynchronous operations on.
     ///   - completion: The completion handler .
     func load(
@@ -51,7 +51,7 @@ public protocol ManifestLoaderProtocol {
         toolsVersion: ToolsVersion,
         identityResolver: IdentityResolver,
         fileSystem: FileSystem,
-        diagnostics: DiagnosticsEngine?,
+        observabilityScope: ObservabilityScope,
         on queue: DispatchQueue,
         completion: @escaping (Result<Manifest, Error>) -> Void
     )
@@ -173,7 +173,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                 toolsVersion: toolsVersion,
                 identityResolver: identityResolver,
                 fileSystem: fileSystem,
-                diagnostics: diagnostics,
+                observabilityScope: ObservabilitySystem(diagnosticEngine: diagnostics ?? DiagnosticsEngine()).topScope,
                 on: queue,
                 completion: completion
             )
@@ -192,24 +192,26 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         toolsVersion: ToolsVersion,
         identityResolver: IdentityResolver,
         fileSystem: FileSystem,
-        diagnostics: DiagnosticsEngine? = nil,
+        observabilityScope: ObservabilityScope,
         on queue: DispatchQueue,
         completion: @escaping (Result<Manifest, Error>) -> Void
     ) {
         do {
             let manifestPath = try Manifest.path(atPackagePath: path, fileSystem: fileSystem)
-            self.loadFile(at: manifestPath,
-                          packageIdentity: packageIdentity,
-                          packageKind: packageKind,
-                          packageLocation: packageLocation,
-                          version: version,
-                          revision: revision,
-                          toolsVersion: toolsVersion,
-                          identityResolver: identityResolver,
-                          fileSystem: fileSystem,
-                          diagnostics: diagnostics,
-                          on: queue,
-                          completion: completion)
+            self.loadFile(
+                at: manifestPath,
+                packageIdentity: packageIdentity,
+                packageKind: packageKind,
+                packageLocation: packageLocation,
+                version: version,
+                revision: revision,
+                toolsVersion: toolsVersion,
+                identityResolver: identityResolver,
+                fileSystem: fileSystem,
+                observabilityScope: observabilityScope,
+                on: queue,
+                completion: completion
+            )
         } catch {
             return completion(.failure(error))
         }
@@ -225,7 +227,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         toolsVersion: ToolsVersion,
         identityResolver: IdentityResolver,
         fileSystem: FileSystem,
-        diagnostics: DiagnosticsEngine? = nil,
+        observabilityScope: ObservabilityScope,
         on queue: DispatchQueue,
         completion: @escaping (Result<Manifest, Error>) -> Void
     ) {
@@ -249,7 +251,8 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                     identityResolver: identityResolver,
                     delegateQueue: queue,
                     fileSystem: fileSystem,
-                    diagnostics: diagnostics)
+                    observabilityScope: observabilityScope
+                )
 
                 // Convert legacy system packages to the current target‐based model.
                 var products = parsedManifest.products
@@ -290,9 +293,9 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                     targets: targets
                 )
 
-                try self.validate(manifest, toolsVersion: toolsVersion, diagnostics: diagnostics)
+                try self.validate(manifest, toolsVersion: toolsVersion, observabilityScope: observabilityScope)
 
-                if let diagnostics = diagnostics, diagnostics.hasErrors {
+                if observabilityScope.errorsReported {
                     throw Diagnostics.fatalError
                 }
 
@@ -308,44 +311,44 @@ public final class ManifestLoader: ManifestLoaderProtocol {
     }
 
     /// Validate the provided manifest.
-    private func validate(_ manifest: Manifest, toolsVersion: ToolsVersion, diagnostics: DiagnosticsEngine?) throws {
-        try self.validateTargets(manifest, diagnostics: diagnostics)
-        try self.validateProducts(manifest, diagnostics: diagnostics)
-        try self.validateDependencies(manifest, toolsVersion: toolsVersion, diagnostics: diagnostics)
+    private func validate(_ manifest: Manifest, toolsVersion: ToolsVersion, observabilityScope: ObservabilityScope) throws {
+        try self.validateTargets(manifest, observabilityScope: observabilityScope)
+        try self.validateProducts(manifest, observabilityScope: observabilityScope)
+        try self.validateDependencies(manifest, toolsVersion: toolsVersion, observabilityScope: observabilityScope)
 
         // Checks reserved for tools version 5.2 features
         if toolsVersion >= .v5_2 {
-            try self.validateTargetDependencyReferences(manifest, diagnostics: diagnostics)
-            try self.validateBinaryTargets(manifest, diagnostics: diagnostics)
+            try self.validateTargetDependencyReferences(manifest, observabilityScope: observabilityScope)
+            try self.validateBinaryTargets(manifest, observabilityScope: observabilityScope)
         }
     }
 
-    private func validateTargets(_ manifest: Manifest, diagnostics: DiagnosticsEngine?) throws {
+    private func validateTargets(_ manifest: Manifest, observabilityScope: ObservabilityScope) throws {
         let duplicateTargetNames = manifest.targets.map({ $0.name }).spm_findDuplicates()
         for name in duplicateTargetNames {
-            try diagnostics.emit(.duplicateTargetName(targetName: name))
+            observabilityScope.emit(.duplicateTargetName(targetName: name))
         }
     }
 
-    private func validateProducts(_ manifest: Manifest, diagnostics: DiagnosticsEngine?) throws {
+    private func validateProducts(_ manifest: Manifest, observabilityScope: ObservabilityScope) throws {
         for product in manifest.products {
             // Check that the product contains targets.
             guard !product.targets.isEmpty else {
-                try diagnostics.emit(.emptyProductTargets(productName: product.name))
+                observabilityScope.emit(.emptyProductTargets(productName: product.name))
                 continue
             }
 
             // Check that the product references existing targets.
             for target in product.targets {
                 if !manifest.targetMap.keys.contains(target) {
-                    try diagnostics.emit(.productTargetNotFound(productName: product.name, targetName: target, validTargets: manifest.targetMap.keys.sorted()))
+                    observabilityScope.emit(.productTargetNotFound(productName: product.name, targetName: target, validTargets: manifest.targetMap.keys.sorted()))
                 }
             }
 
             // Check that products that reference only binary targets don't define a type.
             let areTargetsBinary = product.targets.allSatisfy { manifest.targetMap[$0]?.type == .binary }
             if areTargetsBinary && product.type != .library(.automatic) {
-                try diagnostics.emit(.invalidBinaryProductType(productName: product.name))
+                observabilityScope.emit(.invalidBinaryProductType(productName: product.name))
             }
         }
     }
@@ -353,7 +356,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
     private func validateDependencies(
         _ manifest: Manifest,
         toolsVersion: ToolsVersion,
-        diagnostics: DiagnosticsEngine?
+        observabilityScope: ObservabilityScope
     ) throws {
         let dependenciesByIdentity = Dictionary(grouping: manifest.dependencies, by: { dependency in
             dependency.identity
@@ -365,7 +368,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             .map({ $0.key })
 
         for identity in duplicateDependencyIdentities {
-            try diagnostics.emit(.duplicateDependency(dependencyIdentity: identity))
+            observabilityScope.emit(.duplicateDependency(dependencyIdentity: identity))
         }
 
         if toolsVersion >= .v5_2 {
@@ -382,22 +385,22 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                 .spm_findDuplicates()
 
             for name in duplicateDependencyNames {
-                try diagnostics.emit(.duplicateDependencyName(dependencyName: name))
+                observabilityScope.emit(.duplicateDependencyName(dependencyName: name))
             }
         }
     }
 
-    private func validateBinaryTargets(_ manifest: Manifest, diagnostics: DiagnosticsEngine?) throws {
+    private func validateBinaryTargets(_ manifest: Manifest, observabilityScope: ObservabilityScope) throws {
         // Check that binary targets point to the right file type.
         for target in manifest.targets where target.type == .binary {
             guard let location = URL(string: target.url ?? target.path ?? "") else {
-                try diagnostics.emit(.invalidBinaryLocation(targetName: target.name))
+                observabilityScope.emit(.invalidBinaryLocation(targetName: target.name))
                 continue
             }
 
             let validSchemes = ["https"]
             if target.isRemote && (location.scheme.map({ !validSchemes.contains($0) }) ?? true) {
-                try diagnostics.emit(.invalidBinaryURLScheme(
+                observabilityScope.emit(.invalidBinaryURLScheme(
                     targetName: target.name,
                     validSchemes: validSchemes
                 ))
@@ -409,7 +412,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             }
 
             if !validExtensions.contains(location.pathExtension) {
-                try diagnostics.emit(.unsupportedBinaryLocationExtension(
+                observabilityScope.emit(.unsupportedBinaryLocationExtension(
                     targetName: target.name,
                     validExtensions: validExtensions
                 ))
@@ -418,7 +421,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
     }
 
     /// Validates that product target dependencies reference an existing package.
-    private func validateTargetDependencyReferences(_ manifest: Manifest, diagnostics: DiagnosticsEngine?) throws {
+    private func validateTargetDependencyReferences(_ manifest: Manifest, observabilityScope: ObservabilityScope) throws {
         for target in manifest.targets {
             for targetDependency in target.dependencies {
                 switch targetDependency {
@@ -427,7 +430,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                     break
                 case .product(_, let packageName, _):
                     if manifest.packageDependency(referencedBy: targetDependency) == nil {
-                        try diagnostics.emit(.unknownTargetPackageDependency(
+                        observabilityScope.emit(.unknownTargetPackageDependency(
                             packageName: packageName ?? "unknown package name",
                             targetName: target.name,
                             validPackages: manifest.dependencies.map { $0.nameForTargetDependencyResolutionOnly }
@@ -439,7 +442,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                        !manifest.targetMap.keys.contains(name) &&
                        manifest.packageDependency(referencedBy: targetDependency) == nil
                     {
-                        try diagnostics.emit(.unknownTargetDependency(
+                        observabilityScope.emit(.unknownTargetDependency(
                             dependency: name,
                             targetName: target.name,
                             validDependencies: manifest.dependencies.map { $0.nameForTargetDependencyResolutionOnly }
@@ -458,7 +461,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         toolsVersion: ToolsVersion,
         identityResolver: IdentityResolver,
         fileSystem: FileSystem,
-        diagnostics: DiagnosticsEngine?
+        observabilityScope: ObservabilityScope
     ) throws -> ManifestJSONParser.Result {
         // Throw now if we weren't able to parse the manifest.
         guard let manifestJSON = result.manifestJSON, !manifestJSON.isEmpty else {
@@ -474,23 +477,25 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         if let compilerOutput = result.compilerOutput {
             // FIXME: Temporary workaround to filter out debug output from integrated Swift driver. [rdar://73710910]
             if !(compilerOutput.hasPrefix("<unknown>:0: remark: new Swift driver at") && compilerOutput.hasSuffix("will be used")) {
-                /*let metadata = result.diagnosticFile.map { diagnosticFile -> ObservabilityMetadata in
+                let metadata = result.diagnosticFile.map { diagnosticFile -> ObservabilityMetadata in
                     var metadata = ObservabilityMetadata()
                     metadata.manifestLoadingDiagnosticFile = diagnosticFile
                     return metadata
                 }
-                diagnostics.emit(warning: compilerOutput, metadata: metadata)
-                */
+                observabilityScope.emit(warning: compilerOutput, metadata: metadata)
+
                 // FIXME: (diagnostics) deprecate in favor of the metadata version ^^ when transitioning manifest loader to Observability APIs
-                diagnostics?.emit(.warning(ManifestLoadingDiagnostic(output: compilerOutput, diagnosticFile: result.diagnosticFile)))
+                //observabilityScope.emit(.warning(ManifestLoadingDiagnostic(output: compilerOutput, diagnosticFile: result.diagnosticFile)))
             }
         }
 
-        return try ManifestJSONParser.parse(v4: manifestJSON,
-                                            toolsVersion: toolsVersion,
-                                            packageKind: packageKind,
-                                            identityResolver: identityResolver,
-                                            fileSystem: fileSystem)
+        return try ManifestJSONParser.parse(
+            v4: manifestJSON,
+            toolsVersion: toolsVersion,
+            packageKind: packageKind,
+            identityResolver: identityResolver,
+            fileSystem: fileSystem
+        )
     }
 
     private func parseAndCacheManifest(
@@ -501,7 +506,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         identityResolver: IdentityResolver,
         delegateQueue: DispatchQueue,
         fileSystem: FileSystem,
-        diagnostics: DiagnosticsEngine?
+        observabilityScope: ObservabilityScope
     ) throws -> ManifestJSONParser.Result {
         let cache = self.databaseCacheDir.map { cacheDir -> SQLiteBackedCache<EvaluationResult> in
             let path = Self.manifestCacheDBPath(cacheDir)
@@ -538,10 +543,11 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                     toolsVersion: toolsVersion,
                     identityResolver: identityResolver,
                     fileSystem: fileSystem,
-                    diagnostics: diagnostics)
+                    observabilityScope: observabilityScope
+                )
             }
         } catch {
-            diagnostics?.emit(warning: "failed loading cached manifest for '\(key.packageIdentity)': \(error)")
+            observabilityScope.emit(warning: "failed loading cached manifest for '\(key.packageIdentity)': \(error)")
         }
 
         // shells out and compiles the manifest, finally output a JSON
@@ -561,14 +567,14 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             toolsVersion: toolsVersion,
             identityResolver: identityResolver,
             fileSystem: fileSystem,
-            diagnostics: diagnostics
+            observabilityScope: observabilityScope
         )
 
         do {
             // FIXME: (diagnostics) pass in observability scope when we have one
             try cache?.put(key: key.sha256Checksum, value: result)
         } catch {
-            diagnostics?.emit(warning: "failed storing manifest for '\(key.packageIdentity)' in cache: \(error)")
+            observabilityScope.emit(warning: "failed storing manifest for '\(key.packageIdentity)' in cache: \(error)")
         }
 
         return parseManifest
@@ -937,7 +943,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
     }
 }
 
-extension TSCBasic.Diagnostic.Message {
+extension Basics.Diagnostic {
     static func duplicateTargetName(targetName: String) -> Self {
         .error("duplicate target named '\(targetName)'")
     }

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -283,7 +283,7 @@ public final class PackageBuilder {
         self.warnAboutImplicitExecutableTargets = warnAboutImplicitExecutableTargets
         self.observabilityScope = observabilityScope.makeChildScope(
             description: "PackageBuilder",
-            metadata: .packageMetadata(identity: self.identity, location: self.manifest.packageLocation, path: self.packagePath)
+            metadata: .packageMetadata(identity: self.identity, kind: self.manifest.packageKind)
         )
         self.fileSystem = fileSystem
     }
@@ -800,7 +800,7 @@ public final class PackageBuilder {
 
         let sourcesBuilder = TargetSourcesBuilder(
             packageIdentity: self.identity,
-            packageLocation: self.manifest.packageLocation,
+            packageKind: self.manifest.packageKind,
             packagePath: self.packagePath,
             target: manifestTarget,
             path: potentialModule.path,

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -15,13 +15,13 @@ import TSCBasic
 
 /// A utility to compute the source/resource files of a target.
 public struct TargetSourcesBuilder {
-    /// The identity of the package.
+    /// The package identity.
     public let packageIdentity: PackageIdentity
 
-    /// The location of the package.
-    public let packageLocation: String
+    /// The package kind.
+    public let packageKind: PackageReference.Kind
 
-    /// The path of the package.
+    /// The package path.
     public let packagePath: AbsolutePath
 
     /// The target for which we're computing source/resource files.
@@ -57,7 +57,7 @@ public struct TargetSourcesBuilder {
     /// Create a new target builder.
     public init(
         packageIdentity: PackageIdentity,
-        packageLocation: String,
+        packageKind: PackageReference.Kind,
         packagePath: AbsolutePath,
         target: TargetDescription,
         path: AbsolutePath,
@@ -68,7 +68,8 @@ public struct TargetSourcesBuilder {
         observabilityScope: ObservabilityScope
     ) {
         self.packageIdentity = packageIdentity
-        self.packageLocation = packageLocation
+        self.packageKind = packageKind
+        //self.packageLocation = packageLocation
         self.packagePath = packagePath
         self.target = target
         self.defaultLocalization = defaultLocalization
@@ -87,7 +88,7 @@ public struct TargetSourcesBuilder {
         self.fileSystem = fileSystem
 
         self.observabilityScope = observabilityScope.makeChildScope(description: "TargetSourcesBuilder") {
-            var metadata = ObservabilityMetadata.packageMetadata(identity: packageIdentity, location: packageLocation, path: packagePath)
+            var metadata = ObservabilityMetadata.packageMetadata(identity: packageIdentity, kind: packageKind)
             metadata.targetName = target.name
             return metadata
         }

--- a/Sources/PackageModel/Diagnostics.swift
+++ b/Sources/PackageModel/Diagnostics.swift
@@ -14,7 +14,7 @@ import Foundation
 import TSCUtility
 
 /// The diagnostic triggered when the package has a newer tools version than the installed tools.
-public struct RequireNewerTools: DiagnosticData, Swift.Error {
+public struct RequireNewerTools: Error, CustomStringConvertible {
     /// The identity of the package.
     public let packageIdentity: PackageIdentity
 
@@ -50,7 +50,7 @@ public struct RequireNewerTools: DiagnosticData, Swift.Error {
 }
 
 /// The diagnostic triggered when the package has an unsupported tools version.
-public struct UnsupportedToolsVersion: DiagnosticData, Swift.Error {
+public struct UnsupportedToolsVersion: Error, CustomStringConvertible {
     /// The identity of the package.
     public let packageIdentity: PackageIdentity
 

--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -52,7 +52,7 @@ public final class Manifest {
     }
 
     /// Whether kind of package this manifest is from.
-     public let packageKind: PackageReference.Kind
+    public let packageKind: PackageReference.Kind
 
     /// The version this package was loaded from, if known.
     public let version: Version?

--- a/Sources/PackageModel/Package.swift
+++ b/Sources/PackageModel/Package.swift
@@ -115,7 +115,7 @@ extension Package {
 
 extension Package {
     public var diagnosticsMetadata: ObservabilityMetadata {
-        return .packageMetadata(identity: self.identity, location: self.manifest.packageLocation, path: self.path)
+        return .packageMetadata(identity: self.identity, kind: self.manifest.packageKind)
     }
 }
 
@@ -139,12 +139,13 @@ extension Package.Error: CustomStringConvertible {
 }
 
 extension ObservabilityMetadata {
-    public static func packageMetadata(identity: PackageIdentity, location: String, path: AbsolutePath) -> Self {
+    public static func packageMetadata(identity: PackageIdentity, kind: PackageReference.Kind) -> Self {
         var metadata = ObservabilityMetadata()
         metadata.packageIdentity = identity
-        metadata.packageLocation = location
+        metadata.packageKind = kind
+        //metadata.packageLocation = location
         // FIXME: (diagnostics) remove once transition to Observability API is complete
-        metadata.legacyDiagnosticLocation = .init(PackageLocation.Local(name: identity.description, packagePath: path))
+        //metadata.legacyDiagnosticLocation = .init(PackageLocation.Local(name: identity.description, packagePath: path))
         return metadata
     }
 }
@@ -164,6 +165,7 @@ extension ObservabilityMetadata {
     }
 }
 
+/*
 extension ObservabilityMetadata {
     public var packageLocation: String? {
         get {
@@ -176,5 +178,20 @@ extension ObservabilityMetadata {
 
     enum PackageLocationKey: Key {
         typealias Value = String
+    }
+}*/
+
+extension ObservabilityMetadata {
+    public var packageKind: PackageReference.Kind? {
+        get {
+            self[PackageKindKey.self]
+        }
+        set {
+            self[PackageKindKey.self] = newValue
+        }
+    }
+
+    enum PackageKindKey: Key {
+        typealias Value = PackageReference.Kind
     }
 }

--- a/Sources/PackageRegistry/RegistryManager.swift
+++ b/Sources/PackageRegistry/RegistryManager.swift
@@ -54,7 +54,7 @@ public final class RegistryManager {
 
     public func fetchVersions(
         of package: PackageReference,
-        observabilityScope: ObservabilityScope?,
+        observabilityScope: ObservabilityScope,
         on queue: DispatchQueue,
         completion: @escaping (Result<[Version], Error>) -> Void
     ) {
@@ -109,7 +109,7 @@ public final class RegistryManager {
         using manifestLoader: ManifestLoaderProtocol,
         toolsVersion: ToolsVersion = .currentToolsVersion,
         swiftLanguageVersion: SwiftLanguageVersion? = nil,
-        observabilityScope: ObservabilityScope?,
+        observabilityScope: ObservabilityScope,
         on queue: DispatchQueue,
         completion: @escaping (Result<Manifest, Error>) -> Void
     ) {
@@ -173,7 +173,7 @@ public final class RegistryManager {
                         toolsVersion: .currentToolsVersion,
                         identityResolver: self.identityResolver,
                         fileSystem: fileSystem,
-                        diagnostics: observabilityScope?.makeDiagnosticsEngine(),
+                        observabilityScope: observabilityScope,
                         on: .sharedConcurrent,
                         completion: completion
                     )
@@ -194,7 +194,7 @@ public final class RegistryManager {
         into fileSystem: FileSystem,
         at destinationPath: AbsolutePath,
         expectedChecksum: ByteString? = nil,
-        observabilityScope: ObservabilityScope?,
+        observabilityScope: ObservabilityScope,
         on queue: DispatchQueue,
         completion: @escaping (Result<Void, Error>) -> Void
     ) {

--- a/Sources/SPMTestSupport/MockManifestLoader.swift
+++ b/Sources/SPMTestSupport/MockManifestLoader.swift
@@ -57,7 +57,7 @@ public final class MockManifestLoader: ManifestLoaderProtocol {
         toolsVersion: ToolsVersion,
         identityResolver: IdentityResolver,
         fileSystem: FileSystem,
-        diagnostics: DiagnosticsEngine?,
+        observabilityScope: ObservabilityScope,
         on queue: DispatchQueue,
         completion: @escaping (Result<Manifest, Error>) -> Void
     ) {
@@ -82,7 +82,7 @@ extension ManifestLoader {
         toolsVersion: PackageModel.ToolsVersion,
         identityResolver: IdentityResolver = DefaultIdentityResolver(),
         fileSystem: TSCBasic.FileSystem,
-        diagnostics: TSCBasic.DiagnosticsEngine? = nil
+        observabilityScope: ObservabilityScope
     ) throws -> Manifest{
         let packageIdentity: PackageIdentity
         let packageLocation: String
@@ -105,18 +105,20 @@ extension ManifestLoader {
             packageLocation = identity.description
         }
         return try tsc_await {
-            self.load(at: path,
-                      packageIdentity: packageIdentity,
-                      packageKind: packageKind,
-                      packageLocation: packageLocation,
-                      version: nil,
-                      revision: nil,
-                      toolsVersion: toolsVersion,
-                      identityResolver: identityResolver,
-                      fileSystem: fileSystem,
-                      diagnostics: diagnostics,
-                      on: .sharedConcurrent,
-                      completion: $0)
+            self.load(
+                at: path,
+                packageIdentity: packageIdentity,
+                packageKind: packageKind,
+                packageLocation: packageLocation,
+                version: nil,
+                revision: nil,
+                toolsVersion: toolsVersion,
+                identityResolver: identityResolver,
+                fileSystem: fileSystem,
+                observabilityScope: observabilityScope,
+                on: .sharedConcurrent,
+                completion: $0
+            )
         }
     }
 }

--- a/Sources/SPMTestSupport/MockPackageContainer.swift
+++ b/Sources/SPMTestSupport/MockPackageContainer.swift
@@ -7,13 +7,14 @@
  See http://swift.org/LICENSE.txt for license information
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
-import Dispatch
-import XCTest
 
+import Basics
+import Dispatch
 import PackageGraph
 import PackageModel
 import SourceControl
 import TSCBasic
+import XCTest
 
 import struct TSCUtility.Version
 
@@ -63,7 +64,7 @@ public class MockPackageContainer: PackageContainer {
     public func isToolsVersionCompatible(at version: Version) -> Bool {
         return true
     }
-    
+
     public func toolsVersion(for version: Version) throws -> ToolsVersion {
         return ToolsVersion.currentToolsVersion
     }
@@ -111,6 +112,7 @@ public struct MockPackageContainerProvider: PackageContainerProvider {
     public func getContainer(
         for package: PackageReference,
         skipUpdate: Bool,
+        observabilityScope: ObservabilityScope,
         on queue: DispatchQueue,
         completion: @escaping (Result<PackageContainer, Swift.Error>
         ) -> Void

--- a/Sources/Workspace/ResolverPrecomputationProvider.swift
+++ b/Sources/Workspace/ResolverPrecomputationProvider.swift
@@ -55,6 +55,7 @@ struct ResolverPrecomputationProvider: PackageContainerProvider {
     func getContainer(
         for package: PackageReference,
         skipUpdate: Bool,
+        observabilityScope: ObservabilityScope,
         on queue: DispatchQueue,
         completion: @escaping (Result<PackageContainer, Error>) -> Void
     ) {

--- a/Sources/Workspace/SourceControlPackageContainer.swift
+++ b/Sources/Workspace/SourceControlPackageContainer.swift
@@ -58,6 +58,7 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
     private let manifestLoader: ManifestLoaderProtocol
     private let toolsVersionLoader: ToolsVersionLoaderProtocol
     private let currentToolsVersion: ToolsVersion
+    private let observabilityScope: ObservabilityScope
 
     /// The cached dependency information.
     private var dependenciesCache = [String: [ProductFilter: (Manifest, [Constraint])]] ()
@@ -78,7 +79,8 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
         repository: Repository,
         manifestLoader: ManifestLoaderProtocol,
         toolsVersionLoader: ToolsVersionLoaderProtocol,
-        currentToolsVersion: ToolsVersion
+        currentToolsVersion: ToolsVersion,
+        observabilityScope: ObservabilityScope
     ) throws {
         self.package = package
         self.identityResolver = identityResolver
@@ -87,6 +89,7 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
         self.manifestLoader = manifestLoader
         self.toolsVersionLoader = toolsVersionLoader
         self.currentToolsVersion = currentToolsVersion
+        self.observabilityScope = observabilityScope
     }
 
     // Compute the map of known versions.
@@ -337,7 +340,7 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
                                      toolsVersion: toolsVersion,
                                      identityResolver: self.identityResolver,
                                      fileSystem: fileSystem,
-                                     diagnostics: nil,
+                                     observabilityScope: self.observabilityScope,
                                      on: .sharedConcurrent,
                                      completion: $0)
         }

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -45,12 +45,12 @@ public protocol WorkspaceDelegate: AnyObject {
     /// The workspace is about to load a package manifest (which might be in the cache, or might need to be parsed). Note that this does not include speculative loading of manifests that may occr during dependency resolution; rather, it includes only the final manifest loading that happens after a particular package version has been checked out into a working directory.
     func willLoadManifest(packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind)
     /// The workspace has loaded a package manifest, either successfully or not. The manifest is nil if an error occurs, in which case there will also be at least one error in the list of diagnostics (there may be warnings even if a manifest is loaded successfully).
-    func didLoadManifest(packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind, manifest: Manifest?, diagnostics: [Diagnostic])
+    func didLoadManifest(packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind, manifest: Manifest?, diagnostics: [Basics.Diagnostic])
 
     /// The workspace has started fetching this repository.
     func fetchingWillBegin(repository: String, fetchDetails: RepositoryManager.FetchDetails?)
     /// The workspace has finished fetching this repository.
-    func fetchingDidFinish(repository: String, fetchDetails: RepositoryManager.FetchDetails?, diagnostic: Diagnostic?, duration: DispatchTimeInterval)
+    func fetchingDidFinish(repository: String, fetchDetails: RepositoryManager.FetchDetails?, diagnostic: Basics.Diagnostic?, duration: DispatchTimeInterval)
 
     /// The workspace has started updating this repository.
     func repositoryWillUpdate(_ repository: String)
@@ -64,12 +64,12 @@ public protocol WorkspaceDelegate: AnyObject {
     func willCreateWorkingCopy(repository url: String, at path: AbsolutePath)
     /// The workspace has cloned a repository from the local cache to a working directory. The error indicates whether the operation failed or succeeded.
     // deprecated 04/2021, remove once clients moved over
-    func didCreateWorkingCopy(repository url: String, at path: AbsolutePath, error: Diagnostic?)
+    func didCreateWorkingCopy(repository url: String, at path: AbsolutePath, error: Basics.Diagnostic?)
 
     /// The workspace is about to check out a particular revision of a working directory.
     func willCheckOut(repository url: String, revision: String, at path: AbsolutePath)
     /// The workspace has checked out a particular revision of a working directory. The error indicates whether the operation failed or succeeded.
-    func didCheckOut(repository url: String, revision: String, at path: AbsolutePath, error: Diagnostic?)
+    func didCheckOut(repository url: String, revision: String, at path: AbsolutePath, error: Basics.Diagnostic?)
 
     /// The workspace is removing this repository because it is no longer needed.
     func removing(repository: String)
@@ -109,11 +109,7 @@ private class WorkspaceRepositoryManagerDelegate: RepositoryManagerDelegate {
     }
 
     func fetchingDidFinish(handle: RepositoryManager.RepositoryHandle, fetchDetails details: RepositoryManager.FetchDetails?, error: Swift.Error?, duration: DispatchTimeInterval) {
-        let diagnostic: Diagnostic? = error.flatMap({
-            let engine = DiagnosticsEngine()
-            engine.emit($0)
-            return engine.diagnostics.first
-        })
+        let diagnostic = error.map { Basics.Diagnostic.error($0) }
         workspaceDelegate.fetchingDidFinish(repository: handle.repository.location.description, fetchDetails: details, diagnostic: diagnostic, duration: duration)
     }
 
@@ -507,6 +503,12 @@ public class Workspace {
 
 extension Workspace {
 
+    // deprecated 10/2021
+    @available(*, deprecated, message: "use observability system APIs instead")
+    public func edit(packageName: String, path: AbsolutePath? = nil, revision: Revision? = nil, checkoutBranch: String? = nil, diagnostics: DiagnosticsEngine) {
+        self.edit(packageName: packageName, path: path, revision: revision, checkoutBranch: checkoutBranch, observabilityScope: ObservabilitySystem(diagnosticEngine: diagnostics).topScope)
+    }
+
     /// Puts a dependency in edit mode creating a checkout in editables directory.
     ///
     /// - Parameters:
@@ -516,25 +518,31 @@ extension Workspace {
     ///       should be checked out to otherwise current revision.
     ///     - checkoutBranch: If provided, a new branch with this name will be
     ///       created from the revision provided.
-    ///     - diagnostics: The diagnostics engine that reports errors, warnings
-    ///       and notes.
+    ///     - observabilityScope: The observability scope that reports errors, warnings, etc
     public func edit(
         packageName: String,
         path: AbsolutePath? = nil,
         revision: Revision? = nil,
         checkoutBranch: String? = nil,
-        diagnostics: DiagnosticsEngine
+        observabilityScope: ObservabilityScope
     ) {
         do {
-            try _edit(
+            try self._edit(
                 packageName: packageName,
                 path: path,
                 revision: revision,
                 checkoutBranch: checkoutBranch,
-                diagnostics: diagnostics)
+                observabilityScope: observabilityScope
+            )
         } catch {
-            diagnostics.emit(error)
+            observabilityScope.emit(error)
         }
+    }
+
+    // deprecated 10/2021
+    @available(*, deprecated, message: "use observability system APIs instead")
+    public func unedit(packageName: String, forceRemove: Bool, root: PackageGraphRootInput, diagnostics: DiagnosticsEngine) throws {
+        try self.unedit(packageName: packageName, forceRemove: forceRemove, root: root, observabilityScope: ObservabilitySystem(diagnosticEngine: diagnostics).topScope)
     }
 
     /// Ends the edit mode of an edited dependency.
@@ -547,20 +555,25 @@ extension Workspace {
     ///     - forceRemove: If true, the dependency will be unedited even if has unpushed
     ///           or uncommited changes. Otherwise will throw respective errors.
     ///     - root: The workspace root. This is used to resolve the dependencies post unediting.
-    ///     - diagnostics: The diagnostics engine that reports errors, warnings
-    ///           and notes.
+    ///     - observabilityScope: The observability scope that reports errors, warnings, etc
     public func unedit(
         packageName: String,
         forceRemove: Bool,
         root: PackageGraphRootInput,
-        diagnostics: DiagnosticsEngine
+        observabilityScope: ObservabilityScope
     ) throws {
         guard let dependency = self.state.dependencies[.plain(packageName)] else {
-            diagnostics.emit(.dependencyNotFound(packageName: packageName))
+            observabilityScope.emit(.dependencyNotFound(packageName: packageName))
             return
         }
 
-        try unedit(dependency: dependency, forceRemove: forceRemove, root: root, diagnostics: diagnostics)
+        try self.unedit(dependency: dependency, forceRemove: forceRemove, root: root, observabilityScope: observabilityScope)
+    }
+
+    // deprecated 10/2021
+    @available(*, deprecated, message: "use observability system APIs instead")
+    public func resolve(packageName: String, root: PackageGraphRootInput, version: Version? = nil, branch: String? = nil, revision: String? = nil, diagnostics: DiagnosticsEngine) throws {
+        try self.resolve(packageName: packageName, root: root, version: version, branch: branch, revision: revision, observabilityScope: ObservabilitySystem(diagnosticEngine: diagnostics).topScope)
     }
 
     /// Resolve a package at the given state.
@@ -575,22 +588,21 @@ extension Workspace {
     ///   - version: The version to pin at.
     ///   - branch: The branch to pin at.
     ///   - revision: The revision to pin at.
-    ///   - diagnostics: The diagnostics engine that reports errors, warnings
-    ///     and notes.
+    ///   - observabilityScope: The observability scope that reports errors, warnings, etc
     public func resolve(
         packageName: String,
         root: PackageGraphRootInput,
         version: Version? = nil,
         branch: String? = nil,
         revision: String? = nil,
-        diagnostics: DiagnosticsEngine
+        observabilityScope: ObservabilityScope
     ) throws {
         // Look up the dependency and check if we can pin it.
         guard let dependency = self.state.dependencies[.plain(packageName)] else {
-            diagnostics.emit(.dependencyNotFound(packageName: packageName))
+            observabilityScope.emit(.dependencyNotFound(packageName: packageName))
             return
         }
-        guard let currentState = checkoutState(for: dependency, diagnostics: diagnostics) else {
+        guard let currentState = checkoutState(for: dependency, observabilityScope: observabilityScope) else {
             return
         }
 
@@ -614,17 +626,22 @@ extension Workspace {
             root: root,
             forceResolution: false,
             constraints: [constraint],
-            diagnostics: diagnostics
+            observabilityScope: observabilityScope
         )
+    }
+
+
+    // deprecated 10/2021
+    @available(*, deprecated, message: "use observability system APIs instead")
+    public func clean(with diagnostics: DiagnosticsEngine) {
+        self.clean(observabilityScope: ObservabilitySystem(diagnosticEngine: diagnostics).topScope)
     }
 
     /// Cleans the build artifacts from workspace data.
     ///
     /// - Parameters:
-    ///     - diagnostics: The diagnostics engine that reports errors, warnings
-    ///       and notes.
-    public func clean(with diagnostics: DiagnosticsEngine) {
-
+    ///     - observabilityScope: The observability scope that reports errors, warnings, etc
+    public func clean(observabilityScope: ObservabilityScope) {
         // These are the things we don't want to remove while cleaning.
         let protectedAssets = [
             self.repositoryManager.path,
@@ -642,7 +659,7 @@ extension Workspace {
             return
         }
 
-        guard let contents = diagnostics.wrap({ try fileSystem.getDirectoryContents(self.location.workingDirectory) }) else {
+        guard let contents = observabilityScope.trap({ try fileSystem.getDirectoryContents(self.location.workingDirectory) }) else {
             return
         }
 
@@ -653,31 +670,44 @@ extension Workspace {
         }
     }
 
+
+    // deprecated 10/2021
+    @available(*, deprecated, message: "use observability system APIs instead")
+    public func purgeCache(with diagnostics: DiagnosticsEngine) {
+        self.purgeCache(observabilityScope: ObservabilitySystem(diagnosticEngine: diagnostics).topScope)
+    }
+
     /// Cleans the build artifacts from workspace data.
     ///
     /// - Parameters:
-    ///     - diagnostics: The diagnostics engine that reports errors, warnings
-    ///       and notes.
-    public func purgeCache(with diagnostics: DiagnosticsEngine) {
-        diagnostics.wrap {
+    ///     - observabilityScope: The observability scope that reports errors, warnings, etc
+    public func purgeCache(observabilityScope: ObservabilityScope) {
+        observabilityScope.trap {
             try repositoryManager.purgeCache()
             try manifestLoader.purgeCache()
         }
     }
 
+
+    // deprecated 10/2021
+    @available(*, deprecated, message: "use observability system APIs instead")
+    public func reset(with diagnostics: DiagnosticsEngine) {
+        self.reset(observabilityScope: ObservabilitySystem(diagnosticEngine: diagnostics).topScope)
+    }
+
     /// Resets the entire workspace by removing the data directory.
     ///
     /// - Parameters:
-    ///     - diagnostics: The diagnostics engine that reports errors, warnings
-    ///       and notes.
-    public func reset(with diagnostics: DiagnosticsEngine) {
-        let removed = diagnostics.wrap {
+    ///     - observabilityScope: The observability scope that reports errors, warnings, etc
+    public func reset(observabilityScope: ObservabilityScope) {
+        let removed = observabilityScope.trap { () -> Bool in
             try fileSystem.chmod(.userWritable, path: self.location.repositoriesCheckoutsDirectory, options: [.recursive, .onlyFiles])
             // Reset state.
             try self.resetState()
+            return true
         }
 
-        guard removed else { return }
+        guard (removed ?? false) else { return }
         try? repositoryManager.reset()
         try? manifestLoader.resetCache()
         try? fileSystem.removeFileTree(self.location.workingDirectory)
@@ -693,35 +723,41 @@ extension Workspace {
         // FIXME: Need to add cancel support.
     }
 
+    // deprecated 10/2021
+    @available(*, deprecated, message: "use observability system APIs instead")
+    @discardableResult
+    public func updateDependencies(root: PackageGraphRootInput, packages: [String] = [], diagnostics: DiagnosticsEngine, dryRun: Bool = false) throws -> [(PackageReference, Workspace.PackageStateChange)]? {
+        try self.updateDependencies(root: root, packages: packages, dryRun: dryRun, observabilityScope: ObservabilitySystem(diagnosticEngine: diagnostics).topScope)
+    }
+
     /// Updates the current dependencies.
     ///
     /// - Parameters:
-    ///     - diagnostics: The diagnostics engine that reports errors, warnings
-    ///       and notes.
+    ///     - observabilityScope: The observability scope that reports errors, warnings, etc
     @discardableResult
     public func updateDependencies(
         root: PackageGraphRootInput,
         packages: [String] = [],
-        diagnostics: DiagnosticsEngine,
-        dryRun: Bool = false
+        dryRun: Bool = false,
+        observabilityScope: ObservabilityScope
     ) throws -> [(PackageReference, Workspace.PackageStateChange)]? {
         // Create cache directories.
-        createCacheDirectories(with: diagnostics)
+        createCacheDirectories(observabilityScope: observabilityScope)
 
         // FIXME: this should not block
         // Load the root manifests and currently checked out manifests.
-        let rootManifests = try temp_await { self.loadRootManifests(packages: root.packages, diagnostics: diagnostics, completion: $0) }
+        let rootManifests = try temp_await { self.loadRootManifests(packages: root.packages, observabilityScope: observabilityScope, completion: $0) }
         let rootManifestsMinimumToolsVersion = rootManifests.values.map{ $0.toolsVersion }.min() ?? ToolsVersion.currentToolsVersion
 
         // Load the current manifests.
         let graphRoot = PackageGraphRoot(input: root, manifests: rootManifests)
-        let currentManifests = try self.loadDependencyManifests(root: graphRoot, diagnostics: diagnostics)
+        let currentManifests = try self.loadDependencyManifests(root: graphRoot, observabilityScope: observabilityScope)
 
         // Abort if we're unable to load the pinsStore or have any diagnostics.
-        guard let pinsStore = diagnostics.wrap({ try self.pinsStore.load() }) else { return nil }
+        guard let pinsStore = observabilityScope.trap({ try self.pinsStore.load() }) else { return nil }
 
         // Ensure we don't have any error at this point.
-        guard !diagnostics.hasErrors else { return nil }
+        guard !observabilityScope.errorsReported else { return nil }
 
         // Add unversioned constraints for edited packages.
         var updateConstraints = currentManifests.editedPackagesConstraints()
@@ -740,36 +776,36 @@ extension Workspace {
         }
 
         // Resolve the dependencies.
-        let resolver = self.createResolver(pinsMap: pinsMap, observabilityScope: ObservabilitySystem(diagnosticEngine: diagnostics).topScope)
+        let resolver = try self.createResolver(pinsMap: pinsMap, observabilityScope: observabilityScope)
         self.activeResolver = resolver
 
         let updateResults = resolveDependencies(
             resolver: resolver,
             constraints: updateConstraints,
-            diagnostics: diagnostics
+            observabilityScope: observabilityScope
         )
 
         // Reset the active resolver.
         self.activeResolver = nil
 
-        guard !diagnostics.hasErrors else { return nil }
+        guard !observabilityScope.errorsReported else { return nil }
 
         if dryRun {
-            return diagnostics.wrap { return try computePackageStateChanges(root: graphRoot, resolvedDependencies: updateResults, updateBranches: true) }
+            return observabilityScope.trap { return try computePackageStateChanges(root: graphRoot, resolvedDependencies: updateResults, updateBranches: true, observabilityScope: observabilityScope) }
         }
 
         // Update the checkouts based on new dependency resolution.
-        let packageStateChanges = self.updateDependenciesCheckouts(root: graphRoot, updateResults: updateResults, updateBranches: true, diagnostics: diagnostics)
+        let packageStateChanges = self.updateDependenciesCheckouts(root: graphRoot, updateResults: updateResults, updateBranches: true, observabilityScope: observabilityScope)
 
         // Load the updated manifests.
-        let updatedDependencyManifests = try self.loadDependencyManifests(root: graphRoot, diagnostics: diagnostics)
+        let updatedDependencyManifests = try self.loadDependencyManifests(root: graphRoot, observabilityScope: observabilityScope)
 
         // Update the pins store.
         self.pinAll(
             pinsStore: pinsStore,
             dependencyManifests: updatedDependencyManifests,
             rootManifestsMinimumToolsVersion: rootManifestsMinimumToolsVersion,
-            diagnostics: diagnostics
+            observabilityScope: observabilityScope
         )
 
         // Update the binary target artifacts.
@@ -777,20 +813,12 @@ extension Workspace {
         try self.updateBinaryArtifacts(
             manifests: updatedDependencyManifests,
             addedOrUpdatedPackages: addedOrUpdatedPackages,
-            diagnostics: diagnostics)
+            observabilityScope: observabilityScope
+        )
 
         return nil
     }
 
-    /// Loads a package graph from a root package using the resources associated with a particular `swiftc` executable.
-    ///
-    /// - Parameters:
-    ///   - at: The absolute path of the root package.
-    ///   - swiftCompiler: The absolute path of a `swiftc` executable. Its associated resources will be used by the loader.
-    ///   - identityResolver: A helper to resolve identities based on configuration
-    ///   - diagnostics: Optional.  The diagnostics engine.
-    ///   - on: The dispatch queue to perform asynchronous operations on.
-    ///   - completion: The completion handler .
     // deprecated 8/2021
     @available(*, deprecated, message: "use workspace instance API instead")
     public static func loadRootGraph(
@@ -806,7 +834,8 @@ extension Workspace {
         return try workspace.loadPackageGraph(rootPath: packagePath, diagnostics: diagnostics)
     }
 
-    @available(*, deprecated, message: "use observabilityScope variant instead")
+    // deprecated 8/2021
+    @available(*, deprecated, message: "use observability system APIs instead")
     @discardableResult
     public func loadPackageGraph(
         rootInput root: PackageGraphRootInput,
@@ -845,7 +874,7 @@ extension Workspace {
             manifests = try self.resolveBasedOnResolvedVersionsFile(
                 root: root,
                 explicitProduct: explicitProduct,
-                diagnostics: observabilityScope.makeDiagnosticsEngine()
+                observabilityScope: observabilityScope
             )
         } else {
             manifests = try self.resolve(
@@ -853,7 +882,7 @@ extension Workspace {
                 explicitProduct: explicitProduct,
                 forceResolution: false,
                 constraints: [],
-                diagnostics: observabilityScope.makeDiagnosticsEngine()
+                observabilityScope: observabilityScope
             )
         }
 
@@ -914,20 +943,20 @@ extension Workspace {
     public func resolve(
         root: PackageGraphRootInput,
         forceResolution: Bool = false,
-        diagnostics: DiagnosticsEngine
+        observabilityScope: ObservabilityScope
     ) throws {
         try self.resolve(
             root: root,
             forceResolution: forceResolution,
             constraints: [],
-            diagnostics: diagnostics
+            observabilityScope: observabilityScope
         )
     }
 
     /// Loads and returns manifests at the given paths.
     public func loadRootManifests(
         packages: [AbsolutePath],
-        diagnostics: DiagnosticsEngine,
+        observabilityScope: ObservabilityScope,
         completion: @escaping(Result<[AbsolutePath: Manifest], Error>) -> Void
     ) {
         let lock = Lock()
@@ -936,7 +965,13 @@ extension Workspace {
         Set(packages).forEach { package in
             sync.enter()
             // TODO: this does not use the identity resolver which is probably fine since its the root packages
-            self.loadManifest(packageIdentity: PackageIdentity(path: package), packageKind: .root(package), packagePath: package, packageLocation: package.pathString, diagnostics: diagnostics) { result in
+            self.loadManifest(
+                packageIdentity: PackageIdentity(path: package),
+                packageKind: .root(package),
+                packagePath: package,
+                packageLocation: package.pathString,
+                observabilityScope: observabilityScope
+            ) { result in
                 defer { sync.leave() }
                 if case .success(let manifest) = result {
                     lock.withLock {
@@ -951,7 +986,7 @@ extension Workspace {
             let duplicateRoots = rootManifests.values.spm_findDuplicateElements(by: \.name)
             if !duplicateRoots.isEmpty {
                 let name = duplicateRoots[0][0].name
-                diagnostics.emit(error: "found multiple top-level packages named '\(name)'")
+                observabilityScope.emit(error: "found multiple top-level packages named '\(name)'")
                 return completion(.success([:]))
             }
 
@@ -959,26 +994,17 @@ extension Workspace {
         }
     }
 
+    /// Loads and returns manifest at the given path.
     public func loadRootManifest(
         at path: AbsolutePath,
         observabilityScope: ObservabilityScope,
         completion: @escaping(Result<Manifest, Error>) -> Void
     ) {
-        self.loadRootManifest(at: path, diagnostics: observabilityScope.makeDiagnosticsEngine(), completion: completion)
-    }
-
-    // FIXME: (diagnostics) make the observabilityScope variant the main one
-    /// Loads and returns manifest at the given path.
-    public func loadRootManifest(
-        at path: AbsolutePath,
-        diagnostics: DiagnosticsEngine,
-        completion: @escaping(Result<Manifest, Error>) -> Void
-    ) {
-        self.loadRootManifests(packages: [path], diagnostics: diagnostics) { result in
+        self.loadRootManifests(packages: [path], observabilityScope: observabilityScope) { result in
             completion(result.tryMap{
                 // normally, we call loadRootManifests which attempts to load any manifest it can and report errors via diagnostics
                 // in this case, we want to load a specific manifest, so if the diagnostics contains an error we want to throw
-                guard !diagnostics.hasErrors else {
+                guard !observabilityScope.errorsReported else {
                     throw Diagnostics.fatalError
                 }
                 guard let manifest = $0[path] else {
@@ -987,6 +1013,12 @@ extension Workspace {
                 return manifest
             })
         }
+    }
+
+
+    @available(*, deprecated, message: "use observability system APIs instead")
+    public func loadRootManifest(at path: AbsolutePath, diagnostics: DiagnosticsEngine, completion: @escaping(Result<Manifest, Error>) -> Void) {
+        self.loadRootManifest(at: path, observabilityScope: ObservabilitySystem(diagnosticEngine: diagnostics).topScope, completion: completion)
     }
 
     @available(*, deprecated, message: "use observabilityScope variant instead")
@@ -1043,27 +1075,20 @@ extension Workspace {
     }
 
     /// Generates the checksum
-    public func checksum(
-        forBinaryArtifactAt path: AbsolutePath,
-        diagnostics: DiagnosticsEngine
-    ) -> String {
+    public func checksum(forBinaryArtifactAt path: AbsolutePath) throws -> String {
         // Validate the path has a supported extension.
         guard let pathExtension = path.extension, archiver.supportedExtensions.contains(pathExtension) else {
             let supportedExtensionList = archiver.supportedExtensions.joined(separator: ", ")
-            diagnostics.emit(error: "unexpected file type; supported extensions are: \(supportedExtensionList)")
-            return ""
+            throw StringError("unexpected file type; supported extensions are: \(supportedExtensionList)")
         }
 
         // Ensure that the path with the accepted extension is a file.
         guard fileSystem.isFile(path) else {
-            diagnostics.emit(error: "file not found at path: \(path.pathString)")
-            return ""
+            throw StringError("file not found at path: \(path.pathString)")
         }
 
-        return diagnostics.wrap {
-            let contents = try fileSystem.readFileContents(path)
-            return self.checksumAlgorithm.hash(contents).hexadecimalRepresentation
-        } ?? ""
+        let contents = try fileSystem.readFileContents(path)
+        return self.checksumAlgorithm.hash(contents).hexadecimalRepresentation
     }
 }
 
@@ -1073,15 +1098,15 @@ extension Workspace {
 
     func checkoutState(
         for dependency: ManagedDependency,
-        diagnostics: DiagnosticsEngine
+        observabilityScope: ObservabilityScope
     ) -> CheckoutState? {
         switch dependency.state {
         case .checkout(let checkoutState):
             return checkoutState
         case .edited:
-            diagnostics.emit(error: "dependency '\(dependency.packageRef.name)' already in edit mode")
+            observabilityScope.emit(error: "dependency '\(dependency.packageRef.name)' already in edit mode")
         case .local:
-            diagnostics.emit(error: "local dependency '\(dependency.packageRef.name)' can't be edited")
+            observabilityScope.emit(error: "local dependency '\(dependency.packageRef.name)' can't be edited")
         }
         return nil
     }
@@ -1092,15 +1117,15 @@ extension Workspace {
         path: AbsolutePath? = nil,
         revision: Revision? = nil,
         checkoutBranch: String? = nil,
-        diagnostics: DiagnosticsEngine
+        observabilityScope: ObservabilityScope
     ) throws {
         // Look up the dependency and check if we can edit it.
         guard let dependency = self.state.dependencies[.plain(packageName)] else {
-            diagnostics.emit(.dependencyNotFound(packageName: packageName))
+            observabilityScope.emit(.dependencyNotFound(packageName: packageName))
             return
         }
 
-        guard let checkoutState = checkoutState(for: dependency, diagnostics: diagnostics) else {
+        guard let checkoutState = self.checkoutState(for: dependency, observabilityScope: observabilityScope) else {
             return
         }
 
@@ -1117,22 +1142,22 @@ extension Workspace {
                                   packageKind: .fileSystem(destination),
                                   packagePath: destination,
                                   packageLocation: dependency.packageRef.locationString,
-                                  diagnostics: diagnostics,
+                                  observabilityScope: observabilityScope,
                                   completion: $0)
             }
 
             guard manifest.name == packageName else {
-                return diagnostics.emit(error: "package at '\(destination)' is \(manifest.name) but was expecting \(packageName)")
+                return observabilityScope.emit(error: "package at '\(destination)' is \(manifest.name) but was expecting \(packageName)")
             }
 
             // Emit warnings for branch and revision, if they're present.
             if let checkoutBranch = checkoutBranch {
-                diagnostics.emit(.editBranchNotCheckedOut(
+                observabilityScope.emit(.editBranchNotCheckedOut(
                     packageName: packageName,
                     branchName: checkoutBranch))
             }
             if let revision = revision {
-                diagnostics.emit(.editRevisionNotUsed(
+                observabilityScope.emit(.editRevisionNotUsed(
                     packageName: packageName,
                     revisionIdentifier: revision.identifier))
             }
@@ -1202,7 +1227,7 @@ extension Workspace {
         dependency: ManagedDependency,
         forceRemove: Bool,
         root: PackageGraphRootInput? = nil,
-        diagnostics: DiagnosticsEngine
+        observabilityScope: ObservabilityScope
     ) throws {
 
         // Compute if we need to force remove.
@@ -1257,7 +1282,7 @@ extension Workspace {
         // Resolve the dependencies if workspace root is provided. We do this to
         // ensure the unedited version of this dependency is resolved properly.
         if let root = root {
-            try self.resolve(root: root, diagnostics: diagnostics)
+            try self.resolve(root: root, observabilityScope: observabilityScope)
         }
     }
 
@@ -1272,7 +1297,7 @@ extension Workspace {
         pinsStore: PinsStore,
         dependencyManifests: DependencyManifests,
         rootManifestsMinimumToolsVersion: ToolsVersion,
-        diagnostics: DiagnosticsEngine
+        observabilityScope: ObservabilityScope
     ) {
         // Reset the pinsStore and start pinning the required dependencies.
         pinsStore.unpinAll()
@@ -1284,7 +1309,7 @@ extension Workspace {
             }
         }
 
-        diagnostics.wrap{
+        observabilityScope.trap{
             try pinsStore.saveState(toolsVersion: rootManifestsMinimumToolsVersion)
         }
 
@@ -1496,13 +1521,11 @@ extension Workspace {
     }
 
     /// Create the cache directories.
-    fileprivate func createCacheDirectories(with diagnostics: DiagnosticsEngine) {
-        do {
+    fileprivate func createCacheDirectories(observabilityScope: ObservabilityScope) {
+        observabilityScope.trap {
             try fileSystem.createDirectory(self.repositoryManager.path, recursive: true)
             try fileSystem.createDirectory(self.location.repositoriesCheckoutsDirectory, recursive: true)
             try fileSystem.createDirectory(self.location.artifactsDirectory, recursive: true)
-        } catch {
-            diagnostics.emit(error)
         }
     }
 
@@ -1540,8 +1563,8 @@ extension Workspace {
     /// current dependencies from the working checkouts.l
     public func loadDependencyManifests(
         root: PackageGraphRoot,
-        diagnostics: DiagnosticsEngine,
-        automaticallyAddManagedDependencies: Bool = false
+        automaticallyAddManagedDependencies: Bool = false,
+        observabilityScope: ObservabilityScope
     ) throws -> DependencyManifests {
         // Utility Just because a raw tuple cannot be hashable.
         struct Key: Hashable {
@@ -1554,21 +1577,21 @@ extension Workspace {
         // Remove any managed dependency which has become a root.
         for dependency in dependenciesToCheck {
             if root.packages.keys.contains(dependency.packageRef.identity) {
-                diagnostics.wrap {
+                observabilityScope.trap {
                     try self.remove(package: dependency.packageRef)
                 }
             }
         }
 
         // Validates that all the managed dependencies are still present in the file system.
-        self.fixManagedDependencies(with: diagnostics)
-        guard !diagnostics.hasErrors else {
+        self.fixManagedDependencies(observabilityScope: observabilityScope)
+        guard !observabilityScope.errorsReported else {
             return DependencyManifests(root: root, dependencies: [], workspace: self)
         }
 
         // Load root dependencies manifests (in parallel)
         let rootDependencies = root.dependencies.map{ $0.createPackageRef() }
-        let rootDependenciesManifests = try temp_await { self.loadManagedManifests(for: rootDependencies, diagnostics: diagnostics, completion: $0) }
+        let rootDependenciesManifests = try temp_await { self.loadManagedManifests(for: rootDependencies, observabilityScope: observabilityScope, completion: $0) }
 
         let topLevelManifests = root.manifests.merging(rootDependenciesManifests, uniquingKeysWith: { lhs, rhs in
             return lhs // prefer roots!
@@ -1576,7 +1599,7 @@ extension Workspace {
 
         // optimization: preload first level dependencies manifest (in parallel)
         let firstLevelDependencies = topLevelManifests.values.map { $0.dependencies.map{ $0.createPackageRef() } }.flatMap { $0 }
-        let firstLevelManifests = try temp_await { self.loadManagedManifests(for: firstLevelDependencies, diagnostics: diagnostics, completion: $0) } // FIXME: this should not block
+        let firstLevelManifests = try temp_await { self.loadManagedManifests(for: firstLevelDependencies, observabilityScope: observabilityScope, completion: $0) } // FIXME: this should not block
 
         // Continue to load the rest of the manifest for this graph
         // Creates a map of loaded manifests. We do this to avoid reloading the shared nodes.
@@ -1592,10 +1615,10 @@ extension Workspace {
                 try dependenciesRequired.filter { $0.isLocal }.forEach { dependency in
                     try self.state.dependencies.add(.local(packageRef: dependency.createPackageRef()))
                 }
-                diagnostics.wrap { try self.state.save() }
+                observabilityScope.trap { try self.state.save() }
             }
             let dependenciesToLoad = dependenciesRequired.map{ $0.createPackageRef() }.filter { !loadedManifests.keys.contains($0.identity) }
-            let dependenciesManifests = try temp_await { self.loadManagedManifests(for: dependenciesToLoad, diagnostics: diagnostics, completion: $0) }
+            let dependenciesManifests = try temp_await { self.loadManagedManifests(for: dependenciesToLoad, observabilityScope: observabilityScope, completion: $0) }
             dependenciesManifests.forEach { loadedManifests[$0.key] = $0.value }
             return pair.item.dependenciesRequired(for: pair.key.productFilter).compactMap{ dependency in
                 loadedManifests[dependency.identity].flatMap {
@@ -1629,7 +1652,7 @@ extension Workspace {
         let rootManifestsByName = Array(root.manifests.values).spm_createDictionary{ ($0.name, $0) }
         dependencyManifests.forEach { identity, manifest, _ in
             if let override = rootManifestsByName[manifest.name], override.packageLocation != manifest.packageLocation  {
-                diagnostics.emit(error: "unable to override package '\(manifest.name)' because its identity '\(PackageIdentity(urlString: manifest.packageLocation))' doesn't match override's identity (directory name) '\(PackageIdentity(urlString: override.packageLocation))'")
+                observabilityScope.emit(error: "unable to override package '\(manifest.name)' because its identity '\(PackageIdentity(urlString: manifest.packageLocation))' doesn't match override's identity (directory name) '\(PackageIdentity(urlString: override.packageLocation))'")
             }
         }
 
@@ -1644,12 +1667,12 @@ extension Workspace {
     }
 
     /// Loads the given manifests, if it is present in the managed dependencies.
-    private func loadManagedManifests(for packages: [PackageReference], diagnostics: DiagnosticsEngine, completion: @escaping (Result<[PackageIdentity: Manifest], Error>) -> Void) {
+    private func loadManagedManifests(for packages: [PackageReference], observabilityScope: ObservabilityScope, completion: @escaping (Result<[PackageIdentity: Manifest], Error>) -> Void) {
         let sync = DispatchGroup()
         let manifests = ThreadSafeKeyValueStore<PackageIdentity, Manifest>()
         Set(packages).forEach { package in
             sync.enter()
-            self.loadManagedManifest(for: package, diagnostics: diagnostics) { manifest in
+            self.loadManagedManifest(for: package, observabilityScope: observabilityScope) { manifest in
                 defer { sync.leave() }
                 if let manifest = manifest {
                     manifests[package.identity] = manifest
@@ -1663,7 +1686,11 @@ extension Workspace {
     }
 
     /// Loads the given manifest, if it is present in the managed dependencies.
-    fileprivate func loadManagedManifest(for package: PackageReference, diagnostics: DiagnosticsEngine, completion: @escaping (Manifest?) -> Void) {
+    fileprivate func loadManagedManifest(
+        for package: PackageReference,
+        observabilityScope: ObservabilityScope,
+        completion: @escaping (Manifest?) -> Void
+    ) {
         // Check if this dependency is available.
         // we also compare the location as this function may attempt to load
         // dependencies that have the same identity but from a different location
@@ -1695,12 +1722,14 @@ extension Workspace {
 
 
         // Load and return the manifest.
-        self.loadManifest(packageIdentity: managedDependency.packageRef.identity,
-                          packageKind: packageKind,
-                          packagePath: packagePath,
-                          packageLocation: managedDependency.packageRef.locationString,
-                          version: version,
-                          diagnostics: diagnostics) { result in
+        self.loadManifest(
+            packageIdentity: managedDependency.packageRef.identity,
+            packageKind: packageKind,
+            packagePath: packagePath,
+            packageLocation: managedDependency.packageRef.locationString,
+            version: version,
+            observabilityScope: observabilityScope
+        ) { result in
             // error is added to diagnostics in the function above
             completion(try? result.get())
         }
@@ -1715,12 +1744,17 @@ extension Workspace {
         packagePath: AbsolutePath,
         packageLocation: String,
         version: Version? = nil,
-        diagnostics: DiagnosticsEngine,
+        observabilityScope: ObservabilityScope,
         completion: @escaping (Result<Manifest, Error>) -> Void
     ) {
         // Load the manifest, bracketed by the calls to the delegate callbacks.
         delegate?.willLoadManifest(packagePath: packagePath, url: packageLocation, version: version, packageKind: packageKind)
-        diagnostics.with(location: PackageLocation.Local(packagePath: packagePath)) { diagnostics in
+
+        let observabilityScope = observabilityScope.makeChildScope(description: "Loading manifest") {
+            .packageMetadata(identity: packageIdentity, kind: packageKind)
+        }
+
+        //diagnostics.with(location: PackageLocation.Local(packagePath: packagePath)) { diagnostics in
             do {
                 // Load the tools version for the package.
                 let toolsVersion = try toolsVersionLoader.load(at: packagePath, fileSystem: fileSystem)
@@ -1730,43 +1764,54 @@ extension Workspace {
 
                 // Load the manifest.
                 // The delegate callback is only passed any diagnostics emitted during the parsing of the manifest, but they are also forwarded up to the caller.
-                let manifestLoadingDiagnostics = DiagnosticsEngine(handlers: [{ diagnostics.emit($0) }], defaultLocation: diagnostics.defaultLocation)
-                manifestLoader.load(at: packagePath,
-                                    packageIdentity: packageIdentity,
-                                    packageKind: packageKind,
-                                    packageLocation: packageLocation,
-                                    version: version,
-                                    revision: nil,
-                                    toolsVersion: toolsVersion,
-                                    identityResolver: self.identityResolver,
-                                    fileSystem: localFileSystem,
-                                    diagnostics: manifestLoadingDiagnostics,
-                                    on: .sharedConcurrent) { result in
+                //let manifestLoadingDiagnostics = DiagnosticsEngine(handlers: [{ diagnostics.emit($0) }], defaultLocation: diagnostics.defaultLocation)
+                //let manifestLoadingObservabilityScope = observabilityScope.makeChildScope(description: "Loading manifest")
 
+                let manifestLoadingDiagnostics = ThreadSafeArrayStore<Basics.Diagnostic>()
+                let manifestLoadingScope = ObservabilitySystem( { _, diagnostic in
+                    observabilityScope.emit(diagnostic)
+                    manifestLoadingDiagnostics.append(diagnostic)
+                }).topScope.makeChildScope(description: "Loading manifest") {
+                    .packageMetadata(identity: packageIdentity, kind: packageKind)
+                }
+
+                manifestLoader.load(
+                    at: packagePath,
+                    packageIdentity: packageIdentity,
+                    packageKind: packageKind,
+                    packageLocation: packageLocation,
+                    version: version,
+                    revision: nil,
+                    toolsVersion: toolsVersion,
+                    identityResolver: self.identityResolver,
+                    fileSystem: localFileSystem,
+                    observabilityScope: manifestLoadingScope,
+                    on: .sharedConcurrent
+                ) { result in
                     switch result {
                     // Diagnostics.fatalError indicates that a more specific diagnostic has already been added.
                     case .failure(Diagnostics.fatalError):
-                        self.delegate?.didLoadManifest(packagePath: packagePath, url: packageLocation, version: version, packageKind: packageKind, manifest: nil, diagnostics: manifestLoadingDiagnostics.diagnostics)
+                        self.delegate?.didLoadManifest(packagePath: packagePath, url: packageLocation, version: version, packageKind: packageKind, manifest: nil, diagnostics: manifestLoadingDiagnostics.get())
                     case .failure(let error):
-                        manifestLoadingDiagnostics.emit(error)
-                        self.delegate?.didLoadManifest(packagePath: packagePath, url: packageLocation, version: version, packageKind: packageKind, manifest: nil, diagnostics: manifestLoadingDiagnostics.diagnostics)
+                        manifestLoadingScope.emit(error)
+                        self.delegate?.didLoadManifest(packagePath: packagePath, url: packageLocation, version: version, packageKind: packageKind, manifest: nil, diagnostics: manifestLoadingDiagnostics.get())
                     case .success(let manifest):
-                        self.delegate?.didLoadManifest(packagePath: packagePath, url: packageLocation, version: version, packageKind: packageKind, manifest: manifest, diagnostics: manifestLoadingDiagnostics.diagnostics)
+                        self.delegate?.didLoadManifest(packagePath: packagePath, url: packageLocation, version: version, packageKind: packageKind, manifest: manifest, diagnostics: manifestLoadingDiagnostics.get())
                     }
                     completion(result)
                 }
             } catch {
-                diagnostics.emit(error)
+                observabilityScope.emit(error)
                 completion(.failure(error))
             }
-        }
+        //}
     }
 
     /// Validates that all the edited dependencies are still present in the file system.
     /// If some checkout dependency is removed form the file system, clone it again.
     /// If some edited dependency is removed from the file system, mark it as unedited and
     /// fallback on the original checkout.
-    fileprivate func fixManagedDependencies(with diagnostics: DiagnosticsEngine) {
+    fileprivate func fixManagedDependencies(observabilityScope: ObservabilityScope) {
 
         // Reset managed dependencies if the state file was removed during the lifetime of the Workspace object.
         if !self.state.dependencies.isEmpty && !self.state.stateFileExists() {
@@ -1776,7 +1821,7 @@ extension Workspace {
         // Make a copy of dependencies as we might mutate them in the for loop.
         let allDependencies = Array(self.state.dependencies)
         for dependency in allDependencies {
-            diagnostics.wrap {
+            observabilityScope.trap {
 
                 // If the dependency is present, we're done.
                 let dependencyPath = self.path(to: dependency)
@@ -1786,7 +1831,7 @@ extension Workspace {
                 case .checkout(let checkoutState):
                     // If some checkout dependency has been removed, retrieve it again.
                     _ = try self.retrieve(package: dependency.packageRef, at: checkoutState)
-                    diagnostics.emit(.checkedOutDependencyMissing(packageName: dependency.packageRef.name))
+                    observabilityScope.emit(.checkedOutDependencyMissing(packageName: dependency.packageRef.name))
 
                 case .edited:
                     // If some edited dependency has been removed, mark it as unedited.
@@ -1794,9 +1839,9 @@ extension Workspace {
                     // Note: We don't resolve the dependencies when unediting
                     // here because we expect this method to be called as part
                     // of some other resolve operation (i.e. resolve, update, etc).
-                    try unedit(dependency: dependency, forceRemove: true, diagnostics: diagnostics)
+                    try self.unedit(dependency: dependency, forceRemove: true, observabilityScope: observabilityScope)
 
-                    diagnostics.emit(.editedDependencyMissing(packageName: dependency.packageRef.name))
+                    observabilityScope.emit(.editedDependencyMissing(packageName: dependency.packageRef.name))
 
                 case .local:
                     self.state.dependencies.remove(dependency.packageRef.identity)
@@ -1813,7 +1858,7 @@ extension Workspace {
     fileprivate func updateBinaryArtifacts(
         manifests: DependencyManifests,
         addedOrUpdatedPackages: [PackageReference],
-        diagnostics: DiagnosticsEngine
+        observabilityScope: ObservabilityScope
     ) throws {
         let manifestArtifacts = try self.parseArtifacts(from: manifests)
 
@@ -1838,8 +1883,7 @@ extension Workspace {
             if artifact.path.extension == self.manifestLoader.supportedArchiveExtension {
                 // If we already have an artifact that was extracted from an archive with the same checksum,
                 // we don't need to extract the artifact again.
-                if case .local(let existingChecksum) = existingArtifact?.source,
-                   existingChecksum == self.checksum(forBinaryArtifactAt: artifact.path, diagnostics: diagnostics) {
+                if case .local(let existingChecksum) = existingArtifact?.source, existingChecksum == (try self.checksum(forBinaryArtifactAt: artifact.path)) {
                     continue
                 }
 
@@ -1869,7 +1913,7 @@ extension Workspace {
 
                     // If the checksum is different but the package wasn't updated, this is a security risk.
                     if !addedOrUpdatedPackages.contains(artifact.packageRef) {
-                        diagnostics.emit(.artifactChecksumChanged(targetName: artifact.targetName))
+                        observabilityScope.emit(.artifactChecksumChanged(targetName: artifact.targetName))
                         continue
                     }
                 }
@@ -1884,7 +1928,7 @@ extension Workspace {
         }
 
         // Remove the artifacts and directories which are not needed anymore.
-        diagnostics.wrap {
+        observabilityScope.trap {
             for artifact in artifactsToRemove {
                 state.artifacts.remove(packageIdentity: artifact.packageRef.identity, targetName: artifact.targetName)
 
@@ -1901,16 +1945,16 @@ extension Workspace {
             }
         }
 
-        guard !diagnostics.hasErrors else {
+        guard !observabilityScope.errorsReported else {
             throw Diagnostics.fatalError
         }
 
         // Download the artifacts
-        let downloadedArtifacts = try self.download(artifactsToDownload, diagnostics: diagnostics)
+        let downloadedArtifacts = try self.download(artifactsToDownload, observabilityScope: observabilityScope)
         artifactsToAdd.append(contentsOf: downloadedArtifacts)
 
         // Extract the local archived artifacts
-        let extractedLocalArtifacts = try self.extract(artifactsToExtract, diagnostics: diagnostics)
+        let extractedLocalArtifacts = try self.extract(artifactsToExtract, observabilityScope: observabilityScope)
         artifactsToAdd.append(contentsOf: extractedLocalArtifacts)
 
         // Add the new artifacts
@@ -1918,11 +1962,11 @@ extension Workspace {
             self.state.artifacts.add(artifact)
         }
 
-        guard !diagnostics.hasErrors else {
+        guard !observabilityScope.errorsReported else {
             throw Diagnostics.fatalError
         }
 
-        diagnostics.wrap {
+        observabilityScope.trap {
             try self.state.save()
         }
     }
@@ -1963,9 +2007,8 @@ extension Workspace {
         return (local: localArtifacts, remote: remoteArtifacts)
     }
 
-    private func download(_ artifacts: [RemoteArtifact], diagnostics: DiagnosticsEngine) throws -> [ManagedArtifact] {
+    private func download(_ artifacts: [RemoteArtifact], observabilityScope: ObservabilityScope) throws -> [ManagedArtifact] {
         let group = DispatchGroup()
-        let tempDiagnostics = DiagnosticsEngine() // FIXME: transition to DiagnosticsEmmiter
         let result = ThreadSafeArrayStore<ManagedArtifact>()
 
         // zip files to download
@@ -1977,6 +2020,7 @@ extension Workspace {
         // fetch and parse "artifactbundleindex" files, if any
         let indexFiles = artifacts.filter { $0.url.pathExtension.lowercased() == "artifactbundleindex" }
         if !indexFiles.isEmpty {
+            let errors = ThreadSafeArrayStore<Error>()
             let hostToolchain = try UserToolchain(destination: .hostDestination())
             let jsonDecoder = JSONDecoder.makeWithDefaults()
             for indexFile in indexFiles {
@@ -2015,7 +2059,8 @@ extension Workspace {
                             )
                         }
                     } catch {
-                        tempDiagnostics.emit(error: "failed retrieving '\(indexFile.url)': \(error)")
+                        errors.append(error)
+                        observabilityScope.emit(error: "failed retrieving '\(indexFile.url)': \(error)")
                     }
                 }
             }
@@ -2024,9 +2069,7 @@ extension Workspace {
             group.wait()
 
             // no reason to continue if we already ran into issues
-            if tempDiagnostics.hasErrors {
-                // collect all diagnostics
-                diagnostics.append(contentsOf: tempDiagnostics)
+            if !errors.isEmpty {
                 throw Diagnostics.fatalError
             }
         }
@@ -2037,7 +2080,7 @@ extension Workspace {
             defer { group.leave() }
 
             let parentDirectory =  self.location.artifactsDirectory.appending(component: artifact.packageRef.name)
-            guard tempDiagnostics.wrap ({ try fileSystem.createDirectory(parentDirectory, recursive: true) }) else {
+            guard observabilityScope.trap ({ try fileSystem.createDirectory(parentDirectory, recursive: true) }) else {
                 continue
             }
 
@@ -2062,14 +2105,16 @@ extension Workspace {
 
                     switch downloadResult {
                     case .success:
-                        let archiveChecksum = self.checksum(forBinaryArtifactAt: archivePath, diagnostics: tempDiagnostics )
+                        guard let archiveChecksum = observabilityScope.trap ({ try self.checksum(forBinaryArtifactAt: archivePath) }) else {
+                            return
+                        }
                         guard archiveChecksum == artifact.checksum else {
-                            tempDiagnostics.emit(.artifactInvalidChecksum(targetName: artifact.targetName, expectedChecksum: artifact.checksum, actualChecksum: archiveChecksum))
-                            tempDiagnostics.wrap { try self.fileSystem.removeFileTree(archivePath) }
+                            observabilityScope.emit(.artifactInvalidChecksum(targetName: artifact.targetName, expectedChecksum: artifact.checksum, actualChecksum: archiveChecksum))
+                            observabilityScope.trap { try self.fileSystem.removeFileTree(archivePath) }
                             return
                         }
 
-                        guard let tempExtractionDirectory = tempDiagnostics.wrap({ () -> AbsolutePath in
+                        guard let tempExtractionDirectory = observabilityScope.trap({ () -> AbsolutePath in
                             let path = self.location.artifactsDirectory.appending(components: "extract", artifact.packageRef.name, artifact.targetName, UUID().uuidString)
                             try self.fileSystem.forceCreateDirectory(at: path)
                             return path
@@ -2085,7 +2130,7 @@ extension Workspace {
                             switch extractResult {
                             case .success:
                                 var artifactPath: AbsolutePath? = nil
-                                tempDiagnostics.wrap {
+                                observabilityScope.trap {
                                     try self.fileSystem.withLock(on: parentDirectory, type: .exclusive) {
                                         // copy from temp location to actual location
                                         let content = try self.fileSystem.getDirectoryContents(tempExtractionDirectory)
@@ -2106,7 +2151,7 @@ extension Workspace {
                                 }
 
                                 guard let mainArtifactPath = artifactPath else {
-                                    return tempDiagnostics.emit(.artifactNotFound(targetName: artifact.targetName, artifactName: artifact.targetName))
+                                    return observabilityScope.emit(.artifactNotFound(targetName: artifact.targetName, artifactName: artifact.targetName))
                                 }
 
                                 result.append(
@@ -2120,13 +2165,13 @@ extension Workspace {
                                 )
                             case .failure(let error):
                                 let reason = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
-                                tempDiagnostics.emit(.artifactFailedExtraction(artifactURL: artifact.url, targetName: artifact.targetName, reason: reason))
+                                observabilityScope.emit(.artifactFailedExtraction(artifactURL: artifact.url, targetName: artifact.targetName, reason: reason))
                             }
 
-                            tempDiagnostics.wrap { try self.fileSystem.removeFileTree(archivePath) }
+                            observabilityScope.trap { try self.fileSystem.removeFileTree(archivePath) }
                         })
                     case .failure(let error):
-                        tempDiagnostics.emit(.artifactFailedDownload(artifactURL: artifact.url, targetName: artifact.targetName, reason: "\(error)"))
+                        observabilityScope.emit(.artifactFailedDownload(artifactURL: artifact.url, targetName: artifact.targetName, reason: "\(error)"))
                     }
                 })
         }
@@ -2137,13 +2182,10 @@ extension Workspace {
             delegate?.didDownloadBinaryArtifacts()
         }
 
-        // collect all diagnostics
-        diagnostics.append(contentsOf: tempDiagnostics)
-
         return result.map{ $0 }
     }
 
-    private func extract(_ artifacts: [ManagedArtifact], diagnostics: DiagnosticsEngine) throws -> [ManagedArtifact] {
+    private func extract(_ artifacts: [ManagedArtifact], observabilityScope: ObservabilityScope) throws -> [ManagedArtifact] {
         let result = ThreadSafeArrayStore<ManagedArtifact>()
         let group = DispatchGroup()
 
@@ -2160,8 +2202,8 @@ extension Workspace {
 
                 switch extractResult {
                 case .success:
-                    var artifactPath: AbsolutePath? = nil
-                    diagnostics.wrap {
+                    observabilityScope.trap { () -> Void in
+                        var artifactPath: AbsolutePath? = nil
                         // copy from temp location to actual location
                         let content = try self.fileSystem.getDirectoryContents(tempExtractionDirectory)
                         for file in content {
@@ -2175,27 +2217,30 @@ extension Workspace {
                                 artifactPath = destination
                             }
                         }
+
                         // remove temp location
                         try self.fileSystem.removeFileTree(tempExtractionDirectory)
-                    }
 
-                    guard let mainArtifactPath = artifactPath else {
-                        return diagnostics.emit(.localArtifactNotFound(targetName: artifact.targetName, artifactName: artifact.targetName))
-                    }
+                        guard let mainArtifactPath = artifactPath else {
+                            return observabilityScope.emit(.localArtifactNotFound(targetName: artifact.targetName, artifactName: artifact.targetName))
+                        }
 
-                    result.append(
-                        .local(
-                            packageRef: artifact.packageRef,
-                            targetName: artifact.targetName,
-                            path: mainArtifactPath,
-                            checksum: self.checksum(forBinaryArtifactAt: artifact.path, diagnostics: diagnostics)
+                        // compute the checksum
+                        let artifactChecksum = try self.checksum(forBinaryArtifactAt: artifact.path)
+
+                        result.append(
+                            .local(
+                                packageRef: artifact.packageRef,
+                                targetName: artifact.targetName,
+                                path: mainArtifactPath,
+                                checksum: artifactChecksum
+                            )
                         )
-                    )
-
+                    }
                 case .failure(let error):
                     let reason = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
 
-                    diagnostics.emit(.localArtifactFailedExtraction(artifactPath: artifact.path, targetName: artifact.targetName, reason: reason))
+                    observabilityScope.emit(.localArtifactFailedExtraction(artifactPath: artifact.path, targetName: artifact.targetName, reason: reason))
                 }
             })
         }
@@ -2214,17 +2259,18 @@ extension Workspace {
 
 extension Workspace {
 
+    // deprecated 8/2021
     @available(*, deprecated, message: "renamed to resolveBasedOnResolvedVersionsFile")
-    public func resolveToResolvedVersion(root: PackageGraphRootInput,diagnostics: DiagnosticsEngine) throws {
-        try self.resolveBasedOnResolvedVersionsFile(root: root, diagnostics: diagnostics)
+    public func resolveToResolvedVersion(root: PackageGraphRootInput, diagnostics: DiagnosticsEngine) throws {
+        try self.resolveBasedOnResolvedVersionsFile(root: root, observabilityScope: ObservabilitySystem(diagnosticEngine: diagnostics).topScope)
     }
 
     /// Resolves the dependencies according to the entries present in the Package.resolved file.
     ///
     /// This method bypasses the dependency resolution and resolves dependencies
     /// according to the information in the resolved file.
-    public func resolveBasedOnResolvedVersionsFile(root: PackageGraphRootInput, diagnostics: DiagnosticsEngine) throws {
-        try self.resolveBasedOnResolvedVersionsFile(root: root, explicitProduct: .none, diagnostics: diagnostics)
+    public func resolveBasedOnResolvedVersionsFile(root: PackageGraphRootInput, observabilityScope: ObservabilityScope) throws {
+        try self.resolveBasedOnResolvedVersionsFile(root: root, explicitProduct: .none, observabilityScope: observabilityScope)
     }
 
     /// Resolves the dependencies according to the entries present in the Package.resolved file.
@@ -2235,18 +2281,18 @@ extension Workspace {
     fileprivate func resolveBasedOnResolvedVersionsFile(
         root: PackageGraphRootInput,
         explicitProduct: String?,
-        diagnostics: DiagnosticsEngine
+        observabilityScope: ObservabilityScope
     ) throws -> DependencyManifests {
         // Ensure the cache path exists.
-        self.createCacheDirectories(with: diagnostics)
+        self.createCacheDirectories(observabilityScope: observabilityScope)
 
         // FIXME: this should not block
-        let rootManifests = try temp_await { self.loadRootManifests(packages: root.packages, diagnostics: diagnostics, completion: $0) }
+        let rootManifests = try temp_await { self.loadRootManifests(packages: root.packages, observabilityScope: observabilityScope, completion: $0) }
         let graphRoot = PackageGraphRoot(input: root, manifests: rootManifests, explicitProduct: explicitProduct)
 
         // Load the pins store or abort now.
-        guard let pinsStore = diagnostics.wrap({ try self.pinsStore.load() }), !diagnostics.hasErrors else {
-            return try self.loadDependencyManifests(root: graphRoot, diagnostics: diagnostics)
+        guard let pinsStore = observabilityScope.trap({ try self.pinsStore.load() }), !observabilityScope.errorsReported else {
+            return try self.loadDependencyManifests(root: graphRoot, observabilityScope: observabilityScope)
         }
 
         // Request all the containers to fetch them in parallel.
@@ -2254,7 +2300,7 @@ extension Workspace {
         // We just request the packages here, repository manager will
         // automatically manage the parallelism.
         for pin in pinsStore.pins {
-            self.getContainer(for: pin.packageRef, skipUpdate: true, on: .sharedConcurrent, completion: { _ in })
+            self.getContainer(for: pin.packageRef, skipUpdate: true, observabilityScope: observabilityScope, on: .sharedConcurrent, completion: { _ in })
         }
 
         // Compute the pins that we need to actually clone.
@@ -2276,31 +2322,32 @@ extension Workspace {
 
         // Retrieve the required pins.
         for pin in requiredPins {
-            diagnostics.wrap {
+            observabilityScope.trap {
                 _ = try self.retrieve(package: pin.packageRef, at: pin.state)
             }
         }
 
-        let currentManifests = try self.loadDependencyManifests(root: graphRoot, diagnostics: diagnostics, automaticallyAddManagedDependencies: true)
+        let currentManifests = try self.loadDependencyManifests(root: graphRoot, automaticallyAddManagedDependencies: true, observabilityScope: observabilityScope)
 
         let precomputationResult = try self.precomputeResolution(
             root: graphRoot,
             dependencyManifests: currentManifests,
             pinsStore: pinsStore,
-            constraints: []
+            constraints: [],
+            observabilityScope: observabilityScope
         )
 
         if case let .required(reason) = precomputationResult {
             let reasonString = Self.format(workspaceResolveReason: reason)
 
             if !fileSystem.exists(self.location.resolvedVersionsFile) {
-                diagnostics.emit(error: "a resolved file is required when automatic dependency resolution is disabled and should be placed at \(self.location.resolvedVersionsFile.pathString). \(reasonString)")
+                observabilityScope.emit(error: "a resolved file is required when automatic dependency resolution is disabled and should be placed at \(self.location.resolvedVersionsFile.pathString). \(reasonString)")
             } else {
-                diagnostics.emit(error: "an out-of-date resolved file was detected at \(self.location.resolvedVersionsFile.pathString), which is not allowed when automatic dependency resolution is disabled; please make sure to update the file to reflect the changes in dependencies. \(reasonString)")
+                observabilityScope.emit(error: "an out-of-date resolved file was detected at \(self.location.resolvedVersionsFile.pathString), which is not allowed when automatic dependency resolution is disabled; please make sure to update the file to reflect the changes in dependencies. \(reasonString)")
             }
         }
 
-        try self.updateBinaryArtifacts(manifests: currentManifests, addedOrUpdatedPackages: [], diagnostics: diagnostics)
+        try self.updateBinaryArtifacts(manifests: currentManifests, addedOrUpdatedPackages: [], observabilityScope: observabilityScope)
 
         return currentManifests
     }
@@ -2317,30 +2364,29 @@ extension Workspace {
         explicitProduct: String? = nil,
         forceResolution: Bool,
         constraints: [PackageContainerConstraint],
-        diagnostics: DiagnosticsEngine,
         retryOnPackagePathMismatch: Bool = true,
-        resetPinsStoreOnFailure: Bool = true
+        resetPinsStoreOnFailure: Bool = true,
+        observabilityScope: ObservabilityScope
     ) throws -> DependencyManifests {
-
         // Ensure the cache path exists and validate that edited dependencies.
-        self.createCacheDirectories(with: diagnostics)
+        self.createCacheDirectories(observabilityScope: observabilityScope)
 
         // FIXME: this should not block
         // Load the root manifests and currently checked out manifests.
-        let rootManifests = try temp_await { self.loadRootManifests(packages: root.packages, diagnostics: diagnostics, completion: $0) }
+        let rootManifests = try temp_await { self.loadRootManifests(packages: root.packages, observabilityScope: observabilityScope, completion: $0) }
         let rootManifestsMinimumToolsVersion = rootManifests.values.map{ $0.toolsVersion }.min() ?? ToolsVersion.currentToolsVersion
 
         // Load the current manifests.
         let graphRoot = PackageGraphRoot(input: root, manifests: rootManifests, explicitProduct: explicitProduct)
-        let currentManifests = try self.loadDependencyManifests(root: graphRoot, diagnostics: diagnostics)
-        guard !diagnostics.hasErrors else {
+        let currentManifests = try self.loadDependencyManifests(root: graphRoot, observabilityScope: observabilityScope)
+        guard !observabilityScope.errorsReported else {
             return currentManifests
         }
 
-        self.validatePinsStore(dependencyManifests: currentManifests, rootManifestsMinimumToolsVersion: rootManifestsMinimumToolsVersion, diagnostics: diagnostics)
+        self.validatePinsStore(dependencyManifests: currentManifests, rootManifestsMinimumToolsVersion: rootManifestsMinimumToolsVersion, observabilityScope: observabilityScope)
 
         // Abort if pinsStore is unloadable or if diagnostics has errors.
-        guard !diagnostics.hasErrors, let pinsStore = diagnostics.wrap({ try pinsStore.load() }) else {
+        guard !observabilityScope.errorsReported, let pinsStore = observabilityScope.trap({ try pinsStore.load() }) else {
             return currentManifests
         }
 
@@ -2358,7 +2404,8 @@ extension Workspace {
                 root: graphRoot,
                 dependencyManifests: currentManifests,
                 pinsStore: pinsStore,
-                constraints: constraints
+                constraints: constraints,
+                observabilityScope: observabilityScope
             )
 
             switch result {
@@ -2366,7 +2413,8 @@ extension Workspace {
                 try self.updateBinaryArtifacts(
                     manifests: currentManifests,
                     addedOrUpdatedPackages: [],
-                    diagnostics: diagnostics)
+                    observabilityScope: observabilityScope
+                )
 
                 return currentManifests
             case .required(let reason):
@@ -2380,29 +2428,30 @@ extension Workspace {
         computedConstraints += try graphRoot.constraints() + constraints
 
         // Perform dependency resolution.
-        let resolver = self.createResolver(pinsMap: pinsStore.pinsMap, observabilityScope: ObservabilitySystem(diagnosticEngine: diagnostics).topScope)
+        let resolver = try self.createResolver(pinsMap: pinsStore.pinsMap, observabilityScope: observabilityScope)
         self.activeResolver = resolver
 
         let result = self.resolveDependencies(
             resolver: resolver,
             constraints: computedConstraints,
-            diagnostics: diagnostics)
+            observabilityScope: observabilityScope
+        )
 
         // Reset the active resolver.
         self.activeResolver = nil
 
-        guard !diagnostics.hasErrors else {
+        guard !observabilityScope.errorsReported else {
             return currentManifests
         }
 
         // Update the checkouts with dependency resolution result.
-        let packageStateChanges = self.updateDependenciesCheckouts(root: graphRoot, updateResults: result, diagnostics: diagnostics)
-        guard !diagnostics.hasErrors else {
+        let packageStateChanges = self.updateDependenciesCheckouts(root: graphRoot, updateResults: result, observabilityScope: observabilityScope)
+        guard !observabilityScope.errorsReported else {
             return currentManifests
         }
 
         // Update the pinsStore.
-        let updatedDependencyManifests = try self.loadDependencyManifests(root: graphRoot, diagnostics: diagnostics)
+        let updatedDependencyManifests = try self.loadDependencyManifests(root: graphRoot, observabilityScope: observabilityScope)
 
         // If we still have required URLs, we probably cloned a wrong URL for
         // some package dependency.
@@ -2421,9 +2470,9 @@ extension Workspace {
                     explicitProduct: explicitProduct,
                     forceResolution: forceResolution,
                     constraints: constraints,
-                    diagnostics: diagnostics,
                     retryOnPackagePathMismatch: false,
-                    resetPinsStoreOnFailure: resetPinsStoreOnFailure
+                    resetPinsStoreOnFailure: resetPinsStoreOnFailure,
+                    observabilityScope: observabilityScope
                 )
             } else if resetPinsStoreOnFailure, !pinsStore.pinsMap.isEmpty {
                 // If we weren't able to resolve properly even after a retry, it
@@ -2438,14 +2487,14 @@ extension Workspace {
                     explicitProduct: explicitProduct,
                     forceResolution: forceResolution,
                     constraints: constraints,
-                    diagnostics: diagnostics,
                     retryOnPackagePathMismatch: false,
-                    resetPinsStoreOnFailure: false
+                    resetPinsStoreOnFailure: false,
+                    observabilityScope: observabilityScope
                 )
             } else {
                 // give up
                 let missing = stillMissingPackages.map{ $0.description }
-                diagnostics.emit(error: "exhausted attempts to resolve the dependencies graph, with '\(missing.joined(separator: "', '"))' unresolved.")
+                observabilityScope.emit(error: "exhausted attempts to resolve the dependencies graph, with '\(missing.joined(separator: "', '"))' unresolved.")
                 return updatedDependencyManifests
             }
         }
@@ -2454,14 +2503,15 @@ extension Workspace {
             pinsStore: pinsStore,
             dependencyManifests: updatedDependencyManifests,
             rootManifestsMinimumToolsVersion: rootManifestsMinimumToolsVersion,
-            diagnostics: diagnostics
+            observabilityScope: observabilityScope
         )
 
         let addedOrUpdatedPackages = packageStateChanges.compactMap({ $0.1.isAddedOrUpdated ? $0.0 : nil })
         try self.updateBinaryArtifacts(
             manifests: updatedDependencyManifests,
             addedOrUpdatedPackages: addedOrUpdatedPackages,
-            diagnostics: diagnostics)
+            observabilityScope: observabilityScope
+        )
 
         return updatedDependencyManifests
     }
@@ -2480,18 +2530,18 @@ extension Workspace {
         root: PackageGraphRoot,
         updateResults: [(PackageReference, BoundVersion, ProductFilter)],
         updateBranches: Bool = false,
-        diagnostics: DiagnosticsEngine
+        observabilityScope: ObservabilityScope
     ) -> [(PackageReference, PackageStateChange)] {
         // Get the update package states from resolved results.
-        guard let packageStateChanges = diagnostics.wrap({
-            try computePackageStateChanges(root: root, resolvedDependencies: updateResults, updateBranches: updateBranches)
+        guard let packageStateChanges = observabilityScope.trap({
+            try computePackageStateChanges(root: root, resolvedDependencies: updateResults, updateBranches: updateBranches, observabilityScope: observabilityScope)
         }) else {
             return []
         }
 
         // First remove the checkouts that are no longer required.
         for (packageRef, state) in packageStateChanges {
-            diagnostics.wrap {
+            observabilityScope.trap {
                 switch state {
                 case .added, .updated, .unchanged: break
                 case .removed:
@@ -2502,12 +2552,12 @@ extension Workspace {
 
         // Update or clone new packages.
         for (packageRef, state) in packageStateChanges {
-            diagnostics.wrap {
+            observabilityScope.trap {
                 switch state {
                 case .added(let state):
-                    _ = try self.updateDependency(package: packageRef, requirement: state.requirement, productFilter: state.products)
+                    _ = try self.updateDependency(package: packageRef, requirement: state.requirement, productFilter: state.products, observabilityScope: observabilityScope)
                 case .updated(let state):
-                    _ = try self.updateDependency(package: packageRef, requirement: state.requirement, productFilter: state.products)
+                    _ = try self.updateDependency(package: packageRef, requirement: state.requirement, productFilter: state.products, observabilityScope: observabilityScope)
                 case .removed, .unchanged: break
                 }
             }
@@ -2524,7 +2574,8 @@ extension Workspace {
     private func updateDependency(
         package: PackageReference,
         requirement: PackageStateChange.Requirement,
-        productFilter: ProductFilter
+        productFilter: ProductFilter,
+        observabilityScope: ObservabilityScope
     ) throws -> AbsolutePath {
         let checkoutState: CheckoutState
 
@@ -2537,7 +2588,7 @@ extension Workspace {
             // FIXME: this should not block
             // FIXME: this should be updated to support registry
             guard let container = (try temp_await {
-                self.getContainer(for: package, skipUpdate: true, on: .sharedConcurrent, completion: $0)
+                self.getContainer(for: package, skipUpdate: true, observabilityScope: observabilityScope, on: .sharedConcurrent, completion: $0)
             }) as? SourceControlPackageContainer else {
                 throw InternalError("invalid container for \(package) expected a RepositoryPackageContainer")
             }
@@ -2588,7 +2639,8 @@ extension Workspace {
         root: PackageGraphRoot,
         dependencyManifests: DependencyManifests,
         pinsStore: PinsStore,
-        constraints: [PackageContainerConstraint]
+        constraints: [PackageContainerConstraint],
+        observabilityScope: ObservabilityScope
     ) throws -> ResolutionPrecomputationResult {
         let computedConstraints =
             try root.constraints() +
@@ -2598,7 +2650,7 @@ extension Workspace {
             constraints
 
         let precomputationProvider = ResolverPrecomputationProvider(root: root, dependencyManifests: dependencyManifests)
-        let resolver = PubgrubDependencyResolver(provider: precomputationProvider, pinsMap: pinsStore.pinsMap)
+        let resolver = PubgrubDependencyResolver(provider: precomputationProvider, pinsMap: pinsStore.pinsMap, observabilityScope: observabilityScope)
         let result = resolver.solve(constraints: computedConstraints)
 
         switch result {
@@ -2621,9 +2673,9 @@ extension Workspace {
     private func validatePinsStore(
         dependencyManifests: DependencyManifests,
         rootManifestsMinimumToolsVersion: ToolsVersion,
-        diagnostics: DiagnosticsEngine
+        observabilityScope: ObservabilityScope
     ) {
-        guard let pinsStore = diagnostics.wrap({ try pinsStore.load() }) else {
+        guard let pinsStore = observabilityScope.trap({ try pinsStore.load() }) else {
             return
         }
 
@@ -2652,7 +2704,7 @@ extension Workspace {
                 pinsStore: pinsStore,
                 dependencyManifests: dependencyManifests,
                 rootManifestsMinimumToolsVersion: rootManifestsMinimumToolsVersion,
-                diagnostics: diagnostics
+                observabilityScope: observabilityScope
             )
         }
     }
@@ -2740,7 +2792,8 @@ extension Workspace {
     fileprivate func computePackageStateChanges(
         root: PackageGraphRoot,
         resolvedDependencies: [(PackageReference, BoundVersion, ProductFilter)],
-        updateBranches: Bool
+        updateBranches: Bool,
+        observabilityScope: ObservabilityScope
     ) throws -> [(PackageReference, PackageStateChange)] {
         // Load pins store and managed dependencies.
         let pinsStore = try self.pinsStore.load()
@@ -2787,7 +2840,7 @@ extension Workspace {
                 // Get the latest revision from the container.
                 // TODO: replace with async/await when available
                 guard let container = (try temp_await {
-                    self.getContainer(for: packageRef, skipUpdate: true, on: .sharedConcurrent, completion: $0)
+                    self.getContainer(for: packageRef, skipUpdate: true, observabilityScope: observabilityScope, on: .sharedConcurrent, completion: $0)
                 }) as? SourceControlPackageContainer else {
                     throw InternalError("invalid container for \(packageRef) expected a RepositoryPackageContainer")
                 }
@@ -2847,7 +2900,7 @@ extension Workspace {
     }
 
     /// Creates resolver for the workspace.
-    fileprivate func createResolver(pinsMap: PinsStore.PinsMap, observabilityScope: ObservabilityScope) -> PubgrubDependencyResolver {
+    fileprivate func createResolver(pinsMap: PinsStore.PinsMap, observabilityScope: ObservabilityScope) throws -> PubgrubDependencyResolver {
         var delegate: DependencyResolverDelegate
         let observabilityDelegate = ObservabilityDependencyResolverDelegate(observabilityScope: observabilityScope)
         if let workspaceDelegate = self.delegate {
@@ -2864,6 +2917,7 @@ extension Workspace {
             pinsMap: pinsMap,
             updateEnabled: self.resolverUpdateEnabled,
             prefetchingEnabled: self.resolverPrefetchingEnabled,
+            observabilityScope: observabilityScope,
             delegate: delegate
         )
     }
@@ -2872,7 +2926,7 @@ extension Workspace {
     fileprivate func resolveDependencies(
         resolver: PubgrubDependencyResolver,
         constraints: [PackageContainerConstraint],
-        diagnostics: DiagnosticsEngine
+        observabilityScope: ObservabilityScope
     ) -> [(package: PackageReference, binding: BoundVersion, products: ProductFilter)] {
 
         os_signpost(.begin, log: .swiftpm, name: SignpostName.resolution)
@@ -2884,7 +2938,7 @@ extension Workspace {
         case .success(let bindings):
             return bindings
         case .failure(let error):
-            diagnostics.emit(error)
+            observabilityScope.emit(error)
             return []
         }
     }
@@ -2955,6 +3009,7 @@ extension Workspace: PackageContainerProvider {
     public func getContainer(
         for package: PackageReference,
         skipUpdate: Bool,
+        observabilityScope: ObservabilityScope,
         on queue: DispatchQueue,
         completion: @escaping (Result<PackageContainer, Swift.Error>) -> Void
     ) {
@@ -2969,7 +3024,9 @@ extension Workspace: PackageContainerProvider {
                         manifestLoader: self.manifestLoader,
                         toolsVersionLoader: self.toolsVersionLoader,
                         currentToolsVersion: self.currentToolsVersion,
-                        fileSystem: self.fileSystem)
+                        fileSystem: self.fileSystem,
+                        observabilityScope: observabilityScope
+                    )
                     completion(.success(container))
                 } catch {
                     completion(.failure(error))
@@ -2994,7 +3051,8 @@ extension Workspace: PackageContainerProvider {
                                 repository: repository,
                                 manifestLoader: self.manifestLoader,
                                 toolsVersionLoader: self.toolsVersionLoader,
-                                currentToolsVersion: self.currentToolsVersion
+                                currentToolsVersion: self.currentToolsVersion,
+                                observabilityScope: observabilityScope
                             )
                         }
                         completion(result)

--- a/Tests/BasicsTests/ObservabilitySystemTests.swift
+++ b/Tests/BasicsTests/ObservabilitySystemTests.swift
@@ -33,8 +33,15 @@ final class ObservabilitySystemTest: XCTestCase {
         emitter1.emit(error: "error 1.5")
 
         testDiagnostics(collector.diagnostics) { result in
-            result.check(diagnostic: "error 1", severity: .error, metadata: metadata1)
-            result.check(diagnostic: "error 1.5", severity: .error, metadata: metadata1)
+            let diagnostic1 = result.check(diagnostic: "error 1", severity: .error)
+            XCTAssertEqual(diagnostic1?.metadata?.testKey1, metadata1.testKey1)
+            XCTAssertEqual(diagnostic1?.metadata?.testKey2, metadata1.testKey2)
+            XCTAssertEqual(diagnostic1?.metadata?.testKey3, metadata1.testKey3)
+
+            let diagnostic1_5 = result.check(diagnostic: "error 1.5", severity: .error)
+            XCTAssertEqual(diagnostic1_5?.metadata?.testKey1, metadata1.testKey1)
+            XCTAssertEqual(diagnostic1_5?.metadata?.testKey2, metadata1.testKey2)
+            XCTAssertEqual(diagnostic1_5?.metadata?.testKey3, metadata1.testKey3)
         }
 
         collector.clear()
@@ -55,8 +62,15 @@ final class ObservabilitySystemTest: XCTestCase {
         emitter2.emit(error: "error 2.5")
 
         testDiagnostics(collector.diagnostics) { result in
-            result.check(diagnostic: "error 2", severity: .error, metadata: mergedMetadata2)
-            result.check(diagnostic: "error 2.5", severity: .error, metadata: mergedMetadata2)
+            let diagnostic2 = result.check(diagnostic: "error 2", severity: .error)!
+            XCTAssertEqual(diagnostic2.metadata?.testKey1, mergedMetadata2.testKey1)
+            XCTAssertEqual(diagnostic2.metadata?.testKey2, mergedMetadata2.testKey2)
+            XCTAssertEqual(diagnostic2.metadata?.testKey3, mergedMetadata2.testKey3)
+
+            let diagnostic2_5 = result.check(diagnostic: "error 2.5", severity: .error)
+            XCTAssertEqual(diagnostic2_5?.metadata?.testKey1, mergedMetadata2.testKey1)
+            XCTAssertEqual(diagnostic2_5?.metadata?.testKey2, mergedMetadata2.testKey2)
+            XCTAssertEqual(diagnostic2_5?.metadata?.testKey3, mergedMetadata2.testKey3)
         }
 
         collector.clear()
@@ -84,8 +98,15 @@ final class ObservabilitySystemTest: XCTestCase {
         emitter3.emit(error: "error 3.5")
 
         testDiagnostics(collector.diagnostics) { result in
-            result.check(diagnostic: "error 3", severity: .error, metadata: mergedMetadata3)
-            result.check(diagnostic: "error 3.5", severity: .error, metadata: mergedMetadata3_5)
+            let diagnostic3 = result.check(diagnostic: "error 3", severity: .error)
+            XCTAssertEqual(diagnostic3?.metadata?.testKey1, mergedMetadata3.testKey1)
+            XCTAssertEqual(diagnostic3?.metadata?.testKey2, mergedMetadata3.testKey2)
+            XCTAssertEqual(diagnostic3?.metadata?.testKey3, mergedMetadata3.testKey3)
+
+            let diagnostic3_5 = result.check(diagnostic: "error 3.5", severity: .error)
+            XCTAssertEqual(diagnostic3_5?.metadata?.testKey1, mergedMetadata3_5.testKey1)
+            XCTAssertEqual(diagnostic3_5?.metadata?.testKey2, mergedMetadata3_5.testKey2)
+            XCTAssertEqual(diagnostic3_5?.metadata?.testKey3, mergedMetadata3_5.testKey3)
         }
     }
 
@@ -109,15 +130,43 @@ final class ObservabilitySystemTest: XCTestCase {
         emitter.emit(.debug("debug 2"))
 
         testDiagnostics(collector.diagnostics, problemsOnly: false) { result in
-            result.check(diagnostic: "error", severity: .error, metadata: metadata)
-            result.check(diagnostic: "error 2", severity: .error, metadata: metadata)
-            result.check(diagnostic: "error 3", severity: .error, metadata: metadata)
-            result.check(diagnostic: "warning", severity: .warning, metadata: metadata)
-            result.check(diagnostic: "warning 2", severity: .warning, metadata: metadata)
-            result.check(diagnostic: "info", severity: .info, metadata: metadata)
-            result.check(diagnostic: "info 2", severity: .info, metadata: metadata)
-            result.check(diagnostic: "debug", severity: .debug, metadata: metadata)
-            result.check(diagnostic: "debug 2", severity: .debug, metadata: metadata)
+            do {
+                let diagnostic = result.check(diagnostic: "error", severity: .error)
+                XCTAssertEqual(diagnostic?.metadata?.testKey1, metadata.testKey1)
+            }
+            do {
+                let diagnostic = result.check(diagnostic: "error 2", severity: .error)
+                XCTAssertEqual(diagnostic?.metadata?.testKey1, metadata.testKey1)
+            }
+            do {
+                let diagnostic = result.check(diagnostic: "error 3", severity: .error)
+                XCTAssertEqual(diagnostic?.metadata?.testKey1, metadata.testKey1)
+                XCTAssertEqual(diagnostic?.metadata?.underlyingError as? StringError, StringError("error 3"))
+            }
+            do {
+                let diagnostic = result.check(diagnostic: "warning", severity: .warning)
+                XCTAssertEqual(diagnostic?.metadata?.testKey1, metadata.testKey1)
+            }
+            do {
+                let diagnostic = result.check(diagnostic: "warning 2", severity: .warning)
+                XCTAssertEqual(diagnostic?.metadata?.testKey1, metadata.testKey1)
+            }
+            do {
+                let diagnostic = result.check(diagnostic: "info", severity: .info)
+                XCTAssertEqual(diagnostic?.metadata?.testKey1, metadata.testKey1)
+            }
+            do {
+                let diagnostic = result.check(diagnostic: "info 2", severity: .info)
+                XCTAssertEqual(diagnostic?.metadata?.testKey1, metadata.testKey1)
+            }
+            do {
+                let diagnostic = result.check(diagnostic: "debug", severity: .debug)
+                XCTAssertEqual(diagnostic?.metadata?.testKey1, metadata.testKey1)
+            }
+            do {
+                let diagnostic = result.check(diagnostic: "debug 2", severity: .debug)
+                XCTAssertEqual(diagnostic?.metadata?.testKey1, metadata.testKey1)
+            }
         }
     }
 
@@ -155,8 +204,18 @@ final class ObservabilitySystemTest: XCTestCase {
         emitter.emit(warning: "warning", metadata: diagnosticMetadata)
 
         testDiagnostics(collector.diagnostics) { result in
-            result.check(diagnostic: "error", severity: .error, metadata: emitterMergedMetadata)
-            result.check(diagnostic: "warning", severity: .warning, metadata: diagnosticMergedMetadata)
+            do {
+                let diagnostic = result.check(diagnostic: "error", severity: .error)
+                XCTAssertEqual(diagnostic?.metadata?.testKey1, emitterMergedMetadata.testKey1)
+                XCTAssertEqual(diagnostic?.metadata?.testKey2, emitterMergedMetadata.testKey2)
+                XCTAssertEqual(diagnostic?.metadata?.testKey3, emitterMergedMetadata.testKey3)
+            }
+            do {
+                let diagnostic = result.check(diagnostic: "warning", severity: .warning)
+                XCTAssertEqual(diagnostic?.metadata?.testKey1, diagnosticMergedMetadata.testKey1)
+                XCTAssertEqual(diagnostic?.metadata?.testKey2, diagnosticMergedMetadata.testKey2)
+                XCTAssertEqual(diagnostic?.metadata?.testKey3, diagnosticMergedMetadata.testKey3)
+            }
         }
     }
 
@@ -172,12 +231,9 @@ final class ObservabilitySystemTest: XCTestCase {
 
             diagnosticsEngine.emit(.error(data), location: location)
 
-            var expectedMetadata = ObservabilityMetadata()
-            expectedMetadata.legacyDiagnosticLocation = .init(location)
-            expectedMetadata.legacyDiagnosticData = .init(data)
-
             XCTAssertEqual(collector.diagnostics.count, 1)
-            XCTAssertEqual(collector.diagnostics.first?.metadata, expectedMetadata)
+            XCTAssertEqual(collector.diagnostics.first!.metadata?.legacyDiagnosticLocation?.description, location.description)
+            XCTAssertEqual(collector.diagnostics.first!.metadata?.legacyDiagnosticData?.underlying.description, data.description)
         }
 
         do {

--- a/Tests/CommandsTests/MultiRootSupportTests.swift
+++ b/Tests/CommandsTests/MultiRootSupportTests.swift
@@ -39,7 +39,7 @@ final class MultiRootSupportTests: XCTestCase {
         }
 
         let observability = ObservabilitySystem.makeForTesting()
-        let result = try XcodeWorkspaceLoader(diagnostics: observability.topScope.makeDiagnosticsEngine(), fs: fs).load(workspace: path)
+        let result = try XcodeWorkspaceLoader(fileSystem: fs, observabilityScope: observability.topScope).load(workspace: path)
 
         XCTAssertNoDiagnostics(observability.diagnostics)
         XCTAssertEqual(result.map{ $0.pathString }.sorted(), ["/tmp/test/dep", "/tmp/test/local"])

--- a/Tests/PackageCollectionsTests/PackageCollectionsStorageTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsStorageTests.swift
@@ -8,9 +8,11 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
+import Basics
 @testable import PackageCollections
 import TSCBasic
 import TSCTestSupport
+import TSCUtility
 import XCTest
 
 class PackageCollectionsStorageTests: XCTestCase {
@@ -239,5 +241,14 @@ class PackageCollectionsStorageTests: XCTestCase {
                 XCTAssertEqual(false, storage2.useSearchIndices.get(), "populateTargetTrie should fail only if FTS is not available")
             }
         }
+    }
+}
+
+extension SQLitePackageCollectionsStorage {
+    convenience init(location: SQLite.Location? = nil, configuration: Configuration = .init()) {
+        self.init(location: location, configuration: configuration, observabilityScope: ObservabilitySystem.NOOP)
+    }
+    convenience init(path: AbsolutePath) {
+        self.init(location: .path(path), observabilityScope: ObservabilitySystem.NOOP)
     }
 }

--- a/Tests/PackageCollectionsTests/Utility.swift
+++ b/Tests/PackageCollectionsTests/Utility.swift
@@ -125,7 +125,7 @@ func makeMockPackageBasicMetadata() -> PackageCollectionsModel.PackageBasicMetad
 func makeMockStorage(_ collectionsStorageConfig: SQLitePackageCollectionsStorage.Configuration = .init()) -> PackageCollections.Storage {
     let mockFileSystem = InMemoryFileSystem()
     return .init(sources: FilePackageCollectionsSourcesStorage(fileSystem: mockFileSystem),
-                 collections: SQLitePackageCollectionsStorage(location: .memory, configuration: collectionsStorageConfig))
+                 collections: SQLitePackageCollectionsStorage(location: .memory, configuration: collectionsStorageConfig, observabilityScope: ObservabilitySystem.NOOP))
 }
 
 struct MockCollectionsProvider: PackageCollectionProvider {

--- a/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
@@ -8,17 +8,15 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
-import XCTest
-
+import Basics
 import PackageGraph
 import PackageLoading
 import PackageModel
 import SourceControl
-import TSCBasic
-
-import struct TSCUtility.Version
-
 import SPMTestSupport
+import TSCBasic
+import struct TSCUtility.Version
+import XCTest
 
 private let v1: Version = "1.0.0"
 private let v1Range: VersionSetSpecifier = .range("1.0.0" ..< "2.0.0")
@@ -54,7 +52,7 @@ class DependencyResolverRealWorldPerfTests: XCTestCasePerf {
 
         measure {
             for _ in 0 ..< N {
-                let resolver = PubgrubDependencyResolver(provider: provider)
+                let resolver = PubgrubDependencyResolver(provider: provider, observabilityScope: ObservabilitySystem.NOOP)
                 switch resolver.solve(constraints: graph.constraints) {
                 case .success(let result):
                     let result: [(container: PackageReference, version: Version)] = result.compactMap {

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -513,13 +513,11 @@ class PackageGraphTests: XCTestCase {
         testDiagnostics(observability.diagnostics) { result in
             result.check(
                 diagnostic: "Source files for target Bar should be located under /Bar/Sources/Bar",
-                severity: .warning,
-                metadata: .packageMetadata(identity: .plain("bar"), location: "/Bar", path: .init("/Bar"))
+                severity: .warning
             )
             result.check(
                 diagnostic: "target 'Bar' referenced in product 'Bar' is empty",
-                severity: .error,
-                metadata: .packageMetadata(identity: .plain("bar"), location: "/Bar", path: .init("/Bar"))
+                severity: .error
             )
         }
     }
@@ -546,8 +544,7 @@ class PackageGraphTests: XCTestCase {
         testDiagnostics(observability.diagnostics) { result in
             result.check(
                 diagnostic: "product 'Barx' required by package 'foo' target 'FooTarget' not found.",
-                severity: .error,
-                metadata: .packageMetadata(identity: .plain("foo"), location: "/Foo", path: .init("/Foo"))
+                severity: .error
             )
         }
     }
@@ -579,8 +576,7 @@ class PackageGraphTests: XCTestCase {
         testDiagnostics(observability.diagnostics) { result in
             result.check(
                 diagnostic: "product 'Foo' is declared in the same package 'foo' and can't be used as a dependency for target 'FooTests'.",
-                severity: .error,
-                metadata: .packageMetadata(identity: .plain("foo"), location: "/Foo", path: .init("/Foo"))
+                severity: .error
             )
         }
     }
@@ -658,8 +654,7 @@ class PackageGraphTests: XCTestCase {
         testDiagnostics(observability.diagnostics) { result in
             result.check(
                 diagnostic: "product 'Barx' required by package 'foo' target 'FooTarget' not found in package 'Bar'.",
-                severity: .error,
-                metadata: .packageMetadata(identity: .plain("foo"), location: "/Foo", path: .init("/Foo"))
+                severity: .error
             )
         }
     }
@@ -688,8 +683,7 @@ class PackageGraphTests: XCTestCase {
         testDiagnostics(observability.diagnostics) { result in
             result.check(
                 diagnostic: "product 'Barx' required by package 'foo' target 'FooTarget' not found.",
-                severity: .error,
-                metadata: .packageMetadata(identity: .plain("foo"), location: "/Foo", path: .init("/Foo"))
+                severity: .error
             )
         }
     }
@@ -756,22 +750,19 @@ class PackageGraphTests: XCTestCase {
                 diagnostic: """
                 dependency 'BarLib' in target 'Foo' requires explicit declaration; reference the package in the target dependency with '.product(name: "BarLib", package: "Bar")'
                 """,
-                severity: .error,
-                metadata: .packageMetadata(identity: .plain("foo"), location: "/Foo", path: .init("/Foo"))
+                severity: .error
             )
             result.checkUnordered(
                 diagnostic: """
                 dependency 'Biz' in target 'Foo' requires explicit declaration; reference the package in the target dependency with '.product(name: "Biz", package: "BizPath")'
                 """,
-                severity: .error,
-                metadata: .packageMetadata(identity: .plain("foo"), location: "/Foo", path: .init("/Foo"))
+                severity: .error
             )
             result.checkUnordered(
                 diagnostic: """
                 dependency 'FizLib' in target 'Foo' requires explicit declaration; reference the package in the target dependency with '.product(name: "FizLib", package: "FizPath")'
                 """,
-                severity: .error,
-                metadata: .packageMetadata(identity: .plain("foo"), location: "/Foo", path: .init("/Foo"))
+                severity: .error
             )
         }
     }
@@ -1072,11 +1063,12 @@ class PackageGraphTests: XCTestCase {
         testDiagnostics(observability.diagnostics) { result in
             var expectedMetadata = ObservabilityMetadata()
             expectedMetadata.targetName = "Foo2"
-            result.checkUnordered(diagnostic: .contains("the target 'Bar2' in product 'TransitiveBar' contains unsafe build flags"), severity: .error, metadata: expectedMetadata)
-            expectedMetadata = ObservabilityMetadata()
-            expectedMetadata.targetName = "Foo"
-            result.checkUnordered(diagnostic: .contains("the target 'Bar' in product 'Bar' contains unsafe build flags"), severity: .error, metadata: expectedMetadata)
-            result.checkUnordered(diagnostic: .contains("the target 'Bar2' in product 'Bar' contains unsafe build flags"), severity: .error, metadata: expectedMetadata)
+            let diagnostic1 = result.checkUnordered(diagnostic: .contains("the target 'Bar2' in product 'TransitiveBar' contains unsafe build flags"), severity: .error)
+            XCTAssertEqual(diagnostic1?.metadata?.targetName, "Foo2")
+            let diagnostic2 = result.checkUnordered(diagnostic: .contains("the target 'Bar' in product 'Bar' contains unsafe build flags"), severity: .error)
+            XCTAssertEqual(diagnostic2?.metadata?.targetName, "Foo")
+            let diagnostic3 = result.checkUnordered(diagnostic: .contains("the target 'Bar2' in product 'Bar' contains unsafe build flags"), severity: .error)
+            XCTAssertEqual(diagnostic3?.metadata?.targetName, "Foo")
         }
     }
 
@@ -1353,8 +1345,7 @@ class PackageGraphTests: XCTestCase {
                 diagnostic: """
                     product 'Unknown' required by package 'foo' target 'Foo' not found.
                     """,
-                severity: .error,
-                metadata: .packageMetadata(identity: .plain("foo"), location: "/Foo", path: .init("/Foo"))
+                severity: .error
             )
         }
     }
@@ -1435,8 +1426,7 @@ class PackageGraphTests: XCTestCase {
                 diagnostic: """
                     product 'Unknown' required by package 'foo' target 'Foo' not found.
                     """,
-                severity: .error,
-                metadata: .packageMetadata(identity: .plain("foo"), location: "/Foo", path: .init("/Foo"))
+                severity: .error
             )
         }
     }
@@ -1478,8 +1468,7 @@ class PackageGraphTests: XCTestCase {
                     diagnostic: """
                         dependency 'ProductBar' in target 'Foo' requires explicit declaration; reference the package in the target dependency with '.product(name: "ProductBar", package: "Bar")'
                         """,
-                    severity: .error,
-                    metadata: .packageMetadata(identity: .plain("foo"), location: "/Foo", path: .init("/Foo"))
+                    severity: .error
                 )
             }
         }
@@ -1539,8 +1528,7 @@ class PackageGraphTests: XCTestCase {
                     diagnostic: """
                         dependency 'ProductBar' in target 'Foo' requires explicit declaration; reference the package in the target dependency with '.product(name: "ProductBar", package: "Bar")'
                         """,
-                    severity: .error,
-                    metadata: .packageMetadata(identity: .plain("foo"), location: "/Foo", path: .init("/Foo"))
+                    severity: .error
                 )
             }
         }
@@ -1599,8 +1587,7 @@ class PackageGraphTests: XCTestCase {
                     diagnostic: """
                         dependency 'Bar' in target 'Foo' requires explicit declaration; reference the package in the target dependency with '.product(name: "Bar", package: "Some-Bar")'
                         """,
-                    severity: .error,
-                    metadata: .packageMetadata(identity: .plain("foo"), location: "/Foo", path: .init("/Foo"))
+                    severity: .error
                 )
             }
         }
@@ -1654,13 +1641,13 @@ class PackageGraphTests: XCTestCase {
             let observability = ObservabilitySystem.makeForTesting()
             _ = try loadPackageGraph(fs: fs, manifests: manifests, observabilityScope: observability.topScope)
             testDiagnostics(observability.diagnostics) { result in
-                result.check(
+                let diagnostic = result.check(
                     diagnostic: """
                         dependency 'ProductBar' in target 'Foo' requires explicit declaration; reference the package in the target dependency with '.product(name: "ProductBar", package: "Some-Bar")'
                         """,
-                    severity: .error,
-                    metadata: .packageMetadata(identity: .plain("foo"), location: "/Foo", path: .init("/Foo"))
+                    severity: .error
                 )
+                XCTAssertEqual(diagnostic?.metadata?.packageIdentity, .plain("foo"))
             }
         }
 
@@ -1751,13 +1738,13 @@ class PackageGraphTests: XCTestCase {
             let observability = ObservabilitySystem.makeForTesting()
             _ = try loadPackageGraph(fs: fs, manifests: manifests, observabilityScope: observability.topScope)
             testDiagnostics(observability.diagnostics) { result in
-                result.check(
+                let diagnostic = result.check(
                     diagnostic: """
                         dependency 'ProductBar' in target 'Foo' requires explicit declaration; reference the package in the target dependency with '.product(name: "ProductBar", package: "Bar")'
                         """,
-                    severity: .error,
-                    metadata: .packageMetadata(identity: .plain("foo"), location: "/Foo", path: .init("/Foo"))
+                    severity: .error
                 )
+                XCTAssertEqual(diagnostic?.metadata?.packageIdentity, .plain("foo"))
             }
         }
 

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -306,7 +306,7 @@ final class PubgrubTests: XCTestCase {
 
         let provider = MockProvider(containers: [foo])
 
-        let resolver = PubgrubDependencyResolver(provider: provider)
+        let resolver = PubgrubDependencyResolver(provider: provider, observabilityScope: ObservabilitySystem.NOOP)
         let deps = builder.create(dependencies: [
             "foo": (.versionSet(v1Range), .specific(["foo"]))
         ])
@@ -323,7 +323,7 @@ final class PubgrubTests: XCTestCase {
     }
 
     func testResolverConflictResolution() throws  {
-        let solver1 = PubgrubDependencyResolver(provider: emptyProvider)
+        let solver1 = PubgrubDependencyResolver(provider: emptyProvider, observabilityScope: ObservabilitySystem.NOOP)
         let state1 = PubgrubDependencyResolver.State(root: rootNode)
 
         let notRoot = try Incompatibility(Term(not: rootNode, .any),
@@ -334,7 +334,7 @@ final class PubgrubTests: XCTestCase {
     }
 
     func testResolverDecisionMaking() throws {
-        let solver1 = PubgrubDependencyResolver(provider: emptyProvider)
+        let solver1 = PubgrubDependencyResolver(provider: emptyProvider, observabilityScope: ObservabilitySystem.NOOP)
         let state1 = PubgrubDependencyResolver.State(root: rootNode)
 
         // No decision can be made if no unsatisfied terms are available.
@@ -346,7 +346,7 @@ final class PubgrubTests: XCTestCase {
         ])
 
         let provider = MockProvider(containers: [a])
-        let solver2 = PubgrubDependencyResolver(provider: provider)
+        let solver2 = PubgrubDependencyResolver(provider: provider, observabilityScope: ObservabilitySystem.NOOP)
         let solution = PartialSolution(assignments: [
             .derivation("a^1.0.0", cause: rootCause, decisionLevel: 0)
         ])
@@ -369,7 +369,7 @@ final class PubgrubTests: XCTestCase {
     }
 
     func testResolverUnitPropagation() throws {
-        let solver1 = PubgrubDependencyResolver(provider: emptyProvider)
+        let solver1 = PubgrubDependencyResolver(provider: emptyProvider, observabilityScope: ObservabilitySystem.NOOP)
         let state1 = PubgrubDependencyResolver.State(root: rootNode)
 
         // no known incompatibilities should result in no satisfaction checks
@@ -387,7 +387,7 @@ final class PubgrubTests: XCTestCase {
         // try solver1.propagate(aRef)
 
         // Unit propagation should derive a new assignment from almost satisfied incompatibilities.
-        let solver2 = PubgrubDependencyResolver(provider: emptyProvider)
+        let solver2 = PubgrubDependencyResolver(provider: emptyProvider, observabilityScope: ObservabilitySystem.NOOP)
         let state2 = PubgrubDependencyResolver.State(root: rootNode)
         state2.addIncompatibility(try Incompatibility(Term(.root(package: "root"), .any),
                                     Term("¬a@1.0.0"),
@@ -2168,6 +2168,7 @@ public struct MockProvider: PackageContainerProvider {
     public func getContainer(
         for package: PackageReference,
         skipUpdate: Bool,
+        observabilityScope: ObservabilityScope,
         on queue: DispatchQueue,
         completion: @escaping (Result<PackageContainer, Error>
     ) -> Void) {
@@ -2255,7 +2256,7 @@ class DependencyGraphBuilder {
             self.references = [:]
         }
         let provider = MockProvider(containers: self.containers.values.map { $0 })
-        return PubgrubDependencyResolver(provider :provider, pinsMap: pinsMap, delegate: delegate)
+        return PubgrubDependencyResolver(provider :provider, pinsMap: pinsMap, observabilityScope: ObservabilitySystem.NOOP, delegate: delegate)
     }
 }
 

--- a/Tests/PackageLoadingPerformanceTests/ManifestLoadingTests.swift
+++ b/Tests/PackageLoadingPerformanceTests/ManifestLoadingTests.swift
@@ -8,6 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import Basics
 import PackageModel
 import PackageLoading
 import SPMTestSupport
@@ -39,7 +40,8 @@ class ManifestLoadingPerfTests: XCTestCasePerf {
                         at: path,
                         packageKind: .root(.init("/Trivial")),
                         toolsVersion: .v4_2,
-                        fileSystem: localFileSystem
+                        fileSystem: localFileSystem,
+                        observabilityScope: ObservabilitySystem.NOOP
                     )
                     XCTAssertEqual(manifest.name, "Trivial")
                 }
@@ -72,7 +74,8 @@ class ManifestLoadingPerfTests: XCTestCasePerf {
                         at: path,
                         packageKind: .root(.init("/Trivial")),
                         toolsVersion: .v4_2,
-                        fileSystem: localFileSystem
+                        fileSystem: localFileSystem,
+                        observabilityScope: ObservabilitySystem.NOOP
                     )
                     XCTAssertEqual(manifest.name, "Foo")
                 }

--- a/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
+++ b/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
@@ -97,13 +97,11 @@ class ModuleMapGeneration: XCTestCase {
         ModuleMapTester("Foo", in: fs) { result in
             result.checkNotCreated()
             result.checkDiagnostics { result in
-                var expectedMetadata = ObservabilityMetadata()
-                expectedMetadata.targetName = "Foo"
-                result.check(
+                let diagnostic = result.check(
                     diagnostic: "no include directory found for target \'Foo\'; libraries cannot be imported without public headers",
-                    severity: .warning,
-                    metadata: expectedMetadata
+                    severity: .warning
                 )
+                XCTAssertEqual(diagnostic?.metadata?.targetName, "Foo")
             }
         }
 
@@ -119,13 +117,11 @@ class ModuleMapGeneration: XCTestCase {
 
                 """)
             result.checkDiagnostics { result in
-                var expectedMetadata = ObservabilityMetadata()
-                expectedMetadata.targetName = "F-o-o"
-                result.check(
+                let diagnostic = result.check(
                     diagnostic: "/include/F-o-o.h should be renamed to /include/F_o_o.h to be used as an umbrella header",
-                    severity: .warning,
-                    metadata: expectedMetadata
+                    severity: .warning
                 )
+                XCTAssertEqual(diagnostic?.metadata?.targetName, "F-o-o")
             }
         }
     }
@@ -137,13 +133,11 @@ class ModuleMapGeneration: XCTestCase {
         ModuleMapTester("Foo", in: fs) { result in
             result.checkNotCreated()
             result.checkDiagnostics { result in
-                var expectedMetadata = ObservabilityMetadata()
-                expectedMetadata.targetName = "Foo"
-                result.check(
+                let diagnostic = result.check(
                     diagnostic: "target 'Foo' has invalid header layout: umbrella header found at '/include/Foo/Foo.h', but more than one directory exists next to its parent directory: /include/Bar; consider reducing them to one",
-                    severity: .error,
-                    metadata: expectedMetadata
+                    severity: .error
                 )
+                XCTAssertEqual(diagnostic?.metadata?.targetName, "Foo")
             }
         }
 
@@ -153,13 +147,11 @@ class ModuleMapGeneration: XCTestCase {
         ModuleMapTester("Foo", in: fs) { result in
             result.checkNotCreated()
             result.checkDiagnostics { result in
-                var expectedMetadata = ObservabilityMetadata()
-                expectedMetadata.targetName = "Foo"
-                result.check(
+                let diagnostic = result.check(
                     diagnostic: "target 'Foo' has invalid header layout: umbrella header found at '/include/Foo.h', but directories exist next to it: /include/Bar; consider removing them",
-                    severity: .error,
-                    metadata: expectedMetadata
+                    severity: .error
                 )
+                XCTAssertEqual(diagnostic?.metadata?.targetName, "Foo")
             }
         }
     }

--- a/Tests/PackageLoadingTests/PDLoadingTests.swift
+++ b/Tests/PackageLoadingTests/PDLoadingTests.swift
@@ -1,9 +1,9 @@
 /*
  This source file is part of the Swift.org open source project
- 
+
  Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
- 
+
  See http://swift.org/LICENSE.txt for license information
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
@@ -26,186 +26,32 @@ class PackageDescriptionLoadingTests: XCTestCase, ManifestLoaderDelegate {
     public func willParse(manifest: AbsolutePath) {
         parsedManifest = manifest
     }
-    
+
     var toolsVersion: ToolsVersion {
         fatalError("implement in subclass")
     }
-    
-    func loadManifestThrowing(
+
+    func loadManifest(
         _ contents: String,
         toolsVersion: ToolsVersion? = nil,
         packageKind: PackageReference.Kind? = nil,
+        observabilityScope: ObservabilityScope,
         file: StaticString = #file,
-        line: UInt = #line,
-        body: (Manifest) -> Void
-    ) throws {
-        try self.loadManifestThrowing(ByteString(encodingAsUTF8: contents),
-                                      toolsVersion: toolsVersion,
-                                      packageKind: packageKind,
-                                      file: file,
-                                      line: line,
-                                      body: body)
-    }
-
-    // TODO: deprecate in favor of String version
-    func loadManifestThrowing(
-        _ contents: ByteString,
-        toolsVersion: ToolsVersion? = nil,
-        packageKind: PackageReference.Kind? = nil,
-        file: StaticString = #file,
-        line: UInt = #line,
-        body: (Manifest) -> Void
-    ) throws {
-        let packageKind = packageKind ?? .fileSystem(.root)
-        let packagePath: AbsolutePath
-        switch packageKind {
-        case .root(let path):
-            packagePath = path
-        case .fileSystem(let path):
-            packagePath = path
-        case .localSourceControl(let path):
-            packagePath = path
-        case .remoteSourceControl, .registry:
-            throw InternalError("invalid package kind \(packageKind)")
-        }
-
-        let toolsVersion = toolsVersion ?? self.toolsVersion
-        let fs = InMemoryFileSystem()
-        let manifestPath = packagePath.appending(component: Manifest.filename)
-        try fs.writeFileContents(manifestPath, bytes: contents)
-        let m = try manifestLoader.load(
-            at: packagePath,
-            packageKind: packageKind,
+        line: UInt = #line
+    ) throws -> Manifest {
+        try self.loadManifest(
+            ByteString(encodingAsUTF8: contents),
             toolsVersion: toolsVersion,
-            fileSystem: fs)
-        guard m.toolsVersion == toolsVersion else {
-            return XCTFail("Invalid manifest version", file: file, line: line)
-        }
-        body(m)
-    }
-    
-    func loadManifest(
-        _ contents: String,
-        toolsVersion: ToolsVersion? = nil,
-        packageKind: PackageReference.Kind? = nil,
-        line: UInt = #line,
-        body: (Manifest) -> Void
-    ) {
-        self.loadManifest(ByteString(encodingAsUTF8: contents),
-                          toolsVersion: toolsVersion,
-                          packageKind: packageKind,
-                          line: line,
-                          body: body)
+            packageKind: packageKind,
+            observabilityScope: observabilityScope
+        )
     }
 
-    // TODO: deprecate in favor of String version
     func loadManifest(
-        _ contents: ByteString,
+        _ bytes: ByteString,
         toolsVersion: ToolsVersion? = nil,
         packageKind: PackageReference.Kind? = nil,
-        line: UInt = #line,
-        body: (Manifest) -> Void
-    ) {
-        do {
-            let toolsVersion = toolsVersion ?? self.toolsVersion
-            try loadManifestThrowing(
-                contents,
-                toolsVersion: toolsVersion,
-                packageKind: packageKind,
-                line: line,
-                body: body
-            )
-        } catch ManifestParseError.invalidManifestFormat(let error, _) {
-            print(error)
-            XCTFail(file: #file, line: line)
-        } catch {
-            XCTFail("Unexpected error: \(error)", file: #file, line: line)
-        }
-    }
-
-    func XCTAssertManifestLoadNoThrows(
-        _ contents: String,
-        toolsVersion: ToolsVersion? = nil,
-        packageKind: PackageReference.Kind? = nil,
-        file: StaticString = #file,
-        line: UInt = #line,
-        onSuccess: ((Manifest, DiagnosticsTestResult) -> Void)? = nil
-    ) {
-        let observability = ObservabilitySystem.makeForTesting()
-        
-        do {
-            let manifest = try loadManifest(
-                contents,
-                toolsVersion: toolsVersion ?? self.toolsVersion,
-                packageKind: packageKind,
-                diagnostics: observability.topScope.makeDiagnosticsEngine(),
-                file: file,
-                line: line)
-            
-            if let onSuccess = onSuccess {
-                testDiagnostics(observability.diagnostics) { result in
-                    onSuccess(manifest, result)
-                }
-            }
-        } catch {
-            XCTFail("Unexpected error: \(error)", file: file, line: line)
-        }
-    }
-
-    func XCTAssertManifestLoadThrows(
-        _ contents: String,
-        toolsVersion: ToolsVersion? = nil,
-        packageKind: PackageReference.Kind? = nil,
-        file: StaticString = #file,
-        line: UInt = #line,
-        onCatch: ((Error, DiagnosticsTestResult) -> Void)? = nil
-    ) {
-        let observability = ObservabilitySystem.makeForTesting()
-        
-        do {
-            let manifest = try loadManifest(
-                contents,
-                toolsVersion: toolsVersion ?? self.toolsVersion,
-                packageKind: packageKind,
-                diagnostics: observability.topScope.makeDiagnosticsEngine(),
-                file: file,
-                line: line)
-            
-            XCTFail("Unexpected success: \(manifest)", file: file, line: line)
-        } catch {
-            if let onCatch = onCatch {
-                testDiagnostics(observability.diagnostics, file: file, line: line) { result in
-                    onCatch(error, result)
-                }
-            }
-        }
-    }
-    
-    func XCTAssertManifestLoadThrows<E: Error & Equatable>(
-        _ expectedError: E,
-        _ contents: String,
-        toolsVersion: ToolsVersion? = nil,
-        packageKind: PackageReference.Kind? = nil,
-        file: StaticString = #file,
-        line: UInt = #line,
-        onCatch: ((DiagnosticsTestResult) -> Void)? = nil
-    ) {
-        XCTAssertManifestLoadThrows(contents, toolsVersion: toolsVersion, file: file, line: line) { error, result in
-            if let typedError = error as? E, typedError == expectedError {
-                // Everything okay
-            } else {
-                XCTFail("Unexpected error: \(error)", file: file, line: line)
-            }
-            
-            onCatch?(result)
-        }
-    }
-    
-    func loadManifest(
-        _ contents: String,
-        toolsVersion: ToolsVersion?,
-        packageKind: PackageReference.Kind? = nil,
-        diagnostics: DiagnosticsEngine?,
+        observabilityScope: ObservabilityScope,
         file: StaticString = #file,
         line: UInt = #line
     ) throws -> Manifest {
@@ -225,18 +71,19 @@ class PackageDescriptionLoadingTests: XCTestCase, ManifestLoaderDelegate {
         let toolsVersion = toolsVersion ?? self.toolsVersion
         let fileSystem = InMemoryFileSystem()
         let manifestPath = packagePath.appending(component: Manifest.filename)
-        try fileSystem.writeFileContents(manifestPath, bytes: ByteString(encodingAsUTF8: contents))
+        try fileSystem.writeFileContents(manifestPath, bytes: bytes)
         let manifest = try manifestLoader.load(
             at: packagePath,
             packageKind: packageKind,
             toolsVersion: toolsVersion,
             fileSystem: fileSystem,
-            diagnostics: diagnostics)
-        
+            observabilityScope: observabilityScope
+        )
+
         if manifest.toolsVersion != toolsVersion {
             XCTFail("Invalid manifest version", file: file, line: line)
         }
-        
+
         return manifest
     }
 }

--- a/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
@@ -22,9 +22,8 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
         .v4_2
     }
 
-    func testBasics() {
-        let stream = BufferedOutputByteStream()
-        stream <<< """
+    func testBasics() throws {
+        let content = """
             import PackageDescription
             let package = Package(
                 name: "Trivial",
@@ -48,157 +47,169 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        loadManifest(stream.bytes) { manifest in
-            XCTAssertEqual(manifest.name, "Trivial")
+        let observability = ObservabilitySystem.makeForTesting()
+        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        XCTAssertNoDiagnostics(observability.diagnostics)
 
-            // Check targets.
-            let foo = manifest.targetMap["foo"]!
-            XCTAssertEqual(foo.name, "foo")
-            XCTAssertFalse(foo.isTest)
-            XCTAssertEqual(foo.dependencies, ["dep1", .product(name: "product"), .target(name: "target")])
+        XCTAssertEqual(manifest.name, "Trivial")
 
-            let bar = manifest.targetMap["bar"]!
-            XCTAssertEqual(bar.name, "bar")
-            XCTAssertTrue(bar.isTest)
-            XCTAssertEqual(bar.dependencies, ["foo"])
+        // Check targets.
+        let foo = manifest.targetMap["foo"]!
+        XCTAssertEqual(foo.name, "foo")
+        XCTAssertFalse(foo.isTest)
+        XCTAssertEqual(foo.dependencies, ["dep1", .product(name: "product"), .target(name: "target")])
 
-            // Check dependencies.
-            let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
-            XCTAssertEqual(deps["foo1"], .localSourceControl(path: .init("/foo1"), requirement: .upToNextMajor(from: "1.0.0")))
+        let bar = manifest.targetMap["bar"]!
+        XCTAssertEqual(bar.name, "bar")
+        XCTAssertTrue(bar.isTest)
+        XCTAssertEqual(bar.dependencies, ["foo"])
 
-            // Check products.
-            let products = Dictionary(uniqueKeysWithValues: manifest.products.map{ ($0.name, $0) })
+        // Check dependencies.
+        let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
+        XCTAssertEqual(deps["foo1"], .localSourceControl(path: .init("/foo1"), requirement: .upToNextMajor(from: "1.0.0")))
 
-            let tool = products["tool"]!
-            XCTAssertEqual(tool.name, "tool")
-            XCTAssertEqual(tool.targets, ["tool"])
-            XCTAssertEqual(tool.type, .executable)
+        // Check products.
+        let products = Dictionary(uniqueKeysWithValues: manifest.products.map{ ($0.name, $0) })
 
-            let fooProduct = products["Foo"]!
-            XCTAssertEqual(fooProduct.name, "Foo")
-            XCTAssertEqual(fooProduct.type, .library(.automatic))
-            XCTAssertEqual(fooProduct.targets, ["foo"])
-        }
+        let tool = products["tool"]!
+        XCTAssertEqual(tool.name, "tool")
+        XCTAssertEqual(tool.targets, ["tool"])
+        XCTAssertEqual(tool.type, .executable)
+
+        let fooProduct = products["Foo"]!
+        XCTAssertEqual(fooProduct.name, "Foo")
+        XCTAssertEqual(fooProduct.type, .library(.automatic))
+        XCTAssertEqual(fooProduct.targets, ["foo"])
     }
 
     func testSwiftLanguageVersions() throws {
         // Ensure integer values are not accepted.
-        var stream = BufferedOutputByteStream()
-        stream <<< """
-            import PackageDescription
-            let package = Package(
-               name: "Foo",
-               swiftLanguageVersions: [3, 4]
-            )
-            """
-
         do {
-            try loadManifestThrowing(stream.bytes) { _ in }
-            XCTFail()
-        } catch {
-            guard case let ManifestParseError.invalidManifestFormat(output, _) = error else {
-                return XCTFail()
+            let content = """
+                import PackageDescription
+                let package = Package(
+                   name: "Foo",
+                   swiftLanguageVersions: [3, 4]
+                )
+                """
+
+            let observability = ObservabilitySystem.makeForTesting()
+            XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error") { error in
+                if case ManifestParseError.invalidManifestFormat(let message, _) = error {
+                    XCTAssertMatch(
+                        message,
+                            .and(
+                                .contains("'init(name:pkgConfig:providers:products:dependencies:targets:swiftLanguageVersions:cLanguageStandard:cxxLanguageStandard:)' is unavailable"),
+                                    .contains("was obsoleted in PackageDescription 4.2")
+                            )
+                    )
+                } else {
+                    XCTFail("unexpected error: \(error)")
+                }
             }
-            XCTAssertMatch(output, .and(.contains("'init(name:pkgConfig:providers:products:dependencies:targets:swiftLanguageVersions:cLanguageStandard:cxxLanguageStandard:)' is unavailable"), .contains("was obsoleted in PackageDescription 4.2")))
         }
 
         // Check when Swift language versions is empty.
-        stream = BufferedOutputByteStream()
-        stream <<< """
-            import PackageDescription
-            let package = Package(
-               name: "Foo",
-               swiftLanguageVersions: []
-            )
-            """
-        loadManifest(stream.bytes) { manifest in
+        do {
+            let content = """
+                import PackageDescription
+                let package = Package(
+                   name: "Foo",
+                   swiftLanguageVersions: []
+                )
+                """
+
+            let observability = ObservabilitySystem.makeForTesting()
+            let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+            XCTAssertNoDiagnostics(observability.diagnostics)
+
             XCTAssertEqual(manifest.swiftLanguageVersions, [])
         }
 
-        stream = BufferedOutputByteStream()
-        stream <<< """
-            import PackageDescription
-            let package = Package(
-               name: "Foo",
-               swiftLanguageVersions: [.v3, .v4, .v4_2, .version("5")]
-            )
-            """
-        loadManifest(stream.bytes) { manifest in
+        do {
+            let content = """
+                import PackageDescription
+                let package = Package(
+                   name: "Foo",
+                   swiftLanguageVersions: [.v3, .v4, .v4_2, .version("5")]
+                )
+                """
+
+            let observability = ObservabilitySystem.makeForTesting()
+            let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+            XCTAssertNoDiagnostics(observability.diagnostics)
+
             XCTAssertEqual(
                 manifest.swiftLanguageVersions,
                 [.v3, .v4, .v4_2, SwiftLanguageVersion(string: "5")!]
             )
         }
 
-        stream = BufferedOutputByteStream()
-        stream <<< """
-            import PackageDescription
-            let package = Package(
-               name: "Foo",
-               swiftLanguageVersions: [.v5]
-            )
-            """
-
         do {
-            try loadManifestThrowing(stream.bytes) { _ in }
-            XCTFail()
-        } catch {
-            guard case let ManifestParseError.invalidManifestFormat(message, _) = error else {
-                return XCTFail("\(error)")
-            }
+            let content = """
+                import PackageDescription
+                let package = Package(
+                   name: "Foo",
+                   swiftLanguageVersions: [.v5]
+                )
+                """
 
-            XCTAssertMatch(message, .contains("is unavailable"))
-            XCTAssertMatch(message, .contains("was introduced in PackageDescription 5"))
+            let observability = ObservabilitySystem.makeForTesting()
+            XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error") { error in
+                if case ManifestParseError.invalidManifestFormat(let message, _) = error {
+                    XCTAssertMatch(message, .contains("is unavailable"))
+                    XCTAssertMatch(message, .contains("was introduced in PackageDescription 5"))
+                } else {
+                    XCTFail("unexpected error: \(error)")
+                }
+            }
         }
     }
 
     func testPlatforms() throws {
-        var stream = BufferedOutputByteStream()
-        stream <<< """
-            import PackageDescription
-            let package = Package(
-               name: "Foo",
-               platforms: nil
-            )
-            """
-
         do {
-            try loadManifestThrowing(stream.bytes) { _ in }
-            XCTFail()
-        } catch {
-            guard case let ManifestParseError.invalidManifestFormat(message, _) = error else {
-                return XCTFail("\(error)")
-            }
+            let content = """
+                import PackageDescription
+                let package = Package(
+                   name: "Foo",
+                   platforms: nil
+                )
+                """
 
-            XCTAssertMatch(message, .contains("is unavailable"))
-            XCTAssertMatch(message, .contains("was introduced in PackageDescription 5"))
+            let observability = ObservabilitySystem.makeForTesting()
+            XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error") { error in
+                if case ManifestParseError.invalidManifestFormat(let message, _) = error {
+                    XCTAssertMatch(message, .contains("is unavailable"))
+                    XCTAssertMatch(message, .contains("was introduced in PackageDescription 5"))
+                } else {
+                    XCTFail("unexpected error: \(error)")
+                }
+            }
         }
 
-        stream = BufferedOutputByteStream()
-        stream <<< """
-            import PackageDescription
-            let package = Package(
-               name: "Foo",
-               platforms: [.macOS(.v10_10)]
-            )
-            """
-
         do {
-            try loadManifestThrowing(stream.bytes) { _ in }
-            XCTFail()
-        } catch {
-            guard case let ManifestParseError.invalidManifestFormat(message, _) = error else {
-                return XCTFail("\(error)")
-            }
+            let content = """
+                import PackageDescription
+                let package = Package(
+                   name: "Foo",
+                   platforms: [.macOS(.v10_10)]
+                )
+                """
 
-            XCTAssertMatch(message, .contains("is unavailable"))
-            XCTAssertMatch(message, .contains("was introduced in PackageDescription 5"))
+            let observability = ObservabilitySystem.makeForTesting()
+            XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error") { error in
+                if case ManifestParseError.invalidManifestFormat(let message, _) = error {
+                    XCTAssertMatch(message, .contains("is unavailable"))
+                    XCTAssertMatch(message, .contains("was introduced in PackageDescription 5"))
+                } else {
+                    XCTFail("unexpected error: \(error)")
+                }
+            }
         }
     }
 
     func testBuildSettings() throws {
-        let stream = BufferedOutputByteStream()
-        stream <<< """
+        let content = """
             import PackageDescription
             let package = Package(
                name: "Foo",
@@ -216,22 +227,19 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        do {
-            try loadManifestThrowing(stream.bytes) { _ in }
-            XCTFail()
-        } catch {
-            guard case let ManifestParseError.invalidManifestFormat(message, _) = error else {
-                return XCTFail("\(error)")
+        let observability = ObservabilitySystem.makeForTesting()
+        XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error") { error in
+            if case ManifestParseError.invalidManifestFormat(let message, _) = error {
+                XCTAssertMatch(message, .contains("is unavailable"))
+                XCTAssertMatch(message, .contains("was introduced in PackageDescription 5"))
+            } else {
+                XCTFail("unexpected error: \(error)")
             }
-
-            XCTAssertMatch(message, .contains("is unavailable"))
-            XCTAssertMatch(message, .contains("was introduced in PackageDescription 5"))
         }
     }
 
     func testPackageDependencies() throws {
-        let stream = BufferedOutputByteStream()
-        stream <<< """
+        let content = """
             import PackageDescription
             let package = Package(
                name: "Foo",
@@ -253,65 +261,67 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                ]
             )
             """
-       loadManifest(stream.bytes) { manifest in
-            let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
-            XCTAssertEqual(deps["foo1"], .localSourceControl(path: .init("/foo1"), requirement: .upToNextMajor(from: "1.0.0")))
-            XCTAssertEqual(deps["foo2"], .localSourceControl(path: .init("/foo2"), requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
 
-            if case .fileSystem(let dep) = deps["foo3"] {
-                XCTAssertEqual(dep.path.pathString, "/foo3")
-            } else {
-                XCTFail("expected to be local dependency")
-            }
+        let observability = ObservabilitySystem.makeForTesting()
+        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        XCTAssertNoDiagnostics(observability.diagnostics)
 
-            if case .fileSystem(let dep) = deps["foo4"] {
-                XCTAssertEqual(dep.path.pathString, "/path/to/foo4")
-            } else {
-                XCTFail("expected to be local dependency")
-            }
+        let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
+        XCTAssertEqual(deps["foo1"], .localSourceControl(path: .init("/foo1"), requirement: .upToNextMajor(from: "1.0.0")))
+        XCTAssertEqual(deps["foo2"], .localSourceControl(path: .init("/foo2"), requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
 
-            XCTAssertEqual(deps["foo5"], .localSourceControl(path: .init("/foo5"), requirement: .exact("1.2.3")))
-            XCTAssertEqual(deps["foo6"], .localSourceControl(path: .init("/foo6"), requirement: .range("1.2.3"..<"2.0.0")))
-            XCTAssertEqual(deps["foo7"], .localSourceControl(path: .init("/foo7"), requirement: .branch("master")))
-            XCTAssertEqual(deps["foo8"], .localSourceControl(path: .init("/foo8"), requirement: .upToNextMinor(from: "1.3.4")))
-            XCTAssertEqual(deps["foo9"], .localSourceControl(path: .init("/foo9"), requirement: .upToNextMajor(from: "1.3.4")))
+        if case .fileSystem(let dep) = deps["foo3"] {
+            XCTAssertEqual(dep.path.pathString, "/foo3")
+        } else {
+            XCTFail("expected to be local dependency")
+        }
 
-            let homeDir = "/home/user"
-            if case .fileSystem(let dep) = deps["foo10"] {
-                XCTAssertEqual(dep.path.pathString, "\(homeDir)/path/to/foo10")
-            } else {
-                XCTFail("expected to be local dependency")
-            }
+        if case .fileSystem(let dep) = deps["foo4"] {
+            XCTAssertEqual(dep.path.pathString, "/path/to/foo4")
+        } else {
+            XCTFail("expected to be local dependency")
+        }
 
-            if case .fileSystem(let dep) = deps["~foo11"] {
-                XCTAssertEqual(dep.path.pathString, "/~foo11")
-            } else {
-                XCTFail("expected to be local dependency")
-            }
+        XCTAssertEqual(deps["foo5"], .localSourceControl(path: .init("/foo5"), requirement: .exact("1.2.3")))
+        XCTAssertEqual(deps["foo6"], .localSourceControl(path: .init("/foo6"), requirement: .range("1.2.3"..<"2.0.0")))
+        XCTAssertEqual(deps["foo7"], .localSourceControl(path: .init("/foo7"), requirement: .branch("master")))
+        XCTAssertEqual(deps["foo8"], .localSourceControl(path: .init("/foo8"), requirement: .upToNextMinor(from: "1.3.4")))
+        XCTAssertEqual(deps["foo9"], .localSourceControl(path: .init("/foo9"), requirement: .upToNextMajor(from: "1.3.4")))
 
-            if case .fileSystem(let dep) = deps["foo12"] {
-                XCTAssertEqual(dep.path.pathString, "\(homeDir)/path/to/~/foo12")
-            } else {
-                XCTFail("expected to be local dependency")
-            }
+        let homeDir = "/home/user"
+        if case .fileSystem(let dep) = deps["foo10"] {
+            XCTAssertEqual(dep.path.pathString, "\(homeDir)/path/to/foo10")
+        } else {
+            XCTFail("expected to be local dependency")
+        }
 
-            if case .fileSystem(let dep) = deps["~"] {
-                XCTAssertEqual(dep.path.pathString, "/~")
-            } else {
-                XCTFail("expected to be local dependency")
-            }
+        if case .fileSystem(let dep) = deps["~foo11"] {
+            XCTAssertEqual(dep.path.pathString, "/~foo11")
+        } else {
+            XCTFail("expected to be local dependency")
+        }
 
-            if case .fileSystem(let dep) = deps["foo13"] {
-                XCTAssertEqual(dep.path.pathString, "/path/to/foo13")
-            } else {
-                XCTFail("expected to be local dependency")
-            }
+        if case .fileSystem(let dep) = deps["foo12"] {
+            XCTAssertEqual(dep.path.pathString, "\(homeDir)/path/to/~/foo12")
+        } else {
+            XCTFail("expected to be local dependency")
+        }
+
+        if case .fileSystem(let dep) = deps["~"] {
+            XCTAssertEqual(dep.path.pathString, "/~")
+        } else {
+            XCTFail("expected to be local dependency")
+        }
+
+        if case .fileSystem(let dep) = deps["foo13"] {
+            XCTAssertEqual(dep.path.pathString, "/path/to/foo13")
+        } else {
+            XCTFail("expected to be local dependency")
         }
     }
 
     func testSystemLibraryTargets() throws {
-        let stream = BufferedOutputByteStream()
-        stream <<< """
+        let content = """
             import PackageDescription
             let package = Package(
                name: "Foo",
@@ -329,19 +339,22 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                 ]
             )
             """
-       loadManifest(stream.bytes) { manifest in
-            let foo = manifest.targetMap["foo"]!
-            XCTAssertEqual(foo.name, "foo")
-            XCTAssertFalse(foo.isTest)
-            XCTAssertEqual(foo.type, .regular)
-            XCTAssertEqual(foo.dependencies, ["bar"])
 
-            let bar = manifest.targetMap["bar"]!
-            XCTAssertEqual(bar.name, "bar")
-            XCTAssertEqual(bar.type, .system)
-            XCTAssertEqual(bar.pkgConfig, "libbar")
-            XCTAssertEqual(bar.providers, [.brew(["libgit"]), .apt(["a", "b"])])
-        }
+        let observability = ObservabilitySystem.makeForTesting()
+        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
+        let foo = manifest.targetMap["foo"]!
+        XCTAssertEqual(foo.name, "foo")
+        XCTAssertFalse(foo.isTest)
+        XCTAssertEqual(foo.type, .regular)
+        XCTAssertEqual(foo.dependencies, ["bar"])
+
+        let bar = manifest.targetMap["bar"]!
+        XCTAssertEqual(bar.name, "bar")
+        XCTAssertEqual(bar.type, .system)
+        XCTAssertEqual(bar.pkgConfig, "libbar")
+        XCTAssertEqual(bar.providers, [.brew(["libgit"]), .apt(["a", "b"])])
     }
 
     /// Check that we load the manifest appropriate for the current version, if
@@ -381,17 +394,19 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                 at: root,
                 packageKind: .root(.root),
                 toolsVersion: .v4_2,
-                fileSystem: fs
+                fileSystem: fs,
+                observabilityScope: ObservabilitySystem.NOOP
             )
             XCTAssertEqual(manifest.name, "Trivial")
         }
     }
-    
+
     // Check that ancient `Package@swift-3.swift` manifests are properly treated as 3.1 even without a tools-version comment.
     func testVersionSpecificLoadingOfVersion3Manifest() throws {
         // Create a temporary FS to hold the package manifests.
         let fs = InMemoryFileSystem()
-        
+        let observability = ObservabilitySystem.makeForTesting()
+
         // Write a regular manifest with a tools version comment, and a `Package@swift-3.swift` manifest without one.
         let packageDir = AbsolutePath.root
         let manifestContents = "import PackageDescription\nlet package = Package(name: \"Trivial\")"
@@ -402,9 +417,10 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             packageDir.appending(component: Manifest.basename + "@swift-3.swift"),
             bytes: ByteString(encodingAsUTF8: manifestContents))
         // Check we can load the manifest.
-        let manifest = try manifestLoader.load(at: packageDir, packageKind: .root(packageDir), toolsVersion: .v4_2, fileSystem: fs)
+        let manifest = try manifestLoader.load(at: packageDir, packageKind: .root(packageDir), toolsVersion: .v4_2, fileSystem: fs, observabilityScope: observability.topScope)
+        XCTAssertNoDiagnostics(observability.diagnostics)
         XCTAssertEqual(manifest.name, "Trivial")
-        
+
         // Switch it around so that the main manifest is now the one that doesn't have a comment.
         try fs.writeFileContents(
             packageDir.appending(component: Manifest.basename + ".swift"),
@@ -413,13 +429,13 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             packageDir.appending(component: Manifest.basename + "@swift-4.swift"),
             bytes: ByteString(encodingAsUTF8: "// swift-tools-version:4.0\n" + manifestContents))
         // Check we can load the manifest.
-        let manifest2 = try manifestLoader.load(at: packageDir, packageKind: .root(packageDir), toolsVersion: .v4_2, fileSystem: fs)
+        let manifest2 = try manifestLoader.load(at: packageDir, packageKind: .root(packageDir), toolsVersion: .v4_2, fileSystem: fs, observabilityScope: observability.topScope)
+        XCTAssertNoDiagnostics(observability.diagnostics)
         XCTAssertEqual(manifest2.name, "Trivial")
     }
 
     func testRuntimeManifestErrors() throws {
-        let stream = BufferedOutputByteStream()
-        stream <<< """
+        let content = """
             import PackageDescription
             let package = Package(
                 name: "Trivial",
@@ -441,17 +457,18 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-
-        do {
-            try loadManifestThrowing(stream.bytes) { _ in }
-            XCTFail("Unexpected success")
-        } catch ManifestParseError.runtimeManifestErrors(let errors) {
-            XCTAssertEqual(errors, ["Invalid semantic version string '1.0,0'"])
+        let observability = ObservabilitySystem.makeForTesting()
+        XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error") { error in
+            if case ManifestParseError.runtimeManifestErrors(let errors) = error {
+                XCTAssertEqual(errors, ["Invalid semantic version string '1.0,0'"])
+            } else {
+                XCTFail("unexpected error: \(error)")
+            }
         }
     }
 
     func testDuplicateDependencyDecl() throws {
-        let manifest = """
+        let content = """
             import PackageDescription
             let package = Package(
                 name: "Trivial",
@@ -471,15 +488,16 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        XCTAssertManifestLoadThrows(manifest) { _, diagnostics in
-            diagnostics.check(diagnostic: .regex("duplicate dependency 'foo(1|2)'"), severity: .error)
-            diagnostics.check(diagnostic: .regex("duplicate dependency 'foo(1|2)'"), severity: .error)
+        let observability = ObservabilitySystem.makeForTesting()
+        XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error")
+        testDiagnostics(observability.diagnostics) { result in
+            result.check(diagnostic: .regex("duplicate dependency 'foo(1|2)'"), severity: .error)
+            result.check(diagnostic: .regex("duplicate dependency 'foo(1|2)'"), severity: .error)
         }
     }
 
     func testNotAbsoluteDependencyPath() throws {
-        let stream = BufferedOutputByteStream()
-        stream <<< """
+        let content = """
         import PackageDescription
         let package = Package(
             name: "Trivial",
@@ -494,12 +512,14 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
         )
         """
 
-        do {
-            try loadManifestThrowing(stream.bytes) { _ in }
-            XCTFail("Unexpected success")
-        } catch ManifestParseError.invalidManifestFormat(let message, let diagnosticFile) {
-            XCTAssertNil(diagnosticFile)
-            XCTAssertEqual(message, "'https://someurl.com' is not a valid path for path-based dependencies; use relative or absolute path instead.")
+        let observability = ObservabilitySystem.makeForTesting()
+        XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error") { error in
+            if case ManifestParseError.invalidManifestFormat(let message, let diagnosticFile) = error {
+                XCTAssertNil(diagnosticFile)
+                XCTAssertEqual(message, "'https://someurl.com' is not a valid path for path-based dependencies; use relative or absolute path instead.")
+            } else {
+                XCTFail("unexpected error: \(error)")
+            }
         }
     }
 
@@ -524,7 +544,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
           ("file://localhost/bar", .unsupportedHostname), // Local but non-trivial (e.g. on Windows, this is a UNC path).
         ]
         for (url, expectedError) in urls {
-            let manifest = """
+            let content = """
             import PackageDescription
             let package = Package(
                 name: "Trivial",
@@ -538,13 +558,18 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                 ]
             )
             """
-            XCTAssertManifestLoadThrows(expectedError.manifestError, manifest)
+
+            let observability = ObservabilitySystem.makeForTesting()
+            XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error") { error in
+                XCTAssertEqual(error as? ManifestParseError, expectedError.manifestError)
+            }
         }
     }
 
     func testCacheInvalidationOnEnv() throws {
         try testWithTemporaryDirectory { path in
             let fs = localFileSystem
+            let observability = ObservabilitySystem.makeForTesting()
 
             let manifestPath = path.appending(components: "pkg", "Package.swift")
             try fs.writeFileContents(manifestPath) { stream in
@@ -573,9 +598,11 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                     at: manifestPath.parentDirectory,
                     packageKind: .fileSystem(manifestPath.parentDirectory),
                     toolsVersion: .v4_2,
-                    fileSystem: fs
+                    fileSystem: fs,
+                    observabilityScope: observability.topScope
                 )
 
+                XCTAssertNoDiagnostics(observability.diagnostics)
                 XCTAssertEqual(try delegate.loaded(timeout: .now() + 1), [manifestPath])
                 XCTAssertEqual(try delegate.parsed(timeout: .now() + 1), expectCached ? [] : [manifestPath])
                 XCTAssertEqual(manifest.name, "Trivial")
@@ -602,6 +629,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
     func testCaching() throws {
         try testWithTemporaryDirectory { path in
             let fs = localFileSystem
+            let observability = ObservabilitySystem.makeForTesting()
 
             let manifestPath = path.appending(components: "pkg", "Package.swift")
             try fs.writeFileContents(manifestPath) { stream in
@@ -630,9 +658,11 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                     at: manifestPath.parentDirectory,
                     packageKind: .fileSystem(manifestPath.parentDirectory),
                     toolsVersion: .v4_2,
-                    fileSystem: fs
+                    fileSystem: fs,
+                    observabilityScope: observability.topScope
                 )
 
+                XCTAssertNoDiagnostics(observability.diagnostics)
                 XCTAssertEqual(try delegate.loaded(timeout: .now() + 1), [manifestPath])
                 XCTAssertEqual(try delegate.parsed(timeout: .now() + 1), expectCached ? [] : [manifestPath])
                 XCTAssertEqual(manifest.name, "Trivial")
@@ -697,6 +727,8 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
 
             func check(loader: ManifestLoader) throws {
                 let fs = InMemoryFileSystem()
+                let observability = ObservabilitySystem.makeForTesting()
+
                 let manifestPath = AbsolutePath.root.appending(component: Manifest.filename)
                 try fs.writeFileContents(manifestPath, bytes: stream.bytes)
 
@@ -704,8 +736,11 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                     at: .root,
                     packageKind: .root(.root),
                     toolsVersion: .v4_2,
-                    fileSystem: fs)
+                    fileSystem: fs,
+                    observabilityScope: observability.topScope
+                )
 
+                XCTAssertNoDiagnostics(observability.diagnostics)
                 XCTAssertEqual(m.name, "Trivial")
             }
 
@@ -734,7 +769,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
     }
 
     func testProductTargetNotFound() throws {
-        let manifest = """
+        let content = """
             import PackageDescription
 
             let package = Package(
@@ -750,12 +785,19 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
+        let observability = ObservabilitySystem.makeForTesting()
+        //_ = try loadManifest(content, observabilityScope: observability.topScope)
+        XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error")
+        testDiagnostics(observability.diagnostics) { result in
+            result.check(diagnostic: .contains("target 'B' referenced in product 'Product' could not be found; valid targets are: 'A', 'C', 'b'"), severity: .error)
+        }
+        /*
         XCTAssertManifestLoadThrows(manifest) { _, diagnostics in
             diagnostics.check(diagnostic: "target 'B' referenced in product 'Product' could not be found; valid targets are: 'A', 'C', 'b'", severity: .error)
-        }
+        }*/
     }
 
-    func testLoadingWithoutDiagnostics() throws {
+    /*func testLoadingWithoutDiagnostics() throws {
         let manifest = """
             import PackageDescription
 
@@ -781,7 +823,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
         } catch let error as StringError {
             XCTAssertMatch(error.description, "target 'B' referenced in product 'Product' could not be found; valid targets are: 'A'")
         }
-    }
+    }*/
 
     // run this with TSAN/ASAN to detect concurrency issues
     func testConcurrencyWithWarmup() throws {
@@ -810,42 +852,51 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
 
             // warm up caches
             delegate.prepare()
-            let manifest = try tsc_await { manifestLoader.load(at: manifestPath.parentDirectory,
-                                                               packageIdentity: .plain("Trivial"),
-                                                               packageKind: .fileSystem(manifestPath.parentDirectory),
-                                                               packageLocation: manifestPath.pathString,
-                                                               version: nil,
-                                                               revision: nil,
-                                                               toolsVersion: .v4_2,
-                                                               identityResolver: identityResolver,
-                                                               fileSystem: localFileSystem,
-                                                               on: .global(),
-                                                               completion: $0) }
+            let manifest = try tsc_await {
+                manifestLoader.load(
+                    at: manifestPath.parentDirectory,
+                    packageIdentity: .plain("Trivial"),
+                    packageKind: .fileSystem(manifestPath.parentDirectory),
+                    packageLocation: manifestPath.pathString,
+                    version: nil,
+                    revision: nil,
+                    toolsVersion: .v4_2,
+                    identityResolver: identityResolver,
+                    fileSystem: localFileSystem,
+                    observabilityScope: observability.topScope,
+                    on: .global(),
+                    completion: $0
+                )
+            }
+
+            XCTAssertNoDiagnostics(observability.diagnostics)
             XCTAssertEqual(manifest.name, "Trivial")
             XCTAssertEqual(manifest.targets[0].name, "foo")
-
 
             let sync = DispatchGroup()
             for _ in 0 ..< total {
                 sync.enter()
                 delegate.prepare(expectParsing: false)
-                manifestLoader.load(at: manifestPath.parentDirectory,
-                                    packageIdentity: .plain("Trivial"),
-                                    packageKind: .fileSystem(manifestPath.parentDirectory),
-                                    packageLocation: manifestPath.pathString,
-                                    version: nil,
-                                    revision: nil,
-                                    toolsVersion: .v4_2,
-                                    identityResolver: identityResolver,
-                                    fileSystem: localFileSystem,
-                                    diagnostics: observability.topScope.makeDiagnosticsEngine(),
-                                    on: .global()) { result in
+                manifestLoader.load(
+                    at: manifestPath.parentDirectory,
+                    packageIdentity: .plain("Trivial"),
+                    packageKind: .fileSystem(manifestPath.parentDirectory),
+                    packageLocation: manifestPath.pathString,
+                    version: nil,
+                    revision: nil,
+                    toolsVersion: .v4_2,
+                    identityResolver: identityResolver,
+                    fileSystem: localFileSystem,
+                    observabilityScope: observability.topScope,
+                    on: .global()
+                ) { result in
                     defer { sync.leave() }
 
                     switch result {
                     case .failure(let error):
                         XCTFail("\(error)")
                     case .success(let manifest):
+                        XCTAssertNoDiagnostics(observability.diagnostics)
                         XCTAssertEqual(manifest.name, "Trivial")
                         XCTAssertEqual(manifest.targets[0].name, "foo")
                     }
@@ -894,17 +945,19 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
 
                 sync.enter()
                 delegate.prepare()
-                manifestLoader.load(at: manifestPath.parentDirectory,
-                                    packageIdentity: .plain("Trivial-\(random)"),
-                                    packageKind: .fileSystem(manifestPath.parentDirectory),
-                                    packageLocation: manifestPath.pathString,
-                                    version: nil,
-                                    revision: nil,
-                                    toolsVersion: .v4_2,
-                                    identityResolver: identityResolver,
-                                    fileSystem: localFileSystem,
-                                    diagnostics: observability.topScope.makeDiagnosticsEngine(),
-                                    on: .global()) { result in
+                manifestLoader.load(
+                    at: manifestPath.parentDirectory,
+                    packageIdentity: .plain("Trivial-\(random)"),
+                    packageKind: .fileSystem(manifestPath.parentDirectory),
+                    packageLocation: manifestPath.pathString,
+                    version: nil,
+                    revision: nil,
+                    toolsVersion: .v4_2,
+                    identityResolver: identityResolver,
+                    fileSystem: localFileSystem,
+                    observabilityScope: observability.topScope,
+                    on: .global()
+                ) { result in
                     defer { sync.leave() }
 
                     switch result {

--- a/Tests/PackageLoadingTests/PD_5_6_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_6_LoadingTests.swift
@@ -1,14 +1,16 @@
 /*
  This source file is part of the Swift.org open source project
- 
+
  Copyright (c) 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
- 
+
  See http://swift.org/LICENSE.txt for license information
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
+import Basics
 import PackageModel
+import SPMTestSupport
 import TSCBasic
 import XCTest
 
@@ -18,7 +20,7 @@ class PackageDescription5_6LoadingTests: PackageDescriptionLoadingTests {
     }
 
     func testSourceControlDependencies() throws {
-        let manifest = """
+        let content = """
             import PackageDescription
             let package = Package(
                name: "MyPackage",
@@ -47,28 +49,31 @@ class PackageDescription5_6LoadingTests: PackageDescriptionLoadingTests {
                ]
             )
             """
-        loadManifest(manifest, toolsVersion: self.toolsVersion) { manifest in
-            let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
-            XCTAssertEqual(deps["foo1"], .remoteSourceControl(identity: .plain("foo1"), deprecatedName: "foo1", url: URL(string: "http://localhost/foo1")!, requirement: .range("1.1.1" ..< "2.0.0")))
-            XCTAssertEqual(deps["foo2"], .remoteSourceControl(identity: .plain("foo2"), url: URL(string: "http://localhost/foo2")!, requirement: .range("1.1.1" ..< "2.0.0")))
-            XCTAssertEqual(deps["bar1"], .remoteSourceControl(identity: .plain("bar1"), deprecatedName: "bar1", url: URL(string: "http://localhost/bar1")!, requirement: .range("1.1.1" ..< "2.0.0")))
-            XCTAssertEqual(deps["bar2"], .remoteSourceControl(identity: .plain("bar2"), url: URL(string: "http://localhost/bar2")!, requirement: .range("1.1.1" ..< "2.0.0")))
-            XCTAssertEqual(deps["baz1"], .remoteSourceControl(identity: .plain("baz1"), deprecatedName: "baz1", url: URL(string: "http://localhost/baz1")!, requirement: .range("1.1.1" ..< "1.2.0")))
-            XCTAssertEqual(deps["baz2"], .remoteSourceControl(identity: .plain("baz2"), url: URL(string: "http://localhost/baz2")!, requirement: .range("1.1.1" ..< "1.2.0")))
-            XCTAssertEqual(deps["qux1"], .remoteSourceControl(identity: .plain("qux1"), deprecatedName: "qux1", url: URL(string: "http://localhost/qux1")!, requirement: .exact("1.1.1")))
-            XCTAssertEqual(deps["qux2"], .remoteSourceControl(identity: .plain("qux2"), url: URL(string: "http://localhost/qux2")!, requirement: .exact("1.1.1")))
-            XCTAssertEqual(deps["qux3"], .remoteSourceControl(identity: .plain("qux3"), url: URL(string: "http://localhost/qux3")!, requirement: .exact("1.1.1")))
-            XCTAssertEqual(deps["quux1"], .remoteSourceControl(identity: .plain("quux1"), deprecatedName: "quux1", url: URL(string: "http://localhost/quux1")!, requirement: .branch("main")))
-            XCTAssertEqual(deps["quux2"], .remoteSourceControl(identity: .plain("quux2"), url: URL(string: "http://localhost/quux2")!, requirement: .branch("main")))
-            XCTAssertEqual(deps["quux3"], .remoteSourceControl(identity: .plain("quux3"), url: URL(string: "http://localhost/quux3")!, requirement: .branch("main")))
-            XCTAssertEqual(deps["quuz1"], .remoteSourceControl(identity: .plain("quuz1"), deprecatedName: "quuz1", url: URL(string: "http://localhost/quuz1")!, requirement: .revision("abcdefg")))
-            XCTAssertEqual(deps["quuz2"], .remoteSourceControl(identity: .plain("quuz2"), url: URL(string: "http://localhost/quuz2")!, requirement: .revision("abcdefg")))
-            XCTAssertEqual(deps["quuz3"], .remoteSourceControl(identity: .plain("quuz3"), url: URL(string: "http://localhost/quuz3")!, requirement: .revision("abcdefg")))
-        }
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        XCTAssertFalse(observability.diagnostics.hasErrors)
+
+        let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
+        XCTAssertEqual(deps["foo1"], .remoteSourceControl(identity: .plain("foo1"), deprecatedName: "foo1", url: URL(string: "http://localhost/foo1")!, requirement: .range("1.1.1" ..< "2.0.0")))
+        XCTAssertEqual(deps["foo2"], .remoteSourceControl(identity: .plain("foo2"), url: URL(string: "http://localhost/foo2")!, requirement: .range("1.1.1" ..< "2.0.0")))
+        XCTAssertEqual(deps["bar1"], .remoteSourceControl(identity: .plain("bar1"), deprecatedName: "bar1", url: URL(string: "http://localhost/bar1")!, requirement: .range("1.1.1" ..< "2.0.0")))
+        XCTAssertEqual(deps["bar2"], .remoteSourceControl(identity: .plain("bar2"), url: URL(string: "http://localhost/bar2")!, requirement: .range("1.1.1" ..< "2.0.0")))
+        XCTAssertEqual(deps["baz1"], .remoteSourceControl(identity: .plain("baz1"), deprecatedName: "baz1", url: URL(string: "http://localhost/baz1")!, requirement: .range("1.1.1" ..< "1.2.0")))
+        XCTAssertEqual(deps["baz2"], .remoteSourceControl(identity: .plain("baz2"), url: URL(string: "http://localhost/baz2")!, requirement: .range("1.1.1" ..< "1.2.0")))
+        XCTAssertEqual(deps["qux1"], .remoteSourceControl(identity: .plain("qux1"), deprecatedName: "qux1", url: URL(string: "http://localhost/qux1")!, requirement: .exact("1.1.1")))
+        XCTAssertEqual(deps["qux2"], .remoteSourceControl(identity: .plain("qux2"), url: URL(string: "http://localhost/qux2")!, requirement: .exact("1.1.1")))
+        XCTAssertEqual(deps["qux3"], .remoteSourceControl(identity: .plain("qux3"), url: URL(string: "http://localhost/qux3")!, requirement: .exact("1.1.1")))
+        XCTAssertEqual(deps["quux1"], .remoteSourceControl(identity: .plain("quux1"), deprecatedName: "quux1", url: URL(string: "http://localhost/quux1")!, requirement: .branch("main")))
+        XCTAssertEqual(deps["quux2"], .remoteSourceControl(identity: .plain("quux2"), url: URL(string: "http://localhost/quux2")!, requirement: .branch("main")))
+        XCTAssertEqual(deps["quux3"], .remoteSourceControl(identity: .plain("quux3"), url: URL(string: "http://localhost/quux3")!, requirement: .branch("main")))
+        XCTAssertEqual(deps["quuz1"], .remoteSourceControl(identity: .plain("quuz1"), deprecatedName: "quuz1", url: URL(string: "http://localhost/quuz1")!, requirement: .revision("abcdefg")))
+        XCTAssertEqual(deps["quuz2"], .remoteSourceControl(identity: .plain("quuz2"), url: URL(string: "http://localhost/quuz2")!, requirement: .revision("abcdefg")))
+        XCTAssertEqual(deps["quuz3"], .remoteSourceControl(identity: .plain("quuz3"), url: URL(string: "http://localhost/quuz3")!, requirement: .revision("abcdefg")))
     }
 
     func testBuildToolPluginTarget() throws {
-        let manifest = """
+        let content = """
             import PackageDescription
             let package = Package(
                name: "Foo",
@@ -81,14 +86,16 @@ class PackageDescription5_6LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        loadManifest(manifest) { manifest in
-            XCTAssertEqual(manifest.targets[0].type, .plugin)
-            XCTAssertEqual(manifest.targets[0].pluginCapability, .buildTool)
-        }
+        let observability = ObservabilitySystem.makeForTesting()
+        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
+        XCTAssertEqual(manifest.targets[0].type, .plugin)
+        XCTAssertEqual(manifest.targets[0].pluginCapability, .buildTool)
     }
 
     func testPluginTargetCustomization() throws {
-        let manifest = """
+        let content = """
             import PackageDescription
             let package = Package(
                name: "Foo",
@@ -104,74 +111,80 @@ class PackageDescription5_6LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        loadManifest(manifest) { manifest in
-            XCTAssertEqual(manifest.targets[0].type, .plugin)
-            XCTAssertEqual(manifest.targets[0].pluginCapability, .buildTool)
-            XCTAssertEqual(manifest.targets[0].path, "Sources/Foo")
-            XCTAssertEqual(manifest.targets[0].exclude, ["IAmOut.swift"])
-            XCTAssertEqual(manifest.targets[0].sources, ["CountMeIn.swift"])
-        }
+        let observability = ObservabilitySystem.makeForTesting()
+        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
+        XCTAssertEqual(manifest.targets[0].type, .plugin)
+        XCTAssertEqual(manifest.targets[0].pluginCapability, .buildTool)
+        XCTAssertEqual(manifest.targets[0].path, "Sources/Foo")
+        XCTAssertEqual(manifest.targets[0].exclude, ["IAmOut.swift"])
+        XCTAssertEqual(manifest.targets[0].sources, ["CountMeIn.swift"])
     }
 
     func testCustomPlatforms() throws {
         // One custom platform.
-        var stream = BufferedOutputByteStream()
-        stream <<< """
-            import PackageDescription
-            let package = Package(
-               name: "Foo",
-               platforms: [
-                   .custom("customos", versionString: "1.0"),
-               ]
-            )
-            """
+        do {
+            let content = """
+                import PackageDescription
+                let package = Package(
+                   name: "Foo",
+                   platforms: [
+                       .custom("customos", versionString: "1.0"),
+                   ]
+                )
+                """
 
-        loadManifest(stream.bytes) { manifest in
+            let observability = ObservabilitySystem.makeForTesting()
+            let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+            XCTAssertNoDiagnostics(observability.diagnostics)
+
             XCTAssertEqual(manifest.platforms, [
                 PlatformDescription(name: "customos", version: "1.0"),
             ])
         }
 
         // Two custom platforms.
-        stream = BufferedOutputByteStream()
-        stream <<< """
-            import PackageDescription
-            let package = Package(
-               name: "Foo",
-               platforms: [
-                   .custom("customos", versionString: "1.0"),
-                   .custom("anothercustomos", versionString: "2.3"),
-               ]
-            )
-            """
+        do {
+            let content = """
+                import PackageDescription
+                let package = Package(
+                   name: "Foo",
+                   platforms: [
+                       .custom("customos", versionString: "1.0"),
+                       .custom("anothercustomos", versionString: "2.3"),
+                   ]
+                )
+                """
 
-        loadManifest(stream.bytes) { manifest in
+            let observability = ObservabilitySystem.makeForTesting()
+            let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+            XCTAssertNoDiagnostics(observability.diagnostics)
+
             XCTAssertEqual(manifest.platforms, [
                 PlatformDescription(name: "customos", version: "1.0"),
                 PlatformDescription(name: "anothercustomos", version: "2.3"),
             ])
         }
-
     }
     
     /// Tests use of Context.current.packageDirectory
     func testPackageContextName() throws {
-        let stream = BufferedOutputByteStream()
-        stream <<< """
+        let content = """
             import PackageDescription
             let package = Package(name: Context.packageDirectory)
             """
 
-        loadManifest(stream.bytes) { manifest in
-            let name = parsedManifest?.parentDirectory.pathString ?? ""
-            XCTAssertEqual(manifest.name, name)
-        }
+        let observability = ObservabilitySystem.makeForTesting()
+        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+
+        let name = parsedManifest?.parentDirectory.pathString ?? ""
+        XCTAssertEqual(manifest.name, name)
     }
 
     /// Tests access to the package's directory contents.
     func testPackageContextDirectory() throws {
-        let stream = BufferedOutputByteStream()
-        stream <<< """
+        let content = """
             import PackageDescription
             import Foundation
             
@@ -182,10 +195,11 @@ class PackageDescription5_6LoadingTests: PackageDescriptionLoadingTests {
             let package = Package(name: swiftFiles.joined(separator: ","))
             """
 
-        loadManifest(stream.bytes) { manifest in
-            let name = parsedManifest?.components.last ?? ""
-            let swiftFiles = manifest.name.split(separator: ",").map(String.init)
-            XCTAssertNotNil(swiftFiles.firstIndex(of: name))
-        }
+        let observability = ObservabilitySystem.makeForTesting()
+        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+
+        let name = parsedManifest?.components.last ?? ""
+        let swiftFiles = manifest.name.split(separator: ",").map(String.init)
+        XCTAssertNotNil(swiftFiles.firstIndex(of: name))
     }
 }

--- a/Tests/PackageLoadingTests/PD_Next_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_Next_LoadingTests.swift
@@ -8,16 +8,18 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import Basics
 import PackageModel
+import SPMTestSupport
 import XCTest
 
 class PackageDescriptionNextLoadingTests: PackageDescriptionLoadingTests {
     override var toolsVersion: ToolsVersion {
         .vNext
     }
-    
+
     func testRegistryDependencies() throws {
-        let manifest = """
+        let content = """
             import PackageDescription
             let package = Package(
                name: "MyPackage",
@@ -30,13 +32,16 @@ class PackageDescriptionNextLoadingTests: PackageDescriptionLoadingTests {
                ]
             )
             """
-        loadManifest(manifest, toolsVersion: self.toolsVersion) { manifest in
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
         let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
-            XCTAssertEqual(deps["x.foo"], .registry(identity: "x.foo", requirement: .range("1.1.1" ..< "2.0.0")))
-            XCTAssertEqual(deps["x.bar"], .registry(identity: "x.bar", requirement: .exact("1.1.1")))
-            XCTAssertEqual(deps["x.baz"], .registry(identity: "x.baz", requirement: .range("1.1.1" ..< "2.0.0")))
-            XCTAssertEqual(deps["x.qux"], .registry(identity: "x.qux", requirement: .range("1.1.1" ..< "1.2.0")))
-            XCTAssertEqual(deps["x.quux"], .registry(identity: "x.quux", requirement: .range("1.1.1" ..< "3.0.0")))
-        }
+        XCTAssertEqual(deps["x.foo"], .registry(identity: "x.foo", requirement: .range("1.1.1" ..< "2.0.0")))
+        XCTAssertEqual(deps["x.bar"], .registry(identity: "x.bar", requirement: .exact("1.1.1")))
+        XCTAssertEqual(deps["x.baz"], .registry(identity: "x.baz", requirement: .range("1.1.1" ..< "2.0.0")))
+        XCTAssertEqual(deps["x.qux"], .registry(identity: "x.qux", requirement: .range("1.1.1" ..< "1.2.0")))
+        XCTAssertEqual(deps["x.quux"], .registry(identity: "x.quux", requirement: .range("1.1.1" ..< "3.0.0")))
     }
 }

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -80,12 +80,9 @@ class PackageBuilderTests: XCTestCase {
             )
 
             PackageBuilderTester(manifest, path: path, in: fs) { package, diagnostics in
-                var expectedMetadata = ObservabilityMetadata.packageMetadata(identity: .init(urlString: manifest.packageLocation), location: manifest.packageLocation, path: path)
-                expectedMetadata.targetName = manifest.targets.first!.name
                 diagnostics.check(
                     diagnostic: "ignoring broken symlink \(linkPath)",
-                    severity: .warning,
-                    metadata: expectedMetadata
+                    severity: .warning
                 )
                 package.checkModule("foo")
             }
@@ -146,8 +143,7 @@ class PackageBuilderTests: XCTestCase {
           #if os(Linux)
             diagnostics.check(
                 diagnostic: "ignoring target 'MyPackageTests' in package 'MyPackage'; C language in tests is not yet supported",
-                severity: .warning,
-                metadata: .packageMetadata(identity: .init(urlString: manifest.packageLocation), location: manifest.packageLocation, path: .root)
+                severity: .warning
             )
           #elseif os(macOS) || os(Android)
             package.checkProduct("MyPackagePackageTests") { _ in }
@@ -248,12 +244,9 @@ class PackageBuilderTests: XCTestCase {
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, diags in
-            var expectedMetadata = ObservabilityMetadata.packageMetadata(identity: .init(urlString: manifest.packageLocation), location: manifest.packageLocation, path: .root)
-            expectedMetadata.targetName = manifest.targets.first!.name
             diags.check(
                 diagnostic: "found duplicate sources declaration in the package manifest: /Sources/clib",
-                severity: .warning,
-                metadata: expectedMetadata
+                severity: .warning
             )
             package.checkModule("clib") { module in
                 module.check(c99name: "clib", type: .library)
@@ -499,8 +492,7 @@ class PackageBuilderTests: XCTestCase {
         PackageBuilderTester(manifest, in: fs) { package, diagnostics in
             diagnostics.check(
                 diagnostic: "'exec2' was identified as an executable target given the presence of a 'main.swift' file. Starting with tools version 5.4.0 executable targets should be declared as 'executableTarget()'",
-                severity: .warning,
-                metadata: .packageMetadata(identity: .init(urlString: manifest.packageLocation), location: manifest.packageLocation, path: .root)
+                severity: .warning
             )
             package.checkModule("lib") { _ in }
             package.checkModule("exec2") { _ in }
@@ -1111,8 +1103,7 @@ class PackageBuilderTests: XCTestCase {
             PackageBuilderTester(manifest, in: fs) { package, diagnostics in
                 diagnostics.check(
                     diagnostic: "Source files for target pkg2 should be located under /Sources/pkg2",
-                    severity: .warning,
-                    metadata: .packageMetadata(identity: .init(urlString: manifest.packageLocation), location: manifest.packageLocation, path: .root)
+                    severity: .warning
                 )
                 package.checkModule("pkg1") { module in
                     module.check(c99name: "pkg1", type: .library)
@@ -1485,13 +1476,11 @@ class PackageBuilderTests: XCTestCase {
             }
             diagnostics.check(
                 diagnostic: "ignoring duplicate product 'foo' (static)",
-                severity: .warning,
-                metadata: .packageMetadata(identity: .init(urlString: manifest.packageLocation), location: manifest.packageLocation, path: .root)
+                severity: .warning
             )
             diagnostics.check(
                 diagnostic: "ignoring duplicate product 'foo' (dynamic)",
-                severity: .warning,
-                metadata: .packageMetadata(identity: .init(urlString: manifest.packageLocation), location: manifest.packageLocation, path: .root)
+                severity: .warning
             )
         }
     }
@@ -1517,8 +1506,7 @@ class PackageBuilderTests: XCTestCase {
             }
             diagnostics.check(
                 diagnostic: "ignoring declared target(s) 'foo, bar' in the system package",
-                severity: .warning,
-                metadata: .packageMetadata(identity: .init(urlString: manifest.packageLocation), location: manifest.packageLocation, path: .root)
+                severity: .warning
             )
         }
     }
@@ -1576,8 +1564,7 @@ class PackageBuilderTests: XCTestCase {
             package.checkModule("bar") { _ in }
             diagnostics.check(
                 diagnostic: "system library product foo shouldn't have a type and contain only one target",
-                severity: .error,
-                metadata: .packageMetadata(identity: .init(urlString: manifest.packageLocation), location: manifest.packageLocation, path: .root)
+                severity: .error
             )
         }
 
@@ -1596,8 +1583,7 @@ class PackageBuilderTests: XCTestCase {
             package.checkModule("bar") { _ in }
             diagnostics.check(
                 diagnostic: "system library product foo shouldn't have a type and contain only one target",
-                severity: .error,
-                metadata: .packageMetadata(identity: .init(urlString: manifest.packageLocation), location: manifest.packageLocation, path: .root)
+                severity: .error
             )
         }
 
@@ -1650,21 +1636,18 @@ class PackageBuilderTests: XCTestCase {
                     executable product 'foo1' expects target 'FooLib1' to be executable; an executable target requires \
                     a 'main.swift' file
                     """,
-                severity: .error,
-                metadata: .packageMetadata(identity: .init(urlString: manifest.packageLocation), location: manifest.packageLocation, path: .root)
+                severity: .error
             )
             diagnostics.check(
                 diagnostic: """
                     executable product 'foo2' should have one executable target; an executable target requires a \
                     'main.swift' file
                     """,
-                severity: .error,
-                metadata: .packageMetadata(identity: .init(urlString: manifest.packageLocation), location: manifest.packageLocation, path: .root)
+                severity: .error
             )
             diagnostics.check(
                 diagnostic: "executable product 'foo3' should not have more than one executable target",
-                severity: .error,
-                metadata: .packageMetadata(identity: .init(urlString: manifest.packageLocation), location: manifest.packageLocation, path: .root)
+                severity: .error
             )
         }
     }
@@ -1686,8 +1669,7 @@ class PackageBuilderTests: XCTestCase {
             package.checkProduct("exe") { _ in }
             diagnostics.check(
                 diagnostic: "unable to synthesize a REPL product as there are no library targets in the package",
-                severity: .error,
-                metadata: .packageMetadata(identity: .init(urlString: manifest.packageLocation), location: manifest.packageLocation, path: .root)
+                severity: .error
             )
         }
     }
@@ -2223,13 +2205,11 @@ class PackageBuilderTests: XCTestCase {
             package.checkModule("Foo2")
             diagnostics.checkUnordered(
                 diagnostic: "invalid duplicate target dependency declaration 'Bar' in target 'Foo' from package 'Foo'",
-                severity: .warning,
-                metadata: .packageMetadata(identity: .init(urlString: manifest.packageLocation), location: manifest.packageLocation, path: AbsolutePath("/Foo"))
+                severity: .warning
             )
             diagnostics.checkUnordered(
                 diagnostic: "invalid duplicate target dependency declaration 'Foo2' in target 'Foo' from package 'Foo'",
-                severity: .warning,
-                metadata: .packageMetadata(identity: .init(urlString: manifest.packageLocation), location: manifest.packageLocation, path: AbsolutePath("/Foo"))
+                severity: .warning
             )
         }
     }

--- a/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
+++ b/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
@@ -47,7 +47,7 @@ class TargetSourcesBuilderTests: XCTestCase {
 
         let builder = TargetSourcesBuilder(
             packageIdentity: .plain("test"),
-            packageLocation: "test",
+            packageKind: .root(.root),
             packagePath: .root,
             target: target,
             path: .root,
@@ -92,7 +92,7 @@ class TargetSourcesBuilderTests: XCTestCase {
 
         let builder = TargetSourcesBuilder(
             packageIdentity: .plain("test"),
-            packageLocation: "test",
+            packageKind: .root(.root),
             packagePath: .root,
             target: target,
             path: .root,
@@ -132,7 +132,7 @@ class TargetSourcesBuilderTests: XCTestCase {
 
         let builder = TargetSourcesBuilder(
             packageIdentity: .plain("test"),
-            packageLocation: "test",
+            packageKind: .root(.root),
             packagePath: .root,
             target: target,
             path: .root,
@@ -172,7 +172,7 @@ class TargetSourcesBuilderTests: XCTestCase {
 
         let builder = TargetSourcesBuilder(
             packageIdentity: .plain("test"),
-            packageLocation: "test",
+            packageKind: .root(.root),
             packagePath: .root,
             target: target,
             path: .root,
@@ -278,12 +278,17 @@ class TargetSourcesBuilderTests: XCTestCase {
                 "/Resources/Sub/foo.txt"
             )
 
-            build(target: target, toolsVersion: .v5_3, fs: fs, checkOnlyProblems: false) { _, _, _, _, identity, location, path, diagnostics in
-                var expectedMetadata = ObservabilityMetadata.packageMetadata(identity: identity, location: location, path: path)
-                expectedMetadata.targetName = target.name
-                diagnostics.check(diagnostic: "multiple resources named 'foo.txt' in target 'Foo'", severity: .error, metadata: expectedMetadata)
-                diagnostics.checkUnordered(diagnostic: "found 'Resources/foo.txt'", severity: .info, metadata: expectedMetadata)
-                diagnostics.checkUnordered(diagnostic: "found 'Resources/Sub/foo.txt'", severity: .info, metadata: expectedMetadata)
+            build(target: target, toolsVersion: .v5_3, checkProblemsOnly: false, fs: fs) { _, _, _, _, identity, kind, path, diagnostics in
+                var diagnosticsFound = [Basics.Diagnostic?]()
+                diagnosticsFound.append(diagnostics.check(diagnostic: "multiple resources named 'foo.txt' in target 'Foo'", severity: .error))
+                diagnosticsFound.append(diagnostics.checkUnordered(diagnostic: "found 'Resources/foo.txt'", severity: .info))
+                diagnosticsFound.append(diagnostics.checkUnordered(diagnostic: "found 'Resources/Sub/foo.txt'", severity: .info))
+
+                for diagnostic in diagnosticsFound {
+                    XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
+                    XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
+                    XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+                }
             }
         }
 
@@ -300,12 +305,17 @@ class TargetSourcesBuilderTests: XCTestCase {
                 "/Copied/foo.txt"
             )
 
-            build(target: target, toolsVersion: .v5_3, fs: fs, checkOnlyProblems: false) { _, _, _, _, identity, location, path, diagnostics in
-                var expectedMetadata = ObservabilityMetadata.packageMetadata(identity: identity, location: location, path: path)
-                expectedMetadata.targetName = target.name
-                diagnostics.check(diagnostic: "multiple resources named 'foo.txt' in target 'Foo'", severity: .error, metadata: expectedMetadata)
-                diagnostics.checkUnordered(diagnostic: "found 'Processed/foo.txt'", severity: .info, metadata: expectedMetadata)
-                diagnostics.checkUnordered(diagnostic: "found 'Copied/foo.txt'", severity: .info, metadata: expectedMetadata)
+            build(target: target, toolsVersion: .v5_3, checkProblemsOnly: false, fs: fs) { _, _, _, _, identity, kind, path, diagnostics in
+                var diagnosticsFound = [Basics.Diagnostic?]()
+                diagnosticsFound.append(diagnostics.check(diagnostic: "multiple resources named 'foo.txt' in target 'Foo'", severity: .error))
+                diagnosticsFound.append(diagnostics.checkUnordered(diagnostic: "found 'Processed/foo.txt'", severity: .info))
+                diagnosticsFound.append(diagnostics.checkUnordered(diagnostic: "found 'Copied/foo.txt'", severity: .info))
+
+                for diagnostic in diagnosticsFound {
+                    XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
+                    XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
+                    XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+                }
             }
         }
 
@@ -340,12 +350,17 @@ class TargetSourcesBuilderTests: XCTestCase {
                 "/B/Copy/foo.txt"
             )
 
-            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, location, path, diagnostics in
-                var expectedMetadata = ObservabilityMetadata.packageMetadata(identity: identity, location: location, path: path)
-                expectedMetadata.targetName = target.name
-                diagnostics.check(diagnostic: "multiple resources named 'Copy' in target 'Foo'", severity: .error, metadata: expectedMetadata)
-                diagnostics.checkUnordered(diagnostic: "found 'A/Copy'", severity: .info, metadata: expectedMetadata)
-                diagnostics.checkUnordered(diagnostic: "found 'B/Copy'", severity: .info, metadata: expectedMetadata)
+            build(target: target, toolsVersion: .v5_3, checkProblemsOnly: false, fs: fs) { _, _, _, _, identity, kind, path, diagnostics in
+                var diagnosticsFound = [Basics.Diagnostic?]()
+                diagnosticsFound.append(diagnostics.check(diagnostic: "multiple resources named 'Copy' in target 'Foo'", severity: .error))
+                diagnosticsFound.append(diagnostics.checkUnordered(diagnostic: "found 'A/Copy'", severity: .info))
+                diagnosticsFound.append(diagnostics.checkUnordered(diagnostic: "found 'B/Copy'", severity: .info))
+
+                for diagnostic in diagnosticsFound {
+                    XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
+                    XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
+                    XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+                }
             }
         }
 
@@ -362,12 +377,17 @@ class TargetSourcesBuilderTests: XCTestCase {
                 "/B/EN.lproj/foo.txt"
             )
 
-            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, location, path, diagnostics in
-                var expectedMetadata = ObservabilityMetadata.packageMetadata(identity: identity, location: location, path: path)
-                expectedMetadata.targetName = target.name
-                diagnostics.check(diagnostic: "multiple resources named 'en.lproj/foo.txt' in target 'Foo'", severity: .error, metadata: expectedMetadata)
-                diagnostics.checkUnordered(diagnostic: "found 'A/en.lproj/foo.txt'", severity: .info, metadata: expectedMetadata)
-                diagnostics.checkUnordered(diagnostic: "found 'B/EN.lproj/foo.txt'", severity: .info, metadata: expectedMetadata)
+            build(target: target, toolsVersion: .v5_3, checkProblemsOnly: false, fs: fs) { _, _, _, _, identity, kind, path, diagnostics in
+                var diagnosticsFound = [Basics.Diagnostic?]()
+                diagnosticsFound.append(diagnostics.check(diagnostic: "multiple resources named 'en.lproj/foo.txt' in target 'Foo'", severity: .error))
+                diagnosticsFound.append(diagnostics.checkUnordered(diagnostic: "found 'A/en.lproj/foo.txt'", severity: .info))
+                diagnosticsFound.append(diagnostics.checkUnordered(diagnostic: "found 'B/EN.lproj/foo.txt'", severity: .info))
+
+                for diagnostic in diagnosticsFound {
+                    XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
+                    XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
+                    XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+                }
             }
         }
 
@@ -384,14 +404,14 @@ class TargetSourcesBuilderTests: XCTestCase {
                 "/B/en.lproj/foo.txt"
             )
 
-            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, location, path, diagnostics in
-                var expectedMetadata = ObservabilityMetadata.packageMetadata(identity: identity, location: location, path: path)
-                expectedMetadata.targetName = target.name
-                diagnostics.check(
+            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, kind, path, diagnostics in
+                let diagnostic = diagnostics.check(
                     diagnostic: "resource 'B/en.lproj' in target 'Foo' conflicts with other localization directories",
-                    severity: .error,
-                    metadata: expectedMetadata
+                    severity: .error
                 )
+                XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
+                XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
+                XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
             }
         }
     }
@@ -420,14 +440,14 @@ class TargetSourcesBuilderTests: XCTestCase {
             "/Copied/en.lproj/sub/Localizable.strings"
         )
 
-        build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, location, path, diagnostics in
-            var expectedMetadata = ObservabilityMetadata.packageMetadata(identity: identity, location: location, path: path)
-            expectedMetadata.targetName = target.name
-            diagnostics.check(
+        build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, kind, path, diagnostics in
+            let diagnostic = diagnostics.check(
                 diagnostic: "localization directory 'Processed/en.lproj' in target 'Foo' contains sub-directories, which is forbidden",
-                severity: .error,
-                metadata: expectedMetadata
+                severity: .error
             )
+            XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
+            XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
+            XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
         }
     }
 
@@ -440,17 +460,17 @@ class TargetSourcesBuilderTests: XCTestCase {
             "/Resources/en.lproj/Localizable.strings"
         )
 
-        build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, location, path, diagnostics in
-            var expectedMetadata = ObservabilityMetadata.packageMetadata(identity: identity, location: location, path: path)
-            expectedMetadata.targetName = target.name
-            diagnostics.check(
+        build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, kind, path, diagnostics in
+            let diagnostic = diagnostics.check(
                 diagnostic: .contains("""
                     resource 'Resources/en.lproj/Localizable.strings' in target 'Foo' is in a localization directory \
                     and has an explicit localization declaration
                     """),
-                severity: .error,
-                metadata: expectedMetadata
+                severity: .error
             )
+            XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
+            XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
+            XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
         }
     }
 
@@ -471,14 +491,14 @@ class TargetSourcesBuilderTests: XCTestCase {
             "/Icon.png"
         )
 
-        build(target: target, defaultLocalization: "fr", toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, location, path, diagnostics in
-            var expectedMetadata = ObservabilityMetadata.packageMetadata(identity: identity, location: location, path: path)
-            expectedMetadata.targetName = target.name
-            diagnostics.check(
+        build(target: target, defaultLocalization: "fr", toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, kind, path, diagnostics in
+            let diagnostic = diagnostics.check(
                 diagnostic: .contains("resource 'Icon.png' in target 'Foo' is missing the default localization 'fr'"),
-                severity: .warning,
-                metadata: expectedMetadata
+                severity: .warning
             )
+            XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
+            XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
+            XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
         }
     }
 
@@ -500,29 +520,30 @@ class TargetSourcesBuilderTests: XCTestCase {
             "/Icon.png"
         )
 
-        build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, location, path, diagnostics in
-            var expectedMetadata = ObservabilityMetadata.packageMetadata(identity: identity, location: location, path: path)
-            expectedMetadata.targetName = target.name
-            diagnostics.checkUnordered(
+        build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, kind, path, diagnostics in
+            var diagnosticsFound = [Basics.Diagnostic?]()
+            diagnosticsFound.append(diagnostics.checkUnordered(
                 diagnostic: .contains("resource 'Localizable.strings' in target 'Foo' has both localized and un-localized variants"),
-                severity: .warning,
-                metadata: expectedMetadata
-            )
-            diagnostics.checkUnordered(
+                severity: .warning
+            ))
+            diagnosticsFound.append(diagnostics.checkUnordered(
                 diagnostic: .contains("resource 'Storyboard.storyboard' in target 'Foo' has both localized and un-localized variants"),
-                severity: .warning,
-                metadata: expectedMetadata
-            )
-            diagnostics.checkUnordered(
+                severity: .warning
+            ))
+            diagnosticsFound.append(diagnostics.checkUnordered(
                 diagnostic: .contains("resource 'Image.png' in target 'Foo' has both localized and un-localized variants"),
-                severity: .warning,
-                metadata: expectedMetadata
-            )
-            diagnostics.checkUnordered(
+                severity: .warning
+            ))
+            diagnosticsFound.append(diagnostics.checkUnordered(
                 diagnostic: .contains("resource 'Icon.png' in target 'Foo' has both localized and un-localized variants"),
-                severity: .warning,
-                metadata: expectedMetadata
-            )
+                severity: .warning
+            ))
+
+            for diagnostic in diagnosticsFound {
+                XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
+                XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
+                XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+            }
         }
     }
 
@@ -585,14 +606,14 @@ class TargetSourcesBuilderTests: XCTestCase {
                 "/Resources/Processed/Info.plist"
             )
 
-            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, location, path, diagnostics in
-                var expectedMetadata = ObservabilityMetadata.packageMetadata(identity: identity, location: location, path: path)
-                expectedMetadata.targetName = target.name
-                diagnostics.check(
+            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, kind, path, diagnostics in
+                let diagnostic = diagnostics.check(
                     diagnostic: .contains("resource 'Resources/Processed/Info.plist' in target 'Foo' is forbidden"),
-                    severity: .error,
-                    metadata: expectedMetadata
+                    severity: .error
                 )
+                XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
+                XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
+                XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
             }
         }
 
@@ -605,54 +626,18 @@ class TargetSourcesBuilderTests: XCTestCase {
                 "/Resources/Copied/Info.plist"
             )
 
-            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, location, path, diagnostics in
-                var expectedMetadata = ObservabilityMetadata.packageMetadata(identity: identity, location: location, path: path)
-                expectedMetadata.targetName = target.name
-                diagnostics.check(
+            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, kind, path, diagnostics in
+                let diagnostic = diagnostics.check(
                     diagnostic: .contains("resource 'Resources/Copied/Info.plist' in target 'Foo' is forbidden"),
-                    severity: .error,
-                    metadata: expectedMetadata
+                    severity: .error
                 )
+                XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
+                XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
+                XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
             }
         }
     }
 
-    func build(
-        target: TargetDescription,
-        defaultLocalization: String? = nil,
-        additionalFileRules: [FileRuleDescription] = [],
-        toolsVersion: ToolsVersion,
-        fs: FileSystem,
-        checkOnlyProblems: Bool = false,
-        file: StaticString = #file,
-        line: UInt = #line,
-        checker: (Sources, [Resource], [AbsolutePath], [AbsolutePath], PackageIdentity, String, AbsolutePath, DiagnosticsTestResult) -> ()
-    ) {
-        let observability = ObservabilitySystem.makeForTesting()
-        let builder = TargetSourcesBuilder(
-            packageIdentity: .plain("test"),
-            packageLocation: "/test",
-            packagePath: .root,
-            target: target,
-            path: .root,
-            defaultLocalization: defaultLocalization,
-            additionalFileRules: additionalFileRules,
-            toolsVersion: toolsVersion,
-            fileSystem: fs,
-            observabilityScope: observability.topScope
-        )
-
-        do {
-            let (sources, resources, headers, others) = try builder.run()
-
-            testDiagnostics(observability.diagnostics, problemsOnly: checkOnlyProblems, file: file, line: line) { diagnostics in
-                checker(sources, resources, headers, others, builder.packageIdentity, builder.packageLocation, builder.packagePath, diagnostics)
-            }
-        } catch {
-            XCTFail(error.localizedDescription, file: file, line: line)
-        }
-    }
-    
     func testMissingExclude() throws {
         let target = try TargetDescription(
             name: "Foo",
@@ -674,7 +659,7 @@ class TargetSourcesBuilderTests: XCTestCase {
 
         let builder = TargetSourcesBuilder(
             packageIdentity: .plain("test"),
-            packageLocation: "/test",
+            packageKind: .root(.init("/test")),
             packagePath: .init("/test"),
             target: target,
             path: .root,
@@ -685,10 +670,15 @@ class TargetSourcesBuilderTests: XCTestCase {
         )
 
         testDiagnostics(observability.diagnostics) { result in
-            var expectedMetadata = ObservabilityMetadata.packageMetadata(identity: builder.packageIdentity, location: builder.packageLocation, path: builder.packagePath)
-            expectedMetadata.targetName = target.name
-            result.checkUnordered(diagnostic: "Invalid Exclude '/fileOutsideRoot.py': File not found.", severity: .warning, metadata: expectedMetadata)
-            result.checkUnordered(diagnostic: "Invalid Exclude '/fakeDir': File not found.", severity: .warning, metadata: expectedMetadata)
+            var diagnosticsFound = [Basics.Diagnostic?]()
+            diagnosticsFound.append(result.checkUnordered(diagnostic: "Invalid Exclude '/fileOutsideRoot.py': File not found.", severity: .warning))
+            diagnosticsFound.append(result.checkUnordered(diagnostic: "Invalid Exclude '/fakeDir': File not found.", severity: .warning))
+
+            for diagnostic in diagnosticsFound {
+                XCTAssertEqual(diagnostic?.metadata?.packageIdentity, builder.packageIdentity)
+                XCTAssertEqual(diagnostic?.metadata?.packageKind, builder.packageKind)
+                XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+            }
         }
     }
     
@@ -714,7 +704,7 @@ class TargetSourcesBuilderTests: XCTestCase {
 
         let builder = TargetSourcesBuilder(
             packageIdentity: .plain("test"),
-            packageLocation: "/test",
+            packageKind: .root(.root),
             packagePath: .root,
             target: target,
             path: .root,
@@ -726,10 +716,15 @@ class TargetSourcesBuilderTests: XCTestCase {
         _ = try builder.run()
 
         testDiagnostics(observability.diagnostics) { result in
-            var expectedMetadata = ObservabilityMetadata.packageMetadata(identity: builder.packageIdentity, location: builder.packageLocation, path: builder.packagePath)
-            expectedMetadata.targetName = target.name
-            result.checkUnordered(diagnostic: "Invalid Resource '../../../Fake.txt': File not found.", severity: .warning, metadata: expectedMetadata)
-            result.checkUnordered(diagnostic: "Invalid Resource 'NotReal': File not found.", severity: .warning, metadata: expectedMetadata)
+            var diagnosticsFound = [Basics.Diagnostic?]()
+            diagnosticsFound.append(result.checkUnordered(diagnostic: "Invalid Resource '../../../Fake.txt': File not found.", severity: .warning))
+            diagnosticsFound.append(result.checkUnordered(diagnostic: "Invalid Resource 'NotReal': File not found.", severity: .warning))
+
+            for diagnostic in diagnosticsFound {
+                XCTAssertEqual(diagnostic?.metadata?.packageIdentity, builder.packageIdentity)
+                XCTAssertEqual(diagnostic?.metadata?.packageKind, builder.packageKind)
+                XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+            }
         }
     }
     
@@ -756,7 +751,7 @@ class TargetSourcesBuilderTests: XCTestCase {
 
         let builder = TargetSourcesBuilder(
             packageIdentity: .plain("test"),
-            packageLocation: "/test",
+            packageKind: .root(.init("/test")),
             packagePath: .root,
             target: target,
             path: .root,
@@ -767,11 +762,16 @@ class TargetSourcesBuilderTests: XCTestCase {
         )
 
         testDiagnostics(observability.diagnostics) { result in
-            var expectedMetadata = ObservabilityMetadata.packageMetadata(identity: builder.packageIdentity, location: builder.packageLocation, path: builder.packagePath)
-            expectedMetadata.targetName = target.name
-            result.checkUnordered(diagnostic: "Invalid Source '/InvalidPackage.swift': File not found.", severity: .warning, metadata: expectedMetadata)
-            result.checkUnordered(diagnostic: "Invalid Source '/DoesNotExist.swift': File not found.", severity: .warning, metadata: expectedMetadata)
-            result.checkUnordered(diagnostic: "Invalid Source '/Tests/InvalidPackageTests/InvalidPackageTests.swift': File not found.", severity: .warning, metadata: expectedMetadata)
+            var diagnosticsFound = [Basics.Diagnostic?]()
+            diagnosticsFound.append(result.checkUnordered(diagnostic: "Invalid Source '/InvalidPackage.swift': File not found.", severity: .warning))
+            diagnosticsFound.append(result.checkUnordered(diagnostic: "Invalid Source '/DoesNotExist.swift': File not found.", severity: .warning))
+            diagnosticsFound.append(result.checkUnordered(diagnostic: "Invalid Source '/Tests/InvalidPackageTests/InvalidPackageTests.swift': File not found.", severity: .warning))
+
+            for diagnostic in diagnosticsFound {
+                XCTAssertEqual(diagnostic?.metadata?.packageIdentity, builder.packageIdentity)
+                XCTAssertEqual(diagnostic?.metadata?.packageKind, builder.packageKind)
+                XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+            }
         }
     }
 
@@ -796,7 +796,7 @@ class TargetSourcesBuilderTests: XCTestCase {
 
         let builder = TargetSourcesBuilder(
             packageIdentity: .plain("test"),
-            packageLocation: "/test",
+            packageKind: .root(.init("/test")),
             packagePath: .root,
             target: target,
             path: .root,
@@ -808,9 +808,9 @@ class TargetSourcesBuilderTests: XCTestCase {
         _ = try builder.run()
 
         testDiagnostics(observability.diagnostics) { result in
-            var expectedMetadata = ObservabilityMetadata.packageMetadata(identity: builder.packageIdentity, location: builder.packageLocation, path: builder.packagePath)
-            expectedMetadata.targetName = target.name
-            result.check(diagnostic: "found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target\n    /Foo.xcdatamodel\n", severity: .warning, metadata: expectedMetadata)
+            let diagnostic = result.check(diagnostic: "found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target\n    /Foo.xcdatamodel\n", severity: .warning)
+            XCTAssertEqual(diagnostic?.metadata?.packageIdentity, builder.packageIdentity)
+            XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
         }
     }
 
@@ -835,7 +835,7 @@ class TargetSourcesBuilderTests: XCTestCase {
 
         let builder = TargetSourcesBuilder(
             packageIdentity: .plain("test"),
-            packageLocation: "test",
+            packageKind: .root(.root),
             packagePath: .root,
             target: target,
             path: .root,
@@ -849,4 +849,43 @@ class TargetSourcesBuilderTests: XCTestCase {
 
         XCTAssertNoDiagnostics(observability.diagnostics)
     }
+
+    // MARK: -  Utilities
+
+    private func build(
+        target: TargetDescription,
+        defaultLocalization: String? = nil,
+        additionalFileRules: [FileRuleDescription] = [],
+        toolsVersion: ToolsVersion,
+        checkProblemsOnly: Bool = true,
+        fs: FileSystem,
+        file: StaticString = #file,
+        line: UInt = #line,
+        checker: (Sources, [Resource], [AbsolutePath], [AbsolutePath], PackageIdentity, PackageReference.Kind, AbsolutePath, DiagnosticsTestResult) throws -> Void
+    ) {
+        let observability = ObservabilitySystem.makeForTesting()
+        let builder = TargetSourcesBuilder(
+            packageIdentity: .plain("test"),
+            packageKind: .root(.root),
+            packagePath: .root,
+            target: target,
+            path: .root,
+            defaultLocalization: defaultLocalization,
+            additionalFileRules: additionalFileRules,
+            toolsVersion: toolsVersion,
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+
+        do {
+            let (sources, resources, headers, others) = try builder.run()
+
+            testDiagnostics(observability.diagnostics, problemsOnly: checkProblemsOnly, file: file, line: line) { diagnostics in
+                try checker(sources, resources, headers, others, builder.packageIdentity, builder.packageKind, builder.packagePath, diagnostics)
+            }
+        } catch {
+            XCTFail(error.localizedDescription, file: file, line: line)
+        }
+    }
+
 }

--- a/Tests/PackageRegistryTests/RegistryManagerTests.swift
+++ b/Tests/PackageRegistryTests/RegistryManagerTests.swift
@@ -89,7 +89,8 @@ final class RegistryManagerTests: XCTestCase {
 
         let expectation = XCTestExpectation(description: "fetch versions")
 
-        registryManager.fetchVersions(of: package, observabilityScope: nil, on: .sharedConcurrent) { result in
+        let observability = ObservabilitySystem.makeForTesting()
+        registryManager.fetchVersions(of: package, observabilityScope: observability.topScope, on: .sharedConcurrent) { result in
             defer { expectation.fulfill() }
 
             guard case .success(let versions) = result else {
@@ -101,6 +102,8 @@ final class RegistryManagerTests: XCTestCase {
         }
 
         wait(for: [expectation], timeout: 10.0)
+
+        XCTAssertNoDiagnostics(observability.diagnostics)
     }
 
     func testFetchManifest() {
@@ -143,14 +146,15 @@ final class RegistryManagerTests: XCTestCase {
 
         let expectation = XCTestExpectation(description: "fetch manifest")
 
+        let observability = ObservabilitySystem.makeForTesting()
         let manifestLoader = ManifestLoader(toolchain: .default)
-        registryManager.fetchManifest(for: "1.1.1", of: package, using: manifestLoader, observabilityScope: nil, on: .sharedConcurrent) { result in
+        registryManager.fetchManifest(for: "1.1.1", of: package, using: manifestLoader, observabilityScope: observability.topScope, on: .sharedConcurrent) { result in
             defer { expectation.fulfill() }
 
             guard case .success(let manifest) = result else {
                 return XCTAssertResultSuccess(result)
             }
-            
+
             XCTAssertEqual(manifest.name, "LinkedList")
 
             XCTAssertEqual(manifest.products.count, 1)
@@ -166,6 +170,8 @@ final class RegistryManagerTests: XCTestCase {
             XCTAssertEqual(manifest.swiftLanguageVersions, [.v4, .v5])
         }
         wait(for: [expectation], timeout: 10.0)
+
+        XCTAssertNoDiagnostics(observability.diagnostics)
     }
 
     func testDownloadSourceArchive() {
@@ -193,9 +199,10 @@ final class RegistryManagerTests: XCTestCase {
 
         let expectation = XCTestExpectation(description: "download source archive")
 
+        let observability = ObservabilitySystem.makeForTesting()
         let fileSystem = InMemoryFileSystem()
         let path = AbsolutePath("/LinkedList-1.1.1")
-        registryManager.downloadSourceArchive(for: "1.1.1", of: package, into: fileSystem, at: path, observabilityScope: nil, on: .sharedConcurrent) { result in
+        registryManager.downloadSourceArchive(for: "1.1.1", of: package, into: fileSystem, at: path, observabilityScope: observability.topScope, on: .sharedConcurrent) { result in
             defer { expectation.fulfill() }
 
             guard case .success = result else { return XCTAssertResultSuccess(result) }
@@ -206,5 +213,7 @@ final class RegistryManagerTests: XCTestCase {
             }
         }
         wait(for: [expectation], timeout: 10.0)
+
+        XCTAssertNoDiagnostics(observability.diagnostics)
     }
 }

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -1,13 +1,14 @@
 /*
  This source file is part of the Swift.org open source project
- 
+
  Copyright (c) 2020 - 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
- 
+
  See http://swift.org/LICENSE.txt for license information
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
+import Basics
 import PackageGraph
 import PackageLoading
 import PackageModel
@@ -17,7 +18,7 @@ import Workspace
 import XCTest
 
 class ManifestSourceGenerationTests: XCTestCase {
-    
+
     /// Private function that writes the contents of a package manifest to a temporary package directory and then loads it, then serializes the loaded manifest back out again and loads it once again, after which it compares that no information was lost. Return the source of the newly generated manifest.
     @discardableResult
     private func testManifestWritingRoundTrip(
@@ -28,6 +29,8 @@ class ManifestSourceGenerationTests: XCTestCase {
         fs: FileSystem = localFileSystem
     ) throws -> String {
         try withTemporaryDirectory { packageDir in
+            let observability = ObservabilitySystem.makeForTesting()
+
             // Write the original manifest file contents, and load it.
             try fs.writeFileContents(packageDir.appending(component: Manifest.filename), bytes: ByteString(encodingAsUTF8: manifestContents))
             let manifestLoader = ManifestLoader(toolchain: ToolchainConfiguration.default)
@@ -42,19 +45,22 @@ class ManifestSourceGenerationTests: XCTestCase {
                                     toolsVersion: toolsVersion,
                                     identityResolver: identityResolver,
                                     fileSystem: fs,
+                                    observabilityScope: observability.topScope,
                                     on: .global(),
                                     completion: $0)
             }
+
+            XCTAssertNoDiagnostics(observability.diagnostics)
 
             // Generate source code for the loaded manifest,
             let newContents = try manifest.generateManifestFileContents(
                 toolsVersionHeaderComment: toolsVersionHeaderComment,
                 additionalImportModuleNames: additionalImportModuleNames)
-            
+
             // Check that the tools version was serialized properly.
             let versionSpacing = (toolsVersion >= .v5_4) ? " " : ""
             XCTAssertMatch(newContents, .prefix("// swift-tools-version:\(versionSpacing)\(toolsVersion.major).\(toolsVersion.minor)"))
-            
+
             // Write out the generated manifest to replace the old manifest file contents, and load it again.
             try fs.writeFileContents(packageDir.appending(component: Manifest.filename), bytes: ByteString(encodingAsUTF8: newContents))
             let newManifest = try tsc_await {
@@ -67,10 +73,13 @@ class ManifestSourceGenerationTests: XCTestCase {
                                     toolsVersion: toolsVersion,
                                     identityResolver: identityResolver,
                                     fileSystem: fs,
+                                    observabilityScope: observability.topScope,
                                     on: .global(),
                                     completion: $0)
             }
-            
+
+            XCTAssertNoDiagnostics(observability.diagnostics)
+
             // Check that all the relevant properties survived.
             let failureDetails = "\n--- ORIGINAL MANIFEST CONTENTS ---\n" + manifestContents + "\n--- REWRITTEN MANIFEST CONTENTS ---\n" + newContents
             XCTAssertEqual(newManifest.toolsVersion, manifest.toolsVersion, failureDetails)

--- a/Tests/WorkspaceTests/PackageContainerProviderTests.swift
+++ b/Tests/WorkspaceTests/PackageContainerProviderTests.swift
@@ -656,6 +656,6 @@ class PackageContainerProviderTests: XCTestCase {
 
 extension PackageContainerProvider {
     fileprivate func getContainer(for package: PackageReference, skipUpdate: Bool) throws -> PackageContainer {
-        try tsc_await { self.getContainer(for: package, skipUpdate: skipUpdate, on: .global(), completion: $0)  }
+        try tsc_await { self.getContainer(for: package, skipUpdate: skipUpdate, observabilityScope: ObservabilitySystem.NOOP, on: .global(), completion: $0)  }
     }
 }


### PR DESCRIPTION
motivation: complete the transition to observability APIs

changes:
* update manifest loading to user observability APIs
* update workspace to user observability APIs
* update plugins runner to user observability APIs
* adjust call-sites and tests
* refresh package loading tests

note: this touches workspace delegate APIs, so may break clients


