### PR TITLE
Enable Target‐Based Resolution

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -558,3 +558,12 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(path: "../swift-crypto"),
     ]
 }
+
+// FIXME: Once we are confident target based dependency resolution is reliable, this switch can be removed.
+if ProcessInfo.processInfo.environment["DISABLE_TARGET_BASED_DEPENDENCY_RESOLUTION"] == nil {  // Currently enabled by default.
+    for target in package.targets {
+        var swiftSettings = target.swiftSettings ?? []
+        defer { target.swiftSettings = swiftSettings }
+        swiftSettings.append(.define("ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION"))
+    }
+}


### PR DESCRIPTION
This is the last piece of #3838 that actually turns target‐based resolution on by default. It is just a few lines in the manifest in order to be easy to revert if problems arise again.

This applies `ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION` to every target.

If needed for debugging, it can still be temporarily disabled during development by either setting `DISABLE_TARGET_BASED_DEPENDENCY_RESOLUTION` in the environment or by commenting out this bit of the manifest, whichever is more convenient at any given time.

At a later date, if everything has gone smoothly for a while, then all references to the compilation condition can be removed.