### PR TITLE
[5.6] Enforce read-only-ness of package directory even when it's inside writable directories (#3996)

### DIFF
--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -344,7 +344,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
                 // TODO: We need to also use any working directory, but that support isn't yet available on all platforms at a lower level.
                 var commandLine = [command.configuration.executable.pathString] + command.configuration.arguments
                 if !self.disableSandboxForPluginCommands {
-                    commandLine = Sandbox.apply(command: commandLine, writableDirectories: [pluginResult.pluginOutputDirectory], strictness: .writableTemporaryDirectory)
+                    commandLine = Sandbox.apply(command: commandLine, strictness: .writableTemporaryDirectory, writableDirectories: [pluginResult.pluginOutputDirectory])
                 }
                 let processResult = try Process.popen(arguments: commandLine, environment: command.configuration.environment)
                 let output = try processResult.utf8Output() + processResult.utf8stderrOutput()

--- a/Sources/Build/LLBuildManifestBuilder.swift
+++ b/Sources/Build/LLBuildManifestBuilder.swift
@@ -618,7 +618,7 @@ extension LLBuildManifestBuilder {
                 let displayName = command.configuration.displayName ?? execPath.basename
                 var commandLine = [execPath.pathString] + command.configuration.arguments
                 if !self.disableSandboxForPluginCommands {
-                    commandLine = Sandbox.apply(command: commandLine, writableDirectories: [result.pluginOutputDirectory], strictness: .writableTemporaryDirectory)
+                    commandLine = Sandbox.apply(command: commandLine, strictness: .writableTemporaryDirectory, writableDirectories: [result.pluginOutputDirectory])
                 }
                 manifest.addShellCmd(
                     name: displayName + "-" + ByteString(encodingAsUTF8: uniquedName).sha256Checksum,

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -895,10 +895,6 @@ extension SwiftPackageTool {
               help: "Allow the plugin to write to an additional directory")
         var additionalAllowedWritableDirectories: [String] = []
 
-        @Flag(name: .customLong("block-writing-to-temporary-directory"),
-              help: "Block the plugin from writing to the package directory (by default this is allowed)")
-        var blockWritingToTemporaryDirectory: Bool = false
-
         @Argument(parsing: .unconditionalRemaining,
                   help: "Name and arguments of the command plugin to invoke")
         var pluginCommand: [String] = []
@@ -979,13 +975,6 @@ extension SwiftPackageTool {
             if allowWritingToPackageDirectory {
                 writableDirectories.append(package.path)
             }
-            if !blockWritingToTemporaryDirectory {
-                writableDirectories.append(AbsolutePath("/tmp"))
-                writableDirectories.append(AbsolutePath(NSTemporaryDirectory()))
-            }
-            if allowWritingToPackageDirectory {
-                writableDirectories.append(package.path)
-            }
             else {
                 // If the plugin requires write permission but it wasn't provided, we ask the user for approval.
                 if case .command(_, let permissions) = plugin.capability {
@@ -998,6 +987,9 @@ extension SwiftPackageTool {
             for pathString in additionalAllowedWritableDirectories {
                 writableDirectories.append(AbsolutePath(pathString, relativeTo: swiftTool.originalWorkingDirectory))
             }
+
+            // Make sure that the package path is read-only unless it's covered by any of the explicitly writable directories.
+            let readOnlyDirectories = writableDirectories.contains{ package.path.isDescendantOfOrEqual(to: $0) } ? [] : [package.path]
 
             // Use the directory containing the compiler as an additional search directory, and add the $PATH.
             let toolSearchDirs = [try swiftTool.getToolchain().swiftCompilerPath.parentDirectory]
@@ -1051,6 +1043,7 @@ extension SwiftPackageTool {
                 toolSearchDirectories: toolSearchDirs,
                 toolNamesToPaths: toolNamesToPaths,
                 writableDirectories: writableDirectories,
+                readOnlyDirectories: readOnlyDirectories,
                 fileSystem: localFileSystem,
                 observabilityScope: swiftTool.observabilityScope,
                 callbackQueue: delegateQueue,

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -900,7 +900,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                     if self.isManifestSandboxEnabled {
                         let cacheDirectories = [self.databaseCacheDir, moduleCachePath].compactMap{ $0 }
                         let strictness: Sandbox.Strictness = toolsVersion < .v5_3 ? .manifest_pre_53 : .default
-                        cmd = Sandbox.apply(command: cmd, writableDirectories: cacheDirectories, strictness: strictness)
+                        cmd = Sandbox.apply(command: cmd, strictness: strictness, writableDirectories: cacheDirectories)
                     }
 
                     // Run the compiled manifest.

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -429,6 +429,7 @@ class PluginTests: XCTestCase {
                         toolSearchDirectories: [UserToolchain.default.swiftCompilerPath.parentDirectory],
                         toolNamesToPaths: [:],
                         writableDirectories: [pluginDir.appending(component: "output")],
+                        readOnlyDirectories: [package.path],
                         fileSystem: localFileSystem,
                         observabilityScope: observability.topScope,
                         callbackQueue: delegateQueue,

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -93,6 +93,7 @@ class PluginInvocationTests: XCTestCase {
                 input: PluginScriptRunnerInput,
                 toolsVersion: ToolsVersion,
                 writableDirectories: [AbsolutePath],
+                readOnlyDirectories: [AbsolutePath],
                 fileSystem: FileSystem,
                 observabilityScope: ObservabilityScope,
                 callbackQueue: DispatchQueue,


### PR DESCRIPTION
5.6 cherrypick of https://github.com/apple/swift-package-manager/pull/3996