### PR TITLE
Mark `Platform.openbsd` as available since 5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Note: This is in reverse chronological order, so newer entries are added to the 
 
 Swift 5.6
 -----------
+* `openbsd` has been added to the set of possible platform values for packages that specify a 5.6 tools version.
+
 * [#3649]
 
   Semantic version dependencies can now be resolved against Git tag names that contain only major and minor version identifiers.  A tag with the form `X.Y` will be treated as `X.Y.0`. This improves compatibility with existing repositories.

--- a/Sources/PackageDescription/SupportedPlatforms.swift
+++ b/Sources/PackageDescription/SupportedPlatforms.swift
@@ -58,7 +58,7 @@ public struct Platform: Encodable, Equatable {
     public static let wasi: Platform = Platform(name: "wasi")
     
     /// The OpenBSD platform.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 5.6)
     public static let openbsd: Platform = Platform(name: "openbsd")
 }
 


### PR DESCRIPTION
Mark `Platform.openbsd` as available since 5.6.

### Motivation:

Allows this new enum to be used in packages marked with 5.6.

### Modifications:

- Change 999.0 to 5.6 availability and add a CHANGELOG entry.

This will also be nominated to the `release/5.6` branch.