### PR TITLE
[5.6] Allow running tests from a command plugin (#4002)

### DIFF
--- a/Sources/Basics/DispatchTimeInterval+Extensions.swift
+++ b/Sources/Basics/DispatchTimeInterval+Extensions.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Copyright (c) 2020-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -12,7 +12,7 @@ import Dispatch
 import struct Foundation.TimeInterval
 
 extension DispatchTimeInterval {
-    func timeInterval() -> TimeInterval? {
+    public func timeInterval() -> TimeInterval? {
         switch self {
         case .seconds(let value):
             return Double(value)
@@ -27,7 +27,7 @@ extension DispatchTimeInterval {
         }
     }
 
-    func milliseconds() -> Int? {
+    public func milliseconds() -> Int? {
         switch self {
         case .seconds(let value):
             return value.multipliedReportingOverflow(by: 1000).partialValue
@@ -42,7 +42,7 @@ extension DispatchTimeInterval {
         }
     }
 
-    func seconds() -> Int? {
+    public func seconds() -> Int? {
         switch self {
         case .seconds(let value):
             return value

--- a/Sources/Commands/CMakeLists.txt
+++ b/Sources/Commands/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See http://swift.org/LICENSE.txt for license information
@@ -28,6 +28,7 @@ add_library(Commands
   SwiftTestTool.swift
   SwiftTool.swift
   SymbolGraphExtract.swift
+  TestingSupport.swift
   WatchmanHelper.swift)
 target_link_libraries(Commands PUBLIC
   ArgumentParser

--- a/Sources/Commands/TestingSupport.swift
+++ b/Sources/Commands/TestingSupport.swift
@@ -1,0 +1,143 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Basics
+import SPMBuildCore
+import TSCBasic
+import Workspace
+
+
+/// Internal helper functionality for the SwiftTestTool command and for the
+/// plugin support.
+///
+/// Note: In the long term this should be factored into a reusable module that
+/// can run and report results on tests from both CLI and libSwiftPM API.
+enum TestingSupport {
+    /// Locates XCTestHelper tool inside the libexec directory and bin directory.
+    /// Note: It is a fatalError if we are not able to locate the tool.
+    ///
+    /// - Returns: Path to XCTestHelper tool.
+    static func xctestHelperPath(swiftTool: SwiftTool) throws -> AbsolutePath {
+        let xctestHelperBin = "swiftpm-xctest-helper"
+        let binDirectory = AbsolutePath(CommandLine.arguments.first!,
+            relativeTo: swiftTool.originalWorkingDirectory).parentDirectory
+        // XCTestHelper tool is installed in libexec.
+        let maybePath = binDirectory.parentDirectory.appending(components: "libexec", "swift", "pm", xctestHelperBin)
+        if localFileSystem.isFile(maybePath) {
+            return maybePath
+        }
+        // This will be true during swiftpm development.
+        // FIXME: Factor all of the development-time resource location stuff into a common place.
+        let path = binDirectory.appending(component: xctestHelperBin)
+        if localFileSystem.isFile(path) {
+            return path
+        }
+        throw InternalError("XCTestHelper binary not found.")
+    }
+
+    static func getTestSuites(in testProducts: [BuiltTestProduct], swiftTool: SwiftTool, swiftOptions: SwiftToolOptions) throws -> [AbsolutePath: [TestSuite]] {
+        let testSuitesByProduct = try testProducts
+            .map { try ($0.bundlePath, TestingSupport.getTestSuites(fromTestAt: $0.bundlePath, swiftTool: swiftTool, swiftOptions: swiftOptions)) }
+        return Dictionary(uniqueKeysWithValues: testSuitesByProduct)
+    }
+
+    /// Runs the corresponding tool to get tests JSON and create TestSuite array.
+    /// On macOS, we use the swiftpm-xctest-helper tool bundled with swiftpm.
+    /// On Linux, XCTest can dump the json using `--dump-tests-json` mode.
+    ///
+    /// - Parameters:
+    ///     - path: Path to the XCTest bundle(macOS) or executable(Linux).
+    ///
+    /// - Throws: TestError, SystemError, TSCUtility.Error
+    ///
+    /// - Returns: Array of TestSuite
+    static func getTestSuites(fromTestAt path: AbsolutePath, swiftTool: SwiftTool, swiftOptions: SwiftToolOptions) throws -> [TestSuite] {
+        // Run the correct tool.
+        #if os(macOS)
+        let data: String = try withTemporaryFile { tempFile in
+            let args = [try TestingSupport.xctestHelperPath(swiftTool: swiftTool).pathString, path.pathString, tempFile.path.pathString]
+            var env = try TestingSupport.constructTestEnvironment(toolchain: try swiftTool.getToolchain(), options: swiftOptions, buildParameters: swiftTool.buildParametersForTest())
+            // Add the sdk platform path if we have it. If this is not present, we
+            // might always end up failing.
+            if let sdkPlatformFrameworksPath = Destination.sdkPlatformFrameworkPaths() {
+                // appending since we prefer the user setting (if set) to the one we inject
+                env.appendPath("DYLD_FRAMEWORK_PATH", value: sdkPlatformFrameworksPath.fwk.pathString)
+                env.appendPath("DYLD_LIBRARY_PATH", value: sdkPlatformFrameworksPath.lib.pathString)
+            }
+            try Process.checkNonZeroExit(arguments: args, environment: env)
+            // Read the temporary file's content.
+            return try localFileSystem.readFileContents(tempFile.path).validDescription ?? ""
+        }
+        #else
+        let env = try constructTestEnvironment(toolchain: try swiftTool.getToolchain(), options: swiftOptions, buildParameters: swiftTool.buildParametersForTest())
+        let args = [path.description, "--dump-tests-json"]
+        let data = try Process.checkNonZeroExit(arguments: args, environment: env)
+        #endif
+        // Parse json and return TestSuites.
+        return try TestSuite.parse(jsonString: data)
+    }
+
+    /// Creates the environment needed to test related tools.
+    static func constructTestEnvironment(
+        toolchain: UserToolchain,
+        options: SwiftToolOptions,
+        buildParameters: BuildParameters
+    ) throws -> EnvironmentVariables {
+        var env = EnvironmentVariables.process()
+
+        // Add the code coverage related variables.
+        if options.shouldEnableCodeCoverage {
+            // Defines the path at which the profraw files will be written on test execution.
+            //
+            // `%m` will create a pool of profraw files and append the data from
+            // each execution in one of the files. This doesn't matter for serial
+            // execution but is required when the tests are running in parallel as
+            // SwiftPM repeatedly invokes the test binary with the test case name as
+            // the filter.
+            let codecovProfile = buildParameters.buildPath.appending(components: "codecov", "default%m.profraw")
+            env["LLVM_PROFILE_FILE"] = codecovProfile.pathString
+        }
+        #if !os(macOS)
+        #if os(Windows)
+        if let location = toolchain.configuration.xctestPath {
+            env.prependPath("Path", value: location.pathString)
+        }
+        #endif
+        return env
+        #else
+        // Fast path when no sanitizers are enabled.
+        if options.sanitizers.isEmpty {
+            return env
+        }
+
+        // Get the runtime libraries.
+        var runtimes = try options.sanitizers.map({ sanitizer in
+            return try toolchain.runtimeLibrary(for: sanitizer).pathString
+        })
+
+        // Append any existing value to the front.
+        if let existingValue = env["DYLD_INSERT_LIBRARIES"], !existingValue.isEmpty {
+            runtimes.insert(existingValue, at: 0)
+        }
+
+        env["DYLD_INSERT_LIBRARIES"] = runtimes.joined(separator: ":")
+        return env
+        #endif
+    }
+}
+
+extension SwiftTool {
+    func buildParametersForTest() throws -> BuildParameters {
+        var parameters = try self.buildParameters()
+        // for test commands, alway enable building with testability enabled
+        parameters.enableTestability = true
+        return parameters
+    }
+}

--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -223,12 +223,12 @@ public final class UserToolchain: Toolchain {
 
     /// Returns the path to llvm-cov tool.
     public func getLLVMCov() throws -> AbsolutePath {
-        return try UserToolchain.getTool("llvm-cov", binDir: self.destination.binDir)
+        return try UserToolchain.getTool("llvm-cov", binDir: self.swiftCompilerPath.parentDirectory)
     }
 
     /// Returns the path to llvm-prof tool.
     public func getLLVMProf() throws -> AbsolutePath {
-        return try UserToolchain.getTool("llvm-profdata", binDir: self.destination.binDir)
+        return try UserToolchain.getTool("llvm-profdata", binDir: self.swiftCompilerPath.parentDirectory)
     }
 
     public func getSwiftAPIDigester() throws -> AbsolutePath {


### PR DESCRIPTION
This is a cherry-pick of https://github.com/apple/swift-package-manager/pull/4002.

**Explanation:**  This cherrypicks the change to allow package command plugins to run tests in SwiftPM and get the results back in structured form.  This change is on the main branch but should be included in the 5.6 release as command plugins are available in SwiftPM 5.6 for the first time.

**Scope of Issue:**  This applies to command plugins that want to use the `PackageManager.test(_:parameters:)` function.

**Reason for Nominating to 5.6:**  This allows command plugins to use the new `PackageManager.test(_:parameters:)` function in SE-0332.

**Risk:**  Low — the material changes affects only a new code path that was introduced for command plugins, so only plugins that use `PackageManager.test(_:parameters:)` are affected.

**Reviewed By:**  @tomerd

**Automated Testing:**  A new unit test verifies the information sent to the plugin.

**Dependencies:**  None

**Impact on CI:**  None

**How to Verify:**  Create a command package plugin that calls `PackageManager.test(_:parameters:)` and verify the return results.  See the new unit test for an example.

rdar://87529139