### PR TITLE
[5.6] Make sure that NSTemporaryDirectory() is included when `writableTemporaryDirectory` is set.

### DIFF
--- a/Sources/Basics/Sandbox.swift
+++ b/Sources/Basics/Sandbox.swift
@@ -8,6 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
+import Foundation
 import TSCBasic
 import TSCUtility
 
@@ -73,9 +74,9 @@ fileprivate func macOSSandboxProfile(
     }
     // Optionally allow writing to temporary directories (a lot of use of Foundation requires this).
     else if strictness == .writableTemporaryDirectory {
-        writableDirectoriesExpression.append("(subpath \"/private/tmp\")")
-        if let tmpDir = try? TSCBasic.determineTempDirectory() {
-            writableDirectoriesExpression += ["(subpath \(resolveSymlinks(tmpDir).quotedAsSubpathForSandboxProfile))"]
+        // Add `subpath` expressions for the regular and the Foundation temporary directories.
+        for tmpDir in ["/tmp", NSTemporaryDirectory()] {
+            writableDirectoriesExpression += ["(subpath \(resolveSymlinks(AbsolutePath(tmpDir)).quotedAsSubpathForSandboxProfile))"]
         }
     }
 


### PR DESCRIPTION
This is the 5.6 cherry-pick of #3918 and its refinement #3920.

This change makes the sandbox cover the regular "/tmp" and NSTemporaryDirectory() paths.  If environment entries are used to set other temporary directories in the subprocess, then the calling code should pass those to the `writableDirectories` parameter.

rdar://86150592
(cherry picked from commit 5546a97a5d48ab170b625bede6cd030ba2f1c962 and  3ba330585206c717c6e2067d0a9f24e298ffe88c)