### PR TITLE
Mark command plugins as 5.6 instead of 999.0 now that SE-0332 has been accepted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,7 @@ Swift 3.0
 [SE-0201]: https://github.com/apple/swift-evolution/blob/master/proposals/0201-package-manager-local-dependencies.md
 [SE-0208]: https://github.com/apple/swift-evolution/blob/master/proposals/0208-package-manager-system-library-targets.md
 [SE-0209]: https://github.com/apple/swift-evolution/blob/master/proposals/0209-package-manager-swift-lang-version-update.md
+[SE-0332]: https://github.com/apple/swift-evolution/blob/main/proposals/0332-swiftpm-command-plugins.md
 
 [SR-5918]: https://bugs.swift.org/browse/SR-5918
 [SR-6978]: https://bugs.swift.org/browse/SR-6978

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Note: This is in reverse chronological order, so newer entries are added to the 
 
 Swift 5.6
 -----------
+* [SE-0332]
+
+  Package plugins of the type `command` can now be declared in packages that specify a tools version of 5.6 or later, and can be invoked using the `swift package` subcommand.
+
 * [#3649]
 
   Semantic version dependencies can now be resolved against Git tag names that contain only major and minor version identifiers.  A tag with the form `X.Y` will be treated as `X.Y.0`. This improves compatibility with existing repositories.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,11 +157,11 @@ Swift 3.0
 
 * The `Package` initializer now requires the `name:` parameter.
 
-[SE-0129]: https://github.com/apple/swift-evolution/blob/master/proposals/0129-package-manager-test-naming-conventions.md
-[SE-0135]: https://github.com/apple/swift-evolution/blob/master/proposals/0135-package-manager-support-for-differentiating-packages-by-swift-version.md
-[SE-0201]: https://github.com/apple/swift-evolution/blob/master/proposals/0201-package-manager-local-dependencies.md
-[SE-0208]: https://github.com/apple/swift-evolution/blob/master/proposals/0208-package-manager-system-library-targets.md
-[SE-0209]: https://github.com/apple/swift-evolution/blob/master/proposals/0209-package-manager-swift-lang-version-update.md
+[SE-0129]: https://github.com/apple/swift-evolution/blob/main/proposals/0129-package-manager-test-naming-conventions.md
+[SE-0135]: https://github.com/apple/swift-evolution/blob/main/proposals/0135-package-manager-support-for-differentiating-packages-by-swift-version.md
+[SE-0201]: https://github.com/apple/swift-evolution/blob/main/proposals/0201-package-manager-local-dependencies.md
+[SE-0208]: https://github.com/apple/swift-evolution/blob/main/proposals/0208-package-manager-system-library-targets.md
+[SE-0209]: https://github.com/apple/swift-evolution/blob/main/proposals/0209-package-manager-swift-lang-version-update.md
 [SE-0332]: https://github.com/apple/swift-evolution/blob/main/proposals/0332-swiftpm-command-plugins.md
 
 [SR-5918]: https://bugs.swift.org/browse/SR-5918

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -60,9 +60,9 @@ public struct SwiftPackageTool: ParsableCommand {
             ComputeChecksum.self,
             ArchiveSource.self,
             CompletionTool.self,
+            PluginCommand.self,
         ]
-        + (ProcessInfo.processInfo.environment["SWIFTPM_ENABLE_SNIPPETS"] == "1" ? [Learn.self] : [])
-        + (ProcessInfo.processInfo.environment["SWIFTPM_ENABLE_COMMAND_PLUGINS"] == "1" ? [PluginCommand.self] : []),
+        + (ProcessInfo.processInfo.environment["SWIFTPM_ENABLE_SNIPPETS"] == "1" ? [Learn.self] : []),
         helpNames: [.short, .long, .customLong("help", withSingleDash: true)])
 
     @OptionGroup()

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -131,7 +131,7 @@ public final class Target {
     /// this enum will be extended as new plugin capabilities are added.
     public enum PluginCapability {
         case _buildTool
-        @available(_PackageDescription, introduced: 999.0)
+        @available(_PackageDescription, introduced: 5.6)
         case _command(intent: PluginCommandIntent, permissions: [PluginPermission])
     }
     
@@ -1016,7 +1016,7 @@ extension Target.PluginCapability {
     /// Specifies that the plugin provides a user command capability. It will
     /// be available to invoke manually on one or more targets in a package.
     /// The package can specify the verb that is used to invoke the command.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 5.6)
     /// Plugins that specify a `command` capability define commands that can be run
     /// using the SwiftPM CLI (`swift package <verb>`), or in an IDE that supports
     /// Swift Packages.
@@ -1034,14 +1034,14 @@ extension Target.PluginCapability {
     }
 }
 
-@available(_PackageDescription, introduced: 999.0)
+@available(_PackageDescription, introduced: 5.6)
 public enum PluginCommandIntent {
     case _documentationGeneration
     case _sourceCodeFormatting
     case _custom(verb: String, description: String)
 }
 
-@available(_PackageDescription, introduced: 999.0)
+@available(_PackageDescription, introduced: 5.6)
 public extension PluginCommandIntent {
     /// The intent of the command is to generate documentation, either by parsing the
     /// package contents directly or by using the build system support for generating
@@ -1063,12 +1063,12 @@ public extension PluginCommandIntent {
     }
 }
 
-@available(_PackageDescription, introduced: 999.0)
+@available(_PackageDescription, introduced: 5.6)
 public enum PluginPermission {
     case _writeToPackageDirectory(reason: String)
 }
 
-@available(_PackageDescription, introduced: 999.0)
+@available(_PackageDescription, introduced: 5.6)
 public extension PluginPermission {
     /// The command plugin wants permission to modify the files under the package
     /// directory. The `reason` string is shown to the user at the time of request

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -1046,7 +1046,7 @@ final class PackageToolTests: CommandsTestCase {
             let packageDir = tmpPath.appending(components: "MyPackage")
             try localFileSystem.writeFileContents(packageDir.appending(component: "Package.swift")) {
                 $0 <<< """
-                // swift-tools-version: 999.0
+                // swift-tools-version: 5.5
                 import PackageDescription
                 let package = Package(
                     name: "MyPackage",
@@ -1174,7 +1174,7 @@ final class PackageToolTests: CommandsTestCase {
             let packageDir = tmpPath.appending(components: "MyPackage")
             try localFileSystem.writeFileContents(packageDir.appending(components: "Package.swift")) {
                 $0 <<< """
-                // swift-tools-version: 999.0
+                // swift-tools-version: 5.6
                 import PackageDescription
                 let package = Package(
                     name: "MyPackage",
@@ -1318,14 +1318,14 @@ final class PackageToolTests: CommandsTestCase {
 
             // Invoke it, and check the results.
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["plugin", "mycmd"], packagePath: packageDir, env: ["SWIFTPM_ENABLE_COMMAND_PLUGINS": "1"])
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["plugin", "mycmd"], packagePath: packageDir)
                 XCTAssertEqual(result.exitStatus, .terminated(code: 0))
                 XCTAssert(try result.utf8Output().contains("This is MyCommandPlugin."))
             }
 
             // Testing listing the available command plugins.
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["plugin", "--list"], packagePath: packageDir, env: ["SWIFTPM_ENABLE_COMMAND_PLUGINS": "1"])
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["plugin", "--list"], packagePath: packageDir)
                 XCTAssertEqual(result.exitStatus, .terminated(code: 0))
                 XCTAssert(try result.utf8Output().contains("‘mycmd’ (plugin ‘MyPlugin’ in package ‘MyPackage’)"))
             }

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -193,7 +193,7 @@ class PluginTests: XCTestCase {
             let packageDir = tmpPath.appending(components: "MyPackage")
             try localFileSystem.writeFileContents(packageDir.appending(component: "Package.swift")) {
                 $0 <<< """
-                // swift-tools-version: 999.0
+                // swift-tools-version: 5.6
                 import PackageDescription
                 let package = Package(
                     name: "MyPackage",


### PR DESCRIPTION
Mark command plugins as 5.6 instead of 999.0 now that SE-0332 has been accepted, and remove the feature flag that controls it.

### Motivation:

Allows packages with a 5.6 tools version to define command plugins.

### Modifications:

- Change 999.0 to 5.6 in the right places
- Remove the feature flag that controls it

This change will also be nominated for the `release/5.6` branch.
