### PR TITLE
[5.5] Add automatic library product for SwiftPMDataModel

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -79,6 +79,19 @@ let package = Package(
                 "Workspace"
             ]
         ),
+        .library(
+            name: "SwiftPMDataModel-auto",
+            targets: [
+                "SourceControl",
+                "PackageCollections",
+                "PackageCollectionsModel",
+                "PackageModel",
+                "PackageLoading",
+                "PackageGraph",
+                "Xcodeproj",
+                "Workspace"
+            ]
+        ),
 
         .library(
             name: "XCBuildSupport",


### PR DESCRIPTION
Adds an auto linked variant of SwiftPMDataModel library.

### Motivation:

We want to statically link to `SwiftPMDataModel` library in a [CLI app](https://github.com/swiftwasm/carton) to resolve [duplicate symbols issues](https://github.com/swiftwasm/carton/issues/274).

### Modifications:

Directly adds another build product. This is already solved [more generically](https://github.com/yonihemi/swift-package-manager/blob/d644f4d0577c2c7f4074ea322134a492e229a796/Package.swift#L54) on `main` but we're still relying on the 5.5 branch.

