### PR TITLE
[Collections] Honor --config-path and --cache-path options

### DIFF
--- a/Sources/PackageCollections/PackageCollections+Configuration.swift
+++ b/Sources/PackageCollections/PackageCollections+Configuration.swift
@@ -1,12 +1,14 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2020-2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2020-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
+
+import TSCBasic
 
 // TODO: how do we read default config values? ENV variables? user settings?
 extension PackageCollections {
@@ -14,11 +16,21 @@ extension PackageCollections {
         // TODO: add configuration including:
         // JSONPackageCollectionProvider: maximumSizeInBytes
         // JSONPackageCollectionValidator: maximumPackageCount, maximumMajorVersionCount, maximumMinorVersionCount
+        
+        /// Path of the parent directory for collections-related configuration files
+        public var configurationDirectory: AbsolutePath?
+        
+        /// Path of the parent directory for collections-related cache(s)
+        public var cacheDirectory: AbsolutePath?
 
         /// Auth tokens for the collections or metadata provider
         public var authTokens: () -> [AuthTokenType: String]?
 
-        public init(authTokens: @escaping () -> [AuthTokenType: String]? = { nil }) {
+        public init(
+            configurationDirectory: AbsolutePath? = nil,
+            cacheDirectory: AbsolutePath? = nil,
+            authTokens: @escaping () -> [AuthTokenType: String]? = { nil }
+        ) {
             self.authTokens = authTokens
         }
     }

--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -35,8 +35,13 @@ public struct PackageCollections: PackageCollectionsProtocol {
     // initialize with defaults
     public init(configuration: Configuration = .init(), observabilityScope: ObservabilityScope) {
         let storage = Storage(
-            sources: FilePackageCollectionsSourcesStorage(),
-            collections: SQLitePackageCollectionsStorage(observabilityScope: observabilityScope)
+            sources: FilePackageCollectionsSourcesStorage(
+                path: configuration.configurationDirectory?.appending(component: "collections.json")
+            ),
+            collections: SQLitePackageCollectionsStorage(
+                location: configuration.cacheDirectory.map { .path($0.appending(components: "package-collection.db")) },
+                observabilityScope: observabilityScope
+            )
         )
 
         let collectionProviders = [
@@ -44,7 +49,10 @@ public struct PackageCollections: PackageCollectionsProtocol {
         ]
 
         let metadataProvider = GitHubPackageMetadataProvider(
-            configuration: .init(authTokens: configuration.authTokens),
+            configuration: .init(
+                authTokens: configuration.authTokens,
+                cacheDir: configuration.cacheDirectory?.appending(components: "package-metadata")
+            ),
             observabilityScope: observabilityScope
         )
         


### PR DESCRIPTION
Package collections configuration and storage paths should be customizable via `--config-path` and `--cache-path` options.

rdar://74887473
