### PR TITLE
[Registry] Package release 'url' is optional

### DIFF
--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -586,10 +586,10 @@ extension RegistryClient {
             }
 
             public struct Release: Codable {
-                public var url: String
+                public var url: String?
                 public var problem: Problem?
 
-                public init(url: String, problem: Problem? = .none) {
+                public init(url: String?, problem: Problem? = .none) {
                     self.url = url
                     self.problem = problem
                 }


### PR DESCRIPTION
Per the [API spec](https://github.com/apple/swift-package-manager/blob/main/Documentation/Registry.md#41-list-package-releases), a release's `url` field in the "list package releases" (`GET /{scope}/{name}`) API response is optional.
