### PR TITLE
Make PackagePlugin `Path.init()` public, clean up conformances

### DIFF
--- a/Sources/PackagePlugin/Diagnostics.swift
+++ b/Sources/PackagePlugin/Diagnostics.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -19,32 +19,32 @@ public struct Diagnostics {
     }
     
     /// Emits an error with a specified severity and message, and optional file path and line number.
-    public static func emit(_ severity: Severity, _ description: String, file: Path? = #file, line: Int? = #line) {
+    public static func emit(_ severity: Severity, _ description: String, file: String? = #file, line: Int? = #line) {
         let message: PluginToHostMessage
         switch severity {
         case .error:
-            message = .emitDiagnostic(severity: .error, message: description, file: file?.string, line: line)
+            message = .emitDiagnostic(severity: .error, message: description, file: file, line: line)
         case .warning:
-            message = .emitDiagnostic(severity: .warning, message: description, file: file?.string, line: line)
+            message = .emitDiagnostic(severity: .warning, message: description, file: file, line: line)
         case .remark:
-            message = .emitDiagnostic(severity: .remark, message: description, file: file?.string, line: line)
+            message = .emitDiagnostic(severity: .remark, message: description, file: file, line: line)
         }
         // FIXME: Handle problems sending the message.
         try? pluginHostConnection.sendMessage(message)
     }
 
     /// Emits an error with the specified message, and optional file path and line number.
-    public static func error(_ message: String, file: Path? = #file, line: Int? = #line) {
+    public static func error(_ message: String, file: String? = #file, line: Int? = #line) {
         self.emit(.error, message, file: file, line: line)
     }
 
     /// Emits a warning with the specified message, and optional file path and line number.
-    public static func warning(_ message: String, file: Path? = #file, line: Int? = #line) {
+    public static func warning(_ message: String, file: String? = #file, line: Int? = #line) {
         self.emit(.warning, message, file: file, line: line)
     }
 
     /// Emits a remark with the specified message, and optional file path and line number.
-    public static func remark(_ message: String, file: Path? = #file, line: Int? = #line) {
+    public static func remark(_ message: String, file: String? = #file, line: Int? = #line) {
         self.emit(.remark, message, file: file, line: line)
     }
 }

--- a/Sources/PackagePlugin/Path.swift
+++ b/Sources/PackagePlugin/Path.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -9,10 +9,12 @@
  */
 
 /// A simple representation of a path in the file system.
-public struct Path {
+public struct Path: Hashable {
     private let _string: String
 
-    init(_ string: String) {
+    /// Initializes the path from the contents a string, which should be an
+    /// absolute path in platform representation.
+    public init(_ string: String) {
         self._string = string
     }
 
@@ -88,7 +90,8 @@ public struct Path {
         return Path(String(_string.prefix(upTo: idx)))
     }
     
-    /// The result of appending a subpath.
+    /// The result of appending a subpath, which should be a relative path in
+    /// platform representation.
     public func appending(subpath: String) -> Path {
         return Path(_string + (_string.hasSuffix("/") ? "" : "/") + subpath)
     }
@@ -101,21 +104,6 @@ public struct Path {
     /// The result of appending one or more path components.
     public func appending(_ components: String...) -> Path {
         return self.appending(components)
-    }
-}
-
-extension Path: ExpressibleByStringLiteral {
-
-    public init(stringLiteral value: String) {
-        self.init(value)
-    }
-
-    public init(extendedGraphemeClusterLiteral value: String) {
-        self.init(stringLiteral: value)
-    }
-
-    public init(unicodeScalarLiteral value: String) {
-        self.init(stringLiteral: value)
     }
 }
 

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -1104,7 +1104,7 @@ final class PackageToolTests: CommandsTestCase {
 
                             // Create and return a build command that uses all the `.foo` files in the target as inputs, so they get counted as having been handled.
                             let fooFiles = (target as? SourceModuleTarget)?.sourceFiles.compactMap{ $0.path.extension == "foo" ? $0.path : nil } ?? []
-                            return [ .buildCommand(displayName: "A command", executable: "/bin/echo", arguments: ["Hello"], inputFiles: fooFiles) ]
+                            return [ .buildCommand(displayName: "A command", executable: Path("/bin/echo"), arguments: ["Hello"], inputFiles: fooFiles) ]
                         }
 
                     }

--- a/Tests/PackagePluginAPITests/PathTests.swift
+++ b/Tests/PackagePluginAPITests/PathTests.swift
@@ -1,0 +1,28 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import PackagePlugin
+import XCTest
+
+class PathAPITests: XCTestCase {
+
+    func testBasics() throws {
+        let path = Path("/tmp/file.foo")
+        XCTAssertEqual(path.lastComponent, "file.foo")
+        XCTAssertEqual(path.stem, "file")
+        XCTAssertEqual(path.extension, "foo")
+        XCTAssertEqual(path.removingLastComponent(), Path("/tmp"))
+    }
+
+    func testEdgeCases() throws {
+        let path = Path("/tmp/file.foo")
+        XCTAssertEqual(path.removingLastComponent().removingLastComponent().removingLastComponent(), Path("/"))
+    }
+}


### PR DESCRIPTION
Remove ExpressibleByStringLiteral conformance but allow initializer to be invoked, reducing surprises.  Add Hashable conformance.  Adjust diagnostics, and add unit test.

### Motivation:

These are further ergonomic changes for plugins based on usage experience.

### Modifications:

- mark `PackagePlugin.Path.init()` public
- remove ExpressibleByStringLiteral conformance
- add Hashable conformance
- add a unit test
