### PR TITLE
Thread sanitize package loading tests

### DIFF
--- a/Tests/PackageLoadingTests/PDLoadingTests.swift
+++ b/Tests/PackageLoadingTests/PDLoadingTests.swift
@@ -18,13 +18,13 @@ import XCTest
 
 class PackageDescriptionLoadingTests: XCTestCase, ManifestLoaderDelegate {
     lazy var manifestLoader = ManifestLoader(toolchain: ToolchainConfiguration.default, delegate: self)
-    var parsedManifest : AbsolutePath?
-
+    var parsedManifest = ThreadSafeBox<AbsolutePath>()
+    
     public func willLoad(manifest: AbsolutePath) {
     }
     
     public func willParse(manifest: AbsolutePath) {
-        parsedManifest = manifest
+        parsedManifest.put(manifest)
     }
 
     var toolsVersion: ToolsVersion {

--- a/Tests/PackageLoadingTests/PD_5_6_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_6_LoadingTests.swift
@@ -178,7 +178,7 @@ class PackageDescription5_6LoadingTests: PackageDescriptionLoadingTests {
         let observability = ObservabilitySystem.makeForTesting()
         let manifest = try loadManifest(content, observabilityScope: observability.topScope)
 
-        let name = parsedManifest?.parentDirectory.pathString ?? ""
+        let name = parsedManifest.parentDirectory?.pathString ?? ""
         XCTAssertEqual(manifest.displayName, name)
     }
 
@@ -198,7 +198,7 @@ class PackageDescription5_6LoadingTests: PackageDescriptionLoadingTests {
         let observability = ObservabilitySystem.makeForTesting()
         let manifest = try loadManifest(content, observabilityScope: observability.topScope)
 
-        let name = parsedManifest?.components.last ?? ""
+        let name = parsedManifest.components?.last ?? ""
         let swiftFiles = manifest.displayName.split(separator: ",").map(String.init)
         XCTAssertNotNil(swiftFiles.firstIndex(of: name))
     }


### PR DESCRIPTION
Fix a thread sanitizer warning

### Motivation:

When running thread sanitizer with unit tests, there was a thread writing and another thread reading warning.

### Modifications:

Switch to using ThreadSafeBox<T> to do the reading and writing protected by a lock.

### Result:

Thread sanitizer no longer warns.
