### PR TITLE
[Collections] Call VACUUM in async queue

### DIFF
--- a/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
+++ b/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
@@ -706,59 +706,63 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
             try self.removeFromSearchIndices(identifier: collection.identifier)
             // Update search indices
             try self.withDB { db in
-                try db.exec(query: "BEGIN TRANSACTION;")
-
                 let packagesStatement = try db.prepare(query: "INSERT INTO \(Self.packagesFTSName) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);")
                 let targetsStatement = try db.prepare(query: "INSERT INTO \(Self.targetsFTSName) VALUES (?, ?, ?);")
+                
+                try db.exec(query: "BEGIN TRANSACTION;")
+                do {
+                    // Then insert new data
+                    try collection.packages.forEach { package in
+                        var targets = Set<String>()
 
-                // Then insert new data
-                try collection.packages.forEach { package in
-                    var targets = Set<String>()
+                        try package.versions.forEach { version in
+                            try version.manifests.values.forEach { manifest in
+                                // Packages FTS
+                                let packagesBindings: [SQLite.SQLiteValue] = [
+                                    .string(try self.encoder.encode(collection.identifier).base64EncodedString()),
+                                    .string(package.identity.description),
+                                    .string(version.version.description),
+                                    .string(manifest.packageName),
+                                    .string(package.location),
+                                    package.summary.map { .string($0) } ?? .null,
+                                    package.keywords.map { .string($0.joined(separator: ",")) } ?? .null,
+                                    .string(manifest.products.map { $0.name }.joined(separator: ",")),
+                                    .string(manifest.targets.map { $0.name }.joined(separator: ",")),
+                                ]
+                                try packagesStatement.bind(packagesBindings)
+                                try packagesStatement.step()
 
-                    try package.versions.forEach { version in
-                        try version.manifests.values.forEach { manifest in
-                            // Packages FTS
-                            let packagesBindings: [SQLite.SQLiteValue] = [
+                                try packagesStatement.clearBindings()
+                                try packagesStatement.reset()
+
+                                manifest.targets.forEach { targets.insert($0.name) }
+                            }
+                        }
+
+                        let collectionPackage = CollectionPackage(collection: collection.identifier, package: package.identity)
+                        try targets.forEach { target in
+                            // Targets in-memory trie
+                            self.targetTrie.insert(word: target.lowercased(), foundIn: collectionPackage)
+
+                            // Targets FTS
+                            let targetsBindings: [SQLite.SQLiteValue] = [
                                 .string(try self.encoder.encode(collection.identifier).base64EncodedString()),
-                                .string(package.identity.description),
-                                .string(version.version.description),
-                                .string(manifest.packageName),
                                 .string(package.location),
-                                package.summary.map { .string($0) } ?? .null,
-                                package.keywords.map { .string($0.joined(separator: ",")) } ?? .null,
-                                .string(manifest.products.map { $0.name }.joined(separator: ",")),
-                                .string(manifest.targets.map { $0.name }.joined(separator: ",")),
+                                .string(target),
                             ]
-                            try packagesStatement.bind(packagesBindings)
-                            try packagesStatement.step()
+                            try targetsStatement.bind(targetsBindings)
+                            try targetsStatement.step()
 
-                            try packagesStatement.clearBindings()
-                            try packagesStatement.reset()
-
-                            manifest.targets.forEach { targets.insert($0.name) }
+                            try targetsStatement.clearBindings()
+                            try targetsStatement.reset()
                         }
                     }
-
-                    let collectionPackage = CollectionPackage(collection: collection.identifier, package: package.identity)
-                    try targets.forEach { target in
-                        // Targets in-memory trie
-                        self.targetTrie.insert(word: target.lowercased(), foundIn: collectionPackage)
-
-                        // Targets FTS
-                        let targetsBindings: [SQLite.SQLiteValue] = [
-                            .string(try self.encoder.encode(collection.identifier).base64EncodedString()),
-                            .string(package.location),
-                            .string(target),
-                        ]
-                        try targetsStatement.bind(targetsBindings)
-                        try targetsStatement.step()
-
-                        try targetsStatement.clearBindings()
-                        try targetsStatement.reset()
-                    }
+                    
+                    try db.exec(query: "COMMIT;")
+                } catch {
+                    try db.exec(query: "ROLLBACK;")
+                    throw error
                 }
-
-                try db.exec(query: "COMMIT;")
 
                 try packagesStatement.finalize()
                 try targetsStatement.finalize()
@@ -785,12 +789,16 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
             try statement.step()
         }
 
-        // Repack database file to reduce size (rdar://77077510)
-        try self.withDB { db in
+        // Run VACUUM asynchronously since it's just an optimization measure and could take some time to complete.
+        // Add a delay since VACUUM often fails if run immediately after the deletions.
+        DispatchQueue.sharedConcurrent.asyncAfter(deadline: .now() + 0.5) {
+            // Repack database file to reduce size (rdar://77077510)
             do {
-                try db.exec(query: "VACUUM;")
+                try self.withDB { db in
+                    try db.exec(query: "VACUUM;")
+                }
             } catch {
-                self.observabilityScope.emit(warning: "Failed to 'VACUUM' the database: \(error)")
+                self.observabilityScope.emit(info: "Failed to 'VACUUM' the database: \(error)")
             }
         }
 


### PR DESCRIPTION
Motivation:
I noticed that when I run `package-collection remove` in CLI there is a warning in the output:

```
Failed to 'VACUUM' the database: SQL logic error
```

Modifications:
- Not sure what the real cause is, but the problem doesn't occur if there is a sleep between `DELETE` and `VACUUM`, so perhaps `VACUUM` fails because other operations are not done yet. Instead of calling `VACUUM` synchronously, do that in an async queue, which is probably more appropriate since `VACUUM` can be time consuming.
- Fix a bug in the same file where we didn't do `ROLLBACK` when a transaction fails.
