### PR TITLE
remove the use of ObjectIdentifierProtocol

### DIFF
--- a/Sources/PackageGraph/ResolvedPackage.swift
+++ b/Sources/PackageGraph/ResolvedPackage.swift
@@ -12,8 +12,7 @@ import TSCBasic
 import PackageModel
 
 /// A fully resolved package. Contains resolved targets, products and dependencies of the package.
-public final class ResolvedPackage: ObjectIdentifierProtocol {
-
+public final class ResolvedPackage {
     /// The underlying package reference.
     public let underlyingPackage: Package
 
@@ -64,6 +63,16 @@ public final class ResolvedPackage: ObjectIdentifierProtocol {
         self.dependencies = dependencies
         self.targets = targets
         self.products = products
+    }
+}
+
+extension ResolvedPackage: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(self))
+    }
+
+    public static func == (lhs: ResolvedPackage, rhs: ResolvedPackage) -> Bool {
+        ObjectIdentifier(lhs) == ObjectIdentifier(rhs)
     }
 }
 

--- a/Sources/PackageGraph/ResolvedProduct.swift
+++ b/Sources/PackageGraph/ResolvedProduct.swift
@@ -11,8 +11,7 @@
 import TSCBasic
 import PackageModel
 
-public final class ResolvedProduct: ObjectIdentifierProtocol {
-
+public final class ResolvedProduct {
     /// The underlying product.
     public let underlyingProduct: Product
 
@@ -69,6 +68,16 @@ public final class ResolvedProduct: ObjectIdentifierProtocol {
     public func recursiveTargetDependencies() throws -> [ResolvedTarget] {
         let recursiveDependencies = try targets.lazy.flatMap { try $0.recursiveTargetDependencies() }
         return Array(Set(targets).union(recursiveDependencies))
+    }
+}
+
+extension ResolvedProduct: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(self))
+    }
+
+    public static func == (lhs: ResolvedProduct, rhs: ResolvedProduct) -> Bool {
+        ObjectIdentifier(lhs) == ObjectIdentifier(rhs)
     }
 }
 

--- a/Sources/PackageGraph/ResolvedTarget.swift
+++ b/Sources/PackageGraph/ResolvedTarget.swift
@@ -12,8 +12,7 @@ import TSCBasic
 import PackageModel
 
 /// Represents a fully resolved target. All the dependencies for the target are resolved.
-public final class ResolvedTarget: ObjectIdentifierProtocol {
-
+public final class ResolvedTarget {
     /// Represents dependency of a resolved target.
     public enum Dependency {
         /// Direct dependency of the target. This target is in the same package and should be statically linked.
@@ -125,6 +124,16 @@ public final class ResolvedTarget: ObjectIdentifierProtocol {
     public init(target: Target, dependencies: [Dependency]) {
         self.underlyingTarget = target
         self.dependencies = dependencies
+    }
+}
+
+extension ResolvedTarget: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(self))
+    }
+
+    public static func == (lhs: ResolvedTarget, rhs: ResolvedTarget) -> Bool {
+        ObjectIdentifier(lhs) == ObjectIdentifier(rhs)
     }
 }
 

--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -15,7 +15,7 @@ import Foundation
 
 /// This contains the declarative specification loaded from package manifest
 /// files, and the tools for working with the manifest.
-public final class Manifest: ObjectIdentifierProtocol {
+public final class Manifest {
 
     /// The standard filename for the manifest.
     public static let filename = basename + ".swift"
@@ -95,7 +95,7 @@ public final class Manifest: ObjectIdentifierProtocol {
 
     /// The system package providers of a system package.
     public let providers: [SystemPackageProviderDescription]?
-    
+
     /// Targets required for building particular product filters.
     private var _requiredTargets = ThreadSafeKeyValueStore<ProductFilter, [TargetDescription]>()
 
@@ -181,9 +181,9 @@ public final class Manifest: ObjectIdentifierProtocol {
         guard toolsVersion >= .v5_2 && !packageKind.isRoot else {
             return self.dependencies
         }
-        
+
         var requiredDependencyURLs: Set<PackageIdentity> = []
-        
+
         for target in self.targetsRequired(for: products) {
             for targetDependency in target.dependencies {
                 if let dependency = self.packageDependency(referencedBy: targetDependency) {
@@ -191,7 +191,7 @@ public final class Manifest: ObjectIdentifierProtocol {
                 }
             }
         }
-        
+
         return self.dependencies.filter { requiredDependencyURLs.contains($0.identity) }
         #endif
     }
@@ -225,10 +225,10 @@ public final class Manifest: ObjectIdentifierProtocol {
 
                 return dependencies + plugins
             }
-            
+
             return []
 
-            
+
         })
 
         let requiredTargetNames = Set(productTargetNames).union(dependentTargetNames)
@@ -381,6 +381,16 @@ public final class Manifest: ObjectIdentifierProtocol {
         } else {
             return false
         }
+    }
+}
+
+extension Manifest: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(self))
+    }
+
+    public static func == (lhs: Manifest, rhs: Manifest) -> Bool {
+        ObjectIdentifier(lhs) == ObjectIdentifier(rhs)
     }
 }
 

--- a/Sources/PackageModel/Package.swift
+++ b/Sources/PackageModel/Package.swift
@@ -43,7 +43,7 @@ import TSCUtility
 /// 5. A loaded package, as in #4, for which the targets have also been
 /// loaded. There is not currently a data structure for this, but it is the
 /// result after `PackageLoading.transmute()`.
-public final class Package: ObjectIdentifierProtocol, Encodable {
+public final class Package: Encodable {
     /// The identity of the package.
     public let identity: PackageIdentity
 

--- a/Sources/PackageModel/Product.swift
+++ b/Sources/PackageModel/Product.swift
@@ -12,7 +12,6 @@ import TSCBasic
 import TSCUtility
 
 public class Product: Codable {
-
     /// The name of the product.
     public let name: String
 
@@ -48,6 +47,16 @@ public class Product: Codable {
     }
 }
 
+extension Product: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(self))
+    }
+
+    public static func == (lhs: Product, rhs: Product) -> Bool {
+        ObjectIdentifier(lhs) == ObjectIdentifier(rhs)
+    }
+}
+
 /// The type of product.
 public enum ProductType: Equatable, Hashable {
 
@@ -72,7 +81,7 @@ public enum ProductType: Equatable, Hashable {
 
     /// An executable code snippet.
     case snippet
-    
+
     /// An plugin product.
     case plugin
 
@@ -84,6 +93,7 @@ public enum ProductType: Equatable, Hashable {
         return true
     }
 }
+
 
 /// The products requested of a package.
 ///

--- a/Sources/PackageModel/Target.swift
+++ b/Sources/PackageModel/Target.swift
@@ -11,7 +11,7 @@
 import TSCBasic
 import TSCUtility
 
-public class Target: ObjectIdentifierProtocol, PolymorphicCodableProtocol {
+public class Target: PolymorphicCodableProtocol {
     public static var implementations: [PolymorphicCodableProtocol.Type] = [
         SwiftTarget.self,
         ClangTarget.self,
@@ -49,7 +49,6 @@ public class Target: ObjectIdentifierProtocol, PolymorphicCodableProtocol {
 
     /// A target dependency to a target or product.
     public enum Dependency {
-
         /// A dependency referencing another target, with conditions.
         case target(_ target: Target, conditions: [PackageConditionProtocol])
 
@@ -130,7 +129,7 @@ public class Target: ObjectIdentifierProtocol, PolymorphicCodableProtocol {
 
     /// The resource files in the target.
     public let resources: [Resource]
-    
+
     /// Other kinds of files in the target.
     public let others: [AbsolutePath]
 
@@ -144,7 +143,7 @@ public class Target: ObjectIdentifierProtocol, PolymorphicCodableProtocol {
 
     /// The build settings assignments of this target.
     public let buildSettings: BuildSettings.AssignmentTable
-    
+
     /// The usages of package plugins by this target.
     public let pluginUsages: [PluginUsage]
 
@@ -215,6 +214,16 @@ public class Target: ObjectIdentifierProtocol, PolymorphicCodableProtocol {
         // FIXME: pluginUsages property is skipped on purpose as it points to
         // the actual target dependency object.
         self.pluginUsages = []
+    }
+}
+
+extension Target: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(self))
+    }
+
+    public static func == (lhs: Target, rhs: Target) -> Bool {
+        ObjectIdentifier(lhs) == ObjectIdentifier(rhs)
     }
 }
 
@@ -394,7 +403,7 @@ public final class ClangTarget: Target {
 
     /// The path to include directory.
     public let includeDir: AbsolutePath
-    
+
     /// The target's module map type, which determines whether this target vends a custom module map, a generated module map, or no module map at all.
     public let moduleMapType: ModuleMapType
 
@@ -603,7 +612,7 @@ public final class BinaryTarget: Target {
 public final class PluginTarget: Target {
 
     public let capability: PluginCapability
-    
+
     public init(
         name: String,
         platforms: [SupportedPlatform] = [],

--- a/Sources/XCBuildSupport/PIF.swift
+++ b/Sources/XCBuildSupport/PIF.swift
@@ -362,7 +362,7 @@ public enum PIF {
             )
 
             self.children = children
-            
+
             super.init(guid: guid, path: path, sourceTree: sourceTree, name: name)
         }
 
@@ -432,7 +432,7 @@ public enum PIF {
         }
     }
 
-    public class BaseTarget: TypedObject, ObjectIdentifierProtocol {
+    public class BaseTarget: TypedObject {
         class override var type: String { "target" }
         public let guid: GUID
         public var name: String
@@ -1095,7 +1095,7 @@ public enum PIF {
     }
 }
 
-/// Repesents a filetype recognized by the Xcode build system. 
+/// Repesents a filetype recognized by the Xcode build system.
 public struct XCBuildFileType: CaseIterable {
     public static let xcdatamodeld: XCBuildFileType = XCBuildFileType(
         fileType: "xcdatamodeld",

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -405,7 +405,7 @@ class PackageBuilderTests: XCTestCase {
             "/Sources/exec2/main.swift",
             "/Sources/lib/lib.swift"
         )
-        
+
         // Check that an explicitly declared target without a main source file works.
         var manifest = Manifest.createRootManifest(
             name: "pkg",
@@ -509,7 +509,7 @@ class PackageBuilderTests: XCTestCase {
             }
         }
     }
-    
+
     func testTestManifestFound() throws {
         try SwiftTarget.testManifestNames.forEach { name in
             let fs = InMemoryFileSystem(emptyFiles:
@@ -1050,7 +1050,7 @@ class PackageBuilderTests: XCTestCase {
                     try TargetDescription(name: "foo2", path: "./foo2.zip", type: .binary)
                 ]
             )
-            
+
             try fs.writeFileContents(AbsolutePath("/foo2.zip"), bytes: "")
 
             let binaryArtifacts = [
@@ -1600,7 +1600,7 @@ class PackageBuilderTests: XCTestCase {
                 metadata: .packageMetadata(identity: .init(urlString: manifest.packageLocation), location: manifest.packageLocation, path: .root)
             )
         }
-        
+
         manifest = Manifest.createRootManifest(
             name: "bar",
             products: [
@@ -2351,8 +2351,6 @@ class PackageBuilderTests: XCTestCase {
     }
 }
 
-extension PackageModel.Product: ObjectIdentifierProtocol {}
-
 final class PackageBuilderTester {
     private enum Result {
         case package(PackageModel.Package)
@@ -2583,7 +2581,7 @@ final class PackageBuilderTester {
             let platform = target.getSupportedPlatform(for: platform)
             XCTAssertEqual(platform?.options, options, file: file, line: line)
         }
-        
+
         func check(pluginCapability: PluginCapability, file: StaticString = #file, line: UInt = #line) {
             guard case let target as PluginTarget = target else {
                 return XCTFail("Plugin capability is being checked on a target", file: file, line: line)


### PR DESCRIPTION
motivation: ObjectIdentifierProtocol is being deprecated

changes:
* replace use of ObjectIdentifierProtocol with Hashable where still needed
* update call sites
