### PR TITLE
cleanup use test-discovery main file name

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -9,14 +9,15 @@
 */
 
 import Basics
-import TSCBasic
-import TSCUtility
-import PackageModel
+import Foundation
+import LLBuildManifest
 import PackageGraph
 import PackageLoading
-import Foundation
+import PackageModel
 import SPMBuildCore
 @_implementationOnly import SwiftDriver
+import TSCBasic
+import TSCUtility
 
 extension String {
     fileprivate var asSwiftStringLiteralConstant: String {
@@ -1478,7 +1479,7 @@ public class BuildPlan {
             } else {
                 // We'll generate sources containing the test names as part of the build process.
                 let derivedTestListDir = buildParameters.buildPath.appending(components: "\(testProduct.name).derived")
-                let mainFile = derivedTestListDir.appending(component: "runner.swift")
+                let mainFile = derivedTestListDir.appending(component: LLBuildManifest.TestDiscoveryTool.mainFileName)
 
                 var paths: [AbsolutePath] = []
                 paths.append(mainFile)


### PR DESCRIPTION
motivation: small follow up cleanup to #3992 which consolidates the use of a share definition for the test discovery main file name

changes: use the shared definition for the main file name used for test discovery everywhere
