### PR TITLE
Add default argument for ObservabilityScope

### DIFF
--- a/Sources/PackageCollectionsSigning/PackageCollectionSigning.swift
+++ b/Sources/PackageCollectionsSigning/PackageCollectionSigning.swift
@@ -95,7 +95,7 @@ public struct PackageCollectionSigning: PackageCollectionSigner, PackageCollecti
 
     private let observabilityScope: ObservabilityScope
 
-    public init(trustedRootCertsDir: URL? = nil, additionalTrustedRootCerts: [String]? = nil, observabilityScope: ObservabilityScope, callbackQueue: DispatchQueue) {
+    public init(trustedRootCertsDir: URL? = nil, additionalTrustedRootCerts: [String]? = nil, observabilityScope: ObservabilityScope = ObservabilitySystem { _, _ in }.topScope, callbackQueue: DispatchQueue) {
         self.trustedRootCertsDir = trustedRootCertsDir
         self.additionalTrustedRootCerts = additionalTrustedRootCerts.map { $0.compactMap {
             guard let data = Data(base64Encoded: $0) else {


### PR DESCRIPTION
This adds a "NOP" default parameter for `ObservabilityScope` to the `PackageCollectionSigning` initialiser.

### Motivation:

It is currently not possible to instantiate `PackageCollectionSigning` from a dependent package (unless I'm missing something!) due to the `ObservabilityScope` reference. `ObservabilityScope` lives in `Basics`, which is not exported as a library I could import.

Adding a default argument to the initialiser is a simple way of dealing with this, and at least for us (the Swift Package Index), the scope's callback is of no use anyway.

I guess alternatively `Basics` could be a library but for our use case that'd be more than we need.