### PR TITLE
Rename the package `name` property to `displayName` in the plugin API

### DIFF
--- a/Sources/PackagePlugin/PackageModel.swift
+++ b/Sources/PackagePlugin/PackageModel.swift
@@ -15,7 +15,7 @@ public struct Package {
     public typealias ID = String
 
     /// The name of the package (for display purposes only).
-    public let name: String
+    public let displayName: String
 
     /// The absolute path of the package directory in the local file system.
     public let directory: Path

--- a/Sources/PackagePlugin/PluginInput.swift
+++ b/Sources/PackagePlugin/PluginInput.swift
@@ -264,8 +264,8 @@ fileprivate struct PluginInputDeserializer {
         let products = try wirePackage.productIds.map { try self.product(for: $0) }
         let targets = try wirePackage.targetIds.map { try self.target(for: $0) }
         let package = Package(
-            id: String(id),
-            name: wirePackage.name,
+            id: wirePackage.identity,
+            displayName: wirePackage.displayName,
             directory: directory,
             origin: .root,
             toolsVersion: toolsVersion,
@@ -312,7 +312,8 @@ fileprivate struct WireInput: Decodable {
     /// their ID numbers.
     struct Package: Decodable {
         typealias Id = Int
-        let name: String
+        let identity: String
+        let displayName: String
         let directoryId: Path.Id
         let origin: Origin
         let toolsVersion: ToolsVersion

--- a/Sources/PackagePlugin/Protocols.swift
+++ b/Sources/PackagePlugin/Protocols.swift
@@ -72,4 +72,12 @@ extension BuildToolPlugin {
             builtProductsDirectory: context.builtProductsDirectory,
             toolNamesToPaths: context.toolNamesToPaths))
     }
+
+    /// Default implementation that does nothing.
+    public func createBuildCommands(
+        context: TargetBuildContext
+    ) throws -> [Command] {
+        return []
+    }
 }
+

--- a/Sources/SPMBuildCore/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/PluginInvocation.swift
@@ -395,7 +395,8 @@ struct PluginScriptRunnerInput: Codable {
     /// their ID numbers.
     struct Package: Codable {
         typealias Id = Int
-        let name: String
+        let identity: String
+        let displayName: String
         let directoryId: Path.Id
         let origin: Origin
         let toolsVersion: ToolsVersion
@@ -790,8 +791,8 @@ struct PluginScriptRunnerInputSerializer {
         // Assign the next wire ID to the package and append a serialized Package record.
         let id = packages.count
         packages.append(.init(
-            // FIXME: can we use package identity instead?
-            name: package.manifest.displayName,
+            identity: package.identity.description,
+            displayName: package.manifest.displayName,
             directoryId: try serialize(path: package.path),
             origin: try origin(for: package),
             toolsVersion: .init(


### PR DESCRIPTION
### Motivation:

This brings it in line with SE-0325.

### Modifications:

- rename `name` to `displayName` as SE-0325 says
- pass the identity in the serialized data and use it as the `Package.id` instead of a constructed string
- add a unit test that checks the value of display name