### PR TITLE
Fix CommandsTests.PackageToolTests/testArchiveSource by removing git version specific error message

### DIFF
--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -1160,8 +1160,7 @@ final class PackageToolTests: CommandsTestCase {
 
                 let stderrOutput = try result.utf8stderrOutput()
                 XCTAssert(
-                    stderrOutput.contains("error: Couldn’t create an archive:") &&
-                        stderrOutput.contains("fatal: could not create archive file '/': Is a directory"),
+                    stderrOutput.contains("error: Couldn’t create an archive:"),
                     #"actual: "\#(stderrOutput)""#
                 )
             }


### PR DESCRIPTION
Make tests pass with different version of git installed.

### Motivation:

On my system, I have a more recent version of git installed (git version 2.33.1) than comes with Xcode (git version 2.30.1 (Apple Git-130)). This causes the unit test  CommandsTests.PackageToolTests/testArchiveSource to fail.

### Modifications:

Remove the test of the version-specific string.

### Result:

Test will pass on more platforms. This addresses https://bugs.swift.org/browse/SR-15500
