### PR TITLE
move PkgConfig frmo TSC into SwiftPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -457,7 +457,7 @@ let package = Package(
         .testTarget(
             name: "PackageLoadingTests",
             dependencies: ["PackageLoading", "SPMTestSupport"],
-            exclude: ["Inputs"]
+            exclude: ["Inputs", "pkgconfigInputs"]
         ),
         .testTarget(
             name: "PackageLoadingPerformanceTests",

--- a/Sources/PackageLoading/CMakeLists.txt
+++ b/Sources/PackageLoading/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(PackageLoading
   PackageBuilder.swift
   ManifestJSONParser.swift
   PlatformRegistry.swift
+  PkgConfig.swift
   Target+PkgConfig.swift
   TargetSourcesBuilder.swift
   ToolsVersionLoader.swift)

--- a/Sources/PackageLoading/PkgConfig.swift
+++ b/Sources/PackageLoading/PkgConfig.swift
@@ -1,0 +1,446 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Basics
+import Foundation
+import TSCBasic
+
+/// Information on an individual `pkg-config` supported package.
+public struct PkgConfig {
+    /// The name of the package.
+    public let name: String
+
+    /// The path to the definition file.
+    public let pcFile: AbsolutePath
+
+    /// The list of C compiler flags in the definition.
+    public let cFlags: [String]
+
+    /// The list of libraries to link.
+    public let libs: [String]
+
+    /// Load the information for the named package.
+    ///
+    /// It will search `fileSystem` for the pkg config file in the following order:
+    /// * Paths defined in `PKG_CONFIG_PATH` environment variable
+    /// * Paths defined in `additionalSearchPaths` argument
+    /// * Built-in search paths (see `PCFileFinder.searchPaths`)
+    ///
+    /// - parameter name: Name of the pkg config file (without file extension).
+    /// - parameter additionalSearchPaths: Additional paths to search for pkg config file.
+    /// - parameter fileSystem: The file system to use
+    ///
+    /// - throws: PkgConfigError
+    public init(
+        name: String,
+        additionalSearchPaths: [AbsolutePath]? = .none,
+        brewPrefix: AbsolutePath? = .none,
+        fileSystem: FileSystem,
+        observabilityScope: ObservabilityScope
+    ) throws {
+        try self.init(
+            name: name,
+            additionalSearchPaths: additionalSearchPaths ?? [],
+            brewPrefix: brewPrefix,
+            loadingContext: LoadingContext(),
+            fileSystem: fileSystem,
+            observabilityScope: observabilityScope
+        )
+    }
+
+    private init(
+        name: String,
+        additionalSearchPaths: [AbsolutePath],
+        brewPrefix: AbsolutePath?,
+        loadingContext: LoadingContext,
+        fileSystem: FileSystem,
+        observabilityScope: ObservabilityScope
+    ) throws {
+        loadingContext.pkgConfigStack.append(name)
+
+        if let path = try? AbsolutePath(validating: name) {
+            guard fileSystem.isFile(path) else { throw PkgConfigError.couldNotFindConfigFile(name: name) }
+            self.name = path.basenameWithoutExt
+            self.pcFile = path
+        } else {
+            self.name = name
+            let pkgFileFinder = PCFileFinder(brewPrefix: brewPrefix)
+            self.pcFile = try pkgFileFinder.locatePCFile(
+                name: name,
+                customSearchPaths: PkgConfig.envSearchPaths + additionalSearchPaths,
+                fileSystem: fileSystem,
+                observabilityScope: observabilityScope
+            )
+        }
+
+        var parser = PkgConfigParser(pcFile: pcFile, fileSystem: fileSystem)
+        try parser.parse()
+
+        func getFlags(from dependencies: [String]) throws -> (cFlags: [String], libs: [String]) {
+            var cFlags = [String]()
+            var libs = [String]()
+
+            for dep in dependencies {
+                if let index = loadingContext.pkgConfigStack.firstIndex(of: dep) {
+                    observabilityScope.emit(warning: "circular dependency detected while parsing \(loadingContext.pkgConfigStack[0]): \(loadingContext.pkgConfigStack[index..<loadingContext.pkgConfigStack.count].joined(separator: " -> ")) -> \(dep)")
+                    continue
+                }
+
+                // FIXME: This is wasteful, we should be caching the PkgConfig result.
+                let pkg = try PkgConfig(
+                    name: dep,
+                    additionalSearchPaths: additionalSearchPaths,
+                    brewPrefix: brewPrefix,
+                    loadingContext: loadingContext,
+                    fileSystem: fileSystem,
+                    observabilityScope: observabilityScope
+                )
+
+                cFlags += pkg.cFlags
+                libs += pkg.libs
+            }
+
+            return (cFlags: cFlags, libs: libs)
+        }
+
+        let dependencyFlags = try getFlags(from: parser.dependencies)
+        let privateDependencyFlags = try getFlags(from: parser.privateDependencies)
+
+        self.cFlags = parser.cFlags + dependencyFlags.cFlags + privateDependencyFlags.cFlags
+        self.libs = parser.libs + dependencyFlags.libs
+
+        loadingContext.pkgConfigStack.removeLast();
+    }
+
+    private static var envSearchPaths: [AbsolutePath] {
+        if let configPath = ProcessEnv.vars["PKG_CONFIG_PATH"] {
+            return configPath.split(separator: ":").map({ AbsolutePath(String($0)) })
+        }
+        return []
+    }
+}
+
+extension PkgConfig {
+    /// Informations to track circular dependencies and other PkgConfig issues
+    public class LoadingContext {
+        public init() {
+            pkgConfigStack = [String]()
+        }
+
+        public var pkgConfigStack: [String]
+    }
+}
+
+
+/// Parser for the `pkg-config` `.pc` file format.
+///
+/// See: https://www.freedesktop.org/wiki/Software/pkg-config/
+// This is only internal so it can be unit tested.
+internal struct PkgConfigParser {
+    public let pcFile: AbsolutePath
+    private let fileSystem: FileSystem
+    public private(set) var variables = [String: String]()
+    public private(set) var dependencies = [String]()
+    public private(set) var privateDependencies = [String]()
+    public private(set) var cFlags = [String]()
+    public private(set) var libs = [String]()
+
+    public init(pcFile: AbsolutePath, fileSystem: FileSystem) {
+        precondition(fileSystem.isFile(pcFile))
+        self.pcFile = pcFile
+        self.fileSystem = fileSystem
+    }
+
+    public mutating func parse() throws {
+        func removeComment(line: String) -> String {
+            if let commentIndex = line.firstIndex(of: "#") {
+                return String(line[line.startIndex..<commentIndex])
+            }
+            return line
+        }
+
+        // Add pcfiledir variable. This is the path of the directory containing this pc file.
+        variables["pcfiledir"] = pcFile.parentDirectory.pathString
+
+        // Add pc_sysrootdir variable. This is the path of the sysroot directory for pc files.
+        variables["pc_sysrootdir"] = ProcessEnv.vars["PKG_CONFIG_SYSROOT_DIR"] ?? "/"
+
+        let fileContents = try fileSystem.readFileContents(pcFile)
+        // FIXME: Should we error out instead if content is not UTF8 representable?
+        for line in fileContents.validDescription?.components(separatedBy: "\n") ?? [] {
+            // Remove commented or any trailing comment from the line.
+            let uncommentedLine = removeComment(line: line)
+            // Ignore any empty or whitespace line.
+            guard let line = uncommentedLine.spm_chuzzle() else { continue }
+
+            if line.contains(":") {
+                // Found a key-value pair.
+                try parseKeyValue(line: line)
+            } else if line.contains("=") {
+                // Found a variable.
+                let (name, maybeValue) = line.spm_split(around: "=")
+                let value = maybeValue?.spm_chuzzle() ?? ""
+                variables[name.spm_chuzzle() ?? ""] = try resolveVariables(value)
+            } else {
+                // Unexpected thing in the pc file, abort.
+                throw PkgConfigError.parsingError("Unexpected line: \(line) in \(pcFile)")
+            }
+        }
+    }
+
+    private mutating func parseKeyValue(line: String) throws {
+        precondition(line.contains(":"))
+        let (key, maybeValue) = line.spm_split(around: ":")
+        let value = try resolveVariables(maybeValue?.spm_chuzzle() ?? "")
+        switch key {
+        case "Requires":
+            dependencies = try parseDependencies(value)
+        case "Requires.private":
+            privateDependencies = try parseDependencies(value)
+        case "Libs":
+            libs = try splitEscapingSpace(value)
+        case "Cflags":
+            cFlags = try splitEscapingSpace(value)
+        default:
+            break
+        }
+    }
+
+    /// Parses `Requires: ` string into array of dependencies.
+    ///
+    /// The dependency string has seperator which can be (multiple) space or a
+    /// comma.  Additionally each there can be an optional version constaint to
+    /// a dependency.
+    private func parseDependencies(_ depString: String) throws -> [String] {
+        let operators = ["=", "<", ">", "<=", ">="]
+        let separators = [" ", ","]
+
+        // Look at a char at an index if present.
+        func peek(idx: Int) -> Character? {
+            guard idx <= depString.count - 1 else { return nil }
+            return depString[depString.index(depString.startIndex, offsetBy: idx)]
+        }
+
+        // This converts the string which can be separated by comma or spaces
+        // into an array of string.
+        func tokenize() -> [String] {
+            var tokens = [String]()
+            var token = ""
+            for (idx, char) in depString.enumerated() {
+                // Encountered a seperator, use the token.
+                if separators.contains(String(char)) {
+                    // If next character is a space skip.
+                    if let peeked = peek(idx: idx+1), peeked == " " { continue }
+                    // Append to array of tokens and reset token variable.
+                    tokens.append(token)
+                    token = ""
+                } else {
+                    token += String(char)
+                }
+            }
+            // Append the last collected token if present.
+            if !token.isEmpty { tokens += [token] }
+            return tokens
+        }
+
+        var deps = [String]()
+        var it = tokenize().makeIterator()
+        while let arg = it.next() {
+            // If we encounter an operator then we need to skip the next token.
+            if operators.contains(arg) {
+                // We should have a version number next, skip.
+                guard it.next() != nil else {
+                    throw PkgConfigError.parsingError("""
+                        Expected version number after \(deps.last.debugDescription) \(arg) in \"\(depString)\" in \
+                        \(pcFile)
+                        """)
+                }
+            } else {
+                // Otherwise it is a dependency.
+                deps.append(arg)
+            }
+        }
+        return deps
+    }
+
+    /// Perform variable expansion on the line by processing the each fragment
+    /// of the string until complete.
+    ///
+    /// Variables occur in form of ${variableName}, we search for a variable
+    /// linearly in the string and if found, lookup the value of the variable in
+    /// our dictionary and replace the variable name with its value.
+    private func resolveVariables(_ line: String) throws -> String {
+        // Returns variable name, start index and end index of a variable in a string if present.
+        // We make sure it of form ${name} otherwise it is not a variable.
+        func findVariable(_ fragment: String)
+            -> (name: String, startIndex: String.Index, endIndex: String.Index)? {
+            guard let dollar = fragment.firstIndex(of: "$"),
+                  dollar != fragment.endIndex && fragment[fragment.index(after: dollar)] == "{",
+                  let variableEndIndex = fragment.firstIndex(of: "}")
+            else { return nil }
+            return (String(fragment[fragment.index(dollar, offsetBy: 2)..<variableEndIndex]), dollar, variableEndIndex)
+        }
+
+        var result = ""
+        var fragment = line
+        while !fragment.isEmpty {
+            // Look for a variable in our current fragment.
+            if let variable = findVariable(fragment) {
+                // Append the contents before the variable.
+                result += fragment[fragment.startIndex..<variable.startIndex]
+                guard let variableValue = variables[variable.name] else {
+                    throw PkgConfigError.parsingError(
+                        "Expected a value for variable '\(variable.name)' in \(pcFile). Variables: \(variables)")
+                }
+                // Append the value of the variable.
+                result += variableValue
+                // Update the fragment with post variable string.
+                fragment = String(fragment[fragment.index(after: variable.endIndex)...])
+            } else {
+                // No variable found, just append rest of the fragment to result.
+                result += fragment
+                fragment = ""
+            }
+        }
+        return String(result)
+    }
+
+    /// Split line on unescaped spaces.
+    ///
+    /// Will break on space in "abc def" and "abc\\ def" but not in "abc\ def"
+    /// and ignore multiple spaces such that "abc def" will split into ["abc",
+    /// "def"].
+    private func splitEscapingSpace(_ line: String) throws -> [String] {
+        var splits = [String]()
+        var fragment = [Character]()
+
+        func saveFragment() {
+            if !fragment.isEmpty {
+                splits.append(String(fragment))
+                fragment.removeAll()
+            }
+        }
+
+        var it = line.makeIterator()
+        // Indicates if we're in a quoted fragment, we shouldn't append quote.
+        var inQuotes = false
+        while let char = it.next() {
+            if char == "\"" {
+                inQuotes = !inQuotes
+            } else if char == "\\" {
+                if let next = it.next() {
+                    fragment.append(next)
+                }
+            } else if char == " " && !inQuotes {
+                saveFragment()
+            } else {
+                fragment.append(char)
+            }
+        }
+        guard !inQuotes else {
+            throw PkgConfigError.parsingError(
+                "Text ended before matching quote was found in line: \(line) file: \(pcFile)")
+        }
+        saveFragment()
+        return splits
+    }
+}
+
+// This is only internal so it can be unit tested.
+internal struct PCFileFinder {
+    /// Cached results of locations `pkg-config` will search for `.pc` files
+    /// FIXME: This shouldn't use a static variable, since the first lookup
+    /// will cache the result of whatever `brewPrefix` was passed in.  It is
+    /// also not threadsafe.
+    public private(set) static var pkgConfigPaths: [AbsolutePath]? // FIXME: @testable(internal)
+    private static var shouldEmitPkgConfigPathsDiagnostic = false
+
+    /// The built-in search path list.
+    ///
+    /// By default, this is combined with the search paths inferred from
+    /// `pkg-config` itself.
+    static let searchPaths = [
+        AbsolutePath("/usr/local/lib/pkgconfig"),
+        AbsolutePath("/usr/local/share/pkgconfig"),
+        AbsolutePath("/usr/lib/pkgconfig"),
+        AbsolutePath("/usr/share/pkgconfig"),
+    ]
+
+    /// Get search paths from `pkg-config` itself to locate `.pc` files.
+    ///
+    /// This is needed because on Linux machines, the search paths can be different
+    /// from the standard locations that we are currently searching.
+    public init(brewPrefix: AbsolutePath? = .none) {
+        //self.diagnostics = diagnostics
+        if PCFileFinder.pkgConfigPaths == nil {
+            do {
+                let pkgConfigPath: String
+                if let brewPrefix = brewPrefix {
+                    pkgConfigPath = brewPrefix.appending(components: "bin", "pkg-config").pathString
+                } else {
+                    pkgConfigPath = "pkg-config"
+                }
+                let searchPaths = try Process.checkNonZeroExit(
+                args: pkgConfigPath, "--variable", "pc_path", "pkg-config").spm_chomp()
+                PCFileFinder.pkgConfigPaths = searchPaths.split(separator: ":").map({ AbsolutePath(String($0)) })
+            } catch {
+                PCFileFinder.shouldEmitPkgConfigPathsDiagnostic = true
+                PCFileFinder.pkgConfigPaths = []
+            }
+        }
+    }
+
+    /// Reset the cached `pkgConfigPaths` property, so that it will be evaluated
+    /// again when instantiating a `PCFileFinder()`.  This is intended only for
+    /// use by testing.  This is a temporary workaround for the use of a static
+    /// variable by this class.
+    internal static func resetCachedPkgConfigPaths() {
+        PCFileFinder.pkgConfigPaths = nil
+    }
+
+    public func locatePCFile(
+        name: String,
+        customSearchPaths: [AbsolutePath],
+        fileSystem: FileSystem,
+        observabilityScope: ObservabilityScope
+    ) throws -> AbsolutePath {
+        // FIXME: We should consider building a registry for all items in the
+        // search paths, which is likely to be substantially more efficient if
+        // we end up searching for a reasonably sized number of packages.
+        for path in OrderedSet(customSearchPaths + PCFileFinder.pkgConfigPaths! + PCFileFinder.searchPaths) {
+            let pcFile = path.appending(component: name + ".pc")
+            if fileSystem.isFile(pcFile) {
+                return pcFile
+            }
+        }
+        if PCFileFinder.shouldEmitPkgConfigPathsDiagnostic {
+            PCFileFinder.shouldEmitPkgConfigPathsDiagnostic = false
+            observabilityScope.emit(warning: "failed to retrieve search paths with pkg-config; maybe pkg-config is not installed")
+        }
+        throw PkgConfigError.couldNotFindConfigFile(name: name)
+    }
+}
+
+internal enum PkgConfigError: Swift.Error, CustomStringConvertible {
+    case couldNotFindConfigFile(name: String)
+    case parsingError(String)
+    case prohibitedFlags(String)
+
+    public var description: String {
+        switch self {
+        case .couldNotFindConfigFile(let name):
+            return "couldn't find pc file for \(name)"
+        case .parsingError(let error):
+            return "parsing error(s): \(error)"
+        case .prohibitedFlags(let flags):
+            return "prohibited flag(s): \(flags)"
+        }
+    }
+}

--- a/Sources/PackageLoading/Target+PkgConfig.swift
+++ b/Sources/PackageLoading/Target+PkgConfig.swift
@@ -11,7 +11,7 @@
 import Basics
 import PackageModel
 import TSCBasic
-import TSCUtility
+import enum TSCUtility.Platform
 
 /// Wrapper struct containing result of a pkgConfig query.
 public struct PkgConfigResult {
@@ -72,9 +72,9 @@ public func pkgConfigArgs(for target: SystemLibraryTarget, brewPrefix: AbsoluteP
             let pkgConfig = try PkgConfig(
                 name: pkgConfigName,
                 additionalSearchPaths: additionalSearchPaths,
-                diagnostics: observabilityScope.makeDiagnosticsEngine(),
+                brewPrefix: brewPrefix,
                 fileSystem: fileSystem,
-                brewPrefix: brewPrefix
+                observabilityScope: observabilityScope
             )
 
             // Run the allow list checker.

--- a/Tests/PackageLoadingTests/PkgConfigParserTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigParserTests.swift
@@ -1,0 +1,216 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Basics
+@testable import PackageLoading
+import TSCBasic
+import SPMTestSupport
+import XCTest
+
+final class PkgConfigParserTests: XCTestCase {
+    func testCircularPCFile() throws {
+        let observability = ObservabilitySystem.makeForTesting()
+
+        _ = try PkgConfig(
+            name: "harfbuzz",
+            additionalSearchPaths: [AbsolutePath(#file).parentDirectory.appending(components: "pkgconfigInputs")],
+            fileSystem: localFileSystem,
+            observabilityScope: observability.topScope
+        )
+
+        testDiagnostics(observability.diagnostics) { result in
+            result.check(diagnostic: .equal("circular dependency detected while parsing harfbuzz: harfbuzz -> freetype2 -> harfbuzz"), severity: .warning)
+        }
+    }
+
+    func testGTK3PCFile() {
+        try! loadPCFile("gtk+-3.0.pc") { parser in
+            XCTAssertEqual(parser.variables, [
+                "libdir": "/usr/local/Cellar/gtk+3/3.18.9/lib",
+                "gtk_host": "x86_64-apple-darwin15.3.0",
+                "includedir": "/usr/local/Cellar/gtk+3/3.18.9/include",
+                "prefix": "/usr/local/Cellar/gtk+3/3.18.9",
+                "gtk_binary_version": "3.0.0",
+                "exec_prefix": "/usr/local/Cellar/gtk+3/3.18.9",
+                "targets": "quartz",
+                "pcfiledir": parser.pcFile.parentDirectory.pathString,
+                "pc_sysrootdir": "/"
+            ])
+            XCTAssertEqual(parser.dependencies, ["gdk-3.0", "atk", "cairo", "cairo-gobject", "gdk-pixbuf-2.0", "gio-2.0"])
+            XCTAssertEqual(parser.privateDependencies, ["atk", "epoxy", "gio-unix-2.0"])
+            XCTAssertEqual(parser.cFlags, ["-I/usr/local/Cellar/gtk+3/3.18.9/include/gtk-3.0"])
+            XCTAssertEqual(parser.libs, ["-L/usr/local/Cellar/gtk+3/3.18.9/lib", "-lgtk-3"])
+        }
+    }
+
+    func testEmptyCFlags() {
+        try! loadPCFile("empty_cflags.pc") { parser in
+            XCTAssertEqual(parser.variables, [
+                "prefix": "/usr/local/bin",
+                "exec_prefix": "/usr/local/bin",
+                "pcfiledir": parser.pcFile.parentDirectory.pathString,
+                "pc_sysrootdir": "/"
+            ])
+            XCTAssertEqual(parser.dependencies, ["gdk-3.0", "atk"])
+            XCTAssertEqual(parser.cFlags, [])
+            XCTAssertEqual(parser.libs, ["-L/usr/local/bin", "-lgtk-3"])
+        }
+    }
+
+    func testVariableinDependency() {
+        try! loadPCFile("deps_variable.pc") { parser in
+            XCTAssertEqual(parser.variables, [
+                "prefix": "/usr/local/bin",
+                "exec_prefix": "/usr/local/bin",
+                "my_dep": "atk",
+                "pcfiledir": parser.pcFile.parentDirectory.pathString,
+                "pc_sysrootdir": "/"
+            ])
+            XCTAssertEqual(parser.dependencies, ["gdk-3.0", "atk"])
+            XCTAssertEqual(parser.cFlags, ["-I"])
+            XCTAssertEqual(parser.libs, ["-L/usr/local/bin", "-lgtk-3"])
+        }
+    }
+
+    func testUnresolvablePCFile() throws {
+        do {
+            try loadPCFile("failure_case.pc")
+            XCTFail("Unexpected success")
+        } catch PkgConfigError.parsingError(let desc) {
+            XCTAssert(desc.hasPrefix("Expected a value for variable"))
+        }
+    }
+
+    func testEscapedSpaces() {
+        try! loadPCFile("escaped_spaces.pc") { parser in
+            XCTAssertEqual(parser.variables, [
+                "prefix": "/usr/local/bin",
+                "exec_prefix": "/usr/local/bin",
+                "my_dep": "atk",
+                "pcfiledir": parser.pcFile.parentDirectory.pathString,
+                "pc_sysrootdir": "/"
+            ])
+            XCTAssertEqual(parser.dependencies, ["gdk-3.0", "atk"])
+            XCTAssertEqual(parser.cFlags, ["-I/usr/local/Wine Cellar/gtk+3/3.18.9/include/gtk-3.0", "-I/after/extra/spaces"])
+            XCTAssertEqual(parser.libs, ["-L/usr/local/bin", "-lgtk 3", "-wantareal\\here", "-one\\", "-two"])
+        }
+    }
+
+    /// Test custom search path get higher priority for locating pc files.
+    func testCustomPcFileSearchPath() throws {
+        let observability = ObservabilitySystem.makeForTesting()
+
+        /// Temporary workaround for PCFileFinder's use of static variables.
+        PCFileFinder.resetCachedPkgConfigPaths()
+
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/usr/lib/pkgconfig/foo.pc",
+            "/usr/local/opt/foo/lib/pkgconfig/foo.pc",
+            "/custom/foo.pc")
+        XCTAssertEqual(
+            "/custom/foo.pc",
+            try PCFileFinder().locatePCFile(name: "foo", customSearchPaths: [AbsolutePath("/custom")], fileSystem: fs, observabilityScope: observability.topScope).pathString
+        )
+        XCTAssertEqual(
+            "/custom/foo.pc",
+            try PkgConfig(name: "foo", additionalSearchPaths: [AbsolutePath("/custom")], fileSystem: fs, observabilityScope: observability.topScope).pcFile.pathString
+        )
+        XCTAssertEqual(
+            "/usr/lib/pkgconfig/foo.pc",
+            try PCFileFinder().locatePCFile(name: "foo", customSearchPaths: [], fileSystem: fs, observabilityScope: observability.topScope).pathString
+        )
+        try withCustomEnv(["PKG_CONFIG_PATH": "/usr/local/opt/foo/lib/pkgconfig"]) {
+            XCTAssertEqual("/usr/local/opt/foo/lib/pkgconfig/foo.pc", try PkgConfig(name: "foo", fileSystem: fs, observabilityScope: observability.topScope).pcFile.pathString)
+        }
+        try withCustomEnv(["PKG_CONFIG_PATH": "/usr/local/opt/foo/lib/pkgconfig:/usr/lib/pkgconfig"]) {
+            XCTAssertEqual("/usr/local/opt/foo/lib/pkgconfig/foo.pc", try PkgConfig(name: "foo", fileSystem: fs, observabilityScope: observability.topScope).pcFile.pathString)
+        }
+    }
+
+    func testBrewPrefix() throws {
+        /// Temporary workaround for PCFileFinder's use of static variables.
+        PCFileFinder.resetCachedPkgConfigPaths()
+
+        try testWithTemporaryDirectory { tmpdir in
+            let fakePkgConfig = tmpdir.appending(components: "bin", "pkg-config")
+            try localFileSystem.createDirectory(fakePkgConfig.parentDirectory)
+
+            let stream = BufferedOutputByteStream()
+            stream <<< """
+            #!/bin/sh
+            echo "/Volumes/BestDrive/pkgconfig"
+            """
+            try localFileSystem.writeFileContents(fakePkgConfig, bytes: stream.bytes)
+            // `FileSystem` does not support `chmod` on Linux, so we shell out instead.
+            _ = try Process.popen(args: "chmod", "+x", fakePkgConfig.pathString)
+
+            _ = PCFileFinder(brewPrefix: fakePkgConfig.parentDirectory.parentDirectory)
+        }
+
+        XCTAssertEqual(PCFileFinder.pkgConfigPaths, [AbsolutePath("/Volumes/BestDrive/pkgconfig")])
+    }
+
+    func testAbsolutePathDependency() throws {
+
+        let libffiPath = "/usr/local/opt/libffi/lib/pkgconfig/libffi.pc"
+
+        try loadPCFile("gobject-2.0.pc") { parser in
+            XCTAssert(parser.dependencies.isEmpty)
+            XCTAssertEqual(parser.privateDependencies, [libffiPath])
+        }
+
+        try loadPCFile("libffi.pc") { parser in
+            XCTAssert(parser.dependencies.isEmpty)
+            XCTAssert(parser.privateDependencies.isEmpty)
+        }
+
+        let fileSystem = try InMemoryFileSystem(
+            files: [
+                "/usr/local/opt/glib/lib/pkgconfig/gobject-2.0.pc": pcFileByteString("gobject-2.0.pc"),
+                libffiPath: pcFileByteString("libffi.pc")
+            ]
+        )
+
+        let observability = ObservabilitySystem.makeForTesting()
+
+        XCTAssertNoThrow(
+            try PkgConfig(
+                name: "gobject-2.0",
+                additionalSearchPaths: [AbsolutePath("/usr/local/opt/glib/lib/pkgconfig")],
+                brewPrefix: AbsolutePath("/usr/local"),
+                fileSystem: fileSystem,
+                observabilityScope: observability.topScope
+            )
+        )
+    }
+
+    func testUnevenQuotes() throws {
+        do {
+            try loadPCFile("quotes_failure.pc")
+            XCTFail("Unexpected success")
+        } catch PkgConfigError.parsingError(let desc) {
+            XCTAssert(desc.hasPrefix("Text ended before matching quote"))
+        }
+    }
+
+    private func pcFilePath(_ inputName: String) -> AbsolutePath {
+        return AbsolutePath(#file).parentDirectory.appending(components: "pkgconfigInputs", inputName)
+    }
+
+    private func loadPCFile(_ inputName: String, body: ((PkgConfigParser) -> Void)? = nil) throws {
+        var parser = PkgConfigParser(pcFile: pcFilePath(inputName), fileSystem: localFileSystem)
+        try parser.parse()
+        body?(parser)
+    }
+
+    private func pcFileByteString(_ inputName: String) throws -> ByteString {
+        return try localFileSystem.readFileContents(pcFilePath(inputName))
+    }
+}

--- a/Tests/PackageLoadingTests/PkgConfigTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigTests.swift
@@ -9,11 +9,10 @@
 */
 
 import Basics
-import PackageLoading
+@testable import PackageLoading
 import PackageModel
 import SPMTestSupport
 import TSCBasic
-import TSCUtility
 import XCTest
 
 extension SystemLibraryTarget {
@@ -128,7 +127,7 @@ class PkgConfigTests: XCTestCase {
         // Use additionalSearchPaths instead of pkgConfigArgs to test handling
         // of search paths when loading dependencies.
         let observability = ObservabilitySystem.makeForTesting()
-        let result = try PkgConfig(name: "Dependent", additionalSearchPaths: [inputsDir], diagnostics: observability.topScope.makeDiagnosticsEngine(), brewPrefix: nil)
+        let result = try PkgConfig(name: "Dependent", additionalSearchPaths: [inputsDir], fileSystem: localFileSystem, observabilityScope: observability.topScope)
 
         XCTAssertEqual(result.name, "Dependent")
         XCTAssertEqual(result.cFlags, ["-I/path/to/dependent/include", "-I/path/to/dependency/include"])

--- a/Tests/PackageLoadingTests/pkgconfigInputs/deps_variable.pc
+++ b/Tests/PackageLoadingTests/pkgconfigInputs/deps_variable.pc
@@ -1,0 +1,8 @@
+prefix=/usr/local/bin
+exec_prefix=${prefix}
+my_dep=atk
+#some comment
+
+Requires: gdk-3.0 >= 1.0.0 ${my_dep}
+Libs: -L${prefix} -lgtk-3 
+Cflags: -I

--- a/Tests/PackageLoadingTests/pkgconfigInputs/empty_cflags.pc
+++ b/Tests/PackageLoadingTests/pkgconfigInputs/empty_cflags.pc
@@ -1,0 +1,8 @@
+prefix=/usr/local/bin
+exec_prefix=${prefix}
+
+#some comment
+
+Requires: gdk-3.0 atk
+Libs:-L${prefix} -lgtk-3 
+Cflags:

--- a/Tests/PackageLoadingTests/pkgconfigInputs/escaped_spaces.pc
+++ b/Tests/PackageLoadingTests/pkgconfigInputs/escaped_spaces.pc
@@ -1,0 +1,8 @@
+prefix=/usr/local/bin
+exec_prefix=${prefix}
+my_dep=atk
+#some comment
+
+Requires: gdk-3.0 >= 1.0.0 ${my_dep}
+Libs: -L"${prefix}" -l"gtk 3" -wantareal\\here -one\\ -two
+Cflags: -I/usr/local/Wine\ Cellar/gtk+3/3.18.9/include/gtk-3.0    -I/after/extra/spaces

--- a/Tests/PackageLoadingTests/pkgconfigInputs/failure_case.pc
+++ b/Tests/PackageLoadingTests/pkgconfigInputs/failure_case.pc
@@ -1,0 +1,8 @@
+prefix=/usr/local/bin
+exec_prefix=${prefix}
+
+#some comment
+
+Requires: gdk-3.0 >= 1.0.0
+Libs: -L${prefix} -lgtk-3 ${my_dep}
+Cflags: -I

--- a/Tests/PackageLoadingTests/pkgconfigInputs/freetype2.pc
+++ b/Tests/PackageLoadingTests/pkgconfigInputs/freetype2.pc
@@ -1,0 +1,14 @@
+prefix=/usr
+exec_prefix=/usr
+libdir=/usr/lib
+includedir=/usr/include
+
+Name: FreeType 2
+URL: https://freetype.org
+Description: A free, high-quality, and portable font engine.
+Version: 23.4.17
+Requires:
+Requires.private: harfbuzz
+Libs: -L${libdir} -lfreetype
+Libs.private: -lbz2
+Cflags: -I${includedir}/freetype2

--- a/Tests/PackageLoadingTests/pkgconfigInputs/gobject-2.0.pc
+++ b/Tests/PackageLoadingTests/pkgconfigInputs/gobject-2.0.pc
@@ -1,0 +1,12 @@
+prefix=/usr/local/Cellar/glib/2.64.3
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: GObject
+Description: GLib Type, Object, Parameter and Signal Library
+Version: 2.64.3
+# Requires: glib-2.0
+Requires.private: /usr/local/opt/libffi/lib/pkgconfig/libffi.pc >=  3.0.0
+Libs: -L${libdir} -lgobject-2.0
+Libs.private: -lintl
+Cflags:-I${includedir}

--- a/Tests/PackageLoadingTests/pkgconfigInputs/gtk+-3.0.pc
+++ b/Tests/PackageLoadingTests/pkgconfigInputs/gtk+-3.0.pc
@@ -1,0 +1,16 @@
+prefix = /usr/local/Cellar/gtk+3/3.18.9
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+targets=quartz
+#some comment
+gtk_binary_version=3.0.0
+gtk_host=x86_64-apple-darwin15.3.0
+
+Name: GTK+
+Description: GTK+ Graphical UI Library
+Version: 3.18.9
+Requires: gdk-3.0,atk    >=   2.15.1    cairo >= 1.14.0 cairo-gobject >= 1.14.0 gdk-pixbuf-2.0 >= 2.30.0 gio-2.0 >= 2.45.8        #some random comment 
+Requires.private: atk   epoxy >= 1.0 gio-unix-2.0 >= 2.45.8
+Libs: -L${libdir} -lgtk-3 
+Cflags: -I${includedir}/gtk-3.0 

--- a/Tests/PackageLoadingTests/pkgconfigInputs/harfbuzz.pc
+++ b/Tests/PackageLoadingTests/pkgconfigInputs/harfbuzz.pc
@@ -1,0 +1,11 @@
+prefix=/usr
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: harfbuzz
+Description: HarfBuzz text shaping library
+Version: 2.7.4
+Requires.private: freetype2 
+Libs: -L${libdir} -lharfbuzz
+Libs.private: -pthread -lm
+Cflags: -I${includedir}/harfbuzz

--- a/Tests/PackageLoadingTests/pkgconfigInputs/libffi.pc
+++ b/Tests/PackageLoadingTests/pkgconfigInputs/libffi.pc
@@ -1,0 +1,11 @@
+prefix=/usr/local/Cellar/libffi/3.3
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+toolexeclibdir=${libdir}
+includedir=${prefix}/include
+
+Name: libffi
+Description: Library supporting Foreign Function Interfaces
+Version: 3.3
+Libs: -L${toolexeclibdir} -lffi
+Cflags: -I${includedir}

--- a/Tests/PackageLoadingTests/pkgconfigInputs/quotes_failure.pc
+++ b/Tests/PackageLoadingTests/pkgconfigInputs/quotes_failure.pc
@@ -1,0 +1,8 @@
+prefix=/usr/local/bin
+exec_prefix=${prefix}
+my_dep=atk
+#some comment
+
+Requires: gdk-3.0 >= 1.0.0 ${my_dep}
+Libs: -L"${prefix}" -l"gt"k3" -wantareal\\here -one\\ -two
+Cflags: -I/usr/local/Wine\ Cellar/gtk+3/3.18.9/include/gtk-3.0    -I/after/extra/spaces


### PR DESCRIPTION
motivation: PkgConfig was moved from SwiftPM into TSC, but really is closer to SwiftPM (not generic enough) and would be easier to maintain within SwiftPM itself

changes:
* copy the PkgConfig code into SwiftPM
* replace use of DiagnosticsEngine with ObservabilityScope
* minor cleanup (more needed, epecially use of statics)
* also copy and adjust tests
