### PR TITLE
remove resolution retry on resolution failure

### DIFF
--- a/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
+++ b/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
@@ -1394,14 +1394,14 @@ private final class ContainerProvider {
     /// Get the container for the given identifier, loading it if necessary.
     func getContainer(for package: PackageReference, completion: @escaping (Result<PubGrubPackageContainer, Error>) -> Void) {
         // Return the cached container, if available.
-        if let container = self.containersCache[package] {
+        if let container = self.containersCache[package], package.equalsIncludingLocation(container.package) {
             return completion(.success(container))
         }
 
         if let prefetchSync = self.prefetches[package] {
             // If this container is already being prefetched, wait for that to complete
             prefetchSync.notify(queue: .sharedConcurrent) {
-                if let container = self.containersCache[package] {
+                if let container = self.containersCache[package], package.equalsIncludingLocation(container.package) {
                     // should be in the cache once prefetch completed
                     return completion(.success(container))
                 } else {

--- a/Sources/Workspace/ManagedDependency.swift
+++ b/Sources/Workspace/ManagedDependency.swift
@@ -80,7 +80,7 @@ extension Workspace {
         ///     - unmanagedPath: A custom absolute path instead of the subpath.
         public func edited(subpath: RelativePath, unmanagedPath: AbsolutePath?) throws -> ManagedDependency {
             guard case .sourceControlCheckout =  self.state else {
-                throw InternalError("invalid depenedency state: \(self.state)")
+                throw InternalError("invalid dependency state: \(self.state)")
             }
             return ManagedDependency(
                 packageRef: self.packageRef,


### PR DESCRIPTION
motivation: resolution retry + removing of package resolved in failure is difficult to justify

changes: remove the retry code from package resolution and "give up" after one attempt without mutating the package resolved file
