### PR TITLE
improve dependency resolution diagnostics when resolving non-versioned dependencies

### DIFF
--- a/Sources/Basics/Dictionary+Extensions.swift
+++ b/Sources/Basics/Dictionary+Extensions.swift
@@ -20,3 +20,13 @@ extension Dictionary {
         return value
     }
 }
+
+extension OrderedDictionary {
+    public subscript(key: Key, `default` `default`: Value) -> Value {
+        set {
+            self[key] = newValue
+        } get {
+            self[key] ?? `default`
+        }
+    }
+}

--- a/Sources/PackageGraph/DependencyResolutionNode.swift
+++ b/Sources/PackageGraph/DependencyResolutionNode.swift
@@ -39,7 +39,7 @@ public enum DependencyResolutionNode {
     ///   They derive from the manifest.
     ///
     ///   Tools versions before 5.2 do not know which products belong to which packages, so each product is required from every dependency.
-    ///   Since a non‐existant product ends up with only its implicit dependency on its own package,
+    ///   Since a non‐existent product ends up with only its implicit dependency on its own package,
     ///   only whichever package contains the product will end up adding additional constraints.
     ///   See `ProductFilter` and `Manifest.register(...)`.
     case product(String, package: PackageReference)
@@ -52,7 +52,7 @@ public enum DependencyResolutionNode {
     ///
     /// - zero or more dependencies on each external product node required to build any of its targets (vended or not).
     /// - zero or more dependencies directly on external empty package nodes.
-    ///   This special case occurs when a dependecy is declared but not used.
+    ///   This special case occurs when a dependency is declared but not used.
     ///   It is a warning condition, and builds do not actually need these dependencies.
     ///   However, forcing the graph to resolve and fetch them anyway allows the diagnostics passes access
     ///   to the information needed in order to provide actionable suggestions to help the user stitch up the dependency declarations properly.

--- a/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
+++ b/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
@@ -132,10 +132,18 @@ public struct PubgrubDependencyResolver {
 
     /// Execute the resolution algorithm to find a valid assignment of versions.
     public func solve(constraints: [Constraint]) -> Result<[DependencyResolver.Binding], Error> {
-        let root = DependencyResolutionNode.root(package: .root(
-            identity: .plain("<synthesized-root>"),
-            path: .root
-        ))
+        // 👀 is this the right thing to do?
+        let root: DependencyResolutionNode
+        if constraints.count == 1, let constraint = constraints.first, constraint.package.kind.isRoot {
+            // root level package, use it as our resolution root
+            root = .root(package: constraint.package)
+        } else {
+            // more complex setup requires a synthesized root
+            root = .root(package: .root(
+                identity: .plain("<synthesized-root>"),
+                path: .root
+            ))
+        }
 
         do {
             // strips state


### PR DESCRIPTION
motivation:  when resolving graphs with non-versioned depedendencies (such as branch dependencies), the dependencies get "flattened" onto the root node which looses the original association with the dependency's parent yielding incorrect diagnostics

changes:
* more accuretly track the underlying dependency when computing root dependencies from non-versioned depedendencie
* peek into the "real" cause when producing depedency based diagnostics for the root node
* TBD: use top level package as root instead of synthesized root when appropriate 
* add a bunch of tests

rdar://87486528
rdar://64226666
