### PR TITLE
use idiomatic location for security directory and update location of configuration directory

### DIFF
--- a/Sources/Basics/FileSystem+Extensions.swift
+++ b/Sources/Basics/FileSystem+Extensions.swift
@@ -100,13 +100,14 @@ extension FileSystem {
             // but leave them there for backwards compatibility (eg older xcode)
             let oldConfigDirectory = idiomaticConfigurationDirectory.parentDirectory
             if self.exists(oldConfigDirectory, followSymlink: false) && self.isDirectory(oldConfigDirectory) {
-                let content = try self.getDirectoryContents(oldConfigDirectory).filter{ !$0.hasSuffix(".lock") }
-                for item in content {
-                    if self.isFile(oldConfigDirectory.appending(component: item)) &&
-                        !self.isSymlink(oldConfigDirectory.appending(component: item)) &&
-                        !self.exists(idiomaticConfigurationDirectory.appending(component: item)) {
-                        observabilityScope?.emit(warning: "Usage of \(oldConfigDirectory.appending(component: item)) has been deprecated. Please delete it and use the new \(idiomaticConfigurationDirectory.appending(component: item)) instead.")
-                        try self.copy(from: oldConfigDirectory.appending(component: item), to: idiomaticConfigurationDirectory.appending(component: item))
+                let configurationFiles = try self.getDirectoryContents(oldConfigDirectory)
+                    .map{ oldConfigDirectory.appending(component: $0) }
+                    .filter{ self.isFile($0) && !self.isSymlink($0) && $0.extension != "lock"}
+                for file in configurationFiles {
+                    let destination = idiomaticConfigurationDirectory.appending(component: file.basename)
+                    observabilityScope?.emit(warning: "Usage of \(file) has been deprecated. Please delete it and use the new \(destination) instead.")
+                    if !self.exists(destination) {
+                        try self.copy(from: file, to: destination)
                     }
                 }
             }
@@ -116,13 +117,14 @@ extension FileSystem {
             // but leave them there for backwards compatibility (eg older toolchain)
             let oldConfigDirectory = self.dotSwiftPM.appending(component: "config")
             if self.exists(oldConfigDirectory, followSymlink: false) && self.isDirectory(oldConfigDirectory) {
-                let content = try self.getDirectoryContents(oldConfigDirectory).filter{ !$0.hasSuffix(".lock") }
-                for item in content {
-                    if self.isFile(oldConfigDirectory.appending(component: item)) &&
-                        !self.isSymlink(oldConfigDirectory.appending(component: item)) &&
-                        !self.exists(idiomaticConfigurationDirectory.appending(component: item)) {
-                        observabilityScope?.emit(warning: "Usage of \(oldConfigDirectory.appending(component: item)) has been deprecated. Please delete it and use the new \(idiomaticConfigurationDirectory.appending(component: item)) instead.")
-                        try self.copy(from: oldConfigDirectory.appending(component: item), to: idiomaticConfigurationDirectory.appending(component: item))
+                let configurationFiles = try self.getDirectoryContents(oldConfigDirectory)
+                    .map{ oldConfigDirectory.appending(component: $0) }
+                    .filter{ self.isFile($0) && !self.isSymlink($0) && $0.extension != "lock"}
+                for file in configurationFiles {
+                    let destination = idiomaticConfigurationDirectory.appending(component: file.basename)
+                    observabilityScope?.emit(warning: "Usage of \(file) has been deprecated. Please delete it and use the new \(destination) instead.")
+                    if !self.exists(destination) {
+                        try self.copy(from: file, to: destination)
                     }
                 }
             }

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -149,6 +149,9 @@ public struct SwiftToolOptions: ParsableArguments {
     @Option(help: "Specify the shared configuration directory")
     var configPath: AbsolutePath?
 
+    @Option(help: "Specify the shared security directory")
+    var securityPath: AbsolutePath?
+
     /// Disables repository caching.
     @Flag(name: .customLong("repository-cache"), inversion: .prefixedEnableDisable, help: "Use a shared cache when fetching repositories")
     var useRepositoriesCache: Bool = true

--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -55,7 +55,7 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
         self.decoder = JSONDecoder.makeWithDefaults()
         self.validator = JSONModel.Validator(configuration: configuration.validator)
         self.signatureValidator = signatureValidator ?? PackageCollectionSigning(
-            trustedRootCertsDir: configuration.trustedRootCertsDir ?? fileSystem.swiftPMConfigDirectory.appending(component: "trust-root-certs").asURL,
+            trustedRootCertsDir: configuration.trustedRootCertsDir ?? fileSystem.swiftPMConfigurationDirectory.appending(component: "trust-root-certs").asURL,
             additionalTrustedRootCerts: sourceCertPolicy.allRootCerts.map { Array($0) },
             observabilityScope: observabilityScope,
             callbackQueue: .sharedConcurrent

--- a/Sources/PackageCollections/Storage/FilePackageCollectionsSourcesStorage.swift
+++ b/Sources/PackageCollections/Storage/FilePackageCollectionsSourcesStorage.swift
@@ -26,7 +26,7 @@ struct FilePackageCollectionsSourcesStorage: PackageCollectionsSourcesStorage {
     init(fileSystem: FileSystem = localFileSystem, path: AbsolutePath? = nil) {
         self.fileSystem = fileSystem
 
-        self.path = path ?? fileSystem.swiftPMConfigDirectory.appending(component: "collections.json")
+        self.path = path ?? fileSystem.swiftPMConfigurationDirectory.appending(component: "collections.json")
         self.encoder = JSONEncoder.makeWithDefaults()
         self.decoder = JSONDecoder.makeWithDefaults()
     }

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -241,7 +241,7 @@ public final class MockWorkspace {
                 resolvedVersionsFile: self.sandbox.appending(component: "Package.resolved"),
                 sharedSecurityDirectory: self.fileSystem.swiftPMSecurityDirectory,  
                 sharedCacheDirectory: self.fileSystem.swiftPMCacheDirectory,
-                sharedConfigurationDirectory: self.fileSystem.swiftPMConfigDirectory
+                sharedConfigurationDirectory: self.fileSystem.swiftPMConfigurationDirectory
             ),
             mirrors: self.mirrors,
             customToolsVersion: self.toolsVersion,

--- a/Sources/Workspace/WorkspaceConfiguration.swift
+++ b/Sources/Workspace/WorkspaceConfiguration.swift
@@ -126,7 +126,7 @@ extension Workspace {
                 resolvedVersionsFile: DefaultLocations.resolvedVersionsFile(forRootPackage: rootPath),
                 sharedSecurityDirectory: fileSystem.swiftPMSecurityDirectory,
                 sharedCacheDirectory: fileSystem.swiftPMCacheDirectory,
-                sharedConfigurationDirectory: fileSystem.swiftPMConfigDirectory
+                sharedConfigurationDirectory: fileSystem.swiftPMConfigurationDirectory
             )
         }
     }

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -415,7 +415,7 @@ class MiscellaneousTestCase: XCTestCase {
             XCTAssert(output.contains("does not exist"), "Error from git was not propagated to process output: \(output)")
         }
     }
-    
+
     func testLocalPackageUsedAsURL() throws {
         fixture(name: "Miscellaneous/LocalPackageAsURL", createGitRepo: false) { prefix in
             // This fixture has a setup that is trying to use a local package
@@ -431,7 +431,7 @@ class MiscellaneousTestCase: XCTestCase {
             XCTAssert(output.contains("Cannot clone from local directory"), "Didn't find expected output: \(output)")
         }
     }
-    
+
     func testUnicode() {
         #if !os(Linux) && !os(Android) // TODO: - Linux has trouble with this and needs investigation.
         fixture(name: "Miscellaneous/Unicode") { prefix in
@@ -505,7 +505,7 @@ class MiscellaneousTestCase: XCTestCase {
             XCTAssertMatch(stderr, .contains("warning: '--generate-linuxmain' option is deprecated"))
         }
     }
-    
+
     func testGenerateLinuxMain() {
         #if os(macOS)
         fixture(name: "Miscellaneous/TestDiscovery/Simple") { path in
@@ -552,13 +552,13 @@ class MiscellaneousTestCase: XCTestCase {
         }
         #endif
     }
-    
+
     func testTestsCanLinkAgainstExecutable() throws {
         // Check if the host compiler supports the '-entry-point-function-name' flag.
         #if swift(<5.5)
         try XCTSkipIf(true, "skipping because host compiler doesn't support '-entry-point-function-name'")
         #endif
-        
+
         fixture(name: "Miscellaneous/TestableExe") { prefix in
             do {
                 let (stdout, _) = try executeSwiftTest(prefix)
@@ -648,6 +648,17 @@ class MiscellaneousTestCase: XCTestCase {
             try SwiftPMProduct.SwiftBuild.execute(["--cache-path", customCachePath.pathString], packagePath: path)
             XCTAssertDirectoryExists(customCachePath)
         }
+
+        fixture(name: "Miscellaneous/Simple") { path in
+            try localFileSystem.chmod(.userUnWritable, path: path)
+            let customCachePath = path.appending(components: "custom", "cache")
+            XCTAssertNoSuchPath(customCachePath)
+            let result = try SwiftPMProduct.SwiftBuild.executeProcess(["--cache-path", customCachePath.pathString], packagePath: path)
+            XCTAssert(result.exitStatus != .terminated(code: 0))
+            let output = try result.utf8stderrOutput()
+            XCTAssert(output.contains("error: You don’t have permission"), "expected permissions error")
+            XCTAssertNoSuchPath(customCachePath)
+        }
     }
 
     func testCustomConfigPath() {
@@ -656,6 +667,37 @@ class MiscellaneousTestCase: XCTestCase {
             XCTAssertNoSuchPath(customConfigPath)
             try SwiftPMProduct.SwiftBuild.execute(["--config-path", customConfigPath.pathString], packagePath: path)
             XCTAssertDirectoryExists(customConfigPath)
+        }
+
+        fixture(name: "Miscellaneous/Simple") { path in
+            try localFileSystem.chmod(.userUnWritable, path: path)
+            let customConfigPath = path.appending(components: "custom", "config")
+            XCTAssertNoSuchPath(customConfigPath)
+            let result = try SwiftPMProduct.SwiftBuild.executeProcess(["--config-path", customConfigPath.pathString], packagePath: path)
+            XCTAssert(result.exitStatus != .terminated(code: 0))
+            let output = try result.utf8stderrOutput()
+            XCTAssert(output.contains("error: You don’t have permission"), "expected permissions error")
+            XCTAssertNoSuchPath(customConfigPath)
+        }
+    }
+
+    func testCustomSecurityPath() {
+        fixture(name: "Miscellaneous/Simple") { path in
+            let customSecurityPath = path.appending(components: "custom", "security")
+            XCTAssertNoSuchPath(customSecurityPath)
+            try SwiftPMProduct.SwiftBuild.execute(["--security-path", customSecurityPath.pathString], packagePath: path)
+            XCTAssertDirectoryExists(customSecurityPath)
+        }
+
+        fixture(name: "Miscellaneous/Simple") { path in
+            try localFileSystem.chmod(.userUnWritable, path: path)
+            let customSecurityPath = path.appending(components: "custom", "security")
+            XCTAssertNoSuchPath(customSecurityPath)
+            let result = try SwiftPMProduct.SwiftBuild.executeProcess(["--security-path", customSecurityPath.pathString], packagePath: path)
+            XCTAssert(result.exitStatus != .terminated(code: 0))
+            let output = try result.utf8stderrOutput()
+            XCTAssert(output.contains("error: You don’t have permission"), "expected permissions error")
+            XCTAssertNoSuchPath(customSecurityPath)
         }
     }
 }

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -649,6 +649,8 @@ class MiscellaneousTestCase: XCTestCase {
             XCTAssertDirectoryExists(customCachePath)
         }
 
+        // `FileSystem` does not support `chmod` on Linux
+        #if os(macOS)
         fixture(name: "Miscellaneous/Simple") { path in
             try localFileSystem.chmod(.userUnWritable, path: path)
             let customCachePath = path.appending(components: "custom", "cache")
@@ -659,6 +661,7 @@ class MiscellaneousTestCase: XCTestCase {
             XCTAssert(output.contains("error: You don’t have permission"), "expected permissions error")
             XCTAssertNoSuchPath(customCachePath)
         }
+        #endif
     }
 
     func testCustomConfigPath() {
@@ -669,6 +672,8 @@ class MiscellaneousTestCase: XCTestCase {
             XCTAssertDirectoryExists(customConfigPath)
         }
 
+        // `FileSystem` does not support `chmod` on Linux
+        #if os(macOS)
         fixture(name: "Miscellaneous/Simple") { path in
             try localFileSystem.chmod(.userUnWritable, path: path)
             let customConfigPath = path.appending(components: "custom", "config")
@@ -679,6 +684,7 @@ class MiscellaneousTestCase: XCTestCase {
             XCTAssert(output.contains("error: You don’t have permission"), "expected permissions error")
             XCTAssertNoSuchPath(customConfigPath)
         }
+        #endif
     }
 
     func testCustomSecurityPath() {
@@ -689,6 +695,8 @@ class MiscellaneousTestCase: XCTestCase {
             XCTAssertDirectoryExists(customSecurityPath)
         }
 
+        // `FileSystem` does not support `chmod` on Linux
+        #if os(macOS)
         fixture(name: "Miscellaneous/Simple") { path in
             try localFileSystem.chmod(.userUnWritable, path: path)
             let customSecurityPath = path.appending(components: "custom", "security")
@@ -699,5 +707,6 @@ class MiscellaneousTestCase: XCTestCase {
             XCTAssert(output.contains("error: You don’t have permission"), "expected permissions error")
             XCTAssertNoSuchPath(customSecurityPath)
         }
+        #endif
     }
 }

--- a/Utilities/Docker/docker-compose.2004.55.yaml
+++ b/Utilities/Docker/docker-compose.2004.55.yaml
@@ -16,7 +16,6 @@ services:
       args:
         ubuntu_version: "focal"
         swift_version: "5.5"
-        base_image: "swiftlang/swift:nightly-5.5-focal"
 
   build:
     image: swift-package-manager:20.04-5.5

--- a/Utilities/Docker/docker-compose.yaml
+++ b/Utilities/Docker/docker-compose.yaml
@@ -27,7 +27,9 @@ services:
       - ~/.ssh:/root/.ssh
       - ~/.cache:/root/.cache
       - ~/.swiftpm/cache:/root/.swiftpm/cache
-      - ~/.swiftpm/config:/root/.swiftpm/config
+      - ~/.swiftpm/configuration:/root/.swiftpm/config # old location, remove after 5.6
+      - ~/.swiftpm/configuration:/root/.swiftpm/configuration
+      - ~/.swiftpm/security:/root/.swiftpm/security
       # swift-package-manager code
       - ../..:/code/swift-package-manager:z
       # bootstrap script requires dependencies to be pre-fetched and in a specific place


### PR DESCRIPTION
motivation: use idiomatic location for security directory on macOS

changes:
* allow users to customize security directory location with new --security-path CLI option
* on macOS use <user>/Library/org.swiftpm/security for security files and symlink from ~/.swiftpm/security
* move configuration directory from <user>/Library/org.swiftpm to <user>/Library/org.swiftpm/configuration
* add migration code from old configuraiton location to new one
* add and adjust tests
* update docker setup for new locations
