### PR TITLE
Add the ability to pass an output path to command plugins

### DIFF
--- a/Sources/PackagePlugin/Path.swift
+++ b/Sources/PackagePlugin/Path.swift
@@ -90,7 +90,7 @@ public struct Path {
     
     /// The result of appending a subpath.
     public func appending(subpath: String) -> Path {
-        return Path(_string + "/" + subpath)
+        return Path(_string + (_string.hasSuffix("/") ? "" : "/") + subpath)
     }
 
     /// The result of appending one or more path components.

--- a/Sources/PackagePlugin/Plugin.swift
+++ b/Sources/PackagePlugin/Plugin.swift
@@ -135,11 +135,14 @@ extension Plugin {
                 // Check that the plugin implements the appropriate protocol
                 // for its declared capability.
                 guard let plugin = plugin as? BuildToolPlugin else {
-                    throw PluginDeserializationError.malformedInputJSON("Plugin declared with `buildTool` capability but doesn't conform to `BuildToolPlugin` protocol")
+                    throw PluginDeserializationError.malformedInputJSON(
+                        "Plugin declared with `buildTool` capability but doesn't conform to `BuildToolPlugin` protocol")
                 }
                 
                 // Invoke the plugin to create build commands for the target.
-                let generatedCommands = try plugin.createBuildCommands(context: context, target: target)
+                let generatedCommands = try plugin.createBuildCommands(
+                    context: context,
+                    target: target)
                 
                 // Send each of the generated commands to the host.
                 for command in generatedCommands {
@@ -172,15 +175,20 @@ extension Plugin {
                     }
                 }
                 
-            case .performCommand(let targets, let arguments):
+            case .performCommand(let targets, let arguments, let outputPath):
                 // Check that the plugin implements the appropriate protocol
                 // for its declared capability.
                 guard let plugin = plugin as? CommandPlugin else {
-                    throw PluginDeserializationError.malformedInputJSON("Plugin declared with `command` capability but doesn't conform to `CommandPlugin` protocol")
+                    throw PluginDeserializationError.malformedInputJSON(
+                        "Plugin declared with `command` capability but doesn't conform to `CommandPlugin` protocol")
                 }
                 
                 // Invoke the plugin to perform its custom logic.
-                try plugin.performCommand(context: context, targets: targets, arguments: arguments)
+                try plugin.performCommand(
+                    context: context,
+                    targets: targets,
+                    arguments: arguments,
+                    outputPath: outputPath)
             }
             
             // Send back a message to the host indicating that we're done.

--- a/Sources/PackagePlugin/Protocols.swift
+++ b/Sources/PackagePlugin/Protocols.swift
@@ -99,13 +99,49 @@ public protocol CommandPlugin: Plugin {
         arguments: [String]
     ) throws
 
+    /// Invoked by SwiftPM to perform the custom actions of the command.
+    func performCommand(
+        /// The context in which the plugin is invoked. This is the same for all
+        /// kinds of plugins, and provides access to the package graph, to cache
+        /// directories, etc.
+        context: PluginContext,
+
+        /// The targets to which the command should be applied. If the invoker of
+        /// the command has not specified particular targets, this will be a list
+        /// of all the targets in the package to which the command is applied.
+        targets: [Target],
+
+        /// Any literal arguments passed after the verb in the command invocation.
+        arguments: [String],
+
+        /// Optional output path to which the command is allowed to write.
+        outputPath: Path?
+    ) throws
+
     /// A proxy to the Swift Package Manager or IDE hosting the command plugin,
     /// through which the plugin can ask for specialized information or actions.
     var packageManager: PackageManager { get }
 }
 
 extension CommandPlugin {
-    
+
+    public func performCommand(
+        context: PluginContext,
+        targets: [Target],
+        arguments: [String]
+    ) throws {
+        try self.performCommand(context: context, targets: targets, arguments: arguments, outputPath: .none)
+    }
+
+    public func performCommand(
+        context: PluginContext,
+        targets: [Target],
+        arguments: [String],
+        outputPath: Path?
+    ) throws {
+        try self.performCommand(context: context, targets: targets, arguments: arguments)
+    }
+
     /// A proxy to the Swift Package Manager or IDE hosting the command plugin,
     /// through which the plugin can ask for specialized information or actions.
     public var packageManager: PackageManager {

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -1249,7 +1249,8 @@ final class PackageToolTests: CommandsTestCase {
                     func performCommand(
                         context: PluginContext,
                         targets: [Target],
-                        arguments: [String]
+                        arguments: [String],
+                        outputPath: Path?
                     ) throws {
                         print("This is MyCommandPlugin.")
 
@@ -1272,6 +1273,11 @@ final class PackageToolTests: CommandsTestCase {
                         print("Looking for swiftc...")
                         let swiftc = try context.tool(named: "swiftc")
                         print("... found it at \\(swiftc.path)")
+
+                        // Check the output path.
+                        if let outputPath = outputPath {
+                            print("Got output path \\(outputPath.string).")
+                        }
                     }
                 }
                 """
@@ -1318,14 +1324,21 @@ final class PackageToolTests: CommandsTestCase {
 
             // Invoke it, and check the results.
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["plugin", "mycmd"], packagePath: packageDir, env: ["SWIFTPM_ENABLE_COMMAND_PLUGINS": "1"])
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(
+                    ["plugin", "--output", "/abc/def", "mycmd"],
+                    packagePath: packageDir,
+                    env: ["SWIFTPM_ENABLE_COMMAND_PLUGINS": "1"])
                 XCTAssertEqual(result.exitStatus, .terminated(code: 0))
                 XCTAssert(try result.utf8Output().contains("This is MyCommandPlugin."))
+                XCTAssert(try result.utf8Output().contains("Got output path /abc/def."))
             }
 
             // Testing listing the available command plugins.
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["plugin", "--list"], packagePath: packageDir, env: ["SWIFTPM_ENABLE_COMMAND_PLUGINS": "1"])
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(
+                    ["plugin", "--list"],
+                    packagePath: packageDir,
+                    env: ["SWIFTPM_ENABLE_COMMAND_PLUGINS": "1"])
                 XCTAssertEqual(result.exitStatus, .terminated(code: 0))
                 XCTAssert(try result.utf8Output().contains("‘mycmd’ (plugin ‘MyPlugin’ in package ‘MyPackage’)"))
             }

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -231,7 +231,8 @@ class PluginTests: XCTestCase {
                         func performCommand(
                             context: PluginContext,
                             targets: [Target],
-                            arguments: [String]
+                            arguments: [String],
+                            outputPath: Path?
                         ) throws {
                             // Check the identity of the root packages.
                             print("Root package is \\(context.package.displayName).")
@@ -239,7 +240,12 @@ class PluginTests: XCTestCase {
                             // Check that we can find a tool in the toolchain.
                             let swiftc = try context.tool(named: "swiftc")
                             print("Found the swiftc tool at \\(swiftc.path).")
-                        }
+
+                            // Check the output path.
+                            if let outputPath = outputPath {
+                                print("Got output path \\(outputPath.string).")
+                            }
+                       }
                     }
                 """
             }
@@ -337,10 +343,12 @@ class PluginTests: XCTestCase {
             let pluginOutputDir = tmpPath.appending(component: "plugin-output")
             let pluginScriptRunner = DefaultPluginScriptRunner(cacheDir: pluginCacheDir, toolchain: ToolchainConfiguration.default)
             let target = try XCTUnwrap(package.targets.first{ $0.underlyingTarget == libraryTarget })
+            let outputPath = tmpPath.appending(component: UUID().uuidString)
             let invocationSucceeded = try tsc_await { pluginTarget.invoke(
                 action: .performCommand(
-                    targets: [ target ],
-                    arguments: ["veni", "vidi", "vici"]),
+                    targets: [target],
+                    arguments: ["veni", "vidi", "vici"],
+                    outputPath: outputPath),
                 package: package,
                 buildEnvironment: BuildEnvironment(platform: .macOS, configuration: .debug),
                 scriptRunner: pluginScriptRunner,
@@ -358,6 +366,7 @@ class PluginTests: XCTestCase {
             let outputText = String(decoding: pluginDelegate.outputData, as: UTF8.self)
             XCTAssertTrue(outputText.contains("Root package is MyPackage."), outputText)
             XCTAssertTrue(outputText.contains("Found the swiftc tool"), outputText)
+            XCTAssertTrue(outputText.contains("Got output path \(outputPath.pathString)"), outputText)
         }
     }
 }


### PR DESCRIPTION
Add the ability to pass an output path to command plugins.  This output path is given to the plugin and is added to the sandbox as a place to which it can write.

This is a proposed amendment to the SE-0332 proposal currently being reviewed.

### Motivation:

Like all plugins, command plugins are run in a sandbox that only provides write access to temporary directories.  But it's quite common for a plugin to generate output, so there needs to be a way for a user to provide the path to the command and for SwiftPM to add that as a writable path to the sandbox.  This path can be either a directory or a file — it's up to the plugin to decide what it creates at that path.

### Modifications:

- extend the plugin protocol to have a `outputPath` parameter
- add compatibility glue to allow existing plugins to continue working
- add the optional output path field to the transport structure to be sent to the plugin
- add the `--outputPath` option to the `swift package plugin` subcommand
- extend unit tests

### Result:

Command plugins can access the optional `outputPath` parameter, and have write permission to it.
