### PR TITLE
Make sure that NSTemporaryDirectory() is included in the sandbox when `writableTemporaryDirectory` is set

### DIFF
--- a/Sources/Basics/Sandbox.swift
+++ b/Sources/Basics/Sandbox.swift
@@ -8,6 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
+import Foundation
 import TSCBasic
 import TSCUtility
 
@@ -73,8 +74,13 @@ fileprivate func macOSSandboxProfile(
     }
     // Optionally allow writing to temporary directories (a lot of use of Foundation requires this).
     else if strictness == .writableTemporaryDirectory {
-        writableDirectoriesExpression.append("(subpath \"/private/tmp\")")
-        if let tmpDir = try? TSCBasic.determineTempDirectory() {
+        // Add the standard and Foundation temporary directories, and the one determined by TSC (which also taked into account environment variables).
+        var temporaryDirectories = Set([AbsolutePath("/tmp"), AbsolutePath(NSTemporaryDirectory())])
+        if let tscTmpDir = try? TSCBasic.determineTempDirectory() {
+            temporaryDirectories.insert(tscTmpDir)
+        }
+        // Add `subpath` expressions for all of them.
+        for tmpDir in temporaryDirectories.sorted() {
             writableDirectoriesExpression += ["(subpath \(resolveSymlinks(tmpDir).quotedAsSubpathForSandboxProfile))"]
         }
     }


### PR DESCRIPTION
It seems that `TSCBasic.determineTempDirectory()` lets environment variables override the temporary directory, which might be alright for the process itself but not necessarily for spawned subprocesses.  If the subprocess uses NSTemporaryDirectory(), then that still won't be covered by the sandbox.

This change makes sure that it is covered by the sandbox, and uses a set to avoid duplicates (which wouldn't actually hurt but is inelegant).

This fixes a CI problem such as seen in https://ci.swift.org/job/oss-swift-package-macos/6399.

### Modifications:

- add NSTemporaryDirectory() to the set of writable directories in the sandbox, and don't just rely on TSC's notion of the temporary directory
- use a set to avoid duplicates

It's interesting to note that the PR build passed.  Perhaps the set of environment overrides is different for PR builds.

Since 5.6 was branched today this will also need to be merged there.

rdar://86150592
