### PR TITLE
Package command plugins should have the same initial working directory as the invocation

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -1050,6 +1050,7 @@ extension SwiftPackageTool {
                 package: package,
                 buildEnvironment: buildEnvironment,
                 scriptRunner: pluginScriptRunner,
+                workingDirectory: swiftTool.originalWorkingDirectory,
                 outputDirectory: outputDir,
                 toolSearchDirectories: toolSearchDirs,
                 toolNamesToPaths: toolNamesToPaths,

--- a/Sources/SPMBuildCore/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/PluginInvocation.swift
@@ -40,6 +40,7 @@ extension PluginTarget {
     ///   - action: The plugin action (i.e. entry point) to invoke, possibly containing parameters.
     ///   - package: The root of the package graph to pass down to the plugin.
     ///   - scriptRunner: Entity responsible for actually running the code of the plugin.
+    ///   - workingDirectory: The initial working directory of the invoked plugin.
     ///   - outputDirectory: A directory under which the plugin can write anything it wants to.
     ///   - toolNamesToPaths: A mapping from name of tools available to the plugin to the corresponding absolute paths.
     ///   - fileSystem: The file system to which all of the paths refers.
@@ -50,6 +51,7 @@ extension PluginTarget {
         package: ResolvedPackage,
         buildEnvironment: BuildEnvironment,
         scriptRunner: PluginScriptRunner,
+        workingDirectory: AbsolutePath,
         outputDirectory: AbsolutePath,
         toolSearchDirectories: [AbsolutePath],
         toolNamesToPaths: [String: AbsolutePath],
@@ -90,6 +92,7 @@ extension PluginTarget {
             sources: sources,
             input: inputStruct,
             toolsVersion: self.apiVersion,
+            workingDirectory: workingDirectory,
             writableDirectories: writableDirectories,
             readOnlyDirectories: readOnlyDirectories,
             fileSystem: fileSystem,
@@ -242,6 +245,7 @@ extension PackageGraph {
                     package: package,
                     buildEnvironment: buildEnvironment,
                     scriptRunner: pluginScriptRunner,
+                    workingDirectory: package.path,
                     outputDirectory: pluginOutputDir,
                     toolSearchDirectories: toolSearchDirectories,
                     toolNamesToPaths: toolNamesToPaths,
@@ -390,6 +394,7 @@ public protocol PluginScriptRunner {
         sources: Sources,
         input: PluginScriptRunnerInput,
         toolsVersion: ToolsVersion,
+        workingDirectory: AbsolutePath,
         writableDirectories: [AbsolutePath],
         readOnlyDirectories: [AbsolutePath],
         fileSystem: FileSystem,

--- a/Sources/Workspace/DefaultPluginScriptRunner.swift
+++ b/Sources/Workspace/DefaultPluginScriptRunner.swift
@@ -70,6 +70,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner {
         sources: Sources,
         input: PluginScriptRunnerInput,
         toolsVersion: ToolsVersion,
+        workingDirectory: AbsolutePath,
         writableDirectories: [AbsolutePath],
         readOnlyDirectories: [AbsolutePath],
         fileSystem: FileSystem,
@@ -93,6 +94,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner {
                     // Compilation succeeded, so run the executable. We are already running on an asynchronous queue.
                     self.invoke(
                         compiledExec: result.compiledExecutable,
+                        workingDirectory: workingDirectory,
                         writableDirectories: writableDirectories,
                         readOnlyDirectories: readOnlyDirectories,
                         input: input,
@@ -343,6 +345,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner {
     /// Private function that invokes a compiled plugin executable and communicates with it until it finishes.
     fileprivate func invoke(
         compiledExec: AbsolutePath,
+        workingDirectory: AbsolutePath,
         writableDirectories: [AbsolutePath],
         readOnlyDirectories: [AbsolutePath],
         input: PluginScriptRunnerInput,
@@ -369,7 +372,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner {
         process.executableURL = Foundation.URL(fileURLWithPath: command[0])
         process.arguments = Array(command.dropFirst())
         process.environment = ProcessInfo.processInfo.environment
-        process.currentDirectoryURL = self.cacheDir.asURL
+        process.currentDirectoryURL = workingDirectory.asURL
         
         // Set up a pipe for sending structured messages to the plugin on its stdin.
         let stdinPipe = Pipe()

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -425,6 +425,7 @@ class PluginTests: XCTestCase {
                         package: package,
                         buildEnvironment: BuildEnvironment(platform: .macOS, configuration: .debug),
                         scriptRunner: scriptRunner,
+                        workingDirectory: package.path,
                         outputDirectory: pluginDir.appending(component: "output"),
                         toolSearchDirectories: [UserToolchain.default.swiftCompilerPath.parentDirectory],
                         toolNamesToPaths: [:],

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -92,6 +92,7 @@ class PluginInvocationTests: XCTestCase {
                 sources: Sources,
                 input: PluginScriptRunnerInput,
                 toolsVersion: ToolsVersion,
+                workingDirectory: AbsolutePath,
                 writableDirectories: [AbsolutePath],
                 readOnlyDirectories: [AbsolutePath],
                 fileSystem: FileSystem,


### PR DESCRIPTION
### Motivation

This allows relative paths passed as parameters to work.  For build tool plugins we pass in the package directory so that relative paths in configuration files work there as well.  This also matches the behavior of many build systems.  The proposal didn't specify the initial working directory and usually all paths are absolute, but having predictable initial working directories follows the principle of least surprise.

### Changes

- pass through the working directory as a parameter to the plugin invocation
- for build tool invocations, make it the package directory
- for command invocations, keep the original working directory

rdar://86831942
