### PR TITLE
make tests that check stderr more robust

### DIFF
--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -135,42 +135,42 @@ final class BuildToolTests: CommandsTestCase {
                 _ = try execute(["--product", "exec1", "--target", "exec2"], packagePath: path)
                 XCTFail("Expected to fail")
             } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-                XCTAssertEqual(stderr, "error: '--product' and '--target' are mutually exclusive\n")
+                XCTAssertMatch(stderr, .contains("error: '--product' and '--target' are mutually exclusive"))
             }
 
             do {
                 _ = try execute(["--product", "exec1", "--build-tests"], packagePath: path)
                 XCTFail("Expected to fail")
             } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-                XCTAssertEqual(stderr, "error: '--product' and '--build-tests' are mutually exclusive\n")
+                XCTAssertMatch(stderr, .contains("error: '--product' and '--build-tests' are mutually exclusive"))
             }
 
             do {
                 _ = try execute(["--build-tests", "--target", "exec2"], packagePath: path)
                 XCTFail("Expected to fail")
             } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-                XCTAssertEqual(stderr, "error: '--target' and '--build-tests' are mutually exclusive\n")
+                XCTAssertMatch(stderr, .contains("error: '--target' and '--build-tests' are mutually exclusive"))
             }
 
             do {
                 _ = try execute(["--build-tests", "--target", "exec2", "--product", "exec1"], packagePath: path)
                 XCTFail("Expected to fail")
             } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-                XCTAssertEqual(stderr, "error: '--product', '--target', and '--build-tests' are mutually exclusive\n")
+                XCTAssertMatch(stderr, .contains("error: '--product', '--target', and '--build-tests' are mutually exclusive"))
             }
 
             do {
                 _ = try execute(["--product", "UnkownProduct"], packagePath: path)
                 XCTFail("Expected to fail")
             } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-                XCTAssertEqual(stderr, "error: no product named 'UnkownProduct'\n")
+                XCTAssertMatch(stderr, .contains("error: no product named 'UnkownProduct'"))
             }
 
             do {
                 _ = try execute(["--target", "UnkownTarget"], packagePath: path)
                 XCTFail("Expected to fail")
             } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-                XCTAssertEqual(stderr, "error: no target named 'UnkownTarget'\n")
+                XCTAssertMatch(stderr, .contains("error: no target named 'UnkownTarget'"))
             }
         }
     }

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -852,7 +852,7 @@ final class PackageToolTests: CommandsTestCase {
                     try execute("resolve", "bar")
                     XCTFail("This should have been an error")
                 } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-                    XCTAssertMatch(stderr, .prefix("error: edited dependency 'bar' can't be resolved"))
+                    XCTAssertMatch(stderr, .contains("error: edited dependency 'bar' can't be resolved"))
                 }
                 try execute("unedit", "bar")
             }
@@ -979,7 +979,7 @@ final class PackageToolTests: CommandsTestCase {
                     try block()
                     XCTFail()
                 } catch SwiftPMProductError.executionFailure(_, _, let stderrOutput) {
-                    XCTAssertEqual(stderrOutput, stderr)
+                    XCTAssertMatch(stderrOutput, .contains(stderr))
                 } catch {
                     XCTFail("unexpected error: \(error)")
                 }

--- a/Tests/CommandsTests/RunToolTests.swift
+++ b/Tests/CommandsTests/RunToolTests.swift
@@ -57,7 +57,7 @@ final class RunToolTests: CommandsTestCase {
                 _ = try execute(["unknown"], packagePath: path)
                 XCTFail("Unexpected success")
             } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-                XCTAssertEqual(stderr, "error: no executable product named 'unknown'\n")
+                XCTAssertMatch(stderr, .contains("error: no executable product named 'unknown'"))
             }
         }
     }
@@ -68,7 +68,7 @@ final class RunToolTests: CommandsTestCase {
                 _ = try execute([], packagePath: path)
                 XCTFail("Unexpected success")
             } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-                XCTAssertEqual(stderr, "error: multiple executable products available: exec1, exec2\n")
+                XCTAssertMatch(stderr, .contains("error: multiple executable products available: exec1, exec2"))
             }
             
             var (runOutput, _) = try execute(["exec1"], packagePath: path)
@@ -103,7 +103,7 @@ final class RunToolTests: CommandsTestCase {
                 _ = try execute(["--build-tests", "--skip-build"], packagePath: path)
                 XCTFail("Expected to fail")
             } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-                XCTAssertEqual(stderr, "error: '--build-tests' and '--skip-build' are mutually exclusive\n")
+                XCTAssertMatch(stderr, .contains("error: '--build-tests' and '--skip-build' are mutually exclusive"))
             }
         }
     }

--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -41,7 +41,7 @@ final class TestToolTests: CommandsTestCase {
             do {
                 _ = try execute(["--num-workers", "1"])
             } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-                XCTAssertEqual(stderr, "error: --num-workers must be used with --parallel\n")
+                XCTAssertMatch(stderr, .contains("error: --num-workers must be used with --parallel"))
             }
         }
         #endif
@@ -53,7 +53,7 @@ final class TestToolTests: CommandsTestCase {
             do {
                 _ = try execute(["--parallel", "--num-workers", "0"])
             } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-                XCTAssertEqual(stderr, "error: '--num-workers' must be greater than zero\n")
+                XCTAssertMatch(stderr, .contains("error: '--num-workers' must be greater than zero"))
             }
         }
         #endif


### PR DESCRIPTION
motivation: broken tests when warnings are present in stderr

changes: use XCTAssertMatch and check for error instead of straight comparison
