### PR TITLE
Load manifests asynchronously

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -253,16 +253,8 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                     fileSystem: fileSystem,
                     observabilityScope: observabilityScope
                 ) { parseResult in
-                    let parsedManifest : ManifestJSONParser.Result
-                    switch parseResult {
-                    case .success(let result):
-                        parsedManifest = result
-                    case .failure(let error):
-                        return queue.async {
-                            completion(.failure(error))
-                        }
-                    }
                     do {
+                        let parsedManifest = try parseResult.get()
                         // Convert legacy system packages to the current target‐based model.
                         var products = parsedManifest.products
                         var targets = parsedManifest.targets

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -243,7 +243,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                     throw PackageModel.Package.Error.noManifest(at: path, version: version?.description)
                 }
 
-                try self.parseAndCacheManifest(
+                self.parseAndCacheManifest(
                     at: path,
                     packageIdentity: packageIdentity,
                     packageKind: packageKind,

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -243,7 +243,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                     throw PackageModel.Package.Error.noManifest(at: path, version: version?.description)
                 }
 
-                let parsedManifest = try self.parseAndCacheManifest(
+                try self.parseAndCacheManifest(
                     at: path,
                     packageIdentity: packageIdentity,
                     packageKind: packageKind,
@@ -252,55 +252,70 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                     delegateQueue: queue,
                     fileSystem: fileSystem,
                     observabilityScope: observabilityScope
-                )
-
-                // Convert legacy system packages to the current target‐based model.
-                var products = parsedManifest.products
-                var targets = parsedManifest.targets
-                if products.isEmpty, targets.isEmpty,
-                    fileSystem.isFile(path.parentDirectory.appending(component: moduleMapFilename)) {
-                        products.append(ProductDescription(
-                        name: parsedManifest.name,
-                        type: .library(.automatic),
-                        targets: [parsedManifest.name])
-                    )
-                    targets.append(try TargetDescription(
-                        name: parsedManifest.name,
-                        path: "",
-                        type: .system,
-                        pkgConfig: parsedManifest.pkgConfig,
-                        providers: parsedManifest.providers
-                    ))
-                }
-
-                let manifest = Manifest(
-                    displayName: parsedManifest.name,
-                    path: path,
-                    packageKind: packageKind,
-                    packageLocation: packageLocation,
-                    defaultLocalization: parsedManifest.defaultLocalization,
-                    platforms: parsedManifest.platforms,
-                    version: version,
-                    revision: revision,
-                    toolsVersion: toolsVersion,
-                    pkgConfig: parsedManifest.pkgConfig,
-                    providers: parsedManifest.providers,
-                    cLanguageStandard: parsedManifest.cLanguageStandard,
-                    cxxLanguageStandard: parsedManifest.cxxLanguageStandard,
-                    swiftLanguageVersions: parsedManifest.swiftLanguageVersions,
-                    dependencies: parsedManifest.dependencies,
-                    products: products,
-                    targets: targets
-                )
-
-                try self.validate(manifest, toolsVersion: toolsVersion, observabilityScope: observabilityScope)
-
-                if observabilityScope.errorsReported {
-                    throw Diagnostics.fatalError
-                }
-
-                queue.async {
-                    completion(.success(manifest))
+                ) { parseResult in
+                    let parsedManifest : ManifestJSONParser.Result
+                    switch parseResult {
+                    case .success(let result):
+                        parsedManifest = result
+                    case .failure(let error):
+                        return queue.async {
+                            completion(.failure(error))
+                        }
+                    }
+                    do {
+                        // Convert legacy system packages to the current target‐based model.
+                        var products = parsedManifest.products
+                        var targets = parsedManifest.targets
+                        if products.isEmpty, targets.isEmpty,
+                           fileSystem.isFile(path.parentDirectory.appending(component: moduleMapFilename)) {
+                            products.append(ProductDescription(
+                                name: parsedManifest.name,
+                                type: .library(.automatic),
+                                targets: [parsedManifest.name])
+                            )
+                            targets.append(try TargetDescription(
+                                name: parsedManifest.name,
+                                path: "",
+                                type: .system,
+                                pkgConfig: parsedManifest.pkgConfig,
+                                providers: parsedManifest.providers
+                            ))
+                        }
+                        
+                        let manifest = Manifest(
+                            displayName: parsedManifest.name,
+                            path: path,
+                            packageKind: packageKind,
+                            packageLocation: packageLocation,
+                            defaultLocalization: parsedManifest.defaultLocalization,
+                            platforms: parsedManifest.platforms,
+                            version: version,
+                            revision: revision,
+                            toolsVersion: toolsVersion,
+                            pkgConfig: parsedManifest.pkgConfig,
+                            providers: parsedManifest.providers,
+                            cLanguageStandard: parsedManifest.cLanguageStandard,
+                            cxxLanguageStandard: parsedManifest.cxxLanguageStandard,
+                            swiftLanguageVersions: parsedManifest.swiftLanguageVersions,
+                            dependencies: parsedManifest.dependencies,
+                            products: products,
+                            targets: targets
+                        )
+                        
+                        try self.validate(manifest, toolsVersion: toolsVersion, observabilityScope: observabilityScope)
+                        
+                        if observabilityScope.errorsReported {
+                            throw Diagnostics.fatalError
+                        }
+                        
+                        queue.async {
+                            completion(.success(manifest))
+                        }
+                    } catch {
+                        queue.async {
+                            completion(.failure(error))
+                        }
+                    }
                 }
             } catch {
                 queue.async {
@@ -506,8 +521,9 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         identityResolver: IdentityResolver,
         delegateQueue: DispatchQueue,
         fileSystem: FileSystem,
-        observabilityScope: ObservabilityScope
-    ) throws -> ManifestJSONParser.Result {
+        observabilityScope: ObservabilityScope,
+        completion: @escaping (Result<ManifestJSONParser.Result, Error>) -> Void
+    ) throws {
         let cache = self.databaseCacheDir.map { cacheDir -> SQLiteBackedCache<EvaluationResult> in
             let path = Self.manifestCacheDBPath(cacheDir)
             var configuration = SQLiteBackedCacheConfiguration()
@@ -536,7 +552,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         do {
             // try to get it from the cache
             if let result = try cache?.get(key: key.sha256Checksum), let manifestJSON = result.manifestJSON, !manifestJSON.isEmpty {
-                return try self.parseManifest(
+                return completion(.success(try self.parseManifest(
                     result,
                     packageIdentity: packageIdentity,
                     packageKind: packageKind,
@@ -544,40 +560,49 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                     identityResolver: identityResolver,
                     fileSystem: fileSystem,
                     observabilityScope: observabilityScope
-                )
+                )))
             }
         } catch {
             observabilityScope.emit(warning: "failed loading cached manifest for '\(key.packageIdentity)': \(error)")
+            completion(.failure(error))
         }
 
         // shells out and compiles the manifest, finally output a JSON
-        let result = self.evaluateManifest(
+        self.evaluateManifest(
             packageIdentity: key.packageIdentity,
             manifestPath: key.manifestPath,
             manifestContents: key.manifestContents,
             toolsVersion: key.toolsVersion,
             delegateQueue: delegateQueue
-        )
+        ) { result in
+            do {
+                let evaluationResult : EvaluationResult
+                switch result {
+                case .success(let result):
+                    evaluationResult = result
+                case .failure(let error):
+                    return completion(.failure(error))
+                }
+                // only cache successfully parsed manifests
+                let parseManifest = try self.parseManifest(
+                    evaluationResult,
+                    packageIdentity: packageIdentity,
+                    packageKind: packageKind,
+                    toolsVersion: toolsVersion,
+                    identityResolver: identityResolver,
+                    fileSystem: fileSystem,
+                    observabilityScope: observabilityScope
+                )
 
-        // only cache successfully parsed manifests
-        let parseManifest = try self.parseManifest(
-            result,
-            packageIdentity: packageIdentity,
-            packageKind: packageKind,
-            toolsVersion: toolsVersion,
-            identityResolver: identityResolver,
-            fileSystem: fileSystem,
-            observabilityScope: observabilityScope
-        )
+                // FIXME: (diagnostics) pass in observability scope when we have one
+                try cache?.put(key: key.sha256Checksum, value: evaluationResult)
 
-        do {
-            // FIXME: (diagnostics) pass in observability scope when we have one
-            try cache?.put(key: key.sha256Checksum, value: result)
-        } catch {
-            observabilityScope.emit(warning: "failed storing manifest for '\(key.packageIdentity)' in cache: \(error)")
+                completion(.success(parseManifest))
+            } catch {
+                observabilityScope.emit(warning: "failed storing manifest for '\(key.packageIdentity)' in cache: \(error)")
+                completion(.failure(error))
+            }
         }
-
-        return parseManifest
     }
 
     internal struct CacheKey: Hashable {
@@ -665,10 +690,9 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         manifestPath: AbsolutePath,
         manifestContents: [UInt8],
         toolsVersion: ToolsVersion,
-        delegateQueue: DispatchQueue
-    ) -> EvaluationResult {
-
-        var result = EvaluationResult()
+        delegateQueue: DispatchQueue,
+        completion: @escaping (Result<EvaluationResult, Error>) -> Void
+    ) {
         do {
             if localFileSystem.isFile(manifestPath) {
                 try self.evaluateManifest(
@@ -676,26 +700,25 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                     packageIdentity: packageIdentity,
                     toolsVersion: toolsVersion,
                     delegateQueue:  delegateQueue,
-                    result: &result
+                    completion: completion
                 )
             } else {
-                try withTemporaryFile(suffix: ".swift") { tempFile in
+                try withTemporaryFile(suffix: ".swift") { tempFile, cleanupTempFile in
                     try localFileSystem.writeFileContents(tempFile.path, bytes: ByteString(manifestContents))
                     try self.evaluateManifest(
                         at: tempFile.path,
                         packageIdentity: packageIdentity,
                         toolsVersion: toolsVersion,
-                        delegateQueue: delegateQueue,
-                        result: &result
-                    )
+                        delegateQueue: delegateQueue
+                    ) { result in
+                        cleanupTempFile(tempFile)
+                        completion(result)
+                    }
                 }
             }
         } catch {
-            assert(result.manifestJSON == nil)
-            result.errorOutput = error.localizedDescription
+            completion(.failure(error))
         }
-
-        return result
     }
 
     /// Helper method for evaluating the manifest.
@@ -704,8 +727,10 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         packageIdentity: PackageIdentity,
         toolsVersion: ToolsVersion,
         delegateQueue: DispatchQueue,
-        result: inout EvaluationResult
+        completion: @escaping (Result<EvaluationResult, Error>) -> Void
     ) throws {
+        var evaluationResult = EvaluationResult()
+
         delegateQueue.async {
             self.delegate?.willParse(manifest: manifestPath)
         }
@@ -783,14 +808,14 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             let diagnosticFile = diaDir.appending(component: "\(packageIdentity).dia")
             try localFileSystem.createDirectory(diaDir, recursive: true)
             cmd += ["-Xfrontend", "-serialize-diagnostics-path", "-Xfrontend", diagnosticFile.pathString]
-            result.diagnosticFile = diagnosticFile
+            evaluationResult.diagnosticFile = diagnosticFile
         }
 
         cmd += [manifestPath.pathString]
 
         cmd += self.extraManifestFlags
 
-        try withTemporaryDirectory(removeTreeOnDeinit: true) { tmpDir in
+        try withTemporaryDirectory { tmpDir, cleanupTmpDir in
             // Set path to compiled manifest executable.
 #if os(Windows)
             let executableSuffix = ".exe"
@@ -801,69 +826,104 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             cmd += ["-o", compiledManifestFile.pathString]
 
             // Compile the manifest.
-            let compilerResult = try Process.popen(arguments: cmd, environment: toolchain.swiftCompilerEnvironment)
-            let compilerOutput = try (compilerResult.utf8Output() + compilerResult.utf8stderrOutput()).spm_chuzzle()
-            result.compilerOutput = compilerOutput
+            Process.popen(arguments: cmd, environment: toolchain.swiftCompilerEnvironment) { result in
+                let compilerResult : ProcessResult
+                switch result {
+                case .success(let result):
+                    compilerResult = result
+                case .failure(let error):
+                    return completion(.failure(error))
+                }
+                
+                do {
+                    evaluationResult.compilerOutput = try (compilerResult.utf8Output() + compilerResult.utf8stderrOutput()).spm_chuzzle()
+                } catch {
+                    return completion(.failure(error))
+                }
 
-            // Return now if there was an error.
-            if compilerResult.exitStatus != .terminated(code: 0) {
-                return
+                // Return now if there was an error.
+                if compilerResult.exitStatus != .terminated(code: 0) {
+                    return completion(.failure(ProcessResult.Error.nonZeroExit(compilerResult)))
+                }
+
+                // Pass an open file descriptor of a file to which the JSON representation of the manifest will be written.
+                let jsonOutputFile = tmpDir.appending(component: "\(packageIdentity)-output.json")
+                guard let jsonOutputFileDesc = fopen(jsonOutputFile.pathString, "w") else {
+                    return completion(.failure(StringError("couldn't create the manifest's JSON output file")))
+                }
+
+                cmd = [compiledManifestFile.pathString]
+    #if os(Windows)
+                // NOTE: `_get_osfhandle` returns a non-owning, unsafe,
+                // unretained HANDLE.  DO NOT invoke `CloseHandle` on `hFile`.
+                let hFile: Int = _get_osfhandle(_fileno(jsonOutputFileDesc))
+                cmd += ["-handle", "\(String(hFile, radix: 16))"]
+    #else
+                cmd += ["-fileno", "\(fileno(jsonOutputFileDesc))"]
+    #endif
+
+                do {
+                    let packageDirectory = manifestPath.parentDirectory.pathString
+                    let contextModel = ContextModel(packageDirectory: packageDirectory)
+                    cmd += ["-context", try contextModel.encode()]
+                } catch {
+                    return completion(.failure(error))
+                }
+
+                // If enabled, run command in a sandbox.
+                // This provides some safety against arbitrary code execution when parsing manifest files.
+                // We only allow the permissions which are absolutely necessary.
+                if self.isManifestSandboxEnabled {
+                    let cacheDirectories = [self.databaseCacheDir, moduleCachePath].compactMap{ $0 }
+                    let strictness: Sandbox.Strictness = toolsVersion < .v5_3 ? .manifest_pre_53 : .default
+                    cmd = Sandbox.apply(command: cmd, writableDirectories: cacheDirectories, strictness: strictness)
+                }
+
+                // Run the compiled manifest.
+                var environment = ProcessEnv.vars
+    #if os(Windows)
+                let windowsPathComponent = runtimePath.pathString.replacingOccurrences(of: "/", with: "\\")
+                environment["Path"] = "\(windowsPathComponent);\(environment["Path"] ?? "")"
+    #endif
+    
+                Process.popen(arguments: cmd, environment: environment) { result in
+                    defer { cleanupTmpDir(tmpDir) }
+                    fclose(jsonOutputFileDesc)
+                    
+                    let runResult : ProcessResult
+                    switch result {
+                    case .success(let result):
+                        runResult = result
+                    case .failure(let error):
+                        return completion(.failure(error))
+                    }
+                    
+                    do {
+                        if let runOutput = try (runResult.utf8Output() + runResult.utf8stderrOutput()).spm_chuzzle() {
+                            // Append the runtime output to any compiler output we've received.
+                            evaluationResult.compilerOutput = (evaluationResult.compilerOutput ?? "") + runOutput
+                        }
+
+                        // Return now if there was an error.
+                        if runResult.exitStatus != .terminated(code: 0) {
+                            // TODO: should this simply be an error?
+                            // return completion(.failure(ProcessResult.Error.nonZeroExit(runResult)))
+                            evaluationResult.errorOutput = evaluationResult.compilerOutput
+                            return completion(.success(evaluationResult))
+                        }
+
+                        // Read the JSON output that was emitted by libPackageDescription.
+                        guard let jsonOutput = try localFileSystem.readFileContents(jsonOutputFile).validDescription else {
+                            return completion(.failure(StringError("the manifest's JSON output has invalid encoding")))
+                        }
+                        evaluationResult.manifestJSON = jsonOutput
+                        
+                        completion(.success(evaluationResult))
+                    } catch {
+                        completion(.failure(error))
+                    }
+                }
             }
-
-            // Pass an open file descriptor of a file to which the JSON representation of the manifest will be written.
-            let jsonOutputFile = tmpDir.appending(component: "\(packageIdentity)-output.json")
-            guard let jsonOutputFileDesc = fopen(jsonOutputFile.pathString, "w") else {
-                throw StringError("couldn't create the manifest's JSON output file")
-            }
-
-            cmd = [compiledManifestFile.pathString]
-#if os(Windows)
-            // NOTE: `_get_osfhandle` returns a non-owning, unsafe,
-            // unretained HANDLE.  DO NOT invoke `CloseHandle` on `hFile`.
-            let hFile: Int = _get_osfhandle(_fileno(jsonOutputFileDesc))
-            cmd += ["-handle", "\(String(hFile, radix: 16))"]
-#else
-            cmd += ["-fileno", "\(fileno(jsonOutputFileDesc))"]
-#endif
-
-            let packageDirectory = manifestPath.parentDirectory.pathString
-            let contextModel = ContextModel(packageDirectory: packageDirectory)
-            cmd += ["-context", try contextModel.encode()]
-
-            // If enabled, run command in a sandbox.
-            // This provides some safety against arbitrary code execution when parsing manifest files.
-            // We only allow the permissions which are absolutely necessary.
-            if isManifestSandboxEnabled {
-                let cacheDirectories = [self.databaseCacheDir, moduleCachePath].compactMap{ $0 }
-                let strictness: Sandbox.Strictness = toolsVersion < .v5_3 ? .manifest_pre_53 : .default
-                cmd = Sandbox.apply(command: cmd, writableDirectories: cacheDirectories, strictness: strictness)
-            }
-
-            // Run the compiled manifest.
-            var environment = ProcessEnv.vars
-#if os(Windows)
-            let windowsPathComponent = runtimePath.pathString.replacingOccurrences(of: "/", with: "\\")
-            environment["Path"] = "\(windowsPathComponent);\(environment["Path"] ?? "")"
-#endif
-            let runResult = try Process.popen(arguments: cmd, environment: environment)
-            fclose(jsonOutputFileDesc)
-            let runOutput = try (runResult.utf8Output() + runResult.utf8stderrOutput()).spm_chuzzle()
-            if let runOutput = runOutput {
-                // Append the runtime output to any compiler output we've received.
-                result.compilerOutput = (result.compilerOutput ?? "") + runOutput
-            }
-
-            // Return now if there was an error.
-            if runResult.exitStatus != .terminated(code: 0) {
-                result.errorOutput = runOutput
-                return
-            }
-
-            // Read the JSON output that was emitted by libPackageDescription.
-            guard let jsonOutput = try localFileSystem.readFileContents(jsonOutputFile).validDescription else {
-                throw StringError("the manifest's JSON output has invalid encoding")
-            }
-            result.manifestJSON = jsonOutput
         }
     }
 

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -855,7 +855,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 
                 // Return now if there was an error.
                 if compilerResult.exitStatus != .terminated(code: 0) {
-                    return completion(.failure(ProcessResult.Error.nonZeroExit(compilerResult)))
+                    return completion(.success(evaluationResult))
                 }
 
                 // Pass an open file descriptor of a file to which the JSON representation of the manifest will be written.

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -568,13 +568,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             delegateQueue: delegateQueue
         ) { result in
             do {
-                let evaluationResult : EvaluationResult
-                switch result {
-                case .success(let result):
-                    evaluationResult = result
-                case .failure(let error):
-                    return completion(.failure(error))
-                }
+                let evaluationResult = try result.get()
                 // only cache successfully parsed manifests
                 let parseManifest = try self.parseManifest(
                     evaluationResult,
@@ -820,14 +814,8 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             // Compile the manifest.
             Process.popen(arguments: cmd, environment: toolchain.swiftCompilerEnvironment) { result in
                 let compilerResult : ProcessResult
-                switch result {
-                case .success(let result):
-                    compilerResult = result
-                case .failure(let error):
-                    return completion(.failure(error))
-                }
-                
                 do {
+                    compilerResult = try result.get()
                     evaluationResult.compilerOutput = try (compilerResult.utf8Output() + compilerResult.utf8stderrOutput()).spm_chuzzle()
                 } catch {
                     return completion(.failure(error))
@@ -882,15 +870,8 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                     defer { cleanupTmpDir(tmpDir) }
                     fclose(jsonOutputFileDesc)
                     
-                    let runResult : ProcessResult
-                    switch result {
-                    case .success(let result):
-                        runResult = result
-                    case .failure(let error):
-                        return completion(.failure(error))
-                    }
-                    
                     do {
+                        let runResult = try result.get()
                         if let runOutput = try (runResult.utf8Output() + runResult.utf8stderrOutput()).spm_chuzzle() {
                             // Append the runtime output to any compiler output we've received.
                             evaluationResult.compilerOutput = (evaluationResult.compilerOutput ?? "") + runOutput

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -841,7 +841,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             cmd += ["-o", compiledManifestFile.pathString]
 
             // Compile the manifest.
-            Process.popen(arguments: cmd, environment: toolchain.swiftCompilerEnvironment) { result in
+            Process.popen(arguments: cmd, environment: toolchain.swiftCompilerEnvironment, queue: delegateQueue) { result in
                 var cleanupIfError = DelayableAction(target: tmpDir, action: cleanupTmpDir)
                 defer { cleanupIfError.perform() }
 
@@ -899,7 +899,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
     #endif
 
                 let cleanupAfterRunning = cleanupIfError.delay()
-                Process.popen(arguments: cmd, environment: environment) { result in
+                Process.popen(arguments: cmd, environment: environment, queue: delegateQueue) { result in
                     defer { cleanupAfterRunning.perform() }
                     fclose(jsonOutputFileDesc)
                     

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -581,7 +581,6 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             }
         } catch {
             observabilityScope.emit(warning: "failed loading cached manifest for '\(key.packageIdentity)': \(error)")
-            return completion(.failure(error))
         }
 
         // delay closing cache until after write.


### PR DESCRIPTION
This change set changes the ManifestLoader class to use the new asynchronous `Process.popen()` API, introduced in https://github.com/apple/swift-tools-support-core/pull/261.

### Motivation:

Each time `Process.popen()` is used in the current SPM codebase, it blocks a thread by synchronously waiting for a sub-process to finish. This wastes resources (stack memory, thread overhead) and hurts performance.

### Modifications:

This change set primarily refactors the parsing and loading methods to use completion blocks in order to support asynchronous execution. Synchronous throwing methods returning type `T`, are replaced with methods that take completion blocks that accept `Result<T, Swift.Error>` parameters, an enum that can hold either type.

### Result:

Fewer total threads will be blocked, which should reduce the overall number of worker threads needed by SPM.
