### PR TITLE
[Registry] Update server API spec for the fetch manifest endpoint

### DIFF
--- a/Documentation/Registry.md
+++ b/Documentation/Registry.md
@@ -593,7 +593,7 @@ the name of the manifest file
 It is RECOMMENDED for clients and servers to support
 caching as described by [RFC 7234].
 
-A server SHOULD include a `Link` header field
+A server MUST include a `Link` header field
 with a value for each version-specific package manifest file
 in the release's source archive,
 whose filename matches the following regular expression pattern:


### PR DESCRIPTION
Motivation:
`RegistryClient` relies on the HTTP `Link` header returned by the `/{scope}/{name}/{version}/Package.swift` endpoint to know the existence of alternative manifests.

Modification:
Update registry server API spec to make `Link` required in the response for `/{scope}/{name}/{version}/Package.swift`. For requests that include the `swift-version` query param, the server is not required to set `Link`.
