### PR TITLE
Replace deprecated `url` with a more useful one

### DIFF
--- a/Sources/SourceControl/Repository.swift
+++ b/Sources/SourceControl/Repository.swift
@@ -29,11 +29,12 @@ public struct RepositorySpecifier: Hashable {
         self.init(location: .url(url))
     }
 
-    /// The URL of the repository.
-    // FIXME: transition url to location
-    @available(*, deprecated, message: "user location instead")
-    public var url: String {
-        self.location.description
+    /// The location of the repository as URL.
+    public var url: URL {
+        switch self.location {
+        case .path(let path): return URL(fileURLWithPath: path.pathString)
+        case .url(let url): return url
+        }
     }
 
     /// A unique identifier for this specifier.


### PR DESCRIPTION
Many clients of libSwiftPM will want to deal with Foundation URLs here, so it makes sense to offer a computed property to convert a `RepositorySpecifier` location into that.