### PR TITLE
Add support for correctly discovering async test methods on non-Apple platforms

### DIFF
--- a/Fixtures/Miscellaneous/TestDiscovery/Async/Package.swift
+++ b/Fixtures/Miscellaneous/TestDiscovery/Async/Package.swift
@@ -1,0 +1,10 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "Async",
+    targets: [
+        .target(name: "Async"),
+        .testTarget(name: "AsyncTests", dependencies: ["Async"]),
+    ]
+)

--- a/Fixtures/Miscellaneous/TestDiscovery/Async/Sources/Async/Async.swift
+++ b/Fixtures/Miscellaneous/TestDiscovery/Async/Sources/Async/Async.swift
@@ -1,0 +1,3 @@
+struct Async {
+
+}

--- a/Fixtures/Miscellaneous/TestDiscovery/Async/Tests/AsyncTests/SwiftTests.swift
+++ b/Fixtures/Miscellaneous/TestDiscovery/Async/Tests/AsyncTests/SwiftTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import Async
+
+class AsyncTests: XCTestCase {
+
+    func testAsync() async {
+        XCTAssertFalse(Thread.isMainThread)
+    }
+
+    @MainActor func testMainActor() async {
+        XCTAssertTrue(Thread.isMainThread)
+    }
+
+    func testNotAsync() {
+        XCTAssertTrue(Thread.isMainThread)
+    }
+}

--- a/Fixtures/Miscellaneous/TestDiscovery/Async/Tests/AsyncTests/SwiftTests.swift
+++ b/Fixtures/Miscellaneous/TestDiscovery/Async/Tests/AsyncTests/SwiftTests.swift
@@ -4,7 +4,6 @@ import XCTest
 class AsyncTests: XCTestCase {
 
     func testAsync() async {
-        XCTAssertFalse(Thread.isMainThread)
     }
 
     @MainActor func testMainActor() async {

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -47,23 +47,10 @@ class CustomLLBuildCommand: SPMLLBuild.ExternalCommand {
 
 private extension IndexStore.TestCaseClass.TestMethod {
 
-    var baseName: String {
-        let name = self.name
-        return name.hasSuffix("()") ? String(name.dropLast(2)) : name
-    }
-
     var allTestsEntry: String {
-        let baseName = self.baseName
-        let testCaseClosure: String
+        let baseName = name.hasSuffix("()") ? String(name.dropLast(2)) : name
 
-        switch self {
-        case .standard(_):
-            testCaseClosure = baseName
-        case .async(_):
-            testCaseClosure = "asyncTest(\(baseName))"
-        }
-
-        return "(\"\(baseName)\", \(testCaseClosure))"
+        return "(\"\(baseName)\", \(isAsync ? "asyncTest(\(baseName))" : baseName ))"
     }
 }
 

--- a/Tests/FunctionalTests/TestDiscoveryTests.swift
+++ b/Tests/FunctionalTests/TestDiscoveryTests.swift
@@ -51,6 +51,19 @@ class TestDiscoveryTests: XCTestCase {
         }
     }
 
+    func testAsyncMethods() throws {
+        fixture(name: "Miscellaneous/TestDiscovery/Async") { path in
+            let (stdout, stderr) = try executeSwiftTest(path)
+            #if os(macOS)
+            XCTAssertMatch(stdout, .contains("module Async"))
+            XCTAssertMatch(stderr, .contains("Executed 3 tests"))
+            #else
+            XCTAssertMatch(stdout, .contains("module Async"))
+            XCTAssertMatch(stdout, .contains("Executed 3 tests"))
+            #endif
+        }
+    }
+
     func testManifestOverride() throws {
         #if os(macOS)
         try XCTSkipIf(true)


### PR DESCRIPTION
This adopts [a recent enhancement to swift-corelibs-xctest for supporting `async` test methods](https://github.com/apple/swift-corelibs-xctest/pull/331) by ensuring the automatic test discovery machinery used on non-Apple platforms generates the correct test manifest code for the harness to run async tests.

### Modifications:

I have adjusted the code-gen logic used during test discovery to notice async test methods, using the richer IndexStore data provided by https://github.com/apple/swift-tools-support-core/pull/258, and wrap such methods in the `asyncTest` helper from swift-corelibs-xctest so that they can execute correctly.

### Result:

With this change, it is now possible to transparently run async XCTests on Linux via `swift test`.
