### PR TITLE
[5.6] Mark the SwiftPM 5.6 branch as a release branch

### DIFF
--- a/Sources/Basics/SwiftVersion.swift
+++ b/Sources/Basics/SwiftVersion.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -64,7 +64,7 @@ extension SwiftVersion {
     /// The current version of the package manager.
     public static let currentVersion = SwiftVersion(
         version: (5, 6, 0),
-        isDevelopment: true,
+        isDevelopment: false,
         buildIdentifier: getBuildIdentifier()
     )
 }


### PR DESCRIPTION
Mark the SwiftPM 5.6 branch as a release branch.

### Motivation

As happens with every release, the development bit in SwiftPM needs to be turned off in the release branch so that it disallows use of 999.0 package manifest tools versions.  This also causes `swift package --version` to show the version without a `-dev` suffix.

### Modifications

- change `development` from `true` to `false` in SwiftVersion.swift

rdar://87535197