### PR TITLE
[5.6] Allow package plugins to be invoked using just `swift package`, and not require `swift package plugin` (#3977)

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -63,6 +63,7 @@ public struct SwiftPackageTool: ParsableCommand {
             PluginCommand.self,
         ]
         + (ProcessInfo.processInfo.environment["SWIFTPM_ENABLE_SNIPPETS"] == "1" ? [Learn.self] : []),
+        defaultSubcommand: PluginCommand.self,
         helpNames: [.short, .long, .customLong("help", withSingleDash: true)])
 
     @OptionGroup()
@@ -872,7 +873,7 @@ extension SwiftPackageTool {
     struct PluginCommand: SwiftCommand {
         static let configuration = CommandConfiguration(
             commandName: "plugin",
-            abstract: "Invoke a command plugin (note: the use of a `plugin` subcommand for this is temporary)"
+            abstract: "Invoke a command plugin or perform other actions on command plugins"
         )
 
         @OptionGroup(_hiddenFromHelp: true)
@@ -911,20 +912,17 @@ extension SwiftPackageTool {
 
             // Otherwise find the plugins that match the command verb.
             guard let commandVerb = pluginCommand.first else {
-                swiftTool.observabilityScope.emit(error: "No plugin command name specified")
-                throw ExitCode.failure
+                throw ValidationError("No plugin command name specified")
             }
-            swiftTool.observabilityScope.emit(info: "Finding plugin for command '\(commandVerb)'")
+            swiftTool.observabilityScope.emit(info: "Finding plugin for command ‘\(commandVerb)’")
             let matchingPlugins = findPlugins(matching: commandVerb, in: packageGraph)
 
             // Complain if we didn't find exactly one.
             if matchingPlugins.isEmpty {
-                swiftTool.observabilityScope.emit(error: "No command plugins found for '\(commandVerb)'")
-                throw ExitCode.failure
+                throw ValidationError("No command plugins found for ‘\(commandVerb)’")
             }
             else if matchingPlugins.count > 1 {
-                swiftTool.observabilityScope.emit(error: "\(matchingPlugins.count) plugins found for '\(commandVerb)'")
-                throw ExitCode.failure
+                throw ValidationError("\(matchingPlugins.count) plugins found for ‘\(commandVerb)’")
             }
             
             // At this point we know we found exactly one command plugin, so we run it.
@@ -941,8 +939,7 @@ extension SwiftPackageTool {
             var targets: [String: ResolvedTarget] = [:]
             for target in package.targets where targetNames.contains(target.name) {
                 if targets[target.name] != nil {
-                    swiftTool.observabilityScope.emit(error: "Ambiguous target name: ‘\(target.name)’")
-                    throw ExitCode.failure
+                    throw ValidationError("Ambiguous target name: ‘\(target.name)’")
                 }
                 if target.isEligibleForPluginCommand {
                     targets[target.name] = target
@@ -951,8 +948,7 @@ extension SwiftPackageTool {
             assert(targets.count <= targetNames.count)
             if targets.count != targetNames.count {
                 let unknownTargetNames = Set(targetNames).subtracting(targets.keys)
-                swiftTool.observabilityScope.emit(error: "Unknown targets: ‘\(unknownTargetNames.sorted().joined(separator: "’, ‘"))’")
-                throw ExitCode.failure
+                throw ValidationError("Unknown targets: ‘\(unknownTargetNames.sorted().joined(separator: "’, ‘"))’")
             }
             
             // If the plugin requires additional permissions, we ask the user for approval.

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -1337,14 +1337,28 @@ final class PackageToolTests: CommandsTestCase {
             do {
                 let result = try SwiftPMProduct.SwiftPackage.executeProcess(["plugin", "mycmd"], packagePath: packageDir)
                 XCTAssertEqual(result.exitStatus, .terminated(code: 0))
-                XCTAssert(try result.utf8Output().contains("This is MyCommandPlugin."))
+                XCTAssertMatch(try result.utf8Output(), .contains("This is MyCommandPlugin."))
+            }
+
+            // Check that we can also invoke it without the "plugin" subcommand.
+            do {
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["mycmd"], packagePath: packageDir)
+                XCTAssertEqual(result.exitStatus, .terminated(code: 0))
+                XCTAssertMatch(try result.utf8Output(), .contains("This is MyCommandPlugin."))
             }
 
             // Testing listing the available command plugins.
             do {
                 let result = try SwiftPMProduct.SwiftPackage.executeProcess(["plugin", "--list"], packagePath: packageDir)
                 XCTAssertEqual(result.exitStatus, .terminated(code: 0))
-                XCTAssert(try result.utf8Output().contains("‘mycmd’ (plugin ‘MyPlugin’ in package ‘MyPackage’)"))
+                XCTAssertMatch(try result.utf8Output(), .contains("‘mycmd’ (plugin ‘MyPlugin’ in package ‘MyPackage’)"))
+            }
+
+            // Check that we get the expected error if trying to invoke a plugin with the wrong name.
+            do {
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["my-nonexistent-cmd"], packagePath: packageDir)
+                XCTAssertNotEqual(result.exitStatus, .terminated(code: 0))
+                XCTAssertMatch(try result.utf8stderrOutput(), .contains("No command plugins found for ‘my-nonexistent-cmd’"))
             }
         }
     }


### PR DESCRIPTION
5.6 cherry-pick of #3977