### PR TITLE
Improve Resolver Determinism

### DIFF
--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -230,7 +230,7 @@ private func createResolvedPackages(
             metadata: package.diagnosticsMetadata
         )
 
-        var dependencies = [PackageIdentity: ResolvedPackageBuilder]()
+        var dependencies = OrderedDictionary<PackageIdentity, ResolvedPackageBuilder>()
         var dependenciesByNameForTargetDependencyResolution = [String: ResolvedPackageBuilder]()
 
         // Establish the manifest-declared package dependencies.
@@ -257,7 +257,7 @@ private func createResolvedPackages(
                 // check if this resolved package already listed in the dependencies
                 // this means that the dependencies share the same identity
                 // FIXME: this works but the way we find out about this is based on a side effect, need to improve it
-                guard !dependencies.keys.contains(resolvedPackage.package.identity) else {
+                guard dependencies[resolvedPackage.package.identity] == nil else {
                     let error = PackageGraphError.dependencyAlreadySatisfiedByIdentifier(
                         package: package.identity.description,
                         dependencyLocation: dependencyLocation,


### PR DESCRIPTION
Spun out of #3838. This makes sure the order of resolution diagnostics is deterministic.

Unlike the first iteration in #3838, this does it properly and preserves the user’s order (which turned out to be much easier than I expected). It also adds a test that would catch any regression, regardless of the resolution mode.