### PR TITLE
SourceControl: avoid the builtin FS monitor

### DIFF
--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -105,7 +105,11 @@ public struct GitRepositoryProvider: RepositoryProvider {
         // FIXME: Ideally we should pass `--progress` here and report status regularly.  We currently don't have callbacks for that.
         //
         // NOTE: Explicitly set `core.symlinks=true` on `git clone` to ensure that symbolic links are correctly resolved.
-        try self.callGit("clone", "-c", "core.symlinks=true", "--mirror", repository.location.gitURL, path.pathString,
+        // NOTE: Explicitly set `core.useBuiltinFSMonitor` on `git clone` to ensure that we do not spawn a monitor on the repository.  This is particularly important for Windows where the process can prevent future operations.
+        try self.callGit("clone",
+                         "-c", "core.symlinks=true",
+                         "-c", "core.useBuiltinFSMonitor=false",
+                         "--mirror", repository.location.gitURL, path.pathString,
                          repository: repository,
                          failureMessage: "Failed to clone repository \(repository.location)",
                          progress: progressHandler)


### PR DESCRIPTION
This disables the builtin FS monitor on the checkouts of the
dependencies.  This ensures that the global configuration of
the setting does not influence the repository local behavior
as that can cause problems on Windows. Due to the filesystem
behaviour on Windows, we cannot remove a directory with open
descriptors - which the monitor implies. This should resolve
the problem where a series of `swift package` commands would
result in failures.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
