### PR TITLE
add "building for <configuration>" message

### DIFF
--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -135,6 +135,8 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         let buildSystem = try self.createBuildSystem(buildDescription: buildDescription)
         self.buildSystem = buildSystem
 
+        buildSystemDelegate?.buildStart(configuration: self.buildParameters.configuration)
+
         // Perform the build.
         let llbuildTarget = try computeLLBuildTargetName(for: subset)
         let success = buildSystem.build(target: llbuildTarget)

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -804,7 +804,7 @@ public final class SwiftTargetBuildDescription {
             args += ["-color-diagnostics"]
         }
 
-        // Add agruments from declared build settings.
+        // Add arguments from declared build settings.
         args += self.buildSettingsFlags()
 
         // Add the output for the `.swiftinterface`, if requested or if library evolution has been enabled some other way.

--- a/Sources/LLBuildManifest/Tools.swift
+++ b/Sources/LLBuildManifest/Tools.swift
@@ -70,9 +70,9 @@ public struct CopyTool: ToolProtocol {
     }
 }
 
-/// Package strcuture tool is used to determine if the package has changed in some way
+/// Package structure tool is used to determine if the package has changed in some way
 /// that requires regenerating the build manifest file. This allows us to skip a lot of
-/// redundent work (package graph loading, build planning, manifest generation) during
+/// redundant work (package graph loading, build planning, manifest generation) during
 /// incremental builds.
 public struct PackageStructureTool: ToolProtocol {
     public static let name: String = "package-structure-tool"

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -280,7 +280,21 @@ final class BuildToolTests: XCTestCase {
             do {
                 let result = try execute([], packagePath: path)
                 // test second time, to make sure message is presented even when nothing to build (cached)
-                XCTAssertMatch(result.stdout, .equal("[1/1] Planning build\nBuild complete!\n"))
+                XCTAssertMatch(result.stdout, .equal("[1/1] Planning build\nBuilding for debugging...\nBuild complete!\n"))
+            }
+        }
+    }
+
+    func testBuildStartMessage() {
+        fixture(name: "DependencyResolution/Internal/Simple") { path in
+            do {
+                let result = try execute(["-c", "debug"], packagePath: path)
+                XCTAssertMatch(result.stdout, .prefix("Building for debugging"))
+            }
+
+            do {
+                let result = try execute(["-c", "release"], packagePath: path)
+                XCTAssertMatch(result.stdout, .prefix("Building for production"))
             }
         }
     }


### PR DESCRIPTION
motivation: inform users of configuration they building for

changes: add "building for <configuration>" message at the begining of the build

rdar://84533229
