### PR TITLE
[5.6] Don't emit "package dependency is unused" warning for packages containing command plugin products

### DIFF
--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -468,4 +468,156 @@ class PluginTests: XCTestCase {
             }
         }
     }
+
+    func testUnusedPluginProductWarnings() throws {
+        // Test the warnings we get around unused plugin products in package dependencies.
+        try testWithTemporaryDirectory { tmpPath in
+            // Create a sample package that uses three packages that vend plugins.
+            let packageDir = tmpPath.appending(components: "MyPackage")
+            try localFileSystem.createDirectory(packageDir, recursive: true)
+            try localFileSystem.writeFileContents(packageDir.appending(component: "Package.swift"), string: """
+                // swift-tools-version: 5.6
+                import PackageDescription
+                let package = Package(
+                    name: "MyPackage",
+                    dependencies: [
+                        .package(name: "BuildToolPluginPackage", path: "VendoredDependencies/BuildToolPluginPackage"),
+                        .package(name: "UnusedBuildToolPluginPackage", path: "VendoredDependencies/UnusedBuildToolPluginPackage"),
+                        .package(name: "CommandPluginPackage", path: "VendoredDependencies/CommandPluginPackage")
+                    ],
+                    targets: [
+                        .target(
+                            name: "MyLibrary",
+                            path: ".",
+                            plugins: [
+                                .plugin(name: "BuildToolPlugin", package: "BuildToolPluginPackage")
+                            ]
+                        ),
+                    ]
+                )
+                """)
+            try localFileSystem.writeFileContents(packageDir.appending(component: "Library.swift"), string: """
+                public var Foo: String
+                """)
+
+            // Create the depended-upon package that vends a build tool plugin that is used by the main package.
+            let buildToolPluginPackageDir = packageDir.appending(components: "VendoredDependencies", "BuildToolPluginPackage")
+            try localFileSystem.createDirectory(buildToolPluginPackageDir, recursive: true)
+            try localFileSystem.writeFileContents(buildToolPluginPackageDir.appending(component: "Package.swift"), string: """
+                // swift-tools-version: 5.6
+                import PackageDescription
+                let package = Package(
+                    name: "BuildToolPluginPackage",
+                    products: [
+                        .plugin(
+                            name: "BuildToolPlugin",
+                            targets: ["BuildToolPlugin"])
+                    ],
+                    targets: [
+                        .plugin(
+                            name: "BuildToolPlugin",
+                            capability: .buildTool(),
+                            path: ".")
+                    ]
+                )
+                """)
+            try localFileSystem.writeFileContents(buildToolPluginPackageDir.appending(component: "Plugin.swift"), string: """
+                import PackagePlugin
+                @main struct MyPlugin: BuildToolPlugin {
+                    func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
+                        return []
+                    }
+                }
+                """)
+
+            // Create the depended-upon package that vends a build tool plugin that is not used by the main package.
+            let unusedBuildToolPluginPackageDir = packageDir.appending(components: "VendoredDependencies", "UnusedBuildToolPluginPackage")
+            try localFileSystem.createDirectory(unusedBuildToolPluginPackageDir, recursive: true)
+            try localFileSystem.writeFileContents(unusedBuildToolPluginPackageDir.appending(component: "Package.swift"), string: """
+                // swift-tools-version: 5.6
+                import PackageDescription
+                let package = Package(
+                    name: "UnusedBuildToolPluginPackage",
+                    products: [
+                        .plugin(
+                            name: "UnusedBuildToolPlugin",
+                            targets: ["UnusedBuildToolPlugin"])
+                    ],
+                    targets: [
+                        .plugin(
+                            name: "UnusedBuildToolPlugin",
+                            capability: .buildTool(),
+                            path: ".")
+                    ]
+                )
+                """)
+            try localFileSystem.writeFileContents(unusedBuildToolPluginPackageDir.appending(component: "Plugin.swift"), string: """
+                import PackagePlugin
+                @main struct MyPlugin: BuildToolPlugin {
+                    func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
+                        return []
+                    }
+                }
+                """)
+
+            // Create the depended-upon package that vends a command plugin.
+            let commandPluginPackageDir = packageDir.appending(components: "VendoredDependencies", "CommandPluginPackage")
+            try localFileSystem.createDirectory(commandPluginPackageDir, recursive: true)
+            try localFileSystem.writeFileContents(commandPluginPackageDir.appending(component: "Package.swift"), string: """
+                // swift-tools-version: 5.6
+                import PackageDescription
+                let package = Package(
+                    name: "CommandPluginPackage",
+                    products: [
+                        .plugin(
+                            name: "CommandPlugin",
+                            targets: ["CommandPlugin"])
+                    ],
+                    targets: [
+                        .plugin(
+                            name: "CommandPlugin",
+                            capability: .command(intent: .custom(verb: "how", description: "why")),
+                            path: ".")
+                    ]
+                )
+                """)
+            try localFileSystem.writeFileContents(commandPluginPackageDir.appending(component: "Plugin.swift"), string: """
+                import PackagePlugin
+                @main struct MyPlugin: CommandPlugin {
+                    func performCommand(context: PluginContext, targets: [Target], arguments: [String]) throws {
+                    }
+                }
+                """)
+
+            // Load a workspace from the package.
+            let observability = ObservabilitySystem.makeForTesting()
+            let workspace = try Workspace(
+                fileSystem: localFileSystem,
+                location: .init(forRootPackage: packageDir, fileSystem: localFileSystem),
+                customManifestLoader: ManifestLoader(toolchain: ToolchainConfiguration.default),
+                delegate: MockWorkspaceDelegate()
+            )
+
+            // Load the root manifest.
+            let rootInput = PackageGraphRootInput(packages: [packageDir], dependencies: [])
+            let rootManifests = try tsc_await {
+                workspace.loadRootManifests(
+                    packages: rootInput.packages,
+                    observabilityScope: observability.topScope,
+                    completion: $0
+                )
+            }
+            XCTAssert(rootManifests.count == 1, "\(rootManifests)")
+
+            // Load the package graph.
+            let packageGraph = try workspace.loadPackageGraph(rootInput: rootInput, observabilityScope: observability.topScope)
+            XCTAssert(packageGraph.packages.count == 4, "\(packageGraph.packages)")
+            XCTAssert(packageGraph.rootPackages.count == 1, "\(packageGraph.rootPackages)")
+
+            // Check that we have only a warning about the unused build tool plugin (not about the used one and not about the command plugin).
+            testDiagnostics(observability.diagnostics, problemsOnly: true) { result in
+                result.checkUnordered(diagnostic: .contains("dependency 'unusedbuildtoolpluginpackage' is not used by any target"), severity: .warning)
+            }
+        }
+    }
 }


### PR DESCRIPTION
5.6 nomination cherry-picked from https://github.com/apple/swift-package-manager/pull/4028

**Explanation:**  If a package depends on another package that vends a command plugin, and if it does not use any other product from that package, then SwiftPM emits a warning saying that the dependency is unused.  This warning predates the introduction of command plugins, and is no longer correct when a package dependency vends command plugins, because the reason for the dependency might be to make those plugins available when using the package.  Since those command plugins could be invoked by the user at any time, this change elides the warning when the package dependency contains command plugin products (but not when it contains only unused build tool plugins, since the warning does apply in that case).

**Scope of Issue:**  This applies to packages that depend on other packages that vend command plugins, but where the top-level package does not depend on any other library from the package.

**Reason for Nominating to 5.6:**  When authoring a command plugin, it's not unusual for that plugin to be the only thing that other packages use from the package that defines it.  Feedback based on early use of command plugins shows that this warning causes confusion when it appears, since the command plugin _could_ be used at any time, it's just that SwiftPM doesn't know what the user is going to do.

**Risk:**  Low. The largest risk if the logic is wrong would be to incorrectly hide the warning in cases where it should be shown.  This is mitigated by the presence of the unit tests that check that this warning is emitted in the absence of command plugins.

**Reviewed By:**  @tomerd

**Automated Testing:**  A new unit test checks that 1) the warning is emitted for build tool plugins that are _not_ used, but 2) that this warning is not emitted for build tool plugins that _are_ used, and 3) that it is not emitted for command plugins.  Extant unit tests check that the warning is emitted in the older uses cases that do not involve plugins.

**Dependencies:**  None

**Impact on CI:**  None

**How to Verify:**  Write a command plugin that doesn't have any other products than a command plugin, and add a dependency on it from another package.  Verify that the warning isn't shown when the top-level package is used.

rdar://86787186
