### PR TITLE
Allow signing from key provided as `Data` in addition to `URL`

### DIFF
--- a/Sources/PackageCollectionsSigning/PackageCollectionSigning.swift
+++ b/Sources/PackageCollectionsSigning/PackageCollectionSigning.swift
@@ -33,6 +33,15 @@ public protocol PackageCollectionSigner {
 }
 
 extension PackageCollectionSigner {
+    /// Signs package collection using the given certificate and key.
+    ///
+    /// - Parameters:
+    ///   - collection: The package collection to be signed
+    ///   - certChainPaths: Paths to all DER-encoded certificates in the chain. The certificate used for signing
+    ///                     must be the first in the array.
+    ///   - certPrivateKeyPath: Path to the private key (*.pem) of the certificate
+    ///   - certPolicyKey: The key of the `CertificatePolicy` to use for validating certificates
+    ///   - callback: The callback to invoke when the signed collection is available.
     public func sign(collection: PackageCollectionModel.V1.Collection,
                      certChainPaths: [URL],
                      certPrivateKeyPath: URL,
@@ -40,11 +49,11 @@ extension PackageCollectionSigner {
                      callback: @escaping (Result<PackageCollectionModel.V1.SignedCollection, Error>) -> Void) {
         do {
             let privateKey = try Data(contentsOf: certPrivateKeyPath)
-            sign(collection: collection,
-                 certChainPaths: certChainPaths,
-                 privateKeyPEM: privateKey,
-                 certPolicyKey: certPolicyKey,
-                 callback: callback)
+            self.sign(collection: collection,
+                      certChainPaths: certChainPaths,
+                      privateKeyPEM: privateKey,
+                      certPolicyKey: certPolicyKey,
+                      callback: callback)
         } catch {
             callback(.failure(error))
         }

--- a/Sources/PackageCollectionsSigning/PackageCollectionSigning.swift
+++ b/Sources/PackageCollectionsSigning/PackageCollectionSigning.swift
@@ -22,14 +22,33 @@ public protocol PackageCollectionSigner {
     ///   - collection: The package collection to be signed
     ///   - certChainPaths: Paths to all DER-encoded certificates in the chain. The certificate used for signing
     ///                     must be the first in the array.
-    ///   - certPrivateKeyPath: Path to the private key (*.pem) of the certificate
+    ///   - privateKeyPEM: Data of the private key (*.pem) of the certificate
     ///   - certPolicyKey: The key of the `CertificatePolicy` to use for validating certificates
     ///   - callback: The callback to invoke when the signed collection is available.
     func sign(collection: PackageCollectionModel.V1.Collection,
               certChainPaths: [URL],
-              certPrivateKeyPath: URL,
+              privateKeyPEM: Data,
               certPolicyKey: CertificatePolicyKey,
               callback: @escaping (Result<PackageCollectionModel.V1.SignedCollection, Error>) -> Void)
+}
+
+extension PackageCollectionSigner {
+    public func sign(collection: PackageCollectionModel.V1.Collection,
+                     certChainPaths: [URL],
+                     certPrivateKeyPath: URL,
+                     certPolicyKey: CertificatePolicyKey = .default,
+                     callback: @escaping (Result<PackageCollectionModel.V1.SignedCollection, Error>) -> Void) {
+        do {
+            let privateKey = try Data(contentsOf: certPrivateKeyPath)
+            sign(collection: collection,
+                 certChainPaths: certChainPaths,
+                 privateKeyPEM: privateKey,
+                 certPolicyKey: certPolicyKey,
+                 callback: callback)
+        } catch {
+            callback(.failure(error))
+        }
+    }
 }
 
 public protocol PackageCollectionSignatureValidator {
@@ -126,7 +145,7 @@ public struct PackageCollectionSigning: PackageCollectionSigner, PackageCollecti
 
     public func sign(collection: Model.Collection,
                      certChainPaths: [URL],
-                     certPrivateKeyPath: URL,
+                     privateKeyPEM: Data,
                      certPolicyKey: CertificatePolicyKey = .default,
                      callback: @escaping (Result<Model.SignedCollection, Error>) -> Void) {
         do {
@@ -147,9 +166,6 @@ public struct PackageCollectionSigning: PackageCollectionSigner, PackageCollecti
                             algorithm: signatureAlgorithm,
                             certChain: certChainData.map { $0.base64EncodedString() }
                         )
-
-                        // Key for signing
-                        let privateKeyPEM = try Data(contentsOf: certPrivateKeyPath)
 
                         let privateKey: PrivateKey
                         switch keyType {


### PR DESCRIPTION
This extends `PackageCollectionSigner` with a signature that accepts the private key PEM as `Data` in addition to the existing `URL`.

The existing `URL` based signature is conformed to via this new signature such that clients only need to implement the `Data` one.

For example, the sole change required in https://github.com/apple/swift-package-collection-generator to adopt this is

```diff
@@ -62,7 +62,7 @@ final class PackageCollectionSignTests: XCTestCase {
 private struct MockPackageCollectionSigner: PackageCollectionSigner {
     func sign(collection: Model.Collection,
               certChainPaths: [URL],
-              certPrivateKeyPath: URL,
+              privateKeyPEM: Data,
               certPolicyKey: CertificatePolicyKey,
               callback: @escaping (Result<Model.SignedCollection, Error>) -> Void) {
         let signature = Model.Signature(
```

I can open a matching pull request in the `swift-package-collection-generator` repo if this change is acceptable.

### Motivation:

With this change, we can provide the private signing key via an environment variable in the Swift Package Index and pass the data straight to the `sign` function without having to flush it to disk first.

This change would also allow `swift-package-collection-generator` to more easily be extended to read the private key from stdin and pass it to the `sign` function.

cc @yim-lee 