### PR TITLE
[Registry] Package release 'metadata' is optional

### DIFF
--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -750,13 +750,13 @@ public extension RegistryClient {
             public var id: String
             public var version: String
             public var resources: [Resource]
-            public var metadata: AdditionalMetadata
+            public var metadata: AdditionalMetadata?
 
             public init(
                 id: String,
                 version: String,
                 resources: [Resource],
-                metadata: AdditionalMetadata
+                metadata: AdditionalMetadata?
             ) {
                 self.id = id
                 self.version = version


### PR DESCRIPTION
Per [API spec](https://github.com/apple/swift-package-manager/blob/main/Documentation/Registry.md#42-fetch-information-about-a-package-release), `metadata` is optional:

> A server MAY include metadata in its package release response.
