### PR TITLE
fix a warning on linux

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -1167,13 +1167,13 @@ public final class PackageBuilder {
         // Collect all test targets.
         let testModules = targets.filter({ target in
             guard target.type == .test else { return false }
-          #if os(Linux)
+            #if os(Linux)
             // FIXME: Ignore C language test targets on linux for now.
             if target is ClangTarget {
-                self.observabilityScope.emit(.unsupportedCTestTarget(package: manifest.name, target: target.name))
+                self.observabilityScope.emit(.unsupportedCTestTarget(package: self.identity.description, target: target.name))
                 return false
             }
-          #endif
+            #endif
             return true
         })
 

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -2329,7 +2329,7 @@ class DependencyGraphBuilder {
         }
         for (product, filteredDependencies) in dependencies {
             let packageDependencies: [MockContainer.Dependency] = filteredDependencies.map {
-                (container: reference(for: $0), requirement: $1.0, products: $1.1)
+                (container: reference(for: $0), requirement: $1.0, productFilter: $1.1)
             }
             container.dependencies[version.description, default: [:]][product, default: []] += packageDependencies
         }

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -140,14 +140,14 @@ class PackageBuilderTests: XCTestCase {
 
             package.checkProduct("MyPackage") { _ in }
 
-          #if os(Linux)
+            #if os(Linux)
             diagnostics.check(
-                diagnostic: "ignoring target 'MyPackageTests' in package 'MyPackage'; C language in tests is not yet supported",
+                diagnostic: "ignoring target 'MyPackageTests' in package '\(package.packageIdentity)'; C language in tests is not yet supported",
                 severity: .warning
             )
-          #elseif os(macOS) || os(Android)
+            #elseif os(macOS) || os(Android)
             package.checkProduct("MyPackagePackageTests") { _ in }
-          #endif
+            #endif
         }
     }
 


### PR DESCRIPTION
motivation: less warngings, happier developers

changes:
* use package identity instead of deprecated manifest name
