### PR TITLE
add a test for new binary artifact download concurrent download limit

### DIFF
--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -398,12 +398,20 @@ public final class MockWorkspace {
             packages: rootPaths(for: roots), dependencies: dependencies
         )
         let workspace = try self.getOrCreateWorkspace()
-        let graph = try workspace.loadPackageGraph(
-            rootInput: rootInput,
-            forceResolvedVersions: forceResolvedVersions,
-            observabilityScope: observability.topScope
-        )
-        result(graph, observability.diagnostics)
+        do {
+            let graph = try workspace.loadPackageGraph(
+                rootInput: rootInput,
+                forceResolvedVersions: forceResolvedVersions,
+                observabilityScope: observability.topScope
+            )
+            result(graph, observability.diagnostics)
+        } catch {
+            // helpful when graph fails to load
+            if observability.hasErrorDiagnostics {
+                print(observability.diagnostics.map{ $0.description }.joined(separator: "\n"))
+            }
+            throw error
+        }
     }
 
     public func checkPackageGraphFailure(


### PR DESCRIPTION
motivation: recent change to SwiftPM introduce a limit on # of concurrent binary artofacts downloads, but was missing a test

changes: add a test for the new functionality
