### PR TITLE
[5.6] Implement the `--list` option for command plugins. (#3916)

### DIFF
--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -1317,10 +1317,18 @@ final class PackageToolTests: CommandsTestCase {
             }
 
             // Invoke it, and check the results.
-            let result = try SwiftPMProduct.SwiftPackage.executeProcess(["plugin", "mycmd"], packagePath: packageDir, env: ["SWIFTPM_ENABLE_COMMAND_PLUGINS": "1"])
-            print(try result.utf8Output() + result.utf8stderrOutput())
-            XCTAssertEqual(result.exitStatus, .terminated(code: 0))
-            XCTAssert(try result.utf8Output().contains("This is MyCommandPlugin."))
+            do {
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["plugin", "mycmd"], packagePath: packageDir, env: ["SWIFTPM_ENABLE_COMMAND_PLUGINS": "1"])
+                XCTAssertEqual(result.exitStatus, .terminated(code: 0))
+                XCTAssert(try result.utf8Output().contains("This is MyCommandPlugin."))
+            }
+
+            // Testing listing the available command plugins.
+            do {
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["plugin", "--list"], packagePath: packageDir, env: ["SWIFTPM_ENABLE_COMMAND_PLUGINS": "1"])
+                XCTAssertEqual(result.exitStatus, .terminated(code: 0))
+                XCTAssert(try result.utf8Output().contains("‘mycmd’ (plugin ‘MyPlugin’ in package ‘MyPackage’)"))
+            }
         }
     }
 }


### PR DESCRIPTION
This is the 5.6 cherry-pick of #3916 

It shows the command, along with the target and package that provides them.  A later change can easily refine this to also list the intent (separately from the command).

(cherry picked from commit 8ebbc236ac4305642ed77ae12d41f9339a3c5f78)