### PR TITLE
Fix some availability annotations in PackageDescription APIs that say "999"

### DIFF
--- a/Sources/PackageDescription/PackageDependency.swift
+++ b/Sources/PackageDescription/PackageDependency.swift
@@ -488,7 +488,7 @@ extension Package.Dependency {
     /// - Parameters:
     ///     - id: The identity of the package.
     ///     - version: The minimum version requirement.
-    @available(_PackageDescription, introduced: 999)
+    @available(_PackageDescription, introduced: 5.6)
     public static func package(
         id: String,
         from version: Version
@@ -512,7 +512,7 @@ extension Package.Dependency {
     /// - Parameters:
     ///     - id: The identity of the package.
     ///     - version: The minimum version requirement.
-    @available(_PackageDescription, introduced: 999)
+    @available(_PackageDescription, introduced: 5.6)
     public static func package(
         id: String,
         exact version: Version
@@ -541,7 +541,7 @@ extension Package.Dependency {
     /// - Parameters:
     ///     - id: The identity of the package.
     ///     - range: The custom version range requirement.
-    @available(_PackageDescription, introduced: 999)
+    @available(_PackageDescription, introduced: 5.6)
     public static func package(
         id: String,
         _ range: Range<Version>
@@ -560,7 +560,7 @@ extension Package.Dependency {
     /// - Parameters:
     ///     - id: The identity of the package.
     ///     - range: The closed version range requirement.
-    @available(_PackageDescription, introduced: 999)
+    @available(_PackageDescription, introduced: 5.6)
     public static func package(
         id: String,
         _ range: ClosedRange<Version>
@@ -575,7 +575,7 @@ extension Package.Dependency {
     }
 
     // intentionally private to hide enum detail
-    @available(_PackageDescription, introduced: 999)
+    @available(_PackageDescription, introduced: 5.6)
     private static func package(
         id: String,
         requirement: Package.Dependency.RegistryRequirement

--- a/Sources/PackageDescription/PackageRequirement.swift
+++ b/Sources/PackageDescription/PackageRequirement.swift
@@ -191,7 +191,7 @@ extension Package.Dependency {
     /// The version rule requires Swift packages to conform to semantic
     /// versioning. To learn more about the semantic versioning standard,
     /// visit [semver.org](https://semver.org).
-    @available(_PackageDescription, introduced: 999)
+    @available(_PackageDescription, introduced: 5.6)
     public enum RegistryRequirement {
         case exact(Version)
         case range(Range<Version>)


### PR DESCRIPTION
These should be marked as 5.6, where they were introduced.  They were missed because they used "999" instead of "999.0" (both are valid) and therefore didn't show up in the too-narrowly-focus grep to change them earlier.

### Motivation:

When marked as 999.0, these APIs will be available only on main SwiftPM and not on release branches.

### Modifications:

- change the "999" to "5.6" for relevant PackageDescription entries

### Result:

Packages can use these APIs even in the release build of SwiftPM 5.6.

This has already been changed in the 5.6 branch in #4015 and this is just the back-cherry-pick to main.
