### PR TITLE
Only recompile plugin scripts to executables when needed

### DIFF
--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -337,7 +337,7 @@ class PluginTests: XCTestCase {
             let pluginOutputDir = tmpPath.appending(component: "plugin-output")
             let pluginScriptRunner = DefaultPluginScriptRunner(cacheDir: pluginCacheDir, toolchain: ToolchainConfiguration.default)
             let target = try XCTUnwrap(package.targets.first{ $0.underlyingTarget == libraryTarget })
-            let _ = try tsc_await { pluginTarget.invoke(
+            let invocationSucceeded = try tsc_await { pluginTarget.invoke(
                 action: .performCommand(
                     targets: [ target ],
                     arguments: ["veni", "vidi", "vici"]),
@@ -354,6 +354,7 @@ class PluginTests: XCTestCase {
                 completion: $0) }
             
             // Check the results.
+            XCTAssertTrue(invocationSucceeded)
             let outputText = String(decoding: pluginDelegate.outputData, as: UTF8.self)
             XCTAssertTrue(outputText.contains("Root package is MyPackage."), outputText)
             XCTAssertTrue(outputText.contains("Found the swiftc tool"), outputText)


### PR DESCRIPTION
This is an optimization that skips the compilation step of a package plugin if a compiled version already exists, if none of the input files have changed, and if none of the compiler flags have changed.

### Motivation:

Better performance by avoiding unnecessary work.

### Modifications:

- compute hash of the input conditions and store it next to the compiled executable
- if the compiled executable exists and the hash is the same since the next time, skip compiling
- add a field to the compilation result structure to reflect whether the compilation was cached
- extend a unit test to verify that diagnostics (e.g. warnings) are still emitted

### Result:

No functional change, but less time spent compiling plugins.

rdar://74663095