### PR TITLE
[5.5] Include rpath for back-deployed concurrency on macOS prior to 12.0.

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -1277,6 +1277,19 @@ public final class ProductBuildDescription {
             let stdlib = buildParameters.toolchain.macosSwiftStdlib
             args += ["-Xlinker", "-rpath", "-Xlinker", stdlib.pathString]
           }
+
+          // When deploying to macOS prior to macOS 12, add an rpath to the
+          // back-deployed concurrency libraries.
+          if buildParameters.triple.isDarwin(),
+             let macOSSupportedPlatform = product.targets[0].underlyingTarget.getSupportedPlatform(for: .macOS),
+             macOSSupportedPlatform.version.major < 12 {
+            let backDeployedStdlib = buildParameters.toolchain.macosSwiftStdlib
+              .parentDirectory
+              .parentDirectory
+              .appending(component: "swift-5.5")
+              .appending(component: "macosx")
+            args += ["-Xlinker", "-rpath", "-Xlinker", backDeployedStdlib.pathString]
+          }
         }
 
         // Don't link runtime compatibility patch libraries if there are no

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -974,20 +974,19 @@ final class BuildPlanTests: XCTestCase {
                     ],
                     v: .v5,
                     targets: [
-                        TargetDescription(name: "Foo", dependencies: []),
-                        TargetDescription(name: "FooTests", dependencies: ["Foo"], type: .test),
+                        TargetDescription(name: "exe", dependencies: []),
                     ]),
             ]
         )
         XCTAssertNoDiagnostics(diagnostics)
 
-        let result = BuildPlanResult(plan: try BuildPlan(buildParameters: mockBuildParameters(), graph: graph, diagnostics: diagnostics, fileSystem: fs))
+        let result = BuildPlanResult(plan: try BuildPlan(buildParameters: mockBuildParameters(config: .release), graph: graph, diagnostics: diagnostics, fileSystem: fs))
 
         result.checkProductsCount(1)
         result.checkTargetsCount(1)
 
         let exe = try result.target(for: "exe").swiftTarget().compileArguments()
-        XCTAssertMatch(exe, ["-swift-version", "4", "-O", "-g", .equal(j), "-DSWIFT_PACKAGE", "-module-cache-path", "/path/to/build/release/ModuleCache", .anySequence])
+        XCTAssertMatch(exe, ["-swift-version", "5", "-O", "-g", .equal(j), "-DSWIFT_PACKAGE", "-module-cache-path", "/path/to/build/release/ModuleCache", .anySequence])
 
       #if os(macOS)
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [


### PR DESCRIPTION
When building an executable or test target for macOS prior to 12.0,
add an additional rpath to point into the toolchain's copy of the
back-deployed concurrency shared libraries. This allows `swift build`
to build executables that can run on the same macOS that predates
macOS 12.0.

Fixes rdar://problem/85209998 / SR-15445.
