### PR TITLE
gracefully fail workspace state loading when duplicate entries found

### DIFF
--- a/Sources/Workspace/ManagedArtifact.swift
+++ b/Sources/Workspace/ManagedArtifact.swift
@@ -115,10 +115,22 @@ extension Workspace {
             AnyCollection(self.artifactMap.values.lazy.flatMap{ $0.values })
         }
 
-        init(_ artifacts: [ManagedArtifact] = []) {
+        init() {
+            self.artifactMap = [:]
+        }
+
+        init(_ artifacts: [ManagedArtifact]) throws {
             let artifactsByPackagePath = Dictionary(grouping: artifacts, by: { $0.packageRef.identity })
-            self.artifactMap = artifactsByPackagePath.mapValues{ artifacts in
-                Dictionary(uniqueKeysWithValues: artifacts.map{ ($0.targetName, $0) })
+            self.artifactMap = try artifactsByPackagePath.mapValues{ artifacts in
+                // rdar://86857825 do not use Dictionary(uniqueKeysWithValues:) as it can crash the process when input is incorrect such as in older versions of SwiftPM
+                var map = [String: ManagedArtifact]()
+                for artifact in artifacts {
+                    if map[artifact.targetName] != nil {
+                        throw StringError("binary artifact for '\(artifact.targetName)' already exists in managed artifacts")
+                    }
+                    map[artifact.targetName] = artifact
+                }
+                return map
             }
         }
 

--- a/Sources/Workspace/WorkspaceState.swift
+++ b/Sources/Workspace/WorkspaceState.swift
@@ -96,12 +96,12 @@ fileprivate struct WorkspaceStateStorage {
                 let v4 = try self.decoder.decode(path: self.path, fileSystem: self.fileSystem, as: V4.self)
                 let dependencies = try v4.object.dependencies.map{ try Workspace.ManagedDependency($0) }
                 let artifacts = try v4.object.artifacts.map{ try Workspace.ManagedArtifact($0) }
-                return (dependencies: .init(dependencies), artifacts: .init(artifacts))
+                return try (dependencies: .init(dependencies), artifacts: .init(artifacts))
             case 5:
                 let v5 = try self.decoder.decode(path: self.path, fileSystem: self.fileSystem, as: V5.self)
                 let dependencies = try v5.object.dependencies.map{ try Workspace.ManagedDependency($0) }
                 let artifacts = try v5.object.artifacts.map{ try Workspace.ManagedArtifact($0) }
-                return (dependencies: .init(dependencies), artifacts: .init(artifacts))
+                return try (dependencies: .init(dependencies), artifacts: .init(artifacts))
             default:
                 throw StringError("unknown 'WorkspaceStateStorage' version '\(version.version)' at '\(self.path)'")
             }

--- a/Tests/WorkspaceTests/WorkspaceStateTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceStateTests.swift
@@ -19,66 +19,66 @@ final class WorkspaceStateTests: XCTestCase {
         let buildDir = AbsolutePath("/.build")
         let statePath = buildDir.appending(component: "workspace-state.json")
 
+        try fs.createDirectory(buildDir, recursive: true)
         try fs.writeFileContents(statePath) {
-            $0 <<<
-                """
-                {
-                    "version": 4,
-                    "object": {
-                        "artifacts": [],
-                        "dependencies": [
-                            {
-                                "basedOn": null,
-                                "packageRef": {
-                                  "identity": "yams",
-                                  "kind": "remote",
-                                  "location": "https://github.com/jpsim/Yams.git",
-                                  "name": "Yams"
-                                },
-                                "state": {
-                                  "checkoutState": {
-                                    "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
-                                    "version": "4.0.6"
-                                  },
-                                  "name": "checkout"
-                                },
-                                "subpath": "Yams"
+            """
+            {
+                "version": 4,
+                "object": {
+                    "artifacts": [],
+                    "dependencies": [
+                        {
+                            "basedOn": null,
+                            "packageRef": {
+                              "identity": "yams",
+                              "kind": "remote",
+                              "location": "https://github.com/jpsim/Yams.git",
+                              "name": "Yams"
                             },
-                            {
-                                "basedOn": null,
-                                "packageRef": {
-                                  "identity": "swift-tools-support-core",
-                                  "kind": "remote",
-                                  "location": "https://github.com/apple/swift-tools-support-core.git",
-                                  "name": "swift-tools-support-core"
-                                },
-                                "state": {
-                                  "checkoutState": {
-                                    "branch": "main",
-                                    "revision": "f9bbd6b80d67408021576adf6247e17c2e957d92",
-                                    "version": null
-                                  },
-                                  "name": "checkout"
-                                },
-                                "subpath": "swift-tools-support-core"
+                            "state": {
+                              "checkoutState": {
+                                "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
+                                "version": "4.0.6"
+                              },
+                              "name": "checkout"
                             },
-                            {
-                                "basedOn": null,
-                                "packageRef": {
-                                  "identity": "swift-argument-parser",
-                                  "kind": "local",
-                                  "location": "/Users/tomerd/code/swift/swift-argument-parser",
-                                  "name": "swift-argument-parser"
-                                },
-                                "state": {
-                                  "name": "local"
-                                },
-                                "subpath": "swift-argument-parser"
-                            }
-                        ]
-                    }
+                            "subpath": "Yams"
+                        },
+                        {
+                            "basedOn": null,
+                            "packageRef": {
+                              "identity": "swift-tools-support-core",
+                              "kind": "remote",
+                              "location": "https://github.com/apple/swift-tools-support-core.git",
+                              "name": "swift-tools-support-core"
+                            },
+                            "state": {
+                              "checkoutState": {
+                                "branch": "main",
+                                "revision": "f9bbd6b80d67408021576adf6247e17c2e957d92",
+                                "version": null
+                              },
+                              "name": "checkout"
+                            },
+                            "subpath": "swift-tools-support-core"
+                        },
+                        {
+                            "basedOn": null,
+                            "packageRef": {
+                              "identity": "swift-argument-parser",
+                              "kind": "local",
+                              "location": "/Users/tomerd/code/swift/swift-argument-parser",
+                              "name": "swift-argument-parser"
+                            },
+                            "state": {
+                              "name": "local"
+                            },
+                            "subpath": "swift-argument-parser"
+                        }
+                    ]
                 }
-                """
+            }
+            """
         }
 
         let state = WorkspaceState(dataPath: buildDir, fileSystem: fs)
@@ -93,66 +93,66 @@ final class WorkspaceStateTests: XCTestCase {
         let buildDir = AbsolutePath("/.build")
         let statePath = buildDir.appending(component: "workspace-state.json")
 
+        try fs.createDirectory(buildDir, recursive: true)
         try fs.writeFileContents(statePath) {
-            $0 <<<
-                """
-                {
-                    "version": 4,
-                    "object": {
-                        "artifacts": [],
-                        "dependencies": [
-                            {
-                                "basedOn": null,
-                                "packageRef": {
-                                  "identity": "yams",
-                                  "kind": "remote",
-                                  "path": "https://github.com/jpsim/Yams.git",
-                                  "name": "Yams"
-                                },
-                                "state": {
-                                  "checkoutState": {
-                                    "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
-                                    "version": "4.0.6"
-                                  },
-                                  "name": "checkout"
-                                },
-                                "subpath": "Yams"
+            """
+            {
+                "version": 4,
+                "object": {
+                    "artifacts": [],
+                    "dependencies": [
+                        {
+                            "basedOn": null,
+                            "packageRef": {
+                              "identity": "yams",
+                              "kind": "remote",
+                              "path": "https://github.com/jpsim/Yams.git",
+                              "name": "Yams"
                             },
-                            {
-                                "basedOn": null,
-                                "packageRef": {
-                                  "identity": "swift-tools-support-core",
-                                  "kind": "remote",
-                                  "path": "https://github.com/apple/swift-tools-support-core.git",
-                                  "name": "swift-tools-support-core"
-                                },
-                                "state": {
-                                  "checkoutState": {
-                                    "branch": "main",
-                                    "revision": "f9bbd6b80d67408021576adf6247e17c2e957d92",
-                                    "version": null
-                                  },
-                                  "name": "checkout"
-                                },
-                                "subpath": "swift-tools-support-core"
+                            "state": {
+                              "checkoutState": {
+                                "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
+                                "version": "4.0.6"
+                              },
+                              "name": "checkout"
                             },
-                            {
-                                "basedOn": null,
-                                "packageRef": {
-                                  "identity": "swift-argument-parser",
-                                  "kind": "local",
-                                  "path": "/Users/tomerd/code/swift/swift-argument-parser",
-                                  "name": "swift-argument-parser"
-                                },
-                                "state": {
-                                  "name": "local"
-                                },
-                                "subpath": "swift-argument-parser"
-                            }
-                        ]
-                    }
+                            "subpath": "Yams"
+                        },
+                        {
+                            "basedOn": null,
+                            "packageRef": {
+                              "identity": "swift-tools-support-core",
+                              "kind": "remote",
+                              "path": "https://github.com/apple/swift-tools-support-core.git",
+                              "name": "swift-tools-support-core"
+                            },
+                            "state": {
+                              "checkoutState": {
+                                "branch": "main",
+                                "revision": "f9bbd6b80d67408021576adf6247e17c2e957d92",
+                                "version": null
+                              },
+                              "name": "checkout"
+                            },
+                            "subpath": "swift-tools-support-core"
+                        },
+                        {
+                            "basedOn": null,
+                            "packageRef": {
+                              "identity": "swift-argument-parser",
+                              "kind": "local",
+                              "path": "/Users/tomerd/code/swift/swift-argument-parser",
+                              "name": "swift-argument-parser"
+                            },
+                            "state": {
+                              "name": "local"
+                            },
+                            "subpath": "swift-argument-parser"
+                        }
+                    ]
                 }
-                """
+            }
+            """
         }
 
         let state = WorkspaceState(dataPath: buildDir, fileSystem: fs)
@@ -167,66 +167,66 @@ final class WorkspaceStateTests: XCTestCase {
         let buildDir = AbsolutePath("/.build")
         let statePath = buildDir.appending(component: "workspace-state.json")
 
+        try fs.createDirectory(buildDir, recursive: true)
         try fs.writeFileContents(statePath) {
-            $0 <<<
-                """
-                {
-                    "version": 5,
-                    "object": {
-                        "artifacts": [],
-                        "dependencies": [
-                            {
-                                "basedOn": null,
-                                "packageRef": {
-                                  "identity": "yams",
-                                  "kind": "remoteSourceControl",
-                                  "location": "https://github.com/jpsim/Yams.git",
-                                  "name": "Yams"
-                                },
-                                "state": {
-                                  "checkoutState": {
-                                    "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
-                                    "version": "4.0.6"
-                                  },
-                                  "name": "checkout"
-                                },
-                                "subpath": "Yams"
+            """
+            {
+                "version": 5,
+                "object": {
+                    "artifacts": [],
+                    "dependencies": [
+                        {
+                            "basedOn": null,
+                            "packageRef": {
+                              "identity": "yams",
+                              "kind": "remoteSourceControl",
+                              "location": "https://github.com/jpsim/Yams.git",
+                              "name": "Yams"
                             },
-                            {
-                                "basedOn": null,
-                                "packageRef": {
-                                  "identity": "swift-tools-support-core",
-                                  "kind": "remoteSourceControl",
-                                  "location": "https://github.com/apple/swift-tools-support-core.git",
-                                  "name": "swift-tools-support-core"
-                                },
-                                "state": {
-                                  "checkoutState": {
-                                    "branch": "main",
-                                    "revision": "f9bbd6b80d67408021576adf6247e17c2e957d92"
-                                  },
-                                  "name": "checkout"
-                                },
-                                "subpath": "swift-tools-support-core"
+                            "state": {
+                              "checkoutState": {
+                                "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
+                                "version": "4.0.6"
+                              },
+                              "name": "checkout"
                             },
-                            {
-                                "basedOn": null,
-                                "packageRef": {
-                                  "identity": "swift-argument-parser",
-                                  "kind": "fileSystem",
-                                  "location": "/Users/tomerd/code/swift/swift-argument-parser",
-                                  "name": "swift-argument-parser"
-                                },
-                                "state": {
-                                  "name": "local",
-                                  "path": "/Users/tomerd/code/swift/swift-argument-parser"
-                                },
-                                "subpath": "swift-argument-parser"
-                            }
-                        ]
-                    }
+                            "subpath": "Yams"
+                        },
+                        {
+                            "basedOn": null,
+                            "packageRef": {
+                              "identity": "swift-tools-support-core",
+                              "kind": "remoteSourceControl",
+                              "location": "https://github.com/apple/swift-tools-support-core.git",
+                              "name": "swift-tools-support-core"
+                            },
+                            "state": {
+                              "checkoutState": {
+                                "branch": "main",
+                                "revision": "f9bbd6b80d67408021576adf6247e17c2e957d92"
+                              },
+                              "name": "checkout"
+                            },
+                            "subpath": "swift-tools-support-core"
+                        },
+                        {
+                            "basedOn": null,
+                            "packageRef": {
+                              "identity": "swift-argument-parser",
+                              "kind": "fileSystem",
+                              "location": "/Users/tomerd/code/swift/swift-argument-parser",
+                              "name": "swift-argument-parser"
+                            },
+                            "state": {
+                              "name": "local",
+                              "path": "/Users/tomerd/code/swift/swift-argument-parser"
+                            },
+                            "subpath": "swift-argument-parser"
+                        }
+                    ]
                 }
-                """
+            }
+            """
         }
 
         let state = WorkspaceState(dataPath: buildDir, fileSystem: fs)
@@ -241,52 +241,52 @@ final class WorkspaceStateTests: XCTestCase {
         let buildDir = AbsolutePath("/.build")
         let statePath = buildDir.appending(component: "workspace-state.json")
 
+        try fs.createDirectory(buildDir, recursive: true)
         try fs.writeFileContents(statePath) {
-            $0 <<<
-                """
-                {
-                    "version": 5,
-                    "object": {
-                        "artifacts": [],
-                        "dependencies": [
-                            {
-                                "basedOn": null,
-                                "packageRef": {
-                                  "identity": "yams",
-                                  "kind": "remoteSourceControl",
-                                  "location": "https://github.com/jpsim/Yams.git",
-                                  "name": "Yams"
-                                },
-                                "state": {
-                                  "checkoutState": {
-                                    "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
-                                    "version": "4.0.6"
-                                  },
-                                  "name": "checkout"
-                                },
-                                "subpath": "Yams"
+            """
+            {
+                "version": 5,
+                "object": {
+                    "artifacts": [],
+                    "dependencies": [
+                        {
+                            "basedOn": null,
+                            "packageRef": {
+                              "identity": "yams",
+                              "kind": "remoteSourceControl",
+                              "location": "https://github.com/jpsim/Yams.git",
+                              "name": "Yams"
                             },
-                            {
-                                "basedOn": null,
-                                "packageRef": {
-                                  "identity": "swift-argument-parser",
-                                  "kind": "remoteSourceControl",
-                                  "location": "https://github.com/apple/swift-argument-parser.git",
-                                  "name": "swift-argument-parser"
-                                },
-                                "state": {
-                                  "checkoutState": {
-                                    "revision": "83b23d940471b313427da226196661856f6ba3e0",
-                                    "version": "0.4.4"
-                                  },
-                                  "name": "checkout"
-                                },
-                                "subpath": "swift-argument-parser"
-                            }
-                        ]
-                    }
+                            "state": {
+                              "checkoutState": {
+                                "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
+                                "version": "4.0.6"
+                              },
+                              "name": "checkout"
+                            },
+                            "subpath": "Yams"
+                        },
+                        {
+                            "basedOn": null,
+                            "packageRef": {
+                              "identity": "swift-argument-parser",
+                              "kind": "remoteSourceControl",
+                              "location": "https://github.com/apple/swift-argument-parser.git",
+                              "name": "swift-argument-parser"
+                            },
+                            "state": {
+                              "checkoutState": {
+                                "revision": "83b23d940471b313427da226196661856f6ba3e0",
+                                "version": "0.4.4"
+                              },
+                              "name": "checkout"
+                            },
+                            "subpath": "swift-argument-parser"
+                        }
+                    ]
                 }
-                """
+            }
+            """
         }
 
         let state = WorkspaceState(dataPath: buildDir, fileSystem: fs)
@@ -298,5 +298,194 @@ final class WorkspaceStateTests: XCTestCase {
         let yamsRange = try XCTUnwrap(serialized.range(of: "yams"))
 
         XCTAssertTrue(argpRange.lowerBound < yamsRange.lowerBound)
+    }
+
+    func testArtifacts() throws {
+        let fs = InMemoryFileSystem()
+
+        let buildDir = AbsolutePath("/.build")
+        let statePath = buildDir.appending(component: "workspace-state.json")
+
+        try fs.createDirectory(buildDir, recursive: true)
+        try fs.writeFileContents(statePath) {
+            """
+            {
+                "version": 5,
+                "object": {
+                    "artifacts": [
+                        {
+                            "packageRef": {
+                              "identity": "foo",
+                              "kind": "remoteSourceControl",
+                              "location": "https://github.com/org/foo.git",
+                              "name": "foo"
+                            },
+                            "targetName": "foo",
+                            "source": {
+                                "type": "remote",
+                                "url": "https://github.com/org/binary1.zip",
+                                "checksum": "77AFD0BA-D1CF-4628-A43B-B6E66F44448A"
+                            },
+                            "path": "/path/to/binary1"
+                        },
+                        {
+                            "packageRef": {
+                              "identity": "foo",
+                              "kind": "remoteSourceControl",
+                              "location": "https://github.com/org/foo.git",
+                              "name": "foo"
+                            },
+                            "targetName": "bar",
+                            "source": {
+                                "type": "remote",
+                                "url": "https://github.com/org/binary2.zip",
+                                "checksum": "77AFD0BA-D1CF-4628-A43B-B6E66F44448A"
+                            },
+                            "path": "/path/to/binary2"
+                        },
+                        {
+                            "packageRef": {
+                              "identity": "bar",
+                              "kind": "remoteSourceControl",
+                              "location": "https://github.com/org/bar.git",
+                              "name": "bar"
+                            },
+                            "targetName": "bar",
+                            "source": {
+                                "type": "remote",
+                                "url": "https://github.com/org/binary3.zip",
+                                "checksum": "77AFD0BA-D1CF-4628-A43B-B6E66F44448A"
+                            },
+                            "path": "/path/to/binary3"
+                        }
+                    ],
+                    "dependencies": []
+                }
+            }
+            """
+        }
+
+        let state = WorkspaceState(dataPath: buildDir, fileSystem: fs)
+        XCTAssertTrue(state.artifacts.contains(where: { $0.packageRef.identity == .plain("foo") && $0.targetName == "foo" }))
+        XCTAssertTrue(state.artifacts.contains(where: { $0.packageRef.identity == .plain("foo") && $0.targetName == "bar" }))
+        XCTAssertTrue(state.artifacts.contains(where: { $0.packageRef.identity == .plain("bar") && $0.targetName == "bar" }))
+    }
+
+    // rdar://86857825
+    func testDuplicateDependenciesDoNotCrash() throws {
+        let fs = InMemoryFileSystem()
+
+        let buildDir = AbsolutePath("/.build")
+        let statePath = buildDir.appending(component: "workspace-state.json")
+
+        try fs.createDirectory(buildDir, recursive: true)
+        try fs.writeFileContents(statePath) {
+            """
+            {
+                "version": 5,
+                "object": {
+                    "artifacts": [],
+                    "dependencies": [
+                        {
+                            "basedOn": null,
+                            "packageRef": {
+                              "identity": "yams",
+                              "kind": "remoteSourceControl",
+                              "location": "https://github.com/jpsim/Yams.git",
+                              "name": "Yams"
+                            },
+                            "state": {
+                              "checkoutState": {
+                                "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
+                                "version": "4.0.6"
+                              },
+                              "name": "checkout"
+                            },
+                            "subpath": "Yams"
+                        },
+                        {
+                            "basedOn": null,
+                            "packageRef": {
+                              "identity": "yams",
+                              "kind": "remoteSourceControl",
+                              "location": "https://github.com/jpsim/Yams.git",
+                              "name": "Yams"
+                            },
+                            "state": {
+                              "checkoutState": {
+                                "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
+                                "version": "4.0.6"
+                              },
+                              "name": "checkout"
+                            },
+                            "subpath": "Yams"
+                        },
+                    ]
+                }
+            }
+            """
+        }
+
+        let state = WorkspaceState(dataPath: buildDir, fileSystem: fs)
+        // empty since we have dups so we warn and fail the loading
+        // TODO: test for diagnostics when we can get them from the WorkspaceState initializer
+        XCTAssertTrue(state.dependencies.isEmpty)
+    }
+
+    // rdar://86857825
+    func testDuplicateArtifactsDoNotCrash() throws {
+        let fs = InMemoryFileSystem()
+
+        let buildDir = AbsolutePath("/.build")
+        let statePath = buildDir.appending(component: "workspace-state.json")
+
+        try fs.createDirectory(buildDir, recursive: true)
+        try fs.writeFileContents(statePath) {
+            """
+            {
+                "version": 5,
+                "object": {
+                    "artifacts": [
+                        {
+                            "packageRef": {
+                              "identity": "foo",
+                              "kind": "remoteSourceControl",
+                              "location": "https://github.com/org/foo.git",
+                              "name": "foo"
+                            },
+                            "targetName": "foo",
+                            "source": {
+                                "type": "remote",
+                                "url": "https://github.com/org/binary1.zip",
+                                "checksum": "77AFD0BA-D1CF-4628-A43B-B6E66F44448A"
+                            },
+                            "path": "/path/to/binary1"
+                        },
+                        {
+                            "packageRef": {
+                              "identity": "foo",
+                              "kind": "remoteSourceControl",
+                              "location": "https://github.com/org/foo.git",
+                              "name": "foo"
+                            },
+                            "targetName": "foo",
+                            "source": {
+                                "type": "remote",
+                                "url": "https://github.com/org/binary2.zip",
+                                "checksum": "77AFD0BA-D1CF-4628-A43B-B6E66F44448A"
+                            },
+                            "path": "/path/to/binary2"
+                        }
+                    ],
+                    "dependencies": []
+                }
+            }
+            """
+        }
+
+        let state = WorkspaceState(dataPath: buildDir, fileSystem: fs)
+        // empty since we have dups so we warn and fail the loading
+        // TODO: test for diagnostics when we can get them from the WorkspaceState initializer
+        XCTAssertTrue(state.artifacts.isEmpty)
     }
 }


### PR DESCRIPTION


motivation: some older versions of SwiftPM wrote duplicate entries into workspace-state.json which can cause a crash due to use of Dictionary::uniquingKeysWith

changes:
* do not use Dictionary::uniquingKeysWith for non-santized input such as workspace state
* add tests

rdar://86857825