### PR TITLE
[5.6] Only recompile plugin scripts to executables when needed (#3915)

### DIFF
--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -337,7 +337,7 @@ class PluginTests: XCTestCase {
             let pluginOutputDir = tmpPath.appending(component: "plugin-output")
             let pluginScriptRunner = DefaultPluginScriptRunner(cacheDir: pluginCacheDir, toolchain: ToolchainConfiguration.default)
             let target = try XCTUnwrap(package.targets.first{ $0.underlyingTarget == libraryTarget })
-            let _ = try tsc_await { pluginTarget.invoke(
+            let invocationSucceeded = try tsc_await { pluginTarget.invoke(
                 action: .performCommand(
                     targets: [ target ],
                     arguments: ["veni", "vidi", "vici"]),
@@ -354,6 +354,7 @@ class PluginTests: XCTestCase {
                 completion: $0) }
             
             // Check the results.
+            XCTAssertTrue(invocationSucceeded)
             let outputText = String(decoding: pluginDelegate.outputData, as: UTF8.self)
             XCTAssertTrue(outputText.contains("Root package is MyPackage."), outputText)
             XCTAssertTrue(outputText.contains("Found the swiftc tool"), outputText)


### PR DESCRIPTION
5.6 cherry-pick of #3915 

This is an optimization that skips the compilation step of a package plugin if a compiled version already exists, if none of the input files have changed, and if none of the compiler flags have changed.

rdar://74663095
(cherry picked from commit 1148eed8eab9da8d7c6ff17b34270e00897ea836)
