### PR TITLE
integrate registry dependencies into dependency resolution

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -381,6 +381,7 @@ let package = Package(
                 "Basics",
                 "PackageGraph",
                 "PackageLoading",
+                "PackageRegistry",
                 "SourceControl",
                 .product(name: "TSCTestSupport", package: "swift-tools-support-core"),
                 "Workspace",

--- a/Sources/Basics/HTTPClient.swift
+++ b/Sources/Basics/HTTPClient.swift
@@ -387,7 +387,11 @@ public struct HTTPClientResponse {
 
 extension HTTPClientResponse {
     public static func okay(body: String? = nil) -> HTTPClientResponse {
-        return HTTPClientResponse(statusCode: 200, body: body?.data(using: .utf8))
+        return .okay(body: body?.data(using: .utf8))
+    }
+
+    public static func okay(body: Data?) -> HTTPClientResponse {
+        return HTTPClientResponse(statusCode: 200, body: body)
     }
 
     public static func notFound(reason: String? = nil) -> HTTPClientResponse {

--- a/Sources/Commands/SwiftPackageRegistryTool.swift
+++ b/Sources/Commands/SwiftPackageRegistryTool.swift
@@ -84,9 +84,7 @@ public struct SwiftPackageRegistryTool: ParsableCommand {
         var url: String
 
         func run(_ swiftTool: SwiftTool) throws {
-            guard let url = URL(string: self.url),
-                  url.scheme == "https"
-            else {
+            guard let url = URL(string: self.url), url.scheme == "https" else {
                 throw RegistryConfigurationError.invalidURL(self.url)
             }
 

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -248,7 +248,6 @@ private func createResolvedPackages(
                     dependencyLocation = url.absoluteString
                 }
             case .registry(let settings):
-                // TODO: this is
                 dependencyLocation = settings.identity.description
             }
 

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -247,9 +247,9 @@ private func createResolvedPackages(
                 case .remote(let url):
                     dependencyLocation = url.absoluteString
                 }
-            case .registry:
-                // FIXME
-                fatalError("registry based dependencies not implemented yet")
+            case .registry(let settings):
+                // TODO: this is
+                dependencyLocation = settings.identity.description
             }
 
             // Otherwise, look it up by its identity.

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -353,9 +353,13 @@ public struct ToolsVersionLoader: ToolsVersionLoaderProtocol {
         guard let manifestContentsDecodedWithUTF8 = manifestContents.validDescription else {
             throw Error.nonUTF8EncodedManifest(path: file)
         }
-        
+
+        return try self.load(utf8String: manifestContentsDecodedWithUTF8)
+    }
+
+    public func load(utf8String: String) throws -> ToolsVersion {
         /// The manifest represented in its constituent parts.
-        let manifestComponents = ToolsVersionLoader.split(manifestContentsDecodedWithUTF8)
+        let manifestComponents = ToolsVersionLoader.split(utf8String)
         /// The Swift tools version specification represented in its constituent parts.
         let toolsVersionSpecificationComponents = manifestComponents.toolsVersionSpecificationComponents
         

--- a/Sources/PackageModel/PackageIdentity.swift
+++ b/Sources/PackageModel/PackageIdentity.swift
@@ -65,14 +65,14 @@ public struct PackageIdentity: CustomStringConvertible {
     }
 
     // TODO: formalize package registry identifier
-    public var scopeAndName: (Scope, Name)? {
+    public var scopeAndName: (scope: Scope, name: Name)? {
         let components = description.split(separator: ".", maxSplits: 1, omittingEmptySubsequences: true)
         guard components.count == 2,
               let scope = Scope(components.first),
               let name = Name(components.last)
-        else { return nil }
+        else { return .none }
 
-        return (scope, name)
+        return (scope: scope, name: name)
     }
 }
 

--- a/Sources/PackageRegistry/CMakeLists.txt
+++ b/Sources/PackageRegistry/CMakeLists.txt
@@ -9,7 +9,7 @@
 add_library(PackageRegistry
   Registry.swift
   RegistryConfiguration.swift
-  RegistryManager.swift
+  RegistryClient.swift
   SourceArchiver.swift)
 target_link_libraries(PackageRegistry PUBLIC
   Basics

--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -592,8 +592,8 @@ extension RegistryClient {
             }
 
             public struct Problem: Codable {
-                public var status: Int
-                public var title: String
+                public var status: Int?
+                public var title: String?
                 public var detail: String
 
                 public init(status: Int, title: String, detail: String) {

--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -10,13 +10,14 @@
 
 import Basics
 import Dispatch
+import class Foundation.JSONDecoder
 import struct Foundation.URL
 import struct Foundation.URLComponents
 import struct Foundation.URLQueryItem
 import PackageLoading
 import PackageModel
 import TSCBasic
-import TSCUtility
+import protocol TSCUtility.Archiver
 
 /// Package registry client.
 /// API specification: https://github.com/apple/swift-package-manager/blob/main/Documentation/Registry.md
@@ -33,9 +34,10 @@ public enum RegistryError: Error {
     case unsupportedHashAlgorithm(String)
     case failedToDetermineExpectedChecksum(Error)
     case invalidChecksum(expected: String, actual: String)
+    case pathAlreadyExists(AbsolutePath)
 }
 
-public final class RegistryManager {
+public final class RegistryClient {
     private let apiVersion: APIVersion = .v1
 
     private let configuration: RegistryConfiguration
@@ -43,6 +45,7 @@ public final class RegistryManager {
     private let archiverProvider: (FileSystem) -> Archiver
     private let httpClient: HTTPClient
     private let authorizationProvider: HTTPClientAuthorizationProvider?
+    private let jsonDecoder: JSONDecoder
 
     public init(configuration: RegistryConfiguration,
                 identityResolver: IdentityResolver,
@@ -55,6 +58,7 @@ public final class RegistryManager {
         self.archiverProvider = customArchiverProvider ?? { fileSystem in SourceArchiver(fileSystem: fileSystem) }
         self.httpClient = customHTTPClient ?? HTTPClient()
         self.authorizationProvider = authorizationProvider
+        self.jsonDecoder = JSONDecoder.makeWithDefaults()
     }
 
     public func fetchVersions(
@@ -81,29 +85,26 @@ public final class RegistryManager {
             return completion(.failure(RegistryError.invalidURL))
         }
 
-        var request = HTTPClient.Request(
+        let request = HTTPClient.Request(
             method: .get,
             url: url,
             headers: [
                 "Accept": self.acceptHeader(mediaType: .json),
-            ]
+            ],
+            options: self.defaultRequestOptions(timeout: timeout, callbackQueue: callbackQueue)
         )
-        request.options.timeout = timeout
-        request.options.callbackQueue = callbackQueue
-        request.options.authorizationProvider = authorizationProvider
 
         self.httpClient.execute(request, observabilityScope: observabilityScope, progress: nil) { result in
             completion(result.tryMap { response in
                 try self.checkResponseStatusAndHeaders(response, expectedStatusCode: 200, expectedContentType: .json)
 
-                guard let data = response.body,
-                      case .dictionary(let payload) = try? JSON(data: data),
-                      case .dictionary(let releases) = payload["releases"]
-                else {
+                guard let data = response.body else {
                     throw RegistryError.invalidResponse
                 }
 
-                let versions = releases.filter { (try? $0.value.getJSON("problem")) == nil }
+                let packageMetadata = try self.jsonDecoder.decode(Serialization.PackageMetadata.self, from: data)
+
+                let versions = packageMetadata.releases.filter { $0.value.problem == nil }
                     .compactMap { Version($0.key) }
                     .sorted(by: >)
                 return versions
@@ -111,15 +112,134 @@ public final class RegistryManager {
         }
     }
 
-    public func fetchManifest(
+    public func getAvailableManifests(
         package: PackageIdentity,
         version: Version,
-        manifestLoader: ManifestLoaderProtocol,
-        toolsVersion: ToolsVersion?,
         timeout: DispatchTimeInterval? = .none,
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue,
-        completion: @escaping (Result<Manifest, Error>) -> Void
+        completion: @escaping (Result<[String: ToolsVersion], Error>) -> Void
+    ) {
+        let completion = self.makeAsync(completion, on: callbackQueue)
+
+        guard case (let scope, let name)? = package.scopeAndName else {
+            return completion(.failure(RegistryError.invalidPackage(package)))
+        }
+
+        guard let registry = configuration.registry(for: scope) else {
+            return completion(.failure(RegistryError.registryNotConfigured(scope: scope)))
+        }
+
+        var components = URLComponents(url: registry.url, resolvingAgainstBaseURL: true)
+        components?.appendPathComponents("\(scope)", "\(name)", "\(version)", Manifest.filename)
+
+        guard let url = components?.url else {
+            return completion(.failure(RegistryError.invalidURL))
+        }
+
+        let request = HTTPClient.Request(
+            method: .get,
+            url: url,
+            headers: [
+                "Accept": self.acceptHeader(mediaType: .swift),
+            ],
+            options: self.defaultRequestOptions(timeout: timeout, callbackQueue: callbackQueue)
+        )
+
+        self.httpClient.execute(request, observabilityScope: observabilityScope, progress: nil) { result in
+            completion(result.tryMap { response in
+                try self.checkResponseStatusAndHeaders(response, expectedStatusCode: 200, expectedContentType: .swift)
+
+                guard let data = response.body else {
+                    throw RegistryError.invalidResponse
+                }
+                guard let manifestContent = String(data: data, encoding: .utf8) else {
+                    throw RegistryError.invalidResponse
+                }
+
+                var result = [String: ToolsVersion]()
+                let toolsVersion = try ToolsVersionLoader().load(utf8String: manifestContent)
+                result[Manifest.filename] = toolsVersion
+
+                let alternativeManifests = try response.headers.get("Link").map { try parseLinkHeader($0) }.flatMap{ $0 }
+                for alternativeManifest in alternativeManifests {
+                    result[alternativeManifest.filename] = alternativeManifest.toolsVersion
+                }
+                return result
+            })
+        }
+
+        func parseLinkHeader(_ value: String) throws -> [ManifestLink] {
+            let linkLines = value.split(separator: ",").map(String.init).map{ $0.spm_chuzzle() ?? $0 }
+            return try linkLines.compactMap { linkLine in
+                try parseLinkLine(linkLine)
+            }
+        }
+
+        // <http://packages.example.com/mona/LinkedList/1.1.1/Package.swift?swift-version=4>; rel="alternate"; filename="Package@swift-4.swift"; swift-tools-version="4.0",
+        func parseLinkLine(_ value: String) throws -> ManifestLink? {
+            let fields = value.split(separator: ";")
+                .map(String.init)
+                .map{ $0.spm_chuzzle() ?? $0 }
+
+            guard fields.count == 4 else {
+                return nil
+            }
+
+            guard let link = fields.first(where: { $0.hasPrefix("<") }).map({ String($0.dropFirst().dropLast()) }) else {
+                return nil
+            }
+
+            guard let rel = fields.first(where: { $0.hasPrefix("rel=") }).flatMap({ parseLinkFieldValue($0) }), rel == "alternate" else {
+                return nil
+            }
+
+            guard let filename = fields.first(where: { $0.hasPrefix("filename=") }).flatMap({ parseLinkFieldValue($0) }) else {
+                return nil
+            }
+
+            guard let toolsVersion = fields.first(where: { $0.hasPrefix("swift-tools-version=") }).flatMap({ parseLinkFieldValue($0) }) else {
+                return nil
+            }
+
+            guard let toolsVersion = ToolsVersion(string: toolsVersion) else {
+                throw StringError("Invalid tools version in alternate manifest link '\(value)'")
+            }
+
+            return ManifestLink(
+                value: link,
+                filename: filename,
+                toolsVersion: toolsVersion
+            )
+        }
+
+        func parseLinkFieldValue(_ field: String) -> String? {
+            let parts = field.split(separator: "=")
+                .map(String.init)
+                .map{ $0.spm_chuzzle() ?? $0 }
+
+            guard parts.count == 2 else {
+                return nil
+            }
+
+            return parts[1].replacingOccurrences(of: "\"", with: "")
+        }
+
+        struct ManifestLink {
+            let value: String
+            let filename: String
+            let toolsVersion: ToolsVersion
+        }
+    }
+
+    public func getManifestContent(
+        package: PackageIdentity,
+        version: Version,
+        customToolsVersion: ToolsVersion?,
+        timeout: DispatchTimeInterval? = .none,
+        observabilityScope: ObservabilityScope,
+        callbackQueue: DispatchQueue,
+        completion: @escaping (Result<String, Error>) -> Void
     ) {
         let completion = self.makeAsync(completion, on: callbackQueue)
 
@@ -134,7 +254,7 @@ public final class RegistryManager {
         var components = URLComponents(url: registry.url, resolvingAgainstBaseURL: true)
         components?.appendPathComponents("\(scope)", "\(name)", "\(version)", "Package.swift")
 
-        if let toolsVersion = toolsVersion {
+        if let toolsVersion = customToolsVersion {
             components?.queryItems = [
                 URLQueryItem(name: "swift-version", value: toolsVersion.description),
             ]
@@ -144,59 +264,28 @@ public final class RegistryManager {
             return completion(.failure(RegistryError.invalidURL))
         }
 
-        var request = HTTPClient.Request(
+        let request = HTTPClient.Request(
             method: .get,
             url: url,
             headers: [
                 "Accept": self.acceptHeader(mediaType: .swift),
-            ]
+            ],
+            options: self.defaultRequestOptions(timeout: timeout, callbackQueue: callbackQueue)
         )
-        request.options.timeout = timeout
-        request.options.callbackQueue = callbackQueue
-        request.options.authorizationProvider = authorizationProvider
 
         self.httpClient.execute(request, observabilityScope: observabilityScope, progress: nil) { result in
-            do {
-                switch result {
-                case .success(let response):
-                    try self.checkResponseStatusAndHeaders(response, expectedStatusCode: 200, expectedContentType: .swift)
+            completion(result.tryMap { response -> String in
+                try self.checkResponseStatusAndHeaders(response, expectedStatusCode: 200, expectedContentType: .swift)
 
-                    guard let data = response.body else {
-                        throw RegistryError.invalidResponse
-                    }
-
-                    let fileSystem = InMemoryFileSystem()
-
-                    let filename: String
-                    if let toolsVersion = toolsVersion {
-                        filename = Manifest.basename + "@swift-\(toolsVersion).swift"
-                    } else {
-                        filename = Manifest.basename + ".swift"
-                    }
-
-                    try fileSystem.writeFileContents(.root.appending(component: filename), bytes: ByteString(data))
-
-                    // FIXME: this doesn't work for version-specific manifest
-                    manifestLoader.load(
-                        at: .root,
-                        packageIdentity: package,
-                        packageKind: .registry(package),
-                        packageLocation: package.description, // FIXME: was originally PackageReference.locationString
-                        version: version,
-                        revision: nil,
-                        toolsVersion: toolsVersion ?? .currentToolsVersion,
-                        identityResolver: self.identityResolver,
-                        fileSystem: fileSystem,
-                        observabilityScope: observabilityScope,
-                        on: callbackQueue,
-                        completion: completion
-                    )
-                case .failure(let error):
-                    throw error
+                guard let data = response.body else {
+                    throw RegistryError.invalidResponse
                 }
-            } catch {
-                completion(.failure(error))
-            }
+                guard let manifestContent = String(data: data, encoding: .utf8) else {
+                    throw RegistryError.invalidResponse
+                }
+
+                return manifestContent
+            })
         }
     }
 
@@ -225,33 +314,29 @@ public final class RegistryManager {
             return completion(.failure(RegistryError.invalidURL))
         }
 
-        var request = HTTPClient.Request(
+        let request = HTTPClient.Request(
             method: .get,
             url: url,
             headers: [
                 "Accept": self.acceptHeader(mediaType: .json),
-            ]
+            ],
+            options: self.defaultRequestOptions(timeout: timeout, callbackQueue: callbackQueue)
         )
-        request.options.timeout = timeout
-        request.options.callbackQueue = callbackQueue
-        request.options.authorizationProvider = authorizationProvider
 
         self.httpClient.execute(request, observabilityScope: observabilityScope, progress: nil) { result in
             completion(result.tryMap { response in
                 try self.checkResponseStatusAndHeaders(response, expectedStatusCode: 200, expectedContentType: .json)
 
-                guard let data = response.body,
-                      case .dictionary(let payload) = try? JSON(data: data),
-                      case .array(let resources) = payload["resources"]
-                else {
+                guard let data = response.body else {
                     throw RegistryError.invalidResponse
                 }
 
-                guard let sourceArchive = resources.first(where: { (try? $0.get(String.self, forKey: "name")) == "source-archive" }) else {
+                let versionMetadata = try self.jsonDecoder.decode(Serialization.VersionMetadata.self, from: data)
+                guard let sourceArchive = versionMetadata.resources.first(where: { $0.name == "source-archive" }) else {
                     throw RegistryError.missingSourceArchive
                 }
 
-                guard let checksum = try? sourceArchive.get(String.self, forKey: "checksum") else {
+                guard let checksum = sourceArchive.checksum else {
                     throw RegistryError.invalidSourceArchive
                 }
 
@@ -267,6 +352,7 @@ public final class RegistryManager {
         destinationPath: AbsolutePath,
         expectedChecksum: String?, // previously recorded checksum, if any
         checksumAlgorithm: HashAlgorithm, // the same algorithm used by `package compute-checksum` tool
+        progressHandler: ((_ bytesReceived: Int64, _ totalBytes: Int64?) -> Void)?,
         timeout: DispatchTimeInterval? = .none,
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue,
@@ -282,6 +368,73 @@ public final class RegistryManager {
             return completion(.failure(RegistryError.registryNotConfigured(scope: scope)))
         }
 
+        var components = URLComponents(url: registry.url, resolvingAgainstBaseURL: true)
+        components?.appendPathComponents("\(scope)", "\(name)", "\(version).zip")
+
+        guard let url = components?.url else {
+            return completion(.failure(RegistryError.invalidURL))
+        }
+
+        // prepare target download locations
+        let downloadPath = destinationPath.withExtension("zip")
+        do {
+            // validate that the destination does not already exist
+            guard !fileSystem.exists(destinationPath) else {
+                throw RegistryError.pathAlreadyExists(destinationPath)
+            }
+            // clear out download path if exists
+            try fileSystem.removeFileTree(downloadPath)
+        } catch {
+            return completion(.failure(error))
+        }
+
+        let request = HTTPClient.Request.download(
+            url: url,
+            headers: [
+                "Accept": self.acceptHeader(mediaType: .zip),
+            ],
+            options: self.defaultRequestOptions(timeout: timeout, callbackQueue: callbackQueue),
+            fileSystem: fileSystem,
+            destination: downloadPath
+        )
+
+        self.httpClient.execute(request, observabilityScope: observabilityScope, progress: progressHandler) { result in
+            switch result {
+            case .success(let response):
+                do {
+                    try self.checkResponseStatusAndHeaders(response, expectedStatusCode: 200, expectedContentType: .zip)
+                } catch {
+                    return completion(.failure(error))
+                }
+
+                withExpectedChecksum { result in
+                    switch result {
+                    case .success(let expectedChecksum):
+                        do {
+                            let contents = try fileSystem.readFileContents(downloadPath)
+                            let actualChecksum = checksumAlgorithm.hash(contents).hexadecimalRepresentation
+                            guard expectedChecksum == actualChecksum else {
+                                return completion(.failure(RegistryError.invalidChecksum(expected: expectedChecksum, actual: actualChecksum)))
+                            }
+
+                            let archiver = self.archiverProvider(fileSystem)
+                            // TODO: Bail if archive contains relative paths or overlapping files
+                            archiver.extract(from: downloadPath, to: destinationPath) { result in
+                                defer { try? fileSystem.removeFileTree(downloadPath) }
+                                completion(result)
+                            }
+                        } catch {
+                            completion(.failure(error))
+                        }
+                    case .failure(let error):
+                        completion(.failure(RegistryError.failedToDetermineExpectedChecksum(error)))
+                    }
+                }
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+
         // We either use a previously recorded checksum, or fetch it from the registry
         func withExpectedChecksum(body: @escaping (Result<String, Error>) -> Void) {
             if let expectedChecksum = expectedChecksum {
@@ -294,71 +447,6 @@ public final class RegistryManager {
                 callbackQueue: callbackQueue,
                 completion: body
             )
-        }
-
-        var components = URLComponents(url: registry.url, resolvingAgainstBaseURL: true)
-        components?.appendPathComponents("\(scope)", "\(name)", "\(version).zip")
-
-        guard let url = components?.url else {
-            return completion(.failure(RegistryError.invalidURL))
-        }
-
-        var request = HTTPClient.Request(
-            method: .get,
-            url: url,
-            headers: [
-                "Accept": self.acceptHeader(mediaType: .zip),
-            ]
-        )
-        request.options.timeout = timeout
-        request.options.callbackQueue = callbackQueue
-        request.options.authorizationProvider = authorizationProvider
-
-        self.httpClient.execute(request, observabilityScope: observabilityScope, progress: nil) { result in
-            switch result {
-            case .success(let response):
-                do {
-                    try self.checkResponseStatusAndHeaders(response, expectedStatusCode: 200, expectedContentType: .zip)
-                } catch {
-                    return completion(.failure(error))
-                }
-
-                guard let data = response.body else {
-                    return completion(.failure(RegistryError.invalidResponse))
-                }
-                let contents = ByteString(data)
-
-                withExpectedChecksum { result in
-                    switch result {
-                    case .success(let expectedChecksum):
-                        let actualChecksum = checksumAlgorithm.hash(contents).hexadecimalRepresentation
-                        guard expectedChecksum == actualChecksum else {
-                            return completion(.failure(RegistryError.invalidChecksum(expected: expectedChecksum, actual: actualChecksum)))
-                        }
-
-                        do {
-                            try fileSystem.createDirectory(destinationPath, recursive: true)
-
-                            let archivePath = destinationPath.withExtension("zip")
-                            try fileSystem.writeFileContents(archivePath, bytes: contents)
-
-                            let archiver = self.archiverProvider(fileSystem)
-                            // TODO: Bail if archive contains relative paths or overlapping files
-                            archiver.extract(from: archivePath, to: destinationPath) { result in
-                                completion(result)
-                                try? fileSystem.removeFileTree(archivePath)
-                            }
-                        } catch {
-                            try? fileSystem.removeFileTree(destinationPath)
-                            completion(.failure(error))
-                        }
-                    case .failure(let error):
-                        completion(.failure(RegistryError.failedToDetermineExpectedChecksum(error)))
-                    }
-                }
-            case .failure(let error):
-                completion(.failure(error))
-            }
         }
     }
 
@@ -386,16 +474,14 @@ public final class RegistryManager {
             return completion(.failure(RegistryError.invalidURL))
         }
 
-        var request = HTTPClient.Request(
+        let request = HTTPClient.Request(
             method: .get,
             url: url,
             headers: [
                 "Accept": self.acceptHeader(mediaType: .json),
-            ]
+            ],
+            options: self.defaultRequestOptions(timeout: timeout, callbackQueue: callbackQueue)
         )
-        request.options.timeout = timeout
-        request.options.callbackQueue = callbackQueue
-        request.options.authorizationProvider = authorizationProvider
 
         self.httpClient.execute(request, observabilityScope: observabilityScope, progress: nil) { result in
             completion(result.tryMap { response in
@@ -423,15 +509,26 @@ public final class RegistryManager {
     private func makeAsync<T>(_ closure: @escaping (Result<T, Error>) -> Void, on queue: DispatchQueue) -> (Result<T, Error>) -> Void {
         { result in queue.async { closure(result) } }
     }
+
+    private func defaultRequestOptions(
+        timeout: DispatchTimeInterval? = .none,
+        callbackQueue: DispatchQueue
+    ) -> HTTPClient.Request.Options {
+        var options = HTTPClient.Request.Options()
+        options.timeout = timeout
+        options.callbackQueue = callbackQueue
+        options.authorizationProvider = self.authorizationProvider
+        return options
+    }
 }
 
-private extension RegistryManager {
+private extension RegistryClient {
     enum APIVersion: String {
         case v1 = "1"
     }
 }
 
-private extension RegistryManager {
+private extension RegistryClient {
     enum MediaType: String {
         case json
         case swift
@@ -461,6 +558,82 @@ private extension RegistryManager {
         let contentType = response.headers.get("Content-Type").first
         guard contentType?.hasPrefix(expectedContentType.rawValue) == true else {
             throw RegistryError.invalidContentType(expected: expectedContentType.rawValue, actual: contentType)
+        }
+    }
+}
+
+// MARK: - Serialization
+
+extension RegistryClient {
+    public enum Serialization {
+
+        public struct PackageMetadata: Codable {
+            public var releases: [String: Release]
+
+            public init(releases: [String: Release]) {
+                self.releases = releases
+            }
+
+            public struct Release: Codable {
+                public var url: String
+                public var problem: Problem?
+
+                public init(url: String, problem: Problem? = .none) {
+                    self.url = url
+                    self.problem = problem
+                }
+            }
+
+            public struct Problem: Codable {
+                public var status: Int
+                public var title: String
+                public var detail: String
+
+                public init(status: Int, title: String, detail: String) {
+                    self.status = status
+                    self.title = title
+                    self.detail = detail
+                }
+            }
+        }
+
+        public struct VersionMetadata: Codable {
+            public var id: String
+            public var version: String
+            public var resources: [Resource]
+            public var metadata: AdditionalMetadata
+
+            public init(
+                id: String,
+                version: String,
+                resources: [Resource],
+                metadata: AdditionalMetadata
+            ) {
+                self.id = id
+                self.version = version
+                self.resources = resources
+                self.metadata = metadata
+            }
+
+            public struct Resource: Codable {
+                public let name: String
+                public let type: String
+                public let checksum: String?
+
+                public init(name: String, type: String, checksum: String) {
+                    self.name = name
+                    self.type = type
+                    self.checksum = checksum
+                }
+            }
+
+            public struct AdditionalMetadata: Codable {
+                public let description: String
+
+                public init(description: String) {
+                    self.description = description
+                }
+            }
         }
     }
 }

--- a/Sources/SPMTestSupport/MockDependency.swift
+++ b/Sources/SPMTestSupport/MockDependency.swift
@@ -13,9 +13,10 @@ import PackageLoading
 import PackageModel
 import TSCBasic
 
-public struct MockDependency {
-    public typealias Requirement = PackageDependency.SourceControl.Requirement
+public typealias SourceControlRequirement = PackageDependency.SourceControl.Requirement
+public typealias RegistryRequirement = PackageDependency.Registry.Requirement
 
+public struct MockDependency {
     public let deprecatedName: String?
     public let location: Location
     public let products: ProductFilter
@@ -63,6 +64,12 @@ public struct MockDependency {
                 requirement: requirement,
                 productFilter: self.products
             )
+        case .registry(let identity, let requirement):
+            return .registry(
+                identity: identity,
+                requirement: requirement,
+                productFilter: self.products
+            )
         }
     }
 
@@ -70,29 +77,38 @@ public struct MockDependency {
         MockDependency(location: .fileSystem(path: RelativePath(path)), products: products)
     }
 
-    public static func sourceControl(path: String, requirement: Requirement, products: ProductFilter = .everything) -> MockDependency {
+    public static func sourceControl(path: String, requirement: SourceControlRequirement, products: ProductFilter = .everything) -> MockDependency {
         .sourceControl(path: RelativePath(path), requirement: requirement, products: products)
     }
 
-    public static func sourceControl(path: RelativePath, requirement: Requirement, products: ProductFilter = .everything) -> MockDependency {
+    public static func sourceControl(path: RelativePath, requirement: SourceControlRequirement, products: ProductFilter = .everything) -> MockDependency {
         MockDependency(location: .localSourceControl(path: path, requirement: requirement), products: products)
     }
 
-    public static func sourceControlWithDeprecatedName(name: String, path: String, requirement: Requirement, products: ProductFilter = .everything) -> MockDependency {
+    public static func sourceControlWithDeprecatedName(name: String, path: String, requirement: SourceControlRequirement, products: ProductFilter = .everything) -> MockDependency {
         MockDependency(deprecatedName: name, location: .localSourceControl(path: RelativePath(path), requirement: requirement), products: products)
     }
 
-    public static func sourceControl(url: String, requirement: Requirement, products: ProductFilter = .everything) -> MockDependency {
+    public static func sourceControl(url: String, requirement: SourceControlRequirement, products: ProductFilter = .everything) -> MockDependency {
         .sourceControl(url: URL(string: url)!, requirement: requirement, products: products)
     }
 
-    public static func sourceControl(url: URL, requirement: Requirement, products: ProductFilter = .everything) -> MockDependency {
+    public static func sourceControl(url: URL, requirement: SourceControlRequirement, products: ProductFilter = .everything) -> MockDependency {
         MockDependency(location: .remoteSourceControl(url: url, requirement: requirement), products: products)
+    }
+
+    public static func registry(identity: String, requirement: RegistryRequirement, products: ProductFilter = .everything) -> MockDependency {
+        .registry(identity: .plain(identity), requirement: requirement)
+    }
+
+    public static func registry(identity: PackageIdentity, requirement: RegistryRequirement, products: ProductFilter = .everything) -> MockDependency {
+        MockDependency(location: .registry(identity: identity, requirement: requirement), products: products)
     }
 
     public enum Location {
         case fileSystem(path: RelativePath)
-        case localSourceControl(path: RelativePath, requirement: Requirement)
-        case remoteSourceControl(url: URL, requirement: Requirement)
+        case localSourceControl(path: RelativePath, requirement: SourceControlRequirement)
+        case remoteSourceControl(url: URL, requirement: SourceControlRequirement)
+        case registry(identity: PackageIdentity, requirement: RegistryRequirement)
     }
 }

--- a/Sources/SPMTestSupport/MockPackage.swift
+++ b/Sources/SPMTestSupport/MockPackage.swift
@@ -63,6 +63,26 @@ public struct MockPackage {
         self.toolsVersion = toolsVersion
     }
 
+    public init(
+        name: String,
+        platforms: [PlatformDescription] = [],
+        identity: String,
+        targets: [MockTarget],
+        products: [MockProduct],
+        dependencies: [MockDependency] = [],
+        versions: [String?] = [],
+        toolsVersion: ToolsVersion? = nil
+    ) {
+        self.name = name
+        self.platforms = platforms
+        self.location = .registry(identity: .plain(identity))
+        self.targets = targets
+        self.products = products
+        self.dependencies = dependencies
+        self.versions = versions
+        self.toolsVersion = toolsVersion
+    }
+
     public static func genericPackage1(named name: String) throws -> MockPackage {
         return MockPackage(
             name: name,
@@ -79,5 +99,6 @@ public struct MockPackage {
     public enum Location {
         case fileSystem(path: RelativePath)
         case sourceControl(url: Foundation.URL)
+        case registry(identity: PackageIdentity)
     }
 }

--- a/Sources/SPMTestSupport/MockRegistry.swift
+++ b/Sources/SPMTestSupport/MockRegistry.swift
@@ -1,0 +1,293 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import Basics
+import Foundation
+import PackageGraph
+import PackageLoading
+import PackageModel
+import PackageRegistry
+import TSCBasic
+import protocol TSCUtility.Archiver
+
+class MockRegistry {
+    private static let mockRegistryURL = URL(string: "http://localhost/registry/mock")!
+
+    private let checksumAlgorithm: HashAlgorithm
+    private let fileSystem: FileSystem
+    var registryClient: RegistryClient!
+    private let jsonEncoder: JSONEncoder
+
+    private var packages = [PackageIdentity: [String: InMemoryRegistrySource]]()
+    private let packagesLock = Lock()
+
+    init(
+        identityResolver: IdentityResolver,
+        checksumAlgorithm: HashAlgorithm,
+        filesystem: FileSystem
+    ) {
+        self.checksumAlgorithm = checksumAlgorithm
+        self.fileSystem = filesystem
+        self.jsonEncoder = JSONEncoder.makeWithDefaults()
+
+        var configuration = RegistryConfiguration()
+        configuration.defaultRegistry = .init(url: Self.mockRegistryURL)
+
+        self.registryClient = RegistryClient(
+            configuration: configuration,
+            identityResolver: identityResolver,
+            customArchiverProvider: { fileSystem in MockRegistryArchiver(fileSystem: fileSystem) },
+            customHTTPClient: HTTPClient(handler: self.httpHandler),
+            authorizationProvider: .none
+        )
+    }
+
+    func addPackage(identity: PackageIdentity, versions: [String], source: InMemoryRegistrySource) {
+        self.packagesLock.withLock {
+            var value = self.packages[identity] ?? [:]
+            for version in versions {
+                value[version] = source
+            }
+            self.packages[identity] = value
+        }
+    }
+
+    func httpHandler(request: HTTPClient.Request, progress: HTTPClient.ProgressHandler?, completion: @escaping (Result<HTTPClient.Response, Error>) -> Void) {
+        do {
+            guard request.url.absoluteString.hasPrefix(Self.mockRegistryURL.absoluteString) else {
+                throw StringError("url outside mock registry \(Self.mockRegistryURL)")
+            }
+
+            switch request.kind {
+            case .generic:
+                let response = try self.handleRequest(request: request)
+                completion(.success(response))
+            case .download(let fileSystem, let destination):
+                let response = try self.handleDownloadRequest(
+                    request: request,
+                    progress: progress,
+                    fileSystem: fileSystem,
+                    destination: destination
+                )
+                completion(.success(response))
+            }
+        } catch {
+            completion(.failure(error))
+        }
+    }
+
+    private func handleRequest(request: HTTPClient.Request) throws -> HTTPClient.Response {
+        let routeComponents = request.url.absoluteString.dropFirst(Self.mockRegistryURL.absoluteString.count + 1).split(separator: "/")
+        switch routeComponents.count {
+        case 2:
+            let package = PackageIdentity.plain(routeComponents.joined(separator: "."))
+            return try self.listReleases(packageIdentity: package)
+        case 3:
+            let package = PackageIdentity.plain(routeComponents[0...1].joined(separator: "."))
+            let version = String(routeComponents[2])
+            return try self.getMetadata(packageIdentity: package, version: version)
+        case 4 where routeComponents[3] == "Package.swift":
+            let package = PackageIdentity.plain(routeComponents[0...1].joined(separator: "."))
+            let version = String(routeComponents[2])
+            guard let components = URLComponents(url: request.url, resolvingAgainstBaseURL: false) else {
+                throw StringError("invalid url: \(request.url)")
+            }
+            let toolsVersion = components.queryItems?.first(where: {$0.name == "swift-version"})?.value.flatMap(ToolsVersion.init(string:))
+            return try self.getManifest(packageIdentity: package, version: version, toolsVersion: toolsVersion)
+        default:
+            throw StringError("unknown request \(request.url)")
+        }
+    }
+
+    private func listReleases(packageIdentity: PackageIdentity) throws -> HTTPClientResponse {
+        guard let (scope, name) = packageIdentity.scopeAndName else {
+            throw StringError("invalid package identity \(packageIdentity)")
+        }
+
+        let package = self.packages[packageIdentity] ?? [:]
+        let metadata = RegistryClient.Serialization.PackageMetadata(
+            releases: package.keys.reduce(into: [String: RegistryClient.Serialization.PackageMetadata.Release]()) { partial, item in
+                partial[item] = .init(url: "\(Self.mockRegistryURL.absoluteString)/\(scope)/\(name)/\(item)")
+            }
+        )
+
+        var headers = HTTPClientHeaders()
+        headers.add(name: "Content-Version", value: "1")
+        headers.add(name: "Content-Type", value: "application/json")
+
+        return try HTTPClientResponse(
+            statusCode: 200,
+            headers: headers,
+            body: self.jsonEncoder.encode(metadata)
+        )
+    }
+
+    private func getMetadata(packageIdentity: PackageIdentity, version: String) throws -> HTTPClientResponse {
+        guard let package = self.packages[packageIdentity]?[version] else {
+            return .notFound()
+        }
+
+        let zipfileContent = try self.zipFileContent(packageIdentity: packageIdentity, version: version, source: package)
+        let zipfileChecksum = self.checksumAlgorithm.hash(zipfileContent)
+
+        let metadata = RegistryClient.Serialization.VersionMetadata(
+            id: packageIdentity.description,
+            version: version,
+            resources: [
+                .init(
+                    name: "source-archive",
+                    type: "application/zip",
+                    checksum: zipfileChecksum.hexadecimalRepresentation
+                )
+            ],
+            metadata: .init(description: "\(packageIdentity) description")
+        )
+
+        var headers = HTTPClientHeaders()
+        headers.add(name: "Content-Version", value: "1")
+        headers.add(name: "Content-Type", value: "application/json")
+
+        return try HTTPClientResponse(
+            statusCode: 200,
+            headers: headers,
+            body: self.jsonEncoder.encode(metadata)
+        )
+    }
+
+    private func getManifest(packageIdentity: PackageIdentity, version: String, toolsVersion: ToolsVersion? = .none) throws -> HTTPClientResponse {
+        guard let package = self.packages[packageIdentity]?[version] else {
+            return .notFound()
+        }
+
+        let filename: String
+        if let toolsVersion = toolsVersion {
+            filename = Manifest.basename + "@swift-\(toolsVersion).swift"
+        } else {
+            filename = Manifest.basename + ".swift"
+        }
+
+        let content = try package.fileSystem.readFileContents(package.path.appending(component: filename))
+
+        var headers = HTTPClientHeaders()
+        headers.add(name: "Content-Version", value: "1")
+        headers.add(name: "Content-Type", value: "text/x-swift")
+
+        return HTTPClientResponse(
+            statusCode: 200,
+            headers: headers,
+            body: Data(content.contents)
+        )
+    }
+
+    private func handleDownloadRequest(
+        request: HTTPClient.Request,
+        progress: HTTPClient.ProgressHandler?,
+        fileSystem: FileSystem,
+        destination: AbsolutePath
+    ) throws -> HTTPClientResponse {
+        let routeComponents = request.url.absoluteString.dropFirst(Self.mockRegistryURL.absoluteString.count + 1).split(separator: "/")
+        guard routeComponents.count == 3, routeComponents[2].hasSuffix(".zip") else {
+            throw StringError("invalid request \(request.url), expecting zip suffix")
+        }
+
+        let packageIdentity = PackageIdentity.plain(routeComponents[0...1].joined(separator: "."))
+        let version = String(routeComponents[2].dropLast(4))
+
+        guard let package = self.packages[packageIdentity]?[version] else {
+            return .notFound()
+        }
+
+        if !fileSystem.exists(destination.parentDirectory) {
+            try fileSystem.createDirectory(destination.parentDirectory, recursive: true)
+        }
+
+        let zipfileContent = try self.zipFileContent(packageIdentity: packageIdentity, version: version, source: package)
+        try fileSystem.writeFileContents(destination, string: zipfileContent)
+
+        var headers = HTTPClientHeaders()
+        headers.add(name: "Content-Version", value: "1")
+        headers.add(name: "Content-Type", value: "application/zip")
+
+        return HTTPClientResponse(
+            statusCode: 200,
+            headers: headers
+        )
+    }
+
+    private func zipFileContent(packageIdentity: PackageIdentity, version: String, source: InMemoryRegistrySource) throws -> String {
+        var content = "\(packageIdentity)_\(version)\n"
+        content += source.path.pathString + "\n"
+        for file in try source.listFiles() {
+            content += file.pathString + "\n"
+        }
+        return content
+    }
+}
+
+struct InMemoryRegistrySource {
+    let path: AbsolutePath
+    let fileSystem: FileSystem
+
+    init(path: AbsolutePath, fileSystem: FileSystem) {
+        self.path = path
+        self.fileSystem = fileSystem
+    }
+
+    func listFiles(root: AbsolutePath? = .none) throws -> [AbsolutePath] {
+        var files = [AbsolutePath]()
+        let root = root ?? self.path
+        let entries = try self.fileSystem.getDirectoryContents(root)
+        for entry in entries.map({ root.appending(component: $0) }) {
+            if self.fileSystem.isDirectory(entry) {
+                let directoryFiles = try self.listFiles(root: entry)
+                files.append(contentsOf: directoryFiles)
+            } else if self.fileSystem.isFile(entry) {
+                files.append(entry)
+            } else {
+                throw StringError("invalid entry type")
+            }
+        }
+        return files
+    }
+}
+
+private struct MockRegistryArchiver: Archiver {
+    let supportedExtensions = Set<String>(["zip"])
+    let fileSystem: FileSystem
+
+    init(fileSystem: FileSystem) {
+        self.fileSystem = fileSystem
+    }
+
+    func extract(from archivePath: AbsolutePath, to destinationPath: AbsolutePath, completion: @escaping (Result<Void, Error>) -> Void) {
+        do {
+            guard let content = try String(bytes: self.fileSystem.readFileContents(archivePath).contents, encoding: .utf8) else {
+                throw StringError("invalid mock zip format")
+            }
+            let lines = content.split(separator: "\n").map(String.init)
+            guard lines.count >= 2 else {
+                throw StringError("invalid mock zip format, not enough lines")
+            }
+
+            let rootPath = lines[1]
+            for path in lines[2..<lines.count] {
+                let relativePath = String(path.dropFirst(rootPath.count + 1))
+                let targetPath = destinationPath.appending(RelativePath(relativePath))
+                if !self.fileSystem.exists(targetPath.parentDirectory) {
+                    try self.fileSystem.createDirectory(targetPath.parentDirectory, recursive: true)
+                }
+                try self.fileSystem.copy(from: AbsolutePath(path), to: targetPath)
+            }
+            completion(.success(()))
+        } catch {
+            completion(.failure(error))
+        }
+    }
+}

--- a/Sources/SPMTestSupport/MockRegistry.swift
+++ b/Sources/SPMTestSupport/MockRegistry.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information

--- a/Sources/SPMTestSupport/PackageDependencyDescriptionExtensions.swift
+++ b/Sources/SPMTestSupport/PackageDependencyDescriptionExtensions.swift
@@ -64,7 +64,17 @@ public extension PackageDependency {
 }
 
 // backwards compatibility with existing tests
+
 extension PackageDependency.SourceControl.Requirement {
+    public static func upToNextMajor(from version: Version) -> Self {
+        return .range(.upToNextMajor(from: version))
+    }
+    public static func upToNextMinor(from version: Version) -> Self {
+        return .range(.upToNextMinor(from: version))
+    }
+}
+
+extension PackageDependency.Registry.Requirement {
     public static func upToNextMajor(from version: Version) -> Self {
         return .range(.upToNextMajor(from: version))
     }

--- a/Sources/Workspace/CMakeLists.txt
+++ b/Sources/Workspace/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(Workspace
   InitPackage.swift
   ManagedArtifact.swift
   ManagedDependency.swift
+  RegistryPackageContainer.swift
   ResolvedFileWatcher.swift
   ResolverPrecomputationProvider.swift
   SourceControlPackageContainer.swift

--- a/Sources/Workspace/RegistryPackageContainer.swift
+++ b/Sources/Workspace/RegistryPackageContainer.swift
@@ -1,0 +1,210 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Basics
+import Dispatch
+import PackageGraph
+import PackageLoading
+import PackageModel
+import PackageRegistry
+import TSCBasic
+
+public class RegistryPackageContainer: PackageContainer {
+    public let package: PackageReference
+
+    private let registryClient: RegistryClient
+    private let identityResolver: IdentityResolver
+    private let manifestLoader: ManifestLoaderProtocol
+    private let toolsVersionLoader: ToolsVersionLoaderProtocol
+    private let currentToolsVersion: ToolsVersion
+    private let observabilityScope: ObservabilityScope
+
+    private var knownVersionsCache = ThreadSafeBox<[Version]>()
+    private var toolsVersionsCache = ThreadSafeKeyValueStore<Version, ToolsVersion>()
+    private var validToolsVersionsCache = ThreadSafeKeyValueStore<Version, Bool>()
+    private var manifestsCache = ThreadSafeKeyValueStore<Version, Manifest>()
+
+    public init(
+        package: PackageReference,
+        identityResolver: IdentityResolver,
+        registryClient: RegistryClient,
+        manifestLoader: ManifestLoaderProtocol,
+        toolsVersionLoader: ToolsVersionLoaderProtocol,
+        currentToolsVersion: ToolsVersion,
+        observabilityScope: ObservabilityScope
+    ) {
+        self.package = package
+        self.identityResolver = identityResolver
+        self.registryClient = registryClient
+        self.manifestLoader = manifestLoader
+        self.toolsVersionLoader = toolsVersionLoader
+        self.currentToolsVersion = currentToolsVersion
+        self.observabilityScope = observabilityScope
+    }
+
+    // MARK: - PackageContainer
+
+    public func isToolsVersionCompatible(at version: Version) -> Bool {
+        self.validToolsVersionsCache.memoize(version) {
+            do {
+                let toolsVersion = try self.toolsVersion(for: version)
+                try toolsVersion.validateToolsVersion(currentToolsVersion, packageIdentity: package.identity)
+                return true
+            } catch {
+                return false
+            }
+        }
+    }
+
+    public func toolsVersion(for version: Version) throws -> ToolsVersion {
+        try self.toolsVersionsCache.memoize(version) {
+            let manifests = try temp_await {
+                self.registryClient.getAvailableManifests(
+                    package: self.package.identity,
+                    version: version,
+                    observabilityScope: self.observabilityScope,
+                    callbackQueue: .sharedConcurrent,
+                    completion: $0
+                )
+            }
+
+            // ToolsVersionLoader is designed to scan files to decide which is the best tools-version
+            // as such, this writes a fake manifest based on the information returned by the registry
+            // with only the header line which is all that is needed by ToolsVersionLoader
+            let fileSystem = InMemoryFileSystem()
+            for manifest in manifests {
+                try fileSystem.writeFileContents(AbsolutePath.root.appending(component: manifest.key), string: "// swift-tools-version: \(manifest.value)")
+            }
+            return try self.toolsVersionLoader.load(at: .root, fileSystem: fileSystem)
+        }
+    }
+
+    public func versionsDescending() throws -> [Version] {
+        try self.knownVersionsCache.memoize {
+            let versions = try temp_await {
+                self.registryClient.fetchVersions(
+                    package: self.package.identity,
+                    observabilityScope: self.observabilityScope,
+                    callbackQueue: .sharedConcurrent,
+                    completion: $0
+                )
+            }
+            return versions.sorted(by: >)
+        }
+    }
+
+    public func versionsAscending() throws -> [Version] {
+        try self.versionsDescending().reversed()
+    }
+
+    public func toolsVersionsAppropriateVersionsDescending() throws -> [Version] {
+        try self.versionsDescending().filter(self.isToolsVersionCompatible(at:))
+    }
+
+    public func getDependencies(at version: Version, productFilter: ProductFilter) throws -> [PackageContainerConstraint] {
+        let manifest = try manifestsCache.memoize(version) {
+            return try self.loadManifest(version: version)
+        }
+        return try manifest.dependencyConstraints(productFilter: productFilter)
+    }
+
+    public func getDependencies(at revision: String, productFilter: ProductFilter) throws -> [PackageContainerConstraint] {
+        throw InternalError("getDependencies for revision not supported by RegistryPackageContainer")
+    }
+
+    public func getUnversionedDependencies(productFilter: ProductFilter) throws -> [PackageContainerConstraint] {
+        throw InternalError("getUnversionedDependencies not supported by RegistryPackageContainer")
+    }
+
+    public func loadPackageReference(at boundVersion: BoundVersion) throws -> PackageReference {
+        return self.package
+    }
+
+    // FIXME: make this DRYer with toolsVersion(for:)
+    // FIXME: improve the concurrency
+    private func loadManifest(version: Version) throws -> Manifest {
+        let manifests = try temp_await {
+            self.registryClient.getAvailableManifests(
+                package: self.package.identity,
+                version: version,
+                observabilityScope: self.observabilityScope,
+                callbackQueue: .sharedConcurrent,
+                completion: $0
+            )
+        }
+
+        // ToolsVersionLoader is designed to scan files to decide which is the best tools-version
+        // as such, this writes a fake manifest based on the information returned by the registry
+        // with only the header line which is all that is needed by ToolsVersionLoader
+        let fileSystem = InMemoryFileSystem()
+        for manifest in manifests {
+            try fileSystem.writeFileContents(AbsolutePath.root.appending(component: manifest.key), string: "// swift-tools-version: \(manifest.value)")
+        }
+        guard let mainToolsVersion = manifests.first(where: { $0.key == Manifest.filename })?.value else {
+            throw StringError("Could not find the '\(Manifest.filename)' file for '\(self.package.identity)' '\(version)'")
+        }
+        let preferredToolsVersion = try self.toolsVersionLoader.load(at: .root, fileSystem: fileSystem)
+        let customToolsVersion = preferredToolsVersion != mainToolsVersion ? preferredToolsVersion : nil
+
+        // now that we know the tools version we need, fetch the manifest content
+        let manifestContent = try temp_await {
+            self.registryClient.getManifestContent(
+                package: self.package.identity,
+                version: version,
+                customToolsVersion: customToolsVersion,
+                observabilityScope: self.observabilityScope,
+                callbackQueue: .sharedConcurrent,
+                completion: $0
+            )
+        }
+
+        // replace the fake manifest with the real manifest content
+        let filename: String
+        if let toolsVersion = customToolsVersion {
+            filename = Manifest.basename + "@swift-\(toolsVersion).swift"
+        } else {
+            filename = Manifest.filename
+        }
+        try fileSystem.writeFileContents(AbsolutePath.root.appending(component: filename), string: manifestContent)
+
+        // Validate the tools version.
+        try preferredToolsVersion.validateToolsVersion(
+            self.currentToolsVersion,
+            packageIdentity: self.package.identity,
+            packageVersion: "FIMXE"
+        )
+
+        // Load the manifest.
+        return try temp_await {
+            self.manifestLoader.load(
+                at: .root,
+                packageIdentity: self.package.identity,
+                packageKind: self.package.kind,
+                packageLocation: self.package.locationString,
+                version: version,
+                revision: nil,
+                toolsVersion: preferredToolsVersion,
+                identityResolver: self.identityResolver,
+                fileSystem: fileSystem,
+                observabilityScope: self.observabilityScope,
+                on: .sharedConcurrent,
+                completion: $0
+            )
+        }
+    }
+}
+
+// MARK: - CustomStringConvertible
+
+extension RegistryPackageContainer: CustomStringConvertible {
+    public var description: String {
+        return "RegistryPackageContainer(\(package.identity))"
+    }
+}

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -3311,7 +3311,11 @@ extension Workspace {
              throw StringError("registry not configured")
          }
 
-         let downloadPath = self.location.registryDownloadDirectory.appending(components: package.identity.description, version.description)
+         guard case (let scope, let name)? = package.identity.scopeAndName else {
+             throw StringError("invalid package identity")
+         }
+
+         let downloadPath = self.location.registryDownloadDirectory.appending(components: scope.description, name.description, version.description)
          if self.fileSystem.exists(downloadPath) {
              return downloadPath
          }

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -27,7 +27,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Foo",
@@ -220,7 +220,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Foo",
@@ -277,7 +277,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Foo",
@@ -339,7 +339,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Foo",
@@ -376,7 +376,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "FooPackage",
@@ -439,7 +439,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Foo",
@@ -500,7 +500,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Foo",
@@ -578,7 +578,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [],
             packages: [
                 MockPackage(
@@ -640,7 +640,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [],
             packages: [
                 MockPackage(
@@ -736,7 +736,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [],
             packages: [
                 MockPackage(
@@ -800,7 +800,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "A",
@@ -834,12 +834,12 @@ final class WorkspaceTests: XCTestCase {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
-        let v1Requirement: MockDependency.Requirement = .range("1.0.0" ..< "2.0.0")
+        let v1Requirement: SourceControlRequirement = .range("1.0.0" ..< "2.0.0")
         let v1 = CheckoutState.version("1.0.0", revision: Revision(identifier: "hello"))
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "A",
@@ -890,13 +890,13 @@ final class WorkspaceTests: XCTestCase {
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
         let cPath = RelativePath("C")
-        let v1Requirement: MockDependency.Requirement = .range("1.0.0" ..< "2.0.0")
-        let branchRequirement: MockDependency.Requirement = .branch("master")
+        let v1Requirement: SourceControlRequirement = .range("1.0.0" ..< "2.0.0")
+        let branchRequirement: SourceControlRequirement = .branch("master")
         let v1_5 = CheckoutState.version("1.0.5", revision: Revision(identifier: "hello"))
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "A",
@@ -955,7 +955,7 @@ final class WorkspaceTests: XCTestCase {
 
         let testWorkspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "A",
@@ -1000,13 +1000,13 @@ final class WorkspaceTests: XCTestCase {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
-        let v1Requirement: MockDependency.Requirement = .range("1.0.0" ..< "2.0.0")
-        let masterRequirement: MockDependency.Requirement = .branch("master")
+        let v1Requirement: SourceControlRequirement = .range("1.0.0" ..< "2.0.0")
+        let masterRequirement: SourceControlRequirement = .branch("master")
         let v1_5 = CheckoutState.version("1.0.5", revision: Revision(identifier: "hello"))
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "A",
@@ -1062,13 +1062,12 @@ final class WorkspaceTests: XCTestCase {
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
         let cPath = RelativePath("C")
-        let v1Requirement: MockDependency.Requirement = .range("1.0.0" ..< "2.0.0")
-        //let localRequirement: MockDependency.Requirement = .localPackage
+        let v1Requirement: SourceControlRequirement = .range("1.0.0" ..< "2.0.0")
         let v1_5 = CheckoutState.version("1.0.5", revision: Revision(identifier: "hello"))
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "A",
@@ -1124,14 +1123,13 @@ final class WorkspaceTests: XCTestCase {
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
         let cPath = RelativePath("C")
-        let v1Requirement: MockDependency.Requirement = .range("1.0.0" ..< "2.0.0")
-        //let localRequirement: MockDependency.Requirement = .localPackage
+        let v1Requirement: SourceControlRequirement = .range("1.0.0" ..< "2.0.0")
         let v1_5 = CheckoutState.version("1.0.5", revision: Revision(identifier: "hello"))
         let master = CheckoutState.branch(name: "master", revision: Revision(identifier: "master"))
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "A",
@@ -1188,13 +1186,13 @@ final class WorkspaceTests: XCTestCase {
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
         let cPath = RelativePath("C")
-        let v1Requirement: MockDependency.Requirement = .range("1.0.0" ..< "2.0.0")
-        let v2Requirement: MockDependency.Requirement = .range("2.0.0" ..< "3.0.0")
+        let v1Requirement: SourceControlRequirement = .range("1.0.0" ..< "2.0.0")
+        let v2Requirement: SourceControlRequirement = .range("2.0.0" ..< "3.0.0")
         let v1_5 = CheckoutState.version("1.0.5", revision: Revision(identifier: "hello"))
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "A",
@@ -1246,14 +1244,14 @@ final class WorkspaceTests: XCTestCase {
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
         let cPath = RelativePath("C")
-        let v1Requirement: MockDependency.Requirement = .range("1.0.0" ..< "2.0.0")
-        let v2Requirement: MockDependency.Requirement = .range("2.0.0" ..< "3.0.0")
+        let v1Requirement: SourceControlRequirement = .range("1.0.0" ..< "2.0.0")
+        let v2Requirement: SourceControlRequirement = .range("2.0.0" ..< "3.0.0")
         let v1_5 = CheckoutState.version("1.0.5", revision: Revision(identifier: "hello"))
         let v2 = CheckoutState.version("2.0.0", revision: Revision(identifier: "hello"))
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "A",
@@ -1306,7 +1304,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 .genericPackage1(named: "A"),
                 .genericPackage1(named: "B"),
@@ -1330,7 +1328,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -1428,7 +1426,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -1521,7 +1519,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -1625,7 +1623,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -1704,7 +1702,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root1",
@@ -1774,7 +1772,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root1",
@@ -1840,7 +1838,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -1879,7 +1877,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Get some revision identifier of Bar.
         let bar = RepositorySpecifier(path: .init("/tmp/ws/pkgs/Bar"))
-        let barRevision = workspace.repoProvider.specifierMap[bar]!.revisions[0]
+        let barRevision = workspace.repositoryProvider.specifierMap[bar]!.revisions[0]
 
         // We request Bar via revision.
         let deps: [MockDependency] = [
@@ -1904,7 +1902,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -1977,7 +1975,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -2023,7 +2021,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -2066,7 +2064,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Foo",
@@ -2140,7 +2138,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -2228,7 +2226,7 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkManagedDependencies { result in
             result.check(dependency: "bar", at: .edited(barPath))
         }
-        let barRepo = try workspace.repoProvider.openWorkingCopy(at: barPath) as! InMemoryGitRepository
+        let barRepo = try workspace.repositoryProvider.openWorkingCopy(at: barPath) as! InMemoryGitRepository
         XCTAssert(barRepo.revisions.contains("dev"))
 
         // Test unediting.
@@ -2248,7 +2246,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -2306,7 +2304,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [],
             packages: [
                 MockPackage(
@@ -2377,7 +2375,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -2498,7 +2496,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -2583,7 +2581,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Foo",
@@ -2668,7 +2666,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -2748,7 +2746,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -2797,7 +2795,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Foo",
@@ -2875,7 +2873,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Foo",
@@ -2936,7 +2934,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Foo",
@@ -3000,7 +2998,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Foo",
@@ -3035,7 +3033,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -3104,7 +3102,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -3173,7 +3171,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -3246,7 +3244,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -3399,7 +3397,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -3455,7 +3453,7 @@ final class WorkspaceTests: XCTestCase {
             let sandbox = AbsolutePath("/tmp/ws/")
             let workspace = try MockWorkspace(
                 sandbox: sandbox,
-                fs: fs,
+                fileSystem: fs,
                 roots: [
                     MockPackage(
                         name: "Root1",
@@ -3518,7 +3516,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             mirrors: mirrors,
             roots: [
                 MockPackage(
@@ -3612,7 +3610,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -3743,7 +3741,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -3803,7 +3801,7 @@ final class WorkspaceTests: XCTestCase {
             let pinsStore = try ws.pinsStore.load()
             let fooPin = pinsStore.pins.first(where: { $0.packageRef.identity.description == "foo" })!
 
-            let fooRepo = workspace.repoProvider.specifierMap[RepositorySpecifier(path: AbsolutePath(fooPin.packageRef.locationString))]!
+            let fooRepo = workspace.repositoryProvider.specifierMap[RepositorySpecifier(path: AbsolutePath(fooPin.packageRef.locationString))]!
             let revision = try fooRepo.resolveRevision(tag: "1.0.0")
             let newState = PinsStore.PinState.version("1.0.0", revision: revision.identifier)
 
@@ -3859,7 +3857,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -3910,7 +3908,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -3997,7 +3995,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -4050,7 +4048,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Baz",
@@ -4095,7 +4093,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Bar",
@@ -4169,7 +4167,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -4278,7 +4276,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -4396,7 +4394,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             archiver: archiver,
             roots: [
                 MockPackage(
@@ -4607,7 +4605,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             httpClient: httpClient,
             archiver: archiver,
             roots: [
@@ -4687,7 +4685,7 @@ final class WorkspaceTests: XCTestCase {
         // Pin A to 1.0.0, Checkout B to 1.0.0
         let aPath = workspace.pathToPackage(withName: "A")
         let aRef = PackageReference.localSourceControl(identity: PackageIdentity(path: aPath), path: aPath)
-        let aRepo = workspace.repoProvider.specifierMap[RepositorySpecifier(path: aPath)]!
+        let aRepo = workspace.repositoryProvider.specifierMap[RepositorySpecifier(path: aPath)]!
         let aRevision = try aRepo.resolveRevision(tag: "1.0.0")
         let aState = CheckoutState.version("1.0.0", revision: aRevision)
 
@@ -4802,7 +4800,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             archiver: archiver,
             roots: [
                 MockPackage(
@@ -4856,7 +4854,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             archiver: archiver,
             roots: [
                 MockPackage(
@@ -4930,7 +4928,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             archiver: archiver,
             roots: [
                 MockPackage(
@@ -5016,7 +5014,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             archiver: archiver,
             roots: [
                 MockPackage(
@@ -5060,7 +5058,7 @@ final class WorkspaceTests: XCTestCase {
         // Pin A to 1.0.0, Checkout B to 1.0.0
         let aPath = workspace.pathToPackage(withName: "A")
         let aRef = PackageReference.localSourceControl(identity: PackageIdentity(path: aPath), path: aPath)
-        let aRepo = workspace.repoProvider.specifierMap[RepositorySpecifier(path: aPath)]!
+        let aRepo = workspace.repositoryProvider.specifierMap[RepositorySpecifier(path: aPath)]!
         let aRevision = try aRepo.resolveRevision(tag: "1.0.0")
         let aState = CheckoutState.version("1.0.0", revision: aRevision)
 
@@ -5121,7 +5119,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Foo",
@@ -5233,7 +5231,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             httpClient: httpClient,
             archiver: archiver,
             roots: [
@@ -5416,7 +5414,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             httpClient: httpClient,
             archiver: archiver,
             roots: [
@@ -5506,7 +5504,7 @@ final class WorkspaceTests: XCTestCase {
         // Pin A to 1.0.0, Checkout B to 1.0.0
         let aPath = workspace.pathToPackage(withName: "A")
         let aRef = PackageReference.localSourceControl(identity: PackageIdentity(path: aPath), path: aPath)
-        let aRepo = workspace.repoProvider.specifierMap[RepositorySpecifier(path: aPath)]!
+        let aRepo = workspace.repositoryProvider.specifierMap[RepositorySpecifier(path: aPath)]!
         let aRevision = try aRepo.resolveRevision(tag: "1.0.0")
         let aState = CheckoutState.version("1.0.0", revision: aRevision)
 
@@ -5699,7 +5697,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             httpClient: httpClient,
             archiver: archiver,
             roots: [
@@ -5818,7 +5816,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             httpClient: httpClient,
             archiver: archiver,
             roots: [
@@ -5889,7 +5887,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             httpClient: httpClient,
             roots: [
                 MockPackage(
@@ -5920,7 +5918,7 @@ final class WorkspaceTests: XCTestCase {
         // Pin A to 1.0.0, Checkout A to 1.0.0
         let aPath = workspace.pathToPackage(withName: "A")
         let aRef = PackageReference.localSourceControl(identity: PackageIdentity(path: aPath), path: aPath)
-        let aRepo = workspace.repoProvider.specifierMap[RepositorySpecifier(path: aPath)]!
+        let aRepo = workspace.repositoryProvider.specifierMap[RepositorySpecifier(path: aPath)]!
         let aRevision = try aRepo.resolveRevision(tag: "1.0.0")
         let aState = CheckoutState.version("1.0.0", revision: aRevision)
         let aDependency: Workspace.ManagedDependency = try .sourceControlCheckout(packageRef: aRef, state: aState, subpath: RelativePath("A"))
@@ -6003,7 +6001,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             httpClient: httpClient,
             archiver: archiver,
             roots: [
@@ -6108,7 +6106,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             httpClient: httpClient,
             archiver: archiver,
             roots: [
@@ -6325,7 +6323,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             httpClient: httpClient,
             archiver: archiver,
             checksumAlgorithm: checksumAlgorithm,
@@ -6457,7 +6455,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             httpClient: httpClient,
             roots: [
                 MockPackage(
@@ -6530,7 +6528,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             httpClient: httpClient,
             roots: [
                 MockPackage(
@@ -6571,7 +6569,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Foo",
@@ -6601,7 +6599,7 @@ final class WorkspaceTests: XCTestCase {
         // Pin A to 1.0.0, Checkout A to 1.0.0
         let aPath = workspace.pathToPackage(withName: "A")
         let aRef = PackageReference.localSourceControl(identity: PackageIdentity(path: aPath), path: aPath)
-        let aRepo = workspace.repoProvider.specifierMap[RepositorySpecifier(path: aPath)]!
+        let aRepo = workspace.repositoryProvider.specifierMap[RepositorySpecifier(path: aPath)]!
         let aRevision = try aRepo.resolveRevision(tag: "1.0.0")
         let aState = CheckoutState.version("1.0.0", revision: aRevision)
         let aDependency: Workspace.ManagedDependency = try .sourceControlCheckout(packageRef: aRef, state: aState, subpath: RelativePath("A"))
@@ -6709,7 +6707,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             httpClient: httpClient,
             archiver: archiver,
             roots: [
@@ -6788,7 +6786,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             httpClient: httpClient,
             roots: [
                 MockPackage(
@@ -6864,7 +6862,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             httpClient: httpClient,
             roots: [
                 MockPackage(
@@ -6922,7 +6920,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -6983,7 +6981,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -7044,7 +7042,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -7105,7 +7103,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -7160,7 +7158,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -7215,7 +7213,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -7270,7 +7268,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -7334,7 +7332,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -7389,7 +7387,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -7449,7 +7447,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -7509,7 +7507,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -7586,7 +7584,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -7671,7 +7669,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -7743,7 +7741,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -7815,7 +7813,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -7887,7 +7885,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -7959,7 +7957,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -8038,7 +8036,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -8120,7 +8118,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -8204,7 +8202,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",
@@ -8395,6 +8393,173 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertEqual(delegate.manifestLoadingDiagnostics?.count, 1)
             XCTAssertEqual(delegate.manifestLoadingDiagnostics?.first?.message, "boom")
         }
+    }
+
+    func testBasicResolutionFromSourceControl() throws {
+        let sandbox = AbsolutePath("/tmp/ws/")
+        let fs = InMemoryFileSystem()
+
+        let workspace = try MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                MockPackage(
+                    name: "MyPackage",
+                    targets: [
+                        MockTarget(
+                            name: "MyTarget1",
+                            dependencies: [
+                                .product(name: "Foo", package: "foo")
+                            ]),
+                        MockTarget(
+                            name: "MyTarget2",
+                            dependencies: [
+                                .product(name: "Bar", package: "bar")
+                            ]),
+                    ],
+                    products: [
+                        MockProduct(name: "MyProduct", targets: ["MyTarget1", "MyTarget2"]),
+                    ],
+                    dependencies: [
+                        .sourceControl(url: "http://localhost/org/foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .sourceControl(url: "http://localhost/org/bar", requirement: .upToNextMajor(from: "2.0.0")),
+                    ]
+                ),
+            ],
+            packages: [
+                MockPackage(
+                    name: "Foo",
+                    url: "http://localhost/org/foo",
+                    targets: [
+                        MockTarget(name: "Foo"),
+                    ],
+                    products: [
+                        MockProduct(name: "Foo", targets: ["Foo"]),
+                    ],
+                    versions: ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.5.1"]
+                ),
+                MockPackage(
+                    name: "Bar",
+                    url: "http://localhost/org/bar",
+                    targets: [
+                        MockTarget(name: "Bar"),
+                    ],
+                    products: [
+                        MockProduct(name: "Bar", targets: ["Bar"]),
+                    ],
+                    versions: ["2.0.0", "2.1.0", "2.2.0"]
+                ),
+            ]
+        )
+
+        try workspace.checkPackageGraph(roots: ["MyPackage"]) { graph, diagnostics in
+            XCTAssertNoDiagnostics(diagnostics)
+            PackageGraphTester(graph) { result in
+                result.check(roots: "MyPackage")
+                result.check(packages: "Bar", "Foo", "MyPackage")
+                result.check(targets: "Foo", "Bar", "MyTarget1", "MyTarget2")
+                result.checkTarget("MyTarget1") { result in result.check(dependencies: "Foo") }
+                result.checkTarget("MyTarget2") { result in result.check(dependencies: "Bar") }
+            }
+
+        }
+        workspace.checkManagedDependencies { result in
+            result.check(dependency: "foo", at: .checkout(.version("1.5.1")))
+            result.check(dependency: "bar", at: .checkout(.version("2.2.0")))
+        }
+
+        // Check the load-package callbacks.
+        XCTAssertMatch(workspace.delegate.events, ["will load manifest for root package: /tmp/ws/roots/MyPackage"])
+        XCTAssertMatch(workspace.delegate.events, ["did load manifest for root package: /tmp/ws/roots/MyPackage"])
+
+        XCTAssertMatch(workspace.delegate.events, ["will load manifest for remoteSourceControl package: http://localhost/org/foo"])
+        XCTAssertMatch(workspace.delegate.events, ["did load manifest for remoteSourceControl package: http://localhost/org/foo"])
+        XCTAssertMatch(workspace.delegate.events, ["will load manifest for remoteSourceControl package: http://localhost/org/bar"])
+        XCTAssertMatch(workspace.delegate.events, ["did load manifest for remoteSourceControl package: http://localhost/org/bar"])
+    }
+
+    func testBasicResolutionFromRegistry() throws {
+        let sandbox = AbsolutePath("/tmp/ws/")
+        let fs = InMemoryFileSystem()
+
+        let workspace = try MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                MockPackage(
+                    name: "MyPackage",
+                    targets: [
+                        MockTarget(
+                            name: "MyTarget1",
+                            dependencies: [
+                                .product(name: "Foo", package: "org.foo")
+                            ]),
+                        MockTarget(
+                            name: "MyTarget2",
+                            dependencies: [
+                                .product(name: "Bar", package: "org.bar")
+                            ]),
+                    ],
+                    products: [
+                        MockProduct(name: "MyProduct", targets: ["MyTarget1", "MyTarget2"]),
+                    ],
+                    dependencies: [
+                        .registry(identity: "org.foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .registry(identity: "org.bar", requirement: .upToNextMajor(from: "2.0.0")),
+                    ]
+                ),
+            ],
+            packages: [
+                MockPackage(
+                    name: "Foo",
+                    identity: "org.foo",
+                    targets: [
+                        MockTarget(name: "Foo"),
+                    ],
+                    products: [
+                        MockProduct(name: "Foo", targets: ["Foo"]),
+                    ],
+                    versions: ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.5.1"]
+                ),
+                MockPackage(
+                    name: "Bar",
+                    identity: "org.bar",
+                    targets: [
+                        MockTarget(name: "Bar"),
+                    ],
+                    products: [
+                        MockProduct(name: "Bar", targets: ["Bar"]),
+                    ],
+                    versions: ["2.0.0", "2.1.0", "2.2.0"]
+                ),
+            ]
+        )
+
+        try workspace.checkPackageGraph(roots: ["MyPackage"]) { graph, diagnostics in
+            XCTAssertNoDiagnostics(diagnostics)
+            PackageGraphTester(graph) { result in
+                result.check(roots: "MyPackage")
+                result.check(packages: "Bar", "Foo", "MyPackage")
+                result.check(targets: "Foo", "Bar", "MyTarget1", "MyTarget2")
+                result.checkTarget("MyTarget1") { result in result.check(dependencies: "Foo") }
+                result.checkTarget("MyTarget2") { result in result.check(dependencies: "Bar") }
+            }
+
+        }
+
+        workspace.checkManagedDependencies { result in
+            result.check(dependency: "org.foo", at: .registryDownload("1.5.1"))
+            result.check(dependency: "org.bar", at: .registryDownload("2.2.0"))
+        }
+
+        // Check the load-package callbacks.
+        XCTAssertMatch(workspace.delegate.events, ["will load manifest for root package: /tmp/ws/roots/MyPackage"])
+        XCTAssertMatch(workspace.delegate.events, ["did load manifest for root package: /tmp/ws/roots/MyPackage"])
+
+        XCTAssertMatch(workspace.delegate.events, ["will load manifest for registry package: org.foo"])
+        XCTAssertMatch(workspace.delegate.events, ["did load manifest for registry package: org.foo"])
+        XCTAssertMatch(workspace.delegate.events, ["will load manifest for registry package: org.bar"])
+        XCTAssertMatch(workspace.delegate.events, ["did load manifest for registry package: org.bar"])
     }
 }
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -3321,7 +3321,7 @@ final class WorkspaceTests: XCTestCase {
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
-            fs: fs,
+            fileSystem: fs,
             roots: [
                 MockPackage(
                     name: "Root",


### PR DESCRIPTION
motivation: support registries

changes:
* create RegistryPackageContainer to handle dependencies from registry, integrated with the previously introduces registry client
* update workspace to create RegistryPackageContainer when dealing with registry dependencies
* update registry client (RegitryManager) to perform download request (buffered) when downloading the package archive
* update registry client manifest listing and handling so it supportes multi-manifest setups. simplified the client to return the manifest content instead of attempting to load it which is done in RegistryPackageContainer which has additional context
* update registry client to use Codable
* add testing infrastructure to MockWorkspace to mock registry dependencies
* add basic tests for registry scenarios

