### PR TITLE
Fix Identity Resolution

### DIFF
--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -1482,9 +1482,9 @@ final class BuildPlanTests: XCTestCase {
 
         #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
         XCTAssertEqual(observability.diagnostics.count, 1)
-        let firstDiagnostic = observability.diagnostics.first.map({ $0.message.text })
+        let firstDiagnostic = observability.diagnostics.first.map({ $0.message })
         XCTAssert(
-            firstDiagnostic == "dependency 'C' is not used by any target",
+            firstDiagnostic == "dependency 'c' is not used by any target",
             "Unexpected diagnostic: " + (firstDiagnostic ?? "[none]")
         )
         #endif

--- a/Tests/PackageModelTests/ManifestTests.swift
+++ b/Tests/PackageModelTests/ManifestTests.swift
@@ -144,9 +144,9 @@ class ManifestTests: XCTestCase {
             )
 
             #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
-            XCTAssertEqual(manifest.dependenciesRequired(for: .specific(["Foo"])).map({ $0.name }).sorted(), [
-                "Bar1", // Foo → Foo1 → Bar1
-                "Bar2", // Foo → Foo1 → Foo2 → Bar2
+            XCTAssertEqual(manifest.dependenciesRequired(for: .specific(["Foo"])).map({ $0.identity.description }).sorted(), [
+                "bar1", // Foo → Foo1 → Bar1
+                "bar2", // Foo → Foo1 → Foo2 → Bar2
                 // (Bar3 is unreachable.)
             ])
             #endif

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -2051,13 +2051,11 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
         try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
-                result.check(diagnostic: .contains("Foo[Foo] 1.0.0..<2.0.0"), severity: .error)
+                result.check(diagnostic: .contains("'foo' 1.0.0..<2.0.0"), severity: .error)
             }
         }
-        #endif
     }
 
     func testToolsVersionRootPackages() throws {
@@ -2922,11 +2920,9 @@ final class WorkspaceTests: XCTestCase {
                 result.check(packages: "Foo")
                 result.check(targets: "Foo")
             }
-            #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
             testDiagnostics(diagnostics) { result in
-                result.check(diagnostic: .contains("Bar[Bar] {1.0.0..<1.5.0, 1.5.1..<2.0.0} is forbidden"), severity: .error)
+                result.check(diagnostic: .contains("'bar' {1.0.0..<1.5.0, 1.5.1..<2.0.0} cannot be used"), severity: .error)
             }
-            #endif
         }
     }
 


### PR DESCRIPTION
Spun out of #3838. This contains only the pieces related to identities.

The first commit adds a test against an existing bug in the logic that connects the dependency declarations of a target to their respective packages. Named packages (tools versions 5.2 to 5.5) are not looked up correctly, and the resolver ends up looking for them everywhere, as though the manifest were 5.1 or older. I do not think it can lead to anything breaking, but it does lead to excessive work in the resolver, and in rare cases, to more dependencies being fetched than necessary (If two dependencies have products with the same name, and only one of them is actually used, both will be fetched anyway). The test is only meaningful with target‐based resolution engaged, as legacy resolution overrides the logic with a request for `.everything` anyway.

The second commit fixes the bug by repairing the lookup.

The last commit updates several stale tests that were looking for old spellings of diagnostics which changed with the introduction of identities. Two of the four do not actually depend on target‐based resolution, and they were re‐enabled.