### PR TITLE
[5.6] Package command plugins should have the same initial working directory as the invocation

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -1050,6 +1050,7 @@ extension SwiftPackageTool {
                 package: package,
                 buildEnvironment: buildEnvironment,
                 scriptRunner: pluginScriptRunner,
+                workingDirectory: swiftTool.originalWorkingDirectory,
                 outputDirectory: outputDir,
                 toolSearchDirectories: toolSearchDirs,
                 toolNamesToPaths: toolNamesToPaths,

--- a/Sources/SPMBuildCore/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/PluginInvocation.swift
@@ -40,6 +40,7 @@ extension PluginTarget {
     ///   - action: The plugin action (i.e. entry point) to invoke, possibly containing parameters.
     ///   - package: The root of the package graph to pass down to the plugin.
     ///   - scriptRunner: Entity responsible for actually running the code of the plugin.
+    ///   - workingDirectory: The initial working directory of the invoked plugin.
     ///   - outputDirectory: A directory under which the plugin can write anything it wants to.
     ///   - toolNamesToPaths: A mapping from name of tools available to the plugin to the corresponding absolute paths.
     ///   - fileSystem: The file system to which all of the paths refers.
@@ -50,6 +51,7 @@ extension PluginTarget {
         package: ResolvedPackage,
         buildEnvironment: BuildEnvironment,
         scriptRunner: PluginScriptRunner,
+        workingDirectory: AbsolutePath,
         outputDirectory: AbsolutePath,
         toolSearchDirectories: [AbsolutePath],
         toolNamesToPaths: [String: AbsolutePath],
@@ -90,6 +92,7 @@ extension PluginTarget {
             sources: sources,
             input: inputStruct,
             toolsVersion: self.apiVersion,
+            workingDirectory: workingDirectory,
             writableDirectories: writableDirectories,
             readOnlyDirectories: readOnlyDirectories,
             fileSystem: fileSystem,
@@ -242,6 +245,7 @@ extension PackageGraph {
                     package: package,
                     buildEnvironment: buildEnvironment,
                     scriptRunner: pluginScriptRunner,
+                    workingDirectory: package.path,
                     outputDirectory: pluginOutputDir,
                     toolSearchDirectories: toolSearchDirectories,
                     toolNamesToPaths: toolNamesToPaths,
@@ -390,6 +394,7 @@ public protocol PluginScriptRunner {
         sources: Sources,
         input: PluginScriptRunnerInput,
         toolsVersion: ToolsVersion,
+        workingDirectory: AbsolutePath,
         writableDirectories: [AbsolutePath],
         readOnlyDirectories: [AbsolutePath],
         fileSystem: FileSystem,

--- a/Sources/Workspace/DefaultPluginScriptRunner.swift
+++ b/Sources/Workspace/DefaultPluginScriptRunner.swift
@@ -70,6 +70,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner {
         sources: Sources,
         input: PluginScriptRunnerInput,
         toolsVersion: ToolsVersion,
+        workingDirectory: AbsolutePath,
         writableDirectories: [AbsolutePath],
         readOnlyDirectories: [AbsolutePath],
         fileSystem: FileSystem,
@@ -93,6 +94,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner {
                     // Compilation succeeded, so run the executable. We are already running on an asynchronous queue.
                     self.invoke(
                         compiledExec: result.compiledExecutable,
+                        workingDirectory: workingDirectory,
                         writableDirectories: writableDirectories,
                         readOnlyDirectories: readOnlyDirectories,
                         input: input,
@@ -343,6 +345,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner {
     /// Private function that invokes a compiled plugin executable and communicates with it until it finishes.
     fileprivate func invoke(
         compiledExec: AbsolutePath,
+        workingDirectory: AbsolutePath,
         writableDirectories: [AbsolutePath],
         readOnlyDirectories: [AbsolutePath],
         input: PluginScriptRunnerInput,
@@ -369,7 +372,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner {
         process.executableURL = Foundation.URL(fileURLWithPath: command[0])
         process.arguments = Array(command.dropFirst())
         process.environment = ProcessInfo.processInfo.environment
-        process.currentDirectoryURL = self.cacheDir.asURL
+        process.currentDirectoryURL = workingDirectory.asURL
         
         // Set up a pipe for sending structured messages to the plugin on its stdin.
         let stdinPipe = Pipe()

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -425,6 +425,7 @@ class PluginTests: XCTestCase {
                         package: package,
                         buildEnvironment: BuildEnvironment(platform: .macOS, configuration: .debug),
                         scriptRunner: scriptRunner,
+                        workingDirectory: package.path,
                         outputDirectory: pluginDir.appending(component: "output"),
                         toolSearchDirectories: [UserToolchain.default.swiftCompilerPath.parentDirectory],
                         toolNamesToPaths: [:],

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -92,6 +92,7 @@ class PluginInvocationTests: XCTestCase {
                 sources: Sources,
                 input: PluginScriptRunnerInput,
                 toolsVersion: ToolsVersion,
+                workingDirectory: AbsolutePath,
                 writableDirectories: [AbsolutePath],
                 readOnlyDirectories: [AbsolutePath],
                 fileSystem: FileSystem,


### PR DESCRIPTION
5.6 nomination cherry-pick of https://github.com/apple/swift-package-manager/pull/4014

**Explanation:**  The initial working directory of invoked plugin processes isn't defined, but is currently set to the cache directory.  For command plugins this is not a particularly useful default, especially since any relative paths passed as command line arguments should be relative to whatever working directory the command is invoked from (which is not necessarily the package directory).  Before command plugins initially become in SwiftPM 5.6, we should fix this to use the original working directory of the `swift package <verb>` invocation, and as follow-up we should clarify this in SE-0332.

**Scope of Issue:**  This applies to command plugins that accept relative paths as arguments.  SE-0332 leaves formal declaration of plugin parameters to the future, but specifies that argument strings should be passed on to the plugin, and it's likely that some plugins will want to receive relative paths as arguments.

**Reason for Nominating to 5.6:**  We should start with a useful behavior in the first release of SwiftPM with command plugins rather than change the behavior later.

**Risk:**  Very low. By definition there are no current command plugins that depend on the current behavior, and the code change is straightforward.

**Reviewed By:**  @tomerd

**Automated Testing:**  A new unit test checks that the initial directory is the expected one.

**Dependencies:**  None

**Impact on CI:**  None

**How to Verify:**  Write a command plugin and do file operations based on the plugin process' initial working directory.  It should be the directory from which the `swift package <verb>` invocation was made.  See the unit test as an example.

rdar://86831942