### PR TITLE
Don't prefix each line of command plugin output with the name of the plugin

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -1104,7 +1104,7 @@ final class PluginDelegate: PluginInvocationDelegate {
         var needsFlush = false
         while let newlineIdx = lineBufferedOutput.firstIndex(of: UInt8(ascii: "\n")) {
             let lineData = lineBufferedOutput.prefix(upTo: newlineIdx)
-            outputStream <<< "[plugin ‘\(plugin.name)’] " <<< String(decoding: lineData, as: UTF8.self) <<< "\n"
+            outputStream <<< String(decoding: lineData, as: UTF8.self) <<< "\n"
             needsFlush = true
             lineBufferedOutput = lineBufferedOutput.suffix(from: newlineIdx.advanced(by: 1))
         }


### PR DESCRIPTION
### Motivation:

It is noisy and makes the plugin commands look very different from the built in commands, which is opposite of the long-term goal.

### Modifications:

- change the output string to not include the prefix

rdar://86855690