### PR TITLE
do not use Dictionary::uniqueKeysWithValues when input is not sanitized

### DIFF
--- a/Sources/Basics/Dictionary+Extensions.swift
+++ b/Sources/Basics/Dictionary+Extensions.swift
@@ -21,6 +21,18 @@ extension Dictionary {
     }
 }
 
+extension Dictionary {
+    public init<S>(throwingUniqueKeysWithValues keysAndValues: S) throws where S: Sequence, S.Element == (Key, Value) {
+        self.init()
+        for pair in keysAndValues {
+            guard !self.keys.contains(pair.0) else {
+                throw StringError("duplicate key found: '\(pair.0)'")
+            }
+            self[pair.0] = pair.1
+        }
+    }
+}
+
 extension OrderedDictionary {
     public subscript(key: Key, `default` `default`: Value) -> Value {
         set {

--- a/Sources/Commands/TestingSupport.swift
+++ b/Sources/Commands/TestingSupport.swift
@@ -45,7 +45,7 @@ enum TestingSupport {
     static func getTestSuites(in testProducts: [BuiltTestProduct], swiftTool: SwiftTool, swiftOptions: SwiftToolOptions) throws -> [AbsolutePath: [TestSuite]] {
         let testSuitesByProduct = try testProducts
             .map { try ($0.bundlePath, TestingSupport.getTestSuites(fromTestAt: $0.bundlePath, swiftTool: swiftTool, swiftOptions: swiftOptions)) }
-        return Dictionary(uniqueKeysWithValues: testSuitesByProduct)
+        return try Dictionary(throwingUniqueKeysWithValues: testSuitesByProduct)
     }
 
     /// Runs the corresponding tool to get tests JSON and create TestSuite array.

--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -191,97 +191,101 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
     }
 
     private func makeCollection(from collection: JSONModel.Collection, source: Model.CollectionSource, signature: Model.SignatureData?) -> Result<Model.Collection, Error> {
-        if let errors = self.validator.validate(collection: collection)?.errors() {
-            return .failure(JSONPackageCollectionProviderError.invalidCollection("\(errors)"))
-        }
+        do {
+            if let errors = self.validator.validate(collection: collection)?.errors() {
+                throw JSONPackageCollectionProviderError.invalidCollection("\(errors)")
+            }
 
-        var serializationOkay = true
-        let packages = collection.packages.map { package -> Model.Package in
-            let versions = package.versions.compactMap { version -> Model.Package.Version? in
-                // note this filters out / ignores missing / bad data in attempt to make the most out of the provided set
-                guard let parsedVersion = TSCUtility.Version(tag: version.version) else {
-                    return nil
-                }
-
-                let manifests = [ToolsVersion: Model.Package.Version.Manifest](uniqueKeysWithValues: version.manifests.compactMap { key, value in
-                    guard let keyToolsVersion = ToolsVersion(string: key), let manifestToolsVersion = ToolsVersion(string: value.toolsVersion) else {
+            var serializationOkay = true
+            let packages = try collection.packages.map { package -> Model.Package in
+                let versions = try package.versions.compactMap { version -> Model.Package.Version? in
+                    // note this filters out / ignores missing / bad data in attempt to make the most out of the provided set
+                    guard let parsedVersion = TSCUtility.Version(tag: version.version) else {
                         return nil
                     }
 
-                    let targets = value.targets.map { Model.Target(name: $0.name, moduleName: $0.moduleName) }
-                    if targets.count != value.targets.count {
-                        serializationOkay = false
-                    }
-                    let products = value.products.compactMap { Model.Product(from: $0, packageTargets: targets) }
-                    if products.count != value.products.count {
-                        serializationOkay = false
-                    }
-                    let minimumPlatformVersions: [PackageModel.SupportedPlatform]? = value.minimumPlatformVersions?.compactMap { PackageModel.SupportedPlatform(from: $0) }
-                    if minimumPlatformVersions?.count != value.minimumPlatformVersions?.count {
+                    let manifests: [ToolsVersion: Model.Package.Version.Manifest] = try Dictionary(throwingUniqueKeysWithValues: version.manifests.compactMap { key, value in
+                        guard let keyToolsVersion = ToolsVersion(string: key), let manifestToolsVersion = ToolsVersion(string: value.toolsVersion) else {
+                            return nil
+                        }
+
+                        let targets = value.targets.map { Model.Target(name: $0.name, moduleName: $0.moduleName) }
+                        if targets.count != value.targets.count {
+                            serializationOkay = false
+                        }
+                        let products = value.products.compactMap { Model.Product(from: $0, packageTargets: targets) }
+                        if products.count != value.products.count {
+                            serializationOkay = false
+                        }
+                        let minimumPlatformVersions: [PackageModel.SupportedPlatform]? = value.minimumPlatformVersions?.compactMap { PackageModel.SupportedPlatform(from: $0) }
+                        if minimumPlatformVersions?.count != value.minimumPlatformVersions?.count {
+                            serializationOkay = false
+                        }
+
+                        let manifest = Model.Package.Version.Manifest(
+                            toolsVersion: manifestToolsVersion,
+                            packageName: value.packageName,
+                            targets: targets,
+                            products: products,
+                            minimumPlatformVersions: minimumPlatformVersions
+                        )
+                        return (keyToolsVersion, manifest)
+                    })
+                    if manifests.count != version.manifests.count {
                         serializationOkay = false
                     }
 
-                    let manifest = Model.Package.Version.Manifest(
-                        toolsVersion: manifestToolsVersion,
-                        packageName: value.packageName,
-                        targets: targets,
-                        products: products,
-                        minimumPlatformVersions: minimumPlatformVersions
-                    )
-                    return (keyToolsVersion, manifest)
-                })
-                if manifests.count != version.manifests.count {
+                    guard let defaultToolsVersion = ToolsVersion(string: version.defaultToolsVersion) else {
+                        return nil
+                    }
+
+                    let verifiedCompatibility = version.verifiedCompatibility?.compactMap { Model.Compatibility(from: $0) }
+                    if verifiedCompatibility?.count != version.verifiedCompatibility?.count {
+                        serializationOkay = false
+                    }
+                    let license = version.license.flatMap { Model.License(from: $0) }
+
+                    return .init(version: parsedVersion,
+                                 title: nil,
+                                 summary: version.summary,
+                                 manifests: manifests,
+                                 defaultToolsVersion: defaultToolsVersion,
+                                 verifiedCompatibility: verifiedCompatibility,
+                                 license: license,
+                                 createdAt: version.createdAt)
+                }
+                if versions.count != package.versions.count {
                     serializationOkay = false
                 }
 
-                guard let defaultToolsVersion = ToolsVersion(string: version.defaultToolsVersion) else {
-                    return nil
-                }
-
-                let verifiedCompatibility = version.verifiedCompatibility?.compactMap { Model.Compatibility(from: $0) }
-                if verifiedCompatibility?.count != version.verifiedCompatibility?.count {
-                    serializationOkay = false
-                }
-                let license = version.license.flatMap { Model.License(from: $0) }
-
-                return .init(version: parsedVersion,
-                             title: nil,
-                             summary: version.summary,
-                             manifests: manifests,
-                             defaultToolsVersion: defaultToolsVersion,
-                             verifiedCompatibility: verifiedCompatibility,
-                             license: license,
-                             createdAt: version.createdAt)
-            }
-            if versions.count != package.versions.count {
-                serializationOkay = false
+                return .init(identity: .init(url: package.url),
+                             location: package.url.absoluteString,
+                             summary: package.summary,
+                             keywords: package.keywords,
+                             versions: versions,
+                             watchersCount: nil,
+                             readmeURL: package.readmeURL,
+                             license: package.license.flatMap { Model.License(from: $0) },
+                             authors: nil,
+                             languages: nil)
             }
 
-            return .init(identity: .init(url: package.url),
-                         location: package.url.absoluteString,
-                         summary: package.summary,
-                         keywords: package.keywords,
-                         versions: versions,
-                         watchersCount: nil,
-                         readmeURL: package.readmeURL,
-                         license: package.license.flatMap { Model.License(from: $0) },
-                         authors: nil,
-                         languages: nil)
-        }
+            if !serializationOkay {
+                self.observabilityScope.emit(warning: "Some of the information from \(collection.name) could not be deserialized correctly, likely due to invalid format. Contact the collection's author (\(collection.generatedBy?.name ?? "n/a")) to address this issue.")
+            }
 
-        if !serializationOkay {
-            self.observabilityScope.emit(warning: "Some of the information from \(collection.name) could not be deserialized correctly, likely due to invalid format. Contact the collection's author (\(collection.generatedBy?.name ?? "n/a")) to address this issue.")
+            return .success(.init(source: source,
+                                  name: collection.name,
+                                  overview: collection.overview,
+                                  keywords: collection.keywords,
+                                  packages: packages,
+                                  createdAt: collection.generatedAt,
+                                  createdBy: collection.generatedBy.flatMap { Model.Collection.Author(name: $0.name) },
+                                  signature: signature,
+                                  lastProcessedAt: Date()))
+        } catch {
+            return .failure(error)
         }
-
-        return .success(.init(source: source,
-                              name: collection.name,
-                              overview: collection.overview,
-                              keywords: collection.keywords,
-                              packages: packages,
-                              createdAt: collection.generatedAt,
-                              createdBy: collection.generatedBy.flatMap { Model.Collection.Author(name: $0.name) },
-                              signature: signature,
-                              lastProcessedAt: Date()))
     }
 
     private func makeRequestOptions(validResponseCodes: [Int]) -> HTTPClientRequest.Options {

--- a/Sources/PackageFingerprint/FilePackageFingerprintStorage.swift
+++ b/Sources/PackageFingerprint/FilePackageFingerprintStorage.swift
@@ -108,7 +108,7 @@ public struct FilePackageFingerprintStorage: PackageFingerprintStorage {
             try self.fileSystem.createDirectory(self.directoryPath, recursive: true)
         }
 
-        let container = StorageModel.Container(fingerprints)
+        let container = try StorageModel.Container(fingerprints)
         let buffer = try encoder.encode(container)
 
         let path = self.directoryPath.appending(component: package.fingerprintFilename)
@@ -131,8 +131,8 @@ private enum StorageModel {
     struct Container: Codable {
         let versionFingerprints: [String: [String: StoredFingerprint]]
 
-        init(_ versionFingerprints: PackageFingerprints) {
-            self.versionFingerprints = Dictionary(uniqueKeysWithValues: versionFingerprints.map { version, fingerprints in
+        init(_ versionFingerprints: PackageFingerprints) throws {
+            self.versionFingerprints = try Dictionary(throwingUniqueKeysWithValues: versionFingerprints.map { version, fingerprints in
                 let fingerprintByKind: [String: StoredFingerprint] = Dictionary(uniqueKeysWithValues: fingerprints.map { kind, fingerprint in
                     let origin: String
                     switch fingerprint.origin {
@@ -148,7 +148,7 @@ private enum StorageModel {
         }
 
         func packageFingerprints() throws -> PackageFingerprints {
-            try Dictionary(uniqueKeysWithValues: self.versionFingerprints.map { version, fingerprints in
+            try Dictionary(throwingUniqueKeysWithValues: self.versionFingerprints.map { version, fingerprints in
                 let fingerprintByKind: [Fingerprint.Kind: Fingerprint] = try Dictionary(uniqueKeysWithValues: fingerprints.map { kind, fingerprint in
                     guard let kind = Fingerprint.Kind(rawValue: kind) else {
                         throw SerializationError.unknownKind(kind)

--- a/Sources/PackageGraph/PackageGraph.swift
+++ b/Sources/PackageGraph/PackageGraph.swift
@@ -153,11 +153,11 @@ public struct PackageGraph {
         let rootTargets = rootPackages.map({ $0.targets }).flatMap({ $0 })
 
         // Create map of test target to set of its direct dependencies.
-        let testTargetDepMap: [ResolvedTarget: Set<ResolvedTarget>] = {
+        let testTargetDepMap: [ResolvedTarget: Set<ResolvedTarget>] = try {
             let testTargetDeps = rootTargets.filter({ $0.type == .test }).map({
                 ($0, Set($0.dependencies.compactMap({ $0.target })))
             })
-            return Dictionary(uniqueKeysWithValues: testTargetDeps)
+            return try Dictionary(throwingUniqueKeysWithValues: testTargetDeps)
         }()
 
         for target in rootTargets where target.type == .executable {

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -239,7 +239,7 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
             metadata: package.underlyingPackage.diagnosticsMetadata
         )
 
-        executableTargetProductMap = Dictionary(uniqueKeysWithValues:
+        executableTargetProductMap = try Dictionary(throwingUniqueKeysWithValues:
             package.products.filter { $0.type == .executable }.map { ($0.mainTarget, $0) }
         )
 

--- a/Sources/swiftpm-manifest-tool/main.swift
+++ b/Sources/swiftpm-manifest-tool/main.swift
@@ -72,7 +72,7 @@ final class PackageIndex {
         let bytes = try localFileSystem.readFileContents(indexFile).contents
         let entries = try JSONDecoder.makeWithDefaults().decode(Array<Entry>.self, from: Data(bytes: bytes, count: bytes.count))
 
-        index = Dictionary(uniqueKeysWithValues: entries.map{($0.name, $0.url)})
+        self.index = try Dictionary(throwingUniqueKeysWithValues: entries.map{($0.name, $0.url)})
     }
 }
 

--- a/Tests/BasicsTests/DictionaryTest.swift
+++ b/Tests/BasicsTests/DictionaryTest.swift
@@ -1,0 +1,36 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+@testable import Basics
+import TSCBasic
+import XCTest
+
+final class DictionaryTests: XCTestCase {
+    func testThrowingUniqueKeysWithValues() throws {
+        do {
+            let keysWithValues = [("key1", "value1"), ("key2", "value2")]
+            let dictionary = try Dictionary(throwingUniqueKeysWithValues: keysWithValues)
+            XCTAssertEqual(dictionary["key1"], "value1")
+            XCTAssertEqual(dictionary["key2"], "value2")
+        }
+        do {
+            let keysWithValues = [("key1", "value"), ("key2", "value")]
+            let dictionary = try Dictionary(throwingUniqueKeysWithValues: keysWithValues)
+            XCTAssertEqual(dictionary["key1"], "value")
+            XCTAssertEqual(dictionary["key2"], "value")
+        }
+        do {
+            let keysWithValues = [("key", "value1"), ("key", "value2")]
+            XCTAssertThrowsError(try Dictionary(throwingUniqueKeysWithValues: keysWithValues)) { error in
+                XCTAssertEqual(error as? StringError, StringError("duplicate key found: 'key'"))
+            }
+        }
+    }
+}

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -123,7 +123,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = BuildPlanResult(plan: try BuildPlan(
+        let result = try BuildPlanResult(plan: BuildPlan(
             buildParameters: mockBuildParameters(shouldLinkStaticSwiftStdlib: true),
             graph: graph,
             fileSystem: fs,
@@ -406,7 +406,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = BuildPlanResult(plan: try BuildPlan(
+        let result = try BuildPlanResult(plan: BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
             fileSystem: fileSystem,
@@ -446,7 +446,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = BuildPlanResult(plan: try BuildPlan(
+        let result = try BuildPlanResult(plan: BuildPlan(
             buildParameters: mockBuildParameters(config: .release),
             graph: graph,
             fileSystem: fs,
@@ -518,7 +518,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = BuildPlanResult(plan: try BuildPlan(
+        let result = try BuildPlanResult(plan: BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
             fileSystem: fs,
@@ -642,7 +642,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         do {
-            let result = BuildPlanResult(plan: try BuildPlan(
+            let result = try BuildPlanResult(plan: BuildPlan(
                 buildParameters: mockBuildParameters(environment: BuildEnvironment(
                     platform: .linux,
                     configuration: .release
@@ -661,7 +661,7 @@ final class BuildPlanTests: XCTestCase {
         }
 
         do {
-            let result = BuildPlanResult(plan: try BuildPlan(
+            let result = try BuildPlanResult(plan: BuildPlan(
                 buildParameters: mockBuildParameters(environment: BuildEnvironment(
                     platform: .macOS,
                     configuration: .debug
@@ -711,7 +711,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             observabilityScope: observability.topScope
         )
-        let result = BuildPlanResult(plan: plan)
+        let result = try BuildPlanResult(plan: plan)
 
         result.checkProductsCount(1)
         result.checkTargetsCount(2)
@@ -769,7 +769,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = BuildPlanResult(plan: try BuildPlan(
+        let result = try BuildPlanResult(plan: BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
             fileSystem: fs,
@@ -844,7 +844,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = BuildPlanResult(plan: try BuildPlan(
+        let result = try BuildPlanResult(plan: BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
             fileSystem: fs,
@@ -941,7 +941,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = BuildPlanResult(plan: try BuildPlan(
+        let result = try BuildPlanResult(plan: BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
             fileSystem: fs,
@@ -1009,7 +1009,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = BuildPlanResult(plan: try BuildPlan(
+        let result = try BuildPlanResult(plan: BuildPlan(
             buildParameters: mockBuildParameters(config: .release),
             graph: graph,
             fileSystem: fs,
@@ -1063,7 +1063,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = BuildPlanResult(plan: try BuildPlan(
+        let result = try BuildPlanResult(plan: BuildPlan(
             buildParameters: mockBuildParameters(shouldLinkStaticSwiftStdlib: true),
             graph: graph,
             fileSystem: fs,
@@ -1116,7 +1116,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = BuildPlanResult(plan: try BuildPlan(
+        let result = try BuildPlanResult(plan: BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
             fileSystem: fs,
@@ -1172,7 +1172,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = BuildPlanResult(plan: try BuildPlan(
+        let result = try BuildPlanResult(plan: BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
             fileSystem: fs,
@@ -1222,7 +1222,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = BuildPlanResult(plan: try BuildPlan(
+        let result = try BuildPlanResult(plan: BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: g,
             fileSystem: fs,
@@ -1313,7 +1313,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = BuildPlanResult(plan: try BuildPlan(
+        let result = try BuildPlanResult(plan: BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
             fileSystem: fs,
@@ -1381,7 +1381,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = BuildPlanResult(plan: try BuildPlan(
+        let result = try BuildPlanResult(plan: BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
             fileSystem: fs,
@@ -1500,7 +1500,7 @@ final class BuildPlanTests: XCTestCase {
         graphResult.check(targets: "ATarget", "BTarget1", "BTarget2", "CTarget")
         #endif
 
-        let planResult = BuildPlanResult(plan: try BuildPlan(
+        let planResult = try BuildPlanResult(plan: BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
             fileSystem: fileSystem,
@@ -1596,7 +1596,7 @@ final class BuildPlanTests: XCTestCase {
             try graphResult.check(reachableBuildProducts: "aexec", "BLibrary1", "BLibrary2", in: linuxDebug)
             try graphResult.check(reachableBuildTargets: "ATarget", "BTarget1", "BTarget2", in: linuxDebug)
 
-            let planResult = BuildPlanResult(plan: try BuildPlan(
+            let planResult = try BuildPlanResult(plan: BuildPlan(
                 buildParameters: mockBuildParameters(environment: linuxDebug),
                 graph: graph,
                 fileSystem: fileSystem,
@@ -1611,7 +1611,7 @@ final class BuildPlanTests: XCTestCase {
             try graphResult.check(reachableBuildProducts: "aexec", "BLibrary2", in: macosDebug)
             try graphResult.check(reachableBuildTargets: "ATarget", "BTarget2", "BTarget3", in: macosDebug)
 
-            let planResult = BuildPlanResult(plan: try BuildPlan(
+            let planResult = try BuildPlanResult(plan: BuildPlan(
                 buildParameters: mockBuildParameters(environment: macosDebug),
                 graph: graph,
                 fileSystem: fileSystem,
@@ -1626,7 +1626,7 @@ final class BuildPlanTests: XCTestCase {
             try graphResult.check(reachableBuildProducts: "aexec", "CLibrary", in: androidRelease)
             try graphResult.check(reachableBuildTargets: "ATarget", "CTarget", in: androidRelease)
 
-            let planResult = BuildPlanResult(plan: try BuildPlan(
+            let planResult = try BuildPlanResult(plan: BuildPlan(
                 buildParameters: mockBuildParameters(environment: androidRelease),
                 graph: graph,
                 fileSystem: fileSystem,
@@ -1771,7 +1771,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = BuildPlanResult(plan: try BuildPlan(
+        let result = try BuildPlanResult(plan: BuildPlan(
             buildParameters: mockBuildParameters(destinationTriple: .windows),
             graph: graph,
             fileSystem: fs,
@@ -1832,7 +1832,7 @@ final class BuildPlanTests: XCTestCase {
 
         var parameters = mockBuildParameters(destinationTriple: .wasi)
         parameters.shouldLinkStaticSwiftStdlib = true
-        let result = BuildPlanResult(plan: try BuildPlan(
+        let result = try BuildPlanResult(plan: BuildPlan(
             buildParameters: parameters,
             graph: graph,
             fileSystem: fs,
@@ -1915,7 +1915,7 @@ final class BuildPlanTests: XCTestCase {
         )
 
         func createResult(for triple: TSCUtility.Triple) throws -> BuildPlanResult {
-            BuildPlanResult(plan: try BuildPlan(
+            try BuildPlanResult(plan: BuildPlan(
                 buildParameters: mockBuildParameters(canRenameEntrypointFunctionName: true, destinationTriple: triple),
                 graph: graph,
                 fileSystem: fs,
@@ -1963,7 +1963,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         func check(for mode: BuildParameters.IndexStoreMode, config: BuildConfiguration) throws {
-            let result = BuildPlanResult(plan: try BuildPlan(
+            let result = try BuildPlanResult(plan: BuildPlan(
                 buildParameters: mockBuildParameters(config: config, indexStoreMode: mode),
                 graph: graph,
                 fileSystem: fs,
@@ -2029,7 +2029,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = BuildPlanResult(plan: try BuildPlan(
+        let result = try BuildPlanResult(plan: BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
             fileSystem: fileSystem,
@@ -2203,7 +2203,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         func createResult(for dest: TSCUtility.Triple) throws -> BuildPlanResult {
-            return BuildPlanResult(plan: try BuildPlan(
+            return try BuildPlanResult(plan: BuildPlan(
                 buildParameters: mockBuildParameters(destinationTriple: dest),
                 graph: graph,
                 fileSystem: fs,
@@ -2273,7 +2273,7 @@ final class BuildPlanTests: XCTestCase {
 
         var flags = BuildFlags()
         flags.linkerFlags = ["-L", "/path/to/foo", "-L/path/to/foo", "-rpath=foo", "-rpath", "foo"]
-        let result = BuildPlanResult(plan: try BuildPlan(
+        let result = try BuildPlanResult(plan: BuildPlan(
             buildParameters: mockBuildParameters(flags: flags),
             graph: graph,
             fileSystem: fs,
@@ -2314,7 +2314,7 @@ final class BuildPlanTests: XCTestCase {
         let mockToolchain = try UserToolchain(destination: userDestination)
         let extraBuildParameters = mockBuildParameters(toolchain: mockToolchain,
             flags: BuildFlags(xcc: ["-clang-command-line-flag"], xswiftc: ["-swift-command-line-flag"]))
-        let result = BuildPlanResult(plan: try BuildPlan(
+        let result = try BuildPlanResult(plan: BuildPlan(
             buildParameters: extraBuildParameters,
             graph: graph,
             fileSystem: fs,
@@ -2422,7 +2422,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             observabilityScope: observability.topScope
         )
-        let result = BuildPlanResult(plan: plan)
+        let result = try BuildPlanResult(plan: plan)
 
         let fooTarget = try result.target(for: "Foo").swiftTarget().compileArguments()
         #if os(macOS)
@@ -2493,7 +2493,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             observabilityScope: observability.topScope
         )
-        let result = BuildPlanResult(plan: plan)
+        let result = try BuildPlanResult(plan: plan)
 
          let fooTarget = try result.target(for: "Foo").swiftTarget().compileArguments()
          #if os(macOS)
@@ -2565,7 +2565,7 @@ final class BuildPlanTests: XCTestCase {
             observabilityScope: observability.topScope
         )
         let dynamicLibraryExtension = plan.buildParameters.triple.dynamicLibraryExtension
-        let result = BuildPlanResult(plan: plan)
+        let result = try BuildPlanResult(plan: plan)
 
          let fooTarget = try result.target(for: "Foo").swiftTarget().compileArguments()
          #if os(macOS)
@@ -2619,7 +2619,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = BuildPlanResult(plan: try BuildPlan(
+        let result = try BuildPlanResult(plan: BuildPlan(
             buildParameters: mockBuildParameters(destinationTriple: .x86_64Linux),
             graph: graph,
             fileSystem: fs,
@@ -2697,7 +2697,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             observabilityScope: observability.topScope
         )
-        let result = BuildPlanResult(plan: plan)
+        let result = try BuildPlanResult(plan: plan)
 
         let fooTarget = try result.target(for: "Foo").swiftTarget()
         XCTAssertEqual(fooTarget.objects.map{ $0.pathString }, [
@@ -2761,7 +2761,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             observabilityScope: observability.topScope
         )
-        let result = BuildPlanResult(plan: plan)
+        let result = try BuildPlanResult(plan: plan)
 
         let fooTarget = try result.target(for: "Foo").swiftTarget()
         XCTAssertEqual(fooTarget.objects.map{ $0.pathString }, [
@@ -2806,7 +2806,7 @@ final class BuildPlanTests: XCTestCase {
 
         let supportingTriples: [TSCUtility.Triple] = [.x86_64Linux, .arm64Linux, .wasi]
         for triple in supportingTriples {
-            let result = BuildPlanResult(plan: try BuildPlan(
+            let result = try BuildPlanResult(plan: BuildPlan(
                 buildParameters: mockBuildParameters(shouldLinkStaticSwiftStdlib: true, destinationTriple: triple),
                 graph: graph,
                 fileSystem: fs,
@@ -2924,7 +2924,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = BuildPlanResult(plan: try BuildPlan(
+        let result = try BuildPlanResult(plan: BuildPlan(
             buildParameters: mockBuildParameters(destinationTriple: destinationTriple),
             graph: graph,
             fileSystem: fs,
@@ -3027,7 +3027,7 @@ final class BuildPlanTests: XCTestCase {
         )
 
         XCTAssertNoDiagnostics(observability.diagnostics)
-        let result = BuildPlanResult(plan: try BuildPlan(
+        let result = try BuildPlanResult(plan: BuildPlan(
             buildParameters: mockBuildParameters(destinationTriple: destinationTriple),
             graph: graph,
             fileSystem: fs,
@@ -3103,7 +3103,7 @@ final class BuildPlanTests: XCTestCase {
         var parameters = mockBuildParameters(shouldLinkStaticSwiftStdlib: true)
         parameters.sanitizers = EnabledSanitizers([sanitizer])
 
-        let result = BuildPlanResult(plan: try BuildPlan(
+        let result = try BuildPlanResult(plan: BuildPlan(
             buildParameters: parameters,
             graph: graph,
             fileSystem: fs,
@@ -3138,10 +3138,10 @@ private struct BuildPlanResult {
     let targetMap: [String: TargetBuildDescription]
     let productMap: [String: ProductBuildDescription]
 
-    init(plan: BuildPlan) {
+    init(plan: BuildPlan) throws {
         self.plan = plan
-        self.productMap = Dictionary(uniqueKeysWithValues: plan.buildProducts.map{ ($0.product.name, $0) })
-        self.targetMap = Dictionary(uniqueKeysWithValues: plan.targetMap.map{ ($0.0.name, $0.1) })
+        self.productMap = try Dictionary(throwingUniqueKeysWithValues: plan.buildProducts.map{ ($0.product.name, $0) })
+        self.targetMap = try Dictionary(throwingUniqueKeysWithValues: plan.targetMap.map{ ($0.0.name, $0.1) })
     }
 
     func checkTargetsCount(_ count: Int, file: StaticString = #file, line: UInt = #line) {

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -1738,7 +1738,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Check that we can compute missing dependencies.
         try workspace.loadDependencyManifests(roots: ["Root1", "Root2"]) { manifests, diagnostics in
-            XCTAssertEqual(manifests.missingPackages().map { $0.locationString }.sorted(), ["/tmp/ws/pkgs/Bar", "/tmp/ws/pkgs/Foo"])
+            XCTAssertEqual(try! manifests.missingPackages().map { $0.locationString }.sorted(), ["/tmp/ws/pkgs/Bar", "/tmp/ws/pkgs/Foo"])
             XCTAssertNoDiagnostics(diagnostics)
         }
 
@@ -1752,7 +1752,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Check that we compute the correct missing dependencies.
         try workspace.loadDependencyManifests(roots: ["Root1", "Root2"]) { manifests, diagnostics in
-            XCTAssertEqual(manifests.missingPackages().map { $0.locationString }.sorted(), ["/tmp/ws/pkgs/Bar"])
+            XCTAssertEqual(try! manifests.missingPackages().map { $0.locationString }.sorted(), ["/tmp/ws/pkgs/Bar"])
             XCTAssertNoDiagnostics(diagnostics)
         }
 
@@ -1766,7 +1766,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Check that we compute the correct missing dependencies.
         try workspace.loadDependencyManifests(roots: ["Root1", "Root2"]) { manifests, diagnostics in
-            XCTAssertEqual(manifests.missingPackages().map { $0.locationString }.sorted(), [])
+            XCTAssertEqual(try! manifests.missingPackages().map { $0.locationString }.sorted(), [])
             XCTAssertNoDiagnostics(diagnostics)
         }
     }


### PR DESCRIPTION
motivation: Dictionary::uniqueKeysWithValues is asserting and will crash the process on bad data. need a throwing variant

changes:
* create Dictionary::throwingUniqueKeysWithValues which is the same as uniqueKeysWithValues but throwing insteada of asserting on duplicate key
* update call sites that take user data (which is not sanitized) to use the throwing variant
* update relevant call sites to new throwing signatures
* add test