### PR TITLE
Add @available attribute to testAsyncMethods fixture

### DIFF
--- a/Fixtures/Miscellaneous/TestDiscovery/Async/Tests/AsyncTests/SwiftTests.swift
+++ b/Fixtures/Miscellaneous/TestDiscovery/Async/Tests/AsyncTests/SwiftTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import Async
 
+@available(macOS 12.0, *)
 class AsyncTests: XCTestCase {
 
     func testAsync() async {


### PR DESCRIPTION
This fixes a compilation problem when running tests under SPM.

### Motivation:

If running unit tests with SPM like so:

swift test --sanitize=thread --filter FunctionalTests.TestDiscoveryTests/testAsyncMethods

The test fails with these errors:

```
/private/var/folders/s3/556s8dsd7y9272mxm7rydmsr00056_/T/Miscellaneous_TestDiscovery_Async.Guycrz/Miscellaneous_TestDiscovery_Async/Tests/AsyncTests/SwiftTests.swift:6:22: error: concurrency is only available in macOS 12.0.0 or newer
    func testAsync() async {
                     ^
```

This change fixes the problem.

### Modifications:

Add `@available` attribute to the `AsyncTests` class in the test fixture.

### Result:

Test now passes when run under SPM.