### PR TITLE
[5.5] Add support for correctly discovering async test methods on non-Apple platforms

### DIFF
--- a/Fixtures/Miscellaneous/TestDiscovery/Async/Package.swift
+++ b/Fixtures/Miscellaneous/TestDiscovery/Async/Package.swift
@@ -1,0 +1,10 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "Async",
+    targets: [
+        .target(name: "Async"),
+        .testTarget(name: "AsyncTests", dependencies: ["Async"]),
+    ]
+)

--- a/Fixtures/Miscellaneous/TestDiscovery/Async/Sources/Async/Async.swift
+++ b/Fixtures/Miscellaneous/TestDiscovery/Async/Sources/Async/Async.swift
@@ -1,0 +1,3 @@
+struct Async {
+
+}

--- a/Fixtures/Miscellaneous/TestDiscovery/Async/Tests/AsyncTests/SwiftTests.swift
+++ b/Fixtures/Miscellaneous/TestDiscovery/Async/Tests/AsyncTests/SwiftTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import Async
+
+class AsyncTests: XCTestCase {
+
+    func testAsync() async {
+    }
+
+    @MainActor func testMainActor() async {
+        XCTAssertTrue(Thread.isMainThread)
+    }
+
+    func testNotAsync() {
+        XCTAssertTrue(Thread.isMainThread)
+    }
+}

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -45,6 +45,15 @@ class CustomLLBuildCommand: SPMLLBuild.ExternalCommand {
     }
 }
 
+private extension IndexStore.TestCaseClass.TestMethod {
+
+    var allTestsEntry: String {
+        let baseName = name.hasSuffix("()") ? String(name.dropLast(2)) : name
+
+        return "(\"\(baseName)\", \(isAsync ? "asyncTest(\(baseName))" : baseName ))"
+    }
+}
+
 final class TestDiscoveryCommand: CustomLLBuildCommand {
 
     private func write(
@@ -61,13 +70,12 @@ final class TestDiscoveryCommand: CustomLLBuildCommand {
 
         for iterator in testsByClassNames {
             let className = iterator.key
-            let testMethods = iterator.value.flatMap{ $0.methods }
+            let testMethods = iterator.value.flatMap{ $0.testMethods }
             stream <<< "\n"
             stream <<< "fileprivate extension " <<< className <<< " {" <<< "\n"
             stream <<< indent(4) <<< "static let __allTests__\(className) = [" <<< "\n"
             for method in testMethods {
-                let method = method.hasSuffix("()") ? String(method.dropLast(2)) : method
-                stream <<< indent(8) <<< "(\"\(method)\", \(method))," <<< "\n"
+                stream <<< indent(8) <<< method.allTestsEntry <<< ",\n"
             }
             stream <<< indent(4) <<< "]" <<< "\n"
             stream <<< "}" <<< "\n"

--- a/Tests/FunctionalTests/TestDiscoveryTests.swift
+++ b/Tests/FunctionalTests/TestDiscoveryTests.swift
@@ -51,6 +51,19 @@ class TestDiscoveryTests: XCTestCase {
         }
     }
 
+    func testAsyncMethods() throws {
+        fixture(name: "Miscellaneous/TestDiscovery/Async") { path in
+            let (stdout, stderr) = try executeSwiftTest(path)
+            #if os(macOS)
+            XCTAssertMatch(stdout, .contains("module Async"))
+            XCTAssertMatch(stderr, .contains("Executed 3 tests"))
+            #else
+            XCTAssertMatch(stdout, .contains("module Async"))
+            XCTAssertMatch(stdout, .contains("Executed 3 tests"))
+            #endif
+        }
+    }
+
     func testManifestOverride() throws {
         #if os(macOS)
         try XCTSkipIf(true)


### PR DESCRIPTION
Nominating the changes from https://github.com/apple/swift-package-manager/pull/3844 to be pulled back for a 5.5.x dot release.