### PR TITLE
Don't filter out `.docc` bundles from the list of target source files provided to plugins

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -810,7 +810,7 @@ public final class PackageBuilder {
             fileSystem: self.fileSystem,
             observabilityScope: self.observabilityScope
         )
-        let (sources, resources, headers, others) = try sourcesBuilder.run()
+        let (sources, resources, headers, ignored, others) = try sourcesBuilder.run()
 
         // Make sure defaultLocalization is set if the target has localized resources.
         let hasLocalizedResources = resources.contains(where: { $0.localization != nil })
@@ -868,6 +868,7 @@ public final class PackageBuilder {
                 type: targetType,
                 sources: sources,
                 resources: resources,
+                ignored: ignored,
                 others: others,
                 dependencies: dependencies,
                 swiftVersion: try swiftVersion(),
@@ -902,6 +903,7 @@ public final class PackageBuilder {
                 type: targetType,
                 sources: sources,
                 resources: resources,
+                ignored: ignored,
                 dependencies: dependencies,
                 buildSettings: buildSettings
             )

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -154,7 +154,7 @@ public struct TargetSourcesBuilder {
     }
 
     /// Run the builder to produce the sources of the target.
-    public func run() throws -> (sources: Sources, resources: [Resource], headers: [AbsolutePath], others: [AbsolutePath]) {
+    public func run() throws -> (sources: Sources, resources: [Resource], headers: [AbsolutePath], ignored: [AbsolutePath], others: [AbsolutePath]) {
         let contents = self.computeContents()
         var pathToRule: [AbsolutePath: Rule] = [:]
 
@@ -166,6 +166,7 @@ public struct TargetSourcesBuilder {
         let compilePaths = pathToRule.lazy.filter { $0.value.rule == .compile }.map { $0.key }
         let sources = Sources(paths: Array(compilePaths), root: targetPath)
         let resources: [Resource] = pathToRule.compactMap { resource(for: $0.key, with: $0.value) }
+        let ignored = pathToRule.filter { $0.value.rule == .ignored }.map { $0.key }
         let others = pathToRule.filter { $0.value.rule == .none }.map { $0.key }
 
         diagnoseConflictingResources(in: resources)
@@ -180,7 +181,7 @@ public struct TargetSourcesBuilder {
             throw Target.Error.mixedSources(targetPath)
         }
 
-        return (sources, resources, headers, others)
+        return (sources, resources, headers, ignored, others)
     }
 
     private struct Rule {

--- a/Sources/PackageModel/Target.swift
+++ b/Sources/PackageModel/Target.swift
@@ -130,6 +130,9 @@ public class Target: PolymorphicCodableProtocol {
     /// The resource files in the target.
     public let resources: [Resource]
 
+    /// Files in the target that were marked as ignored.
+    public let ignored: [AbsolutePath]
+
     /// Other kinds of files in the target.
     public let others: [AbsolutePath]
 
@@ -155,6 +158,7 @@ public class Target: PolymorphicCodableProtocol {
         type: Kind,
         sources: Sources,
         resources: [Resource] = [],
+        ignored: [AbsolutePath] = [],
         others: [AbsolutePath] = [],
         dependencies: [Target.Dependency],
         buildSettings: BuildSettings.AssignmentTable,
@@ -167,6 +171,7 @@ public class Target: PolymorphicCodableProtocol {
         self.type = type
         self.sources = sources
         self.resources = resources
+        self.ignored = ignored
         self.others = others
         self.dependencies = dependencies
         self.c99name = self.name.spm_mangledToC99ExtendedIdentifier()
@@ -175,7 +180,7 @@ public class Target: PolymorphicCodableProtocol {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case name, bundleName, defaultLocalization, platforms, type, sources, resources, others, buildSettings, pluginUsages
+        case name, bundleName, defaultLocalization, platforms, type, sources, resources, ignored, others, buildSettings, pluginUsages
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -190,6 +195,7 @@ public class Target: PolymorphicCodableProtocol {
         try container.encode(type, forKey: .type)
         try container.encode(sources, forKey: .sources)
         try container.encode(resources, forKey: .resources)
+        try container.encode(ignored, forKey: .ignored)
         try container.encode(others, forKey: .others)
         try container.encode(buildSettings, forKey: .buildSettings)
         // FIXME: pluginUsages property is skipped on purpose as it points to
@@ -205,6 +211,7 @@ public class Target: PolymorphicCodableProtocol {
         self.type = try container.decode(Kind.self, forKey: .type)
         self.sources = try container.decode(Sources.self, forKey: .sources)
         self.resources = try container.decode([Resource].self, forKey: .resources)
+        self.ignored = try container.decode([AbsolutePath].self, forKey: .ignored)
         self.others = try container.decode([AbsolutePath].self, forKey: .others)
         // FIXME: dependencies property is skipped on purpose as it points to
         // the actual target dependency object.
@@ -264,6 +271,7 @@ public final class SwiftTarget: Target {
         type: Kind,
         sources: Sources,
         resources: [Resource] = [],
+        ignored: [AbsolutePath] = [],
         others: [AbsolutePath] = [],
         dependencies: [Target.Dependency] = [],
         swiftVersion: SwiftLanguageVersion,
@@ -279,6 +287,7 @@ public final class SwiftTarget: Target {
             type: type,
             sources: sources,
             resources: resources,
+            ignored: ignored,
             others: others,
             dependencies: dependencies,
             buildSettings: buildSettings,
@@ -434,6 +443,7 @@ public final class ClangTarget: Target {
         type: Kind,
         sources: Sources,
         resources: [Resource] = [],
+        ignored: [AbsolutePath] = [],
         others: [AbsolutePath] = [],
         dependencies: [Target.Dependency] = [],
         buildSettings: BuildSettings.AssignmentTable = .init()
@@ -453,6 +463,7 @@ public final class ClangTarget: Target {
             type: type,
             sources: sources,
             resources: resources,
+            ignored: ignored,
             others: others,
             dependencies: dependencies,
             buildSettings: buildSettings,

--- a/Sources/SPMBuildCore/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/PluginInvocation.swift
@@ -824,6 +824,9 @@ struct PluginScriptRunnerInputSerializer {
         targetFiles.append(contentsOf: try target.underlyingTarget.resources.map {
             .init(basePathId: try serialize(path: $0.path.parentDirectory), name: $0.path.basename, type: .resource)
         })
+        targetFiles.append(contentsOf: try target.underlyingTarget.ignored.map {
+            .init(basePathId: try serialize(path: $0.parentDirectory), name: $0.basename, type: .unknown)
+        })
         targetFiles.append(contentsOf: try target.underlyingTarget.others.map {
             .init(basePathId: try serialize(path: $0.parentDirectory), name: $0.basename, type: .unknown)
         })

--- a/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
+++ b/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
@@ -858,6 +858,7 @@ class TargetSourcesBuilderTests: XCTestCase {
         let outputs = try builder.run()
         XCTAssertEqual(outputs.sources.paths, [AbsolutePath("/File.swift")])
         XCTAssertEqual(outputs.resources, [])
+        XCTAssertEqual(outputs.ignored, [])
         XCTAssertEqual(outputs.others, [AbsolutePath("/Foo.xcdatamodel")])
 
         XCTAssertFalse(observability.hasWarningDiagnostics)
@@ -898,6 +899,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             let outputs = try builder.run()
             XCTAssertEqual(outputs.sources.paths, [AbsolutePath("/File.swift")])
             XCTAssertEqual(outputs.resources, [])
+            XCTAssertEqual(outputs.ignored, [])
             XCTAssertEqual(outputs.others, [AbsolutePath("/foo.bar")])
 
             XCTAssertFalse(observability.hasWarningDiagnostics)
@@ -957,7 +959,11 @@ class TargetSourcesBuilderTests: XCTestCase {
             fileSystem: fs,
             observabilityScope: observability.topScope
         )
-        _ = try builder.run()
+        let outputs = try builder.run()
+        XCTAssertEqual(outputs.sources.paths, [AbsolutePath("/File.swift")])
+        XCTAssertEqual(outputs.resources, [])
+        XCTAssertEqual(outputs.ignored, [AbsolutePath("/Foo.docc")])
+        XCTAssertEqual(outputs.others, [])
 
         XCTAssertNoDiagnostics(observability.diagnostics)
     }
@@ -990,7 +996,7 @@ class TargetSourcesBuilderTests: XCTestCase {
         )
 
         do {
-            let (sources, resources, headers, others) = try builder.run()
+            let (sources, resources, headers, _, others) = try builder.run()
 
             testDiagnostics(observability.diagnostics, problemsOnly: checkProblemsOnly, file: file, line: line) { diagnostics in
                 try checker(sources, resources, headers, others, builder.packageIdentity, builder.packageKind, builder.packagePath, diagnostics)


### PR DESCRIPTION
Make sure that `.docc` bundles (and in the future, any other files that have built-in rules that mark them as ignored) are still passed through to plugins.  Note that this is separate from files marked as excluded by the manifest, with are filtered out at an earlier stage and never seen by plugins or the internal logic.

### Motivation:

Plugins such as documentation generations need to be able to see `.docc` files without having to look in the file system.  It was a bug that ignored files were not being passed through, as all other files were.

### Background

There was a special rule added in 5.5 to mark .docc bundles as ignored, so that there wouldn't be warnings about packages that contained them (since Xcode could deal with them but SwiftPM couldn't).  But that also caused `.docc` files to become filtered out of the source file lists given to plugins, since they weren't included from the array of other files in the target.

This change keeps ignored files from causing unhandled-files warnings, but it passes them along to plugins as "unknown" role, just other general files.  It does this by keeping them in an additional array.

### Modifications:

- keep track of files that were ignored by rules (note that this is different from excluded files)
- pass those along to the plugin
- update unit tests

### Comments

We should consolidate the separate arrays of sources, resources, other files, and now ignored files.  This PR is intended to be nominated to 5.6 so I'm keeping it simple by just adding another one, but will put up a PR for that restructuring in main sometime in the next month.

rdar://86785502
