### PR TITLE
Add thread sanitizer utilities (tsan_utils)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -399,6 +399,11 @@ let package = Package(
             ]
         ),
 
+        .target(
+            /** Test for thread-santizer. */
+            name: "tsan_utils",
+            dependencies: []),
+
         // MARK: SwiftPM tests
 
         .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -408,7 +408,7 @@ let package = Package(
 
         .testTarget(
             name: "BasicsTests",
-            dependencies: ["Basics", "SPMTestSupport"]
+            dependencies: ["Basics", "SPMTestSupport", "tsan_utils"]
         ),
         .testTarget(
             name: "BuildTests",
@@ -496,7 +496,7 @@ let package = Package(
         ),
         .testTarget(
             name: "PackageCollectionsTests",
-            dependencies: ["PackageCollections", "SPMTestSupport"]
+            dependencies: ["PackageCollections", "SPMTestSupport", "tsan_utils"]
         ),
         .testTarget(
             name: "PackageFingerprintTests",

--- a/Sources/tsan_utils/include/module.modulemap
+++ b/Sources/tsan_utils/include/module.modulemap
@@ -1,0 +1,4 @@
+module tsan_utils {
+    header "tsan_utils.h"
+    export *
+}

--- a/Sources/tsan_utils/include/tsan_utils.h
+++ b/Sources/tsan_utils/include/tsan_utils.h
@@ -1,0 +1,4 @@
+#include <stdbool.h>
+
+/// returns true if the current build supports the thread-sanitizer.
+extern bool is_tsan_enabled(void);

--- a/Sources/tsan_utils/tsan_utils.c
+++ b/Sources/tsan_utils/tsan_utils.c
@@ -1,0 +1,9 @@
+#include "tsan_utils.h"
+
+bool is_tsan_enabled() {
+#if defined(__has_feature) && __has_feature(thread_sanitizer)
+    return true;
+#else
+    return false;
+#endif
+}

--- a/Tests/BasicsTests/SQLiteBackedCacheTests.swift
+++ b/Tests/BasicsTests/SQLiteBackedCacheTests.swift
@@ -52,7 +52,7 @@ final class SQLiteBackedCacheTests: XCTestCase {
     }
 
     func testFileDeleted() throws {
-        if is_tsan_enabled() { return }
+        try XCTSkipIf(is_tsan_enabled())
         
         try testWithTemporaryDirectory { tmpPath in
             let path = tmpPath.appending(component: "test.db")
@@ -94,7 +94,7 @@ final class SQLiteBackedCacheTests: XCTestCase {
     }
 
     func testFileCorrupt() throws {
-        if is_tsan_enabled() { return }
+        try XCTSkipIf(is_tsan_enabled())
 
         try testWithTemporaryDirectory { tmpPath in
             let path = tmpPath.appending(component: "test.db")

--- a/Tests/BasicsTests/SQLiteBackedCacheTests.swift
+++ b/Tests/BasicsTests/SQLiteBackedCacheTests.swift
@@ -12,6 +12,7 @@
 import TSCBasic
 import TSCTestSupport
 import TSCUtility
+import tsan_utils
 import XCTest
 
 final class SQLiteBackedCacheTests: XCTestCase {
@@ -51,6 +52,8 @@ final class SQLiteBackedCacheTests: XCTestCase {
     }
 
     func testFileDeleted() throws {
+        if is_tsan_enabled() { return }
+        
         try testWithTemporaryDirectory { tmpPath in
             let path = tmpPath.appending(component: "test.db")
             let cache = SQLiteBackedCache<String>(tableName: "SQLiteBackedCacheTest", path: path)
@@ -91,6 +94,8 @@ final class SQLiteBackedCacheTests: XCTestCase {
     }
 
     func testFileCorrupt() throws {
+        if is_tsan_enabled() { return }
+
         try testWithTemporaryDirectory { tmpPath in
             let path = tmpPath.appending(component: "test.db")
             let cache = SQLiteBackedCache<String>(tableName: "SQLiteBackedCacheTest", path: path)

--- a/Tests/PackageCollectionsTests/PackageCollectionsStorageTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsStorageTests.swift
@@ -70,7 +70,7 @@ class PackageCollectionsStorageTests: XCTestCase {
     }
 
     func testFileDeleted() throws {
-        if is_tsan_enabled() { return }
+        try XCTSkipIf(is_tsan_enabled())
         
         try testWithTemporaryDirectory { tmpPath in
             let path = tmpPath.appending(component: "test.db")
@@ -109,7 +109,7 @@ class PackageCollectionsStorageTests: XCTestCase {
     }
 
     func testFileCorrupt() throws {
-        if is_tsan_enabled() { return }
+        try XCTSkipIf(is_tsan_enabled())
         
         try testWithTemporaryDirectory { tmpPath in
             let path = tmpPath.appending(component: "test.db")

--- a/Tests/PackageCollectionsTests/PackageCollectionsStorageTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsStorageTests.swift
@@ -13,6 +13,7 @@ import Basics
 import TSCBasic
 import TSCTestSupport
 import TSCUtility
+import tsan_utils
 import XCTest
 
 class PackageCollectionsStorageTests: XCTestCase {
@@ -69,6 +70,8 @@ class PackageCollectionsStorageTests: XCTestCase {
     }
 
     func testFileDeleted() throws {
+        if is_tsan_enabled() { return }
+        
         try testWithTemporaryDirectory { tmpPath in
             let path = tmpPath.appending(component: "test.db")
             let storage = SQLitePackageCollectionsStorage(path: path)
@@ -106,6 +109,8 @@ class PackageCollectionsStorageTests: XCTestCase {
     }
 
     func testFileCorrupt() throws {
+        if is_tsan_enabled() { return }
+        
         try testWithTemporaryDirectory { tmpPath in
             let path = tmpPath.appending(component: "test.db")
             let storage = SQLitePackageCollectionsStorage(path: path)


### PR DESCRIPTION
This change set disables a few tests that cause hangs when the thread sanitizer is used.

### Motivation:

A few tests hang when run under the thread sanitizer. These changes provide a workaround.

### Modifications:

Added a small C module, tsan_utils with one function, is_tsan_enabled(). This simply tests the compile-time environment for the flags that indicate thread sanitizer support has been compiled in. This is called from these tests:

```
PackageCollectionsTests.PackageCollectionsStorageTests/testFileDeleted
PackageCollectionsTests.PackageCollectionsStorageTests/testFileCorrupt
BasicsTests.SQLiteBackedCacheTests/testFileDeleted
BasicsTests.SQLiteBackedCacheTests/testFileCorrupt
```

to disable them at runtime if the thread sanitizer is enabled.

### Result:

No more test hangs under thread sanitizer.
