### PR TITLE
Don't emit a "this package dependency is unused" warning for packages that vend command plugins

### DIFF
--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -468,4 +468,156 @@ class PluginTests: XCTestCase {
             }
         }
     }
+
+    func testUnusedPluginProductWarnings() throws {
+        // Test the warnings we get around unused plugin products in package dependencies.
+        try testWithTemporaryDirectory { tmpPath in
+            // Create a sample package that uses three packages that vend plugins.
+            let packageDir = tmpPath.appending(components: "MyPackage")
+            try localFileSystem.createDirectory(packageDir, recursive: true)
+            try localFileSystem.writeFileContents(packageDir.appending(component: "Package.swift"), string: """
+                // swift-tools-version: 5.6
+                import PackageDescription
+                let package = Package(
+                    name: "MyPackage",
+                    dependencies: [
+                        .package(name: "BuildToolPluginPackage", path: "VendoredDependencies/BuildToolPluginPackage"),
+                        .package(name: "UnusedBuildToolPluginPackage", path: "VendoredDependencies/UnusedBuildToolPluginPackage"),
+                        .package(name: "CommandPluginPackage", path: "VendoredDependencies/CommandPluginPackage")
+                    ],
+                    targets: [
+                        .target(
+                            name: "MyLibrary",
+                            path: ".",
+                            plugins: [
+                                .plugin(name: "BuildToolPlugin", package: "BuildToolPluginPackage")
+                            ]
+                        ),
+                    ]
+                )
+                """)
+            try localFileSystem.writeFileContents(packageDir.appending(component: "Library.swift"), string: """
+                public var Foo: String
+                """)
+
+            // Create the depended-upon package that vends a build tool plugin that is used by the main package.
+            let buildToolPluginPackageDir = packageDir.appending(components: "VendoredDependencies", "BuildToolPluginPackage")
+            try localFileSystem.createDirectory(buildToolPluginPackageDir, recursive: true)
+            try localFileSystem.writeFileContents(buildToolPluginPackageDir.appending(component: "Package.swift"), string: """
+                // swift-tools-version: 5.6
+                import PackageDescription
+                let package = Package(
+                    name: "BuildToolPluginPackage",
+                    products: [
+                        .plugin(
+                            name: "BuildToolPlugin",
+                            targets: ["BuildToolPlugin"])
+                    ],
+                    targets: [
+                        .plugin(
+                            name: "BuildToolPlugin",
+                            capability: .buildTool(),
+                            path: ".")
+                    ]
+                )
+                """)
+            try localFileSystem.writeFileContents(buildToolPluginPackageDir.appending(component: "Plugin.swift"), string: """
+                import PackagePlugin
+                @main struct MyPlugin: BuildToolPlugin {
+                    func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
+                        return []
+                    }
+                }
+                """)
+
+            // Create the depended-upon package that vends a build tool plugin that is not used by the main package.
+            let unusedBuildToolPluginPackageDir = packageDir.appending(components: "VendoredDependencies", "UnusedBuildToolPluginPackage")
+            try localFileSystem.createDirectory(unusedBuildToolPluginPackageDir, recursive: true)
+            try localFileSystem.writeFileContents(unusedBuildToolPluginPackageDir.appending(component: "Package.swift"), string: """
+                // swift-tools-version: 5.6
+                import PackageDescription
+                let package = Package(
+                    name: "UnusedBuildToolPluginPackage",
+                    products: [
+                        .plugin(
+                            name: "UnusedBuildToolPlugin",
+                            targets: ["UnusedBuildToolPlugin"])
+                    ],
+                    targets: [
+                        .plugin(
+                            name: "UnusedBuildToolPlugin",
+                            capability: .buildTool(),
+                            path: ".")
+                    ]
+                )
+                """)
+            try localFileSystem.writeFileContents(unusedBuildToolPluginPackageDir.appending(component: "Plugin.swift"), string: """
+                import PackagePlugin
+                @main struct MyPlugin: BuildToolPlugin {
+                    func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
+                        return []
+                    }
+                }
+                """)
+
+            // Create the depended-upon package that vends a command plugin.
+            let commandPluginPackageDir = packageDir.appending(components: "VendoredDependencies", "CommandPluginPackage")
+            try localFileSystem.createDirectory(commandPluginPackageDir, recursive: true)
+            try localFileSystem.writeFileContents(commandPluginPackageDir.appending(component: "Package.swift"), string: """
+                // swift-tools-version: 5.6
+                import PackageDescription
+                let package = Package(
+                    name: "CommandPluginPackage",
+                    products: [
+                        .plugin(
+                            name: "CommandPlugin",
+                            targets: ["CommandPlugin"])
+                    ],
+                    targets: [
+                        .plugin(
+                            name: "CommandPlugin",
+                            capability: .command(intent: .custom(verb: "how", description: "why")),
+                            path: ".")
+                    ]
+                )
+                """)
+            try localFileSystem.writeFileContents(commandPluginPackageDir.appending(component: "Plugin.swift"), string: """
+                import PackagePlugin
+                @main struct MyPlugin: CommandPlugin {
+                    func performCommand(context: PluginContext, targets: [Target], arguments: [String]) throws {
+                    }
+                }
+                """)
+
+            // Load a workspace from the package.
+            let observability = ObservabilitySystem.makeForTesting()
+            let workspace = try Workspace(
+                fileSystem: localFileSystem,
+                location: .init(forRootPackage: packageDir, fileSystem: localFileSystem),
+                customManifestLoader: ManifestLoader(toolchain: ToolchainConfiguration.default),
+                delegate: MockWorkspaceDelegate()
+            )
+
+            // Load the root manifest.
+            let rootInput = PackageGraphRootInput(packages: [packageDir], dependencies: [])
+            let rootManifests = try tsc_await {
+                workspace.loadRootManifests(
+                    packages: rootInput.packages,
+                    observabilityScope: observability.topScope,
+                    completion: $0
+                )
+            }
+            XCTAssert(rootManifests.count == 1, "\(rootManifests)")
+
+            // Load the package graph.
+            let packageGraph = try workspace.loadPackageGraph(rootInput: rootInput, observabilityScope: observability.topScope)
+            XCTAssert(packageGraph.packages.count == 4, "\(packageGraph.packages)")
+            XCTAssert(packageGraph.rootPackages.count == 1, "\(packageGraph.rootPackages)")
+
+            // Check that we have only a warning about the unused build tool plugin (not about the used one and not about the command plugin).
+            testDiagnostics(observability.diagnostics, problemsOnly: true) { result in
+                result.checkUnordered(diagnostic: .contains("dependency 'unusedbuildtoolpluginpackage' is not used by any target"), severity: .warning)
+            }
+        }
+    }
 }


### PR DESCRIPTION
An existing warning about dependencies on packages from which no products are used shouldn't apply if the package has any command plugin products.  The warning assumes that the only use of products is to link against them or use them as build tool plugins, but that's not correct for command plugins, where the dependency is only used to make the plugin available for the user to invoke.

### Motivation

With command plugins it's perfectly reasonable to depend on a package without explicitly having a reference to any of its products, so suppress the warning in that case.

### Modifications:

- added a check to skip the warning if the depended-on-package vends at least one command plugin product
- add a unit test to check the absence of this diagnostic, and the continued presence of diagnostics about unused built tool plugins

Existing unit tests check that the warning still shows up for regular products.

rdar://86787186