### PR TITLE
Actually remove the `--output` option from `swift package plugin`

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -882,10 +882,6 @@ extension SwiftPackageTool {
                 help: "Target(s) to which the plugin command should be applied")
         var targetNames: [String] = []
 
-        @Option(name: .customLong("output"),
-                help: "Optional output directory passed to the command plugin")
-        var outputPath: String?
-
         @Flag(name: .customLong("list"),
               help: "List the available plugin commands")
         var listCommands: Bool = false
@@ -941,9 +937,6 @@ extension SwiftPackageTool {
             // If no targets were specified, default to all the applicable ones in the package.
             let targetNames = targetNames.isEmpty ? package.targets.filter(\.isEligibleForPluginCommand).map(\.name) : targetNames
 
-            // If the user specified an output path, we validate it.
-            let outputPath = try self.outputPath.map{ try AbsolutePath(validating: $0) }
-            
             // Find the targets (if any) specified by the user. We expect them in the root package.
             var targets: [String: ResolvedTarget] = [:]
             for target in package.targets where targetNames.contains(target.name) {


### PR DESCRIPTION
A previous commit removed the parameter to the plugin invocation and made the option not do anything, but this removes it from `swift package plugin` as well.

### Motivation:

This is to align with SE-0332.

### Modifications:

- remove the command line option (it was still present but didn't do anything)
