### PR TITLE
Make the symbol graph extraction requested by plugins more robust

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -564,8 +564,7 @@ extension SwiftPackageTool {
                 skipSynthesizedMembers: skipSynthesizedMembers,
                 minimumAccessLevel: minimumAccessLevel,
                 skipInheritedDocs: skipInheritedDocs,
-                includeSPISymbols: includeSPISymbols,
-                prettyPrintOutputJSON: prettyPrint)
+                includeSPISymbols: includeSPISymbols)
 
             // Run the tool once for every library and executable target in the root package.
             let buildPlan = buildOp.buildPlan!
@@ -576,7 +575,7 @@ extension SwiftPackageTool {
                 try symbolGraphExtractor.extractSymbolGraph(
                     target: target,
                     buildPlan: buildPlan,
-                    verbose: verbosity != .concise,
+                    logLevel: swiftTool.logLevel,
                     outputDirectory: symbolGraphDirectory)
             }
 
@@ -1276,7 +1275,7 @@ final class PluginDelegate: PluginInvocationDelegate {
             target: target,
             buildPlan: buildPlan,
             outputRedirection: .collect,
-            verbose: false,
+            logLevel: .warning,
             outputDirectory: outputDir)
 
         // Return the results to the plugin.

--- a/Sources/Commands/SymbolGraphExtract.swift
+++ b/Sources/Commands/SymbolGraphExtract.swift
@@ -1,97 +1,79 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-
-import TSCBasic
-import TSCUtility
-
-import SPMBuildCore
+import ArgumentParser
 import Build
 import PackageGraph
 import PackageModel
-import SourceControl
-import Workspace
-import ArgumentParser
+import SPMBuildCore
+import TSCBasic
+import TSCUtility
 
 /// A wrapper for swift-symbolgraph-extract tool.
 public struct SymbolGraphExtract {
     let tool: AbsolutePath
+    var skipSynthesizedMembers: Bool = false
+    var minimumAccessLevel: AccessLevel = .public
+    var skipInheritedDocs: Bool = false
+    var includeSPISymbols: Bool = false
+    var prettyPrintOutputJSON: Bool = false
 
-    init(tool: AbsolutePath) {
-        self.tool = tool
+    /// Access control levels.
+    public enum AccessLevel: String, RawRepresentable, CustomStringConvertible, CaseIterable, ExpressibleByArgument {
+        // The cases reflect those found in `include/swift/AST/AttrKind.h` of the swift compiler (at commit 03f55d7bb4204ca54841218eb7cc175ae798e3bd)
+        case `private`, `fileprivate`, `internal`, `public`, `open`
+
+        public var description: String { rawValue }
     }
 
-    public func dumpSymbolGraph(
+    /// Creates a symbol graph for `target` in `outputDirectory` using the build information from `buildPlan`. The `outputDirection` determines how the output from the tool subprocess is handled, and `verbosity` specifies how much console output to ask the tool to emit.
+    public func extractSymbolGraph(
+        target: ResolvedTarget,
         buildPlan: BuildPlan,
-        prettyPrint: Bool,
-        skipSynthesisedMembers: Bool,
-        minimumAccessLevel: AccessLevel,
-        skipInheritedDocs: Bool,
-        includeSPISymbols: Bool
+        outputRedirection: Process.OutputRedirection = .none,
+        verbose: Bool,
+        outputDirectory: AbsolutePath
     ) throws {
         let buildParameters = buildPlan.buildParameters
-        let symbolGraphDirectory = buildPlan.buildParameters.symbolGraph
-        try localFileSystem.createDirectory(symbolGraphDirectory, recursive: true)
+        try localFileSystem.createDirectory(outputDirectory, recursive: true)
 
-        // Run the tool for each target in the root package.
-        let targets = buildPlan.graph.rootPackages.flatMap{ $0.targets }.filter{ $0.type == .library || $0.type == .executable }
-        for target in targets {
-            var args = [String]()
-            args += ["-module-name", target.c99name]
-            args += try buildParameters.targetTripleArgs(for: target)
-
-            args += buildPlan.createAPIToolCommonArgs(includeLibrarySearchPaths: true)
-            args += ["-module-cache-path", buildParameters.moduleCache.pathString]
-
-            args += ["-output-dir", symbolGraphDirectory.pathString]
-
-            if prettyPrint { args.append("-pretty-print") }
-            if skipSynthesisedMembers { args.append("-skip-synthesized-members") }
-            if minimumAccessLevel != SwiftPackageTool.DumpSymbolGraph.defaultMinimumAccessLevel {
-                args += ["-minimum-access-level", minimumAccessLevel.rawValue]
-            }
-            if skipInheritedDocs { args.append("-skip-inherited-docs") }
-            if includeSPISymbols { args.append("-include-spi-symbols") }
-
-            print("-- Emitting symbol graph for", target.name)
-            try runTool(args)
+        // Construct arguments for extracting symbols for a single target.
+        var commandLine = [self.tool.pathString]
+        commandLine += ["-module-name", target.c99name]
+        commandLine += try buildParameters.targetTripleArgs(for: target)
+        commandLine += buildPlan.createAPIToolCommonArgs(includeLibrarySearchPaths: true)
+        commandLine += ["-module-cache-path", buildParameters.moduleCache.pathString]
+        if verbose {
+            commandLine += ["-v"]
         }
-        print("Files written to", symbolGraphDirectory.pathString)
-    }
+        commandLine += ["-minimum-access-level", minimumAccessLevel.rawValue]
+        if skipSynthesizedMembers {
+            commandLine += ["-skip-synthesized-members"]
+        }
+        if skipInheritedDocs {
+            commandLine += ["-skip-inherited-docs"]
+        }
+        if includeSPISymbols {
+            commandLine += ["-include-spi-symbols"]
+        }
+        if prettyPrintOutputJSON {
+            commandLine += ["-pretty-print"]
+        }
+        commandLine += ["-output-dir", outputDirectory.pathString]
 
-    func runTool(_ args: [String]) throws {
-        let arguments = [tool.pathString] + args
+        // Run the extraction.
         let process = Process(
-            arguments: arguments,
-            outputRedirection: .none,
-            verbose: verbosity != .concise
-        )
+            arguments: commandLine,
+            outputRedirection: outputRedirection,
+            verbose: verbose)
         try process.launch()
         try process.waitUntilExit()
-    }
-}
-
-/// Access control levels.
-public enum AccessLevel: String, RawRepresentable, CustomStringConvertible, CaseIterable {
-    // The cases reflect those found in `include/swift/AST/AttrKind.h` of the swift compiler (at commit 03f55d7bb4204ca54841218eb7cc175ae798e3bd)
-    case `private`, `fileprivate`, `internal`, `public`, `open`
-
-    public var description: String { rawValue }
-}
-
-extension AccessLevel: ExpressibleByArgument {}
-
-extension BuildParameters {
-    /// The directory containing artifacts generated by the symbolgraph-extract tool.
-    var symbolGraph: AbsolutePath {
-        dataPath.appending(component: "symbolgraph")
     }
 }

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -1444,6 +1444,9 @@ final class PackageToolTests: CommandsTestCase {
     }
 
     func testCommandPluginSymbolGraphCallbacks() throws {
+        // Depending on how the test is running, the `swift-symbolgraph-extract` tool might be unavailable.
+        try XCTSkipIf((try? UserToolchain.default.getSymbolGraphExtract()) == nil, "skipping test because the `swift-symbolgraph-extract` tools isn't available")
+        
         try testWithTemporaryDirectory { tmpPath in
             // Create a sample package with a library, and executable, and a plugin.
             let packageDir = tmpPath.appending(components: "MyPackage")

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -1508,18 +1508,20 @@ final class PackageToolTests: CommandsTestCase {
             // Check that if we don't pass any target, we successfully get symbol graph information for all targets in the package, and at different paths.
             do {
                 let result = try SwiftPMProduct.SwiftPackage.executeProcess(["generate-documentation"], packagePath: packageDir)
-                XCTAssertEqual(result.exitStatus, .terminated(code: 0))
-                XCTAssertMatch(try result.utf8Output(), .and(.contains("MyLibrary:"), .contains("mypackage/MyLibrary")))
-                XCTAssertMatch(try result.utf8Output(), .and(.contains("MyCommand:"), .contains("mypackage/MyCommand")))
+                let output = try result.utf8Output() + result.utf8stderrOutput()
+                XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
+                XCTAssertMatch(output, .and(.contains("MyLibrary:"), .contains("mypackage/MyLibrary")))
+                XCTAssertMatch(output, .and(.contains("MyCommand:"), .contains("mypackage/MyCommand")))
 
             }
 
             // Check that if we pass a target, we successfully get symbol graph information for just the target we asked for.
             do {
                 let result = try SwiftPMProduct.SwiftPackage.executeProcess(["--target", "MyLibrary", "generate-documentation"], packagePath: packageDir)
-                XCTAssertEqual(result.exitStatus, .terminated(code: 0))
-                XCTAssertMatch(try result.utf8Output(), .and(.contains("MyLibrary:"), .contains("mypackage/MyLibrary")))
-                XCTAssertNoMatch(try result.utf8Output(), .and(.contains("MyCommand:"), .contains("mypackage/MyCommand")))
+                let output = try result.utf8Output() + result.utf8stderrOutput()
+                XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
+                XCTAssertMatch(output, .and(.contains("MyLibrary:"), .contains("mypackage/MyLibrary")))
+                XCTAssertNoMatch(output, .and(.contains("MyCommand:"), .contains("mypackage/MyCommand")))
             }
         }
     }


### PR DESCRIPTION
This includes reworking the SymbolGraphExtract type that so it's more suitable for being called in the context of plugins.

### Motivation:

The symbol graph extraction support for plugins called into the existing SymbolGraphExtract type, but this type was more suited to use from the command line action, and this caused some bugs for its use from plugins.

This PR refactors SymbolGraphExtract to hoist the assumptions about things like destination path out into the caller, and adjusts the call sites.

### Modifications

- factor out assumptions and console output from SymbolGraphExtract to the caller
- when used for plugins, avoid generate symbol graph information for targets other than the one asked for
- use a unique symbol graph output directory for each package/target combination
- add a unit test with better checking for different symbol graph generation usage
- adjust call sites for the `dump-symbol-graph` command as well as its use from plugins
- made verbose mode pass `-v` to `dump-symbol-graph` so it prints additional information too

### Results

Same behavior for `dump-symbol-graph` except that verbose mode is now also passed on to that tool, which is in the spirit of enabling verbose more.  For package plugin use, there are now separate output paths per combination of package and target, and only those symbol graphs that are asked for are emitted.

rdar://87234110&86785765

This will be nominated for inclusion in SwiftPM 5.6.