### PR TITLE
Bump minimum swift-crypto v2 version to 2.0.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -54,7 +54,7 @@ automatic linking type with `-auto` suffix appended to product's name.
 let autoProducts = [swiftPMProduct, swiftPMDataModelProduct]
 
 let useSwiftCryptoV2 = ProcessInfo.processInfo.environment["SWIFTPM_USE_SWIFT_CRYPTO_V2"] != nil
-let minimumCryptoVersion: Version = useSwiftCryptoV2 ? "2.0.0" : "1.1.4"
+let minimumCryptoVersion: Version = useSwiftCryptoV2 ? "2.0.1" : "1.1.4"
 var swiftSettings: [SwiftSetting] = []
 if useSwiftCryptoV2 {
     swiftSettings.append(.define("CRYPTO_v2"))

--- a/Sources/PackageCollectionsSigningLibc/asn1/a_d2i_fp.c
+++ b/Sources/PackageCollectionsSigningLibc/asn1/a_d2i_fp.c
@@ -17,6 +17,62 @@
  * https://www.openssl.org/source/license.html
  */
 
+/* Copyright (C) 1995-1998 Eric Young (eay@cryptsoft.com)
+ * All rights reserved.
+ *
+ * This package is an SSL implementation written
+ * by Eric Young (eay@cryptsoft.com).
+ * The implementation was written so as to conform with Netscapes SSL.
+ *
+ * This library is free for commercial and non-commercial use as long as
+ * the following conditions are aheared to.  The following conditions
+ * apply to all code found in this distribution, be it the RC4, RSA,
+ * lhash, DES, etc., code; not just the SSL code.  The SSL documentation
+ * included with this distribution is covered by the same copyright terms
+ * except that the holder is Tim Hudson (tjh@cryptsoft.com).
+ *
+ * Copyright remains Eric Young's, and as such any Copyright notices in
+ * the code are not to be removed.
+ * If this package is used in a product, Eric Young should be given attribution
+ * as the author of the parts of the library used.
+ * This can be in the form of a textual message at program startup or
+ * in documentation (online or textual) provided with the package.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *    "This product includes cryptographic software written by
+ *     Eric Young (eay@cryptsoft.com)"
+ *    The word 'cryptographic' can be left out if the rouines from the library
+ *    being used are not cryptographic related :-).
+ * 4. If you include any Windows specific code (or a derivative thereof) from
+ *    the apps directory (application code) you must include an acknowledgement:
+ *    "This product includes software written by Tim Hudson (tjh@cryptsoft.com)"
+ *
+ * THIS SOFTWARE IS PROVIDED BY ERIC YOUNG ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * The licence and distribution terms for any publically available version or
+ * derivative of this code cannot be changed.  i.e. this code cannot simply be
+ * copied and put under another distribution licence
+ * [including the GNU Public Licence.] */
+
 #include <limits.h>
 #include <CCryptoBoringSSL_asn1.h>
 #include <CCryptoBoringSSL_buffer.h>
@@ -24,6 +80,13 @@
 #include "CPackageCollectionSigning_asn1.h"
 
 static int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb);
+static int ASN1_get_object_without_inf(const unsigned char **pp, long *plength,
+                                       int *ptag, int *pclass, long omax);
+static int asn1_get_length_without_inf(const unsigned char **pp, long *rl, long max);
+static int asn1_get_length_with_inf(const unsigned char **pp, int *inf,
+                                    long *rl, long max);
+static int ASN1_get_object_with_inf(const unsigned char **pp, long *plength,
+                                    int *ptag, int *pclass, long omax);
 
 void *ASN1_d2i_bio(void *(*xnew) (void), d2i_of_void *d2i, BIO *in, void **x)
 {
@@ -57,7 +120,7 @@ static int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
 
     const unsigned char *q;
     long slen;
-    int inf, tag, xclass;
+    int ret, tag, xclass;
 
     b = BUF_MEM_new();
     if (b == NULL) {
@@ -87,8 +150,8 @@ static int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
 
         p = (unsigned char *)&(b->data[off]);
         q = p;
-        inf = ASN1_get_object(&q, &slen, &tag, &xclass, len - off);
-        if (inf & 0x80) {
+        ret = ASN1_get_object_without_inf(&q, &slen, &tag, &xclass, len - off);
+        if (ret & 0x80) {
             unsigned long e;
 
             e = ERR_GET_REASON(ERR_peek_error());
@@ -100,14 +163,7 @@ static int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
         i = (int)(q - p);            /* header length */
         off += i;               /* end of data */
 
-        if (inf & 1) {
-            /* no data body so go round again */
-            if (eos == UINT32_MAX) {
-                goto err;
-            }
-            eos++;
-            want = HEADER_SIZE;
-        } else if (eos && (slen == 0) && (tag == V_ASN1_EOC)) {
+        if (eos && (slen == 0) && (tag == V_ASN1_EOC)) {
             /* eos value, so go back and read another header */
             eos--;
             if (eos == 0)
@@ -174,4 +230,207 @@ static int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
  err:
     BUF_MEM_free(b);
     return -1;
+}
+
+// https://github.com/google/boringssl/blob/ee510f58895c6a88b59f1b66a94939d08ebdfe5b/crypto/asn1/asn1_lib.c
+static int ASN1_get_object_without_inf(const unsigned char **pp, long *plength,
+                                       int *ptag, int *pclass, long omax)
+{
+    int i, ret;
+    long l;
+    const unsigned char *p = *pp;
+    int tag, xclass;
+    long max = omax;
+
+    if (!max)
+        goto err;
+    ret = (*p & V_ASN1_CONSTRUCTED);
+    xclass = (*p & V_ASN1_PRIVATE);
+    i = *p & V_ASN1_PRIMITIVE_TAG;
+    if (i == V_ASN1_PRIMITIVE_TAG) { /* high-tag */
+        p++;
+        if (--max == 0)
+            goto err;
+        l = 0;
+        while (*p & 0x80) {
+            l <<= 7L;
+            l |= *(p++) & 0x7f;
+            if (--max == 0)
+                goto err;
+            if (l > (INT_MAX >> 7L))
+                goto err;
+        }
+        l <<= 7L;
+        l |= *(p++) & 0x7f;
+        tag = (int)l;
+        if (--max == 0)
+            goto err;
+    } else {
+        tag = i;
+        p++;
+        if (--max == 0)
+            goto err;
+    }
+
+    /* To avoid ambiguity with V_ASN1_NEG, impose a limit on universal tags. */
+    if (xclass == V_ASN1_UNIVERSAL && tag > V_ASN1_MAX_UNIVERSAL)
+        goto err;
+
+    *ptag = tag;
+    *pclass = xclass;
+    if (!asn1_get_length_without_inf(&p, plength, max))
+        goto err;
+
+    if (*plength > (omax - (p - *pp))) {
+        OPENSSL_PUT_ERROR(ASN1, ASN1_R_TOO_LONG);
+        /*
+         * Set this so that even if things are not long enough the values are
+         * set correctly
+         */
+        ret |= 0x80;
+    }
+    *pp = p;
+    return ret;
+ err:
+    OPENSSL_PUT_ERROR(ASN1, ASN1_R_HEADER_TOO_LONG);
+    return 0x80;
+}
+
+static int asn1_get_length_without_inf(const unsigned char **pp, long *rl, long max)
+{
+    const unsigned char *p = *pp;
+    unsigned long ret = 0;
+    unsigned long i;
+
+    if (max-- < 1) {
+        return 0;
+    }
+    if (*p == 0x80) {
+        /* We do not support BER indefinite-length encoding. */
+        return 0;
+    }
+    i = *p & 0x7f;
+    if (*(p++) & 0x80) {
+        if (i > sizeof(ret) || max < (long)i)
+            return 0;
+        while (i-- > 0) {
+            ret <<= 8L;
+            ret |= *(p++);
+        }
+    } else {
+        ret = i;
+    }
+    /*
+     * Bound the length to comfortably fit in an int. Lengths in this module
+     * often switch between int and long without overflow checks.
+     */
+    if (ret > INT_MAX / 2)
+        return 0;
+    *pp = p;
+    *rl = (long)ret;
+    return 1;
+}
+
+// https://github.com/google/boringssl/blob/a7e807481bfab5fcf72cd6b396f57cb2990bf63a/crypto/asn1/asn1_lib.c
+static int ASN1_get_object_with_inf(const unsigned char **pp, long *plength,
+                                    int *ptag, int *pclass, long omax)
+{
+    int i, ret;
+    long l;
+    const unsigned char *p = *pp;
+    int tag, xclass, inf;
+    long max = omax;
+
+    if (!max)
+        goto err;
+    ret = (*p & V_ASN1_CONSTRUCTED);
+    xclass = (*p & V_ASN1_PRIVATE);
+    i = *p & V_ASN1_PRIMITIVE_TAG;
+    if (i == V_ASN1_PRIMITIVE_TAG) { /* high-tag */
+        p++;
+        if (--max == 0)
+            goto err;
+        l = 0;
+        while (*p & 0x80) {
+            l <<= 7L;
+            l |= *(p++) & 0x7f;
+            if (--max == 0)
+                goto err;
+            if (l > (INT_MAX >> 7L))
+                goto err;
+        }
+        l <<= 7L;
+        l |= *(p++) & 0x7f;
+        tag = (int)l;
+        if (--max == 0)
+            goto err;
+    } else {
+        tag = i;
+        p++;
+        if (--max == 0)
+            goto err;
+    }
+
+    /* To avoid ambiguity with V_ASN1_NEG, impose a limit on universal tags. */
+    if (xclass == V_ASN1_UNIVERSAL && tag > V_ASN1_MAX_UNIVERSAL)
+        goto err;
+
+    *ptag = tag;
+    *pclass = xclass;
+    if (!asn1_get_length_with_inf(&p, &inf, plength, max))
+        goto err;
+
+    if (inf && !(ret & V_ASN1_CONSTRUCTED))
+        goto err;
+
+    if (*plength > (omax - (p - *pp))) {
+        OPENSSL_PUT_ERROR(ASN1, ASN1_R_TOO_LONG);
+        /*
+         * Set this so that even if things are not long enough the values are
+         * set correctly
+         */
+        ret |= 0x80;
+    }
+    *pp = p;
+    return (ret | inf);
+ err:
+    OPENSSL_PUT_ERROR(ASN1, ASN1_R_HEADER_TOO_LONG);
+    return 0x80;
+}
+
+static int asn1_get_length_with_inf(const unsigned char **pp, int *inf,
+                                    long *rl, long max)
+{
+    const unsigned char *p = *pp;
+    unsigned long ret = 0;
+    unsigned long i;
+
+    if (max-- < 1)
+        return 0;
+    if (*p == 0x80) {
+        *inf = 1;
+        ret = 0;
+        p++;
+    } else {
+        *inf = 0;
+        i = *p & 0x7f;
+        if (*(p++) & 0x80) {
+            if (i > sizeof(ret) || max < (long)i)
+                return 0;
+            while (i-- > 0) {
+                ret <<= 8L;
+                ret |= *(p++);
+            }
+        } else
+            ret = i;
+    }
+    /*
+     * Bound the length to comfortably fit in an int. Lengths in this module
+     * often switch between int and long without overflow checks.
+     */
+    if (ret > INT_MAX / 2)
+        return 0;
+    *pp = p;
+    *rl = (long)ret;
+    return 1;
 }

--- a/Tests/PackageCollectionsSigningTests/CertificatePolicyTests.swift
+++ b/Tests/PackageCollectionsSigningTests/CertificatePolicyTests.swift
@@ -172,7 +172,7 @@ class CertificatePolicyTests: XCTestCase {
             let certPath = directoryPath.appending(components: "Signing", "development.cer")
             let certificate = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(certPath).contents))
 
-            let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCA.cer")
+            let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCAG3.cer")
             let intermediateCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(intermediateCAPath).contents))
 
             let rootCAPath = directoryPath.appending(components: "Signing", "AppleIncRoot.cer")
@@ -310,7 +310,7 @@ class CertificatePolicyTests: XCTestCase {
             let certPath = directoryPath.appending(components: "Signing", "development.cer")
             let certificate = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(certPath).contents))
 
-            let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCA.cer")
+            let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCAG3.cer")
             let intermediateCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(intermediateCAPath).contents))
 
             let rootCAPath = directoryPath.appending(components: "Signing", "AppleIncRoot.cer")
@@ -318,7 +318,7 @@ class CertificatePolicyTests: XCTestCase {
 
             let certChain = [certificate, intermediateCA, rootCA]
 
-#if os(macOS)
+            #if os(macOS)
             // The Apple root certs come preinstalled on Apple platforms and they are automatically trusted
             do {
                 let policy = AppleDistributionCertificatePolicy(
@@ -378,7 +378,7 @@ class CertificatePolicyTests: XCTestCase {
             let certPath = directoryPath.appending(components: "Signing", "development.cer")
             let certificate = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(certPath).contents))
 
-            let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCA.cer")
+            let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCAG3.cer")
             let intermediateCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(intermediateCAPath).contents))
 
             let rootCAPath = directoryPath.appending(components: "Signing", "AppleIncRoot.cer")
@@ -532,7 +532,7 @@ class CertificatePolicyTests: XCTestCase {
             let certPath = directoryPath.appending(components: "Signing", "development.cer")
             let certificate = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(certPath).contents))
 
-            let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCA.cer")
+            let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCAG3.cer")
             let intermediateCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(intermediateCAPath).contents))
 
             let rootCAPath = directoryPath.appending(components: "Signing", "AppleIncRoot.cer")

--- a/Tests/PackageCollectionsSigningTests/PackageCollectionSigningTest.swift
+++ b/Tests/PackageCollectionsSigningTests/PackageCollectionSigningTest.swift
@@ -210,7 +210,7 @@ class PackageCollectionSigningTests: XCTestCase {
             let collection = try jsonDecoder.decode(PackageCollectionModel.V1.Collection.self, from: collectionData)
 
             let certPath = directoryPath.appending(components: "Signing", "development.cer")
-            let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCA.cer")
+            let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCAG3.cer")
             let rootCAPath = directoryPath.appending(components: "Signing", "AppleIncRoot.cer")
             let rootCAData = Data(try localFileSystem.readFileContents(rootCAPath).contents)
             let certChainPaths = [certPath, intermediateCAPath, rootCAPath].map { $0.asURL }
@@ -320,7 +320,7 @@ class PackageCollectionSigningTests: XCTestCase {
 
             // This must be an Apple Distribution cert
             let certPath = directoryPath.appending(components: "Signing", "development.cer")
-            let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCA.cer")
+            let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCAG3.cer")
             let rootCAPath = directoryPath.appending(components: "Signing", "AppleIncRoot.cer")
             let rootCAData = Data(try localFileSystem.readFileContents(rootCAPath).contents)
             let certChainPaths = [certPath, intermediateCAPath, rootCAPath].map { $0.asURL }
@@ -507,7 +507,7 @@ class PackageCollectionSigningTests: XCTestCase {
             let collection = try jsonDecoder.decode(PackageCollectionModel.V1.Collection.self, from: collectionData)
 
             let certPath = directoryPath.appending(components: "Signing", "development.cer")
-            let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCA.cer")
+            let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCAG3.cer")
             let rootCAPath = directoryPath.appending(components: "Signing", "AppleIncRoot.cer")
             let certChainPaths = [certPath, intermediateCAPath, rootCAPath].map { $0.asURL }
 
@@ -562,7 +562,7 @@ class PackageCollectionSigningTests: XCTestCase {
 
             // This must be an Apple Distribution cert
             let certPath = directoryPath.appending(components: "Signing", "development.cer")
-            let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCA.cer")
+            let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCAG3.cer")
             let rootCAPath = directoryPath.appending(components: "Signing", "AppleIncRoot.cer")
             let certChainPaths = [certPath, intermediateCAPath, rootCAPath].map { $0.asURL }
 


### PR DESCRIPTION
Motivation:

Test and upgrade to the latest swift-crypto [2.0.1](https://github.com/apple/swift-crypto/releases/tag/2.0.1) release, which
includes a BoringSSL update: https://github.com/apple/swift-crypto/pull/95

Modifications:

Tests that use real certs, which execute the OCSP code path, crash on Linux (`swift:5.5` and `swift:5.5-focal` docker images). (rdar://85280061)

The crash happens on L351 of `CertificatePolicy.swift` (`BoringSSLOCSPClient.checkStatus`) because `response`, an `OCSP_RESPONSE` pointer, is `NULL`. It is `NULL` because the logic in BoringSSL's `crypto/asn1/asn1_lib.c` has changed (https://github.com/google/boringssl/commit/ee510f58895c6a88b59f1b66a94939d08ebdfe5b), so the return value needs to be handled differently in `PackageCollectionsSigningLibc/asn1/a_d2i_fp.c`.

I also don't think this change is correct: https://github.com/google/boringssl/commit/efab69bf7323009da8257f47e7e0976a43e12c64#diff-dc711de78524fcd1edcc461a96ca36b80cac1bf03a67287a9b434f772a6f4e3dR170.

- Guard against `NULL` OCSP response in `BoringSSLOCSPClient`.
- Update logic in `PackageCollectionsSigningLibc/asn1/a_d2i_fp.c`:
  - Add `ASN1_get_object_without_inf` and `asn1_get_length_without_inf`, copied from [BoringSSL](https://github.com/google/boringssl/blob/ee510f58895c6a88b59f1b66a94939d08ebdfe5b/crypto/asn1/asn1_lib.c) but reverting the ["0x80 fix"](https://github.com/google/boringssl/commit/efab69bf7323009da8257f47e7e0976a43e12c64#diff-dc711de78524fcd1edcc461a96ca36b80cac1bf03a67287a9b434f772a6f4e3dR170), such that we use the same logic regardless of swift-crypto version. We can probably remove them later when we switch over to swift-crypto 2.x completely (unless I'm correct the 0x80 fix).
  - Remove `inf` in `asn1_d2i_read_bio`.
  - Note that there are `ASN1_get_object_with_inf` and `asn1_get_length_with_inf` too. We can use these instead to keep the same behavior as swift-crypt 2.0.0 and less. I will delete these if reviewers are ok with the current approach.
