### PR TITLE
adjust to TSC SHA256 API changes

### DIFF
--- a/Sources/Basics/ByteString+Extensions.swift
+++ b/Sources/Basics/ByteString+Extensions.swift
@@ -16,12 +16,6 @@ extension ByteString {
     /// Secure Hashing Algorithm 2 (SHA-2) hashing with a 256-bit digest, when available,
     /// falling back on a native implementation in Swift provided by TSCBasic.
     public var sha256Checksum: String {
-        #if canImport(CryptoKit)
-        if #available(macOS 10.15, *) {
-            return CryptoKitSHA256().hash(self).hexadecimalRepresentation
-        }
-        #endif
-
         return SHA256().hash(self).hexadecimalRepresentation
     }
 }

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -336,13 +336,7 @@ public class Workspace {
         let httpClient = customHTTPClient ?? HTTPClient()
         let archiver = customArchiver ?? ZipArchiver()
 
-        var checksumAlgorithm = customChecksumAlgorithm ?? SHA256()
-        #if canImport(CryptoKit)
-        if checksumAlgorithm is SHA256, #available(macOS 10.15, *) {
-            checksumAlgorithm = CryptoKitSHA256()
-        }
-        #endif
-
+        let checksumAlgorithm = customChecksumAlgorithm ?? SHA256()
         let additionalFileRules = additionalFileRules ?? []
         let resolverUpdateEnabled = resolverUpdateEnabled ?? true
         let resolverPrefetchingEnabled = resolverPrefetchingEnabled ?? false


### PR DESCRIPTION
motivation: simplify logic around which SHA256 implementation to use

changes: always call SHA256 which abstracts over platform differences
