### PR TITLE
fix warnings

### DIFF
--- a/Sources/PackageCollections/Model/Package.swift
+++ b/Sources/PackageCollections/Model/Package.swift
@@ -290,6 +290,6 @@ extension PackageCollectionsModel.Package.Version {
 
 extension Model.Package {
     var displayName: String {
-        self.latestVersion?.packageName ?? self.identity.description
+        self.identity.description
     }
 }

--- a/Sources/PackageModel/Package.swift
+++ b/Sources/PackageModel/Package.swift
@@ -143,9 +143,6 @@ extension ObservabilityMetadata {
         var metadata = ObservabilityMetadata()
         metadata.packageIdentity = identity
         metadata.packageKind = kind
-        //metadata.packageLocation = location
-        // FIXME: (diagnostics) remove once transition to Observability API is complete
-        //metadata.legacyDiagnosticLocation = .init(PackageLocation.Local(name: identity.description, packagePath: path))
         return metadata
     }
 }

--- a/Sources/Workspace/SourceControlPackageContainer.swift
+++ b/Sources/Workspace/SourceControlPackageContainer.swift
@@ -23,7 +23,7 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
 
     // A wrapper for getDependencies() errors. This adds additional information
     // about the container to identify it for diagnostics.
-    public struct GetDependenciesError: Error, CustomStringConvertible, DiagnosticLocationProviding {
+    public struct GetDependenciesError: Error, CustomStringConvertible {
 
         /// The repository  that encountered the error.
         public let repository: RepositorySpecifier
@@ -36,10 +36,6 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
 
         /// Optional suggestion for how to resolve the error.
         public let suggestion: String?
-
-        public var diagnosticLocation: DiagnosticLocation? {
-            return PackageLocation.Remote(url: self.repository.location.description, reference: self.reference)
-        }
 
         /// Description shown for errors of this kind.
         public var description: String {

--- a/Tests/WorkspaceTests/PackageContainerProviderTests.swift
+++ b/Tests/WorkspaceTests/PackageContainerProviderTests.swift
@@ -572,7 +572,8 @@ class PackageContainerProviderTests: XCTestCase {
             catch let error as SourceControlPackageContainer.GetDependenciesError {
                 // We expect to get an error message that mentions main.
                 XCTAssertMatch(error.description, .and(.prefix("could not find a branch named ‘master’"), .suffix("(did you mean ‘main’?)")))
-                XCTAssertMatch(error.diagnosticLocation?.description, .suffix("/SomePackage @ master"))
+                XCTAssertMatch(error.repository.description, .suffix("/SomePackage"))
+                XCTAssertMatch(error.reference, "master")
             }
 
             // Simulate accessing a fictitious dependency on some random commit that doesn't exist, and check that we get back the expected error.
@@ -580,7 +581,8 @@ class PackageContainerProviderTests: XCTestCase {
             catch let error as SourceControlPackageContainer.GetDependenciesError {
                 // We expect to get an error message about the specific commit.
                 XCTAssertMatch(error.description, .prefix("could not find the commit 535f4cb5b4a0872fa691473e82d7b27b9894df00"))
-                XCTAssertMatch(error.diagnosticLocation?.description, .suffix("/SomePackage @ 535f4cb5b4a0872fa691473e82d7b27b9894df00"))
+                XCTAssertMatch(error.repository.description, .suffix("/SomePackage"))
+                XCTAssertMatch(error.reference, "535f4cb5b4a0872fa691473e82d7b27b9894df00")
             }
         }
     }


### PR DESCRIPTION
motivations: less warnings, safer code

changes:
* use package identifier for display name in collections
* reduce use of DiagnosticsEngine where possible
* remove use of PackageLocation from Git errors, metadata is already carried on assocaited error
* adjust tests
