### PR TITLE
optimize manifest requests for registry based depedendcies

### DIFF
--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -328,7 +328,7 @@ public struct ToolsVersionLoader: ToolsVersionLoaderProtocol {
 
     public func load(at path: AbsolutePath, fileSystem: FileSystem) throws -> ToolsVersion {
         // The file which contains the tools version.
-        let file = try Manifest.path(atPackagePath: path, currentToolsVersion: currentToolsVersion, fileSystem: fileSystem)
+        let file = try Manifest.path(atPackagePath: path, currentToolsVersion: self.currentToolsVersion, fileSystem: fileSystem)
         guard fileSystem.isFile(file) else {
             // FIXME: We should return an error from here but Workspace tests rely on this in order to work.
             // This doesn't really cause issues (yet) in practice though.

--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -185,7 +185,7 @@ public final class RegistryClient {
         timeout: DispatchTimeInterval? = .none,
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue,
-        completion: @escaping (Result<[String: ToolsVersion], Error>) -> Void
+        completion: @escaping (Result<[String: (toolsVersion: ToolsVersion, content: String?)], Error>) -> Void
     ) {
         let completion = self.makeAsync(completion, on: callbackQueue)
 
@@ -227,13 +227,13 @@ public final class RegistryClient {
                         throw RegistryError.invalidResponse
                     }
 
-                    var result = [String: ToolsVersion]()
+                    var result = [String: (toolsVersion: ToolsVersion, content: String?)]()
                     let toolsVersion = try ToolsVersionLoader().load(utf8String: manifestContent)
-                    result[Manifest.filename] = toolsVersion
+                    result[Manifest.filename] = (toolsVersion: toolsVersion, content: manifestContent)
 
                     let alternativeManifests = try response.headers.get("Link").map { try parseLinkHeader($0) }.flatMap { $0 }
                     for alternativeManifest in alternativeManifests {
-                        result[alternativeManifest.filename] = alternativeManifest.toolsVersion
+                        result[alternativeManifest.filename] = (toolsVersion: alternativeManifest.toolsVersion, content: .none)
                     }
                     return result
                 }.mapError {

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -290,7 +290,7 @@ public class Workspace {
     ) throws {
         // defaults
         let currentToolsVersion = customToolsVersion ?? ToolsVersion.currentToolsVersion
-        let toolsVersionLoader = ToolsVersionLoader()
+        let toolsVersionLoader = ToolsVersionLoader(currentToolsVersion: currentToolsVersion)
         let manifestLoader = try customManifestLoader ?? ManifestLoader(
             toolchain: UserToolchain(destination: .hostDestination()).configuration,
             cacheDir: location.sharedManifestsCacheDirectory

--- a/Tests/PackageRegistryTests/RegistryClientTests.swift
+++ b/Tests/PackageRegistryTests/RegistryClientTests.swift
@@ -84,27 +84,29 @@ final class RegistryClientTests: XCTestCase {
         let version = Version("1.1.1")
         let manifestURL = URL(string: "\(registryURL)/\(scope)/\(name)/\(version)/Package.swift")!
 
+        let defaultManifest = """
+        // swift-tools-version:5.5
+        import PackageDescription
+
+        let package = Package(
+            name: "LinkedList",
+            products: [
+                .library(name: "LinkedList", targets: ["LinkedList"])
+            ],
+            targets: [
+                .target(name: "LinkedList"),
+                .testTarget(name: "LinkedListTests", dependencies: ["LinkedList"]),
+            ],
+            swiftLanguageVersions: [.v4, .v5]
+        )
+        """
+
         let handler: HTTPClient.Handler = { request, _, completion in
             switch (request.method, request.url) {
             case (.get, manifestURL):
                 XCTAssertEqual(request.headers.get("Accept").first, "application/vnd.swift.registry.v1+swift")
 
-                let data = #"""
-                // swift-tools-version:5.5
-                import PackageDescription
-
-                let package = Package(
-                    name: "LinkedList",
-                    products: [
-                        .library(name: "LinkedList", targets: ["LinkedList"])
-                    ],
-                    targets: [
-                        .target(name: "LinkedList"),
-                        .testTarget(name: "LinkedListTests", dependencies: ["LinkedList"]),
-                    ],
-                    swiftLanguageVersions: [.v4, .v5]
-                )
-                """#.data(using: .utf8)!
+                let defaultManifestData = defaultManifest.data(using: .utf8)!
 
                 let links = """
                 <http://packages.example.com/mona/LinkedList/1.1.1/Package.swift?swift-version=4>; rel="alternate"; filename="Package@swift-4.swift"; swift-tools-version="4.0",
@@ -115,12 +117,12 @@ final class RegistryClientTests: XCTestCase {
                 completion(.success(.init(
                     statusCode: 200,
                     headers: .init([
-                        .init(name: "Content-Length", value: "\(data.count)"),
+                        .init(name: "Content-Length", value: "\(defaultManifestData.count)"),
                         .init(name: "Content-Type", value: "text/x-swift"),
                         .init(name: "Content-Version", value: "1"),
                         .init(name: "Link", value: links),
                     ]),
-                    body: data
+                    body: defaultManifestData
                 )))
             default:
                 completion(.failure(StringError("method and url should match")))
@@ -139,13 +141,15 @@ final class RegistryClientTests: XCTestCase {
             package: identity,
             version: version
         )
-        XCTAssertEqual(availableManifests,
-                       [
-                           "Package.swift": .v5_5,
-                           "Package@swift-4.swift": .v4,
-                           "Package@swift-4.2.swift": .v4_2,
-                           "Package@swift-5.3.swift": .v5_3,
-                       ])
+
+        XCTAssertEqual(availableManifests["Package.swift"]?.toolsVersion, .v5_5)
+        XCTAssertEqual(availableManifests["Package.swift"]?.content, defaultManifest)
+        XCTAssertEqual(availableManifests["Package@swift-4.swift"]?.toolsVersion, .v4)
+        XCTAssertEqual(availableManifests["Package@swift-4.swift"]?.content, .none)
+        XCTAssertEqual(availableManifests["Package@swift-4.2.swift"]?.toolsVersion, .v4_2)
+        XCTAssertEqual(availableManifests["Package@swift-4.2.swift"]?.content, .none)
+        XCTAssertEqual(availableManifests["Package@swift-5.3.swift"]?.toolsVersion, .v5_3)
+        XCTAssertEqual(availableManifests["Package@swift-5.3.swift"]?.content, .none)
     }
 
     func testGetManifestContent() throws {
@@ -878,7 +882,7 @@ private extension RegistryClient {
     func getAvailableManifests(
         package: PackageIdentity,
         version: Version
-    ) throws -> [String: ToolsVersion] {
+    ) throws -> [String: (toolsVersion: ToolsVersion, content: String?)] {
         return try tsc_await {
             self.getAvailableManifests(
                 package: package,
@@ -958,11 +962,12 @@ private extension RegistryClient {
     }
 }
 
-private func makeRegistryClient(configuration: RegistryConfiguration,
-                                httpClient: HTTPClient,
-                                fingerprintStorage: PackageFingerprintStorage = MockPackageFingerprintStorage(),
-                                fingerprintCheckingMode: FingerprintCheckingMode = .strict) -> RegistryClient
-{
+private func makeRegistryClient(
+    configuration: RegistryConfiguration,
+    httpClient: HTTPClient,
+    fingerprintStorage: PackageFingerprintStorage = MockPackageFingerprintStorage(),
+    fingerprintCheckingMode: FingerprintCheckingMode = .strict
+) -> RegistryClient {
     RegistryClient(
         configuration: configuration,
         identityResolver: DefaultIdentityResolver(),

--- a/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
@@ -1,0 +1,467 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import Basics
+import Foundation
+import PackageGraph
+import PackageLoading
+import PackageModel
+import PackageRegistry
+import SPMTestSupport
+import TSCBasic
+import TSCUtility
+@testable import Workspace
+import XCTest
+
+class RegistryPackageContainerTests: XCTestCase {
+
+    func testToolsVersionCompatibleVersions() throws {
+        let fs = InMemoryFileSystem()
+
+        let packageIdentity = PackageIdentity.plain("org.foo")
+        let packageVersion = Version("1.0.0")
+        let packagePath = AbsolutePath.root
+
+        func createProvider(_ toolsVersion: ToolsVersion) throws -> PackageContainerProvider {
+            let registryClient = try makeRegistryClient(
+                packageIdentity: packageIdentity,
+                packageVersion: packageVersion,
+                packagePath: packagePath,
+                fileSystem: fs,
+                releasesRequestHandler: { request, _ , completion in
+                    let metadata = RegistryClient.Serialization.PackageMetadata(
+                        releases: [
+                            "1.0.0":  .init(url: .none, problem: .none),
+                            "1.0.1":  .init(url: .none, problem: .none),
+                            "1.0.2":  .init(url: .none, problem: .none),
+                            "1.0.3":  .init(url: .none, problem: .none)
+                        ]
+                    )
+                    completion(.success(
+                        HTTPClientResponse(
+                            statusCode: 200,
+                            headers: [
+                                "Content-Version": "1",
+                                "Content-Type": "application/json"
+                            ],
+                            body: try! JSONEncoder.makeWithDefaults().encode(metadata)
+                        )
+                    ))
+                },
+                manifestRequestHandler: { request, _ , completion in
+                    let toolsVersion: ToolsVersion
+                    switch request.url.deletingLastPathComponent().lastPathComponent {
+                    case "1.0.0":
+                        toolsVersion = .v3
+                    case "1.0.1":
+                        toolsVersion = .v4
+                    case "1.0.2":
+                        toolsVersion = .v4_2
+                    case "1.0.3":
+                        toolsVersion = .v5_4
+                    default:
+                        toolsVersion = .currentToolsVersion
+                    }
+                    completion(.success(
+                        HTTPClientResponse(
+                            statusCode: 200,
+                            headers: [
+                                "Content-Version": "1",
+                                "Content-Type": "text/x-swift"
+                            ],
+                            body: "// swift-tools-version:\(toolsVersion)".data(using: .utf8)
+                        )
+                    ))
+                }
+            )
+
+            return try Workspace(
+                fileSystem: fs,
+                location: .init(forRootPackage: packagePath, fileSystem: fs),
+                customToolsVersion: toolsVersion,
+                customManifestLoader: MockManifestLoader(manifests: [:]),
+                customRegistryClient: registryClient
+            )
+        }
+
+        do {
+            let provider = try createProvider(.v4)
+            let ref = PackageReference.registry(identity: packageIdentity)
+            let container = try provider.getContainer(for: ref, skipUpdate: false)
+            let versions = try container.toolsVersionsAppropriateVersionsDescending().map { $0 }
+            XCTAssertEqual(versions, ["1.0.1"])
+        }
+
+        do {
+            let provider = try createProvider(.v4_2)
+            let ref = PackageReference.registry(identity: packageIdentity)
+            let container = try provider.getContainer(for: ref, skipUpdate: false)
+            let versions = try container.toolsVersionsAppropriateVersionsDescending().map { $0 }
+            XCTAssertEqual(versions, ["1.0.2", "1.0.1"])
+        }
+
+        do {
+            let provider = try createProvider(.v5_4)
+            let ref = PackageReference.registry(identity: packageIdentity)
+            let container = try provider.getContainer(for: ref, skipUpdate: false)
+            let versions = try container.toolsVersionsAppropriateVersionsDescending().map { $0 }
+            XCTAssertEqual(versions, ["1.0.3", "1.0.2", "1.0.1"])
+        }
+    }
+
+    func testAlternateManifests() throws {
+        let fs = InMemoryFileSystem()
+
+        let packageIdentity = PackageIdentity.plain("org.foo")
+        let packageVersion = Version("1.0.0")
+        let packagePath = AbsolutePath.root
+
+        func createProvider(_ toolsVersion: ToolsVersion) throws -> PackageContainerProvider {
+            let registryClient = try makeRegistryClient(
+                packageIdentity: packageIdentity,
+                packageVersion: packageVersion,
+                packagePath: packagePath,
+                fileSystem: fs,
+                manifestRequestHandler: { request, _ , completion in
+                    completion(.success(
+                        HTTPClientResponse(
+                            statusCode: 200,
+                            headers: [
+                                "Content-Version": "1",
+                                "Content-Type": "text/x-swift",
+                                "Link": """
+                                \(self.manifestLink(packageIdentity, .v5_4)),
+                                \(self.manifestLink(packageIdentity, .v5_5)),
+                                """
+                            ],
+                            body: "// swift-tools-version:\(ToolsVersion.v5_3)".data(using: .utf8)
+                        )
+                    ))
+                }
+            )
+
+            return try Workspace(
+                fileSystem: fs,
+                location: .init(forRootPackage: packagePath, fileSystem: fs),
+                customToolsVersion: toolsVersion,
+                customManifestLoader: MockManifestLoader(manifests: [:]),
+                customRegistryClient: registryClient
+            )
+        }
+
+        do {
+            let provider = try createProvider(.v5_2) // the version of the alternate
+            let ref = PackageReference.registry(identity: packageIdentity)
+            let container = try provider.getContainer(for: ref, skipUpdate: false)
+            XCTAssertEqual(try container.toolsVersion(for: packageVersion), .v5_3)
+            let versions = try container.toolsVersionsAppropriateVersionsDescending().map { $0 }
+            XCTAssertEqual(versions, [])
+        }
+
+        do {
+            let provider = try createProvider(.v5_3) // the version of the alternate
+            let ref = PackageReference.registry(identity: packageIdentity)
+            let container = try provider.getContainer(for: ref, skipUpdate: false)
+            XCTAssertEqual(try container.toolsVersion(for: packageVersion), .v5_3)
+            let versions = try container.toolsVersionsAppropriateVersionsDescending().map { $0 }
+            XCTAssertEqual(versions, [packageVersion])
+        }
+
+        do {
+            let provider = try createProvider(.v5_4) // the version of the alternate
+            let ref = PackageReference.registry(identity: packageIdentity)
+            let container = try provider.getContainer(for: ref, skipUpdate: false)
+            XCTAssertEqual(try container.toolsVersion(for: packageVersion), .v5_4)
+            let versions = try container.toolsVersionsAppropriateVersionsDescending().map { $0 }
+            XCTAssertEqual(versions, [packageVersion])
+        }
+
+        do {
+            let provider = try createProvider(.v5_5) // the version of the alternate
+            let ref = PackageReference.registry(identity: packageIdentity)
+            let container = try provider.getContainer(for: ref, skipUpdate: false)
+            XCTAssertEqual(try container.toolsVersion(for: packageVersion), .v5_5)
+            let versions = try container.toolsVersionsAppropriateVersionsDescending().map { $0 }
+            XCTAssertEqual(versions, [packageVersion])
+        }
+
+        do {
+            let provider = try createProvider(.v5_6) // the version of the alternate
+            let ref = PackageReference.registry(identity: packageIdentity)
+            let container = try provider.getContainer(for: ref, skipUpdate: false)
+            XCTAssertEqual(try container.toolsVersion(for: packageVersion), .v5_5)
+            let versions = try container.toolsVersionsAppropriateVersionsDescending().map { $0 }
+            XCTAssertEqual(versions, [packageVersion])
+        }
+    }
+
+    func testLoadManifest() throws {
+        let fs = InMemoryFileSystem()
+
+        let packageIdentity = PackageIdentity.plain("org.foo")
+        let packageVersion = Version("1.0.0")
+        let packagePath = AbsolutePath.root
+
+        func createProvider(_ toolsVersion: ToolsVersion) throws -> PackageContainerProvider {
+            let registryClient = try makeRegistryClient(
+                packageIdentity: packageIdentity,
+                packageVersion: packageVersion,
+                packagePath: packagePath,
+                fileSystem: fs,
+                manifestRequestHandler: { request, _ , completion in
+                    completion(.success(
+                        HTTPClientResponse(
+                            statusCode: 200,
+                            headers: [
+                                "Content-Version": "1",
+                                "Content-Type": "text/x-swift",
+                                "Link": """
+                                \(self.manifestLink(packageIdentity, .v5_4)),
+                                \(self.manifestLink(packageIdentity, .v5_5))
+                                """
+                            ],
+                            body: "// swift-tools-version:\(ToolsVersion.v5_3)".data(using: .utf8)
+                        )
+                    ))
+                }
+            )
+
+            return try Workspace(
+                fileSystem: fs,
+                location: .init(forRootPackage: packagePath, fileSystem: fs),
+                customToolsVersion: toolsVersion,
+                customManifestLoader: MockManifestLoader(),
+                customRegistryClient: registryClient
+            )
+
+            struct MockManifestLoader: ManifestLoaderProtocol {
+                func load(at path: AbsolutePath,
+                          packageIdentity: PackageIdentity,
+                          packageKind: PackageReference.Kind,
+                          packageLocation: String,
+                          version: Version?,
+                          revision: String?,
+                          toolsVersion: ToolsVersion,
+                          identityResolver: IdentityResolver,
+                          fileSystem: FileSystem,
+                          observabilityScope: ObservabilityScope,
+                          on queue: DispatchQueue,
+                          completion: @escaping (Result<Manifest, Error>) -> Void) {
+                    completion(.success(
+                        Manifest(
+                            displayName: packageIdentity.description,
+                            path: path,
+                            packageKind: packageKind,
+                            packageLocation: packageLocation,
+                            platforms: [],
+                            toolsVersion: toolsVersion
+                        )
+                    ))
+                }
+
+                func resetCache() throws {}
+                func purgeCache() throws {}
+            }
+        }
+
+        do {
+            let provider = try createProvider(.v5_3) // the version of the alternate
+            let ref = PackageReference.registry(identity: packageIdentity)
+            let container = try provider.getContainer(for: ref, skipUpdate: false) as! RegistryPackageContainer
+            let manifest = try container.loadManifest(version: packageVersion)
+            XCTAssertEqual(manifest.toolsVersion, .v5_3)
+        }
+
+        do {
+            let provider = try createProvider(.v5_4) // the version of the alternate
+            let ref = PackageReference.registry(identity: packageIdentity)
+            let container = try provider.getContainer(for: ref, skipUpdate: false) as! RegistryPackageContainer
+            let manifest = try container.loadManifest(version: packageVersion)
+            XCTAssertEqual(manifest.toolsVersion, .v5_4)
+        }
+
+        do {
+            let provider = try createProvider(.v5_5) // the version of the alternate
+            let ref = PackageReference.registry(identity: packageIdentity)
+            let container = try provider.getContainer(for: ref, skipUpdate: false) as! RegistryPackageContainer
+            let manifest = try container.loadManifest(version: packageVersion)
+            XCTAssertEqual(manifest.toolsVersion, .v5_5)
+        }
+
+        do {
+            let provider = try createProvider(.v5_6) // the version of the alternate
+            let ref = PackageReference.registry(identity: packageIdentity)
+            let container = try provider.getContainer(for: ref, skipUpdate: false) as! RegistryPackageContainer
+            let manifest = try container.loadManifest(version: packageVersion)
+            XCTAssertEqual(manifest.toolsVersion, .v5_5)
+        }
+    }
+
+    func makeRegistryClient(
+        packageIdentity: PackageIdentity,
+        packageVersion: Version,
+        packagePath: AbsolutePath,
+        fileSystem: FileSystem,
+        configuration: PackageRegistry.RegistryConfiguration? = .none,
+        releasesRequestHandler: HTTPClient.Handler? = .none,
+        versionMetadataRequestHandler: HTTPClient.Handler? = .none,
+        manifestRequestHandler: HTTPClient.Handler? = .none,
+        downloadArchiveRequestHandler: HTTPClient.Handler? = .none,
+        archiver: Archiver? = .none
+    ) throws -> RegistryClient {
+        let jsonEncoder = JSONEncoder.makeWithDefaults()
+
+        let identityResolver = DefaultIdentityResolver()
+        let fingerprintStorage = MockPackageFingerprintStorage()
+
+        guard let (packageScope, packageName) = packageIdentity.scopeAndName else {
+            throw StringError("Invalid package identity")
+        }
+
+        var configuration = configuration
+        if configuration == nil {
+            configuration = PackageRegistry.RegistryConfiguration()
+            configuration!.defaultRegistry = .init(url: URL(string: "http://localhost")!)
+        }
+
+        let releasesRequestHandler = releasesRequestHandler ?? { request, _ , completion in
+            let metadata = RegistryClient.Serialization.PackageMetadata(
+                releases: [packageVersion.description:  .init(url: .none, problem: .none)]
+            )
+            completion(.success(
+                HTTPClientResponse(
+                    statusCode: 200,
+                    headers: [
+                        "Content-Version": "1",
+                        "Content-Type": "application/json"
+                    ],
+                    body: try! jsonEncoder.encode(metadata)
+                )
+            ))
+        }
+
+        let versionMetadataRequestHandler = versionMetadataRequestHandler ?? { request, _ , completion in
+            let metadata = RegistryClient.Serialization.VersionMetadata(
+                id: packageIdentity.description,
+                version: packageVersion.description,
+                resources: [
+                    .init(
+                        name: "source-archive",
+                        type: "application/zip",
+                        checksum: ""
+                    )
+                ],
+                metadata: .init(description: "")
+            )
+            completion(.success(
+                HTTPClientResponse(
+                    statusCode: 200,
+                    headers: [
+                        "Content-Version": "1",
+                        "Content-Type": "application/json"
+                    ],
+                    body: try! jsonEncoder.encode(metadata)
+                )
+            ))
+        }
+
+        let manifestRequestHandler = manifestRequestHandler ?? { request, _ , completion in
+            completion(.success(
+                HTTPClientResponse(
+                    statusCode: 200,
+                    headers: [
+                        "Content-Version": "1",
+                        "Content-Type": "text/x-swift"
+                    ],
+                    body: "// swift-tools-version:\(ToolsVersion.currentToolsVersion)".data(using: .utf8)
+                )
+            ))
+        }
+
+        let downloadArchiveRequestHandler = downloadArchiveRequestHandler ?? { request, _ , completion in
+            // meh
+            let path = packagePath
+                .appending(components: ".build", "registry", "downloads", packageScope.description, packageName.description)
+                .appending(component: "\(packageVersion).zip")
+            try! fileSystem.createDirectory(path.parentDirectory, recursive: true)
+            try! fileSystem.writeFileContents(path, string: "")
+
+            completion(.success(
+                HTTPClientResponse(
+                    statusCode: 200,
+                    headers: [
+                        "Content-Version": "1",
+                        "Content-Type": "application/zip"
+                    ],
+                    body: "".data(using: .utf8)
+                )
+            ))
+        }
+
+        let archiver = archiver ?? MockArchiver(handler: { archiver, from, to, completion in
+            do {
+                try fileSystem.createDirectory(to.appending(component: "top"), recursive: true)
+                completion(.success(()))
+            } catch {
+                completion(.failure(error))
+            }
+        })
+
+        return RegistryClient(
+            configuration: configuration!,
+            identityResolver: identityResolver,
+            fingerprintStorage: fingerprintStorage,
+            fingerprintCheckingMode: .none,
+            authorizationProvider: .none,
+            customHTTPClient: HTTPClient(configuration: .init(), handler: { request, progress , completion in
+                var pathComponents = request.url.pathComponents
+                if pathComponents.first == "/" {
+                    pathComponents = Array(pathComponents.dropFirst())
+                }
+                guard pathComponents.count >= 2 else {
+                    return completion(.failure(StringError("invalid url \(request.url)")))
+                }
+                guard pathComponents[0] == packageScope.description else {
+                    return completion(.failure(StringError("invalid url \(request.url)")))
+                }
+                guard pathComponents[1] == packageName.description else {
+                    return completion(.failure(StringError("invalid url \(request.url)")))
+                }
+
+                switch pathComponents.count {
+                case 2:
+                    releasesRequestHandler(request, progress, completion)
+                case 3 where pathComponents[2].hasSuffix(".zip"):
+                    downloadArchiveRequestHandler(request, progress, completion)
+                case 3:
+                    versionMetadataRequestHandler(request, progress, completion)
+                case 4 where pathComponents[3].hasSuffix(".swift"):
+                    manifestRequestHandler(request, progress, completion)
+                default:
+                    completion(.failure(StringError("unexpected url \(request.url)")))
+                }
+            }),
+            customArchiverProvider: { _ in archiver }
+        )
+    }
+
+    private func manifestLink(_ identity: PackageIdentity, _ version: ToolsVersion) -> String {
+        guard let (scope, name) = identity.scopeAndName else {
+            preconditionFailure("invalid identity")
+        }
+        return "<http://localhost/\(scope)/\(name)/\(version)/\(Manifest.filename)?swift-version=\(version)>; rel=\"alternate\"; filename=\"Package@swift-\(version).swift\"; swift-tools-version=\"\(version)\""
+    }
+}
+
+extension PackageContainerProvider {
+    fileprivate func getContainer(for package: PackageReference, skipUpdate: Bool) throws -> PackageContainer {
+        try tsc_await { self.getContainer(for: package, skipUpdate: skipUpdate, observabilityScope: ObservabilitySystem.NOOP, on: .global(), completion: $0)  }
+    }
+}

--- a/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
@@ -161,7 +161,7 @@ private let v1: Version = "1.0.0"
 private let v2: Version = "2.0.0"
 private let v1Range: VersionSetSpecifier = .range("1.0.0" ..< "2.0.0")
 
-class PackageContainerProviderTests: XCTestCase {
+class SourceControlPackageContainerTests: XCTestCase {
     func testVprefixVersions() throws {
         let fs = InMemoryFileSystem()
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -9413,7 +9413,7 @@ final class WorkspaceTests: XCTestCase {
                         "Content-Version": "1",
                         "Content-Type": "text/x-swift"
                     ],
-                    body: "// swift-tools-version: \(ToolsVersion.currentToolsVersion)".data(using: .utf8)
+                    body: "// swift-tools-version:\(ToolsVersion.currentToolsVersion)".data(using: .utf8)
                 )
             ))
         }
@@ -9438,7 +9438,14 @@ final class WorkspaceTests: XCTestCase {
             ))
         }
 
-        let archiver = archiver ?? MockArchiver()
+        let archiver = archiver ?? MockArchiver(handler: { archiver, from, to, completion in
+            do {
+                try fileSystem.createDirectory(to.appending(component: "top"), recursive: true)
+                completion(.success(()))
+            } catch {
+                completion(.failure(error))
+            }
+        })
         let fingerprintStorage = fingerprintStorage ?? MockPackageFingerprintStorage()
 
         return RegistryClient(


### PR DESCRIPTION
motivation: improve performance by reducing redundant http calls

changes:
* save main manifest on first request
* cache known manifest across calls in RegistryPackageContainer
* add RegistryPackageContainer tests
* fix a bug in workspace where custom tools version is not propogated to the toolsLoader

rdar://86218181