### PR TITLE
improve build complete message

### DIFF
--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -623,8 +623,8 @@ final class BuildOperationBuildSystemDelegateHandler: LLBuildBuildSystemDelegate
         queue.sync {
             if success {
                 self.progressAnimation.update(
-                    step: self.taskTracker.finishedCount,
-                    total: self.taskTracker.totalCount,
+                    step: self.taskTracker.finishedCount+1,
+                    total: self.taskTracker.totalCount+1,
                     text: "Build complete!")
             }
             self.progressAnimation.complete(success: success)

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -621,13 +621,12 @@ final class BuildOperationBuildSystemDelegateHandler: LLBuildBuildSystemDelegate
 
     func buildComplete(success: Bool) {
         queue.sync {
-            if success {
-                self.progressAnimation.update(
-                    step: self.taskTracker.finishedCount+1,
-                    total: self.taskTracker.totalCount+1,
-                    text: "Build complete!")
-            }
             self.progressAnimation.complete(success: success)
+            if success {
+                self.progressAnimation.clear()
+                self.outputStream <<< "Build complete!\n"
+                self.outputStream.flush()
+            }
         }
     }
 

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -279,7 +279,7 @@ final class BuildToolTests: XCTestCase {
             do {
                 let result = try execute([], packagePath: path)
                 // test second time, to make sure message is presented even when nothing to build (cached)
-                XCTAssertMatch(result.stdout, .contains("[0/0] Build complete!"))
+                XCTAssertMatch(result.stdout, .contains("[1/1] Build complete!"))
             }
         }
     }

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -273,13 +273,14 @@ final class BuildToolTests: XCTestCase {
             do {
                 let result = try execute([], packagePath: path)
                 // Number of steps must be greater than 0. e.g., [8/8] Build complete!
-                XCTAssertMatch(result.stdout, .regex("\\[[1-9][0-9]*\\/[1-9][0-9]*\\] Build complete!"))
+                XCTAssertMatch(result.stdout, .regex("\\[[1-9][0-9]*\\/[1-9][0-9]*\\] Linking Foo"))
+                XCTAssertMatch(result.stdout, .suffix("\nBuild complete!\n"))
             }
 
             do {
                 let result = try execute([], packagePath: path)
                 // test second time, to make sure message is presented even when nothing to build (cached)
-                XCTAssertMatch(result.stdout, .contains("[1/1] Build complete!"))
+                XCTAssertMatch(result.stdout, .equal("[1/1] Planning build\nBuild complete!\n"))
             }
         }
     }


### PR DESCRIPTION
motivation: when no work needs to be done the output is `[0/0] Build complete!` which is confusing

changes: treat the build complete step as a discrete step incrementing the step + total counts

