### PR TITLE
reduce the use of manifest name

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -2002,7 +2002,7 @@ public class BuildPlan {
         var arguments = ["-I" + buildPath, "-L" + buildPath]
 
         // Link the special REPL product that contains all of the library targets.
-        let replProductName = graph.rootPackages[0].manifest.name + Product.replProductSuffix
+        let replProductName = graph.rootPackages[0].identity.description + Product.replProductSuffix
         arguments.append("-l" + replProductName)
 
         // The graph should have the REPL product.

--- a/Sources/Commands/Describe.swift
+++ b/Sources/Commands/Describe.swift
@@ -27,7 +27,7 @@ struct DescribedPackage: Encodable {
     let swiftLanguagesVersions: [String]?
 
     init(from package: Package) {
-        self.name = package.manifestName // TODO: rename property to manifestName?
+        self.name = package.manifest.displayName // TODO: rename property to manifestName?
         self.path = package.path.pathString
         self.toolsVersion = "\(package.manifest.toolsVersion.major).\(package.manifest.toolsVersion.minor)"
         + (package.manifest.toolsVersion.patch == 0 ? "" : ".\(package.manifest.toolsVersion.patch)")

--- a/Sources/Commands/Describe.swift
+++ b/Sources/Commands/Describe.swift
@@ -14,7 +14,8 @@ import Foundation
 
 /// Represents a package for the sole purpose of generating a description.
 struct DescribedPackage: Encodable {
-    let name: String
+    let name: String // for backwards compatibility
+    let manifestDisplayName: String
     let path: String
     let toolsVersion: String
     let dependencies: [DescribedPackageDependency]
@@ -27,7 +28,8 @@ struct DescribedPackage: Encodable {
     let swiftLanguagesVersions: [String]?
 
     init(from package: Package) {
-        self.name = package.manifest.displayName // TODO: rename property to manifestName?
+        self.manifestDisplayName = package.manifest.displayName
+        self.name = self.manifestDisplayName // TODO: deprecate, backwards compatibility 11/2021
         self.path = package.path.pathString
         self.toolsVersion = "\(package.manifest.toolsVersion.major).\(package.manifest.toolsVersion.minor)"
         + (package.manifest.toolsVersion.patch == 0 ? "" : ".\(package.manifest.toolsVersion.patch)")

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -840,7 +840,7 @@ extension SwiftPackageTool {
                 destination = output
             } else {
                 let graph = try swiftTool.loadPackageGraph()
-                let packageName = graph.rootPackages[0].manifestName // TODO: use identity instead?
+                let packageName = graph.rootPackages[0].manifest.displayName // TODO: use identity instead?
                 destination = packageRoot.appending(component: "\(packageName).zip")
             }
 
@@ -915,10 +915,10 @@ extension SwiftPackageTool {
                 dstdir = outpath.parentDirectory
             case let outpath?:
                 dstdir = outpath
-                projectName = graph.rootPackages[0].manifestName // TODO: use identity instead?
+                projectName = graph.rootPackages[0].manifest.displayName // TODO: use identity instead?
             case _:
                 dstdir = try swiftTool.getPackageRoot()
-                projectName = graph.rootPackages[0].manifestName // TODO: use identity instead?
+                projectName = graph.rootPackages[0].manifest.displayName // TODO: use identity instead?
             }
             let xcodeprojPath = Xcodeproj.buildXcodeprojPath(outputDir: dstdir, projectName: projectName)
 

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -1314,11 +1314,11 @@ fileprivate func logPackageChanges(changes: [(PackageReference, Workspace.Packag
         let currentVersion = pins.pinsMap[package.identity]?.state.description ?? ""
         switch change {
         case let .added(state):
-            stream <<< "+ \(package.name) \(state.requirement.prettyPrinted)"
+            stream <<< "+ \(package.identity) \(state.requirement.prettyPrinted)"
         case let .updated(state):
-            stream <<< "~ \(package.name) \(currentVersion) -> \(package.name) \(state.requirement.prettyPrinted)"
+            stream <<< "~ \(package.identity) \(currentVersion) -> \(package.identity) \(state.requirement.prettyPrinted)"
         case .removed:
-            stream <<< "- \(package.name) \(currentVersion)"
+            stream <<< "- \(package.identity) \(currentVersion)"
         case .unchanged:
             continue
         }

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -382,7 +382,7 @@ public struct SwiftTestTool: SwiftCommand {
             // Export the codecov data as JSON.
             let jsonPath = codeCovAsJSONPath(
                 buildParameters: buildParameters,
-                packageName: rootManifest.name)
+                packageName: rootManifest.displayName)
             try exportCodeCovAsJSON(to: jsonPath, testBinary: product.binaryPath, swiftTool: swiftTool)
         }
     }

--- a/Sources/Commands/show-dependencies.swift
+++ b/Sources/Commands/show-dependencies.swift
@@ -114,7 +114,8 @@ final class JSONDumper: DependenciesDumper {
     func dump(dependenciesOf rootpkg: ResolvedPackage, on stream: OutputByteStream) {
         func convert(_ package: ResolvedPackage) -> JSON {
             return .orderedDictionary([
-                "name": .string(package.manifestName), // TODO: remove? add identity?
+                "identity": .string(package.identity.description),
+                "name": .string(package.manifest.displayName), // TODO: remove?
                 "url": .string(package.manifest.packageLocation),
                 "version": .string(package.manifest.version?.description ?? "unspecified"),
                 "path": .string(package.path.pathString),

--- a/Sources/PackageGraph/DependencyResolutionNode.swift
+++ b/Sources/PackageGraph/DependencyResolutionNode.swift
@@ -95,7 +95,7 @@ public enum DependencyResolutionNode {
         // Don’t create a version lock for anything but a product.
         guard specificProduct != nil else { return nil }
         return PackageContainerConstraint(
-            package: package,
+            package: self.package,
             versionRequirement: .exact(version),
             products: .specific([])
         )
@@ -108,7 +108,7 @@ public enum DependencyResolutionNode {
         // Don’t create a revision lock for anything but a product.
         guard specificProduct != nil else { return nil }
         return PackageContainerConstraint(
-            package: package,
+            package: self.package,
             requirement: .revision(revision),
             products: .specific([])
         )
@@ -123,13 +123,13 @@ extension DependencyResolutionNode: Equatable {
 
 extension DependencyResolutionNode: Hashable {
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(package)
-        hasher.combine(specificProduct)
+        hasher.combine(self.package)
+        hasher.combine(self.specificProduct)
     }
 }
 
 extension DependencyResolutionNode: CustomStringConvertible {
     public var description: String {
-        return "\(package.name)\(productFilter)"
+        return "\(self.package.identity)\(self.productFilter)"
     }
 }

--- a/Sources/PackageGraph/GraphLoadingNode.swift
+++ b/Sources/PackageGraph/GraphLoadingNode.swift
@@ -44,9 +44,9 @@ extension GraphLoadingNode: CustomStringConvertible {
     public var description: String {
         switch productFilter {
         case .everything:
-            return self.manifest.name
+            return self.identity.description
         case .specific(let set):
-            return "\(self.manifest.name)[\(set.sorted().joined(separator: ", "))]"
+            return "\(self.identity.description)[\(set.sorted().joined(separator: ", "))]"
         }
     }
 }

--- a/Sources/PackageGraph/PackageContainer.swift
+++ b/Sources/PackageGraph/PackageContainer.swift
@@ -90,7 +90,7 @@ public protocol PackageContainer {
     /// This can be used by the containers to fill in the missing information that is obtained
     /// after the container is available. The updated identifier is returned in result of the
     /// dependency resolution.
-    func getUpdatedIdentifier(at boundVersion: BoundVersion) throws -> PackageReference
+    func loadPackageReference(at boundVersion: BoundVersion) throws -> PackageReference
 }
 
 extension PackageContainer {

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -279,7 +279,7 @@ private func createResolvedPackages(
                     // backwards compatibility with older versions of SwiftPM that had too weak of a validation
                     // we will upgrade this to an error in a few versions to tighten up the validation
                     if dependency.explicitNameForTargetDependencyResolutionOnly == .none ||
-                        resolvedPackage.package.manifestName == dependency.explicitNameForTargetDependencyResolutionOnly {
+                        resolvedPackage.package.manifest.displayName == dependency.explicitNameForTargetDependencyResolutionOnly {
                         packageObservabilityScope.emit(warning: error.description + ". this will be escalated to an error in future versions of SwiftPM.")
                     } else {
                         return packageObservabilityScope.emit(error)

--- a/Sources/PackageGraph/PackageGraph.swift
+++ b/Sources/PackageGraph/PackageGraph.swift
@@ -187,8 +187,8 @@ extension PackageGraphError: CustomStringConvertible {
 
         case .cycleDetected(let cycle):
             return "cyclic dependency declaration found: " +
-            (cycle.path + cycle.cycle).map({ $0.name }).joined(separator: " -> ") +
-            " -> " + cycle.cycle[0].name
+            (cycle.path + cycle.cycle).map({ $0.displayName }).joined(separator: " -> ") +
+            " -> " + cycle.cycle[0].displayName
 
         case .productDependencyNotFound(let package, let targetName, let dependencyProductName, let dependencyPackageName, let dependencyProductInDecl):
             if dependencyProductInDecl {

--- a/Sources/PackageGraph/PinsStore.swift
+++ b/Sources/PackageGraph/PinsStore.swift
@@ -129,7 +129,7 @@ fileprivate struct PinsStorage {
                 let v1 = try decoder.decode(path: self.path, fileSystem: self.fileSystem, as: V1.self)
                 return try v1.object.pins.map{ try PinsStore.Pin($0, mirrors: mirrors) }.reduce(into: [PackageIdentity: PinsStore.Pin]()) { partial, iterator in
                     if partial.keys.contains(iterator.packageRef.identity) {
-                        throw StringError("duplicated entry for package \"\(iterator.packageRef.name)\"")
+                        throw StringError("duplicated entry for package \"\(iterator.packageRef.identity)\"")
                     }
                     partial[iterator.packageRef.identity] = iterator
                 }
@@ -234,7 +234,7 @@ fileprivate struct PinsStorage {
                     throw StringError("invalid package type \(pin.packageRef.kind)")
                 }
 
-                self.package = pin.packageRef.name
+                self.package = pin.packageRef.deprecatedName
                 // rdar://52529014, rdar://52529011: pin file should store the original location but remap when loading
                 self.repositoryURL = mirrors.originalURL(for: location) ?? location
                 self.state = .init(pin.state)
@@ -328,7 +328,7 @@ extension PinsStore.Pin {
             throw StringError("invalid package location \(location)")
         }
         if let newName = pin.package {
-            packageRef = packageRef.with(newName: newName)
+            packageRef = packageRef.withName(newName)
         }
         self.init(
             packageRef: packageRef,

--- a/Sources/PackageGraph/ResolvedPackage.swift
+++ b/Sources/PackageGraph/ResolvedPackage.swift
@@ -26,19 +26,6 @@ public final class ResolvedPackage {
         return self.underlyingPackage.manifest
     }
 
-    /// The name of the package.
-    @available(*, deprecated, message: "use identity (or manifestName, but only if you must) instead")
-    public var name: String {
-        return self.underlyingPackage.name
-    }
-
-    /// The name of the package as entered in the manifest.
-    /// This should rarely be used beyond presentation purposes
-    //@available(*, deprecated)
-    public var manifestName: String {
-        return self.underlyingPackage.manifestName
-    }
-
     /// The local path of the package.
     public var path: AbsolutePath {
         return self.underlyingPackage.path

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -274,7 +274,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                 }
 
                 let manifest = Manifest(
-                    name: parsedManifest.name,
+                    displayName: parsedManifest.name,
                     path: path,
                     packageKind: packageKind,
                     packageLocation: packageLocation,

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -460,7 +460,7 @@ public final class PackageBuilder {
             // it's a system library target.
             return [
                 SystemLibraryTarget(
-                    name: self.manifest.name,
+                    name: self.manifest.displayName, // FIXME: use identity instead?
                     platforms: self.platforms(),
                     path: self.packagePath,
                     isImplicit: true,
@@ -474,12 +474,12 @@ public final class PackageBuilder {
         // system target specific configuration.
         guard manifest.pkgConfig == nil else {
             throw ModuleError.invalidManifestConfig(
-                self.manifest.name, "the 'pkgConfig' property can only be used with a System Module Package")
+                self.identity.description, "the 'pkgConfig' property can only be used with a System Module Package")
         }
 
         guard manifest.providers == nil else {
             throw ModuleError.invalidManifestConfig(
-                self.manifest.name, "the 'providers' property can only be used with a System Module Package")
+                self.identity.description, "the 'providers' property can only be used with a System Module Package")
         }
 
         return try constructV4Targets()
@@ -550,7 +550,7 @@ public final class PackageBuilder {
                 let path = packagePath.appending(relativeSubPath)
                 // Make sure the target is inside the package root.
                 guard path.isDescendantOfOrEqual(to: packagePath) else {
-                    throw ModuleError.targetOutsidePackage(package: self.manifest.name, target: target.name)
+                    throw ModuleError.targetOutsidePackage(package: self.identity.description, target: target.name)
                 }
                 if fileSystem.isDirectory(path) {
                     return path
@@ -785,7 +785,7 @@ public final class PackageBuilder {
         // Check for duplicate target dependencies by name
         let combinedDependencyNames = dependencies.map { $0.target?.name ?? $0.product!.name }
         combinedDependencyNames.spm_findDuplicates().forEach {
-            self.observabilityScope.emit(.duplicateTargetDependency(dependency: $0, target: potentialModule.name, package: self.manifest.name))
+            self.observabilityScope.emit(.duplicateTargetDependency(dependency: $0, target: potentialModule.name, package: self.identity.description))
         }
 
         // Create the build setting assignment table for this target.
@@ -818,8 +818,9 @@ public final class PackageBuilder {
             throw ModuleError.defaultLocalizationNotSet
         }
 
+        // FIXME: use identity instead?
         // The name of the bundle, if one is being generated.
-        let bundleName = resources.isEmpty ? nil : self.manifest.name + "_" + potentialModule.name
+        let bundleName = resources.isEmpty ? nil : self.manifest.displayName + "_" + potentialModule.name
 
         if sources.relativePaths.isEmpty && resources.isEmpty {
             return nil
@@ -1082,7 +1083,7 @@ public final class PackageBuilder {
         if let swiftLanguageVersions = manifest.swiftLanguageVersions {
             guard let swiftVersion = swiftLanguageVersions.sorted(by: >).first(where: { $0 <= ToolsVersion.currentToolsVersion }) else {
                 throw ModuleError.incompatibleToolsVersions(
-                    package: manifest.name, required: swiftLanguageVersions, current: .currentToolsVersion)
+                    package: self.identity.description, required: swiftLanguageVersions, current: .currentToolsVersion)
             }
             computedSwiftVersion = swiftVersion
         } else {
@@ -1152,7 +1153,7 @@ public final class PackageBuilder {
         // It is an error if there are multiple linux main files.
         if testManifestFiles.count > 1 {
             throw ModuleError.multipleTestManifestFilesFound(
-                package: self.manifest.name, files: testManifestFiles.map({ $0 }))
+                package: self.identity.description, files: testManifestFiles.map({ $0 }))
         }
         return testManifestFiles.first
     }
@@ -1194,7 +1195,8 @@ public final class PackageBuilder {
             //
             // Add suffix 'PackageTests' to test product name so the target name
             // of linux executable don't collide with main package, if present.
-            let productName = self.manifest.name + "PackageTests"
+            // FIXME: use identity instead
+            let productName = self.manifest.displayName + "PackageTests"
             let testManifest = try self.findTestManifest(in: testModules)
 
             let product = Product(name: productName, type: .test, targets: testModules, testManifest: testManifest)
@@ -1299,7 +1301,7 @@ public final class PackageBuilder {
                 self.observabilityScope.emit(.noLibraryTargetsForREPL)
             } else {
                 let replProduct = Product(
-                    name: self.manifest.name + Product.replProductSuffix,
+                    name: self.identity.description + Product.replProductSuffix,
                     type: .library(.dynamic),
                     targets: libraryTargets
                 )

--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -23,10 +23,15 @@ public final class Manifest {
     /// The standard basename for the manifest.
     public static let basename = "Package"
 
+    /// The name of the package as it appears in the manifest
+    @available(*, deprecated, message: "use displayName instead, and only for display purposes")
+    public var name: String {
+        return self.displayName
+    }
+
+    /// The name of the package as it appears in the manifest
     /// FIXME: deprecate this, there is no value in this once we have real package identifiers
-    /// The name of the package.
-    //@available(*, deprecated)
-    public let name: String
+    public let displayName: String
 
     // FIXME: deprecate this, this is not part of the manifest information, we just use it as a container for this data
     // FIXME: This doesn't belong here, we want the Manifest to be purely tied
@@ -103,7 +108,7 @@ public final class Manifest {
     private var _requiredDependencies = ThreadSafeKeyValueStore<ProductFilter, [PackageDependency]>()
 
     public init(
-        name: String,
+        displayName: String,
         path: AbsolutePath,
         packageKind: PackageReference.Kind,
         packageLocation: String,
@@ -121,7 +126,7 @@ public final class Manifest {
         products: [ProductDescription] = [],
         targets: [TargetDescription] = []
     ) {
-        self.name = name
+        self.displayName = displayName
         self.path = path
         self.packageKind = packageKind
         self.packageLocation = packageLocation
@@ -396,7 +401,7 @@ extension Manifest: Hashable {
 
 extension Manifest: CustomStringConvertible {
     public var description: String {
-        return "<Manifest: \(self.name)>"
+        return "<Manifest: \(self.displayName)>"
     }
 }
 
@@ -414,7 +419,7 @@ extension Manifest: Encodable {
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(self.name, forKey: .name)
+        try container.encode(self.displayName, forKey: .name)
 
         // Hide the keys that users shouldn't see when
         // we're encoding for the dump-package command.

--- a/Sources/PackageModel/ManifestSourceGeneration.swift
+++ b/Sources/PackageModel/ManifestSourceGeneration.swift
@@ -67,7 +67,7 @@ fileprivate extension SourceCodeFragment {
     init(from manifest: Manifest, customProductTypeSourceGenerator: ManifestCustomProductTypeSourceGenerator?) rethrows {
         var params: [SourceCodeFragment] = []
         
-        params.append(SourceCodeFragment(key: "name", string: manifest.name))
+        params.append(SourceCodeFragment(key: "name", string: manifest.displayName))
         
         if let defaultLoc = manifest.defaultLocalization {
             params.append(SourceCodeFragment(key: "defaultLocalization", string: defaultLoc))

--- a/Sources/PackageModel/Package.swift
+++ b/Sources/PackageModel/Package.swift
@@ -53,19 +53,6 @@ public final class Package: Encodable {
     /// The local path of the package.
     public let path: AbsolutePath
 
-    /// The name of the package.
-    @available(*, deprecated, message: "use identity (or manifestName, but only if you must) instead")
-    public var name: String {
-        return self.manifestName
-    }
-
-    /// The name of the package as entered in the manifest.
-    /// This should rarely be used beyond presentation purposes
-    //@available(*, deprecated)
-    public var manifestName: String {
-        return manifest.name
-    }
-
     /// The targets contained in the package.
     @PolymorphicCodableArray
     public var targets: [Target]

--- a/Sources/PackageModel/PackageReference.swift
+++ b/Sources/PackageModel/PackageReference.swift
@@ -80,9 +80,14 @@ public struct PackageReference {
     /// The identity of the package.
     public let identity: PackageIdentity
 
+    @available(*, deprecated)
+    public var name: String {
+        return self.deprecatedName
+    }
+
     /// The name of the package, if available.
-    // FIXME: we should not need this
-    public var name: String
+    // soft deprecated 11/21
+    public private(set) var deprecatedName: String
 
     /// The location of the package.
     ///
@@ -102,21 +107,21 @@ public struct PackageReference {
         self.kind = kind
         switch kind {
         case .root(let path):
-            self.name = name ?? LegacyPackageIdentity.computeDefaultName(fromPath: path)
+            self.deprecatedName = name ?? LegacyPackageIdentity.computeDefaultName(fromPath: path)
         case .fileSystem(let path):
-            self.name = name ?? LegacyPackageIdentity.computeDefaultName(fromPath: path)
+            self.deprecatedName = name ?? LegacyPackageIdentity.computeDefaultName(fromPath: path)
         case .localSourceControl(let path):
-            self.name = name ?? LegacyPackageIdentity.computeDefaultName(fromPath: path)
+            self.deprecatedName = name ?? LegacyPackageIdentity.computeDefaultName(fromPath: path)
         case .remoteSourceControl(let url):
-            self.name = name ?? LegacyPackageIdentity.computeDefaultName(fromURL: url)
+            self.deprecatedName = name ?? LegacyPackageIdentity.computeDefaultName(fromURL: url)
         case .registry(let identity):
             // FIXME: this is a placeholder
-            self.name = name ?? identity.description
+            self.deprecatedName = name ?? identity.description
         }
     }
 
     /// Create a new package reference object with the given name.
-    public func with(newName: String) -> PackageReference {
+    public func withName(_ newName: String) -> PackageReference {
         return PackageReference(identity: self.identity, kind: self.kind, name: newName)
     }
 

--- a/Sources/SPMBuildCore/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/PluginInvocation.swift
@@ -790,7 +790,8 @@ struct PluginScriptRunnerInputSerializer {
         // Assign the next wire ID to the package and append a serialized Package record.
         let id = packages.count
         packages.append(.init(
-            name: package.manifestName,
+            // FIXME: can we use package identity instead?
+            name: package.manifest.displayName,
             directoryId: try serialize(path: package.path),
             origin: try origin(for: package),
             toolsVersion: .init(

--- a/Sources/SPMTestSupport/ManifestExtensions.swift
+++ b/Sources/SPMTestSupport/ManifestExtensions.swift
@@ -179,7 +179,7 @@ public extension Manifest {
         targets: [TargetDescription] = []
     ) -> Manifest {
         return Manifest(
-            name: name,
+            displayName: name,
             path: path.appending(component: Manifest.filename),
             packageKind: packageKind,
             packageLocation: packageLocation ?? path.pathString,
@@ -200,7 +200,7 @@ public extension Manifest {
 
     func with(location: String) -> Manifest {
         return Manifest(
-            name: self.name,
+            displayName: self.displayName,
             path: self.path,
             packageKind: self.packageKind,
             packageLocation: location,

--- a/Sources/SPMTestSupport/MockPackageContainer.swift
+++ b/Sources/SPMTestSupport/MockPackageContainer.swift
@@ -57,7 +57,7 @@ public class MockPackageContainer: PackageContainer {
         return unversionedDeps
     }
 
-    public func getUpdatedIdentifier(at boundVersion: BoundVersion) throws -> PackageReference {
+    public func loadPackageReference(at boundVersion: BoundVersion) throws -> PackageReference {
         return self.package
     }
 

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -139,7 +139,7 @@ public final class MockWorkspace {
             for version in versions {
                 let v = version.flatMap(Version.init(_:))
                 manifests[.init(url: specifier.location.description, version: v)] = try Manifest(
-                    name: package.name,
+                    displayName: package.name,
                     path: manifestPath,
                     packageKind: packageKind,
                     packageLocation: packageLocation,

--- a/Sources/SPMTestSupport/PackageGraphTester.swift
+++ b/Sources/SPMTestSupport/PackageGraphTester.swift
@@ -24,12 +24,22 @@ public final class PackageGraphResult {
         self.graph = graph
     }
 
+    // TODO: deprecate / transition to PackageIdentity
     public func check(roots: String..., file: StaticString = #file, line: UInt = #line) {
-        XCTAssertEqual(graph.rootPackages.map{$0.manifestName}.sorted(), roots.sorted(), file: file, line: line)
+        XCTAssertEqual(graph.rootPackages.map{$0.manifest.displayName }.sorted(), roots.sorted(), file: file, line: line)
     }
 
+    public func check(roots: PackageIdentity..., file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(graph.rootPackages.map{$0.identity }.sorted(), roots.sorted(), file: file, line: line)
+    }
+
+    // TODO: deprecate / transition to PackageIdentity
     public func check(packages: String..., file: StaticString = #file, line: UInt = #line) {
-        XCTAssertEqual(graph.packages.map {$0.manifestName}.sorted(), packages.sorted(), file: file, line: line)
+        XCTAssertEqual(graph.packages.map {$0.manifest.displayName }.sorted(), packages.sorted(), file: file, line: line)
+    }
+
+    public func check(packages: PackageIdentity..., file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(graph.packages.map {$0.identity }.sorted(), packages.sorted(), file: file, line: line)
     }
 
     public func check(targets: String..., file: StaticString = #file, line: UInt = #line) {

--- a/Sources/Workspace/FileSystemPackageContainer.swift
+++ b/Sources/Workspace/FileSystemPackageContainer.swift
@@ -105,7 +105,7 @@ internal struct FileSystemPackageContainer: PackageContainer {
     public func getUpdatedIdentifier(at boundVersion: BoundVersion) throws -> PackageReference {
         assert(boundVersion == .unversioned, "Unexpected bound version \(boundVersion)")
         let manifest = try loadManifest()
-        return package.with(newName: manifest.name)
+        return package.with(newName: manifest.displayName)
     }
 
     public func isToolsVersionCompatible(at version: Version) -> Bool {

--- a/Sources/Workspace/FileSystemPackageContainer.swift
+++ b/Sources/Workspace/FileSystemPackageContainer.swift
@@ -102,10 +102,10 @@ internal struct FileSystemPackageContainer: PackageContainer {
         return try loadManifest().dependencyConstraints(productFilter: productFilter)
     }
 
-    public func getUpdatedIdentifier(at boundVersion: BoundVersion) throws -> PackageReference {
+    public func loadPackageReference(at boundVersion: BoundVersion) throws -> PackageReference {
         assert(boundVersion == .unversioned, "Unexpected bound version \(boundVersion)")
         let manifest = try loadManifest()
-        return package.with(newName: manifest.displayName)
+        return package.withName(manifest.displayName)
     }
 
     public func isToolsVersionCompatible(at version: Version) -> Bool {

--- a/Sources/Workspace/ManagedArtifact.swift
+++ b/Sources/Workspace/ManagedArtifact.swift
@@ -88,7 +88,7 @@ extension Workspace {
 
 extension Workspace.ManagedArtifact: CustomStringConvertible {
     public var description: String {
-        return "<ManagedArtifact: \(self.packageRef.name).\(self.targetName) \(self.source) \(self.path)>"
+        return "<ManagedArtifact: \(self.packageRef.identity).\(self.targetName) \(self.source) \(self.path)>"
     }
 }
 

--- a/Sources/Workspace/ManagedDependency.swift
+++ b/Sources/Workspace/ManagedDependency.swift
@@ -128,7 +128,7 @@ extension Workspace {
 
 extension Workspace.ManagedDependency: CustomStringConvertible {
     public var description: String {
-        return "<ManagedDependency: \(self.packageRef.name) \(self.state)>"
+        return "<ManagedDependency: \(self.packageRef.identity) \(self.state)>"
     }
 }
 

--- a/Sources/Workspace/ResolverPrecomputationProvider.swift
+++ b/Sources/Workspace/ResolverPrecomputationProvider.swift
@@ -158,7 +158,7 @@ private struct LocalPackageContainer: PackageContainer {
     }
 
     // Gets the package reference from the managed dependency or computes it for root packages.
-    func getUpdatedIdentifier(at boundVersion: BoundVersion) throws -> PackageReference {
+    func loadPackageReference(at boundVersion: BoundVersion) throws -> PackageReference {
         if let packageRef = dependency?.packageRef {
             return packageRef
         } else {

--- a/Sources/Workspace/SourceControlPackageContainer.swift
+++ b/Sources/Workspace/SourceControlPackageContainer.swift
@@ -270,7 +270,7 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
         return []
     }
 
-    public func getUpdatedIdentifier(at boundVersion: BoundVersion) throws -> PackageReference {
+    public func loadPackageReference(at boundVersion: BoundVersion) throws -> PackageReference {
         let revision: Revision
         var version: Version?
         switch boundVersion {
@@ -288,7 +288,7 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
         }
 
         let manifest = try self.loadManifest(at: revision, version: version)
-        return self.package.with(newName: manifest.name)
+        return self.package.withName(manifest.displayName)
     }
 
     /// Returns true if the tools version is valid and can be used by this

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -983,9 +983,9 @@ extension Workspace {
 
         sync.notify(queue: .sharedConcurrent) {
             // Check for duplicate root packages.
-            let duplicateRoots = rootManifests.values.spm_findDuplicateElements(by: \.name)
+            let duplicateRoots = rootManifests.values.spm_findDuplicateElements(by: \.displayName)
             if !duplicateRoots.isEmpty {
-                let name = duplicateRoots[0][0].name
+                let name = duplicateRoots[0][0].displayName
                 observabilityScope.emit(error: "found multiple top-level packages named '\(name)'")
                 return completion(.success([:]))
             }
@@ -1146,8 +1146,8 @@ extension Workspace {
                                   completion: $0)
             }
 
-            guard manifest.name == packageName else {
-                return observabilityScope.emit(error: "package at '\(destination)' is \(manifest.name) but was expecting \(packageName)")
+            guard manifest.displayName == packageName else {
+                return observabilityScope.emit(error: "package at '\(destination)' is \(manifest.displayName) but was expecting \(packageName)")
             }
 
             // Emit warnings for branch and revision, if they're present.
@@ -1649,10 +1649,10 @@ extension Workspace {
 
         // TODO: this check should go away when introducing explicit overrides
         // check for overrides attempts with same name but different path
-        let rootManifestsByName = Array(root.manifests.values).spm_createDictionary{ ($0.name, $0) }
+        let rootManifestsByName = Array(root.manifests.values).spm_createDictionary{ ($0.displayName, $0) }
         dependencyManifests.forEach { identity, manifest, _ in
-            if let override = rootManifestsByName[manifest.name], override.packageLocation != manifest.packageLocation  {
-                observabilityScope.emit(error: "unable to override package '\(manifest.name)' because its identity '\(PackageIdentity(urlString: manifest.packageLocation))' doesn't match override's identity (directory name) '\(PackageIdentity(urlString: override.packageLocation))'")
+            if let override = rootManifestsByName[manifest.displayName], override.packageLocation != manifest.packageLocation  {
+                observabilityScope.emit(error: "unable to override package '\(manifest.displayName)' because its identity '\(PackageIdentity(urlString: manifest.packageLocation))' doesn't match override's identity (directory name) '\(PackageIdentity(urlString: override.packageLocation))'")
             }
         }
 

--- a/Sources/Workspace/WorkspaceState.swift
+++ b/Sources/Workspace/WorkspaceState.swift
@@ -369,7 +369,7 @@ extension WorkspaceStateStorage {
                     // FIXME: placeholder
                     self.location = self.identity.description
                 }
-                self.name = reference.name
+                self.name = reference.deprecatedName
             }
 
             enum Kind: String, Codable {

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -110,7 +110,7 @@ public final class PIFBuilder {
         try memoize(to: &pif) {
             let rootPackage = graph.rootPackages[0]
 
-            let sortedPackages = graph.packages.sorted { $0.manifestName < $1.manifestName } // TODO: use identity instead?
+            let sortedPackages = graph.packages.sorted { $0.manifest.displayName < $1.manifest.displayName } // TODO: use identity instead?
             var projects: [PIFProjectBuilder] = try sortedPackages.map { package in
                 try PackagePIFProjectBuilder(
                     package: package,
@@ -124,7 +124,7 @@ public final class PIFBuilder {
 
             let workspace = PIF.Workspace(
                 guid: "Workspace:\(rootPackage.path.pathString)",
-                name: rootPackage.manifestName,  // TODO: use identity instead?
+                name: rootPackage.manifest.displayName,  // TODO: use identity instead?
                 path: rootPackage.path,
                 projects: try projects.map { try $0.construct() }
             )
@@ -246,7 +246,7 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         super.init()
 
         guid = package.pifProjectGUID
-        name = package.manifestName // TODO: use identity instead?
+        name = package.manifest.displayName // TODO: use identity instead?
         path = package.path
         projectDirectory = package.path
         developmentRegion = package.manifest.defaultLocalization ?? "en"
@@ -789,7 +789,7 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
             return nil
         }
 
-        let bundleName = "\(package.manifestName)_\(target.name)" // TODO: use identity instead?
+        let bundleName = "\(package.manifest.displayName)_\(target.name)" // TODO: use identity instead?
         let resourcesTarget = addTarget(
             guid: target.pifResourceTargetGUID,
             name: bundleName,
@@ -807,7 +807,7 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         settings[.TARGET_NAME] = bundleName
         settings[.PRODUCT_NAME] = bundleName
         settings[.PRODUCT_MODULE_NAME] = bundleName
-        let bundleIdentifier = "\(package.manifestName).\(target.name).resources".spm_mangledToBundleIdentifier() // TODO: use identity instead?
+        let bundleIdentifier = "\(package.manifest.displayName).\(target.name).resources".spm_mangledToBundleIdentifier() // TODO: use identity instead?
         settings[.PRODUCT_BUNDLE_IDENTIFIER] = bundleIdentifier
         settings[.GENERATE_INFOPLIST_FILE] = "YES"
         settings[.PACKAGE_RESOURCE_TARGET_KIND] = "resource"

--- a/Sources/Xcodeproj/SchemesGenerator.swift
+++ b/Sources/Xcodeproj/SchemesGenerator.swift
@@ -86,7 +86,7 @@ public final class SchemesGenerator {
             }
         })
         schemes.append(Scheme(
-            name: rootPackage.manifestName + "-Package", // TODO: use identity instead?
+            name: rootPackage.manifest.displayName + "-Package", // TODO: use identity instead?
             regularTargets: regularTargets,
             testTargets: rootPackage.targets.filter({ $0.type == .test })
         ))

--- a/Sources/Xcodeproj/generate.swift
+++ b/Sources/Xcodeproj/generate.swift
@@ -239,7 +239,7 @@ func generateSchemes(
         // tests associated so testing works. We suffix the name of this scheme with
         // -Package so its name doesn't collide with any products or target with
         // same name.
-        let schemeName = "\(graph.rootPackages[0].manifestName)-Package.xcscheme" // TODO: use identity instead?
+        let schemeName = "\(graph.rootPackages[0].manifest.displayName)-Package.xcscheme" // TODO: use identity instead?
         try open(schemesDir.appending(RelativePath(schemeName))) { stream in
             legacySchemeGenerator(
                 container: schemeContainer,

--- a/Sources/Xcodeproj/pbxproj.swift
+++ b/Sources/Xcodeproj/pbxproj.swift
@@ -73,8 +73,10 @@ public func xcodeProject(
         guard let manifestLoader = options.manifestLoader else { return }
 
         let pdTarget = project.addTarget(
-            objectID: "\(package.manifestName)::SwiftPMPackageDescription", // TODO: use identity instead?
-            productType: .framework, name: "\(package.manifestName)PackageDescription") // TODO: use identity instead?
+            objectID: "\(package.manifest.displayName)::SwiftPMPackageDescription", // TODO: use identity instead?
+            productType: .framework,
+            name: "\(package.manifest.displayName)PackageDescription" // TODO: use identity instead?
+        )
         let compilePhase = pdTarget.addSourcesBuildPhase()
         compilePhase.addBuildFile(fileRef: manifestFileRef)
 
@@ -336,7 +338,7 @@ public func xcodeProject(
             }
             // TODO: use identity instead
             // Construct a group name from the package name and optional version.
-            var groupName = package.manifestName // TODO: use identity instead?
+            var groupName = package.manifest.displayName // TODO: use identity instead?
             if let version = package.manifest.version {
                 groupName += " " + version.description
             }
@@ -405,7 +407,7 @@ public func xcodeProject(
         // Create a Xcode target for the target.
         let package = packagesByTarget[target]!
         let xcodeTarget = project.addTarget(
-            objectID: "\(package.manifestName)::\(target.name)", // TODO: use identity instead?
+            objectID: "\(package.manifest.displayName)::\(target.name)", // TODO: use identity instead?
             productType: productType, name: target.name)
 
         // Set the product name to the C99-mangled form of the target name.
@@ -522,7 +524,7 @@ public func xcodeProject(
 
         // TODO: use identity instead
         // Add a file reference for the target's product.
-        let productRef = productsGroup.addFileReference(path: target.productPath.pathString, pathBase: .buildDir, objectID: "\(package.manifestName)::\(target.name)::Product")
+        let productRef = productsGroup.addFileReference(path: target.productPath.pathString, pathBase: .buildDir, objectID: "\(package.manifest.displayName)::\(target.name)::Product")
 
         // Set that file reference as the target's product reference.
         xcodeTarget.productReference = productRef
@@ -691,7 +693,7 @@ public func xcodeProject(
         // Otherwise, create an aggregate target.
         let package = packagesByProduct[product]!
         let aggregateTarget = project.addTarget(
-            objectID: "\(package.manifestName)::\(product.name)::ProductTarget", // TODO: use identity instead?
+            objectID: "\(package.manifest.displayName)::\(product.name)::ProductTarget", // TODO: use identity instead?
             productType: nil, name: product.name)
         // Add dependencies on the targets created for each of the dependencies.
         for target in product.targets {

--- a/Sources/Xcodeproj/pbxproj.swift
+++ b/Sources/Xcodeproj/pbxproj.swift
@@ -73,7 +73,7 @@ public func xcodeProject(
         guard let manifestLoader = options.manifestLoader else { return }
 
         let pdTarget = project.addTarget(
-            objectID: "\(package.manifest.displayName)::SwiftPMPackageDescription", // TODO: use identity instead?
+            objectID: "\(package.identity)::SwiftPMPackageDescription",
             productType: .framework,
             name: "\(package.manifest.displayName)PackageDescription" // TODO: use identity instead?
         )
@@ -407,7 +407,7 @@ public func xcodeProject(
         // Create a Xcode target for the target.
         let package = packagesByTarget[target]!
         let xcodeTarget = project.addTarget(
-            objectID: "\(package.manifest.displayName)::\(target.name)", // TODO: use identity instead?
+            objectID: "\(package.identity)::\(target.name)",
             productType: productType, name: target.name)
 
         // Set the product name to the C99-mangled form of the target name.
@@ -522,9 +522,12 @@ public func xcodeProject(
         // Add framework search path to build settings.
         targetSettings.common.FRAMEWORK_SEARCH_PATHS = ["$(inherited)", "$(PLATFORM_DIR)/Developer/Library/Frameworks"]
 
-        // TODO: use identity instead
         // Add a file reference for the target's product.
-        let productRef = productsGroup.addFileReference(path: target.productPath.pathString, pathBase: .buildDir, objectID: "\(package.manifest.displayName)::\(target.name)::Product")
+        let productRef = productsGroup.addFileReference(
+            path: target.productPath.pathString,
+            pathBase: .buildDir,
+            objectID: "\(package.identity)::\(target.name)::Product"
+        )
 
         // Set that file reference as the target's product reference.
         xcodeTarget.productReference = productRef
@@ -693,8 +696,9 @@ public func xcodeProject(
         // Otherwise, create an aggregate target.
         let package = packagesByProduct[product]!
         let aggregateTarget = project.addTarget(
-            objectID: "\(package.manifest.displayName)::\(product.name)::ProductTarget", // TODO: use identity instead?
-            productType: nil, name: product.name)
+            objectID: "\(package.identity)::\(product.name)::ProductTarget",
+            productType: nil, name: product.name
+        )
         // Add dependencies on the targets created for each of the dependencies.
         for target in product.targets {
             // Find the target that corresponds to the target.  There might not

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -909,12 +909,12 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             observabilityScope: observability.topScope
         )
-        XCTAssertEqual(plan.createREPLArguments().sorted(), ["-I/Dep/Sources/CDep/include", "-I/path/to/build/debug", "-I/path/to/build/debug/lib.build", "-L/path/to/build/debug", "-lPkg__REPL"])
+        XCTAssertEqual(plan.createREPLArguments().sorted(), ["-I/Dep/Sources/CDep/include", "-I/path/to/build/debug", "-I/path/to/build/debug/lib.build", "-L/path/to/build/debug", "-lpkg__REPL"])
 
         XCTAssertEqual(plan.graph.allProducts.map({ $0.name }).sorted(), [
             "Dep",
-            "Pkg__REPL",
             "exe",
+            "pkg__REPL"
         ])
     }
 

--- a/Tests/FunctionalTests/ToolsVersionTests.swift
+++ b/Tests/FunctionalTests/ToolsVersionTests.swift
@@ -124,7 +124,7 @@ class ToolsVersionTests: XCTestCase {
                 _ = try SwiftPMProduct.SwiftBuild.execute([], packagePath: primaryPath)
                 XCTFail()
             } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-                XCTAssertTrue(stderr.contains("package 'Primary' requires minimum Swift language version 1000 which is not supported by the current tools version (\(ToolsVersion.currentToolsVersion))"), stderr)
+                XCTAssertTrue(stderr.contains("package 'primary' requires minimum Swift language version 1000 which is not supported by the current tools version (\(ToolsVersion.currentToolsVersion))"), stderr)
             }
 
              try fs.writeFileContents(primaryPath.appending(component: "Package.swift")) {

--- a/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
@@ -46,7 +46,7 @@ class PackageGraphPerfTests: XCTestCasePerf {
             // Create manifest.
             let isRoot = pkg == 1
             let manifest = Manifest(
-                name: name,
+                displayName: name,
                 path: AbsolutePath(location).appending(component: Manifest.filename),
                 packageKind: isRoot ? .root(.init(location)) : .localSourceControl(.init(location)),
                 packageLocation: location,

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -77,12 +77,12 @@ class PackageGraphTests: XCTestCase {
             result.checkTarget("Baz") { result in result.check(dependencies: "Bar") }
         }
 
-        let fooPackage = try XCTUnwrap(g.packages.first{ $0.manifestName == "Foo" })
+        let fooPackage = try XCTUnwrap(g.packages.first{ $0.identity == .plain("Foo") })
         let fooTarget = try XCTUnwrap(g.allTargets.first{ $0.name == "Foo" })
         let fooDepTarget = try XCTUnwrap(g.allTargets.first{ $0.name == "FooDep" })
         XCTAssert(g.package(for: fooTarget) == fooPackage)
         XCTAssert(g.package(for: fooDepTarget) == fooPackage)
-        let barPackage = try XCTUnwrap(g.packages.first{ $0.manifestName == "Bar" })
+        let barPackage = try XCTUnwrap(g.packages.first{ $0.identity == .plain("Bar") })
         let barTarget = try XCTUnwrap(g.allTargets.first{ $0.name == "Bar" })
         XCTAssert(g.package(for: barTarget) == barPackage)
     }
@@ -1769,7 +1769,7 @@ class PackageGraphTests: XCTestCase {
 extension Manifest {
     func withTargets(_ targets: [TargetDescription]) -> Manifest {
         Manifest.createManifest(
-            name: self.name,
+            name: self.displayName,
             path: self.path.parentDirectory,
             packageKind: self.packageKind,
             packageLocation: self.packageLocation,
@@ -1781,7 +1781,7 @@ extension Manifest {
 
     func withDependencies(_ dependencies: [PackageDependency]) -> Manifest {
         Manifest.createManifest(
-            name: self.name,
+            name: self.displayName,
             path: self.path.parentDirectory,
             packageKind: self.packageKind,
             packageLocation: self.packageLocation,

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -1264,7 +1264,7 @@ class PackageGraphTests: XCTestCase {
 
         let fs = InMemoryFileSystem(files: ["/pins": ByteString(encodingAsUTF8: json)])
 
-        XCTAssertThrows(StringError("Package.resolved file is corrupted or malformed; fix or delete the file to continue: duplicated entry for package \"Yams\""), {
+        XCTAssertThrows(StringError("Package.resolved file is corrupted or malformed; fix or delete the file to continue: duplicated entry for package \"yams\""), {
             _ = try PinsStore(pinsFile: AbsolutePath("/pins"), workingDirectory: .root, fileSystem: fs, mirrors: .init())
         })
     }

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -317,8 +317,8 @@ final class PubgrubTests: XCTestCase {
             XCTFail("Unexpected error: \(error)")
         case .success(let bindings):
             XCTAssertEqual(bindings.count, 1)
-            let foo = bindings.first { $0.package.identity == PackageIdentity("foo") }
-            XCTAssertEqual(foo?.package.name, "bar")
+            let foo = bindings.first { $0.package.identity == .plain("foo") }
+            XCTAssertEqual(foo?.package.deprecatedName, "bar")
         }
     }
 
@@ -2089,9 +2089,9 @@ public class MockContainer: PackageContainer {
         return try getDependencies(at: PackageRequirement.unversioned.description, productFilter: productFilter)
     }
 
-    public func getUpdatedIdentifier(at boundVersion: BoundVersion) throws -> PackageReference {
+    public func loadPackageReference(at boundVersion: BoundVersion) throws -> PackageReference {
         if let manifestName = manifestName {
-            self.package = self.package.with(newName: manifestName.identity.description)
+            self.package = self.package.withName(manifestName.identity.description)
         }
         return self.package
     }

--- a/Tests/PackageLoadingPerformanceTests/ManifestLoadingTests.swift
+++ b/Tests/PackageLoadingPerformanceTests/ManifestLoadingTests.swift
@@ -43,7 +43,7 @@ class ManifestLoadingPerfTests: XCTestCasePerf {
                         fileSystem: localFileSystem,
                         observabilityScope: ObservabilitySystem.NOOP
                     )
-                    XCTAssertEqual(manifest.name, "Trivial")
+                    XCTAssertEqual(manifest.displayName, "Trivial")
                 }
             }
         }
@@ -77,7 +77,7 @@ class ManifestLoadingPerfTests: XCTestCasePerf {
                         fileSystem: localFileSystem,
                         observabilityScope: ObservabilitySystem.NOOP
                     )
-                    XCTAssertEqual(manifest.name, "Foo")
+                    XCTAssertEqual(manifest.displayName, "Foo")
                 }
             }
         }

--- a/Tests/PackageLoadingTests/PD_4_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_0_LoadingTests.swift
@@ -33,7 +33,7 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
         let manifest = try loadManifest(content, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        XCTAssertEqual(manifest.name, "Trivial")
+        XCTAssertEqual(manifest.displayName, "Trivial")
         XCTAssertEqual(manifest.toolsVersion, .v4)
         XCTAssertEqual(manifest.targets, [])
         XCTAssertEqual(manifest.dependencies, [])
@@ -62,7 +62,7 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
         let manifest = try loadManifest(content, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        XCTAssertEqual(manifest.name, "Trivial")
+        XCTAssertEqual(manifest.displayName, "Trivial")
         let foo = manifest.targetMap["foo"]!
         XCTAssertEqual(foo.name, "foo")
         XCTAssertFalse(foo.isTest)
@@ -209,7 +209,7 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
         let manifest = try loadManifest(content, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        XCTAssertEqual(manifest.name, "Copenssl")
+        XCTAssertEqual(manifest.displayName, "Copenssl")
         XCTAssertEqual(manifest.pkgConfig, "openssl")
         XCTAssertEqual(manifest.providers, [
             .brew(["openssl"]),
@@ -320,7 +320,7 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
         let manifest = try loadManifest(content, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        XCTAssertEqual(manifest.name, "testPackage")
+        XCTAssertEqual(manifest.displayName, "testPackage")
         XCTAssertEqual(manifest.cLanguageStandard, "iso9899:199409")
         XCTAssertEqual(manifest.cxxLanguageStandard, "gnu++14")
     }
@@ -350,7 +350,7 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
             observabilityScope: observability.topScope
         )
 
-        XCTAssertEqual(manifest.name, "Trivial")
+        XCTAssertEqual(manifest.displayName, "Trivial")
         XCTAssertEqual(manifest.toolsVersion, .v4)
         XCTAssertEqual(manifest.targets, [])
         XCTAssertEqual(manifest.dependencies, [])

--- a/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
@@ -51,7 +51,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
         let manifest = try loadManifest(content, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        XCTAssertEqual(manifest.name, "Trivial")
+        XCTAssertEqual(manifest.displayName, "Trivial")
 
         // Check targets.
         let foo = manifest.targetMap["foo"]!
@@ -397,7 +397,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                 fileSystem: fs,
                 observabilityScope: ObservabilitySystem.NOOP
             )
-            XCTAssertEqual(manifest.name, "Trivial")
+            XCTAssertEqual(manifest.displayName, "Trivial")
         }
     }
 
@@ -419,7 +419,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
         // Check we can load the manifest.
         let manifest = try manifestLoader.load(at: packageDir, packageKind: .root(packageDir), toolsVersion: .v4_2, fileSystem: fs, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
-        XCTAssertEqual(manifest.name, "Trivial")
+        XCTAssertEqual(manifest.displayName, "Trivial")
 
         // Switch it around so that the main manifest is now the one that doesn't have a comment.
         try fs.writeFileContents(
@@ -431,7 +431,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
         // Check we can load the manifest.
         let manifest2 = try manifestLoader.load(at: packageDir, packageKind: .root(packageDir), toolsVersion: .v4_2, fileSystem: fs, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
-        XCTAssertEqual(manifest2.name, "Trivial")
+        XCTAssertEqual(manifest2.displayName, "Trivial")
     }
 
     func testRuntimeManifestErrors() throws {
@@ -605,7 +605,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                 XCTAssertNoDiagnostics(observability.diagnostics)
                 XCTAssertEqual(try delegate.loaded(timeout: .now() + 1), [manifestPath])
                 XCTAssertEqual(try delegate.parsed(timeout: .now() + 1), expectCached ? [] : [manifestPath])
-                XCTAssertEqual(manifest.name, "Trivial")
+                XCTAssertEqual(manifest.displayName, "Trivial")
                 XCTAssertEqual(manifest.targets[0].name, "foo")
             }
 
@@ -665,7 +665,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                 XCTAssertNoDiagnostics(observability.diagnostics)
                 XCTAssertEqual(try delegate.loaded(timeout: .now() + 1), [manifestPath])
                 XCTAssertEqual(try delegate.parsed(timeout: .now() + 1), expectCached ? [] : [manifestPath])
-                XCTAssertEqual(manifest.name, "Trivial")
+                XCTAssertEqual(manifest.displayName, "Trivial")
                 XCTAssertEqual(manifest.targets[0].name, "foo")
             }
 
@@ -741,7 +741,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                 )
 
                 XCTAssertNoDiagnostics(observability.diagnostics)
-                XCTAssertEqual(m.name, "Trivial")
+                XCTAssertEqual(m.displayName, "Trivial")
             }
 
             do {
@@ -870,7 +870,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             }
 
             XCTAssertNoDiagnostics(observability.diagnostics)
-            XCTAssertEqual(manifest.name, "Trivial")
+            XCTAssertEqual(manifest.displayName, "Trivial")
             XCTAssertEqual(manifest.targets[0].name, "foo")
 
             let sync = DispatchGroup()
@@ -897,7 +897,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                         XCTFail("\(error)")
                     case .success(let manifest):
                         XCTAssertNoDiagnostics(observability.diagnostics)
-                        XCTAssertEqual(manifest.name, "Trivial")
+                        XCTAssertEqual(manifest.displayName, "Trivial")
                         XCTAssertEqual(manifest.targets[0].name, "foo")
                     }
                 }
@@ -964,7 +964,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                     case .failure(let error):
                         XCTFail("\(error)")
                     case .success(let manifest):
-                        XCTAssertEqual(manifest.name, "Trivial-\(random)")
+                        XCTAssertEqual(manifest.displayName, "Trivial-\(random)")
                         XCTAssertEqual(manifest.targets[0].name, "foo-\(random)")
                     }
                 }

--- a/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
@@ -50,7 +50,7 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
         let manifest = try loadManifest(content, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        XCTAssertEqual(manifest.name, "Trivial")
+        XCTAssertEqual(manifest.displayName, "Trivial")
 
         // Check targets.
         let foo = manifest.targetMap["foo"]!
@@ -526,7 +526,7 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
             let manifest = try loadManifest(content, toolsVersion: .v5_2, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
 
-            XCTAssertEqual(manifest.name, "Foo")
+            XCTAssertEqual(manifest.displayName, "Foo")
 
             // Check targets.
             let foo = manifest.targetMap["foo"]!
@@ -580,7 +580,7 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
         let manifest = try loadManifest(content, observabilityScope: observability.topScope)
         XCTAssertFalse(observability.diagnostics.hasErrors)
 
-        XCTAssertEqual(manifest.name, "PackageWithChattyManifest")
+        XCTAssertEqual(manifest.displayName, "PackageWithChattyManifest")
         XCTAssertEqual(manifest.toolsVersion, .v5)
         XCTAssertEqual(manifest.targets, [])
         XCTAssertEqual(manifest.dependencies, [])
@@ -627,7 +627,7 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
             )
 
             XCTAssertNoDiagnostics(observability.diagnostics)
-            XCTAssertEqual(manifest.name, "Trivial")
+            XCTAssertEqual(manifest.displayName, "Trivial")
 
             let moduleTraceJSON = try XCTUnwrap(try localFileSystem.readFileContents(moduleTraceFilePath).validDescription)
             XCTAssertMatch(moduleTraceJSON, .contains("PackageDescription"))

--- a/Tests/PackageLoadingTests/PD_5_2_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_2_LoadingTests.swift
@@ -88,7 +88,7 @@ class PackageDescription5_2LoadingTests: PackageDescriptionLoadingTests {
         let manifest = try loadManifest(content, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        XCTAssertEqual(manifest.name, "Trivial")
+        XCTAssertEqual(manifest.displayName, "Trivial")
         XCTAssertEqual(manifest.dependencies[0].nameForTargetDependencyResolutionOnly, "Foo")
         XCTAssertEqual(manifest.dependencies[1].nameForTargetDependencyResolutionOnly, "Foo2")
         XCTAssertEqual(manifest.dependencies[2].nameForTargetDependencyResolutionOnly, "Foo3")

--- a/Tests/PackageLoadingTests/PD_5_6_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_6_LoadingTests.swift
@@ -179,7 +179,7 @@ class PackageDescription5_6LoadingTests: PackageDescriptionLoadingTests {
         let manifest = try loadManifest(content, observabilityScope: observability.topScope)
 
         let name = parsedManifest?.parentDirectory.pathString ?? ""
-        XCTAssertEqual(manifest.name, name)
+        XCTAssertEqual(manifest.displayName, name)
     }
 
     /// Tests access to the package's directory contents.
@@ -199,7 +199,7 @@ class PackageDescription5_6LoadingTests: PackageDescriptionLoadingTests {
         let manifest = try loadManifest(content, observabilityScope: observability.topScope)
 
         let name = parsedManifest?.components.last ?? ""
-        let swiftFiles = manifest.name.split(separator: ",").map(String.init)
+        let swiftFiles = manifest.displayName.split(separator: ",").map(String.init)
         XCTAssertNotNil(swiftFiles.firstIndex(of: name))
     }
 }

--- a/Tests/PackageRegistryTests/RegistryManagerTests.swift
+++ b/Tests/PackageRegistryTests/RegistryManagerTests.swift
@@ -155,7 +155,7 @@ final class RegistryManagerTests: XCTestCase {
                 return XCTAssertResultSuccess(result)
             }
 
-            XCTAssertEqual(manifest.name, "LinkedList")
+            XCTAssertEqual(manifest.displayName, "LinkedList")
 
             XCTAssertEqual(manifest.products.count, 1)
             XCTAssertEqual(manifest.products.first?.name, "LinkedList")

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -83,7 +83,7 @@ class ManifestSourceGenerationTests: XCTestCase {
             // Check that all the relevant properties survived.
             let failureDetails = "\n--- ORIGINAL MANIFEST CONTENTS ---\n" + manifestContents + "\n--- REWRITTEN MANIFEST CONTENTS ---\n" + newContents
             XCTAssertEqual(newManifest.toolsVersion, manifest.toolsVersion, failureDetails)
-            XCTAssertEqual(newManifest.name, manifest.name, failureDetails)
+            XCTAssertEqual(newManifest.displayName, manifest.displayName, failureDetails)
             XCTAssertEqual(newManifest.defaultLocalization, manifest.defaultLocalization, failureDetails)
             XCTAssertEqual(newManifest.platforms, manifest.platforms, failureDetails)
             XCTAssertEqual(newManifest.pkgConfig, manifest.pkgConfig, failureDetails)
@@ -391,7 +391,7 @@ class ManifestSourceGenerationTests: XCTestCase {
     func testCustomProductSourceGeneration() throws {
         // Create a manifest containing a product for which we'd like to do custom source fragment generation.
         let manifest = Manifest(
-            name: "MyLibrary",
+            displayName: "MyLibrary",
             path: AbsolutePath("/tmp/MyLibrary/Package.swift"),
             packageKind: .root(AbsolutePath("/tmp/MyLibrary")),
             packageLocation: "/tmp/MyLibrary",

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -1829,7 +1829,7 @@ final class WorkspaceTests: XCTestCase {
 
         try workspace.loadDependencyManifests(roots: ["Root1"]) { manifests, diagnostics in
             // Ensure that the order of the manifests is stable.
-            XCTAssertEqual(manifests.allDependencyManifests().map { $0.value.name }, ["Foo", "Baz", "Bam", "Bar"])
+            XCTAssertEqual(manifests.allDependencyManifests().map { $0.value.displayName }, ["Foo", "Baz", "Bam", "Bar"])
             XCTAssertNoDiagnostics(diagnostics)
         }
     }
@@ -2640,7 +2640,7 @@ final class WorkspaceTests: XCTestCase {
             )
 
             workspace.manifestLoader.manifests[fooKey] = Manifest(
-                name: manifest.name,
+                displayName: manifest.displayName,
                 path: manifest.path,
                 packageKind: manifest.packageKind,
                 packageLocation: manifest.packageLocation,
@@ -3902,8 +3902,8 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertFalse(observability.hasWarningDiagnostics, observability.diagnostics.description)
             XCTAssertFalse(observability.hasErrorDiagnostics, observability.diagnostics.description)
 
-            XCTAssertEqual(manifest.name, "MyPkg")
-            XCTAssertEqual(package.manifestName, manifest.name)
+            XCTAssertEqual(manifest.displayName, "MyPkg")
+            XCTAssertEqual(package.identity, .plain(manifest.displayName))
             XCTAssert(graph.reachableProducts.contains(where: { $0.name == "MyPkg" }))
         }
     }
@@ -8249,7 +8249,7 @@ final class WorkspaceTests: XCTestCase {
                 } else {
                     completion(.success(
                         .init(
-                            name: packageIdentity.description,
+                            displayName: packageIdentity.description,
                             path: path,
                             packageKind: packageKind,
                             packageLocation: packageLocation,

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -1960,7 +1960,7 @@ final class WorkspaceTests: XCTestCase {
         // Check failure.
         workspace.checkResolve(pkg: "Foo", roots: ["Root"], version: "1.3.0") { diagnostics in
             testDiagnostics(diagnostics) { result in
-                result.check(diagnostic: .contains("'Foo' 1.3.0"), severity: .error)
+                result.check(diagnostic: .contains("'foo' 1.3.0"), severity: .error)
             }
         }
         workspace.checkManagedDependencies { result in
@@ -2012,7 +2012,7 @@ final class WorkspaceTests: XCTestCase {
                 result.check(packages: "Foo", "Root")
             }
             testDiagnostics(diagnostics) { result in
-                result.check(diagnostic: .contains("dependency 'Foo' is missing; cloning again"), severity: .warning)
+                result.check(diagnostic: .contains("dependency 'foo' is missing; cloning again"), severity: .warning)
             }
         }
     }
@@ -2206,7 +2206,7 @@ final class WorkspaceTests: XCTestCase {
         // Try re-editing foo.
         workspace.checkEdit(packageName: "Foo") { diagnostics in
             testDiagnostics(diagnostics) { result in
-                result.check(diagnostic: .equal("dependency 'Foo' already in edit mode"), severity: .error)
+                result.check(diagnostic: .equal("dependency 'foo' already in edit mode"), severity: .error)
             }
         }
         workspace.checkManagedDependencies { result in
@@ -2292,7 +2292,7 @@ final class WorkspaceTests: XCTestCase {
         try fs.removeFileTree(fooPath)
         try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
-                result.check(diagnostic: .equal("dependency 'Foo' was being edited but is missing; falling back to original checkout"), severity: .warning)
+                result.check(diagnostic: .equal("dependency 'foo' was being edited but is missing; falling back to original checkout"), severity: .warning)
             }
         }
         workspace.checkManagedDependencies { result in
@@ -2737,7 +2737,7 @@ final class WorkspaceTests: XCTestCase {
         ]
         try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
-                result.check(diagnostic: .contains("'Bar' 1.1.0"), severity: .error)
+                result.check(diagnostic: .contains("'bar' 1.1.0"), severity: .error)
             }
         }
     }
@@ -2859,12 +2859,12 @@ final class WorkspaceTests: XCTestCase {
         // Test that its not possible to edit or resolve this package.
         workspace.checkEdit(packageName: "Bar") { diagnostics in
             testDiagnostics(diagnostics) { result in
-                result.check(diagnostic: .contains("local dependency 'Bar' can't be edited"), severity: .error)
+                result.check(diagnostic: .contains("local dependency 'bar' can't be edited"), severity: .error)
             }
         }
         workspace.checkResolve(pkg: "Bar", roots: ["Foo"], version: "1.0.0") { diagnostics in
             testDiagnostics(diagnostics) { result in
-                result.check(diagnostic: .contains("local dependency 'Bar' can't be edited"), severity: .error)
+                result.check(diagnostic: .contains("local dependency 'bar' can't be edited"), severity: .error)
             }
         }
     }
@@ -3956,7 +3956,7 @@ final class WorkspaceTests: XCTestCase {
 
         try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
-                result.check(diagnostic: .equal("package 'Foo' is required using a revision-based requirement and it depends on local package 'Local', which is not supported"), severity: .error)
+                result.check(diagnostic: .equal("package 'foo' is required using a revision-based requirement and it depends on local package 'local', which is not supported"), severity: .error)
             }
         }
     }
@@ -4399,9 +4399,9 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertNoDiagnostics(diagnostics)
 
             // Ensure that the artifacts have been properly extracted
-            XCTAssertTrue(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/A/A1.xcframework")))
-            XCTAssertTrue(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/A/A2.artifactbundle")))
-            XCTAssertTrue(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/B/B.xcframework")))
+            XCTAssertTrue(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/a/A1.xcframework")))
+            XCTAssertTrue(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/a/A2.artifactbundle")))
+            XCTAssertTrue(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/b/B.xcframework")))
 
             // Ensure that the original archives have been untouched
             XCTAssertTrue(fs.exists(a1FrameworkArchivePath))
@@ -4410,32 +4410,32 @@ final class WorkspaceTests: XCTestCase {
 
             // Ensure that the temporary folders have been properly created
             XCTAssertEqual(workspace.archiver.extractions.map { $0.destinationPath.parentDirectory }.sorted(), [
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/A/A1"),
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/A/A2"),
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/B/B")
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A1"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A2"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/b/B")
             ])
 
             // Ensure that the temporary directories have been removed
-            XCTAssertTrue(try! fs.getDirectoryContents(AbsolutePath("/tmp/ws/.build/artifacts/extract/A/A1")).isEmpty)
-            XCTAssertTrue(try! fs.getDirectoryContents(AbsolutePath("/tmp/ws/.build/artifacts/extract/A/A2")).isEmpty)
-            XCTAssertTrue(try! fs.getDirectoryContents(AbsolutePath("/tmp/ws/.build/artifacts/extract/B/B")).isEmpty)
+            XCTAssertTrue(try! fs.getDirectoryContents(AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A1")).isEmpty)
+            XCTAssertTrue(try! fs.getDirectoryContents(AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A2")).isEmpty)
+            XCTAssertTrue(try! fs.getDirectoryContents(AbsolutePath("/tmp/ws/.build/artifacts/extract/b/B")).isEmpty)
         }
 
         workspace.checkManagedArtifacts { result in
             result.check(packageIdentity: .plain("a"),
                          targetName: "A1",
                          source: .local(checksum: "a1"),
-                         path: workspace.artifactsDir.appending(components: "A", "A1.xcframework")
+                         path: workspace.artifactsDir.appending(components: "a", "A1.xcframework")
             )
             result.check(packageIdentity: .plain("a"),
                          targetName: "A2",
                          source: .local(checksum: "a2"),
-                         path: workspace.artifactsDir.appending(components: "A", "A2.artifactbundle")
+                         path: workspace.artifactsDir.appending(components: "a", "A2.artifactbundle")
             )
             result.check(packageIdentity: .plain("b"),
                          targetName: "B",
                          source: .local(checksum: "b0"),
-                         path: workspace.artifactsDir.appending(components: "B", "B.xcframework")
+                         path: workspace.artifactsDir.appending(components: "b", "B.xcframework")
             )
         }
     }
@@ -4660,22 +4660,22 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertTrue(fs.exists(a4FrameworkArchivePath))
 
             // Ensure that the new artifacts have been properly extracted
-            XCTAssertTrue(fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/A/\(a1FrameworkName)")))
-            XCTAssertTrue(fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/A/\(a3FrameworkName)/local-archived")))
-            XCTAssertTrue(fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/A/\(a4FrameworkName)/remote")))
+            XCTAssertTrue(fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/a/\(a1FrameworkName)")))
+            XCTAssertTrue(fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/a/\(a3FrameworkName)/local-archived")))
+            XCTAssertTrue(fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/a/\(a4FrameworkName)/remote")))
 
             // Ensure that the old artifacts have been removed
-            XCTAssertFalse(fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/A/\(a2FrameworkName)")))
-            XCTAssertFalse(fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/A/\(a3FrameworkName)/remote")))
-            XCTAssertFalse(fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/A/\(a4FrameworkName)/local-archived")))
-            XCTAssertFalse(fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/A/\(a5FrameworkName)")))
+            XCTAssertFalse(fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/a/\(a2FrameworkName)")))
+            XCTAssertFalse(fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/a/\(a3FrameworkName)/remote")))
+            XCTAssertFalse(fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/a/\(a4FrameworkName)/local-archived")))
+            XCTAssertFalse(fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/a/\(a5FrameworkName)")))
         }
 
         workspace.checkManagedArtifacts { result in
             result.check(packageIdentity: .plain("a"),
                          targetName: "A1",
                          source: .local(checksum: "a1"),
-                         path: workspace.artifactsDir.appending(components: "A", a1FrameworkName)
+                         path: workspace.artifactsDir.appending(components: "a", a1FrameworkName)
             )
             result.check(packageIdentity: .plain("a"),
                          targetName: "A2",
@@ -4685,12 +4685,12 @@ final class WorkspaceTests: XCTestCase {
             result.check(packageIdentity: .plain("a"),
                          targetName: "A3",
                          source: .local(checksum: "a3"),
-                         path: workspace.artifactsDir.appending(components: "A", a3FrameworkName)
+                         path: workspace.artifactsDir.appending(components: "a", a3FrameworkName)
             )
             result.check(packageIdentity: .plain("a"),
                          targetName: "A4",
                          source: .remote(url: "https://a.com/a4.zip", checksum: "a4"),
-                         path: workspace.artifactsDir.appending(components: "A", a4FrameworkName)
+                         path: workspace.artifactsDir.appending(components: "a", a4FrameworkName)
             )
         }
     }
@@ -4990,13 +4990,13 @@ final class WorkspaceTests: XCTestCase {
                     packageRef: aRef,
                     targetName: "A1",
                     source: .local(checksum: "old-checksum"),
-                    path: workspace.artifactsDir.appending(components: "A", "A1.xcframework")
+                    path: workspace.artifactsDir.appending(components: "a", "A1.xcframework")
                 ),
                 .init(
                     packageRef: aRef,
                     targetName: "A2",
                     source: .local(checksum: "a2"),
-                    path: workspace.artifactsDir.appending(components: "A", "A2.xcframework")
+                    path: workspace.artifactsDir.appending(components: "a", "A2.xcframework")
                 )
             ]
         )
@@ -5014,7 +5014,7 @@ final class WorkspaceTests: XCTestCase {
         try workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
             // Ensure that only the artifact archive with the changed checksum has been extracted
             XCTAssertEqual(workspace.archiver.extractions.map { $0.destinationPath.parentDirectory }.sorted(), [
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/A/A1")
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A1")
             ])
         }
 
@@ -5022,12 +5022,12 @@ final class WorkspaceTests: XCTestCase {
             result.check(packageIdentity: .plain("a"),
                          targetName: "A1",
                          source: .local(checksum: "a1"),
-                         path: workspace.artifactsDir.appending(components: "A", "A1.xcframework")
+                         path: workspace.artifactsDir.appending(components: "a", "A1.xcframework")
             )
             result.check(packageIdentity: .plain("a"),
                          targetName: "A2",
                          source: .local(checksum: "a2"),
-                         path: workspace.artifactsDir.appending(components: "A", "A2.xcframework")
+                         path: workspace.artifactsDir.appending(components: "a", "A2.xcframework")
             )
         }
     }
@@ -5213,8 +5213,8 @@ final class WorkspaceTests: XCTestCase {
 
         try workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/A")))
-            XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/B")))
+            XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/a")))
+            XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/b")))
             XCTAssertEqual(downloads.map { $0.key.absoluteString }.sorted(), [
                 "https://a.com/a1.zip",
                 "https://a.com/a2.zip",
@@ -5226,9 +5226,9 @@ final class WorkspaceTests: XCTestCase {
                 ByteString([0xB0]).hexadecimalRepresentation,
             ])
             XCTAssertEqual(workspace.archiver.extractions.map { $0.destinationPath.parentDirectory }.sorted(), [
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/A/A1"),
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/A/A2"),
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/B/B")
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A1"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A2"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/b/B")
             ])
             XCTAssertEqual(
                 downloads.map { $0.value }.sorted(),
@@ -5243,7 +5243,7 @@ final class WorkspaceTests: XCTestCase {
                             url: "https://a.com/a1.zip",
                             checksum: "a1"
                          ),
-                         path: workspace.artifactsDir.appending(components: "A", "A1.xcframework")
+                         path: workspace.artifactsDir.appending(components: "a", "A1.xcframework")
             )
             result.check(packageIdentity: .plain("a"),
                          targetName: "A2",
@@ -5251,7 +5251,7 @@ final class WorkspaceTests: XCTestCase {
                             url: "https://a.com/a2.zip",
                             checksum: "a2"
                          ),
-                         path: workspace.artifactsDir.appending(components: "A", "A2.xcframework")
+                         path: workspace.artifactsDir.appending(components: "a", "A2.xcframework")
             )
             result.check(packageIdentity: .plain("b"),
                          targetName: "B",
@@ -5259,7 +5259,7 @@ final class WorkspaceTests: XCTestCase {
                             url: "https://b.com/b.zip",
                             checksum: "b0"
                          ),
-                         path: workspace.artifactsDir.appending(components: "B", "B.xcframework")
+                         path: workspace.artifactsDir.appending(components: "b", "B.xcframework")
             )
         }
     }
@@ -5438,7 +5438,7 @@ final class WorkspaceTests: XCTestCase {
                         url: "https://a.com/a1.zip",
                         checksum: "a1"
                     ),
-                    path: workspace.artifactsDir.appending(components: "A", "A1.xcframework")
+                    path: workspace.artifactsDir.appending(components: "a", "A1.xcframework")
                 ),
                 .init(
                     packageRef: aRef,
@@ -5447,7 +5447,7 @@ final class WorkspaceTests: XCTestCase {
                         url: "https://a.com/old/a3.zip",
                         checksum: "a3-old-checksum"
                     ),
-                    path: workspace.artifactsDir.appending(components: "A", "A3.xcframework")
+                    path: workspace.artifactsDir.appending(components: "a", "A3.xcframework")
                 ),
                 .init(
                     packageRef: aRef,
@@ -5456,7 +5456,7 @@ final class WorkspaceTests: XCTestCase {
                         url: "https://a.com/a4.zip",
                         checksum: "a4"
                     ),
-                    path: workspace.artifactsDir.appending(components: "A", "A4.xcframework")
+                    path: workspace.artifactsDir.appending(components: "a", "A4.xcframework")
                 ),
                 .init(
                     packageRef: aRef,
@@ -5465,19 +5465,19 @@ final class WorkspaceTests: XCTestCase {
                         url: "https://a.com/a5.zip",
                         checksum: "a5"
                     ),
-                    path: workspace.artifactsDir.appending(components: "A", "A5.xcframework")
+                    path: workspace.artifactsDir.appending(components: "a", "A5.xcframework")
                 ),
                 .init(
                     packageRef: aRef,
                     targetName: "A6",
                     source: .local(),
-                    path: workspace.artifactsDir.appending(components: "A", "A6.xcframework")
+                    path: workspace.artifactsDir.appending(components: "a", "A6.xcframework")
                 ),
                 .init(
                     packageRef: aRef,
                     targetName: "A7",
                     source: .local(),
-                    path: workspace.packagesDir.appending(components: "A", "XCFrameworks", "A7.xcframework")
+                    path: workspace.packagesDir.appending(components: "a", "XCFrameworks", "A7.xcframework")
                 )
             ]
         )
@@ -5486,11 +5486,11 @@ final class WorkspaceTests: XCTestCase {
             testDiagnostics(diagnostics) { result in
                 result.check(diagnostic: "downloaded archive of binary target 'A3' does not contain expected binary artifact 'A3'", severity: .error)
             }
-            XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/B")))
-            XCTAssert(!fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/A/A3.xcframework")))
-            XCTAssert(!fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/A/A4.xcframework")))
-            XCTAssert(!fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/A/A5.xcframework")))
-            XCTAssert(fs.exists(AbsolutePath("/tmp/ws/pkgs/A/XCFrameworks/A7.xcframework")))
+            XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/b")))
+            XCTAssert(!fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/a/A3.xcframework")))
+            XCTAssert(!fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/a/A4.xcframework")))
+            XCTAssert(!fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/a/A5.xcframework")))
+            XCTAssert(fs.exists(AbsolutePath("/tmp/ws/pkgs/a/XCFrameworks/A7.xcframework")))
             XCTAssert(!fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/Foo")))
             XCTAssertEqual(downloads.map { $0.key.absoluteString }.sorted(), [
                 "https://a.com/a2.zip",
@@ -5505,10 +5505,10 @@ final class WorkspaceTests: XCTestCase {
                 ByteString([0xB0]).hexadecimalRepresentation,
             ])
             XCTAssertEqual(workspace.archiver.extractions.map { $0.destinationPath.parentDirectory }.sorted(), [
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/A/A2"),
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/A/A3"),
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/A/A7"),
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/B/B"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A2"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A3"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A7"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/b/B"),
             ])
             XCTAssertEqual(
                 downloads.map { $0.value }.sorted(),
@@ -5523,7 +5523,7 @@ final class WorkspaceTests: XCTestCase {
                             url: "https://a.com/a1.zip",
                             checksum: "a1"
                          ),
-                         path: workspace.artifactsDir.appending(components: "A", "A1.xcframework")
+                         path: workspace.artifactsDir.appending(components: "a", "A1.xcframework")
             )
             result.check(packageIdentity: .plain("a"),
                          targetName: "A2",
@@ -5531,7 +5531,7 @@ final class WorkspaceTests: XCTestCase {
                             url: "https://a.com/a2.zip",
                             checksum: "a2"
                          ),
-                         path: workspace.artifactsDir.appending(components: "A", "A2.xcframework")
+                         path: workspace.artifactsDir.appending(components: "a", "A2.xcframework")
             )
             result.checkNotPresent(packageName: "A", targetName: "A3")
             result.check(packageIdentity: .plain("a"),
@@ -5545,7 +5545,7 @@ final class WorkspaceTests: XCTestCase {
                             url: "https://a.com/a7.zip",
                             checksum: "a7"
                          ),
-                         path: workspace.artifactsDir.appending(components: "A", "A7.xcframework")
+                         path: workspace.artifactsDir.appending(components: "a", "A7.xcframework")
             )
             result.checkNotPresent(packageName: "A", targetName: "A5")
             result.check(packageIdentity: .plain("b"),
@@ -5554,7 +5554,7 @@ final class WorkspaceTests: XCTestCase {
                             url: "https://b.com/b.zip",
                             checksum: "b0"
                          ),
-                         path: workspace.artifactsDir.appending(components: "B", "B.xcframework")
+                         path: workspace.artifactsDir.appending(components: "b", "B.xcframework")
             )
         }
     }
@@ -5654,7 +5654,7 @@ final class WorkspaceTests: XCTestCase {
 
         try workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/A")))
+            XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/a")))
             XCTAssertEqual(workspace.checksumAlgorithm.hashes.map{ $0.hexadecimalRepresentation }.sorted(), [
                 ByteString([0xA1]).hexadecimalRepresentation,
             ])
@@ -5664,7 +5664,7 @@ final class WorkspaceTests: XCTestCase {
             "https://a.com/a1.zip",
         ])
         XCTAssertEqual(archiver.extractions.map { $0.destinationPath.parentDirectory }.sorted(), [
-            AbsolutePath("/tmp/ws/.build/artifacts/extract/A/A1"),
+            AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A1"),
         ])
         XCTAssertEqual(
             downloads.map { $0.1 }.sorted(),
@@ -5679,7 +5679,7 @@ final class WorkspaceTests: XCTestCase {
 
         try workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/A")))
+            XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/a")))
 
             XCTAssertEqual(workspace.checksumAlgorithm.hashes.map{ $0.hexadecimalRepresentation }.sorted(), [
                 ByteString([0xA1]).hexadecimalRepresentation, ByteString([0xA1]).hexadecimalRepresentation,
@@ -5690,8 +5690,8 @@ final class WorkspaceTests: XCTestCase {
             "https://a.com/a1.zip", "https://a.com/a1.zip",
         ])
         XCTAssertEqual(archiver.extractions.map { $0.destinationPath.parentDirectory }.sorted(), [
-            AbsolutePath("/tmp/ws/.build/artifacts/extract/A/A1"),
-            AbsolutePath("/tmp/ws/.build/artifacts/extract/A/A1"),
+            AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A1"),
+            AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A1"),
         ])
         XCTAssertEqual(
             downloads.map { $0.1 }.sorted(),
@@ -5729,7 +5729,7 @@ final class WorkspaceTests: XCTestCase {
         })
 
         let archiver = MockArchiver(handler: { _, _, destinationPath, completion in
-            XCTAssertEqual(destinationPath.parentDirectory, AbsolutePath("/tmp/ws/.build/artifacts/extract/A/A2"))
+            XCTAssertEqual(destinationPath.parentDirectory, AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A2"))
             completion(.failure(DummyError()))
         })
 
@@ -6107,7 +6107,7 @@ final class WorkspaceTests: XCTestCase {
 
         try workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/A")))
+            XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/a")))
             XCTAssertEqual(downloads.map { $0.key.absoluteString }.sorted(), [
                 "https://a.com/a.zip"
             ])
@@ -6115,7 +6115,7 @@ final class WorkspaceTests: XCTestCase {
                 ByteString([0xA]).hexadecimalRepresentation
             ])
             XCTAssertEqual(workspace.archiver.extractions.map { $0.destinationPath.parentDirectory }.sorted(), [
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/A/A")
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A")
             ])
             XCTAssertEqual(
                 downloads.map { $0.value }.sorted(),
@@ -6131,7 +6131,7 @@ final class WorkspaceTests: XCTestCase {
                     url: "https://a.com/a.zip",
                     checksum: "0a"
                 ),
-                path: workspace.artifactsDir.appending(components: "A", "A.xcframework")
+                path: workspace.artifactsDir.appending(components: "a", "A.xcframework")
             )
         }
     }
@@ -6306,8 +6306,8 @@ final class WorkspaceTests: XCTestCase {
 
         try workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/A")))
-            XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/B")))
+            XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/a")))
+            XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/b")))
             XCTAssertEqual(downloads.map { $0.key.absoluteString }.sorted(), [
                 "https://a.com/a1.zip",
                 "https://a.com/a2/a2.zip",
@@ -6325,9 +6325,9 @@ final class WorkspaceTests: XCTestCase {
                 ).map{ $0.hexadecimalRepresentation }.sorted()
             )
             XCTAssertEqual(workspace.archiver.extractions.map { $0.destinationPath.parentDirectory }.sorted(), [
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/A/A1"),
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/A/A2"),
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/B/B"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A1"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A2"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/b/B"),
             ])
             XCTAssertEqual(
                 downloads.map { $0.value }.sorted(),
@@ -6342,7 +6342,7 @@ final class WorkspaceTests: XCTestCase {
                             url: "https://a.com/a1.zip",
                             checksum: "a1"
                          ),
-                         path: workspace.artifactsDir.appending(components: "A", "A1.artifactbundle")
+                         path: workspace.artifactsDir.appending(components: "a", "A1.artifactbundle")
             )
             result.check(packageIdentity: .plain("a"),
                          targetName: "A2",
@@ -6350,7 +6350,7 @@ final class WorkspaceTests: XCTestCase {
                             url: "https://a.com/a2/a2.zip",
                             checksum: "a2"
                          ),
-                         path: workspace.artifactsDir.appending(components: "A", "A2.artifactbundle")
+                         path: workspace.artifactsDir.appending(components: "a", "A2.artifactbundle")
             )
             result.check(packageIdentity: .plain("b"),
                          targetName: "B",
@@ -6358,7 +6358,7 @@ final class WorkspaceTests: XCTestCase {
                             url: "https://b.com/b.zip",
                             checksum: "b0"
                          ),
-                         path: workspace.artifactsDir.appending(components: "B", "B.artifactbundle")
+                         path: workspace.artifactsDir.appending(components: "b", "B.artifactbundle")
             )
         }
     }


### PR DESCRIPTION
motivation: manifest name is for display purposes only

changes:
* rename Manifest::name to Manifest::displayName to more clearly articulate the purpose
* remove name attribute from Package and ResolvedPackage to make it harder to use it by mistake
* update other call sites where its possible to use identity of name
* adjust tests
