### PR TITLE
Initial version of the `--list` option for command plugins

### DIFF
--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -1317,10 +1317,18 @@ final class PackageToolTests: CommandsTestCase {
             }
 
             // Invoke it, and check the results.
-            let result = try SwiftPMProduct.SwiftPackage.executeProcess(["plugin", "mycmd"], packagePath: packageDir, env: ["SWIFTPM_ENABLE_COMMAND_PLUGINS": "1"])
-            print(try result.utf8Output() + result.utf8stderrOutput())
-            XCTAssertEqual(result.exitStatus, .terminated(code: 0))
-            XCTAssert(try result.utf8Output().contains("This is MyCommandPlugin."))
+            do {
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["plugin", "mycmd"], packagePath: packageDir, env: ["SWIFTPM_ENABLE_COMMAND_PLUGINS": "1"])
+                XCTAssertEqual(result.exitStatus, .terminated(code: 0))
+                XCTAssert(try result.utf8Output().contains("This is MyCommandPlugin."))
+            }
+
+            // Testing listing the available command plugins.
+            do {
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["plugin", "--list"], packagePath: packageDir, env: ["SWIFTPM_ENABLE_COMMAND_PLUGINS": "1"])
+                XCTAssertEqual(result.exitStatus, .terminated(code: 0))
+                XCTAssert(try result.utf8Output().contains("‘mycmd’ (plugin ‘MyPlugin’ in package ‘MyPackage’)"))
+            }
         }
     }
 }


### PR DESCRIPTION
Initial version of the `--list` option for command plugins.  This shows each command, along with the target and package that provides them.  A later change can easily refine this to also list the intent (separately from the command).

### Motivation:

This is useful and is a part of the proposal SE-0332.

### Modifications:

- add a `--list` option to `swift package plugin`
- extend a unit test

### Result:

Invoking `swift package plugin --list` now shows all available command plugins, initially in the form:

`‘mycmd’ (plugin ‘MyPlugin’ in package ‘MyPackage’)`

We could refine this to also group by intent, and should also show the description where there is a custom intent.  Suggestions are welcome.