### PR TITLE
Implement TOFU for package downloads

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -155,6 +155,7 @@ let package = Package(
             name: "PackageRegistry",
             dependencies: [
                 "Basics",
+                "PackageFingerprint",
                 "PackageLoading",
                 "PackageModel"
             ],
@@ -309,6 +310,7 @@ let package = Package(
             name: "Workspace",
             dependencies: [
                 "Basics",
+                "PackageFingerprint",
                 "PackageGraph",
                 "PackageModel",
                 "SourceControl",
@@ -328,6 +330,7 @@ let package = Package(
                 "Basics",
                 "Build",
                 "PackageCollections",
+                "PackageFingerprint",
                 "PackageGraph",
                 "SourceControl",
                 "Workspace",
@@ -388,6 +391,7 @@ let package = Package(
             name: "SPMTestSupport",
             dependencies: [
                 "Basics",
+                "PackageFingerprint",
                 "PackageGraph",
                 "PackageLoading",
                 "PackageRegistry",

--- a/Sources/Basics/FileSystem+Extensions.swift
+++ b/Sources/Basics/FileSystem+Extensions.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Copyright (c) 2020-2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -18,7 +18,12 @@ import TSCBasic
 extension FileSystem {
     /// SwiftPM directory under user's home directory (~/.swiftpm)
     public var dotSwiftPM: AbsolutePath {
-        return self.homeDirectory.appending(component: ".swiftpm")
+        self.homeDirectory.appending(component: ".swiftpm")
+    }
+    
+    /// SwiftPM security directory
+    public var swiftPMSecurityDirectory: AbsolutePath {
+        self.dotSwiftPM.appending(component: "security")
     }
 }
 

--- a/Sources/Commands/CMakeLists.txt
+++ b/Sources/Commands/CMakeLists.txt
@@ -34,6 +34,7 @@ target_link_libraries(Commands PUBLIC
   Basics
   Build
   PackageCollections
+  PackageFingerprint
   PackageGraph
   SourceControl
   TSCBasic

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -11,6 +11,7 @@
 import ArgumentParser
 import TSCBasic
 import TSCUtility
+import PackageFingerprint
 import PackageModel
 import SPMBuildCore
 import Build
@@ -88,6 +89,12 @@ extension AbsolutePath: ExpressibleByArgument {
 enum BuildSystemKind: String, ExpressibleByArgument, CaseIterable {
     case native
     case xcode
+}
+
+extension FingerprintCheckingMode: ExpressibleByArgument {
+    public init?(argument: String) {
+        self.init(rawValue: argument)
+    }
 }
 
 public extension Sanitizer {
@@ -348,6 +355,9 @@ public struct SwiftToolOptions: ParsableArguments {
           help: .hidden)
     var keychain: Bool = false
 #endif
+    
+    @Option(name: .customLong("resolver-fingerprint-checking"))
+    var resolverFingerprintCheckingMode: FingerprintCheckingMode = .warn
 
     @Flag(name: .customLong("netrc"), help: .hidden)
     var _deprecated_netrc: Bool = false

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -658,6 +658,7 @@ public class SwiftTool {
                 workingDirectory: buildPath,
                 editsDirectory: self.editsDirectory(),
                 resolvedVersionsFile: self.resolvedVersionsFile(),
+                sharedSecurityDirectory: localFileSystem.swiftPMSecurityDirectory,
                 sharedCacheDirectory: sharedCacheDirectory,
                 sharedConfigurationDirectory: sharedConfigurationDirectory
             ),
@@ -669,6 +670,7 @@ public class SwiftTool {
             additionalFileRules: isXcodeBuildSystemEnabled ? FileRuleDescription.xcbuildFileTypes : FileRuleDescription.swiftpmFileTypes,
             resolverUpdateEnabled: !options.skipDependencyUpdate,
             resolverPrefetchingEnabled: options.shouldEnableResolverPrefetching,
+            resolverFingerprintCheckingMode: self.options.resolverFingerprintCheckingMode,
             sharedRepositoriesCacheEnabled: self.options.useRepositoriesCache,
             delegate: delegate
         )

--- a/Sources/PackageFingerprint/FilePackageFingerprintStorage.swift
+++ b/Sources/PackageFingerprint/FilePackageFingerprintStorage.swift
@@ -22,7 +22,7 @@ public struct FilePackageFingerprintStorage: PackageFingerprintStorage {
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
 
-    init(fileSystem: FileSystem, directoryPath: AbsolutePath) {
+    public init(fileSystem: FileSystem, directoryPath: AbsolutePath) {
         self.fileSystem = fileSystem
         self.directoryPath = directoryPath
 

--- a/Sources/PackageFingerprint/Model.swift
+++ b/Sources/PackageFingerprint/Model.swift
@@ -14,6 +14,11 @@ import TSCUtility
 public struct Fingerprint: Equatable {
     public let origin: Origin
     public let value: String
+
+    public init(origin: Origin, value: String) {
+        self.origin = origin
+        self.value = value
+    }
 }
 
 public extension Fingerprint {
@@ -26,7 +31,7 @@ public extension Fingerprint {
         case sourceControl(Foundation.URL)
         case registry(Foundation.URL)
 
-        var kind: Fingerprint.Kind {
+        public var kind: Fingerprint.Kind {
             switch self {
             case .sourceControl:
                 return .sourceControl
@@ -35,7 +40,7 @@ public extension Fingerprint {
             }
         }
 
-        var url: Foundation.URL? {
+        public var url: Foundation.URL? {
             switch self {
             case .sourceControl(let url):
                 return url
@@ -56,3 +61,9 @@ public extension Fingerprint {
 }
 
 public typealias PackageFingerprints = [Version: [Fingerprint.Kind: Fingerprint]]
+
+public enum FingerprintCheckingMode: String {
+    case strict
+    case warn
+    case none
+}

--- a/Sources/PackageFingerprint/PackageFingerprintStorage.swift
+++ b/Sources/PackageFingerprint/PackageFingerprintStorage.swift
@@ -28,6 +28,24 @@ public protocol PackageFingerprintStorage {
              callback: @escaping (Result<Void, Error>) -> Void)
 }
 
+public extension PackageFingerprintStorage {
+    func get(package: PackageIdentity,
+             version: Version,
+             kind: Fingerprint.Kind,
+             observabilityScope: ObservabilityScope,
+             callbackQueue: DispatchQueue,
+             callback: @escaping (Result<Fingerprint, Error>) -> Void) {
+        self.get(package: package, version: version, observabilityScope: observabilityScope, callbackQueue: callbackQueue) { result in
+            callback(result.tryMap { fingerprints in
+                guard let fingerprint = fingerprints[kind] else {
+                    throw PackageFingerprintStorageError.notFound
+                }
+                return fingerprint
+            })
+        }
+    }
+}
+
 public enum PackageFingerprintStorageError: Error, Equatable {
     case conflict(given: Fingerprint, existing: Fingerprint)
     case notFound

--- a/Sources/PackageRegistry/CMakeLists.txt
+++ b/Sources/PackageRegistry/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(PackageRegistry
   RegistryClient.swift)
 target_link_libraries(PackageRegistry PUBLIC
   Basics
+  PackageFingerprint
   PackageLoading
   PackageModel
   TSCBasic

--- a/Sources/SPMTestSupport/InMemoryGitRepository.swift
+++ b/Sources/SPMTestSupport/InMemoryGitRepository.swift
@@ -107,9 +107,9 @@ public final class InMemoryGitRepository {
 
     /// Commits the current state of the repository filesystem and returns the commit identifier.
     @discardableResult
-    public func commit() throws -> String {
+    public func commit(hash: String? = nil) throws -> String {
         // Create a fake hash for this commit.
-        let hash = String((UUID().uuidString + UUID().uuidString).prefix(40))
+        let hash = hash ?? String((UUID().uuidString + UUID().uuidString).prefix(40))
         self.lock.withLock {
             self.head.hash = hash
             // Store the commit in history.

--- a/Sources/SPMTestSupport/MockPackage.swift
+++ b/Sources/SPMTestSupport/MockPackage.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -20,6 +20,8 @@ public struct MockPackage {
     public let products: [MockProduct]
     public let dependencies: [MockDependency]
     public let versions: [String?]
+    /// Provides revision identifier for the given version. A random identifier might be assigned if this is nil.
+    public let revisionProvider: ((String) -> String)?
     // FIXME: This should be per-version.
     public let toolsVersion: ToolsVersion?
 
@@ -31,6 +33,7 @@ public struct MockPackage {
         products: [MockProduct] = [],
         dependencies: [MockDependency] = [],
         versions: [String?] = [],
+        revisionProvider: ((String) -> String)? = nil,
         toolsVersion: ToolsVersion? = nil
     ) {
         self.name = name
@@ -40,6 +43,7 @@ public struct MockPackage {
         self.products = products
         self.dependencies = dependencies
         self.versions = versions
+        self.revisionProvider = revisionProvider
         self.toolsVersion = toolsVersion
     }
 
@@ -51,6 +55,7 @@ public struct MockPackage {
         products: [MockProduct],
         dependencies: [MockDependency] = [],
         versions: [String?] = [],
+        revisionProvider: ((String) -> String)? = nil,
         toolsVersion: ToolsVersion? = nil
     ) {
         self.name = name
@@ -60,6 +65,7 @@ public struct MockPackage {
         self.products = products
         self.dependencies = dependencies
         self.versions = versions
+        self.revisionProvider = revisionProvider
         self.toolsVersion = toolsVersion
     }
 
@@ -71,6 +77,7 @@ public struct MockPackage {
         products: [MockProduct],
         dependencies: [MockDependency] = [],
         versions: [String?] = [],
+        revisionProvider: ((String) -> String)? = nil,
         toolsVersion: ToolsVersion? = nil
     ) {
         self.name = name
@@ -80,6 +87,7 @@ public struct MockPackage {
         self.products = products
         self.dependencies = dependencies
         self.versions = versions
+        self.revisionProvider = revisionProvider
         self.toolsVersion = toolsVersion
     }
 

--- a/Sources/SPMTestSupport/MockPackageFingerprintStorage.swift
+++ b/Sources/SPMTestSupport/MockPackageFingerprintStorage.swift
@@ -1,0 +1,78 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import Basics
+import Dispatch
+import PackageFingerprint
+import PackageModel
+import TSCBasic
+import TSCUtility
+
+public class MockPackageFingerprintStorage: PackageFingerprintStorage {
+    private var packageFingerprints: [PackageIdentity: [Version: [Fingerprint.Kind: Fingerprint]]]
+    private let lock = Lock()
+
+    public init(_ packageFingerprints: [PackageIdentity: [Version: [Fingerprint.Kind: Fingerprint]]] = [:]) {
+        self.packageFingerprints = packageFingerprints
+    }
+
+    public func get(package: PackageIdentity,
+                    version: Version,
+                    observabilityScope: ObservabilityScope,
+                    callbackQueue: DispatchQueue,
+                    callback: @escaping (Result<[Fingerprint.Kind: Fingerprint], Error>) -> Void)
+    {
+        if let fingerprints = self.lock.withLock({ self.packageFingerprints[package]?[version] }) {
+            callbackQueue.async {
+                callback(.success(fingerprints))
+            }
+        } else {
+            callbackQueue.async {
+                callback(.failure(PackageFingerprintStorageError.notFound))
+            }
+        }
+    }
+
+    public func put(package: PackageIdentity,
+                    version: Version,
+                    fingerprint: Fingerprint,
+                    observabilityScope: ObservabilityScope,
+                    callbackQueue: DispatchQueue,
+                    callback: @escaping (Result<Void, Error>) -> Void)
+    {
+        do {
+            try self.lock.withLock {
+                var versionFingerprints = self.packageFingerprints[package] ?? [:]
+                var fingerprints = versionFingerprints[version] ?? [:]
+
+                if let existing = fingerprints[fingerprint.origin.kind] {
+                    // Error if we try to write a different fingerprint
+                    guard fingerprint == existing else {
+                        throw PackageFingerprintStorageError.conflict(given: fingerprint, existing: existing)
+                    }
+                    // Don't need to do anything if fingerprints are the same
+                    return
+                }
+
+                fingerprints[fingerprint.origin.kind] = fingerprint
+                versionFingerprints[version] = fingerprints
+                self.packageFingerprints[package] = versionFingerprints
+            }
+
+            callbackQueue.async {
+                callback(.success(()))
+            }
+        } catch {
+            callbackQueue.async {
+                callback(.failure(error))
+            }
+        }
+    }
+}

--- a/Sources/SPMTestSupport/MockRegistry.swift
+++ b/Sources/SPMTestSupport/MockRegistry.swift
@@ -10,6 +10,7 @@
 
 import Basics
 import Foundation
+import PackageFingerprint
 import PackageGraph
 import PackageLoading
 import PackageModel
@@ -31,7 +32,8 @@ class MockRegistry {
     init(
         identityResolver: IdentityResolver,
         checksumAlgorithm: HashAlgorithm,
-        filesystem: FileSystem
+        filesystem: FileSystem,
+        fingerprintStorage: PackageFingerprintStorage
     ) {
         self.checksumAlgorithm = checksumAlgorithm
         self.fileSystem = filesystem
@@ -43,6 +45,8 @@ class MockRegistry {
         self.registryClient = RegistryClient(
             configuration: configuration,
             identityResolver: identityResolver,
+            fingerprintStorage: fingerprintStorage,
+            fingerprintCheckingMode: .strict,
             authorizationProvider: .none,
             customHTTPClient: HTTPClient(handler: self.httpHandler),
             customArchiverProvider: { fileSystem in MockRegistryArchiver(fileSystem: fileSystem) }

--- a/Sources/Workspace/CMakeLists.txt
+++ b/Sources/Workspace/CMakeLists.txt
@@ -30,6 +30,7 @@ target_link_libraries(Workspace PUBLIC
   TSCUtility
   Basics
   SPMBuildCore
+  PackageFingerprint
   PackageGraph
   PackageLoading
   PackageModel

--- a/Sources/Workspace/SourceControlPackageContainer.swift
+++ b/Sources/Workspace/SourceControlPackageContainer.swift
@@ -10,6 +10,7 @@
 
 import Basics
 import Dispatch
+import PackageFingerprint
 import PackageGraph
 import PackageLoading
 import PackageModel
@@ -54,6 +55,8 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
     private let manifestLoader: ManifestLoaderProtocol
     private let toolsVersionLoader: ToolsVersionLoaderProtocol
     private let currentToolsVersion: ToolsVersion
+    private let fingerprintStorage: PackageFingerprintStorage
+    private let fingerprintCheckingMode: FingerprintCheckingMode
     private let observabilityScope: ObservabilityScope
 
     /// The cached dependency information.
@@ -76,6 +79,8 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
         manifestLoader: ManifestLoaderProtocol,
         toolsVersionLoader: ToolsVersionLoaderProtocol,
         currentToolsVersion: ToolsVersion,
+        fingerprintStorage: PackageFingerprintStorage,
+        fingerprintCheckingMode: FingerprintCheckingMode,
         observabilityScope: ObservabilityScope
     ) throws {
         self.package = package
@@ -85,6 +90,8 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
         self.manifestLoader = manifestLoader
         self.toolsVersionLoader = toolsVersionLoader
         self.currentToolsVersion = currentToolsVersion
+        self.fingerprintStorage = fingerprintStorage
+        self.fingerprintCheckingMode = fingerprintCheckingMode
         self.observabilityScope = observabilityScope
     }
 
@@ -140,6 +147,68 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
 
     public func getTag(for version: Version) -> String? {
         return try? self.knownVersions()[version]
+    }
+
+    func checkIntegrity(version: Version, revision: Revision) throws {
+        guard case .remoteSourceControl(let sourceControlURL) = self.package.kind else {
+            return
+        }
+        
+        let packageIdentity = self.package.identity
+        let fingerprint: Fingerprint
+        do {
+            fingerprint = try temp_await {
+                self.fingerprintStorage.get(
+                    package: packageIdentity,
+                    version: version,
+                    kind: .sourceControl,
+                    observabilityScope: self.observabilityScope,
+                    callbackQueue: .sharedConcurrent,
+                    callback: $0
+                )
+            }
+        } catch PackageFingerprintStorageError.notFound {
+            fingerprint = Fingerprint(origin: .sourceControl(sourceControlURL), value: revision.identifier)
+            // Write to storage if fingerprint not yet recorded
+            do {
+                try temp_await {
+                    self.fingerprintStorage.put(
+                        package: packageIdentity,
+                        version: version,
+                        fingerprint: fingerprint,
+                        observabilityScope: self.observabilityScope,
+                        callbackQueue: .sharedConcurrent,
+                        callback: $0
+                    )
+                }
+            } catch PackageFingerprintStorageError.conflict(_, let existing) {
+                let message = "Revision \(revision.identifier) for \(self.package) version \(version) does not match previously recorded value \(existing.value) from \(String(describing: existing.origin.url?.absoluteString))"                
+                switch self.fingerprintCheckingMode {
+                case .strict:
+                    throw StringError(message)
+                case .warn:
+                    observabilityScope.emit(warning: message)
+                case .none:
+                    return
+                }
+            }
+        } catch {
+            self.observabilityScope.emit(error: "Failed to get source control fingerprint for \(self.package) version \(version) from storage: \(error)")
+            throw error
+        }
+        
+        // The revision (i.e., hash) must match that in fingerprint storage otherwise the integrity check fails
+        if revision.identifier != fingerprint.value {
+            let message = "Revision \(revision.identifier) for \(self.package) version \(version) does not match previously recorded value \(fingerprint.value)"
+            switch self.fingerprintCheckingMode {
+            case .strict:
+                throw StringError(message)
+            case .warn:
+                observabilityScope.emit(warning: message)
+            case .none:
+                return
+            }
+        }
     }
 
     /// Returns revision for the given tag.

--- a/Sources/Workspace/WorkspaceConfiguration.swift
+++ b/Sources/Workspace/WorkspaceConfiguration.swift
@@ -30,6 +30,9 @@ extension Workspace {
 
         /// Path to the Package.resolved file.
         public var resolvedVersionsFile: AbsolutePath
+        
+        /// Path to the shared security directory
+        public var sharedSecurityDirectory: AbsolutePath
 
         /// Path to the shared cache directory
         public var sharedCacheDirectory: AbsolutePath?
@@ -56,6 +59,11 @@ extension Workspace {
         public var artifactsDirectory: AbsolutePath {
             self.workingDirectory.appending(component: "artifacts")
         }
+        
+        /// Path to the shared fingerprints directory.
+        public var sharedFingerprintsDirectory: AbsolutePath {
+            self.sharedSecurityDirectory.appending(component: "fingerprints")
+        }
 
         /// Path to the shared repositories cache.
         public var sharedRepositoriesCacheDirectory: AbsolutePath? {
@@ -67,7 +75,7 @@ extension Workspace {
             self.sharedCacheDirectory.map { DefaultLocations.manifestsDirectory(at: $0) }
         }
 
-        /// Path to the shared cache.
+        /// Path to the shared mirrors configuration.
         public var sharedMirrorsConfigurationFile: AbsolutePath? {
             self.sharedConfigurationDirectory.map { DefaultLocations.mirrorsConfigurationFile(at: $0) }
         }
@@ -88,18 +96,21 @@ extension Workspace {
         ///   - workingDirectory: Path to working directory for this workspace.
         ///   - editsDirectory: Path to store the editable versions of dependencies.
         ///   - resolvedVersionsFile: Path to the Package.resolved file.
-        ///   - sharedCacheDirectory: Path to the shared cache directory
-        ///   - sharedConfigurationDirectory: Path to the shared configuration directory
+        ///   - sharedSecurityDirectory: Path to the shared security directory.
+        ///   - sharedCacheDirectory: Path to the shared cache directory.
+        ///   - sharedConfigurationDirectory: Path to the shared configuration directory.
         public init(
             workingDirectory: AbsolutePath,
             editsDirectory: AbsolutePath,
             resolvedVersionsFile: AbsolutePath,
+            sharedSecurityDirectory: AbsolutePath,
             sharedCacheDirectory: AbsolutePath?,
             sharedConfigurationDirectory: AbsolutePath?
         ) {
             self.workingDirectory = workingDirectory
             self.editsDirectory = editsDirectory
             self.resolvedVersionsFile = resolvedVersionsFile
+            self.sharedSecurityDirectory = sharedSecurityDirectory
             self.sharedCacheDirectory = sharedCacheDirectory
             self.sharedConfigurationDirectory = sharedConfigurationDirectory
         }
@@ -113,6 +124,7 @@ extension Workspace {
                 workingDirectory: DefaultLocations.workingDirectory(forRootPackage: rootPath),
                 editsDirectory: DefaultLocations.editsDirectory(forRootPackage: rootPath),
                 resolvedVersionsFile: DefaultLocations.resolvedVersionsFile(forRootPackage: rootPath),
+                sharedSecurityDirectory: fileSystem.swiftPMSecurityDirectory,
                 sharedCacheDirectory: fileSystem.swiftPMCacheDirectory,
                 sharedConfigurationDirectory: fileSystem.swiftPMConfigDirectory
             )


### PR DESCRIPTION
This is a continuation of https://github.com/apple/swift-package-manager/pull/3879.

Wire up fingerprint storage such that it is used for integrity checks of package downloads. Fingerprint must match previously recorded value (if any) or else it would result in an error.

- [x] Registry downloads
- [x] Git clones
- [x] Option (`strictFingerprintChecking`) to ignore TOFU failures (i.e., error -> warning)
- [x] `.swiftpm/security/fingerprints/`