### PR TITLE
Mirrors config migration should not modify user's file

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -525,8 +525,11 @@ public class SwiftTool {
         let legacyPath = try self.getPackageRoot().appending(components: ".swiftpm", "config")
         let newPath = try Workspace.DefaultLocations.mirrorsConfigurationFile(forRootPackage: self.getPackageRoot())
         if localFileSystem.exists(legacyPath) {
-            try localFileSystem.createDirectory(newPath.parentDirectory, recursive: true)
-            try localFileSystem.move(from: legacyPath, to: newPath)
+            observabilityScope.emit(warning: "Usage of \(legacyPath) has been deprecated. Please delete it and use the new \(newPath) instead.")
+            if !localFileSystem.exists(newPath) {
+                try localFileSystem.createDirectory(newPath.parentDirectory, recursive: true)
+                try localFileSystem.copy(from: legacyPath, to: newPath)
+            }
         }
         return newPath
     }


### PR DESCRIPTION
Motivation:
The migration from `.swiftpm/config` to `.swiftpm/configuration/mirrors.json` moves `.swiftpm/config` and leads user to think that the file gets deleted. (rdar://85917746)

Modifications:
- Copy `.swiftpm/config` to `.swiftpm/configuration/mirrors.json` instead of moving it.
- Emit warning that `.swiftpm/config` has been deprecated.
- Don't perform the migration if `.swiftpm/configuration/mirrors.json` already exists to prevent error. (rdar://85917836)
