### PR TITLE
[Docs] Fix broken link in Usage.md

### DIFF
--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -737,8 +737,7 @@ xcodebuild -showdestinations -scheme Foo
 C language targets are similar to Swift targets, except that the C language
 libraries should contain a directory named `include` to hold the public headers.
 
-To allow a Swift target to import a C language target, add a [target
-dependency](#targets) in the manifest file. Swift Package Manager will
+To allow a Swift target to import a C language target, add a [target](PackageDescription.md#target) in the manifest file. Swift Package Manager will
 automatically generate a modulemap for each C language library target for these
 3 cases:
 


### PR DESCRIPTION
Fixes a broken link. 
The link got broken by https://github.com/apple/swift-package-manager/commit/4ee5feda08e7f9d760a4bc1397500fc23ec5bb29, and currently, the linked file no longer exists. Thus, I set to a suitable link.

