### PR TITLE
cleanup redundant maps

### DIFF
--- a/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
+++ b/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
@@ -721,7 +721,7 @@ private struct DiagnosticReportBuilder {
         }
 
         let stream = BufferedOutputByteStream()
-        let padding = lineNumbers.isEmpty ? 0 : "\(lineNumbers.values.map { $0 }.last!) ".count
+        let padding = lineNumbers.isEmpty ? 0 : "\(Array(lineNumbers.values).last!) ".count
 
         for (idx, line) in lines.enumerated() {
             stream <<< Format.asRepeating(string: " ", count: padding)

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -733,7 +733,7 @@ public final class PackageBuilder {
             }
         }
 
-        return targets.values.map{ $0 }.sorted{ $0.name > $1.name  }
+        return targets.values.sorted{ $0.name > $1.name  }
     }
 
     /// Private function that checks whether a target name is valid.  This method doesn't return anything, but rather,

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -2274,7 +2274,7 @@ extension Workspace {
         let semaphore = DispatchSemaphore(value: Concurrency.maxOperations)
 
         // finally download zip files, if any
-        for artifact in (zipArtifacts.map{ $0 }) {
+        for artifact in zipArtifacts.get() {
             let parentDirectory =  self.location.artifactsDirectory.appending(component: artifact.packageRef.identity.description)
             guard observabilityScope.trap ({ try fileSystem.createDirectory(parentDirectory, recursive: true) }) else {
                 continue
@@ -2388,7 +2388,7 @@ extension Workspace {
             delegate?.didDownloadBinaryArtifacts()
         }
 
-        return result.map{ $0 }
+        return result.get()
     }
 
     private func extract(_ artifacts: [ManagedArtifact], observabilityScope: ObservabilityScope) throws -> [ManagedArtifact] {
@@ -2453,7 +2453,7 @@ extension Workspace {
 
         group.wait()
 
-        return result.map{ $0 }
+        return result.get()
     }
 
     private func isAtArtifactsDirectory(_ artifact: ManagedArtifact) -> Bool {

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -2363,7 +2363,7 @@ class DependencyGraphBuilder {
             self.containers = [:]
             self.references = [:]
         }
-        let provider = MockProvider(containers: self.containers.values.map { $0 })
+        let provider = MockProvider(containers: Array(self.containers.values))
         return PubgrubDependencyResolver(provider :provider, pinsMap: pinsMap, observabilityScope: ObservabilitySystem.NOOP, delegate: delegate)
     }
 }

--- a/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
@@ -95,7 +95,7 @@ class RegistryPackageContainerTests: XCTestCase {
             let provider = try createProvider(.v4)
             let ref = PackageReference.registry(identity: packageIdentity)
             let container = try provider.getContainer(for: ref, skipUpdate: false)
-            let versions = try container.toolsVersionsAppropriateVersionsDescending().map { $0 }
+            let versions = try container.toolsVersionsAppropriateVersionsDescending()
             XCTAssertEqual(versions, ["1.0.1"])
         }
 
@@ -103,7 +103,7 @@ class RegistryPackageContainerTests: XCTestCase {
             let provider = try createProvider(.v4_2)
             let ref = PackageReference.registry(identity: packageIdentity)
             let container = try provider.getContainer(for: ref, skipUpdate: false)
-            let versions = try container.toolsVersionsAppropriateVersionsDescending().map { $0 }
+            let versions = try container.toolsVersionsAppropriateVersionsDescending()
             XCTAssertEqual(versions, ["1.0.2", "1.0.1"])
         }
 
@@ -111,7 +111,7 @@ class RegistryPackageContainerTests: XCTestCase {
             let provider = try createProvider(.v5_4)
             let ref = PackageReference.registry(identity: packageIdentity)
             let container = try provider.getContainer(for: ref, skipUpdate: false)
-            let versions = try container.toolsVersionsAppropriateVersionsDescending().map { $0 }
+            let versions = try container.toolsVersionsAppropriateVersionsDescending()
             XCTAssertEqual(versions, ["1.0.3", "1.0.2", "1.0.1"])
         }
     }
@@ -161,7 +161,7 @@ class RegistryPackageContainerTests: XCTestCase {
             let ref = PackageReference.registry(identity: packageIdentity)
             let container = try provider.getContainer(for: ref, skipUpdate: false)
             XCTAssertEqual(try container.toolsVersion(for: packageVersion), .v5_3)
-            let versions = try container.toolsVersionsAppropriateVersionsDescending().map { $0 }
+            let versions = try container.toolsVersionsAppropriateVersionsDescending()
             XCTAssertEqual(versions, [])
         }
 
@@ -170,7 +170,7 @@ class RegistryPackageContainerTests: XCTestCase {
             let ref = PackageReference.registry(identity: packageIdentity)
             let container = try provider.getContainer(for: ref, skipUpdate: false)
             XCTAssertEqual(try container.toolsVersion(for: packageVersion), .v5_3)
-            let versions = try container.toolsVersionsAppropriateVersionsDescending().map { $0 }
+            let versions = try container.toolsVersionsAppropriateVersionsDescending()
             XCTAssertEqual(versions, [packageVersion])
         }
 
@@ -179,7 +179,7 @@ class RegistryPackageContainerTests: XCTestCase {
             let ref = PackageReference.registry(identity: packageIdentity)
             let container = try provider.getContainer(for: ref, skipUpdate: false)
             XCTAssertEqual(try container.toolsVersion(for: packageVersion), .v5_4)
-            let versions = try container.toolsVersionsAppropriateVersionsDescending().map { $0 }
+            let versions = try container.toolsVersionsAppropriateVersionsDescending()
             XCTAssertEqual(versions, [packageVersion])
         }
 
@@ -188,7 +188,7 @@ class RegistryPackageContainerTests: XCTestCase {
             let ref = PackageReference.registry(identity: packageIdentity)
             let container = try provider.getContainer(for: ref, skipUpdate: false)
             XCTAssertEqual(try container.toolsVersion(for: packageVersion), .v5_5)
-            let versions = try container.toolsVersionsAppropriateVersionsDescending().map { $0 }
+            let versions = try container.toolsVersionsAppropriateVersionsDescending()
             XCTAssertEqual(versions, [packageVersion])
         }
 
@@ -197,7 +197,7 @@ class RegistryPackageContainerTests: XCTestCase {
             let ref = PackageReference.registry(identity: packageIdentity)
             let container = try provider.getContainer(for: ref, skipUpdate: false)
             XCTAssertEqual(try container.toolsVersion(for: packageVersion), .v5_5)
-            let versions = try container.toolsVersionsAppropriateVersionsDescending().map { $0 }
+            let versions = try container.toolsVersionsAppropriateVersionsDescending()
             XCTAssertEqual(versions, [packageVersion])
         }
     }

--- a/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
@@ -208,7 +208,7 @@ class SourceControlPackageContainerTests: XCTestCase {
 
         let ref = PackageReference.localSourceControl(identity: PackageIdentity(path: repoPath), path: repoPath)
         let container = try provider.getContainer(for: ref, skipUpdate: false)
-        let v = try container.toolsVersionsAppropriateVersionsDescending().map { $0 }
+        let v = try container.toolsVersionsAppropriateVersionsDescending()
         XCTAssertEqual(v, ["2.0.3", "1.0.3", "1.0.2", "1.0.1", "1.0.0"])
     }
 
@@ -265,7 +265,7 @@ class SourceControlPackageContainerTests: XCTestCase {
             let provider = try createProvider(ToolsVersion(version: "4.0.0"))
             let ref = PackageReference.localSourceControl(identity: PackageIdentity(path: repoPath), path: repoPath)
             let container = try provider.getContainer(for: ref, skipUpdate: false)
-            let v = try container.toolsVersionsAppropriateVersionsDescending().map { $0 }
+            let v = try container.toolsVersionsAppropriateVersionsDescending()
             XCTAssertEqual(v, ["1.0.1"])
         }
 
@@ -274,7 +274,7 @@ class SourceControlPackageContainerTests: XCTestCase {
             let ref = PackageReference.localSourceControl(identity: PackageIdentity(path: repoPath), path: repoPath)
             let container = try provider.getContainer(for: ref, skipUpdate: false) as! SourceControlPackageContainer
             XCTAssertTrue(container.validToolsVersionsCache.isEmpty)
-            let v = try container.toolsVersionsAppropriateVersionsDescending().map { $0 }
+            let v = try container.toolsVersionsAppropriateVersionsDescending()
             XCTAssertEqual(container.validToolsVersionsCache["1.0.0"], false)
             XCTAssertEqual(container.validToolsVersionsCache["1.0.1"], true)
             XCTAssertEqual(container.validToolsVersionsCache["1.0.2"], true)
@@ -286,7 +286,7 @@ class SourceControlPackageContainerTests: XCTestCase {
             let provider = try createProvider(ToolsVersion(version: "3.0.0"))
             let ref = PackageReference.localSourceControl(identity: PackageIdentity(path: repoPath), path: repoPath)
             let container = try provider.getContainer(for: ref, skipUpdate: false)
-            let v = try container.toolsVersionsAppropriateVersionsDescending().map { $0 }
+            let v = try container.toolsVersionsAppropriateVersionsDescending()
             XCTAssertEqual(v, [])
         }
 
@@ -345,7 +345,7 @@ class SourceControlPackageContainerTests: XCTestCase {
 
         let ref = PackageReference.localSourceControl(identity: PackageIdentity(path: repoPath), path: repoPath)
         let container = try provider.getContainer(for: ref, skipUpdate: false)
-        let v = try container.toolsVersionsAppropriateVersionsDescending().map { $0 }
+        let v = try container.toolsVersionsAppropriateVersionsDescending()
         XCTAssertEqual(v, ["1.0.4-alpha", "1.0.2-dev.2", "1.0.2-dev", "1.0.1", "1.0.0", "1.0.0-beta.1", "1.0.0-alpha.1"])
     }
 
@@ -393,7 +393,7 @@ class SourceControlPackageContainerTests: XCTestCase {
         )
         let ref = PackageReference.localSourceControl(identity: PackageIdentity(path: repoPath), path: repoPath)
         let container = try provider.getContainer(for: ref, skipUpdate: false)
-        let v = try container.toolsVersionsAppropriateVersionsDescending().map { $0 }
+        let v = try container.toolsVersionsAppropriateVersionsDescending()
         XCTAssertEqual(v, ["2.0.1", "1.3.0", "1.2.0", "1.1.0", "1.0.4", "1.0.2", "1.0.1", "1.0.0"])
     }
 


### PR DESCRIPTION
motivation: nicer code, better performance

changes: audit use of `.map{ $0 }` which are redundant and remove such

