### PR TITLE
Use async await in ManifestLoader

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -564,12 +564,12 @@ if ProcessInfo.processInfo.environment["SWIFTPM_LLBUILD_FWK"] == nil {
 
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     package.dependencies += [
-        .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch(relatedDependenciesBranch)),
+        .package(url: "https://github.com/pcbeard/swift-tools-support-core.git", .branch("AsyncAwaitPopen")),
         // The 'swift-argument-parser' version declared here must match that
         // used by 'swift-driver' and 'sourcekit-lsp'. Please coordinate
         // dependency version changes here with those projects.
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.0.1")),
-        .package(url: "https://github.com/apple/swift-driver.git", .branch(relatedDependenciesBranch)),
+        .package(url: "https://github.com/pcbeard/swift-driver.git", .branch("AsyncAwaitPopen")),
         .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: minimumCryptoVersion)),
         .package(url: "https://github.com/apple/swift-system.git", .upToNextMinor(from: "1.1.1")),
     ]

--- a/Tests/PackageLoadingTests/PDLoadingTests.swift
+++ b/Tests/PackageLoadingTests/PDLoadingTests.swift
@@ -47,6 +47,23 @@ class PackageDescriptionLoadingTests: XCTestCase, ManifestLoaderDelegate {
         )
     }
 
+    @available(macOS 12.0, *)
+    func loadManifest(
+        _ contents: String,
+        toolsVersion: ToolsVersion? = nil,
+        packageKind: PackageReference.Kind? = nil,
+        observabilityScope: ObservabilityScope,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) async throws -> Manifest {
+        try await self.loadManifest(
+            ByteString(encodingAsUTF8: contents),
+            toolsVersion: toolsVersion,
+            packageKind: packageKind,
+            observabilityScope: observabilityScope
+        )
+    }
+
     func loadManifest(
         _ bytes: ByteString,
         toolsVersion: ToolsVersion? = nil,
@@ -73,6 +90,47 @@ class PackageDescriptionLoadingTests: XCTestCase, ManifestLoaderDelegate {
         let manifestPath = packagePath.appending(component: Manifest.filename)
         try fileSystem.writeFileContents(manifestPath, bytes: bytes)
         let manifest = try manifestLoader.load(
+            at: packagePath,
+            packageKind: packageKind,
+            toolsVersion: toolsVersion,
+            fileSystem: fileSystem,
+            observabilityScope: observabilityScope
+        )
+
+        if manifest.toolsVersion != toolsVersion {
+            XCTFail("Invalid manifest version", file: file, line: line)
+        }
+
+        return manifest
+    }
+
+    @available(macOS 12.0, *)
+    func loadManifest(
+        _ bytes: ByteString,
+        toolsVersion: ToolsVersion? = nil,
+        packageKind: PackageReference.Kind? = nil,
+        observabilityScope: ObservabilityScope,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) async throws -> Manifest {
+        let packageKind = packageKind ?? .fileSystem(.root)
+        let packagePath: AbsolutePath
+        switch packageKind {
+        case .root(let path):
+            packagePath = path
+        case .fileSystem(let path):
+            packagePath = path
+        case .localSourceControl(let path):
+            packagePath = path
+        case .remoteSourceControl, .registry:
+            throw InternalError("invalid package kind \(packageKind)")
+        }
+
+        let toolsVersion = toolsVersion ?? self.toolsVersion
+        let fileSystem = InMemoryFileSystem()
+        let manifestPath = packagePath.appending(component: Manifest.filename)
+        try fileSystem.writeFileContents(manifestPath, bytes: bytes)
+        let manifest = try await manifestLoader.load(
             at: packagePath,
             packageKind: packageKind,
             toolsVersion: toolsVersion,

--- a/Tests/PackageLoadingTests/PD_5_6_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_6_LoadingTests.swift
@@ -167,6 +167,19 @@ class PackageDescription5_6LoadingTests: PackageDescriptionLoadingTests {
             ])
         }
     }
+
+    @available(macOS 12.0, *)
+    func testAsyncManifestLoading() async throws {
+        let content = """
+            import PackageDescription
+            let package = Package(name: "AsyncManifestLoading")
+            """
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let manifest = try await loadManifest(content, observabilityScope: observability.topScope)
+
+        XCTAssertEqual(manifest.displayName, "AsyncManifestLoading")
+    }
     
     /// Tests use of Context.current.packageDirectory
     func testPackageContextName() throws {


### PR DESCRIPTION
Add async / await code paths to ManifestLoader

### Motivation:

This will eventually replace the async completion block versions of the same code.

### Modifications:

Duplicated all completion-block methods with async/await equivalents. Note, this relies on changes in my AsyncAwaitPopen branch in swift-tools-support-core (see https://github.com/apple/swift-tools-support-core/pull/263).

### Result:

ManifestLoading will provide async await APIs in addition to explicit completion blocks.
