### PR TITLE
Optionally use a per-package filesystem for `PackageBuilder`

### DIFF
--- a/Sources/PackageGraph/GraphLoadingNode.swift
+++ b/Sources/PackageGraph/GraphLoadingNode.swift
@@ -28,15 +28,29 @@ public struct GraphLoadingNode: Equatable, Hashable {
     /// The product filter applied to the package.
     public let productFilter: ProductFilter
 
-    public init(identity: PackageIdentity, manifest: Manifest, productFilter: ProductFilter) {
+    /// The file system to use for loading the given package.
+    public let fileSystem: FileSystem
+
+    public init(identity: PackageIdentity, manifest: Manifest, productFilter: ProductFilter, fileSystem: FileSystem) {
         self.identity = identity
         self.manifest = manifest
         self.productFilter = productFilter
+        self.fileSystem = fileSystem
     }
 
     /// Returns the dependencies required by this node.
     internal func requiredDependencies() -> [PackageDependency] {
         return manifest.dependenciesRequired(for: productFilter)
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(identity)
+        hasher.combine(manifest)
+        hasher.combine(productFilter)
+    }
+
+    public static func == (lhs: GraphLoadingNode, rhs: GraphLoadingNode) -> Bool {
+        return lhs.identity == rhs.identity && lhs.manifest == rhs.manifest && lhs.productFilter == rhs.productFilter
     }
 }
 

--- a/Sources/PackageGraph/PackageContainer.swift
+++ b/Sources/PackageGraph/PackageContainer.swift
@@ -11,6 +11,8 @@
 import Basics
 import Dispatch
 import PackageModel
+import struct TSCBasic.AbsolutePath
+import protocol TSCBasic.FileSystem
 import struct TSCUtility.Version
 
 /// A container of packages.
@@ -100,6 +102,24 @@ extension PackageContainer {
 
     public func versionsDescending() throws -> [Version] {
         try self.versionsAscending().reversed()
+    }
+}
+
+public protocol CustomPackageContainer: PackageContainer {
+    /// Retrieve the package using this package container.
+    func retrieve(
+       at version: Version,
+       progressHandler: ((_ bytesReceived: Int64, _ totalBytes: Int64?) -> Void)?,
+       observabilityScope: ObservabilityScope
+    ) throws -> AbsolutePath
+
+    /// Get the custom file system for this package container.
+    func getFileSystem() throws -> FileSystem?
+}
+
+public extension CustomPackageContainer {
+    func retrieve(at version: Version, observabilityScope: ObservabilityScope) throws -> AbsolutePath {
+        return try self.retrieve(at: version, progressHandler: .none, observabilityScope: observabilityScope)
     }
 }
 

--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -231,8 +231,8 @@ public func loadPackageGraph(
     observabilityScope: ObservabilityScope
 ) throws -> PackageGraph {
     let rootManifests = manifests.filter { $0.packageKind.isRoot }.spm_createDictionary{ ($0.path, $0) }
-    let externalManifests = try manifests.filter { !$0.packageKind.isRoot }.reduce(into: OrderedDictionary<PackageIdentity, Manifest>()) { partial, item in
-        partial[try identityResolver.resolveIdentity(for: item.packageKind)] = item
+    let externalManifests = try manifests.filter { !$0.packageKind.isRoot }.reduce(into: OrderedDictionary<PackageIdentity, (manifest: Manifest, fs: FileSystem)>()) { partial, item in
+        partial[try identityResolver.resolveIdentity(for: item.packageKind)] = (item, fs)
     }
 
     let packages = Array(rootManifests.keys)

--- a/Sources/Workspace/Diagnostics.swift
+++ b/Sources/Workspace/Diagnostics.swift
@@ -127,6 +127,10 @@ extension Basics.Diagnostic {
         .warning("dependency '\(packageName)' is missing; downloading again")
     }
 
+    static func customDependencyMissing(packageName: String) -> Self {
+        .warning("dependency '\(packageName)' is missing; retrieving again")
+    }
+
     static func artifactChecksumChanged(targetName: String) -> Self {
         .error("artifact of binary target '\(targetName)' has changed checksum; this is a potential security risk so the new artifact won't be downloaded")
     }

--- a/Sources/Workspace/FileSystemPackageContainer.swift
+++ b/Sources/Workspace/FileSystemPackageContainer.swift
@@ -21,7 +21,7 @@ import TSCBasic
 /// There is no need to perform any git operations on such packages and they
 /// should be used as-is. In fact, they might not even have a git repository.
 /// Examples: Root packages, local dependencies, edited packages.
-internal struct FileSystemPackageContainer: PackageContainer {
+public struct FileSystemPackageContainer: PackageContainer {
     public let package: PackageReference
     private let identityResolver: IdentityResolver
     private let manifestLoader: ManifestLoaderProtocol

--- a/Sources/Workspace/ManagedDependency.swift
+++ b/Sources/Workspace/ManagedDependency.swift
@@ -39,6 +39,8 @@ extension Workspace {
             /// for top of the tree style development.
             case edited(basedOn: ManagedDependency?, unmanagedPath: AbsolutePath?)
 
+            case custom(version: Version, path: AbsolutePath)
+
             public var description: String {
                 switch self {
                 case .fileSystem(let path):
@@ -49,6 +51,8 @@ extension Workspace {
                     return "registryDownload (\(version))"
                 case .edited:
                     return "edited"
+                case .custom:
+                    return "custom"
                 }
             }
         }

--- a/Sources/Workspace/ResolverPrecomputationProvider.swift
+++ b/Sources/Workspace/ResolverPrecomputationProvider.swift
@@ -61,7 +61,7 @@ struct ResolverPrecomputationProvider: PackageContainerProvider {
     ) {
         queue.async {
             // Start by searching manifests from the Workspace's resolved dependencies.
-            if let manifest = self.dependencyManifests.dependencies.first(where: { _, managed, _ in managed.packageRef == package }) {
+            if let manifest = self.dependencyManifests.dependencies.first(where: { _, managed, _, _ in managed.packageRef == package }) {
                 let container = LocalPackageContainer(
                     package: package,
                     manifest: manifest.manifest,

--- a/Sources/Workspace/WorkspaceState.swift
+++ b/Sources/Workspace/WorkspaceState.swift
@@ -238,6 +238,10 @@ extension WorkspaceStateStorage {
                     case "edited":
                         let path = try container.decode(AbsolutePath?.self, forKey: .path)
                         return try self.init(underlying: .edited(basedOn: basedOn.map { try .init($0) }, unmanagedPath: path))
+                    case "custom":
+                        let version = try container.decode(String.self, forKey: .version)
+                        let path = try container.decode(AbsolutePath.self, forKey: .path)
+                        return try self.init(underlying: .custom(version: TSCUtility.Version(versionString: version), path: path))
                     default:
                         throw StringError("unknown dependency state \(kind)")
                     }
@@ -257,6 +261,10 @@ extension WorkspaceStateStorage {
                         try container.encode(version, forKey: .version)
                     case .edited(_, let path):
                         try container.encode("edited", forKey: .name)
+                        try container.encode(path, forKey: .path)
+                    case .custom(let version, let path):
+                        try container.encode("custom", forKey: .name)
+                        try container.encode(version, forKey: .version)
                         try container.encode(path, forKey: .path)
                     }
                 }

--- a/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
@@ -25,7 +25,7 @@ class PackageGraphPerfTests: XCTestCasePerf {
         let fs = InMemoryFileSystem(emptyFiles: files)
 
         let identityResolver = DefaultIdentityResolver()
-        var externalManifests = OrderedDictionary<PackageIdentity, Manifest>()
+        var externalManifests = OrderedDictionary<PackageIdentity, (manifest: Manifest, fs: FileSystem)>()
         var rootManifest: Manifest!
         for pkg in 1...N {
             let name = "Foo\(pkg)"
@@ -63,7 +63,7 @@ class PackageGraphPerfTests: XCTestCasePerf {
                 rootManifest = manifest
             } else {
                 let identity = try identityResolver.resolveIdentity(for: manifest.packageKind)
-                externalManifests[identity] = manifest
+                externalManifests[identity] = (manifest, fs)
             }
         }
 


### PR DESCRIPTION
Currently, we have the ability to provide a custom file system to the whole workspace and we partially use git-backed file system during package resolution. This change aims to allow using a custom file system when running `PackageBuilder` as well which e.g. allows to load a graph without having full checkouts of every package.
    
 To utilize this feature, clients of `Workspace` can pass a custom `PackageContainerProvider` and use the new `CustomPackageContainer` protocol.