### PR TITLE
clear warnings

### DIFF
--- a/Sources/Basics/Observability.swift
+++ b/Sources/Basics/Observability.swift
@@ -270,10 +270,6 @@ public struct Diagnostic: CustomStringConvertible {
         if metadata.underlyingError == nil {
             metadata.underlyingError = .init(error)
         }
-        // FIXME: this brings in the TSC API still
-        if let errorProvidingLocation = error as? DiagnosticLocationProviding, let diagnosticLocation = errorProvidingLocation.diagnosticLocation {
-            metadata.legacyDiagnosticLocation = .init(diagnosticLocation)
-        }
 
         let message: String
         // FIXME: this brings in the TSC API still

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -233,7 +233,7 @@ public struct SwiftTestTool: SwiftCommand {
                 throw StringError("invalid manifests at \(root.packages)")
             }
             let buildParameters = try swiftTool.buildParametersForTest()
-            print(codeCovAsJSONPath(buildParameters: buildParameters, packageName: rootManifest.name))
+            print(codeCovAsJSONPath(buildParameters: buildParameters, packageName: rootManifest.displayName))
 
         case .generateLinuxMain:
             // this functionality is deprecated as of 12/2020

--- a/Sources/PackageCollectionsSigning/Certificate/CertificatePolicy.swift
+++ b/Sources/PackageCollectionsSigning/Certificate/CertificatePolicy.swift
@@ -73,7 +73,7 @@ extension CertificatePolicy {
         let revocationPolicy = SecPolicyCreateRevocation(kSecRevocationOCSPMethod)
 
         var secTrust: SecTrust?
-        guard SecTrustCreateWithCertificates(certChain.map { $0.underlying } as CFArray,
+        guard SecTrustCreateWithCertificates(certChain.map({ $0.underlying }) as CFArray,
                                              [policy, revocationPolicy] as CFArray,
                                              &secTrust) == errSecSuccess,
             let trust = secTrust else {

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -2398,7 +2398,7 @@ extension Term: ExpressibleByStringLiteral {
         guard case let .versionSet(vs) = requirement! else {
             fatalError()
         }
-        self.init(node: .product(packageReference.name, package: packageReference),
+        self.init(node: .product(packageReference.identity.description, package: packageReference),
                   requirement: vs,
                   isPositive: isPositive)
     }


### PR DESCRIPTION
motivation: less warnings, happier developers

changes:
* update use of deprecated package and manifest name attributes
* remove setting of legacyLocation diagnostic metadata which is no longer in use

