### PR TITLE
[5.6] dependency resolution performance (#4007)

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -247,6 +247,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                     at: path,
                     packageIdentity: packageIdentity,
                     packageKind: packageKind,
+                    version: version,
                     toolsVersion: toolsVersion,
                     identityResolver: identityResolver,
                     delegateQueue: queue,
@@ -528,6 +529,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         at path: AbsolutePath,
         packageIdentity: PackageIdentity,
         packageKind: PackageReference.Kind,
+        version: Version?,
         toolsVersion: ToolsVersion,
         identityResolver: IdentityResolver,
         delegateQueue: DispatchQueue,
@@ -569,6 +571,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         do {
             // try to get it from the cache
             if let result = try cache?.get(key: key.sha256Checksum), let manifestJSON = result.manifestJSON, !manifestJSON.isEmpty {
+                observabilityScope.emit(debug: "loading manifest for '\(packageIdentity)' v. \(version?.description ?? "unknown") from cache")
                 return completion(.success(try self.parseManifest(
                     result,
                     packageIdentity: packageIdentity,
@@ -587,6 +590,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         let closeAfterWrite = closeAfterRead.delay()
 
         // shells out and compiles the manifest, finally output a JSON
+        observabilityScope.emit(debug: "evaluating manifest for '\(packageIdentity)' v. \(version?.description ?? "unknown") ")
         self.evaluateManifest(
             packageIdentity: key.packageIdentity,
             manifestPath: key.manifestPath,

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -138,7 +138,7 @@ private struct WorkspaceDependencyResolverDelegate: DependencyResolverDelegate {
     func willResolve(term: Term) {
         // this may be called multiple time by the resolver for various version ranges, but we only want to propagate once since we report at pacakge level
         resolving.memoize(term.node.package.identity) {
-            self.workspaceDelegate.willComputeVersion(package: term.node.package.identity, location: term.node.package.locationString  + " "  + term.description)
+            self.workspaceDelegate.willComputeVersion(package: term.node.package.identity, location: term.node.package.locationString)
             return true
         }
     }

--- a/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
@@ -426,22 +426,11 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
                     observabilityScope: observability.topScope
                 )
 
-                guard let diagnostic = observability.diagnostics.first else {
-                    return XCTFail("Expected a diagnostic")
+                testDiagnostics(observability.diagnostics) { result in
+                    let diagnostic = result.check(diagnostic: .contains("initialization of immutable value"), severity: .warning)
+                    let contents = try diagnostic?.metadata?.manifestLoadingDiagnosticFile.map { try localFileSystem.readFileContents($0) }
+                    XCTAssertNotNil(contents)
                 }
-                XCTAssertMatch(diagnostic.message, .contains("warning: initialization of immutable value"))
-                XCTAssertEqual(diagnostic.severity, .warning)
-                let contents = try diagnostic.metadata?.manifestLoadingDiagnosticFile.map { try localFileSystem.readFileContents($0) }
-                XCTAssertNotNil(contents)
-
-                // FIXME: (diagnostics) bring ^^ back when implemented again
-                /*guard let diagnostic = diagnostics.diagnostics.first else {
-                    return XCTFail("Expected a diagnostic")
-                }
-                XCTAssertMatch(diagnostic.message.text, .contains("warning: initialization of immutable value"))
-                XCTAssertEqual(diagnostic.behavior, .warning)
-                let contents = try (diagnostic.data as? ManifestLoadingDiagnostic)?.diagnosticFile.map { try localFileSystem.readFileContents($0) }
-                XCTAssertNotNil(contents)*/
             }
         }
     }

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -259,7 +259,7 @@ class PluginInvocationTests: XCTestCase {
 
             // Load the package graph.
             let packageGraph = try workspace.loadPackageGraph(rootInput: rootInput, observabilityScope: observability.topScope)
-            XCTAssert(observability.diagnostics.isEmpty, "\(observability.diagnostics)")
+            XCTAssertNoDiagnostics(observability.diagnostics)
             XCTAssert(packageGraph.packages.count == 1, "\(packageGraph.packages)")
             
             // Find the build tool plugin.


### PR DESCRIPTION
5.6 cherry pick of #4007

Explanation:

Fixed dependency resolution issues causing failure on edge cases such with pre-release versions. as a result of that fix, the bounds computation done as part of the resolution is no longer requires which removes a significant performance bottleneck. this PR removes the bounds computation yielding 3x performance improvement on medium to large projects. 

The bounds computation was originally added in [aee02eb](https://github.com/apple/swift-package-manager/commit/aee02eb246442bcc28119101b89feee1d54110b4) in an attempt to improve diagnostics when graph fail to be resolve. https://github.com/apple/swift-package-manager/pull/3985 changes how the underlying data for these diagnostics is captured which yield even better diagnostics. as such this PR is purely about performance gain by not running that expensive calculation any more since it no longer has any functional value.

Scope of Issue: 

This impacts the performance of package dependency resolution, triggered by `swift package update` or when loading the package in Xcode.

Reason for Nominating to 5.6 : 

This yield significant improvement in performance.

Risk: 

Low risk; The risky change was https://github.com/apple/swift-package-manager/pull/3985 which is already part of 5.6. This PR is a followup realization that because of https://github.com/apple/swift-package-manager/pull/3985 we do not need to run that expensive bounds computation at all.

Reviewed By: @neonichu @abertelrud 

Automated Testing: Unit test, package compatibility test suite

Dependencies: None

Impact on CI: None

How to Verify:  Resolve [non-trivial] package dependencies and make sure the resolved versions (eg content of  Package.resolved) are identical but that the performance is better