### PR TITLE
adjust precomputation resolution to registry based dependencies

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -36,7 +36,7 @@ public enum WorkspaceResolveReason: Equatable {
     )
 
     /// An unknown reason.
-    case other
+    case other(String)
 }
 
 /// The delegate interface used by the workspace to report status information.
@@ -2665,8 +2665,8 @@ extension Workspace {
                 state: state,
                 requirement: requirement
             ))
-        default:
-            return .required(reason: .other)
+        case .failure(let error):
+            return .required(reason: .other("\(error)"))
         }
     }
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -1235,7 +1235,10 @@ final class WorkspaceTests: XCTestCase {
 
         try workspace.checkPrecomputeResolution { result in
             XCTAssertEqual(result.diagnostics.hasErrors, false)
-            XCTAssertEqual(result.result, .required(reason: .other))
+            XCTAssertEqual(
+                result.result,
+                .required(reason: .other("Dependencies could not be resolved because no versions of \'c\' match the requirement 2.0.0..<3.0.0 and root depends on \'c\' 2.0.0..<3.0.0."))
+            )
         }
     }
 


### PR DESCRIPTION
motivation: take advantage of precomputation resolution

changes:
* extend condition of ResolverPrecomputationProvider::LocalPackageContainer to handler registry based depndencies along side source control ones
* include error details when precomputation resolution fails in the general / unknown case
