### PR TITLE
Limit concurrent HTTP requests when downloading binary dependencies

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -2291,6 +2291,7 @@ extension Workspace {
             headers.add(name: "Accept", value: "application/octet-stream")
             var request = HTTPClient.Request.download(url: artifact.url, headers: headers, fileSystem: self.fileSystem, destination: archivePath)
             request.options.authorizationProvider = self.authorizationProvider?.httpAuthorizationHeader(for:)
+            request.options.retryStrategy = .exponentialBackoff(maxAttempts: 3, baseDelay: .milliseconds(50))
             request.options.validResponseCodes = [200]
             self.httpClient.execute(
                 request,

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -2271,7 +2271,7 @@ extension Workspace {
         }
 
         // download max n files concurrently
-        let semaphore = DispatchSemaphore(value: 8)
+        let semaphore = DispatchSemaphore(value: Concurrency.maxOperations)
 
         // finally download zip files, if any
         for artifact in (zipArtifacts.map{ $0 }) {

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -2275,10 +2275,6 @@ extension Workspace {
 
         // finally download zip files, if any
         for artifact in (zipArtifacts.map{ $0 }) {
-            semaphore.wait()
-            group.enter()
-            defer { group.leave() }
-
             let parentDirectory =  self.location.artifactsDirectory.appending(component: artifact.packageRef.identity.description)
             guard observabilityScope.trap ({ try fileSystem.createDirectory(parentDirectory, recursive: true) }) else {
                 continue
@@ -2286,6 +2282,7 @@ extension Workspace {
 
             let archivePath = parentDirectory.appending(component: artifact.url.lastPathComponent)
 
+            semaphore.wait()
             group.enter()
             var headers = HTTPClientHeaders()
             headers.add(name: "Accept", value: "application/octet-stream")


### PR DESCRIPTION
Limit the concurrent HTTP requests for downloading binary dependencies to 8 concurrent requests.

### Motivation:

We have a fairly large Package.swift with 50 binary dependencies. In total the size of these 50 zip files is 400 MB. On a slower internet connection (16 MBit) the `swift package resolve` command errors out with some HTTP timeouts. It seems the main problem is that all 50 HTTP requests are executed at the same time.

### Modifications:

Using some `DispatchSemaphore` to limit the concurrently downloaded binary dependencies to 8 concurrent requests. 

### Result:

In our project with the 50 binary dependencies it successfully completes the `swift package resolve` command. It's still open for discussion if the `max 8 concurrent downloads` is the right number. Also not sure if we should introduce another queue for this, reusing `callbackQueue` doesn't feel exactly right. However I found another [TODO](https://github.com/apple/swift-package-manager/blob/main/Sources/Basics/HTTPClient.swift#L152-L153) that's also just using `callbackQueue` and wondering if there should be a separate queue.
