### PR TITLE
Fix archive-source command

### DIFF
--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -536,7 +536,7 @@ public final class GitRepository: Repository, WorkingCheckout {
         try self.lock.withLock {
             try callGit("archive",
                         "--format", "zip",
-                        "--prefix", path.basenameWithoutExt,
+                        "--prefix", "\(path.basenameWithoutExt)/",
                         "--output", path.pathString,
                         "HEAD",
                         failureMessage: "Couldn’t create an archive")


### PR DESCRIPTION
Motivation:
Source archives created using the `archive-source` command doesn't
include top-level directory.

Modification:
The trailing slash `/` in the `--prefix` argument to `git archive`,
which is the underlying command for `archive-source`, is required to
create top level directory. Without it the prefix is simply added to all the files and
dirs in the archive.
