### PR TITLE
emit information diagnostics for dependency resolution

### DIFF
--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -273,8 +273,8 @@ public struct SwiftToolOptions: ParsableArguments {
     var shouldEnableParseableModuleInterfaces: Bool = false
 
     /// Write dependency resolver trace to a file.
-    @Flag(name: .customLong("trace-resolver"))
-    var enableResolverTrace: Bool = false
+    @Flag(name: .customLong("trace-resolver"), help: .hidden)
+    var _deprecated_enableResolverTrace: Bool = false
 
     /// The number of jobs for llbuild to start (aka the number of schedulerLanes)
     @Option(name: .shortAndLong, help: "The number of jobs to spawn in parallel during the build process")

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -467,6 +467,11 @@ public class SwiftTool {
         if options._deprecated_netrcOptional {
             observabilityScope.emit(warning: "'--netrc-optional' option is deprecated; .netrc files are located by default")
         }
+
+        if options._deprecated_enableResolverTrace {
+            observabilityScope.emit(warning: "'--enableResolverTrace' option is deprecated; use --verbose flag to log resolver output")
+        }
+
     }
 
     private func editsDirectory() throws -> AbsolutePath {
@@ -660,7 +665,6 @@ public class SwiftTool {
             additionalFileRules: isXcodeBuildSystemEnabled ? FileRuleDescription.xcbuildFileTypes : FileRuleDescription.swiftpmFileTypes,
             resolverUpdateEnabled: !options.skipDependencyUpdate,
             resolverPrefetchingEnabled: options.shouldEnableResolverPrefetching,
-            resolverTracingEnabled: options.enableResolverTrace,
             sharedRepositoriesCacheEnabled: self.options.useRepositoriesCache,
             delegate: delegate
         )

--- a/Sources/SPMTestSupport/Observability.swift
+++ b/Sources/SPMTestSupport/Observability.swift
@@ -77,8 +77,8 @@ public struct TestingObservability {
     }
 }
 
-
-public func XCTAssertNoDiagnostics(_ diagnostics: [Basics.Diagnostic], file: StaticString = #file, line: UInt = #line) {
+public func XCTAssertNoDiagnostics(_ diagnostics: [Basics.Diagnostic], problemsOnly: Bool = true, file: StaticString = #file, line: UInt = #line) {
+    let diagnostics = problemsOnly ? diagnostics.filter({ $0.severity >= .warning }) : diagnostics
     if diagnostics.isEmpty { return }
     let description = diagnostics.map({ "- " + $0.description }).joined(separator: "\n")
     XCTFail("Found unexpected diagnostics: \n\(description)", file: file, line: line)
@@ -86,10 +86,12 @@ public func XCTAssertNoDiagnostics(_ diagnostics: [Basics.Diagnostic], file: Sta
 
 public func testDiagnostics(
     _ diagnostics: [Basics.Diagnostic],
+    problemsOnly: Bool = true,
     file: StaticString = #file,
     line: UInt = #line,
     handler: (DiagnosticsTestResult) throws -> Void
 ) {
+    let diagnostics = problemsOnly ? diagnostics.filter({ $0.severity >= .warning }) : diagnostics
     let testResult = DiagnosticsTestResult(diagnostics)
 
     do {

--- a/Tests/BasicsTests/ObservabilitySystemTests.swift
+++ b/Tests/BasicsTests/ObservabilitySystemTests.swift
@@ -108,7 +108,7 @@ final class ObservabilitySystemTest: XCTestCase {
         emitter.emit(debug: "debug")
         emitter.emit(.debug("debug 2"))
 
-        testDiagnostics(collector.diagnostics) { result in
+        testDiagnostics(collector.diagnostics, problemsOnly: false) { result in
             result.check(diagnostic: "error", severity: .error, metadata: metadata)
             result.check(diagnostic: "error 2", severity: .error, metadata: metadata)
             result.check(diagnostic: "error 3", severity: .error, metadata: metadata)

--- a/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
+++ b/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
@@ -278,7 +278,7 @@ class TargetSourcesBuilderTests: XCTestCase {
                 "/Resources/Sub/foo.txt"
             )
 
-            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, location, path, diagnostics in
+            build(target: target, toolsVersion: .v5_3, fs: fs, checkOnlyProblems: false) { _, _, _, _, identity, location, path, diagnostics in
                 var expectedMetadata = ObservabilityMetadata.packageMetadata(identity: identity, location: location, path: path)
                 expectedMetadata.targetName = target.name
                 diagnostics.check(diagnostic: "multiple resources named 'foo.txt' in target 'Foo'", severity: .error, metadata: expectedMetadata)
@@ -300,7 +300,7 @@ class TargetSourcesBuilderTests: XCTestCase {
                 "/Copied/foo.txt"
             )
 
-            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, location, path, diagnostics in
+            build(target: target, toolsVersion: .v5_3, fs: fs, checkOnlyProblems: false) { _, _, _, _, identity, location, path, diagnostics in
                 var expectedMetadata = ObservabilityMetadata.packageMetadata(identity: identity, location: location, path: path)
                 expectedMetadata.targetName = target.name
                 diagnostics.check(diagnostic: "multiple resources named 'foo.txt' in target 'Foo'", severity: .error, metadata: expectedMetadata)
@@ -623,6 +623,7 @@ class TargetSourcesBuilderTests: XCTestCase {
         additionalFileRules: [FileRuleDescription] = [],
         toolsVersion: ToolsVersion,
         fs: FileSystem,
+        checkOnlyProblems: Bool = false,
         file: StaticString = #file,
         line: UInt = #line,
         checker: (Sources, [Resource], [AbsolutePath], [AbsolutePath], PackageIdentity, String, AbsolutePath, DiagnosticsTestResult) -> ()
@@ -644,7 +645,7 @@ class TargetSourcesBuilderTests: XCTestCase {
         do {
             let (sources, resources, headers, others) = try builder.run()
 
-            testDiagnostics(observability.diagnostics, file: file, line: line) { diagnostics in
+            testDiagnostics(observability.diagnostics, problemsOnly: checkOnlyProblems, file: file, line: line) { diagnostics in
                 checker(sources, resources, headers, others, builder.packageIdentity, builder.packageLocation, builder.packagePath, diagnostics)
             }
         } catch {


### PR DESCRIPTION
motivation: provide transperancy / debug information when needed

changes:
* add a new dependency resolver delegate that emits debug diagnostics for resover callbacks, wire it into the observability system
* this information will only show when running in verbose mode
* deprecate TracingDependencyResolverDelegate which was a bespoke solution serving the same need
* add and adjust tests