### PR TITLE
dependency resolution performance

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -247,6 +247,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                     at: path,
                     packageIdentity: packageIdentity,
                     packageKind: packageKind,
+                    version: version,
                     toolsVersion: toolsVersion,
                     identityResolver: identityResolver,
                     delegateQueue: queue,
@@ -528,6 +529,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         at path: AbsolutePath,
         packageIdentity: PackageIdentity,
         packageKind: PackageReference.Kind,
+        version: Version?,
         toolsVersion: ToolsVersion,
         identityResolver: IdentityResolver,
         delegateQueue: DispatchQueue,
@@ -569,6 +571,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         do {
             // try to get it from the cache
             if let result = try cache?.get(key: key.sha256Checksum), let manifestJSON = result.manifestJSON, !manifestJSON.isEmpty {
+                observabilityScope.emit(debug: "loading manifest for '\(packageIdentity)' v. \(version?.description ?? "unknown") from cache")
                 return completion(.success(try self.parseManifest(
                     result,
                     packageIdentity: packageIdentity,
@@ -587,6 +590,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         let closeAfterWrite = closeAfterRead.delay()
 
         // shells out and compiles the manifest, finally output a JSON
+        observabilityScope.emit(debug: "evaluating manifest for '\(packageIdentity)' v. \(version?.description ?? "unknown") ")
         self.evaluateManifest(
             packageIdentity: key.packageIdentity,
             manifestPath: key.manifestPath,

--- a/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
@@ -426,22 +426,11 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
                     observabilityScope: observability.topScope
                 )
 
-                guard let diagnostic = observability.diagnostics.first else {
-                    return XCTFail("Expected a diagnostic")
+                testDiagnostics(observability.diagnostics) { result in
+                    let diagnostic = result.check(diagnostic: .contains("initialization of immutable value"), severity: .warning)
+                    let contents = try diagnostic?.metadata?.manifestLoadingDiagnosticFile.map { try localFileSystem.readFileContents($0) }
+                    XCTAssertNotNil(contents)
                 }
-                XCTAssertMatch(diagnostic.message, .contains("warning: initialization of immutable value"))
-                XCTAssertEqual(diagnostic.severity, .warning)
-                let contents = try diagnostic.metadata?.manifestLoadingDiagnosticFile.map { try localFileSystem.readFileContents($0) }
-                XCTAssertNotNil(contents)
-
-                // FIXME: (diagnostics) bring ^^ back when implemented again
-                /*guard let diagnostic = diagnostics.diagnostics.first else {
-                    return XCTFail("Expected a diagnostic")
-                }
-                XCTAssertMatch(diagnostic.message.text, .contains("warning: initialization of immutable value"))
-                XCTAssertEqual(diagnostic.behavior, .warning)
-                let contents = try (diagnostic.data as? ManifestLoadingDiagnostic)?.diagnosticFile.map { try localFileSystem.readFileContents($0) }
-                XCTAssertNotNil(contents)*/
             }
         }
     }

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -259,7 +259,7 @@ class PluginInvocationTests: XCTestCase {
 
             // Load the package graph.
             let packageGraph = try workspace.loadPackageGraph(rootInput: rootInput, observabilityScope: observability.topScope)
-            XCTAssert(observability.diagnostics.isEmpty, "\(observability.diagnostics)")
+            XCTAssertNoDiagnostics(observability.diagnostics)
             XCTAssert(packageGraph.packages.count == 1, "\(packageGraph.packages)")
             
             // Find the build tool plugin.


### PR DESCRIPTION
motivation: improve dependency resolution performance

changes:
* add informational diagnostics on manifest cache hit/miss
* disable expensive optimization in pubgrub resolver that has no functional value given changes from  #3985
* adjust resolver workspace delegate to be less noisy given the difference in resolution callbacks


follow on from https://github.com/apple/swift-package-manager/pull/4006
