### PR TITLE
Simplify the command plugin method to get all the inputs in `arguments` instead of a specific `targets` parameter

### DIFF
--- a/Sources/PackagePlugin/Errors.swift
+++ b/Sources/PackagePlugin/Errors.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -12,6 +12,12 @@ public enum PluginContextError: Error {
     /// Could not find a tool with the given name. This could be either because
     /// it doesn't exist, or because the plugin doesn't have a dependency on it.
     case toolNotFound(name: String)
+
+    /// Could not find a target with the given name.
+    case targetNotFound(name: String, package: Package)
+
+    /// Could not find a product with the given name.
+    case productNotFound(name: String, package: Package)
 }
 
 extension PluginContextError: CustomStringConvertible {
@@ -19,6 +25,10 @@ extension PluginContextError: CustomStringConvertible {
         switch self {
         case .toolNotFound(let name):
             return "Plugin does not have access to a tool named ‘\(name)’"
+        case .targetNotFound(let name, let package):
+            return "Package ‘\(package.displayName)’ has no target named ‘\(name)’"
+        case .productNotFound(let name, let package):
+            return "Package ‘\(package.displayName)’ has no product named ‘\(name)’"
         }
     }
 }

--- a/Sources/PackagePlugin/PackageModel.swift
+++ b/Sources/PackagePlugin/PackageModel.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -412,6 +412,30 @@ public enum FileType {
 
     /// A file not covered by any other rule.
     case unknown
+}
+
+extension Package {
+    /// The list of targets matching the given names. Throws an error if any of
+    /// the targets cannot be found.
+    public func targets(named targetNames: [String]) throws -> [Target] {
+        return try targetNames.map { name in
+            guard let target = self.targets.first(where: { $0.name == name }) else {
+                throw PluginContextError.targetNotFound(name: name, package: self)
+            }
+            return target
+        }
+    }
+
+    /// The list of products matching the given names. Throws an error if any of
+    /// the products cannot be found.
+    public func products(named productNames: [String]) throws -> [Product] {
+        return try productNames.map { name in
+            guard let product = self.products.first(where: { $0.name == name }) else {
+                throw PluginContextError.productNotFound(name: name, package: self)
+            }
+            return product
+        }
+    }
 }
 
 extension Target {

--- a/Sources/PackagePlugin/Plugin.swift
+++ b/Sources/PackagePlugin/Plugin.swift
@@ -180,7 +180,7 @@ extension Plugin {
                     }
                 }
                 
-            case .performCommand(let targets, let arguments):
+            case .performCommand(let arguments):
                 // Check that the plugin implements the appropriate protocol
                 // for its declared capability.
                 guard let plugin = plugin as? CommandPlugin else {
@@ -189,7 +189,7 @@ extension Plugin {
                 }
                 
                 // Invoke the plugin to perform its custom logic.
-                try await plugin.performCommand(context: context, targets: targets, arguments: arguments)
+                try await plugin.performCommand(context: context, arguments: arguments)
             }
             
             // Exit with a zero exit code to indicate success.

--- a/Sources/PackagePlugin/PluginInput.swift
+++ b/Sources/PackagePlugin/PluginInput.swift
@@ -20,7 +20,7 @@ struct PluginInput {
     let pluginAction: PluginAction
     enum PluginAction {
         case createBuildToolCommands(target: Target)
-        case performCommand(targets: [Target], arguments: [String])
+        case performCommand(arguments: [String])
     }
     
     internal init(from input: WireInput) throws {
@@ -37,8 +37,8 @@ struct PluginInput {
         switch input.pluginAction {
         case .createBuildToolCommands(let targetId):
             self.pluginAction = .createBuildToolCommands(target: try deserializer.target(for: targetId))
-        case .performCommand(let targetIds, let arguments):
-            self.pluginAction = .performCommand(targets: try targetIds.map{ try deserializer.target(for: $0) }, arguments: arguments)
+        case .performCommand(let arguments):
+            self.pluginAction = .performCommand(arguments: arguments)
         }
     }
 }
@@ -295,7 +295,7 @@ internal struct WireInput: Decodable {
     /// the capabilities declared for the plugin.
     enum PluginAction: Decodable {
         case createBuildToolCommands(targetId: Target.Id)
-        case performCommand(targetIds: [Target.Id], arguments: [String])
+        case performCommand(arguments: [String])
     }
 
     /// A single absolute path in the wire structure, represented as a tuple

--- a/Sources/PackagePlugin/Protocols.swift
+++ b/Sources/PackagePlugin/Protocols.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -47,11 +47,6 @@ public protocol CommandPlugin: Plugin {
         /// directories, etc.
         context: PluginContext,
         
-        /// The targets to which the command should be applied. If the invoker of
-        /// the command has not specified particular targets, this will be a list
-        /// of all the targets in the package to which the command is applied.
-        targets: [Target],
-        
         /// Any literal arguments passed after the verb in the command invocation.
         arguments: [String]
     ) async throws
@@ -61,8 +56,7 @@ public protocol CommandPlugin: Plugin {
     var packageManager: PackageManager { get }
 }
 
-extension CommandPlugin {
-    
+extension CommandPlugin {    
     /// A proxy to the Swift Package Manager or IDE hosting the command plugin,
     /// through which the plugin can ask for specialized information or actions.
     public var packageManager: PackageManager {

--- a/Sources/SPMBuildCore/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/PluginInvocation.swift
@@ -20,7 +20,7 @@ public typealias Diagnostic = Basics.Diagnostic
 
 public enum PluginAction {
     case createBuildToolCommands(target: ResolvedTarget)
-    case performCommand(targets: [ResolvedTarget], arguments: [String])
+    case performCommand(arguments: [String])
 }
 
 extension PluginTarget {
@@ -600,7 +600,7 @@ public struct PluginScriptRunnerInput: Codable {
     /// the capabilities declared for the plugin.
     enum PluginAction: Codable {
         case createBuildToolCommands(targetId: Target.Id)
-        case performCommand(targetIds: [Target.Id], arguments: [String])
+        case performCommand(arguments: [String])
     }
 
     /// A single absolute path in the wire structure, represented as a tuple
@@ -791,9 +791,8 @@ struct PluginScriptRunnerInputSerializer {
                 throw StringError("unexpectedly was unable to serialize target \(target)")
             }
             serializedPluginAction = .createBuildToolCommands(targetId: targetId)
-        case .performCommand(let targets, let arguments):
-            let targetIds = try targets.compactMap { try serialize(target: $0) }
-            serializedPluginAction = .performCommand(targetIds: targetIds, arguments: arguments)
+        case .performCommand(let arguments):
+            serializedPluginAction = .performCommand(arguments: arguments)
         }
         return PluginScriptRunnerInput(
             paths: paths,

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -229,7 +229,6 @@ class PluginTests: XCTestCase {
                 @main struct MyCommandPlugin: CommandPlugin {
                     func performCommand(
                         context: PluginContext,
-                        targets: [Target],
                         arguments: [String]
                     ) throws {
                         // Check the identity of the root packages.
@@ -249,7 +248,6 @@ class PluginTests: XCTestCase {
                     struct MyCommandPlugin: CommandPlugin {
                         func performCommand(
                             context: PluginContext,
-                            targets: [Target],
                             arguments: [String]
                         ) throws {
                             // Print some output that should appear before the error diagnostic.
@@ -271,7 +269,6 @@ class PluginTests: XCTestCase {
                     struct MyCommandPlugin: CommandPlugin {
                         func performCommand(
                             context: PluginContext,
-                            targets: [Target],
                             arguments: [String]
                         ) throws {
                             // Print some output that should appear before we exit.
@@ -406,7 +403,7 @@ class PluginTests: XCTestCase {
                 let delegate = PluginDelegate(delegateQueue: delegateQueue)
                 do {
                     let success = try tsc_await { plugin.invoke(
-                        action: .performCommand(targets: targets, arguments: arguments),
+                        action: .performCommand(arguments: arguments),
                         package: package,
                         buildEnvironment: BuildEnvironment(platform: .macOS, configuration: .debug),
                         scriptRunner: scriptRunner,


### PR DESCRIPTION
As part of this we simplify the command plugin method to not have a `targets` parameter but to instead get all the inputs in `arguments`.

Any `--target` or `--product` flags from the `swift package` invocation are now prepended as `--target` and `--product` parameters in the plugin arguments, respectively, and the ArgumentExtractor helper type makes it easier to get at this information from the plugin.  Also add methods to make it easier to look up products and targets in the plugin context's package.

### Motivation:

The `targets` parameter was fairly specific and didn't account for products and other entities that the plugin might instead operate on.  Providing API inside the plugin to help look this up based on arguments provides more flexibility for the plugin.

### Modifications:

- pass on any `--target` and `--product` flags to the `swift package` command corresponding parameters in `arguments`
- remove the `targets` parameter from the `performCommand()` method
- add PackagePlugin helpers to look up targets and products
- adjust and extend unit tests

rdar://86786279