### PR TITLE
[5.6] Don't prefix each line of command plugin output with the name of the plugin (#3983)

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -1104,7 +1104,7 @@ final class PluginDelegate: PluginInvocationDelegate {
         var needsFlush = false
         while let newlineIdx = lineBufferedOutput.firstIndex(of: UInt8(ascii: "\n")) {
             let lineData = lineBufferedOutput.prefix(upTo: newlineIdx)
-            outputStream <<< "[plugin ‘\(plugin.name)’] " <<< String(decoding: lineData, as: UTF8.self) <<< "\n"
+            outputStream <<< String(decoding: lineData, as: UTF8.self) <<< "\n"
             needsFlush = true
             lineBufferedOutput = lineBufferedOutput.suffix(from: newlineIdx.advanced(by: 1))
         }


### PR DESCRIPTION
This is the 5.6 cherry pick of https://github.com/apple/swift-package-manager/pull/3983.