### PR TITLE
Specify which Xcode scheme to use to run unit tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ SwiftPM is typically built with a pre-existing version of SwiftPM present on the
 1. Install Xcode from [https://developer.apple.com/xcode](https://developer.apple.com/xcode) (including betas!).
 2. Verify the expected version of Xcode was installed
 3. Open SwiftPM's `Package.swift` manifest with Xcode
-4. Use Xcode to inspect, edit, and build the code
+4. Use Xcode to inspect, edit, and build the code.
 5. Select the `SwiftPM-Package` scheme to run the tests from Xcode.
 
 ### Using the Command Line

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,8 +43,10 @@ SwiftPM is typically built with a pre-existing version of SwiftPM present on the
 ### Using Xcode (Easiest)
 
 1. Install Xcode from [https://developer.apple.com/xcode](https://developer.apple.com/xcode) (including betas!).
-2. Verify the expected version of Xcode was installed.
-3. Open SwiftPM's `Package.swift` manifest with Xcode, and use Xcode to edit the code, build, and run the tests.
+2. Verify the expected version of Xcode was installed
+3. Open SwiftPM's `Package.swift` manifest with Xcode
+4. Use Xcode to inspect, edit, and build the code
+5. Select the `SwiftPM-Package` scheme to run the tests from Xcode
 
 ### Using the Command Line
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ SwiftPM is typically built with a pre-existing version of SwiftPM present on the
 
 1. Install Xcode from [https://developer.apple.com/xcode](https://developer.apple.com/xcode) (including betas!).
 2. Verify the expected version of Xcode was installed
-3. Open SwiftPM's `Package.swift` manifest with Xcode
+3. Open SwiftPM's `Package.swift` manifest with Xcode.
 4. Use Xcode to inspect, edit, and build the code.
 5. Select the `SwiftPM-Package` scheme to run the tests from Xcode.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ SwiftPM is typically built with a pre-existing version of SwiftPM present on the
 ### Using Xcode (Easiest)
 
 1. Install Xcode from [https://developer.apple.com/xcode](https://developer.apple.com/xcode) (including betas!).
-2. Verify the expected version of Xcode was installed
+2. Verify the expected version of Xcode was installed.
 3. Open SwiftPM's `Package.swift` manifest with Xcode.
 4. Use Xcode to inspect, edit, and build the code.
 5. Select the `SwiftPM-Package` scheme to run the tests from Xcode.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ SwiftPM is typically built with a pre-existing version of SwiftPM present on the
 2. Verify the expected version of Xcode was installed
 3. Open SwiftPM's `Package.swift` manifest with Xcode
 4. Use Xcode to inspect, edit, and build the code
-5. Select the `SwiftPM-Package` scheme to run the tests from Xcode
+5. Select the `SwiftPM-Package` scheme to run the tests from Xcode.
 
 ### Using the Command Line
 


### PR DESCRIPTION
### Motivation:

Unit tests fail if ran with the incorrect Xcode scheme. [This can trip up newcomers](https://forums.swift.org/t/spm-support-basic-auth-for-non-git-binary-dependency-hosts/37878/65). This PR improves the docs accordingly.