### PR TITLE
Set 'createGitRepo: false' in test fixtures

### DIFF
--- a/Tests/PackageCollectionsSigningTests/CertificatePolicyTests.swift
+++ b/Tests/PackageCollectionsSigningTests/CertificatePolicyTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -20,7 +20,7 @@ class CertificatePolicyTests: XCTestCase {
     func test_RSA_validate_happyCase() throws {
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let certPath = directoryPath.appending(components: "Signing", "Test_rsa.cer")
             let certificate = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(certPath).contents))
 
@@ -40,7 +40,7 @@ class CertificatePolicyTests: XCTestCase {
     func test_EC_validate_happyCase() throws {
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let certPath = directoryPath.appending(components: "Signing", "Test_ec.cer")
             let certificate = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(certPath).contents))
 
@@ -60,7 +60,7 @@ class CertificatePolicyTests: XCTestCase {
     func test_validate_untrustedRoot() throws {
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let certPath = directoryPath.appending(components: "Signing", "Test_rsa.cer")
             let certificate = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(certPath).contents))
 
@@ -91,7 +91,7 @@ class CertificatePolicyTests: XCTestCase {
     func test_validate_expiredCert() throws {
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let certPath = directoryPath.appending(components: "Signing", "Test_rsa.cer")
             let certificate = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(certPath).contents))
 
@@ -121,7 +121,7 @@ class CertificatePolicyTests: XCTestCase {
 
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let certPath = directoryPath.appending(components: "Signing", "development-revoked.cer")
             let certificate = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(certPath).contents))
 
@@ -168,7 +168,7 @@ class CertificatePolicyTests: XCTestCase {
 
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let certPath = directoryPath.appending(components: "Signing", "development.cer")
             let certificate = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(certPath).contents))
 
@@ -236,7 +236,7 @@ class CertificatePolicyTests: XCTestCase {
 
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             // This must be an Apple Swift Package Collection cert
             let certPath = directoryPath.appending(components: "Signing", "swift_package_collection.cer")
             let certificate = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(certPath).contents))
@@ -305,7 +305,7 @@ class CertificatePolicyTests: XCTestCase {
 
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             // This must be an Apple Distribution cert
             let certPath = directoryPath.appending(components: "Signing", "development.cer")
             let certificate = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(certPath).contents))
@@ -374,7 +374,7 @@ class CertificatePolicyTests: XCTestCase {
 
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let certPath = directoryPath.appending(components: "Signing", "development.cer")
             let certificate = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(certPath).contents))
 
@@ -449,7 +449,7 @@ class CertificatePolicyTests: XCTestCase {
 
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             // This must be an Apple Swift Package Collection cert
             let certPath = directoryPath.appending(components: "Signing", "swift_package_collection.cer")
             let certificate = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(certPath).contents))
@@ -527,7 +527,7 @@ class CertificatePolicyTests: XCTestCase {
 
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             // This must be an Apple Distribution cert
             let certPath = directoryPath.appending(components: "Signing", "development.cer")
             let certificate = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(certPath).contents))

--- a/Tests/PackageCollectionsSigningTests/CertificateTests.swift
+++ b/Tests/PackageCollectionsSigningTests/CertificateTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -19,7 +19,7 @@ class CertificateTests: XCTestCase {
     func test_withRSAKey_fromDER() throws {
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let path = directoryPath.appending(components: "Signing", "Test_rsa.cer")
             let data = Data(try localFileSystem.readFileContents(path).contents)
 
@@ -42,7 +42,7 @@ class CertificateTests: XCTestCase {
     func test_withECKey_fromDER() throws {
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let path = directoryPath.appending(components: "Signing", "Test_ec.cer")
             let data = Data(try localFileSystem.readFileContents(path).contents)
 

--- a/Tests/PackageCollectionsSigningTests/KeyTests+EC.swift
+++ b/Tests/PackageCollectionsSigningTests/KeyTests+EC.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -19,7 +19,7 @@ class ECKeyTests: XCTestCase {
     func testPublicKeyFromCertificate() throws {
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let path = directoryPath.appending(components: "Signing", "Test_ec.cer")
             let data = Data(try localFileSystem.readFileContents(path).contents)
 

--- a/Tests/PackageCollectionsSigningTests/KeyTests+RSA.swift
+++ b/Tests/PackageCollectionsSigningTests/KeyTests+RSA.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -19,7 +19,7 @@ class RSAKeyTests: XCTestCase {
     func testPublicKeyFromCertificate() throws {
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let path = directoryPath.appending(components: "Signing", "Test_rsa.cer")
             let data = Data(try localFileSystem.readFileContents(path).contents)
 

--- a/Tests/PackageCollectionsSigningTests/PackageCollectionSigningTest.swift
+++ b/Tests/PackageCollectionsSigningTests/PackageCollectionSigningTest.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -21,7 +21,7 @@ class PackageCollectionSigningTests: XCTestCase {
     func test_RSA_signAndValidate_happyCase() throws {
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let jsonDecoder = JSONDecoder.makeWithDefaults()
 
             let collectionPath = directoryPath.appending(components: "JSON", "good.json")
@@ -53,7 +53,7 @@ class PackageCollectionSigningTests: XCTestCase {
     func test_RSA_signAndValidate_collectionMismatch() throws {
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let collection1 = PackageCollectionModel.V1.Collection(
                 name: "Test Package Collection 1",
                 overview: nil,
@@ -109,7 +109,7 @@ class PackageCollectionSigningTests: XCTestCase {
     func test_EC_signAndValidate_happyCase() throws {
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let jsonDecoder = JSONDecoder.makeWithDefaults()
 
             let collectionPath = directoryPath.appending(components: "JSON", "good.json")
@@ -141,7 +141,7 @@ class PackageCollectionSigningTests: XCTestCase {
     func test_EC_signAndValidate_collectionMismatch() throws {
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let collection1 = PackageCollectionModel.V1.Collection(
                 name: "Test Package Collection 1",
                 overview: nil,
@@ -202,7 +202,7 @@ class PackageCollectionSigningTests: XCTestCase {
 
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let jsonDecoder = JSONDecoder.makeWithDefaults()
 
             let collectionPath = directoryPath.appending(components: "JSON", "good.json")
@@ -311,7 +311,7 @@ class PackageCollectionSigningTests: XCTestCase {
 
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let jsonDecoder = JSONDecoder.makeWithDefaults()
 
             let collectionPath = directoryPath.appending(components: "JSON", "good.json")
@@ -405,7 +405,7 @@ class PackageCollectionSigningTests: XCTestCase {
 
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let jsonDecoder = JSONDecoder.makeWithDefaults()
 
             let collectionPath = directoryPath.appending(components: "JSON", "good.json")
@@ -499,7 +499,7 @@ class PackageCollectionSigningTests: XCTestCase {
 
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let jsonDecoder = JSONDecoder.makeWithDefaults()
 
             let collectionPath = directoryPath.appending(components: "JSON", "good.json")
@@ -553,7 +553,7 @@ class PackageCollectionSigningTests: XCTestCase {
 
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let jsonDecoder = JSONDecoder.makeWithDefaults()
 
             let collectionPath = directoryPath.appending(components: "JSON", "good.json")
@@ -618,7 +618,7 @@ class PackageCollectionSigningTests: XCTestCase {
 
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let jsonDecoder = JSONDecoder.makeWithDefaults()
 
             let collectionPath = directoryPath.appending(components: "JSON", "good.json")

--- a/Tests/PackageCollectionsSigningTests/SignatureTests.swift
+++ b/Tests/PackageCollectionsSigningTests/SignatureTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -19,7 +19,7 @@ class SignatureTests: XCTestCase {
     func test_RS256_generateAndValidate_happyCase() throws {
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let jsonEncoder = JSONEncoder()
             let jsonDecoder = JSONDecoder()
 
@@ -45,7 +45,7 @@ class SignatureTests: XCTestCase {
     func test_RS256_generateAndValidate_keyMismatch() throws {
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let jsonEncoder = JSONEncoder()
             let jsonDecoder = JSONDecoder()
 
@@ -74,7 +74,7 @@ class SignatureTests: XCTestCase {
     func test_ES256_generateAndValidate_happyCase() throws {
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let jsonEncoder = JSONEncoder()
             let jsonDecoder = JSONDecoder()
 
@@ -100,7 +100,7 @@ class SignatureTests: XCTestCase {
     func test_ES256_generateAndValidate_keyMismatch() throws {
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let jsonEncoder = JSONEncoder()
             let jsonDecoder = JSONDecoder()
 

--- a/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
+++ b/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2020-2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2020-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -80,7 +80,7 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
             let apiURL = URL(string: "https://api.github.com/repos/octocat/Hello-World")!
             let releasesURL = URL(string: "https://api.github.com/repos/octocat/Hello-World/releases?per_page=20")!
 
-            fixture(name: "Collections") { directoryPath in
+            fixture(name: "Collections", createGitRepo: false) { directoryPath in
                 let handler: HTTPClient.Handler = { request, _, completion in
                     switch (request.method, request.url) {
                     case (.get, apiURL):
@@ -181,7 +181,7 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
             let repoURL = URL(string: "https://github.com/octocat/Hello-World.git")!
             let apiURL = URL(string: "https://api.github.com/repos/octocat/Hello-World")!
 
-            fixture(name: "Collections") { directoryPath in
+            fixture(name: "Collections", createGitRepo: false) { directoryPath in
                 let path = directoryPath.appending(components: "GitHub", "metadata.json")
                 let data = try Data(localFileSystem.readFileContents(path).contents)
                 let handler: HTTPClient.Handler = { request, _, completion in
@@ -275,7 +275,7 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
             let total = 5
             var remaining = total
 
-            fixture(name: "Collections") { directoryPath in
+            fixture(name: "Collections", createGitRepo: false) { directoryPath in
                 let path = directoryPath.appending(components: "GitHub", "metadata.json")
                 let data = try Data(localFileSystem.readFileContents(path).contents)
                 let handler: HTTPClient.Handler = { request, _, completion in
@@ -320,7 +320,7 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
 
     func testInvalidURL() throws {
         try testWithTemporaryDirectory { tmpPath in
-            fixture(name: "Collections") { _ in
+            fixture(name: "Collections", createGitRepo: false) { _ in
                 var configuration = GitHubPackageMetadataProvider.Configuration()
                 configuration.cacheDir = tmpPath
                 let provider = GitHubPackageMetadataProvider(configuration: configuration)
@@ -337,7 +337,7 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
 
     func testInvalidURL2() throws {
         try testWithTemporaryDirectory { tmpPath in
-            fixture(name: "Collections") { _ in
+            fixture(name: "Collections", createGitRepo: false) { _ in
                 var configuration = GitHubPackageMetadataProvider.Configuration()
                 configuration.cacheDir = tmpPath
                 let provider = GitHubPackageMetadataProvider(configuration: configuration)

--- a/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
+++ b/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2020-2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2020-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -22,7 +22,7 @@ import TSCUtility
 
 class JSONPackageCollectionProviderTests: XCTestCase {
     func testGood() throws {
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let path = directoryPath.appending(components: "JSON", "good.json")
             let url = URL(string: "https://www.test.com/collection.json")!
             let data = Data(try localFileSystem.readFileContents(path).contents)
@@ -84,7 +84,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
     }
 
     func testLocalFile() throws {
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let path = directoryPath.appending(components: "JSON", "good.json")
 
             var httpClient = HTTPClient(handler: { (_, _, _) -> Void in fatalError("should not be called") })
@@ -361,7 +361,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
     func testSignedGood() throws {
         try skipIfSignatureCheckNotSupported()
 
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let path = directoryPath.appending(components: "JSON", "good_signed.json")
             let url = URL(string: "https://www.test.com/collection.json")!
             let data = Data(try localFileSystem.readFileContents(path).contents)
@@ -430,7 +430,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
     }
 
     func testSigned_skipSignatureCheck() throws {
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let path = directoryPath.appending(components: "JSON", "good_signed.json")
             let url = URL(string: "https://www.test.com/collection.json")!
             let data = Data(try localFileSystem.readFileContents(path).contents)
@@ -497,7 +497,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
     func testSigned_noTrustedRootCertsConfigured() throws {
         try skipIfSignatureCheckNotSupported()
 
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let path = directoryPath.appending(components: "JSON", "good_signed.json")
             let url = URL(string: "https://www.test.com/collection.json")!
             let data = Data(try localFileSystem.readFileContents(path).contents)
@@ -539,7 +539,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
     func testSignedBad() throws {
         try skipIfSignatureCheckNotSupported()
 
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let path = directoryPath.appending(components: "JSON", "good_signed.json")
             let url = URL(string: "https://www.test.com/collection.json")!
             let data = Data(try localFileSystem.readFileContents(path).contents)
@@ -582,7 +582,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
     func testSignedLocalFile() throws {
         try skipIfSignatureCheckNotSupported()
 
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let path = directoryPath.appending(components: "JSON", "good_signed.json")
 
             var httpClient = HTTPClient(handler: { (_, _, _) -> Void in fatalError("should not be called") })
@@ -629,7 +629,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
     }
 
     func testRequiredSigningGood() throws {
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let path = directoryPath.appending(components: "JSON", "good_signed.json")
             let url = URL(string: "https://www.test.com/collection.json")!
             let data = Data(try localFileSystem.readFileContents(path).contents)
@@ -699,7 +699,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
     }
 
     func testRequiredSigningMultiplePoliciesGood() throws {
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let path = directoryPath.appending(components: "JSON", "good_signed.json")
             let url = URL(string: "https://www.test.com/collection.json")!
             let data = Data(try localFileSystem.readFileContents(path).contents)
@@ -774,7 +774,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
     }
 
     func testMissingRequiredSignature() throws {
-        fixture(name: "Collections") { directoryPath in
+        fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let path = directoryPath.appending(components: "JSON", "good.json")
             let url = URL(string: "https://www.test.com/collection.json")!
             let data = Data(try localFileSystem.readFileContents(path).contents)

--- a/Tests/PackageCollectionsTests/PackageCollectionsModelTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsModelTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Copyright (c) 2020-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -89,7 +89,7 @@ final class PackageCollectionsModelTests: XCTestCase {
 
     func testSourceValidation_localFile() throws {
         do {
-            fixture(name: "Collections") { directoryPath in
+            fixture(name: "Collections", createGitRepo: false) { directoryPath in
                 // File must exist in local FS
                 let path = directoryPath.appending(components: "JSON", "good.json")
 


### PR DESCRIPTION
Motivation:
Started seeing Git related errors in package collection tests.

Modifications:
Pass `createGitRepo: false` to `fixture` since the tests don't involve Git repos.
