### PR TITLE
Add initial support for DocC in PackageDescription module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ Utilities/Docker/*.tar.gz
 Package.resolved
 /build
 *.pyc
+.docc-build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -344,16 +344,16 @@ To run package compatibility test suite (validates we do not break 3rd party pac
 
 SwiftPM uses [DocC](https://github.com/apple/swift-docc) to generate some of its documentation (currently only the `PackageDescription` module). Documentation can be built using Xcode's GUI (Product → Build Documentation or `⌃⇧⌘D`) or manually:
 
-1. Build the symbol graph metadata used to generate the documentation:
+1. Build and dump the symbol graph metadata used to generate the documentation:
 
 ```
-swift build --target PackageDescription -Xswiftc -emit-symbol-graph -Xswiftc -emit-symbol-graph-dir -Xswiftc .build/symbol-graphs
+swift package dump-symbol-graph
 ```
 
-2. Regenerate the documentation and start a local preview server to review your changes:
+2. Generate the documentation and start a local preview server to review your changes:
 
 ```
-xcrun docc preview Sources/PackageDescription/PackageDescription.docc --additional-symbol-graph-dir .build/symbol-graphs
+xcrun docc preview Sources/PackageDescription/PackageDescription.docc --additional-symbol-graph-dir .build/*/symbolgraph/
 ```
 
 ## Advanced

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -356,6 +356,8 @@ swift package dump-symbol-graph
 xcrun docc preview Sources/PackageDescription/PackageDescription.docc --additional-symbol-graph-dir .build/*/symbolgraph/
 ```
 
+Note that this may generate documentation for multiple modules — the preview link for PackageDescription will typically be: http://localhost:8000/documentation/packagedescription
+
 ## Advanced
 
 ### Using Custom Swift Compilers

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -340,6 +340,22 @@ To run package compatibility test suite (validates we do not break 3rd party pac
 @swift-ci please test package compatibility
 ```
 
+## Generating Documentation
+
+SwiftPM uses [DocC](https://github.com/apple/swift-docc) to generate some of its documentation (currently only the `PackageDescription` module). Documentation can be built using Xcode's GUI (Product → Build Documentation or `⌃⇧⌘D`) or manually:
+
+1. Build the symbol graph metadata used to generate the documentation:
+
+```
+swift build --target PackageDescription -Xswiftc -emit-symbol-graph -Xswiftc -emit-symbol-graph-dir -Xswiftc .build/symbol-graphs
+```
+
+2. Regenerate the documentation and start a local preview server to review your changes:
+
+```
+xcrun docc preview Sources/PackageDescription/PackageDescription.docc --additional-symbol-graph-dir .build/symbol-graphs
+```
+
 ## Advanced
 
 ### Using Custom Swift Compilers

--- a/Sources/PackageDescription/BuildSettings.swift
+++ b/Sources/PackageDescription/BuildSettings.swift
@@ -26,7 +26,7 @@ public struct BuildConfiguration: Encodable {
 /// A condition that limits the application of a build setting.
 ///
 /// By default, build settings are applicable for all platforms and build
-/// configurations. Use the `.when` modifier to define  a build
+/// configurations. Use the ``when(platforms:configuration:)`` modifier to define  a build
 /// setting for a specific condition. Invalid usage of `.when` emits an error during
 /// manifest parsing. For example, it's invalid to specify a `.when` condition with
 /// both parameters as `nil`.

--- a/Sources/PackageDescription/PackageDescription.docc/Info.plist
+++ b/Sources/PackageDescription/PackageDescription.docc/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>PackageDescription</string>
+    <key>CFBundleDisplayName</key>
+    <string>PackageDescription</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.apple.swift-package-manager.packagedescription</string>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleIconFile</key>
+    <string>DocumentationIcon</string>
+    <key>CFBundleIconName</key>
+    <string>DocumentationIcon</string>
+    <key>CFBundlePackageType</key>
+    <string>DOCS</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
+    <key>CDDefaultCodeListingLanguage</key>
+    <string>swift</string>
+    <key>CFBundleVersion</key>
+    <string>0.1.0</string>
+</dict>
+</plist>

--- a/Sources/PackageDescription/PackageDescription.docc/Info.plist
+++ b/Sources/PackageDescription/PackageDescription.docc/Info.plist
@@ -7,7 +7,7 @@
     <key>CFBundleDisplayName</key>
     <string>PackageDescription</string>
     <key>CFBundleIdentifier</key>
-    <string>com.apple.swift-package-manager.packagedescription</string>
+    <string>org.swift.swiftpm.packagedescription</string>
     <key>CFBundleDevelopmentRegion</key>
     <string>en</string>
     <key>CFBundleIconFile</key>

--- a/Sources/PackageDescription/PackageDescription.docc/PackageDescription.md
+++ b/Sources/PackageDescription/PackageDescription.docc/PackageDescription.md
@@ -1,0 +1,46 @@
+# ``PackageDescription``
+
+Swift package manifest configuration.
+
+## Overview
+
+Swift packages are configured using `Package.swift` manifest files. The manifest file, or package manifest, defines the package's name and its contents using ``Package`` from the `PackageDescription` module. A package has one or more targets, defined using ``Target``. Each target specifies a ``Product`` and may declare one or more dependencies, defined using ``Package/Dependency``.
+
+### About the Swift Tools Version
+
+A `Package.swift` manifest file must begin with the string `// swift-tools-version:` followed by a version number specifier. The following code listing shows a few examples of valid declarations
+of the Swift tools version:
+
+    // swift-tools-version:3.0.2
+    // swift-tools-version:3.1
+    // swift-tools-version:4.0
+    // swift-tools-version:5.0
+    // swift-tools-version:5.1
+    // ...
+    // swift-tools-version:5.6
+
+The Swift tools version declares the version of the `PackageDescription` library, the minimum version of the Swift tools and Swift language compatibility version to process the manifest, and the minimum version of the Swift tools that are needed to use the Swift package. Each version of Swift can introduce updates to the `PackageDescription` framework, but the previous API version will continue to be available to packages which declare a prior tools version. This behavior lets you take advantage of new releases of Swift, the Swift tools, and the `PackageDescription` library, without having to update your package's manifest or losing access to existing packages.
+
+## Topics
+
+### Package Definition
+
+- ``Package``
+- ``Product``
+- ``Package/Dependency``
+- ``Target``
+
+### Settings
+
+- ``BuildSettingCondition``
+- ``LinkerSetting``
+- ``SupportedPlatform``
+- ``SwiftSetting``
+- ``SwiftVersion``
+
+### C/C++ Settings
+
+- ``CSetting``
+- ``CXXSetting``
+- ``CLanguageStandard``
+- ``CXXLanguageStandard``

--- a/Sources/PackageDescription/PackageDescription.swift
+++ b/Sources/PackageDescription/PackageDescription.swift
@@ -49,14 +49,14 @@ import Foundation
 ///         ]
 ///     )
 ///
-/// The package manifest must begin with the string `// swift-tools-version:``,
-/// followed by a version number such as `// swift-tools-version:5.3.
+/// The package manifest must begin with the string `// swift-tools-version:`,
+/// followed by a version number such as `// swift-tools-version:5.3`.
 ///
 /// The Swift tools version declares:
 ///
-///     - The version of the PackageDescription framework
-///     - The Swift language compatibility version to process the manifest
-///     - The required minimum version of the Swift tools to use the package
+///   - The version of the PackageDescription framework
+///   - The Swift language compatibility version to process the manifest
+///   - The required minimum version of the Swift tools to use the package
 ///
 /// Each version of Swift can introduce updates to the PackageDescription
 /// library, but the previous API version is available to packages that declare

--- a/Sources/PackageDescription/Resource.swift
+++ b/Sources/PackageDescription/Resource.swift
@@ -16,12 +16,12 @@
 /// For example, any resources for the `MyLibrary` target must reside in `Sources/MyLibrary`.
 /// Use subdirectories to organize your resource files in a way that simplifies file identification and management.
 /// For example, put all resource files into a directory named `Resources`,
-/// so they reside at `Sources/MyLibrary/Resources.
+/// so they reside at `Sources/MyLibrary/Resources`.
 /// By default, the Swift Package Manager handles common resources types for Apple platforms automatically.
 /// For example, you don’t need to declare XIB files, storyboards, Core Data file types, and asset catalogs
 /// as resources in your package manifest.
-/// However, you must explicitly declare other file types—for example image files—as resources
-/// using the `process(_:localization:)`` or `copy(_:)`` rules. Alternatively, exclude resource files from a target
+/// However, you must explicitly declare other file types  (such as image files) as resources
+/// using the ``process(_:localization:)`` or ``copy(_:)`` rules. Alternatively, exclude resource files from a target
 /// by passing them to the target initializer’s `exclude` parameter.
 public struct Resource: Encodable {
     
@@ -61,7 +61,7 @@ public struct Resource: Encodable {
     /// If the given path represents a directory, the Swift Package Manager
     /// applies the process rule recursively to each file in the directory.
     ///
-    /// If possible use this rule instead of `copy(_:)`.
+    /// If possible use this rule instead of ``copy(_:)``.
     ///
     /// - Parameters:
     ///     - path: The path for a resource.
@@ -72,11 +72,11 @@ public struct Resource: Encodable {
     
     /// Applies the copy rule to a resource at the given path.
     ///
-    /// If possible, use `process(_:localization:)`` and automatically apply optimizations
+    /// If possible, use ``process(_:localization:)`` and automatically apply optimizations
     /// to resources.
     ///
     /// If your resources must remain untouched or must retain a specific folder structure,
-    /// use the `copy` rule. It copies resources at the given path, as is, to the top level
+    /// use the ``copy(_:)`` rule. It copies resources at the given path, as is, to the top level
     /// in the package’s resource bundle. If the given path represents a directory, Xcode preserves its structure.
     ///
     /// - Parameters:

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -88,7 +88,7 @@ public final class Target {
     /// The paths to source and resource files you don’t want to include in the target.
     ///
     /// Excluded paths are relative to the target path.
-    /// This property has precedence over the `sources` and `resources` properties.
+    /// This property has precedence over the ``sources`` and ``resources`` properties.
     public var exclude: [String]
     
     /// A boolean value that indicates if this is a test target.
@@ -299,7 +299,7 @@ public final class Target {
     ///       Don't escape the package root; for example, values like `../Foo` or `/Foo` are invalid.
     ///   - exclude: A list of paths to files or directories that the Swift Package Manager shouldn't consider to be source or resource files.
     ///       A path is relative to the target's directory.
-    ///       This parameter has precedence over the `sources` parameter.
+    ///       This parameter has precedence over the ``sources`` parameter.
     ///   - sources: An explicit list of source files. If you provide a path to a directory,
     ///       the Swift Package Manager searches for valid source files recursively.
     ///   - publicHeadersPath: The directory containing public headers of a C-family library target.
@@ -337,7 +337,7 @@ public final class Target {
     ///       Don't escape the package root; for example, values like `../Foo` or `/Foo` are invalid.
     ///   - exclude: A list of paths to files or directories that the Swift Package Manager shouldn't consider to be source or resource files.
     ///       Paths are relative to the target's directory.
-    ///       This parameter has precedence over the `sources` parameter.
+    ///       This parameter has precedence over the ``sources`` parameter.
     ///   - sources: An explicit list of source files. If you provide a path to a directory,
     ///       the Swift Package Manager searches for valid source files recursively.
     ///   - publicHeadersPath: The directory containing public headers of a C-family library target.
@@ -387,7 +387,7 @@ public final class Target {
     ///       Don't escape the package root; for example, values like `../Foo` or `/Foo` are invalid.
     ///   - exclude: A list of paths to files or directories that the Swift Package Manager shouldn't consider to be source or resource files.
     ///       A path is relative to the target's directory.
-    ///       This parameter has precedence over the `sources` parameter.
+    ///       This parameter has precedence over the ``sources`` parameter.
     ///   - sources: An explicit list of source files. If you provide a path to a directory,
     ///       the Swift Package Manager searches for valid source files recursively.
     ///   - resources: An explicit list of resources files.
@@ -440,7 +440,7 @@ public final class Target {
     ///       Don't escape the package root; for example, values like `../Foo` or `/Foo` are invalid.
     ///   - exclude: A list of paths to files or directories that the Swift Package Manager shouldn't consider to be source or resource files.
     ///       A path is relative to the target's directory.
-    ///       This parameter has precedence over the `sources` parameter.
+    ///       This parameter has precedence over the ``sources`` parameter.
     ///   - sources: An explicit list of source files. If you provide a path to a directory,
     ///       the Swift Package Manager searches for valid source files recursively.
     ///   - resources: An explicit list of resources files.
@@ -497,7 +497,7 @@ public final class Target {
     ///       Don't escape the package root; for example, values like `../Foo` or `/Foo` are invalid.
     ///   - exclude: A list of paths to files or directories that the Swift Package Manager shouldn't consider to be source or resource files.
     ///       A path is relative to the target's directory.
-    ///       This parameter has precedence over the `sources` parameter.
+    ///       This parameter has precedence over the ``sources`` parameter.
     ///   - sources: An explicit list of source files. If you provide a path to a directory,
     ///       the Swift Package Manager searches for valid source files recursively.
     ///   - resources: An explicit list of resources files.
@@ -551,7 +551,7 @@ public final class Target {
     ///       Don't escape the package root; for example, values like `../Foo` or `/Foo` are invalid.
     ///   - exclude: A list of paths to files or directories that the Swift Package Manager shouldn't consider to be source or resource files.
     ///       A path is relative to the target's directory.
-    ///       This parameter has precedence over the `sources` parameter.
+    ///       This parameter has precedence over the ``sources`` parameter.
     ///   - sources: An explicit list of source files. If you provide a path to a directory,
     ///       the Swift Package Manager searches for valid source files recursively.
     ///   - resources: An explicit list of resources files.
@@ -606,7 +606,7 @@ public final class Target {
     ///       Don't escape the package root; for example, values like `../Foo` or `/Foo` are invalid.
     ///   - exclude: A list of paths to files or directories that the Swift Package Manager shouldn't consider to be source or resource files.
     ///       A path is relative to the target's directory.
-    ///       This parameter has precedence over the `sources` parameter.
+    ///       This parameter has precedence over the ``sources`` parameter.
     ///   - sources: An explicit list of source files. If you provide a path to a directory,
     ///       the Swift Package Manager searches for valid source files recursively.
     @available(_PackageDescription, introduced: 4, obsoleted: 5)
@@ -641,7 +641,7 @@ public final class Target {
     ///       Don't escape the package root; for example, values like `../Foo` or `/Foo` are invalid.
     ///   - exclude: A list of paths to files or directories that the Swift Package Manager shouldn't consider to be source or resource files.
     ///       A path is relative to the target's directory.
-    ///       This parameter has precedence over the `sources` parameter.
+    ///       This parameter has precedence over the ``sources`` parameter.
     ///   - sources: An explicit list of source files. If you provide a path to a directory,
     ///       the Swift Package Manager searches for valid source files recursively.
     ///   - cSettings: The C settings for this target.
@@ -688,7 +688,7 @@ public final class Target {
     ///       Don't escape the package root; for example, values like `../Foo` or `/Foo` are invalid.
     ///   - exclude: A list of paths to files or directories that the Swift Package Manager shouldn't consider to be source or resource files.
     ///       A path is relative to the target's directory.
-    ///       This parameter has precedence over the `sources` parameter.
+    ///       This parameter has precedence over the ``sources`` parameter.
     ///   - sources: An explicit list of source files. If you provide a path to a directory,
     ///       the Swift Package Manager searches for valid source files recursively.
     ///   - resources: An explicit list of resources files.
@@ -738,7 +738,7 @@ public final class Target {
     ///       Don't escape the package root; for example, values like `../Foo` or `/Foo` are invalid.
     ///   - exclude: A list of paths to files or directories that the Swift Package Manager shouldn't consider to be source or resource files.
     ///       A path is relative to the target's directory.
-    ///       This parameter has precedence over the `sources` parameter.
+    ///       This parameter has precedence over the ``sources`` parameter.
     ///   - sources: An explicit list of source files. If you provide a path to a directory,
     ///       the Swift Package Manager searches for valid source files recursively.
     ///   - resources: An explicit list of resources files.


### PR DESCRIPTION
Add rough initial cut of PackageDescription.docc and adopt DocC formatting in some of its constituent code.

### Motivation

We'd like to be able to generate documentation for certain parts of SwiftPM using Apple's [DocC](https://github.com/apple/swift-docc) tool, which should allow for easier maintenance and a much better end result.

### Modifications

- Add `Sources/PackageDescription/PackageDescription.docc`, which contains DocC configuration and some documentation meta-content.
- Adopt the DocC double-tick code voice style in some inline PackageDescription docs — this explicitly tells DocC to link that class/method/etc. name to its DocC page/anchor.

[Here's a downloadable `.doccarchive` bundle](https://github.com/apple/swift-package-manager/files/7892868/PackageDescription-89b7b32.doccarchive.zip) for easier review of these changes.

### Future

Formatting here is quite bare and new content is minimal. Future changes should improve organization and flesh out missing content. Once we have these generated docs hosted somewhere, we should delete `Documentation/PackageDescription.md` and update other relevant in-repo docs.

Fixes rdar://83903532.