### PR TITLE
improve observability error description interpolation, especially for manifest parsing error

### DIFF
--- a/Sources/Basics/Observability.swift
+++ b/Sources/Basics/Observability.swift
@@ -9,6 +9,7 @@
  */
 
 import Dispatch
+import Foundation
 import TSCBasic
 import TSCUtility
 
@@ -278,6 +279,8 @@ public struct Diagnostic: CustomStringConvertible {
             message = "\(diagnosticData)"
         } else if let convertible = error as? DiagnosticDataConvertible {
             message = "\(convertible.diagnosticData)"
+        } else if let localizedError = error as? LocalizedError {
+            message = localizedError.errorDescription ?? localizedError.localizedDescription
         } else {
             message = "\(error)"
         }

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -24,6 +24,18 @@ public enum ManifestParseError: Swift.Error, Equatable {
     case runtimeManifestErrors([String])
 }
 
+// used to output the errors via the observability system
+extension ManifestParseError: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .invalidManifestFormat(let error, _):
+            return "Invalid manifest\n\(error)"
+        case .runtimeManifestErrors(let errors):
+            return "Invalid manifest (evaluation failed)\n\(errors.joined(separator: "\n"))"
+        }
+    }
+}
+
 /// Protocol for the manifest loader interface.
 public protocol ManifestLoaderProtocol {
     /// Load the manifest for the package at `path`.

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -209,7 +209,7 @@ final class WorkspaceTests: XCTestCase {
             XCTAssert(rootManifests.count == 0, "\(rootManifests)")
 
             testDiagnostics(observability.diagnostics) { result in
-                let diagnostic = result.check(diagnostic: .contains("An error in MyPkg"), severity: .error)
+                let diagnostic = result.check(diagnostic: .prefix("Invalid manifest\n\(path)/MyPkg/Package.swift:3:8: error: An error in MyPkg"), severity: .error)
                 XCTAssertEqual(diagnostic?.metadata?.packageIdentity, .init(path: pkgDir))
                 XCTAssertEqual(diagnostic?.metadata?.packageKind, .root(pkgDir))
             }


### PR DESCRIPTION
motivation: clearer error descriptions to users

changes:
* add explicit handler for LocalizedError when extracintg its description  string into Diagnostics
* conform ManifestParseError to CustomStringConvertible
* add and adjust test