### PR TITLE
Don't use scoped imports when building with library evolution enabled

### DIFF
--- a/Sources/PackageLoading/ContextModel.swift
+++ b/Sources/PackageLoading/ContextModel.swift
@@ -8,9 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import class Foundation.JSONDecoder
-import class Foundation.JSONEncoder
-import class Foundation.ProcessInfo
+import Foundation
 
 struct ContextModel {
     let packageDirectory : String


### PR DESCRIPTION
Fixes a compiler warning.

### Motivation:

Nobody likes warnings.

### Modifications:

Just use `import Foundation`

### Result:

Warnings are gone.