### PR TITLE
Add C++2b to the CXXLanguageStandard enum

### DIFF
--- a/Documentation/PackageDescription.md
+++ b/Documentation/PackageDescription.md
@@ -1112,6 +1112,7 @@ enum CXXLanguageStandard {
     case cxx17 = "c++17"
     case cxx1z = "c++1z"
     case cxx20 = "c++20"
+    case cxx2b = "c++2b"
     case gnucxx98 = "gnu++98"
     case gnucxx03 = "gnu++03"
     case gnucxx11 = "gnu++11"
@@ -1119,5 +1120,6 @@ enum CXXLanguageStandard {
     case gnucxx17 = "gnu++17"
     case gnucxx1z = "gnu++1z"
     case gnucxx20 = "gnu++20"
+    case gnucxx2b = "gnu++2b"
 }
 ```

--- a/Sources/PackageDescription/LanguageStandardSettings.swift
+++ b/Sources/PackageDescription/LanguageStandardSettings.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2017 - 2020 Apple Inc. and the Swift project authors
+ Copyright (c) 2017 - 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -119,6 +119,10 @@ public enum CXXLanguageStandard: String, Encodable {
     @available(_PackageDescription, introduced: 5.4)
     case cxx20 = "c++20"
 
+    /// Working draft for ISO C++ 2023 DIS.
+    @available(_PackageDescription, introduced: 5.6)
+    case cxx2b = "c++2b"
+
     /// ISO C++ 1998 with amendments and GNU extensions.
     case gnucxx98 = "gnu++98"
 
@@ -142,6 +146,10 @@ public enum CXXLanguageStandard: String, Encodable {
     /// ISO C++ 2020 DIS with GNU extensions.
     @available(_PackageDescription, introduced: 5.4)
     case gnucxx20 = "gnu++20"
+
+    /// Working draft for ISO C++ 2023 DIS with GNU extensions.
+    @available(_PackageDescription, introduced: 5.6)
+    case gnucxx2b = "gnu++2b"
 }
 
 /// The version of the Swift language to use for compiling Swift sources in the package.


### PR DESCRIPTION
[C++2b][] (tentatively ISO C++ 2023) is available in Clang 13+.

* Copy the details from the [LangStandards.def][] file.
* Update the internal documentation.

[C++2b]: <https://clang.llvm.org/cxx_status.html#cxx23>
[LangStandards.def]: <https://github.com/apple/llvm-project/blob/apple/main/clang/include/clang/Basic/LangStandards.def>