### PR TITLE
Allow plugins to look up tools from the toolchain (such as `docc`)

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -957,6 +957,9 @@ extension SwiftPackageTool {
             // Build the map of tools that are available to the plugin. This should include the tools in the executables in the toolchain, as well as any executables the plugin depends on (built executables as well as prebuilt binaries).
             let dataDir = try swiftTool.getActiveWorkspace().location.pluginWorkingDirectory
             let builtToolsDir = dataDir.appending(components: "plugin-tools")
+            
+            // Use the directory containing the compiler as an additional search directory.
+            let toolSearchDirs = [try swiftTool.getToolchain().swiftCompilerPath.parentDirectory]
 
             // Create the cache directory, if needed.
             try localFileSystem.createDirectory(cacheDir, recursive: true)
@@ -985,6 +988,7 @@ extension SwiftPackageTool {
                 buildEnvironment: buildEnvironment,
                 scriptRunner: pluginScriptRunner,
                 outputDirectory: outputDir,
+                toolSearchDirectories: toolSearchDirs,
                 toolNamesToPaths: toolNamesToPaths,
                 fileSystem: localFileSystem,
                 observabilityScope: swiftTool.observabilityScope,

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -758,6 +758,9 @@ public class SwiftTool {
             // binary targets.
             let dataDir = try self.getActiveWorkspace().location.workingDirectory
             let builtToolsDir = dataDir.appending(components: try self._hostToolchain.get().triple.platformBuildPathComponent(), buildEnvironment.configuration.dirname)
+            
+            // Use the directory containing the compiler as an additional search directory.
+            let toolSearchDirs = [try self.getToolchain().swiftCompilerPath.parentDirectory]
 
             // Create the cache directory, if needed.
             try localFileSystem.createDirectory(cacheDir, recursive: true)
@@ -767,6 +770,7 @@ public class SwiftTool {
                 outputDir: outputDir,
                 builtToolsDir: builtToolsDir,
                 buildEnvironment: buildEnvironment,
+                toolSearchDirectories: toolSearchDirs,
                 pluginScriptRunner: pluginScriptRunner,
                 observabilityScope: self.observabilityScope,
                 fileSystem: localFileSystem

--- a/Sources/PackagePlugin/Plugin.swift
+++ b/Sources/PackagePlugin/Plugin.swift
@@ -115,7 +115,8 @@ extension Plugin {
                 package: inputStruct.package,
                 pluginWorkDirectory: inputStruct.pluginWorkDirectory,
                 builtProductsDirectory: inputStruct.builtProductsDirectory,
-                toolNamesToPaths: inputStruct.toolNamesToPaths)
+                toolNamesToPaths: inputStruct.toolNamesToPaths,
+                toolSearchDirectories: inputStruct.toolSearchDirectories)
             
             // Instantiate the plugin. For now there are no parameters, but
             // this is where we would set them up, most likely as properties

--- a/Sources/PackagePlugin/PluginInput.swift
+++ b/Sources/PackagePlugin/PluginInput.swift
@@ -16,6 +16,7 @@ struct PluginInput {
     let package: Package
     let pluginWorkDirectory: Path
     let builtProductsDirectory: Path
+    let toolSearchDirectories: [Path]
     let toolNamesToPaths: [String: Path]
     let pluginAction: PluginAction
     enum PluginAction {
@@ -31,6 +32,7 @@ struct PluginInput {
         self.package = try deserializer.package(for: input.rootPackageId)
         self.pluginWorkDirectory = try deserializer.path(for: input.pluginWorkDirId)
         self.builtProductsDirectory = try deserializer.path(for: input.builtProductsDirId)
+        self.toolSearchDirectories = try input.toolSearchDirIds.map { try deserializer.path(for: $0) }
         self.toolNamesToPaths = try input.toolNamesToPathIds.mapValues { try deserializer.path(for: $0) }
         
         // Unpack the plugin action, which will determine which plugin functionality to invoke.
@@ -288,6 +290,7 @@ internal struct WireInput: Decodable {
     let rootPackageId: Package.Id
     let pluginWorkDirId: Path.Id
     let builtProductsDirId: Path.Id
+    let toolSearchDirIds: [Path.Id]
     let toolNamesToPathIds: [String: Path.Id]
     let pluginAction: PluginAction
 

--- a/Sources/SPMBuildCore/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/PluginInvocation.swift
@@ -51,6 +51,7 @@ extension PluginTarget {
         buildEnvironment: BuildEnvironment,
         scriptRunner: PluginScriptRunner,
         outputDirectory: AbsolutePath,
+        toolSearchDirectories: [AbsolutePath],
         toolNamesToPaths: [String: AbsolutePath],
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope,
@@ -74,6 +75,7 @@ extension PluginTarget {
                 rootPackage: package,
                 pluginWorkDir: outputDirectory,
                 builtProductsDir: outputDirectory,  // FIXME — what is this parameter needed for?
+                toolSearchDirs: toolSearchDirectories,
                 toolNamesToPaths: toolNamesToPaths,
                 pluginAction: action)
         }
@@ -121,6 +123,7 @@ extension PackageGraph {
         outputDir: AbsolutePath,
         builtToolsDir: AbsolutePath,
         buildEnvironment: BuildEnvironment,
+        toolSearchDirectories: [AbsolutePath],
         pluginScriptRunner: PluginScriptRunner,
         observabilityScope: ObservabilityScope,
         fileSystem: FileSystem
@@ -231,6 +234,7 @@ extension PackageGraph {
                     buildEnvironment: buildEnvironment,
                     scriptRunner: pluginScriptRunner,
                     outputDirectory: pluginOutputDir,
+                    toolSearchDirectories: toolSearchDirectories,
                     toolNamesToPaths: toolNamesToPaths,
                     fileSystem: fileSystem,
                     observabilityScope: observabilityScope,
@@ -555,6 +559,7 @@ public struct PluginScriptRunnerInput: Codable {
     let rootPackageId: Package.Id
     let pluginWorkDirId: Path.Id
     let builtProductsDirId: Path.Id
+    let toolSearchDirIds: [Path.Id]
     let toolNamesToPathIds: [String: Path.Id]
     let pluginAction: PluginAction
 
@@ -739,12 +744,14 @@ struct PluginScriptRunnerInputSerializer {
         rootPackage: ResolvedPackage,
         pluginWorkDir: AbsolutePath,
         builtProductsDir: AbsolutePath,
+        toolSearchDirs: [AbsolutePath],
         toolNamesToPaths: [String: AbsolutePath],
         pluginAction: PluginAction
     ) throws -> PluginScriptRunnerInput {
         let rootPackageId = try serialize(package: rootPackage)
         let pluginWorkDirId = try serialize(path: pluginWorkDir)
         let builtProductsDirId = try serialize(path: builtProductsDir)
+        let toolSearchDirIds = try toolSearchDirs.map{ try serialize(path: $0) }
         let toolNamesToPathIds = try toolNamesToPaths.mapValues{ try serialize(path: $0) }
         let serializedPluginAction: PluginScriptRunnerInput.PluginAction
         switch pluginAction {
@@ -761,6 +768,7 @@ struct PluginScriptRunnerInputSerializer {
             rootPackageId: rootPackageId,
             pluginWorkDirId: pluginWorkDirId,
             builtProductsDirId: builtProductsDirId,
+            toolSearchDirIds: toolSearchDirIds,
             toolNamesToPathIds: toolNamesToPathIds,
             pluginAction: serializedPluginAction)
     }

--- a/Sources/Workspace/DefaultPluginScriptRunner.swift
+++ b/Sources/Workspace/DefaultPluginScriptRunner.swift
@@ -442,6 +442,19 @@ public struct PluginCompilationResult {
     public var compiledExecutable: AbsolutePath
 }
 
+extension PluginCompilationResult: CustomStringConvertible {
+    public var description: String {
+        return """
+            <PluginCompilationResult(
+                exitStatus: \(compilerResult.exitStatus),
+                stdout: \((try? compilerResult.utf8Output()) ?? ""),
+                stderr: \((try? compilerResult.utf8stderrOutput()) ?? ""),
+                compiledExecutable: \(compiledExecutable.prettyPath())
+            )>
+            """
+    }
+}
+
 
 /// An error encountered by the default plugin runner.
 public enum DefaultPluginScriptRunnerError: Error {

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -156,6 +156,7 @@ class PluginInvocationTests: XCTestCase {
             outputDir: outputDir,
             builtToolsDir: builtToolsDir,
             buildEnvironment: BuildEnvironment(platform: .macOS, configuration: .debug),
+            toolSearchDirectories: [UserToolchain.default.swiftCompilerPath.parentDirectory],
             pluginScriptRunner: pluginRunner,
             observabilityScope: observability.topScope,
             fileSystem: fileSystem


### PR DESCRIPTION
Add ability to pass down a list of additional search paths to a plugin, and use them when looking up the plugin.  Configure call sites to pass down the toolchain bin directory.

### Motivation:

This implements part of the design of plugins: they have access to binary executables and built executables that they declare dependencies on, plus what is in the toolchain.

### Modifications:

- Add ability to pass down a list of additional search paths to a plugin, and use them when looking up the plugin.
- Configure call sites to pass down the toolchain bin directory.
- Extend a unit test to check that it works.
