### PR TITLE
Simplify the adding of temporary directories to the sandbox profile when strictness is 'writableTemporaryDirectory'

### DIFF
--- a/Sources/Basics/Sandbox.swift
+++ b/Sources/Basics/Sandbox.swift
@@ -74,14 +74,9 @@ fileprivate func macOSSandboxProfile(
     }
     // Optionally allow writing to temporary directories (a lot of use of Foundation requires this).
     else if strictness == .writableTemporaryDirectory {
-        // Add the standard and Foundation temporary directories, and the one determined by TSC (which also taked into account environment variables).
-        var temporaryDirectories = Set([AbsolutePath("/tmp"), AbsolutePath(NSTemporaryDirectory())])
-        if let tscTmpDir = try? TSCBasic.determineTempDirectory() {
-            temporaryDirectories.insert(tscTmpDir)
-        }
-        // Add `subpath` expressions for all of them.
-        for tmpDir in temporaryDirectories.sorted() {
-            writableDirectoriesExpression += ["(subpath \(resolveSymlinks(tmpDir).quotedAsSubpathForSandboxProfile))"]
+        // Add `subpath` expressions for the regular and the Foundation temporary directories.
+        for tmpDir in ["/tmp", NSTemporaryDirectory()] {
+            writableDirectoriesExpression += ["(subpath \(resolveSymlinks(AbsolutePath(tmpDir)).quotedAsSubpathForSandboxProfile))"]
         }
     }
 


### PR DESCRIPTION
Specifically, we add regular and the Foundation temporary directories, but not anything passed in through the environment.

### Motivation:

This reduces the amount of magic and unpredictability regarding what's in the profile.  Client code that wants to add additional directories can do so using the array of writable paths that's already supported.

### Modifications:

- change the sandbox profile creation to just add `"/tmp"` and `NSTemporaryDirectory()`
