### PR TITLE
Stop renaming main symbol for WASI

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -748,7 +748,7 @@ public final class SwiftTargetBuildDescription {
             // we can rename the symbol unconditionally.
             // No `-` for these flags because the set of Strings in driver.supportedFrontendFlags do
             // not have a leading `-`
-            if buildParameters.shouldRenameEntrypointFunctionName,
+            if buildParameters.canRenameEntrypointFunctionName,
                buildParameters.linkerFlagsForRenamingMainFunction(of: target) != nil {
                 args += ["-Xfrontend", "-entry-point-function-name", "-Xfrontend", "\(target.c99name)_main"]
             }
@@ -1231,7 +1231,7 @@ public final class ProductBuildDescription {
             // Support for linking tests againsts executables is conditional on the tools
             // version of the package that defines the executable product.
             if product.executableModule.underlyingTarget is SwiftTarget, toolsVersion >= .v5_5,
-               buildParameters.shouldRenameEntrypointFunctionName {
+               buildParameters.canRenameEntrypointFunctionName {
                 if let flags = buildParameters.linkerFlagsForRenamingMainFunction(of: product.executableModule) {
                     args += flags
                 }

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -869,7 +869,7 @@ public class SwiftTool {
                 xcbuildFlags: options.xcbuildFlags,
                 jobs: options.jobs ?? UInt32(ProcessInfo.processInfo.activeProcessorCount),
                 shouldLinkStaticSwiftStdlib: options.shouldLinkStaticSwiftStdlib,
-                shouldRenameEntrypointFunctionName: SwiftTargetBuildDescription.checkSupportedFrontendFlags(
+                canRenameEntrypointFunctionName: SwiftTargetBuildDescription.checkSupportedFrontendFlags(
                     flags: ["entry-point-function-name"], fileSystem: localFileSystem
                 ),
                 sanitizers: options.enabledSanitizers,

--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -134,7 +134,7 @@ public struct BuildParameters: Encodable {
     public var shouldCreateDylibForDynamicProducts: Bool
 
     /// Whether to enable the entry-point-function-name feature.
-    public var shouldRenameEntrypointFunctionName: Bool
+    public var canRenameEntrypointFunctionName: Bool
 
     /// The current build environment.
     public var buildEnvironment: BuildEnvironment {
@@ -185,7 +185,7 @@ public struct BuildParameters: Encodable {
         jobs: UInt32 = UInt32(ProcessInfo.processInfo.activeProcessorCount),
         shouldLinkStaticSwiftStdlib: Bool = false,
         shouldEnableManifestCaching: Bool = false,
-        shouldRenameEntrypointFunctionName: Bool = false,
+        canRenameEntrypointFunctionName: Bool = false,
         shouldCreateDylibForDynamicProducts: Bool = true,
         sanitizers: EnabledSanitizers = EnabledSanitizers(),
         enableCodeCoverage: Bool = false,
@@ -215,7 +215,7 @@ public struct BuildParameters: Encodable {
         self.shouldLinkStaticSwiftStdlib = shouldLinkStaticSwiftStdlib
         self.shouldEnableManifestCaching = shouldEnableManifestCaching
         self.shouldCreateDylibForDynamicProducts = shouldCreateDylibForDynamicProducts
-        self.shouldRenameEntrypointFunctionName = shouldRenameEntrypointFunctionName
+        self.canRenameEntrypointFunctionName = canRenameEntrypointFunctionName
         self.sanitizers = sanitizers
         self.enableCodeCoverage = enableCodeCoverage
         self.indexStoreMode = indexStoreMode

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -63,7 +63,7 @@ final class BuildPlanTests: XCTestCase {
         toolchain: SPMBuildCore.Toolchain = MockToolchain(),
         flags: BuildFlags = BuildFlags(),
         shouldLinkStaticSwiftStdlib: Bool = false,
-        shouldRenameEntrypointFunctionName: Bool = false,
+        canRenameEntrypointFunctionName: Bool = false,
         destinationTriple: TSCUtility.Triple = hostTriple,
         indexStoreMode: BuildParameters.IndexStoreMode = .off,
         useExplicitModuleBuild: Bool = false
@@ -77,7 +77,7 @@ final class BuildPlanTests: XCTestCase {
             flags: flags,
             jobs: 3,
             shouldLinkStaticSwiftStdlib: shouldLinkStaticSwiftStdlib,
-            shouldRenameEntrypointFunctionName: shouldRenameEntrypointFunctionName,
+            canRenameEntrypointFunctionName: canRenameEntrypointFunctionName,
             indexStoreMode: indexStoreMode,
             useExplicitModuleBuild: useExplicitModuleBuild
         )
@@ -1850,7 +1850,7 @@ final class BuildPlanTests: XCTestCase {
 
         func createResult(for triple: TSCUtility.Triple) throws -> BuildPlanResult {
             BuildPlanResult(plan: try BuildPlan(
-                buildParameters: mockBuildParameters(shouldRenameEntrypointFunctionName: true, destinationTriple: triple),
+                buildParameters: mockBuildParameters(canRenameEntrypointFunctionName: true, destinationTriple: triple),
                 graph: graph,
                 fileSystem: fs,
                 observabilityScope: observability.topScope


### PR DESCRIPTION
Stop renaming main symbol for WASI due to lack of support in the linker

### Motivation:

The latest SwiftPM rename main entry point name of executable target to avoid conflicting "main" with test target since swift-tools-version >= 5.5.
The main symbol is renamed to "{{module_name}}_main" and it's renamed again to be "main" when linking the executable target. The former renaming is done by Swift compiler, and the latter is done by linker, so SwiftPM passes some special linker flags for each platform.
But SwiftPM assumed that wasm-ld supports it by returning an empty array instead of nil even though wasm-ld doesn't support it yet.

### Modifications:

This patch changed `linkerFlagsForRenamingMainFunction` to return nil when targeting WASI to indicate it's not supported.

However, for a long-term solution, this renaming feature should be supported on wasm-ld because it's not a limitation of WebAssembly.

See also: https://github.com/swiftwasm/swift/issues/3645
CC: @MaxDesiatov 
