### PR TITLE
Add a simple argument extractor to PackagePlugin

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -507,6 +507,10 @@ let package = Package(
             dependencies: ["PackageFingerprint", "SPMTestSupport"]
         ),
         .testTarget(
+            name: "PackagePluginAPITests",
+            dependencies: ["PackagePlugin", "SPMTestSupport"]
+        ),
+        .testTarget(
             name: "PackageRegistryTests",
             dependencies: ["SPMTestSupport", "PackageRegistry"]
         ),

--- a/Sources/PackagePlugin/ArgumentExtractor.swift
+++ b/Sources/PackagePlugin/ArgumentExtractor.swift
@@ -1,0 +1,75 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+/// A rudimentary helper for extracting options and flags from a string list representing command line arguments. The idea is to extract all known options and flags, leaving just the positional arguments. This does not handle well the case in which positional arguments (or option argument values) happen to have the same name as an option or a flag. It only handles the long `--<name>` form of options, but it does respect `--` as an indication that all remaining arguments are positional.
+public struct ArgumentExtractor {
+    private var args: [String]
+    private let literals: [String]
+
+    /// Initializes a ArgumentExtractor with a list of strings from which to extract flags and options. If the list contains `--`, any arguments that follow it are considered to be literals.
+    public init(_ arguments: [String]) {
+        // Split the array on the first `--`, if there is one. Everything after that is a literal.
+        let parts = arguments.split(separator: "--", maxSplits: 1, omittingEmptySubsequences: false)
+        self.args = Array(parts[0])
+        self.literals = Array(parts.count == 2 ? parts[1] : [])
+    }
+
+    /// Extracts options of the form `--<name> <value>` or `--<name>=<value>` from the remaining arguments, and returns the extracted values.
+    public mutating func extractOption(named name: String) -> [String] {
+        var values: [String] = []
+        var idx = 0
+        while idx < args.count {
+            var arg = args[idx]
+            if arg == "--\(name)" {
+                args.remove(at: idx)
+                if idx < args.count {
+                    let val = args[idx]
+                    values.append(val)
+                    args.remove(at: idx)
+                }
+            }
+            else if arg.starts(with: "--\(name)=") {
+                arg.removeFirst(2 + name.count + 1)
+                values.append(arg)
+            }
+            else {
+                idx += 1
+            }
+        }
+        return values
+    }
+
+    /// Extracts flags of the form `--<name>` from the remaining arguments, and returns the count.
+    public mutating func extractFlag(named name: String) -> Int {
+        var count = 0
+        var idx = 0
+        while idx < args.count {
+            let arg = args[idx]
+            if arg == "--\(name)" {
+                args.remove(at: idx)
+                count += 1
+            }
+            else {
+                idx += 1
+            }
+        }
+        return count
+    }
+
+    /// Returns any unextracted flags or options (based strictly on whether remaining arguments have a "--" prefix).
+    public var unextractedOptionsOrFlags: [String] {
+        return args.filter{ $0.hasPrefix("--") }
+    }
+
+    /// Returns all remaining arguments, including any literals after the first `--` if there is one.
+    public var remainingArguments: [String] {
+        return args + literals
+    }
+}

--- a/Sources/PackagePlugin/CMakeLists.txt
+++ b/Sources/PackagePlugin/CMakeLists.txt
@@ -1,12 +1,13 @@
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2021 Apple Inc. and the Swift project authors
+# Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_library(PackagePlugin
+  ArgumentExtractor.swift
   Command.swift
   Context.swift
   Diagnostics.swift

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -1728,15 +1728,27 @@ final class PackageToolTests: CommandsTestCase {
                         targets: [Target],
                         arguments: [String]
                     ) throws {
-                        let product = arguments[0]
-                        let verbose = arguments.contains("verbose")
-                        let release = arguments.contains("release")
+                        // Extract the plugin arguments.
+                        var argExtractor = ArgumentExtractor(arguments)
+                        let productNames = argExtractor.extractOption(named: "product")
+                        if productNames.count != 1 {
+                            throw "Expected exactly one product name, but had: \\(productNames.joined(separator: ", "))"
+                        }
+                        let printCommands = (argExtractor.extractFlag(named: "print-commands") > 0)
+                        let release = (argExtractor.extractFlag(named: "release") > 0)
+                        if let unextractedArgs = argExtractor.unextractedOptionsOrFlags.first {
+                            throw "Unknown option: \\(unextractedArgs)"
+                        }
+                        let positionalArgs = argExtractor.remainingArguments
+                        if !positionalArgs.isEmpty {
+                            throw "Unexpected extra arguments: \\(positionalArgs)"
+                        }
                         do {
                             var parameters = PackageManager.BuildParameters()
                             parameters.configuration = release ? .release : .debug
-                            parameters.logging = verbose ? .verbose : .concise
+                            parameters.logging = printCommands ? .verbose : .concise
                             parameters.otherSwiftcFlags = ["-DEXTRA_SWIFT_FLAG"]
-                            let result = try packageManager.build(.product(product), parameters: parameters)
+                            let result = try packageManager.build(.product(productNames[0]), parameters: parameters)
                             print("succeeded: \\(result.succeeded)")
                             for artifact in result.builtArtifacts {
                                 print("artifact-path: \\(artifact.path.string)")
@@ -1749,6 +1761,7 @@ final class PackageToolTests: CommandsTestCase {
                         }
                     }
                 }
+                extension String: Error {}
                 """
             )
             let myLibraryTargetDir = packageDir.appending(components: "Sources", "MyLibrary")
@@ -1767,7 +1780,7 @@ final class PackageToolTests: CommandsTestCase {
 
             // Invoke the plugin with parameters choosing a verbose build of MyExecutable for debugging.
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["my-build-tester", "MyExecutable", "verbose"], packagePath: packageDir)
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["my-build-tester", "--product", "MyExecutable", "--print-commands"], packagePath: packageDir)
                 let output = try result.utf8Output() + result.utf8stderrOutput()
                 XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
                 XCTAssertMatch(output, .contains("Building for debugging..."))
@@ -1782,7 +1795,7 @@ final class PackageToolTests: CommandsTestCase {
 
             // Invoke the plugin with parameters choosing a concise build of MyExecutable for release.
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["my-build-tester", "MyExecutable", "release"], packagePath: packageDir)
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["my-build-tester", "--product", "MyExecutable", "--release"], packagePath: packageDir)
                 let output = try result.utf8Output() + result.utf8stderrOutput()
                 XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
                 XCTAssertMatch(output, .contains("Building for production..."))
@@ -1796,7 +1809,7 @@ final class PackageToolTests: CommandsTestCase {
 
             // Invoke the plugin with parameters choosing a verbose build of MyStaticLibrary for release.
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["my-build-tester", "MyStaticLibrary", "verbose", "release"], packagePath: packageDir)
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["my-build-tester", "--product", "MyStaticLibrary", "--print-commands", "--release"], packagePath: packageDir)
                 let output = try result.utf8Output() + result.utf8stderrOutput()
                 XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
                 XCTAssertMatch(output, .contains("Building for production..."))
@@ -1810,7 +1823,7 @@ final class PackageToolTests: CommandsTestCase {
 
             // Invoke the plugin with parameters choosing a verbose build of MyDynamicLibrary for release.
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["my-build-tester", "MyDynamicLibrary", "verbose", "release"], packagePath: packageDir)
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["my-build-tester", "--product", "MyDynamicLibrary", "--print-commands", "--release"], packagePath: packageDir)
                 let output = try result.utf8Output() + result.utf8stderrOutput()
                 XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
                 XCTAssertMatch(output, .contains("Building for production..."))

--- a/Tests/PackagePluginAPITests/ArgumentExtractorTests.swift
+++ b/Tests/PackagePluginAPITests/ArgumentExtractorTests.swift
@@ -1,0 +1,47 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import PackagePlugin
+import XCTest
+
+class ArgumentExtractorAPITests: XCTestCase {
+
+    func testBasics() throws {
+        var extractor = ArgumentExtractor(["--verbose", "--target", "Target1", "Positional1", "--flag", "--verbose", "--target", "Target2", "Positional2"])
+        XCTAssertEqual(extractor.extractOption(named: "target"), ["Target1", "Target2"])
+        XCTAssertEqual(extractor.extractFlag(named: "flag"), 1)
+        XCTAssertEqual(extractor.extractFlag(named: "verbose"), 2)
+        XCTAssertEqual(extractor.extractFlag(named: "nothing"), 0)
+        XCTAssertEqual(extractor.unextractedOptionsOrFlags, [])
+        XCTAssertEqual(extractor.remainingArguments, ["Positional1", "Positional2"])
+    }
+
+    func testDashDashTerminal() throws {
+        var extractor = ArgumentExtractor(["--verbose", "--", "--target", "Target1", "Positional", "--verbose"])
+        XCTAssertEqual(extractor.extractOption(named: "target"), [])
+        XCTAssertEqual(extractor.extractFlag(named: "verbose"), 1)
+        XCTAssertEqual(extractor.unextractedOptionsOrFlags, [])
+        XCTAssertEqual(extractor.remainingArguments, ["--target", "Target1", "Positional", "--verbose"])
+    }
+
+    func testEdgeCases() throws {
+        var extractor1 = ArgumentExtractor([])
+        XCTAssertEqual(extractor1.extractOption(named: "target"), [])
+        XCTAssertEqual(extractor1.extractFlag(named: "verbose"), 0)
+        XCTAssertEqual(extractor1.unextractedOptionsOrFlags, [])
+        XCTAssertEqual(extractor1.remainingArguments, [])
+
+        var extractor2 = ArgumentExtractor(["--"])
+        XCTAssertEqual(extractor2.extractOption(named: "target"), [])
+        XCTAssertEqual(extractor2.extractFlag(named: "verbose"), 0)
+        XCTAssertEqual(extractor2.unextractedOptionsOrFlags, [])
+        XCTAssertEqual(extractor2.remainingArguments, [])
+    }
+}


### PR DESCRIPTION
This helps with simple cases until it is possible to use SwiftArgumentParser or other package dependencies from package plugins

### Motivation:

The initial version of plugins can't yet link against other modules, which excludes use of SwiftArgumentParser and similar libraries.  Plugins with more advanced needs will probably include an implementation of one of the other, simpler argument parser libraries available, but after discussion we've agreed that something minimal that operates on just string lists may make sense.  The future is clearly to use the proper argument parser, but this is a useful helper until we have that.

### Modifications:

- add an ArgumentExtractor type to the PackagePlugin module
- added a new dedicated unit test for this PackagePlugin API
- extended an end-to-end plugin unit test

### Result:

Simple extraction of argument options and flags from a plugin are possible without additional code.
