### PR TITLE
Fix a build failure in plugins on Windows

### DIFF
--- a/Sources/PackagePlugin/Plugin.swift
+++ b/Sources/PackagePlugin/Plugin.swift
@@ -82,7 +82,7 @@ extension Plugin {
         }
         
         // Turn off full buffering so printed text appears as soon as possible.
-        setlinebuf(stdout)
+        setvbuf(stdout, nil, _IOLBF, 0)
         
         // Open a message channel for communicating with the plugin host.
         pluginHostConnection = PluginHostConnection(


### PR DESCRIPTION
Windows UCRT doesn't have `setlinebuf` but does have `setvbuf` (which `setlinbuf` is just a cover for).

### Motivation:

Fixes a Windows build failure.

### Modifications:

- change `setlinebuf` to `setvbuf`

### Result:

It works on Windows too.