### PR TITLE
Enforce read-only-ness of package directory even when it's inside writable directories

### DIFF
--- a/Sources/Basics/Sandbox.swift
+++ b/Sources/Basics/Sandbox.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -13,13 +13,25 @@ import TSCBasic
 import TSCUtility
 
 public enum Sandbox {
+
+    /// Applies a sandbox invocation to the given command line (if the platform supports it),
+    /// and returns the modified command line. On platforms that don't support sandboxing, the
+    /// command line is returned unmodified.
+    ///
+    /// - Parameters:
+    ///   - command: The command line to sandbox (including executable as first argument)
+    ///   - strictness: The basic strictness level of the standbox.
+    ///   - writableDirectories: Paths under which writing should be allowed.
+    ///   - readOnlyDirectories: Paths under which writing should be denied, even if they would have otherwise been allowed by either the strictness level or paths in `writableDirectories`.
+
     public static func apply(
         command: [String],
+        strictness: Strictness = .default,
         writableDirectories: [AbsolutePath] = [],
-        strictness: Strictness = .default
+        readOnlyDirectories: [AbsolutePath] = []
     ) -> [String] {
         #if os(macOS)
-        let profile = macOSSandboxProfile(writableDirectories: writableDirectories, strictness: strictness)
+        let profile = macOSSandboxProfile(strictness: strictness, writableDirectories: writableDirectories, readOnlyDirectories: readOnlyDirectories)
         return ["/usr/bin/sandbox-exec", "-p", profile] + command
         #else
         // rdar://40235432, rdar://75636874 tracks implementing sandboxes for other platforms.
@@ -27,9 +39,13 @@ public enum Sandbox {
         #endif
     }
 
+    /// Basic strictness level of a sandbox applied to a command line.
     public enum Strictness: Equatable {
+        /// Blocks network access and all file system modifications.
         case `default`
+        /// More lenient restrictions than the default, for compatibility with SwiftPM manifests using a tools version older than 5.3.
         case manifest_pre_53 // backwards compatibility for manifests
+        /// Like `default`, but also makes temporary-files directories (such as `/tmp`) on the platform writable.
         case writableTemporaryDirectory
     }
 }
@@ -38,8 +54,9 @@ public enum Sandbox {
 
 #if os(macOS)
 fileprivate func macOSSandboxProfile(
+    strictness: Sandbox.Strictness,
     writableDirectories: [AbsolutePath],
-    strictness: Sandbox.Strictness
+    readOnlyDirectories: [AbsolutePath]
 ) -> String {
     var contents = "(version 1)\n"
 
@@ -80,10 +97,20 @@ fileprivate func macOSSandboxProfile(
         }
     }
 
+    // Emit rules for paths under which writing is allowed. Some of these expressions may be regular expressions and others literal subpaths.
     if writableDirectoriesExpression.count > 0 {
         contents += "(allow file-write*\n"
         for expression in writableDirectoriesExpression {
             contents += "    \(expression)\n"
+        }
+        contents += ")\n"
+    }
+
+    // Emit rules for paths under which writing should be disallowed, even if they would be covered by a previous rule to allow writing to them. A classic case is a package which is located under the temporary directory, which should be read-only even though the temporary directory as a whole is writable.
+    if readOnlyDirectories.count > 0 {
+        contents += "(deny file-write*\n"
+        for path in readOnlyDirectories {
+            contents += "    (subpath \(resolveSymlinks(path).quotedAsSubpathForSandboxProfile))\n"
         }
         contents += ")\n"
     }

--- a/Sources/Basics/Sandbox.swift
+++ b/Sources/Basics/Sandbox.swift
@@ -23,7 +23,6 @@ public enum Sandbox {
     ///   - strictness: The basic strictness level of the standbox.
     ///   - writableDirectories: Paths under which writing should be allowed.
     ///   - readOnlyDirectories: Paths under which writing should be denied, even if they would have otherwise been allowed by either the strictness level or paths in `writableDirectories`.
-
     public static func apply(
         command: [String],
         strictness: Strictness = .default,

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -344,7 +344,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
                 // TODO: We need to also use any working directory, but that support isn't yet available on all platforms at a lower level.
                 var commandLine = [command.configuration.executable.pathString] + command.configuration.arguments
                 if !self.disableSandboxForPluginCommands {
-                    commandLine = Sandbox.apply(command: commandLine, writableDirectories: [pluginResult.pluginOutputDirectory], strictness: .writableTemporaryDirectory)
+                    commandLine = Sandbox.apply(command: commandLine, strictness: .writableTemporaryDirectory, writableDirectories: [pluginResult.pluginOutputDirectory])
                 }
                 let processResult = try Process.popen(arguments: commandLine, environment: command.configuration.environment)
                 let output = try processResult.utf8Output() + processResult.utf8stderrOutput()

--- a/Sources/Build/LLBuildManifestBuilder.swift
+++ b/Sources/Build/LLBuildManifestBuilder.swift
@@ -618,7 +618,7 @@ extension LLBuildManifestBuilder {
                 let displayName = command.configuration.displayName ?? execPath.basename
                 var commandLine = [execPath.pathString] + command.configuration.arguments
                 if !self.disableSandboxForPluginCommands {
-                    commandLine = Sandbox.apply(command: commandLine, writableDirectories: [result.pluginOutputDirectory], strictness: .writableTemporaryDirectory)
+                    commandLine = Sandbox.apply(command: commandLine, strictness: .writableTemporaryDirectory, writableDirectories: [result.pluginOutputDirectory])
                 }
                 manifest.addShellCmd(
                     name: displayName + "-" + ByteString(encodingAsUTF8: uniquedName).sha256Checksum,

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -895,10 +895,6 @@ extension SwiftPackageTool {
               help: "Allow the plugin to write to an additional directory")
         var additionalAllowedWritableDirectories: [String] = []
 
-        @Flag(name: .customLong("block-writing-to-temporary-directory"),
-              help: "Block the plugin from writing to the package directory (by default this is allowed)")
-        var blockWritingToTemporaryDirectory: Bool = false
-
         @Argument(parsing: .unconditionalRemaining,
                   help: "Name and arguments of the command plugin to invoke")
         var pluginCommand: [String] = []
@@ -979,13 +975,6 @@ extension SwiftPackageTool {
             if allowWritingToPackageDirectory {
                 writableDirectories.append(package.path)
             }
-            if !blockWritingToTemporaryDirectory {
-                writableDirectories.append(AbsolutePath("/tmp"))
-                writableDirectories.append(AbsolutePath(NSTemporaryDirectory()))
-            }
-            if allowWritingToPackageDirectory {
-                writableDirectories.append(package.path)
-            }
             else {
                 // If the plugin requires write permission but it wasn't provided, we ask the user for approval.
                 if case .command(_, let permissions) = plugin.capability {
@@ -998,6 +987,10 @@ extension SwiftPackageTool {
             for pathString in additionalAllowedWritableDirectories {
                 writableDirectories.append(AbsolutePath(pathString, relativeTo: swiftTool.originalWorkingDirectory))
             }
+
+            // Make sure that the package path is read-only unless it's covered by any of the explicitly writable directories.
+            let readOnlyDirectories = writableDirectories.contains{ package.path.isDescendantOfOrEqual(to: $0) } ? [] : [package.path]
+            print("readOnlyDirectories: \(readOnlyDirectories)")
 
             // Use the directory containing the compiler as an additional search directory, and add the $PATH.
             let toolSearchDirs = [try swiftTool.getToolchain().swiftCompilerPath.parentDirectory]
@@ -1051,6 +1044,7 @@ extension SwiftPackageTool {
                 toolSearchDirectories: toolSearchDirs,
                 toolNamesToPaths: toolNamesToPaths,
                 writableDirectories: writableDirectories,
+                readOnlyDirectories: readOnlyDirectories,
                 fileSystem: localFileSystem,
                 observabilityScope: swiftTool.observabilityScope,
                 callbackQueue: delegateQueue,

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -990,7 +990,6 @@ extension SwiftPackageTool {
 
             // Make sure that the package path is read-only unless it's covered by any of the explicitly writable directories.
             let readOnlyDirectories = writableDirectories.contains{ package.path.isDescendantOfOrEqual(to: $0) } ? [] : [package.path]
-            print("readOnlyDirectories: \(readOnlyDirectories)")
 
             // Use the directory containing the compiler as an additional search directory, and add the $PATH.
             let toolSearchDirs = [try swiftTool.getToolchain().swiftCompilerPath.parentDirectory]

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -900,7 +900,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                     if self.isManifestSandboxEnabled {
                         let cacheDirectories = [self.databaseCacheDir, moduleCachePath].compactMap{ $0 }
                         let strictness: Sandbox.Strictness = toolsVersion < .v5_3 ? .manifest_pre_53 : .default
-                        cmd = Sandbox.apply(command: cmd, writableDirectories: cacheDirectories, strictness: strictness)
+                        cmd = Sandbox.apply(command: cmd, strictness: strictness, writableDirectories: cacheDirectories)
                     }
 
                     // Run the compiled manifest.

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -429,6 +429,7 @@ class PluginTests: XCTestCase {
                         toolSearchDirectories: [UserToolchain.default.swiftCompilerPath.parentDirectory],
                         toolNamesToPaths: [:],
                         writableDirectories: [pluginDir.appending(component: "output")],
+                        readOnlyDirectories: [package.path],
                         fileSystem: localFileSystem,
                         observabilityScope: observability.topScope,
                         callbackQueue: delegateQueue,

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -93,6 +93,7 @@ class PluginInvocationTests: XCTestCase {
                 input: PluginScriptRunnerInput,
                 toolsVersion: ToolsVersion,
                 writableDirectories: [AbsolutePath],
+                readOnlyDirectories: [AbsolutePath],
                 fileSystem: FileSystem,
                 observabilityScope: ObservabilityScope,
                 callbackQueue: DispatchQueue,


### PR DESCRIPTION
Enforce read-only-ness of package directory even when it's inside `/tmp` and other writable directories to the number of reduce special cases.

### Motivation

The package directory should always be read-only unless specifically requested to be writable, even if it happens to be in `/tmp` or other implicitly writable locations.

### Details

The sandbox supports a list of `writableDirectories`, which are treated as path component prefixes after package resolution.  The are applied to the sandbox rules after the default-deny and everything-is-read-only rules, carving out cones of writability in specific areas of the file system.

But if the package directory is under one of these directories that is allowed by default, then it is implicitly writable even in the absence `--allow-writing-to-package-directory`.  It also makes unit tests awkward, since they usually create temporary test fixtures inside the temporary directory.

### Modifications:

- extend `Sandbox` with a list of read-only locations
- add function and parameter documentation to Sandbox
- thread through the list of read only directories
- pass the package directory as a specific read-only directory unless it's covered by an explicit `writable-directory` parameter
- switch back to using `strictness` for temporary-directory writability (cleaner)
- remove the flag to make temporary directory read-only that was added mostly for unit tests

### Result:

There are fewer edge cases with respect to when the package directory is writable.
