### PR TITLE
Fix `testDuplicateTransitiveIdentityWithoutNames`

### DIFF
--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -7629,7 +7629,7 @@ final class WorkspaceTests: XCTestCase {
                 // this package never gets loaded since its identity is the same as "FooPackage"
                 MockPackage(
                     name: "OtherUtilityPackage",
-                    path: "other/utility",
+                    path: "other-foo/utility",
                     targets: [
                         MockTarget(name: "OtherUtilityTarget"),
                     ],


### PR DESCRIPTION
Spun out of #3838.

This one‐liner fixes `testDuplicateTransitiveIdentityWithoutNames`. The test exists to check the diagnostics of clashing package identities, however one of its paths is also misspelled.

Under legacy resolution, the resolver happens to traverse the graph in an order that first reaches the expected diagnostic before it actually queries the bad path. But under target‐based resolution the resolver is not so lucky, and traverses the graph in an order that attempts to read from the bad path before it detects the identity clash. Attempting to read from the bad path results in the `InMemoryGitRepositoryProvider` failing to look it up (as expected) and crashing on a force‐unwrap. (In the real world outside of the mocking infrastructure, a `GitRepository` in the same situation would throw a proper error describing that it cannot find any repository at that location.)

This PR simply fixes the path, so that the test components point at each other properly and the only error left in the test is the clashing identity whose diagnostic it is supposed to test.