### PR TITLE
Update the SwiftPM version to 5.7 on main

### DIFF
--- a/Sources/Basics/SwiftVersion.swift
+++ b/Sources/Basics/SwiftVersion.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021 - 2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -63,7 +63,7 @@ public struct SwiftVersion {
 extension SwiftVersion {
     /// The current version of the package manager.
     public static let currentVersion = SwiftVersion(
-        version: (5, 6, 0),
+        version: (5, 7, 0),
         isDevelopment: true,
         buildIdentifier: getBuildIdentifier()
     )

--- a/Sources/PackageModel/ToolsVersion.swift
+++ b/Sources/PackageModel/ToolsVersion.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -25,6 +25,7 @@ public struct ToolsVersion: Equatable, Hashable, Codable {
     public static let v5_4 = ToolsVersion(version: "5.4.0")
     public static let v5_5 = ToolsVersion(version: "5.5.0")
     public static let v5_6 = ToolsVersion(version: "5.6.0")
+    public static let v5_7 = ToolsVersion(version: "5.7.0")
     public static let vNext = ToolsVersion(version: "999.0.0")
 
     /// The current tools version in use.

--- a/Tests/PackageLoadingTests/PD_5_6_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_6_LoadingTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021 - 2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -201,5 +201,30 @@ class PackageDescription5_6LoadingTests: PackageDescriptionLoadingTests {
         let name = parsedManifest.components?.last ?? ""
         let swiftFiles = manifest.displayName.split(separator: ",").map(String.init)
         XCTAssertNotNil(swiftFiles.firstIndex(of: name))
+    }
+
+    func testCommandPluginTarget() throws {
+        let content = """
+            import PackageDescription
+            let package = Package(
+               name: "Foo",
+               targets: [
+                   .plugin(
+                       name: "Foo",
+                       capability: .command(
+                           intent: .custom(verb: "mycmd", description: "helpful description of mycmd"),
+                           permissions: [ .writeToPackageDirectory(reason: "YOLO") ]
+                       )
+                   )
+               ]
+            )
+            """
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
+        XCTAssertEqual(manifest.targets[0].type, .plugin)
+        XCTAssertEqual(manifest.targets[0].pluginCapability, .command(intent: .custom(verb: "mycmd", description: "helpful description of mycmd"), permissions: [.writeToPackageDirectory(reason: "YOLO")]))
     }
 }

--- a/Tests/PackageLoadingTests/PD_5_7_LoadingTests .swift
+++ b/Tests/PackageLoadingTests/PD_5_7_LoadingTests .swift
@@ -1,23 +1,20 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021 - 2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import Basics
+import PackageModel
+import SPMTestSupport
 import XCTest
 
-import TSCBasic
-import TSCUtility
-import SPMTestSupport
-import PackageModel
-import PackageLoading
-
-class PackageDescriptionNextVersionLoadingTests: PackageDescriptionLoadingTests {
+class PackageDescription5_7LoadingTests: PackageDescriptionLoadingTests {
     override var toolsVersion: ToolsVersion {
-        .vNext
+        .v5_7
     }
 }

--- a/Tests/PackageLoadingTests/PD_Next_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_Next_LoadingTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021 - 2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -43,30 +43,5 @@ class PackageDescriptionNextLoadingTests: PackageDescriptionLoadingTests {
         XCTAssertEqual(deps["x.baz"], .registry(identity: "x.baz", requirement: .range("1.1.1" ..< "2.0.0")))
         XCTAssertEqual(deps["x.qux"], .registry(identity: "x.qux", requirement: .range("1.1.1" ..< "1.2.0")))
         XCTAssertEqual(deps["x.quux"], .registry(identity: "x.quux", requirement: .range("1.1.1" ..< "3.0.0")))
-    }
-
-    func testCommandPluginTarget() throws {
-        let content = """
-            import PackageDescription
-            let package = Package(
-               name: "Foo",
-               targets: [
-                   .plugin(
-                       name: "Foo",
-                       capability: .command(
-                           intent: .custom(verb: "mycmd", description: "helpful description of mycmd"),
-                           permissions: [ .writeToPackageDirectory(reason: "YOLO") ]
-                       )
-                   )
-               ]
-            )
-            """
-
-        let observability = ObservabilitySystem.makeForTesting()
-        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
-
-        XCTAssertEqual(manifest.targets[0].type, .plugin)
-        XCTAssertEqual(manifest.targets[0].pluginCapability, .command(intent: .custom(verb: "mycmd", description: "helpful description of mycmd"), permissions: [.writeToPackageDirectory(reason: "YOLO")]))
     }
 }


### PR DESCRIPTION
Also clean up what seems like a couple of mistakes from previous updates (detailed under _Modifications_, below).

### Motivation:

This is necessary bookkeeping that is done whenever a new minor (or major) Swift version is announced.  In this case https://forums.swift.org/t/swift-5-7/54862.

### Modifications:

- add a `v5_7` enum case to `SwiftVersion`
- mark the current version as 5.7.0
- create a new `PD_5_7_LoadingTests.swift` with no tests in it for now
- create a new `PD_Next_LoadingTests.swift`
   - it still has `testRegistryDependencies` since this still needs the 999.0 (`vNext`) availability
- also clean up what seems like a couple of mistakes from previous updates:
  - remove a defunct `PDNextVersionLoadingTests.swift` (the new name is `PD_Next_LoadingTests.swift`)
  - move a the `testCommandPluginTarget` test to the 5.6 tests
