### PR TITLE
Create 'security' directory test should try writing files too

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -648,6 +648,8 @@ public class SwiftTool {
             if !fileSystem.exists(sharedSecurityDirectory) {
                 try fileSystem.createDirectory(sharedSecurityDirectory, recursive: true)
             }
+            // And make sure we can write files (locking the directory writes a lock file)
+            try fileSystem.withLock(on: sharedSecurityDirectory, type: .exclusive) { }
             return sharedSecurityDirectory
         } catch {
             self.observabilityScope.emit(warning: "Failed creating shared security directory: \(error)")
@@ -662,10 +664,8 @@ public class SwiftTool {
         }
 
         let delegate = ToolWorkspaceDelegate(self.outputStream, logLevel: self.logLevel, observabilityScope: self.observabilityScope)
-        let provider = GitRepositoryProvider(processSet: processSet)        
-        // FIXME: rdar://86367436
-        //let sharedSecurityDirectory = try self.getSharedSecurityDirectory()
-        let sharedSecurityDirectory: AbsolutePath? = nil
+        let provider = GitRepositoryProvider(processSet: processSet)
+        let sharedSecurityDirectory = try self.getSharedSecurityDirectory()
         let sharedCacheDirectory = try self.getSharedCacheDirectory()
         let sharedConfigurationDirectory = try self.getSharedConfigurationDirectory()
         let isXcodeBuildSystemEnabled = self.options.buildSystem == .xcode


### PR DESCRIPTION
Motivation:
Source compat test continues to fail even with https://github.com/apple/swift-package-manager/pull/3928:

```
"You don’t have permission to save the file “fingerprints” in the folder “security”
```

https://ci.swift.org/job/swift-PR-source-compat-suite/5709/artifact/

The tests we did with https://github.com/apple/swift-package-manager/pull/3938 shows that we can create directories but not write files.

Modifications:
Test creating `security` directory and writing file in it, and disable TOFU feature if the test fails.
