### PR TITLE
Fix iOS minimum deployment annotation and fix compilation error on iOS from plugin changes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -64,7 +64,7 @@ let package = Package(
     name: "SwiftPM",
     platforms: [
         .macOS("10.15.4"),
-        .iOS(.v13)
+        .iOS("13.4")
     ],
     products:
         autoProducts.flatMap {

--- a/Sources/Workspace/DefaultPluginScriptRunner.swift
+++ b/Sources/Workspace/DefaultPluginScriptRunner.swift
@@ -253,6 +253,11 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner {
         delegate: PluginInvocationDelegate,
         completion: @escaping (Result<Bool, Error>) -> Void
     ) {
+#if os(iOS) || os(watchOS) || os(tvOS)
+        callbackQueue.async {
+            completion(.failure(DefaultPluginScriptRunnerError.invocationFailed(StringError("subprocess invocations are unavailable on this platform"), command: [])))
+        }
+#else
         // Construct the command line. Currently we just invoke the executable built from the plugin without any parameters.
         var command = [compiledExec.pathString]
 
@@ -421,6 +426,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner {
         outputQueue.async {
             try? outputHandle.writePluginMessage(.performAction(input: input))
         }
+#endif
     }
 }
 


### PR DESCRIPTION
Fix iOS minimum deployment annotation and fix compilation error on iOS from plugin changes.

### Motivation:

Fixes a build break on iOS.

### Modifications:

- set the iOS deployment target to 13.4 to match the macOS 10.15.4 set earlier — this provides access to Swift-friendly Foundation.FileHandle APIs
- conditionalize use of Process APIs that aren't available on iOS, watchOS, tvOS

### Result:

Be able to build on iOS again.