### PR TITLE
[5.6] Set `relatedDependenciesBranch` to `release/5.6`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -536,7 +536,7 @@ let package = Package(
 // this right now.
 
 /// When not using local dependencies, the branch to use for llbuild and TSC repositories.
-let relatedDependenciesBranch = "main"
+let relatedDependenciesBranch = "release/5.6"
 
 if ProcessInfo.processInfo.environment["SWIFTPM_LLBUILD_FWK"] == nil {
     if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {


### PR DESCRIPTION
### Motivation:

Tools depending on `release/5.6` branch of SwiftPM together with `release/5.6` branch of TSC fail to build due to conflicting dependencies.

### Modifications:

`relatedDependenciesBranch` now is set to `release/5.6` instead of `main` when SwiftPM `release/5.6` branch is checked out. This makes dependencies consistent and resolvable when other Swift tools are included in the dependency tree. 

### Result:

Tools depending on `release/5.6` branch of SwiftPM can be built without failures.
