### PR TITLE
[DO NOT MERGE] Test creating 'fingerprints' dir

### DIFF
--- a/Sources/Basics/FileSystem+Extensions.swift
+++ b/Sources/Basics/FileSystem+Extensions.swift
@@ -20,11 +20,6 @@ extension FileSystem {
     public var dotSwiftPM: AbsolutePath {
         self.homeDirectory.appending(component: ".swiftpm")
     }
-    
-    /// SwiftPM security directory
-    public var swiftPMSecurityDirectory: AbsolutePath {
-        self.dotSwiftPM.appending(component: "security")
-    }
 }
 
 // MARK: - cache
@@ -114,6 +109,19 @@ extension FileSystem {
             try self.createSymbolicLink(dotSwiftPMConfigDirectory, pointingAt: idiomaticConfigDirectory, relative: false)
         }
         return idiomaticConfigDirectory
+    }
+}
+
+// MARK: - security
+
+extension FileSystem {
+    /// SwiftPM security directory
+    public var swiftPMSecurityDirectory: AbsolutePath {
+        self.dotSwiftPM.appending(component: "security")
+    }
+    
+    public var swiftPMFingerprintsDirectory: AbsolutePath {
+        self.swiftPMSecurityDirectory.appending(component: "fingerprints")
     }
 }
 

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -648,6 +648,8 @@ public class SwiftTool {
             if !fileSystem.exists(sharedFingerprintsDirectory) {
                 try fileSystem.createDirectory(sharedFingerprintsDirectory, recursive: true)
             }
+            // And make sure we can lock the directory (which writes a lock file)
+            try fileSystem.withLock(on: sharedFingerprintsDirectory, type: .exclusive) { }
             return sharedFingerprintsDirectory
         } catch {
             self.observabilityScope.emit(warning: "Failed creating shared fingerprints directory: \(error)")

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -641,16 +641,16 @@ public class SwiftTool {
         }
     }
     
-    private func getSharedSecurityDirectory() throws -> AbsolutePath? {
+    private func getSharedFingerprintsDirectory() throws -> AbsolutePath? {
         do {
             let fileSystem = localFileSystem
-            let sharedSecurityDirectory = fileSystem.swiftPMSecurityDirectory
-            if !fileSystem.exists(sharedSecurityDirectory) {
-                try fileSystem.createDirectory(sharedSecurityDirectory, recursive: true)
+            let sharedFingerprintsDirectory = fileSystem.swiftPMFingerprintsDirectory
+            if !fileSystem.exists(sharedFingerprintsDirectory) {
+                try fileSystem.createDirectory(sharedFingerprintsDirectory, recursive: true)
             }
-            return sharedSecurityDirectory
+            return sharedFingerprintsDirectory
         } catch {
-            self.observabilityScope.emit(warning: "Failed creating shared security directory: \(error)")
+            self.observabilityScope.emit(warning: "Failed creating shared fingerprints directory: \(error)")
             return .none
         }
     }
@@ -662,12 +662,10 @@ public class SwiftTool {
         }
 
         let delegate = ToolWorkspaceDelegate(self.outputStream, logLevel: self.logLevel, observabilityScope: self.observabilityScope)
-        let provider = GitRepositoryProvider(processSet: processSet)        
-        // FIXME: rdar://86367436
-        //let sharedSecurityDirectory = try self.getSharedSecurityDirectory()
-        let sharedSecurityDirectory: AbsolutePath? = nil
+        let provider = GitRepositoryProvider(processSet: processSet)
         let sharedCacheDirectory = try self.getSharedCacheDirectory()
         let sharedConfigurationDirectory = try self.getSharedConfigurationDirectory()
+        let sharedFingerprintsDirectory = try self.getSharedFingerprintsDirectory()
         let isXcodeBuildSystemEnabled = self.options.buildSystem == .xcode
         let workspace = try Workspace(
             fileSystem: localFileSystem,
@@ -675,9 +673,9 @@ public class SwiftTool {
                 workingDirectory: buildPath,
                 editsDirectory: self.editsDirectory(),
                 resolvedVersionsFile: self.resolvedVersionsFile(),
-                sharedSecurityDirectory: sharedSecurityDirectory,
                 sharedCacheDirectory: sharedCacheDirectory,
-                sharedConfigurationDirectory: sharedConfigurationDirectory
+                sharedConfigurationDirectory: sharedConfigurationDirectory,
+                sharedFingerprintsDirectory: sharedFingerprintsDirectory
             ),
             mirrors: self.getMirrorsConfig(sharedConfigurationDirectory: sharedConfigurationDirectory).mirrors,
             registries: try self.getRegistriesConfig(sharedConfigurationDirectory: sharedConfigurationDirectory).configuration,

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -239,9 +239,9 @@ public final class MockWorkspace {
                 workingDirectory: self.sandbox.appending(component: ".build"),
                 editsDirectory: self.sandbox.appending(component: "edits"),
                 resolvedVersionsFile: self.sandbox.appending(component: "Package.resolved"),
-                sharedSecurityDirectory: self.fileSystem.swiftPMSecurityDirectory,  
                 sharedCacheDirectory: self.fileSystem.swiftPMCacheDirectory,
-                sharedConfigurationDirectory: self.fileSystem.swiftPMConfigDirectory
+                sharedConfigurationDirectory: self.fileSystem.swiftPMConfigDirectory,
+                sharedFingerprintsDirectory: self.fileSystem.swiftPMFingerprintsDirectory
             ),
             mirrors: self.mirrors,
             customToolsVersion: self.toolsVersion,

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -417,9 +417,9 @@ public class Workspace {
                 workingDirectory: dataPath,
                 editsDirectory: editablesPath,
                 resolvedVersionsFile: pinsFile,
-                sharedSecurityDirectory: fileSystem.swiftPMSecurityDirectory,
                 sharedCacheDirectory: cachePath,
-                sharedConfigurationDirectory: nil // legacy
+                sharedConfigurationDirectory: nil, // legacy
+                sharedFingerprintsDirectory: fileSystem.swiftPMFingerprintsDirectory
             ),
             mirrors: config?.mirrors,
             authorizationProvider: netrcFilePath.map {

--- a/Sources/Workspace/WorkspaceConfiguration.swift
+++ b/Sources/Workspace/WorkspaceConfiguration.swift
@@ -30,15 +30,15 @@ extension Workspace {
 
         /// Path to the Package.resolved file.
         public var resolvedVersionsFile: AbsolutePath
-        
-        /// Path to the shared security directory
-        public var sharedSecurityDirectory: AbsolutePath?
 
         /// Path to the shared cache directory
         public var sharedCacheDirectory: AbsolutePath?
 
         /// Path to the shared configuration directory
         public var sharedConfigurationDirectory: AbsolutePath?
+        
+        /// Path to the shared fingerprints directory
+        public var sharedFingerprintsDirectory: AbsolutePath?
 
         /// Path to the repositories clones.
         public var repositoriesDirectory: AbsolutePath {
@@ -58,11 +58,6 @@ extension Workspace {
         /// Path to the downloaded binary artifacts.
         public var artifactsDirectory: AbsolutePath {
             self.workingDirectory.appending(component: "artifacts")
-        }
-        
-        /// Path to the shared fingerprints directory.
-        public var sharedFingerprintsDirectory: AbsolutePath? {
-            self.sharedSecurityDirectory.map { $0.appending(component: "fingerprints") }
         }
 
         /// Path to the shared repositories cache.
@@ -96,23 +91,23 @@ extension Workspace {
         ///   - workingDirectory: Path to working directory for this workspace.
         ///   - editsDirectory: Path to store the editable versions of dependencies.
         ///   - resolvedVersionsFile: Path to the Package.resolved file.
-        ///   - sharedSecurityDirectory: Path to the shared security directory.
         ///   - sharedCacheDirectory: Path to the shared cache directory.
         ///   - sharedConfigurationDirectory: Path to the shared configuration directory.
+        ///   - sharedFingerprintsDirectory: Path to the shared fingerprints directory.
         public init(
             workingDirectory: AbsolutePath,
             editsDirectory: AbsolutePath,
             resolvedVersionsFile: AbsolutePath,
-            sharedSecurityDirectory: AbsolutePath?,
             sharedCacheDirectory: AbsolutePath?,
-            sharedConfigurationDirectory: AbsolutePath?
+            sharedConfigurationDirectory: AbsolutePath?,
+            sharedFingerprintsDirectory: AbsolutePath?
         ) {
             self.workingDirectory = workingDirectory
             self.editsDirectory = editsDirectory
             self.resolvedVersionsFile = resolvedVersionsFile
-            self.sharedSecurityDirectory = sharedSecurityDirectory
             self.sharedCacheDirectory = sharedCacheDirectory
             self.sharedConfigurationDirectory = sharedConfigurationDirectory
+            self.sharedFingerprintsDirectory = sharedFingerprintsDirectory
         }
 
         /// Create a new workspace location.
@@ -124,9 +119,9 @@ extension Workspace {
                 workingDirectory: DefaultLocations.workingDirectory(forRootPackage: rootPath),
                 editsDirectory: DefaultLocations.editsDirectory(forRootPackage: rootPath),
                 resolvedVersionsFile: DefaultLocations.resolvedVersionsFile(forRootPackage: rootPath),
-                sharedSecurityDirectory: fileSystem.swiftPMSecurityDirectory,
                 sharedCacheDirectory: fileSystem.swiftPMCacheDirectory,
-                sharedConfigurationDirectory: fileSystem.swiftPMConfigDirectory
+                sharedConfigurationDirectory: fileSystem.swiftPMConfigDirectory,
+                sharedFingerprintsDirectory: fileSystem.swiftPMFingerprintsDirectory
             )
         }
     }


### PR DESCRIPTION
Motivation:
Source compat test continues to fail even with https://github.com/apple/swift-package-manager/pull/3928:

```
"You don’t have permission to save the file “fingerprints” in the folder “security”
```

https://ci.swift.org/job/swift-PR-source-compat-suite/5709/artifact/

Not sure how/why, but it seems like `security` directory is created just fine but not the `fingerprints` sub directory (`fingerprints` is a directory not a file, and the code add a file to the `fingerprints` dir for each downloaded package).

Modifications:
Test creating `fingerprints` directory instead of `security`, and if that fails, disable TOFU feature.