### PR TITLE
Apply sandbox to commands generated by build tools (on platforms that support sandboxing)

### DIFF
--- a/Fixtures/Miscellaneous/Plugins/SandboxTesterPlugin/Plugins/MySourceGenBuildToolPlugin/plugin.swift
+++ b/Fixtures/Miscellaneous/Plugins/SandboxTesterPlugin/Plugins/MySourceGenBuildToolPlugin/plugin.swift
@@ -7,17 +7,25 @@ struct MyPlugin: BuildToolPlugin {
     func createBuildCommands(context: TargetBuildContext) throws -> [Command] {
  
         // Check that we can write to the output directory.
-        let allowedOutputPath = context.pluginWorkDirectory.appending("Foo")
-        if mkdir(allowedOutputPath.string, 0o777) != 0 {
+        let allowedOutputPath = context.pluginWorkDirectory.string + "/" + UUID().uuidString
+        if mkdir(allowedOutputPath, 0o777) != 0 {
              throw StringError("unexpectedly could not write to '\(allowedOutputPath)': \(String(utf8String: strerror(errno)))")
         }
+        rmdir(allowedOutputPath)
 
-        // Check that we cannot write to the source directory.
-        let disallowedOutputPath = context.targetDirectory.appending("Bar")
-        if mkdir(disallowedOutputPath.string, 0o777) == 0 {
+        // Check that we cannot write to the user's home directory.
+        let disallowedOutputPath = NSHomeDirectory() + "/" + UUID().uuidString
+        if mkdir(disallowedOutputPath, 0o777) == 0 {
              throw StringError("unexpectedly could write to '\(disallowedOutputPath)'")
         }
         
+        // Check that we can write to the temporary directory.
+        let allowedTemporaryPath = NSTemporaryDirectory() + "/" + UUID().uuidString
+        if mkdir(allowedTemporaryPath, 0o777) != 0 {
+             throw StringError("unexpectedly could not write to '\(allowedTemporaryPath)': \(String(utf8String: strerror(errno)))")
+        }
+        rmdir(allowedTemporaryPath)
+
         return []
     }
 

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -314,7 +314,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
                 // TODO: We need to also use any working directory, but that support isn't yet available on all platforms at a lower level.
                 var commandLine = [command.configuration.executable.pathString] + command.configuration.arguments
                 if self.enableSandboxForPluginCommands {
-                    commandLine = Sandbox.apply(command: commandLine, writableDirectories: [pluginResult.pluginOutputDirectory])
+                    commandLine = Sandbox.apply(command: commandLine, writableDirectories: [pluginResult.pluginOutputDirectory], strictness: .writableTemporaryDirectory)
                 }
                 let processResult = try Process.popen(arguments: commandLine, environment: command.configuration.environment)
                 let output = try processResult.utf8Output() + processResult.utf8stderrOutput()

--- a/Sources/Build/LLBuildManifestBuilder.swift
+++ b/Sources/Build/LLBuildManifestBuilder.swift
@@ -34,7 +34,7 @@ public class LLBuildManifestBuilder {
     public let plan: BuildPlan
 
     /// Whether to sandbox commands from build tool plugins.
-    public let enableSandboxForPluginCommands: Bool
+    public let disableSandboxForPluginCommands: Bool
 
     /// File system reference.
     private let fileSystem: FileSystem
@@ -49,9 +49,9 @@ public class LLBuildManifestBuilder {
     var buildEnvironment: BuildEnvironment { buildParameters.buildEnvironment }
 
     /// Create a new builder with a build plan.
-    public init(_ plan: BuildPlan, enableSandboxForPluginCommands: Bool = true, fileSystem: FileSystem, observabilityScope: ObservabilityScope) {
+    public init(_ plan: BuildPlan, disableSandboxForPluginCommands: Bool = false, fileSystem: FileSystem, observabilityScope: ObservabilityScope) {
         self.plan = plan
-        self.enableSandboxForPluginCommands = enableSandboxForPluginCommands
+        self.disableSandboxForPluginCommands = disableSandboxForPluginCommands
         self.fileSystem = fileSystem
         self.observabilityScope = observabilityScope
     }
@@ -617,7 +617,7 @@ extension LLBuildManifestBuilder {
                 let uniquedName = ([execPath.pathString] + command.configuration.arguments).joined(separator: "|")
                 let displayName = command.configuration.displayName ?? execPath.basename
                 var commandLine = [execPath.pathString] + command.configuration.arguments
-                if self.enableSandboxForPluginCommands {
+                if !self.disableSandboxForPluginCommands {
                     commandLine = Sandbox.apply(command: commandLine, writableDirectories: [result.pluginOutputDirectory], strictness: .writableTemporaryDirectory)
                 }
                 manifest.addShellCmd(

--- a/Sources/Build/LLBuildManifestBuilder.swift
+++ b/Sources/Build/LLBuildManifestBuilder.swift
@@ -618,7 +618,7 @@ extension LLBuildManifestBuilder {
                 let displayName = command.configuration.displayName ?? execPath.basename
                 var commandLine = [execPath.pathString] + command.configuration.arguments
                 if self.enableSandboxForPluginCommands {
-                    commandLine = Sandbox.apply(command: commandLine, writableDirectories: [result.pluginOutputDirectory])
+                    commandLine = Sandbox.apply(command: commandLine, writableDirectories: [result.pluginOutputDirectory], strictness: .writableTemporaryDirectory)
                 }
                 manifest.addShellCmd(
                     name: displayName + "-" + ByteString(encodingAsUTF8: uniquedName).sha256Checksum,

--- a/Sources/Build/LLBuildManifestBuilder.swift
+++ b/Sources/Build/LLBuildManifestBuilder.swift
@@ -605,7 +605,7 @@ extension LLBuildManifestBuilder {
         }
 
         // Add any regular build commands created by plugins for the target (prebuild commands are handled separately).
-        for command in target.pluginInvocationResults.reduce([], { $0 + $1.buildCommands }) {
+        for command in target.buildToolPluginInvocationResults.reduce([], { $0 + $1.buildCommands }) {
             // Create a shell command to invoke the executable. We include the path of the executable as a dependency, and make sure the name is unique.
             let execPath = command.configuration.executable
             let uniquedName = ([execPath.pathString] + command.configuration.arguments).joined(separator: "|")

--- a/Sources/Commands/APIDigester.swift
+++ b/Sources/Commands/APIDigester.swift
@@ -125,7 +125,7 @@ struct APIDigesterBaselineDumper {
             buildParameters: buildParameters,
             cacheBuildManifest: false,
             packageGraphLoader: { graph },
-            pluginInvoker: { _ in [:] },
+            buildToolPluginInvoker: { _ in [:] },
             outputStream: outputStream,
             logLevel: logLevel,
             fileSystem: localFileSystem,

--- a/Sources/Commands/APIDigester.swift
+++ b/Sources/Commands/APIDigester.swift
@@ -121,6 +121,7 @@ struct APIDigesterBaselineDumper {
         buildParameters.dataPath = workspace.location.workingDirectory
 
         // Build the baseline module.
+        // FIXME: We need to implement the build tool invocation closure here so that build tool plugins work with the APIDigester. rdar://86112934
         let buildOp = BuildOperation(
             buildParameters: buildParameters,
             cacheBuildManifest: false,

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -954,7 +954,7 @@ extension SwiftPackageTool {
 
             // The `cache` directory is in the plugins directory and is where the plugin script runner caches compiled plugin binaries and any other derived information.
             let cacheDir = pluginsDir.appending(component: "cache")
-            let pluginScriptRunner = DefaultPluginScriptRunner(cacheDir: cacheDir, toolchain: try swiftTool.getToolchain().configuration)
+            let pluginScriptRunner = DefaultPluginScriptRunner(cacheDir: cacheDir, toolchain: try swiftTool.getToolchain().configuration, enableSandbox: !swiftTool.options.shouldDisableSandbox)
 
             // The `outputs` directory contains subdirectories for each combination of package, target, and plugin. Each usage of a plugin has an output directory that is writable by the plugin, where it can write additional files, and to which it can configure tools to write their outputs, etc.
             // FIXME: Revisit this path.

--- a/Sources/Commands/SwiftRunTool.swift
+++ b/Sources/Commands/SwiftRunTool.swift
@@ -122,7 +122,7 @@ public struct SwiftRunTool: SwiftCommand {
                 buildParameters: buildParameters,
                 cacheBuildManifest: false,
                 packageGraphLoader: graphLoader,
-                pluginInvoker: { _ in [:] },
+                buildToolPluginInvoker: { _ in [:] },
                 outputStream: swiftTool.outputStream,
                 logLevel: swiftTool.logLevel,
                 fileSystem: localFileSystem,

--- a/Sources/Commands/SwiftRunTool.swift
+++ b/Sources/Commands/SwiftRunTool.swift
@@ -118,6 +118,7 @@ public struct SwiftRunTool: SwiftCommand {
             let buildParameters = try swiftTool.buildParameters()
 
             // Construct the build operation.
+            // FIXME: We need to implement the build tool invocation closure here so that build tool plugins work with the REPL. rdar://86112934
             let buildOp = BuildOperation(
                 buildParameters: buildParameters,
                 cacheBuildManifest: false,

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -824,6 +824,7 @@ public class SwiftTool {
         let graphLoader = { try self.loadPackageGraph(explicitProduct: explicitProduct) }
 
         // Construct the build operation.
+        // FIXME: We need to implement the build tool invocation closure here so that build tool plugins work with dumping the symbol graph (the only case that currently goes through this path, as far as I can tell). rdar://86112934
         let buildOp = try BuildOperation(
             buildParameters: buildParameters(),
             cacheBuildManifest: cacheBuildManifest && self.canUseCachedBuildManifest(),

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -734,8 +734,8 @@ public class SwiftTool {
         }
     }
 
-    /// Invoke plugins for any reachable targets in the graph, and return a mapping from targets to corresponding evaluation results.
-    func invokePlugins(graph: PackageGraph) throws -> [ResolvedTarget: [BuildToolPluginInvocationResult]] {
+    /// Invoke build tool plugins for any reachable targets in the graph, and return a mapping from targets to corresponding evaluation results.
+    func invokeBuildToolPlugins(graph: PackageGraph) throws -> [ResolvedTarget: [BuildToolPluginInvocationResult]] {
         do {
             // Configure the plugin invocation inputs.
 
@@ -828,7 +828,7 @@ public class SwiftTool {
             buildParameters: buildParameters(),
             cacheBuildManifest: cacheBuildManifest && self.canUseCachedBuildManifest(),
             packageGraphLoader: graphLoader,
-            pluginInvoker: { _ in [:] },
+            buildToolPluginInvoker: { _ in [:] },
             outputStream: self.outputStream,
             logLevel: self.logLevel,
             fileSystem: localFileSystem,
@@ -845,12 +845,12 @@ public class SwiftTool {
         switch options.buildSystem {
         case .native:
             let graphLoader = { try self.loadPackageGraph(explicitProduct: explicitProduct) }
-            let pluginInvoker = { try self.invokePlugins(graph: $0) }
+            let buildToolPluginInvoker = { try self.invokeBuildToolPlugins(graph: $0) }
             buildSystem = try BuildOperation(
                 buildParameters: buildParameters ?? self.buildParameters(),
                 cacheBuildManifest: self.canUseCachedBuildManifest(),
                 packageGraphLoader: graphLoader,
-                pluginInvoker: pluginInvoker,
+                buildToolPluginInvoker: buildToolPluginInvoker,
                 outputStream: self.outputStream,
                 logLevel: self.logLevel,
                 fileSystem: localFileSystem,

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -747,7 +747,7 @@ public class SwiftTool {
             // The `cache` directory is in the plugins directory and is where the plugin script runner caches
             // compiled plugin binaries and any other derived information.
             let cacheDir = pluginsDir.appending(component: "cache")
-            let pluginScriptRunner = try DefaultPluginScriptRunner(cacheDir: cacheDir, toolchain: self._hostToolchain.get().configuration)
+            let pluginScriptRunner = try DefaultPluginScriptRunner(cacheDir: cacheDir, toolchain: self._hostToolchain.get().configuration, enableSandbox: !self.options.shouldDisableSandbox)
 
             // The `outputs` directory contains subdirectories for each combination of package, target, and plugin.
             // Each usage of a plugin has an output directory that is writable by the plugin, where it can write

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -851,6 +851,7 @@ public class SwiftTool {
                 cacheBuildManifest: self.canUseCachedBuildManifest(),
                 packageGraphLoader: graphLoader,
                 buildToolPluginInvoker: buildToolPluginInvoker,
+                enableSandboxForPluginCommands: !self.options.shouldDisableSandbox,
                 outputStream: self.outputStream,
                 logLevel: self.logLevel,
                 fileSystem: localFileSystem,

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -852,7 +852,7 @@ public class SwiftTool {
                 cacheBuildManifest: self.canUseCachedBuildManifest(),
                 packageGraphLoader: graphLoader,
                 buildToolPluginInvoker: buildToolPluginInvoker,
-                enableSandboxForPluginCommands: !self.options.shouldDisableSandbox,
+                disableSandboxForPluginCommands: self.options.shouldDisableSandbox,
                 outputStream: self.outputStream,
                 logLevel: self.logLevel,
                 fileSystem: localFileSystem,

--- a/Sources/SPMBuildCore/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/PluginInvocation.swift
@@ -246,6 +246,7 @@ extension PackageGraph {
                 if success {
                     buildToolPluginResults.append(.init(
                         plugin: pluginTarget,
+                        pluginOutputDirectory: pluginOutputDir,
                         diagnostics: delegate.diagnostics,
                         textOutput: String(decoding: delegate.outputData, as: UTF8.self),
                         buildCommands: delegate.buildCommands,
@@ -301,6 +302,9 @@ public extension PluginTarget {
 public struct BuildToolPluginInvocationResult {
     /// The plugin that produced the results.
     public var plugin: PluginTarget
+
+    /// The directory given to the plugin as a place in which it and the commands are allowed to write.
+    public var pluginOutputDirectory: AbsolutePath
 
     /// Any diagnostics emitted by the plugin.
     public var diagnostics: [Diagnostic]

--- a/Sources/Workspace/DefaultPluginScriptRunner.swift
+++ b/Sources/Workspace/DefaultPluginScriptRunner.swift
@@ -263,7 +263,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner {
 
         // Optionally wrap the command in a sandbox, which places some limits on what it can do. In particular, it blocks network access and restricts the paths to which the plugin can make file system changes.
         if self.enableSandbox {
-            command = Sandbox.apply(command: command, writableDirectories: writableDirectories + [self.cacheDir])
+            command = Sandbox.apply(command: command, writableDirectories: writableDirectories + [self.cacheDir], strictness: .writableTemporaryDirectory)
         }
 
         // Create and configure a Process. We set the working directory to the cache directory, so that relative paths end up there.

--- a/Tests/BasicsTests/SandboxTests.swift
+++ b/Tests/BasicsTests/SandboxTests.swift
@@ -113,4 +113,22 @@ final class SandboxTest: XCTestCase {
             XCTAssertNoThrow(try Process.checkNonZeroExit(arguments: command))
         }
     }
+
+    func testWritingToTemporaryDirectoryAllowed() throws {
+        #if !os(macOS)
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
+
+        // Try writing to the per-user temporary directory, which is under /var/folders/.../TemporaryItems.
+        let tmpFile1 = NSTemporaryDirectory() + "/" + UUID().uuidString
+        let command1 = Sandbox.apply(command: ["touch", tmpFile1], strictness: .writableTemporaryDirectory)
+        XCTAssertNoThrow(try Process.checkNonZeroExit(arguments: command1))
+        try? FileManager.default.removeItem(atPath: tmpFile1)
+
+        let tmpFile2 = "/tmp" + "/" + UUID().uuidString
+        let command2 = Sandbox.apply(command: ["touch", tmpFile2], strictness: .writableTemporaryDirectory)
+        XCTAssertNoThrow(try Process.checkNonZeroExit(arguments: command2))
+        try? FileManager.default.removeItem(atPath: tmpFile2)
+    }
+
 }


### PR DESCRIPTION
Sandboxing was already applied to the running of plugins, but for `buildTool` plugins, they were not to the commands they provide for the build system to run.

### Motivation:

Since the plugin can configure commands in any way it wants to, they need to be just as sandboxed as the plugin.

### Modifications:

This change applies the sandbox to the regular build commands and to the prebuild commands returned by `buildTool` plugins.

It also fixes a related bug that caused the sandboxing of plugins in general to ignore the `disable-sandbox` option, which is documented to disable sandboxing for all subprocesses.

Since many Foundation functions requires that the non-persistent temporary directory be writable, this also adds a new strictness level that allows this, and uses that when invoking the build commands.  Without this, many build commands become unusable from command plugins without disabling the sandbox completely.  In fact, half of the unit test fixture plugins (which use Foundation) fail without it.

Another approach is to set `TMPDIR` in the environment, though that counts on having the tool honor that setting.  In testing, it doesn't seem that all tools do that.

Specifically:
- add sandboxing of build commands and prebuild commands on platforms that support it
- make `disable-sandbox` work as advertised for plugin invocations also
- add a sandbox strictness level that allows writing to non-persistent temporary directories (but not caches, as the pre-5.3 manifest behavior)
- fix potential path quoting problems in the sandbox profile
- rename some parameters and properties to clarify that the build-related plugin results are specific to build tool plugins

Note that these changes are split into six separate commits, which might be easier to review individually.

rdar://74665029