### PR TITLE
Make the `@main` entry points for plugins be `async` so they can call other `async` APIs

### DIFF
--- a/Sources/PackagePlugin/Plugin.swift
+++ b/Sources/PackagePlugin/Plugin.swift
@@ -53,7 +53,7 @@ extension Plugin {
     
     /// Main entry point of the plugin — sets up a communication channel with
     /// the plugin host and runs the main message loop.
-    public static func main() throws {
+    public static func main() async throws {
         // Duplicate the `stdin` file descriptor, which we will then use for
         // receiving messages from the plugin host.
         let inputFD = dup(fileno(stdin))
@@ -93,7 +93,7 @@ extension Plugin {
         // indicating that we're done.
         while let message = try pluginHostConnection.waitForNextMessage() {
             do {
-                try handleMessage(message)
+                try await handleMessage(message)
             }
             catch {
                 // Emit a diagnostic and indicate failure to the plugin host,
@@ -104,7 +104,7 @@ extension Plugin {
         }
     }
     
-    fileprivate static func handleMessage(_ message: HostToPluginMessage) throws {
+    fileprivate static func handleMessage(_ message: HostToPluginMessage) async throws {
         switch message {
 
         case .performAction(let wireInput):
@@ -147,7 +147,7 @@ extension Plugin {
                 }
                 
                 // Invoke the plugin to create build commands for the target.
-                let generatedCommands = try plugin.createBuildCommands(context: context, target: target)
+                let generatedCommands = try await plugin.createBuildCommands(context: context, target: target)
                 
                 // Send each of the generated commands to the host.
                 for command in generatedCommands {
@@ -189,7 +189,7 @@ extension Plugin {
                 }
                 
                 // Invoke the plugin to perform its custom logic.
-                try plugin.performCommand(context: context, targets: targets, arguments: arguments)
+                try await plugin.performCommand(context: context, targets: targets, arguments: arguments)
             }
             
             // Exit with a zero exit code to indicate success.

--- a/Sources/PackagePlugin/Protocols.swift
+++ b/Sources/PackagePlugin/Protocols.swift
@@ -35,7 +35,7 @@ public protocol BuildToolPlugin: Plugin {
     func createBuildCommands(
         context: PluginContext,
         target: Target
-    ) throws -> [Command]
+    ) async throws -> [Command]
 }
 
 /// Defines functionality for all plugins that have a `command` capability.
@@ -54,7 +54,7 @@ public protocol CommandPlugin: Plugin {
         
         /// Any literal arguments passed after the verb in the command invocation.
         arguments: [String]
-    ) throws
+    ) async throws
 
     /// A proxy to the Swift Package Manager or IDE hosting the command plugin,
     /// through which the plugin can ask for specialized information or actions.

--- a/Sources/SPMTestSupport/Toolchain.swift
+++ b/Sources/SPMTestSupport/Toolchain.swift
@@ -58,3 +58,38 @@ extension UserToolchain {
         }
     }
 }
+
+extension UserToolchain {
+    /// Helper function to determine if async await actually works in the current environment.
+    public func supportsSwiftConcurrency() -> Bool {
+      #if os(macOS)
+        if #available(macOS 12.0, *) {
+            // On macOS 12 and later, concurrency is assumed to work.
+            return true
+        }
+        else {
+            // On macOS 11 and earlier, we don't know if concurrency actually works because not all SDKs and toolchains have the right bits.  We could examine the SDK and the various libraries, but the most accurate test is to just try to compile and run a snippet of code that requires async/await support.  It doesn't have to actually do anything, it's enough that all the libraries can be found (but because the library reference is weak we do need the linkage reference to `_swift_task_create` and the like).
+            do {
+                try testWithTemporaryDirectory { tmpPath in
+                    let inputPath = tmpPath.appending(component: "foo.swift")
+                    try localFileSystem.writeFileContents(inputPath, string: "public func foo() async {}\nTask { await foo() }")
+                    let outputPath = tmpPath.appending(component: "foo")
+                    let toolchainPath = self.swiftCompilerPath.parentDirectory.parentDirectory
+                    let backDeploymentLibPath = toolchainPath.appending(components: "lib", "swift-5.5", "macosx")
+                    try Process.checkNonZeroExit(arguments: ["/usr/bin/xcrun", "--toolchain", toolchainPath.pathString, "swiftc", inputPath.pathString, "-Xlinker", "-rpath", "-Xlinker", backDeploymentLibPath.pathString, "-o", outputPath.pathString])
+                    try Process.checkNonZeroExit(arguments: [outputPath.pathString])
+                }
+            } catch {
+                // On any failure we assume false.
+                return false
+            }
+            // If we get this far we could compile and run a trivial executable that uses libConcurrency, so we can say that this toolchain supports concurrency on this host.
+            return true
+        }
+      #else
+        // On other platforms, concurrency is assumed to work since with new enough versions of the toolchain.
+        return true
+      #endif
+    }
+    
+}

--- a/Sources/Workspace/DefaultPluginScriptRunner.swift
+++ b/Sources/Workspace/DefaultPluginScriptRunner.swift
@@ -161,6 +161,18 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner {
                 macOSPackageDescriptionPath = runtimePath.appending(component: "libPackagePlugin.dylib")
             }
 
+            #if os(macOS)
+            // On macOS earlier than 12, add an rpath to the directory that contains the concurrency fallback library.
+            if #available(macOS 12.0, *) {
+                // Nothing is needed; the system has everything we need.
+            }
+            else {
+                // Add an `-rpath` so the Swift 5.5 fallback libraries can be found.
+                let swiftSupportLibPath = self.toolchain.swiftCompilerPath.parentDirectory.parentDirectory.appending(components: "lib", "swift-5.5", "macosx")
+                command += ["-Xlinker", "-rpath", "-Xlinker", swiftSupportLibPath.pathString]
+            }
+            #endif
+
             // Use the same minimum deployment target as the PackageDescription library (with a fallback of 10.15).
             #if os(macOS)
             let triple = self.hostTriple

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -1040,6 +1040,8 @@ final class PackageToolTests: CommandsTestCase {
     }
 
     func testBuildToolPlugin() throws {
+        // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
+        try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
         
         try testWithTemporaryDirectory { tmpPath in
             // Create a sample package with a library target and a plugin.
@@ -1125,7 +1127,9 @@ final class PackageToolTests: CommandsTestCase {
     }
 
     func testBuildToolPluginFailure() throws {
-
+        // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
+        try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+        
         try testWithTemporaryDirectory { tmpPath in
             // Create a sample package with a library target and a plugin.
             let packageDir = tmpPath.appending(components: "MyPackage")
@@ -1255,6 +1259,8 @@ final class PackageToolTests: CommandsTestCase {
     }
     
     func testCommandPlugin() throws {
+        // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
+        try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
         
         try testWithTemporaryDirectory { tmpPath in
             // Create a sample package with a library target, a plugin, and a local tool. It depends on a sample package which also has a tool.
@@ -1481,7 +1487,9 @@ final class PackageToolTests: CommandsTestCase {
     }
 
     func testCommandPluginPermissions() throws {
-
+        // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
+        try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+        
         try testWithTemporaryDirectory { tmpPath in
             // Create a sample package with a library target and a plugin.
             let packageDir = tmpPath.appending(components: "MyPackage")
@@ -1570,6 +1578,9 @@ final class PackageToolTests: CommandsTestCase {
     }
 
     func testCommandPluginSymbolGraphCallbacks() throws {
+        // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
+        try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+        
         // Depending on how the test is running, the `swift-symbolgraph-extract` tool might be unavailable.
         try XCTSkipIf((try? UserToolchain.default.getSymbolGraphExtract()) == nil, "skipping test because the `swift-symbolgraph-extract` tools isn't available")
         
@@ -1656,7 +1667,9 @@ final class PackageToolTests: CommandsTestCase {
     }
 
     func testCommandPluginBuildingCallbacks() throws {
-
+        // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
+        try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+        
         try testWithTemporaryDirectory { tmpPath in
             // Create a sample package with a library, an executable, and a command plugin.
             let packageDir = tmpPath.appending(components: "MyPackage")
@@ -1812,6 +1825,9 @@ final class PackageToolTests: CommandsTestCase {
     }
 
     func testCommandPluginTestingCallbacks() throws {
+        // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
+        try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+        
         // Depending on how the test is running, the `llvm-profdata` and `llvm-cov` tool might be unavailable.
         try XCTSkipIf((try? UserToolchain.default.getLLVMProf()) == nil, "skipping test because the `llvm-profdata` tool isn't available")
         try XCTSkipIf((try? UserToolchain.default.getLLVMCov()) == nil, "skipping test because the `llvm-cov` tool isn't available")
@@ -1938,6 +1954,8 @@ final class PackageToolTests: CommandsTestCase {
     }
     
     func testPluginAPIs() throws {
+        // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
+        try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
         
         try testWithTemporaryDirectory { tmpPath in
             // Create a sample package with a plugin to test various parts of the API.

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -22,6 +22,9 @@ import XCTest
 class PluginTests: XCTestCase {
     
     func testUseOfBuildToolPluginTargetByExecutableInSamePackage() throws {
+        // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
+        try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+
         fixture(name: "Miscellaneous/Plugins") { path in
             do {
                 let (stdout, _) = try executeSwiftBuild(path.appending(component: "MySourceGenPlugin"), configuration: .Debug, extraArgs: ["--product", "MyLocalTool"])
@@ -38,6 +41,9 @@ class PluginTests: XCTestCase {
     }
 
     func testUseOfBuildToolPluginProductByExecutableAcrossPackages() throws {
+        // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
+        try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+
         fixture(name: "Miscellaneous/Plugins") { path in
             do {
                 let (stdout, _) = try executeSwiftBuild(path.appending(component: "MySourceGenClient"), configuration: .Debug, extraArgs: ["--product", "MyTool"])
@@ -54,6 +60,9 @@ class PluginTests: XCTestCase {
     }
 
     func testUseOfPrebuildPluginTargetByExecutableAcrossPackages() throws {
+        // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
+        try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+
         fixture(name: "Miscellaneous/Plugins") { path in
             do {
                 let (stdout, _) = try executeSwiftBuild(path.appending(component: "MySourceGenPlugin"), configuration: .Debug, extraArgs: ["--product", "MyOtherLocalTool"])
@@ -69,7 +78,10 @@ class PluginTests: XCTestCase {
         }
     }
 
-    func testUseOfPluginWithInternalExecutable() {
+    func testUseOfPluginWithInternalExecutable() throws {
+        // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
+        try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+        
         fixture(name: "Miscellaneous/Plugins") { path in
             let (stdout, _) = try executeSwiftBuild(path.appending(component: "ClientOfPluginWithInternalExecutable"))
             XCTAssert(stdout.contains("Compiling PluginExecutable main.swift"), "stdout:\n\(stdout)")
@@ -81,7 +93,10 @@ class PluginTests: XCTestCase {
         }
     }
 
-    func testInternalExecutableAvailableOnlyToPlugin() {
+    func testInternalExecutableAvailableOnlyToPlugin() throws {
+        // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
+        try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+
         fixture(name: "Miscellaneous/Plugins") { path in
             do {
                 let (stdout, _) = try executeSwiftBuild(path.appending(component: "InvalidUseOfInternalPluginExecutable"))
@@ -99,6 +114,9 @@ class PluginTests: XCTestCase {
     }
 
     func testContrivedTestCases() throws {
+        // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
+        try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+
         fixture(name: "Miscellaneous/Plugins") { path in
             do {
                 let (stdout, _) = try executeSwiftBuild(path.appending(component: "ContrivedTestPlugin"), configuration: .Debug, extraArgs: ["--product", "MyLocalTool"])
@@ -115,6 +133,9 @@ class PluginTests: XCTestCase {
     }
 
     func testPluginScriptSandbox() throws {
+        // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
+        try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+
         #if os(macOS)
         fixture(name: "Miscellaneous/Plugins") { path in
             do {
@@ -131,6 +152,9 @@ class PluginTests: XCTestCase {
     }
 
     func testUseOfVendedBinaryTool() throws {
+        // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
+        try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+
         #if os(macOS)
         fixture(name: "Miscellaneous/Plugins") { path in
             do {
@@ -147,6 +171,9 @@ class PluginTests: XCTestCase {
     }
     
     func testCommandPluginInvocation() throws {
+        // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
+        try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+        
         // FIXME: This test is getting quite long — we should add some support functionality for creating synthetic plugin tests and factor this out into separate tests.
         try testWithTemporaryDirectory { tmpPath in
             // Create a sample package with a library target and a plugin. It depends on a sample package.


### PR DESCRIPTION
Make the `@main` entry point for plugins be `async`.

### Motivation:

This allows the `@main` entry point for plugins to call APIs marked `async`.

### Modifications:

- mark the protocols in the plugin API as `async`
- use `await` when calling those APIs
- add a required `-rpath` when compiling plugins on macOS older than 12.0 (not needed on other platforms)

rdar://83206272


*Note:*  This builds on https://github.com/apple/swift-package-manager/pull/3898 and will be easier to review once that one is merged.