### PR TITLE
Make the commands tests robust against any working directory changes

### DIFF
--- a/Tests/CommandsTests/APIDiffTests.swift
+++ b/Tests/CommandsTests/APIDiffTests.swift
@@ -18,7 +18,7 @@ import TSCBasic
 import Workspace
 import XCTest
 
-final class APIDiffTests: XCTestCase {
+final class APIDiffTests: CommandsTestCase {
     @discardableResult
     private func execute(
         _ args: [String],

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -25,7 +25,7 @@ struct BuildResult {
     let binContents: [String]
 }
 
-final class BuildToolTests: XCTestCase {
+final class BuildToolTests: CommandsTestCase {
     @discardableResult
     private func execute(
         _ args: [String],

--- a/Tests/CommandsTests/CommandsTestCase.swift
+++ b/Tests/CommandsTests/CommandsTestCase.swift
@@ -1,0 +1,30 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import TSCBasic
+import XCTest
+
+class CommandsTestCase: XCTestCase {
+    
+    /// Original working directory before the test ran (if known).
+    private var originalWorkingDirectory: AbsolutePath? = .none
+    
+    override func setUp() {
+        originalWorkingDirectory = localFileSystem.currentWorkingDirectory
+    }
+    
+    override func tearDown() {
+        if let originalWorkingDirectory = originalWorkingDirectory {
+            try? localFileSystem.changeCurrentWorkingDirectory(to: originalWorkingDirectory)
+        }
+    }
+    
+    // FIXME: We should also hoist the `execute()` helper function that the various test suites implement, but right now they all seem to have slightly different implementations, so that's a later project.
+}

--- a/Tests/CommandsTests/MultiRootSupportTests.swift
+++ b/Tests/CommandsTests/MultiRootSupportTests.swift
@@ -15,7 +15,7 @@ import TSCBasic
 import Workspace
 import XCTest
 
-final class MultiRootSupportTests: XCTestCase {
+final class MultiRootSupportTests: CommandsTestCase {
 
     func testWorkspaceLoader() throws {
         let fs = InMemoryFileSystem(emptyFiles: [

--- a/Tests/CommandsTests/PackageRegistryToolTests.swift
+++ b/Tests/CommandsTests/PackageRegistryToolTests.swift
@@ -19,7 +19,7 @@ import XCTest
 let defaultRegistryBaseURL = URL(string: "https://packages.example.com")!
 let customRegistryBaseURL = URL(string: "https://custom.packages.example.com")!
 
-final class PackageRegistryToolTests: XCTestCase {
+final class PackageRegistryToolTests: CommandsTestCase {
     @discardableResult
     private func execute(
         _ args: [String],

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -22,7 +22,7 @@ import Workspace
 import Xcodeproj
 import XCTest
 
-final class PackageToolTests: XCTestCase {
+final class PackageToolTests: CommandsTestCase {
     @discardableResult
     private func execute(
         _ args: [String],

--- a/Tests/CommandsTests/RunToolTests.swift
+++ b/Tests/CommandsTests/RunToolTests.swift
@@ -14,7 +14,8 @@ import SPMTestSupport
 import Commands
 import TSCBasic
 
-final class RunToolTests: XCTestCase {
+final class RunToolTests: CommandsTestCase {
+    
     private func execute(
         _ args: [String],
         packagePath: AbsolutePath? = nil

--- a/Tests/CommandsTests/SwiftToolTests.swift
+++ b/Tests/CommandsTests/SwiftToolTests.swift
@@ -14,7 +14,8 @@ import SPMTestSupport
 import TSCBasic
 import XCTest
 
-final class SwiftToolTests: XCTestCase {
+final class SwiftToolTests: CommandsTestCase {
+    
     func testVerbosityLogLevel() throws {
         fixture(name: "Miscellaneous/Simple") { packageRoot in
             do {

--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -13,7 +13,8 @@ import XCTest
 import SPMTestSupport
 import Commands
 
-final class TestToolTests: XCTestCase {
+final class TestToolTests: CommandsTestCase {
+    
     private func execute(_ args: [String]) throws -> (stdout: String, stderr: String) {
         return try SwiftPMProduct.SwiftTest.execute(args)
     }


### PR DESCRIPTION
This is a test-only change that makes the commands tests robust against any working directory changes done by the tool being tested in the same process (as for example `--package-path` does).

### Motivation:

Tests are flaky on the local desktop depending on what order they run in.  Not sure why this doesn't happen more in the CI.  The symptom here is that the test fails when run as part of the test suite but succeeds when run individually.

In the particular case that kept hitting me, `SwiftTools` was run on a test fixture in a temporary directory, changed current working directory to that directory, and then after the temporary directory was removed again, new calls to `SwiftTools` failed with "cannot get current working directory".  Which makes sense, since it had been removed.

### Modifications:

- use a common specialization of XCTestCase for the command tests that saves and restores the current working directory

I don't love this change but changing `SwiftTool` to not use `chdir` anymore seems riskier.  And if there are other things that should be saved and restored in setup and teardown this provides a place to do it.  A lot of the custom test classes also have some variant of `execute()` that could be hoisted up to the shared parent test case class, so the case for this class might remain even if we have a better way of dealing with the current working directory later.