### PR TITLE
Increment SwiftPM tools version to 5.5 and minimum deployment target to 10.15.4 on macOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.5
 
 /*
  This source file is part of the Swift.org open source project

--- a/Package.swift
+++ b/Package.swift
@@ -63,7 +63,7 @@ if useSwiftCryptoV2 {
 let package = Package(
     name: "SwiftPM",
     platforms: [
-        .macOS(.v10_15),
+        .macOS("10.15.4"),
         .iOS(.v13)
     ],
     products:


### PR DESCRIPTION
Increment SwiftPM tools version to 5.5 and minimum deployment target to 10.15.4 on macOS

### Motivation:

Allow use of Swift 5.5 features such as automatic `Codable` synthesis.  Minimum deployment target of 10.15.4 allows use of FileHandle improvements such as `read(upToCount:)`.