### PR TITLE
Fix an ordering issue of a print statement and a diagnostic arriving right at the exit of a plugin

### DIFF
--- a/Sources/Workspace/DefaultPluginScriptRunner.swift
+++ b/Sources/Workspace/DefaultPluginScriptRunner.swift
@@ -485,11 +485,11 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner {
             // Close the output handle through which we talked to the plugin.
             try? outputHandle.close()
 
-            // Read and pass on any remaining messages from the plugin.
-            stdoutPipe.fileHandleForReading.readabilityHandler?(stdoutPipe.fileHandleForReading)
-
             // Read and pass on any remaining free-form text output from the plugin.
             stderrPipe.fileHandleForReading.readabilityHandler?(stderrPipe.fileHandleForReading)
+
+            // Read and pass on any remaining messages from the plugin.
+            stdoutPipe.fileHandleForReading.readabilityHandler?(stdoutPipe.fileHandleForReading)
 
             // Call the completion block with a result that depends on how the process ended.
             callbackQueue.async {

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -268,10 +268,10 @@ class PluginTests: XCTestCase {
                             arguments: [String]
                         ) throws {
                             // Print some output that should appear before the error diagnostic.
-                            print("This text should appear before the error.")
+                            print("This text should appear before the uncaught thrown error.")
 
                             // Throw an uncaught error that should be reported as a diagnostics.
-                            throw "Houston, we have a problem."
+                            throw "This is the uncaught thrown error."
                         }
                     }
                     extension String: Error { }
@@ -372,7 +372,7 @@ class PluginTests: XCTestCase {
                     // Add each line of emitted output as a `.info` diagnostic.
                     dispatchPrecondition(condition: .onQueue(delegateQueue))
                     let textlines = String(decoding: data, as: UTF8.self).split(separator: "\n")
-                    print(textlines.map{ "🧩 \($0)" }.joined(separator: "\n"))
+                    print(textlines.map{ "[TEXT] \($0)" }.joined(separator: "\n"))
                     diagnostics.append(contentsOf: textlines.map{
                         Basics.Diagnostic(severity: .info, message: String($0), metadata: .none)
                     })
@@ -381,6 +381,7 @@ class PluginTests: XCTestCase {
                 func pluginEmittedDiagnostic(_ diagnostic: Basics.Diagnostic) {
                     // Add the diagnostic as-is.
                     dispatchPrecondition(condition: .onQueue(delegateQueue))
+                    print("[DIAG] \(diagnostic)")
                     diagnostics.append(diagnostic)
                 }
             }
@@ -453,8 +454,8 @@ class PluginTests: XCTestCase {
 
             // Invoke the command plugin that throws an unhandled error at the top level.
             testCommand(package: package, plugin: "PluginFailingWithError", targets: [], arguments: [], expectFailure: true) { output in
-                output.check(diagnostic: .equal("This text should appear before the error."), severity: .info)
-                output.check(diagnostic: .equal("Houston, we have a problem."), severity: .error)
+                output.check(diagnostic: .equal("This text should appear before the uncaught thrown error."), severity: .info)
+                output.check(diagnostic: .equal("This is the uncaught thrown error."), severity: .error)
 
             }
             // Invoke the command plugin that exits with code 1 without returning an error.


### PR DESCRIPTION
There's no strong ordering between the free form output of a plugin and the diagnostics it emits, but for things like thrown exceptions etc, it makes a bit more sense to show the diagnostic last.

Perhaps the test shouldn't really depend on the order here — we will see if this addresses the issue in the CI (it seems specific to Linux and I was never able to reproduce it in Docker).

### Motivation:

Fix a flaky test in CI, but also to make the order of output from the end of the plugin execution make a little more sense when it exits by throwing an error.

### Modifications:

- after process termination, read the last text output before any diagnostics
- I also made the unit test text a little less whimsical, and got rid of the emoji annotating the plugin output, and added printing out of the received diagnostics

rdar://86729106