### PR TITLE
[5.6] Include the default command search paths for plugin tool lookup. (#3984)

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -999,8 +999,9 @@ extension SwiftPackageTool {
                 writableDirectories.append(AbsolutePath(pathString, relativeTo: swiftTool.originalWorkingDirectory))
             }
 
-            // Use the directory containing the compiler as an additional search directory.
+            // Use the directory containing the compiler as an additional search directory, and add the $PATH.
             let toolSearchDirs = [try swiftTool.getToolchain().swiftCompilerPath.parentDirectory]
+                + getEnvSearchPaths(pathString: ProcessEnv.path, currentWorkingDirectory: .none)
 
             // Create the cache directory, if needed.
             try localFileSystem.createDirectory(cacheDir, recursive: true)

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -1288,6 +1288,11 @@ final class PackageToolTests: CommandsTestCase {
                         print("Looking for swiftc...")
                         let swiftc = try context.tool(named: "swiftc")
                         print("... found it at \\(swiftc.path)")
+
+                        // Check that we can find a standard tool.
+                        print("Looking for sed...")
+                        let sed = try context.tool(named: "sed")
+                        print("... found it at \\(sed.path)")
                     }
                 }
                 """


### PR DESCRIPTION
Nominating https://github.com/apple/swift-package-manager/pull/3984 for SwiftPM 5.6.