### PR TITLE
Support `--allow-writing-to-package-directory` as described in SE-0332 and `--allow-writing-to-directory` to allow arbitrary directories

### DIFF
--- a/Sources/Workspace/DefaultPluginScriptRunner.swift
+++ b/Sources/Workspace/DefaultPluginScriptRunner.swift
@@ -358,7 +358,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner {
 
         // Optionally wrap the command in a sandbox, which places some limits on what it can do. In particular, it blocks network access and restricts the paths to which the plugin can make file system changes.
         if self.enableSandbox {
-            command = Sandbox.apply(command: command, writableDirectories: writableDirectories + [self.cacheDir], strictness: .writableTemporaryDirectory)
+            command = Sandbox.apply(command: command, writableDirectories: writableDirectories + [self.cacheDir], strictness: .default)
         }
 
         // Create and configure a Process. We set the working directory to the cache directory, so that relative paths end up there.

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -1191,8 +1191,7 @@ final class PackageToolTests: CommandsTestCase {
                         .plugin(
                             name: "MyPlugin",
                             capability: .command(
-                                intent: .custom(verb: "mycmd", description: "What is mycmd anyway?"),
-                                permissions: [.writeToPackageDirectory(reason: "YOLO")]
+                                intent: .custom(verb: "mycmd", description: "What is mycmd anyway?")
                             ),
                             dependencies: [
                                 .target(name: "LocalBuiltTool"),
@@ -1328,6 +1327,82 @@ final class PackageToolTests: CommandsTestCase {
                 let result = try SwiftPMProduct.SwiftPackage.executeProcess(["plugin", "--list"], packagePath: packageDir, env: ["SWIFTPM_ENABLE_COMMAND_PLUGINS": "1"])
                 XCTAssertEqual(result.exitStatus, .terminated(code: 0))
                 XCTAssert(try result.utf8Output().contains("‘mycmd’ (plugin ‘MyPlugin’ in package ‘MyPackage’)"))
+            }
+        }
+    }
+
+    func testCommandPluginPermissions() throws {
+
+        try testWithTemporaryDirectory { tmpPath in
+            // Create a sample package with a library target and a plugin.
+            let packageDir = tmpPath.appending(components: "MyPackage")
+            try localFileSystem.writeFileContents(packageDir.appending(components: "Package.swift")) {
+                $0 <<< """
+                // swift-tools-version: 999.0
+                import PackageDescription
+                let package = Package(
+                    name: "MyPackage",
+                    targets: [
+                        .target(
+                            name: "MyLibrary"
+                        ),
+                        .plugin(
+                            name: "MyPlugin",
+                            capability: .command(
+                                intent: .custom(verb: "PackageScribbler", description: "Help description"),
+                                permissions: [.writeToPackageDirectory(reason: "For testing purposes")]
+                            )
+                        ),
+                    ]
+                )
+                """
+            }
+            try localFileSystem.writeFileContents(packageDir.appending(components: "Sources", "MyLibrary", "library.swift")) {
+                $0 <<< """
+                public func Foo() { }
+                """
+            }
+            try localFileSystem.writeFileContents(packageDir.appending(components: "Plugins", "MyPlugin", "plugin.swift")) {
+                $0 <<< """
+                import PackagePlugin
+                import Foundation
+
+                @main
+                struct MyCommandPlugin: CommandPlugin {
+                    func performCommand(
+                        context: PluginContext,
+                        targets: [Target],
+                        arguments: [String]
+                    ) throws {
+                        // Check that we can write to the package directory.
+                        print("Trying to write to the package directory...")
+                        guard FileManager.default.createFile(atPath: context.package.directory.appending("Foo").string, contents: Data("Hello".utf8)) else {
+                            throw "Couldn’t create file at path \\(context.package.directory.appending("Foo"))"
+                        }
+                        print("... successfully created it")
+                    }
+                }
+
+                extension String: Error {}
+                """
+            }
+
+            // Invoke the plugin, and check that we can't write to the package directory by default.  Note that need to pass `--block-writing-to-temporary-directory` here since the test artifact is itself under the temporary directory.  Note that sandboxing is only currently supported on macOS.
+          #if os(macOS)
+            do {
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["plugin", "--block-writing-to-temporary-directory", "PackageScribbler"], packagePath: packageDir, env: ["SWIFTPM_ENABLE_COMMAND_PLUGINS": "1"])
+                XCTAssertNotEqual(result.exitStatus, .terminated(code: 0))
+                XCTAssertNoMatch(try result.utf8Output(), .contains("successfully created it"))
+                XCTAssertMatch(try result.utf8stderrOutput(), .contains("error: Plugin ‘MyPlugin’ needs permission to write to the package directory (stated reason: “For testing purposes”)"))
+            }
+          #endif
+
+            // Invoke the plugin, and check that we can write to the package directory if we pass `--allow-writing-to-package-directory`.  Note that need to pass `--block-writing-to-temporary-directory` here since the test artifact is itself under the temporary directory.
+            do {
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["plugin", "--allow-writing-to-package-directory", "PackageScribbler"], packagePath: packageDir, env: ["SWIFTPM_ENABLE_COMMAND_PLUGINS": "1"])
+                XCTAssertEqual(result.exitStatus, .terminated(code: 0))
+                XCTAssertMatch(try result.utf8Output(), .contains("successfully created it"))
+                XCTAssertNoMatch(try result.utf8stderrOutput(), .contains("error: Couldn’t create file at path"))
             }
         }
     }

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -428,6 +428,7 @@ class PluginTests: XCTestCase {
                         outputDirectory: pluginDir.appending(component: "output"),
                         toolSearchDirectories: [UserToolchain.default.swiftCompilerPath.parentDirectory],
                         toolNamesToPaths: [:],
+                        writableDirectories: [pluginDir.appending(component: "output")],
                         fileSystem: localFileSystem,
                         observabilityScope: observability.topScope,
                         callbackQueue: delegateQueue,


### PR DESCRIPTION
### Motivation:

This adds an option that was spelled out in the proposal.  Also adds an additional useful option to specify arbitrary directories to allow the plugin to write to, which is helpful for plugins that have their own output arguments.

### Modifications:

- adds `--allow-writing-to-package-directory` as described in SE-0332
- also adds `--allow-writing-to-directory`, which takes a relative or absolute path as an argument
- also adds `--block-writing-to-temporary-directory` to provide control over whether the temporary directories can be written to

It also adds in the error to message that is shown if writing to the package directory isn't allowed, which includes the stated reason the plugin provided for why it needs this access.

rdar://86786404