### PR TITLE
Adjust command plugin implementation to match SE-0332 amendments

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -1019,8 +1019,7 @@ extension SwiftPackageTool {
             let _ = try tsc_await { plugin.invoke(
                 action: .performCommand(
                     targets: Array(targets.values),
-                    arguments: Array(pluginCommand.dropFirst()),
-                    outputPath: outputPath),
+                    arguments: Array(pluginCommand.dropFirst())),
                 package: package,
                 buildEnvironment: buildEnvironment,
                 scriptRunner: pluginScriptRunner,

--- a/Sources/PackageDescription/PackageDescriptionSerialization.swift
+++ b/Sources/PackageDescription/PackageDescriptionSerialization.swift
@@ -256,11 +256,11 @@ extension PluginCommandIntent: Encodable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {
-        case .documentationGeneration:
+        case ._documentationGeneration:
             try container.encode(IntentType.documentationGeneration, forKey: .type)
-        case .sourceCodeFormatting:
+        case ._sourceCodeFormatting:
             try container.encode(IntentType.sourceCodeFormatting, forKey: .type)
-        case .custom(let verb, let description):
+        case ._custom(let verb, let description):
             try container.encode(IntentType.custom, forKey: .type)
             try container.encode(verb, forKey: .verb)
             try container.encode(description, forKey: .description)
@@ -280,7 +280,7 @@ extension PluginPermission: Encodable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {
-        case .writeToPackageDirectory(let reason):
+        case ._writeToPackageDirectory(let reason):
             try container.encode(PermissionType.writeToPackageDirectory, forKey: .type)
             try container.encode(reason, forKey: .reason)
         }

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -1036,30 +1036,46 @@ extension Target.PluginCapability {
 
 @available(_PackageDescription, introduced: 999.0)
 public enum PluginCommandIntent {
+    case _documentationGeneration
+    case _sourceCodeFormatting
+    case _custom(verb: String, description: String)
+}
+
+@available(_PackageDescription, introduced: 999.0)
+public extension PluginCommandIntent {
     /// The intent of the command is to generate documentation, either by parsing the
     /// package contents directly or by using the build system support for generating
     /// symbol graphs. Invoked by a `generate-documentation` verb to `swift package`.
-    case documentationGeneration
+    static func documentationGeneration() -> PluginCommandIntent {
+        return _documentationGeneration
+    }
     
     /// The intent of the command is to modify the source code in the package based
     /// on a set of rules. Invoked by a `format-source-code` verb to `swift package`.
-    case sourceCodeFormatting
-
-    /// Any future enum cases should use @available()
+    static func sourceCodeFormatting() -> PluginCommandIntent {
+        return _sourceCodeFormatting
+    }
 
     /// An intent that doesn't fit into any of the other categories, with a custom
     /// verb through which it can be invoked.
-    case custom(verb: String, description: String)
+    static func custom(verb: String, description: String) -> PluginCommandIntent {
+        return _custom(verb: verb, description: description)
+    }
 }
 
 @available(_PackageDescription, introduced: 999.0)
 public enum PluginPermission {
+    case _writeToPackageDirectory(reason: String)
+}
+
+@available(_PackageDescription, introduced: 999.0)
+public extension PluginPermission {
     /// The command plugin wants permission to modify the files under the package
     /// directory. The `reason` string is shown to the user at the time of request
     /// for approval, explaining why the plugin is requesting this access.
-    case writeToPackageDirectory(reason: String)
-
-    /// Any future enum cases should use @available()
+    static func writeToPackageDirectory(reason: String) -> PluginPermission {
+        return _writeToPackageDirectory(reason: reason)
+    }
 }
 
 extension Target.PluginUsage {

--- a/Sources/PackageModel/ManifestSourceGeneration.swift
+++ b/Sources/PackageModel/ManifestSourceGeneration.swift
@@ -429,9 +429,9 @@ fileprivate extension SourceCodeFragment {
     init(from intent: TargetDescription.PluginCommandIntent) {
         switch intent {
         case .documentationGeneration:
-            self.init(enum: "documentationGeneration")
+            self.init(enum: "documentationGeneration", subnodes: [])
         case .sourceCodeFormatting:
-            self.init(enum: "sourceCodeFormatting")
+            self.init(enum: "sourceCodeFormatting", subnodes: [])
         case .custom(let verb, let description):
             let params = [
                 SourceCodeFragment(key: "verb", string: verb),

--- a/Sources/PackageModel/ManifestSourceGeneration.swift
+++ b/Sources/PackageModel/ManifestSourceGeneration.swift
@@ -437,7 +437,7 @@ fileprivate extension SourceCodeFragment {
                 SourceCodeFragment(key: "verb", string: verb),
                 SourceCodeFragment(key: "description", string: description)
             ]
-            self.init(enum: "writeToPackageDirectory", subnodes: params)
+            self.init(enum: "custom", subnodes: params)
         }
     }
 

--- a/Sources/PackagePlugin/PackageManagerProxy.swift
+++ b/Sources/PackagePlugin/PackageManagerProxy.swift
@@ -76,12 +76,12 @@ public struct PackageManager {
     
     /// Represents an overall purpose of the build, which affects such things
     /// asoptimization and generation of debug symbols.
-    public enum BuildConfiguration: Encodable {
+    public enum BuildConfiguration: String, Encodable {
         case debug, release
     }
     
     /// Represents the amount of detail in a build log.
-    public enum BuildLogVerbosity: Encodable {
+    public enum BuildLogVerbosity: String, Encodable {
         case concise, verbose, debug
     }
     
@@ -108,7 +108,7 @@ public struct PackageManager {
             /// Represents the kind of artifact that was built. The specific file
             /// formats may vary from platform to platform — for example, on macOS
             /// a dynamic library may in fact be built as a framework.
-            public enum Kind: Decodable {
+            public enum Kind: String, Decodable {
                 case executable, dynamicLibrary, staticLibrary
             }
         }
@@ -188,7 +188,7 @@ public struct PackageManager {
                     public var duration: Double
 
                     /// Represents the outcome of running a single test.
-                    public enum Outcome: Decodable {
+                    public enum Outcome: String, Decodable {
                         case succeeded, skipped, failed
                     }
                 }

--- a/Sources/PackagePlugin/PackageManagerProxy.swift
+++ b/Sources/PackagePlugin/PackageManagerProxy.swift
@@ -184,11 +184,11 @@ public struct PackageManager {
                 /// Represents the results of running a single test.
                 public struct Test: Decodable {
                     public var name: String
-                    public var outcome: Outcome
+                    public var result: Result
                     public var duration: Double
 
-                    /// Represents the outcome of running a single test.
-                    public enum Outcome: String, Decodable {
+                    /// Represents the result of running a single test.
+                    public enum Result: String, Decodable {
                         case succeeded, skipped, failed
                     }
                 }

--- a/Sources/PackagePlugin/PackageManagerProxy.swift
+++ b/Sources/PackagePlugin/PackageManagerProxy.swift
@@ -27,7 +27,7 @@ public struct PackageManager {
         _ subset: BuildSubset,
         parameters: BuildParameters
     ) throws -> BuildResult {
-        // Ask the plugin host for symbol graph information for the target, and wait for a response.
+        // Ask the plugin host to build the specified products and targets, and wait for a response.
         // FIXME: We'll want to make this asynchronous when there is back deployment support for it.
         return try sendMessageAndWaitForReply(.buildOperationRequest(subset: subset, parameters: parameters)) {
             guard case .buildOperationResponse(let result) = $0 else { return nil }
@@ -127,7 +127,7 @@ public struct PackageManager {
         _ subset: TestSubset,
         parameters: TestParameters
     ) throws -> TestResult {
-        // Ask the plugin host for symbol graph information for the target, and wait for a response.
+        // Ask the plugin host to run the specified tests, and wait for a response.
         // FIXME: We'll want to make this asynchronous when there is back deployment support for it.
         return try sendMessageAndWaitForReply(.testOperationRequest(subset: subset, parameters: parameters)) {
             guard case .testOperationResponse(let result) = $0 else { return nil }

--- a/Sources/PackagePlugin/Plugin.swift
+++ b/Sources/PackagePlugin/Plugin.swift
@@ -140,9 +140,7 @@ extension Plugin {
                 }
                 
                 // Invoke the plugin to create build commands for the target.
-                let generatedCommands = try plugin.createBuildCommands(
-                    context: context,
-                    target: target)
+                let generatedCommands = try plugin.createBuildCommands(context: context, target: target)
                 
                 // Send each of the generated commands to the host.
                 for command in generatedCommands {
@@ -175,7 +173,7 @@ extension Plugin {
                     }
                 }
                 
-            case .performCommand(let targets, let arguments, let outputPath):
+            case .performCommand(let targets, let arguments):
                 // Check that the plugin implements the appropriate protocol
                 // for its declared capability.
                 guard let plugin = plugin as? CommandPlugin else {
@@ -184,11 +182,7 @@ extension Plugin {
                 }
                 
                 // Invoke the plugin to perform its custom logic.
-                try plugin.performCommand(
-                    context: context,
-                    targets: targets,
-                    arguments: arguments,
-                    outputPath: outputPath)
+                try plugin.performCommand(context: context, targets: targets, arguments: arguments)
             }
             
             // Send back a message to the host indicating that we're done.

--- a/Sources/PackagePlugin/PluginInput.swift
+++ b/Sources/PackagePlugin/PluginInput.swift
@@ -21,7 +21,7 @@ struct PluginInput {
     let pluginAction: PluginAction
     enum PluginAction {
         case createBuildToolCommands(target: Target)
-        case performCommand(targets: [Target], arguments: [String], outputPath: Path?)
+        case performCommand(targets: [Target], arguments: [String])
     }
     
     internal init(from input: WireInput) throws {
@@ -38,12 +38,9 @@ struct PluginInput {
         // Unpack the plugin action, which will determine which plugin functionality to invoke.
         switch input.pluginAction {
         case .createBuildToolCommands(let targetId):
-            let target = try deserializer.target(for: targetId)
-            self.pluginAction = .createBuildToolCommands(target: target)
-        case .performCommand(let targetIds, let arguments, let outputPathId):
-            let targets = try targetIds.map{ try deserializer.target(for: $0) }
-            let outputPath = try outputPathId.map{ try deserializer.path(for: $0) }
-            self.pluginAction = .performCommand(targets: targets, arguments: arguments, outputPath: outputPath)
+            self.pluginAction = .createBuildToolCommands(target: try deserializer.target(for: targetId))
+        case .performCommand(let targetIds, let arguments):
+            self.pluginAction = .performCommand(targets: try targetIds.map{ try deserializer.target(for: $0) }, arguments: arguments)
         }
     }
 }
@@ -301,7 +298,7 @@ internal struct WireInput: Decodable {
     /// the capabilities declared for the plugin.
     enum PluginAction: Decodable {
         case createBuildToolCommands(targetId: Target.Id)
-        case performCommand(targetIds: [Target.Id], arguments: [String], outputPathId: Path.Id?)
+        case performCommand(targetIds: [Target.Id], arguments: [String])
     }
 
     /// A single absolute path in the wire structure, represented as a tuple

--- a/Sources/PackagePlugin/Protocols.swift
+++ b/Sources/PackagePlugin/Protocols.swift
@@ -99,49 +99,13 @@ public protocol CommandPlugin: Plugin {
         arguments: [String]
     ) throws
 
-    /// Invoked by SwiftPM to perform the custom actions of the command.
-    func performCommand(
-        /// The context in which the plugin is invoked. This is the same for all
-        /// kinds of plugins, and provides access to the package graph, to cache
-        /// directories, etc.
-        context: PluginContext,
-
-        /// The targets to which the command should be applied. If the invoker of
-        /// the command has not specified particular targets, this will be a list
-        /// of all the targets in the package to which the command is applied.
-        targets: [Target],
-
-        /// Any literal arguments passed after the verb in the command invocation.
-        arguments: [String],
-
-        /// Optional output path to which the command is allowed to write.
-        outputPath: Path?
-    ) throws
-
     /// A proxy to the Swift Package Manager or IDE hosting the command plugin,
     /// through which the plugin can ask for specialized information or actions.
     var packageManager: PackageManager { get }
 }
 
 extension CommandPlugin {
-
-    public func performCommand(
-        context: PluginContext,
-        targets: [Target],
-        arguments: [String]
-    ) throws {
-        try self.performCommand(context: context, targets: targets, arguments: arguments, outputPath: .none)
-    }
-
-    public func performCommand(
-        context: PluginContext,
-        targets: [Target],
-        arguments: [String],
-        outputPath: Path?
-    ) throws {
-        try self.performCommand(context: context, targets: targets, arguments: arguments)
-    }
-
+    
     /// A proxy to the Swift Package Manager or IDE hosting the command plugin,
     /// through which the plugin can ask for specialized information or actions.
     public var packageManager: PackageManager {

--- a/Sources/SPMBuildCore/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/PluginInvocation.swift
@@ -503,14 +503,14 @@ public struct PluginInvocationTestResult: Encodable {
             public var tests: [Test]
             public struct Test: Encodable {
                 public var name: String
-                public var outcome: Outcome
+                public var result: Result
                 public var duration: Double
-                public enum Outcome: String, Encodable {
+                public enum Result: String, Encodable {
                     case succeeded, skipped, failed
                 }
-                public init(name: String, outcome: Outcome, duration: Double) {
+                public init(name: String, result: Result, duration: Double) {
                     self.name = name
-                    self.outcome = outcome
+                    self.result = result
                     self.duration = duration
                 }
             }

--- a/Sources/SPMBuildCore/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/PluginInvocation.swift
@@ -446,11 +446,11 @@ public enum PluginInvocationBuildSubset: Decodable {
 
 public struct PluginInvocationBuildParameters: Decodable {
     public var configuration: Configuration
-    public enum Configuration: Decodable {
+    public enum Configuration: String, Decodable {
         case debug, release
     }
     public var logging: LogVerbosity
-    public enum LogVerbosity: Decodable {
+    public enum LogVerbosity: String, Decodable {
         case concise, verbose, debug
     }
     public var otherCFlags: [String]
@@ -503,16 +503,14 @@ public struct PluginInvocationTestResult: Encodable {
             public var tests: [Test]
             public struct Test: Encodable {
                 public var name: String
-                public var output: String
-                public var status: Status
+                public var outcome: Outcome
                 public var duration: Double
-                public enum Status: String, CaseIterable, Encodable {
+                public enum Outcome: String, Encodable {
                     case succeeded, skipped, failed
                 }
-                public init(name: String, output: String, status: Status, duration: Double) {
+                public init(name: String, outcome: Outcome, duration: Double) {
                     self.name = name
-                    self.output = output
-                    self.status = status
+                    self.outcome = outcome
                     self.duration = duration
                 }
             }

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -1249,8 +1249,7 @@ final class PackageToolTests: CommandsTestCase {
                     func performCommand(
                         context: PluginContext,
                         targets: [Target],
-                        arguments: [String],
-                        outputPath: Path?
+                        arguments: [String]
                     ) throws {
                         print("This is MyCommandPlugin.")
 
@@ -1273,11 +1272,6 @@ final class PackageToolTests: CommandsTestCase {
                         print("Looking for swiftc...")
                         let swiftc = try context.tool(named: "swiftc")
                         print("... found it at \\(swiftc.path)")
-
-                        // Check the output path.
-                        if let outputPath = outputPath {
-                            print("Got output path \\(outputPath.string).")
-                        }
                     }
                 }
                 """
@@ -1324,21 +1318,14 @@ final class PackageToolTests: CommandsTestCase {
 
             // Invoke it, and check the results.
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(
-                    ["plugin", "--output", "/abc/def", "mycmd"],
-                    packagePath: packageDir,
-                    env: ["SWIFTPM_ENABLE_COMMAND_PLUGINS": "1"])
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["plugin", "mycmd"], packagePath: packageDir, env: ["SWIFTPM_ENABLE_COMMAND_PLUGINS": "1"])
                 XCTAssertEqual(result.exitStatus, .terminated(code: 0))
                 XCTAssert(try result.utf8Output().contains("This is MyCommandPlugin."))
-                XCTAssert(try result.utf8Output().contains("Got output path /abc/def."))
             }
 
             // Testing listing the available command plugins.
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(
-                    ["plugin", "--list"],
-                    packagePath: packageDir,
-                    env: ["SWIFTPM_ENABLE_COMMAND_PLUGINS": "1"])
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["plugin", "--list"], packagePath: packageDir, env: ["SWIFTPM_ENABLE_COMMAND_PLUGINS": "1"])
                 XCTAssertEqual(result.exitStatus, .terminated(code: 0))
                 XCTAssert(try result.utf8Output().contains("‘mycmd’ (plugin ‘MyPlugin’ in package ‘MyPackage’)"))
             }

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -231,8 +231,7 @@ class PluginTests: XCTestCase {
                         func performCommand(
                             context: PluginContext,
                             targets: [Target],
-                            arguments: [String],
-                            outputPath: Path?
+                            arguments: [String]
                         ) throws {
                             // Check the identity of the root packages.
                             print("Root package is \\(context.package.displayName).")
@@ -240,12 +239,7 @@ class PluginTests: XCTestCase {
                             // Check that we can find a tool in the toolchain.
                             let swiftc = try context.tool(named: "swiftc")
                             print("Found the swiftc tool at \\(swiftc.path).")
-
-                            // Check the output path.
-                            if let outputPath = outputPath {
-                                print("Got output path \\(outputPath.string).")
-                            }
-                       }
+                        }
                     }
                 """
             }
@@ -343,12 +337,10 @@ class PluginTests: XCTestCase {
             let pluginOutputDir = tmpPath.appending(component: "plugin-output")
             let pluginScriptRunner = DefaultPluginScriptRunner(cacheDir: pluginCacheDir, toolchain: ToolchainConfiguration.default)
             let target = try XCTUnwrap(package.targets.first{ $0.underlyingTarget == libraryTarget })
-            let outputPath = tmpPath.appending(component: UUID().uuidString)
             let invocationSucceeded = try tsc_await { pluginTarget.invoke(
                 action: .performCommand(
-                    targets: [target],
-                    arguments: ["veni", "vidi", "vici"],
-                    outputPath: outputPath),
+                    targets: [ target ],
+                    arguments: ["veni", "vidi", "vici"]),
                 package: package,
                 buildEnvironment: BuildEnvironment(platform: .macOS, configuration: .debug),
                 scriptRunner: pluginScriptRunner,
@@ -366,7 +358,6 @@ class PluginTests: XCTestCase {
             let outputText = String(decoding: pluginDelegate.outputData, as: UTF8.self)
             XCTAssertTrue(outputText.contains("Root package is MyPackage."), outputText)
             XCTAssertTrue(outputText.contains("Found the swiftc tool"), outputText)
-            XCTAssertTrue(outputText.contains("Got output path \(outputPath.pathString)"), outputText)
         }
     }
 }


### PR DESCRIPTION
This adjusts the implementation to match https://github.com/apple/swift-evolution/pull/1496

Specifically:
- removes the `outputPath` parameter to the plugin again
- renamed `outcome` property to `result` in the tests
- change the `PluginCommandIntent` and `PluginPermission` enums into opaque structs, with static constructor functions for the enum cases