### PR TITLE
cache registry downloads

### DIFF
--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -152,9 +152,20 @@ public struct SwiftToolOptions: ParsableArguments {
     @Option(help: "Specify the shared security directory")
     var securityPath: AbsolutePath?
 
-    /// Disables repository caching.
-    @Flag(name: .customLong("repository-cache"), inversion: .prefixedEnableDisable, help: "Use a shared cache when fetching repositories")
-    var useRepositoriesCache: Bool = true
+    /// Disables package caching.
+    @Flag(name: .customLong("dependencies-cache"), inversion: .prefixedEnableDisable, help: "Use a shared cache when fetching dependencies")
+    var _useDependenciesCache: Bool?
+
+    // TODO: simplify when deprecating the older flag
+    var useDependenciesCache: Bool {
+        if let value = self._useDependenciesCache {
+            return value
+        } else if let value = self._deprecated_useRepositoriesCache {
+            return value
+        } else {
+            return true
+        }
+    }
 
     /// The custom working directory that the tool should operate in (deprecated).
     @Option(name: [.long, .customShort("C")])
@@ -367,6 +378,10 @@ public struct SwiftToolOptions: ParsableArguments {
 
     @Flag(name: .customLong("netrc-optional"), help: .hidden)
     var _deprecated_netrcOptional: Bool = false
+
+    /// Disables repository caching.
+    @Flag(name: .customLong("repository-cache"), inversion: .prefixedEnableDisable, help: .hidden)
+    var _deprecated_useRepositoriesCache: Bool?
 
     public init() {}
 }

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -153,7 +153,7 @@ public struct SwiftToolOptions: ParsableArguments {
     var securityPath: AbsolutePath?
 
     /// Disables package caching.
-    @Flag(name: .customLong("dependencies-cache"), inversion: .prefixedEnableDisable, help: "Use a shared cache when fetching dependencies")
+    @Flag(name: .customLong("dependency-cache"), inversion: .prefixedEnableDisable, help: "Use a shared cache when fetching dependencies")
     var _useDependenciesCache: Bool?
 
     // TODO: simplify when deprecating the older flag

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -490,7 +490,7 @@ public class SwiftTool {
         }
 
         if options._deprecated_useRepositoriesCache != nil {
-            observabilityScope.emit(warning: "'--disable-repository-cache'/'--enable-repository-cache' flags are deprecated; use '--disable-dependencies-cache'/'--enable-dependencies-cache' instead")
+            observabilityScope.emit(warning: "'--disable-repository-cache'/'--enable-repository-cache' flags are deprecated; use '--disable-dependency-cache'/'--enable-dependency-cache' instead")
         }
 
     }

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -50,8 +50,8 @@ private class ToolWorkspaceDelegate: WorkspaceDelegate {
     }
 
     private struct FetchProgress {
-        let objectsFetched: Int
-        let totalObjectsToFetch: Int
+        let progress: Int64
+        let total: Int64
     }
 
     /// The progress of each individual downloads.
@@ -74,36 +74,52 @@ private class ToolWorkspaceDelegate: WorkspaceDelegate {
         self.observabilityScope = observabilityScope
     }
 
-    func fetchingWillBegin(repository: String, fetchDetails: RepositoryManager.FetchDetails?) {
+    func willFetchPackage(package: String, fetchDetails: PackageFetchDetails) {
         queue.async {
-            self.outputStream <<< "Fetching \(repository)"
-            if let fetchDetails = fetchDetails {
-                if fetchDetails.fromCache {
-                    self.outputStream <<< " from cache"
-                }
+            self.outputStream <<< "Fetching \(package)"
+            if fetchDetails.fromCache {
+                self.outputStream <<< " from cache"
             }
             self.outputStream <<< "\n"
             self.outputStream.flush()
         }
     }
 
-    func fetchingDidFinish(repository: String, fetchDetails: RepositoryManager.FetchDetails?, diagnostic: Basics.Diagnostic?, duration: DispatchTimeInterval) {
+    func didFetchPackage(package: String, result: Result<PackageFetchDetails, Error>, duration: DispatchTimeInterval) {
         queue.async {
             if self.observabilityScope.errorsReported {
                 self.fetchAnimation.clear()
             }
 
-            let step = self.fetchProgress.values.reduce(0) { $0 + $1.objectsFetched }
-            let total = self.fetchProgress.values.reduce(0) { $0 + $1.totalObjectsToFetch }
+            let progress = self.fetchProgress.values.reduce(0) { $0 + $1.progress }
+            let total = self.fetchProgress.values.reduce(0) { $0 + $1.total }
 
-            if step == total && !self.fetchProgress.isEmpty {
+            if progress == total && !self.fetchProgress.isEmpty {
                 self.fetchAnimation.complete(success: true)
                 self.fetchProgress.removeAll()
             }
 
-            self.outputStream <<< "Fetched \(repository) (\(duration.descriptionInSeconds))"
+            self.outputStream <<< "Fetched \(package) (\(duration.descriptionInSeconds))"
             self.outputStream <<< "\n"
             self.outputStream.flush()
+        }
+    }
+
+    func fetchingPackage(package: String, progress: Int64, total: Int64?) {
+        queue.async {
+            self.fetchProgress[package] = FetchProgress(
+                progress: progress,
+                total: total ?? progress
+            )
+
+            let progress = self.fetchProgress.values.reduce(0) { $0 + $1.progress }
+            let total = self.fetchProgress.values.reduce(0) { $0 + $1.total }
+
+            self.fetchAnimation.update(
+                step: progress > Int.max ? Int.max : Int(progress),
+                total: total > Int.max ? Int.max : Int(total),
+                text: "Fetching \(package)"
+            )
         }
     }
 
@@ -212,18 +228,6 @@ private class ToolWorkspaceDelegate: WorkspaceDelegate {
 
             self.downloadAnimation.complete(success: true)
             self.downloadProgress.removeAll()
-        }
-    }
-
-    func fetchingRepository(from repository: String, objectsFetched: Int, totalObjectsToFetch: Int) {
-        queue.async {
-            self.fetchProgress[repository] = FetchProgress(
-                objectsFetched: objectsFetched,
-                totalObjectsToFetch: totalObjectsToFetch)
-
-            let step = self.fetchProgress.values.reduce(0) { $0 + $1.objectsFetched }
-            let total = self.fetchProgress.values.reduce(0) { $0 + $1.totalObjectsToFetch }
-            self.fetchAnimation.update(step: step, total: total, text: "Fetching objects")
         }
     }
 
@@ -482,7 +486,11 @@ public class SwiftTool {
         }
 
         if options._deprecated_enableResolverTrace {
-            observabilityScope.emit(warning: "'--enableResolverTrace' option is deprecated; use --verbose flag to log resolver output")
+            observabilityScope.emit(warning: "'--enableResolverTrace' flag is deprecated; use '--verbose' option to log resolver output")
+        }
+
+        if options._deprecated_useRepositoriesCache != nil {
+            observabilityScope.emit(warning: "'--disable-repository-cache'/'--enable-repository-cache' flags are deprecated; use '--disable-dependencies-cache'/'--enable-dependencies-cache' instead")
         }
 
     }
@@ -512,7 +520,7 @@ public class SwiftTool {
                 skipDependenciesUpdates: options.skipDependencyUpdate,
                 prefetchBasedOnResolvedFile: options.shouldEnableResolverPrefetching,
                 additionalFileRules: isXcodeBuildSystemEnabled ? FileRuleDescription.xcbuildFileTypes : FileRuleDescription.swiftpmFileTypes,
-                sharedRepositoriesCacheEnabled: self.options.useRepositoriesCache,
+                sharedDependenciesCacheEnabled: self.options.useDependenciesCache,
                 fingerprintCheckingMode: self.options.resolverFingerprintCheckingMode
             ),
             initializationWarningHandler: { self.observabilityScope.emit(warning: $0) },

--- a/Sources/PackageRegistry/CMakeLists.txt
+++ b/Sources/PackageRegistry/CMakeLists.txt
@@ -9,7 +9,8 @@
 add_library(PackageRegistry
   Registry.swift
   RegistryConfiguration.swift
-  RegistryClient.swift)
+  RegistryClient.swift
+  RegistryDownloadsManager.swift)
 target_link_libraries(PackageRegistry PUBLIC
   Basics
   PackageFingerprint

--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -96,7 +96,6 @@ public final class RegistryClient {
     private let apiVersion: APIVersion = .v1
 
     private let configuration: RegistryConfiguration
-    private let identityResolver: IdentityResolver
     private let archiverProvider: (FileSystem) -> Archiver
     private let httpClient: HTTPClient
     private let authorizationProvider: HTTPClientAuthorizationProvider?
@@ -106,7 +105,6 @@ public final class RegistryClient {
 
     public init(
         configuration: RegistryConfiguration,
-        identityResolver: IdentityResolver,
         fingerprintStorage: PackageFingerprintStorage?,
         fingerprintCheckingMode: FingerprintCheckingMode,
         authorizationProvider: HTTPClientAuthorizationProvider? = .none,
@@ -114,7 +112,6 @@ public final class RegistryClient {
         customArchiverProvider: ((FileSystem) -> Archiver)? = .none
     ) {
         self.configuration = configuration
-        self.identityResolver = identityResolver
         self.authorizationProvider = authorizationProvider
         self.httpClient = customHTTPClient ?? HTTPClient()
         self.archiverProvider = customArchiverProvider ?? { fileSystem in ZipArchiver(fileSystem: fileSystem) }
@@ -500,7 +497,6 @@ public final class RegistryClient {
             guard !fileSystem.exists(destinationPath) else {
                 throw RegistryError.pathAlreadyExists(destinationPath)
             }
-            try fileSystem.createDirectory(destinationPath, recursive: true)
         } catch {
             return completion(.failure(error))
         }
@@ -539,7 +535,12 @@ public final class RegistryClient {
                                     observabilityScope.emit(warning: "The checksum \(actualChecksum) does not match previously recorded value \(expectedChecksum)")
                                 }
                             }
-
+                            // validate that the destination does not already exist (again, as this is async)
+                            guard !fileSystem.exists(destinationPath) else {
+                                throw RegistryError.pathAlreadyExists(destinationPath)
+                            }
+                            try fileSystem.createDirectory(destinationPath, recursive: true)
+                            // extract the content
                             let archiver = self.archiverProvider(fileSystem)
                             // TODO: Bail if archive contains relative paths or overlapping files
                             archiver.extract(from: downloadPath, to: destinationPath) { result in

--- a/Sources/PackageRegistry/RegistryDownloadsManager.swift
+++ b/Sources/PackageRegistry/RegistryDownloadsManager.swift
@@ -1,0 +1,310 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import Basics
+import Dispatch
+import Foundation
+import PackageModel
+import TSCBasic
+import PackageLoading
+
+public class RegistryDownloadsManager {
+    public typealias Delegate = RegistryDownloadsManagerDelegate
+
+    private let fileSystem: FileSystem
+    private let path: AbsolutePath
+    private let cachePath: AbsolutePath?
+    private let registryClient: RegistryClient
+    private let checksumAlgorithm: HashAlgorithm
+    private let delegate: Delegate?
+
+    private var pendingLookups = [PackageIdentity: DispatchGroup]()
+    private var pendingLookupsLock = NSLock()
+
+    public init(
+        fileSystem: FileSystem,
+        path: AbsolutePath,
+        cachePath: AbsolutePath?,
+        registryClient: RegistryClient,
+        checksumAlgorithm: HashAlgorithm,
+        delegate: Delegate?
+    ) {
+        self.fileSystem = fileSystem
+        self.path = path
+        self.cachePath = cachePath
+        self.registryClient = registryClient
+        self.checksumAlgorithm = checksumAlgorithm
+        self.delegate = delegate
+    }
+
+    public func lookup(
+        package: PackageIdentity,
+        version: Version,
+        observabilityScope: ObservabilityScope,
+        delegateQueue: DispatchQueue,
+        callbackQueue: DispatchQueue,
+        completion: @escaping  (Result<AbsolutePath, Error>) -> Void
+    ) {
+        // wrap the callback in the requested queue
+        let completion = { result in callbackQueue.async { completion(result) } }
+        
+        let packageRelativePath: RelativePath!
+        let packagePath: AbsolutePath
+
+        do {
+            packageRelativePath = try package.downloadPath(version: version)
+            packagePath = self.path.appending(packageRelativePath)
+
+            // TODO: we can do some finger-print checking to improve the validation
+            // already exists and valid, we can exit early
+            if try self.fileSystem.validPackageDirectory(packagePath) {
+                return completion(.success(packagePath))
+            }
+        } catch {
+            return completion(.failure(error))
+        }
+
+        // next we check if there is a pending lookup
+        self.pendingLookupsLock.lock()
+        if let pendingLookup = self.pendingLookups[package] {
+            self.pendingLookupsLock.unlock()
+            // chain onto the pending lookup
+            pendingLookup.notify(queue: callbackQueue) {
+                // at this point the previous lookup should be complete and we can re-lookup
+                self.lookup(
+                    package: package,
+                    version: version,
+                    observabilityScope: observabilityScope,
+                    delegateQueue: delegateQueue,
+                    callbackQueue: callbackQueue,
+                    completion: completion
+                )
+            }
+        } else {
+            // record the pending lookup
+            assert(self.pendingLookups[package] == nil)
+            let group = DispatchGroup()
+            group.enter()
+            self.pendingLookups[package] = group
+            self.pendingLookupsLock.unlock()
+
+            // make sure destination is free.
+            try? self.fileSystem.removeFileTree(packagePath)
+            let isCached = self.cachePath.map{ self.fileSystem.exists($0.appending(packageRelativePath)) } ?? false
+
+            // inform delegate that we are starting to fetch
+            delegateQueue.async {
+                let details = FetchDetails(fromCache: isCached, updatedCache: false)
+                self.delegate?.willFetch(package: package, version: version, fetchDetails: details)
+            }
+
+            let start = DispatchTime.now()
+            self.downloadAndPopulateCache(
+                package: package,
+                version: version,
+                packagePath: packagePath,
+                observabilityScope: observabilityScope,
+                delegateQueue: delegateQueue,
+                callbackQueue: callbackQueue
+            ) { result in
+                // inform delegate that we finished to fetch
+                let duration = start.distance(to: .now())
+                delegateQueue.async {
+                    self.delegate?.didFetch(package: package, version: version, result: result, duration: duration)
+                }
+                // remove the pending lookup
+                self.pendingLookupsLock.lock()
+                self.pendingLookups[package]?.leave()
+                self.pendingLookups[package] = nil
+                self.pendingLookupsLock.unlock()
+                // and done
+                completion(result.map{ _ in packagePath })
+            }
+        }
+    }
+
+    func downloadAndPopulateCache(
+        package: PackageIdentity,
+        version: Version,
+        packagePath: AbsolutePath,
+        observabilityScope: ObservabilityScope,
+        delegateQueue: DispatchQueue,
+        callbackQueue: DispatchQueue,
+        completion: @escaping  (Result<FetchDetails, Error>) -> Void
+    ) {
+        if let cachePath = self.cachePath {
+            do {
+                let relativePath = try package.downloadPath(version: version)
+                let cachedPacakgePath = cachePath.appending(relativePath)
+
+                try self.initializeCacheIfNeeded(cachePath: cachePath)
+                try self.fileSystem.withLock(on: cachedPacakgePath, type: .exclusive) {
+                    // download the package into the cache unless already exists
+                    if try self.fileSystem.validPackageDirectory(cachedPacakgePath) {
+                        // extra validation to defend from racy edge cases?
+                        if self.fileSystem.exists(packagePath) {
+                            throw StringError("\(packagePath) already exists unexpectedly")
+                        }
+                        // copy the package from the cache into the package path.
+                        try self.fileSystem.createDirectory(packagePath.parentDirectory, recursive: true)
+                        try self.fileSystem.copy(from: cachedPacakgePath, to: packagePath)
+                        completion(.success(.init(fromCache: true, updatedCache: false)))
+                    } else {
+                        // it is possible that we already created the directory before from failed attempts, so clear leftover data if present.
+                        try? self.fileSystem.removeFileTree(cachedPacakgePath)
+                        // download the package from the registry
+                        self.registryClient.downloadSourceArchive(
+                            package: package,
+                            version: version,
+                            fileSystem: self.fileSystem,
+                            destinationPath: cachedPacakgePath,
+                            checksumAlgorithm: self.checksumAlgorithm,
+                            progressHandler: updateDownloadProgress,
+                            observabilityScope: observabilityScope,
+                            callbackQueue: callbackQueue
+                        ) { result in
+                            completion(result.tryMap {
+                                // extra validation to defend from racy edge cases?
+                                if self.fileSystem.exists(packagePath) {
+                                    throw StringError("\(packagePath) already exists unexpectedly")
+                                }
+                                // copy the package from the cache into the package path.
+                                try self.fileSystem.createDirectory(packagePath.parentDirectory, recursive: true)
+                                try self.fileSystem.copy(from: cachedPacakgePath, to: packagePath)
+                                return FetchDetails(fromCache: true, updatedCache: true)
+                            })
+                        }
+                    }
+                }
+            } catch {
+                // download without populating the cache in the case of an error.
+                observabilityScope.emit(warning: "skipping cache due to an error: \(error)")
+                // it is possible that we already created the directory from failed attempts, so clear leftover data if present.
+                try? self.fileSystem.removeFileTree(packagePath)
+                //try self.provider.fetch(repository: handle.repository, to: repositoryPath, progressHandler: updateFetchProgress(progress:))
+                self.registryClient.downloadSourceArchive(
+                    package: package,
+                    version: version,
+                    fileSystem: self.fileSystem,
+                    destinationPath: packagePath,
+                    checksumAlgorithm: self.checksumAlgorithm,
+                    progressHandler: updateDownloadProgress,
+                    observabilityScope: observabilityScope,
+                    callbackQueue: callbackQueue
+                ) { result in
+                    completion(result.map{ FetchDetails(fromCache: false, updatedCache: false) })
+                }
+            }
+        } else {
+            // it is possible that we already created the directory from failed attempts, so clear leftover data if present.
+            try? self.fileSystem.removeFileTree(packagePath)
+            // download without populating the cache when no `cachePath` is set.
+            self.registryClient.downloadSourceArchive(
+                package: package,
+                version: version,
+                fileSystem: self.fileSystem,
+                destinationPath: packagePath,
+                checksumAlgorithm: self.checksumAlgorithm,
+                progressHandler: updateDownloadProgress,
+                observabilityScope: observabilityScope,
+                callbackQueue: callbackQueue
+            ) { result in
+                completion(result.map{ FetchDetails(fromCache: false, updatedCache: false) })
+            }
+        }
+
+        // utility to update progress
+
+        func updateDownloadProgress(downloaded: Int64, total: Int64?) -> Void {
+            delegateQueue.async {
+                self.delegate?.fetching(
+                    package: package,
+                    version: version,
+                    downloaded: downloaded,
+                    total: total
+                )
+            }
+        }
+    }
+
+    public func remove(package: PackageIdentity) throws {
+        let relativePath = try package.downloadPath()
+        let packagesPath = self.path.appending(relativePath)
+        try self.fileSystem.removeFileTree(packagesPath)
+    }
+
+    public func reset() throws {
+        try self.fileSystem.removeFileTree(self.path)
+    }
+
+    public func purgeCache() throws {
+        guard let cachePath = self.cachePath else {
+            return
+        }
+        try self.fileSystem.withLock(on: cachePath, type: .exclusive) {
+            let cachedPackages = try self.fileSystem.getDirectoryContents(cachePath)
+            for packagePath in cachedPackages {
+                try self.fileSystem.removeFileTree(cachePath.appending(component: packagePath))
+            }
+        }
+    }
+
+    private func initializeCacheIfNeeded(cachePath: AbsolutePath) throws {
+        if !self.fileSystem.exists(cachePath) {
+            try self.fileSystem.createDirectory(cachePath, recursive: true)
+        }
+    }
+}
+
+/// Delegate to notify clients about actions being performed by RegistryManager.
+public protocol RegistryDownloadsManagerDelegate {
+    /// Called when a package is about to be fetched.
+    func willFetch(package: PackageIdentity, version: Version, fetchDetails: RegistryDownloadsManager.FetchDetails)
+
+    /// Called when a package has finished fetching.
+    func didFetch(package: PackageIdentity, version: Version, result: Result<RegistryDownloadsManager.FetchDetails, Error>, duration: DispatchTimeInterval)
+
+    /// Called every time the progress of a repository fetch operation updates.
+    func fetching(package: PackageIdentity, version: Version, downloaded: Int64, total: Int64?)
+}
+
+extension RegistryDownloadsManager {
+    /// Additional information about a fetch
+    public struct FetchDetails: Equatable {
+        /// Indicates if the repository was fetched from the cache or from the remote.
+        public let fromCache: Bool
+        /// Indicates wether the wether the repository was already present in the cache and updated or if a clean fetch was performed.
+        public let updatedCache: Bool
+    }
+}
+
+
+extension FileSystem {
+    func validPackageDirectory(_ path: AbsolutePath) throws -> Bool {
+        if !self.exists(path) {
+            return false
+        }
+        return try self.getDirectoryContents(path).contains(Manifest.filename)
+    }
+}
+
+
+extension PackageIdentity {
+    internal func downloadPath() throws -> RelativePath {
+        guard let (scope, name) = self.scopeAndName else {
+            throw StringError("invalid package identity, expected registry scope and name")
+        }
+        return RelativePath(scope.description).appending(component: name.description)
+    }
+
+    internal func downloadPath(version: Version) throws -> RelativePath  {
+        try self.downloadPath().appending(component: version.description)
+    }
+}

--- a/Sources/SPMTestSupport/MockRegistry.swift
+++ b/Sources/SPMTestSupport/MockRegistry.swift
@@ -18,25 +18,27 @@ import PackageRegistry
 import TSCBasic
 import protocol TSCUtility.Archiver
 
-class MockRegistry {
+public class MockRegistry {
     private static let mockRegistryURL = URL(string: "http://localhost/registry/mock")!
 
-    private let checksumAlgorithm: HashAlgorithm
     private let fileSystem: FileSystem
-    var registryClient: RegistryClient!
+    private let identityResolver: IdentityResolver
+    private let checksumAlgorithm: HashAlgorithm
+    public var registryClient: RegistryClient!
     private let jsonEncoder: JSONEncoder
 
-    private var packages = [PackageIdentity: [String: InMemoryRegistrySource]]()
+    private var packages = [PackageIdentity: [String: InMemoryRegistryPackageSource]]()
     private let packagesLock = Lock()
 
-    init(
+    public init(
+        filesystem: FileSystem,
         identityResolver: IdentityResolver,
         checksumAlgorithm: HashAlgorithm,
-        filesystem: FileSystem,
         fingerprintStorage: PackageFingerprintStorage
     ) {
-        self.checksumAlgorithm = checksumAlgorithm
         self.fileSystem = filesystem
+        self.identityResolver = identityResolver
+        self.checksumAlgorithm = checksumAlgorithm
         self.jsonEncoder = JSONEncoder.makeWithDefaults()
 
         var configuration = RegistryConfiguration()
@@ -44,7 +46,6 @@ class MockRegistry {
 
         self.registryClient = RegistryClient(
             configuration: configuration,
-            identityResolver: identityResolver,
             fingerprintStorage: fingerprintStorage,
             fingerprintCheckingMode: .strict,
             authorizationProvider: .none,
@@ -53,7 +54,11 @@ class MockRegistry {
         )
     }
 
-    func addPackage(identity: PackageIdentity, versions: [String], source: InMemoryRegistrySource) {
+    public func addPackage(identity: PackageIdentity, versions: [Version], source: InMemoryRegistryPackageSource) {
+        self.addPackage(identity: identity, versions: versions.map{ $0.description }, source: source)
+    }
+
+    public func addPackage(identity: PackageIdentity, versions: [String], source: InMemoryRegistryPackageSource) {
         self.packagesLock.withLock {
             var value = self.packages[identity] ?? [:]
             for version in versions {
@@ -225,7 +230,7 @@ class MockRegistry {
         )
     }
 
-    private func zipFileContent(packageIdentity: PackageIdentity, version: String, source: InMemoryRegistrySource) throws -> String {
+    private func zipFileContent(packageIdentity: PackageIdentity, version: String, source: InMemoryRegistryPackageSource) throws -> String {
         var content = "\(packageIdentity)_\(version)\n"
         content += source.path.pathString + "\n"
         for file in try source.listFiles() {
@@ -235,16 +240,28 @@ class MockRegistry {
     }
 }
 
-struct InMemoryRegistrySource {
-    let path: AbsolutePath
+public struct InMemoryRegistryPackageSource {
     let fileSystem: FileSystem
+    public let path: AbsolutePath
 
-    init(path: AbsolutePath, fileSystem: FileSystem) {
-        self.path = path
+    public init(fileSystem: FileSystem, path: AbsolutePath, writeContent: Bool = true) {
         self.fileSystem = fileSystem
+        self.path = path
     }
 
-    func listFiles(root: AbsolutePath? = .none) throws -> [AbsolutePath] {
+    public func writePackageContent(targets: [String] = [], toolsVersion: ToolsVersion = .currentToolsVersion) throws {
+        try self.fileSystem.createDirectory(self.path, recursive: true)
+        let sourcesDir = self.path.appending(component: "Sources")
+        for target in targets {
+            let targetDir = sourcesDir.appending(component: target)
+            try self.fileSystem.createDirectory(targetDir, recursive: true)
+            try self.fileSystem.writeFileContents(targetDir.appending(component: "file.swift"), bytes: "")
+        }
+        let manifestPath = self.path.appending(component: Manifest.filename)
+        try self.fileSystem.writeFileContents(manifestPath, string: "// swift-tools-version:\(toolsVersion)")
+    }
+
+    public func listFiles(root: AbsolutePath? = .none) throws -> [AbsolutePath] {
         var files = [AbsolutePath]()
         let root = root ?? self.path
         let entries = try self.fileSystem.getDirectoryContents(root)

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -67,9 +67,9 @@ public final class MockWorkspace {
         self.checksumAlgorithm = customChecksumAlgorithm ?? MockHashAlgorithm()
         self.repositoryProvider = InMemoryGitRepositoryProvider()
         self.registry = MockRegistry(
+            filesystem: self.fileSystem,
             identityResolver: self.identityResolver,
             checksumAlgorithm: self.checksumAlgorithm,
-            filesystem: self.fileSystem,
             fingerprintStorage: self.fingerprints
         )
         self.registryClient = customRegistryClient ?? self.registry.registryClient
@@ -173,7 +173,7 @@ public final class MockWorkspace {
 
                 self.repositoryProvider.add(specifier: specifier, repository: repository)
             } else if let identity = registryIdentity {
-                let source = InMemoryRegistrySource(path: packagePath, fileSystem: self.fileSystem)
+                let source = InMemoryRegistryPackageSource(fileSystem: self.fileSystem, path: packagePath, writeContent: false)
                 try writePackageContent(fileSystem: source.fileSystem, root: source.path, toolsVersion: toolsVersion)
                 self.registry.addPackage(identity: identity, versions: packageVersions.compactMap({ $0 }), source: source)
             } else {
@@ -243,7 +243,7 @@ public final class MockWorkspace {
                 skipDependenciesUpdates: self.skipDependenciesUpdates,
                 prefetchBasedOnResolvedFile: WorkspaceConfiguration.default.prefetchBasedOnResolvedFile,
                 additionalFileRules: WorkspaceConfiguration.default.additionalFileRules,
-                sharedRepositoriesCacheEnabled: WorkspaceConfiguration.default.sharedRepositoriesCacheEnabled,
+                sharedDependenciesCacheEnabled: WorkspaceConfiguration.default.sharedDependenciesCacheEnabled,
                 fingerprintCheckingMode: .strict
             ),
             customFingerprints: self.fingerprints,
@@ -767,15 +767,15 @@ public final class MockWorkspaceDelegate: WorkspaceDelegate {
         self.append("Everything is already up-to-date")
     }
 
-    public func fetchingWillBegin(repository: String, fetchDetails: RepositoryManager.FetchDetails?) {
-        self.append("fetching repo: \(repository)")
+    public func willFetchPackage(package: String, fetchDetails: PackageFetchDetails) {
+        self.append("fetching package: \(package)")
     }
 
-    public func fetchingRepository(from repository: String, objectsFetched: Int, totalObjectsToFetch: Int) {
+    public func fetchingPackage(package: String, progress: Int64, total: Int64?) {
     }
 
-    public func fetchingDidFinish(repository: String, fetchDetails: RepositoryManager.FetchDetails?, diagnostic: Basics.Diagnostic?, duration: DispatchTimeInterval) {
-        self.append("finished fetching repo: \(repository)")
+    public func didFetchPackage(package: String, result: Result<PackageFetchDetails, Error>, duration: DispatchTimeInterval) {
+        self.append("finished fetching package: \(package)")
     }
 
     public func willCreateWorkingCopy(repository url: String, at path: AbsolutePath) {

--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -16,7 +16,7 @@ import TSCBasic
 /// Delegate to notify clients about actions being performed by RepositoryManager.
 public protocol RepositoryManagerDelegate: AnyObject {
     /// Called when a repository is about to be fetched.
-    func fetchingWillBegin(handle: RepositoryManager.RepositoryHandle, fetchDetails: RepositoryManager.FetchDetails?)
+    func fetchingWillBegin(handle: RepositoryManager.RepositoryHandle, fetchDetails: RepositoryManager.FetchDetails)
 
     /// Called when a repository has finished fetching.
     func fetchingDidFinish(handle: RepositoryManager.RepositoryHandle, fetchDetails: RepositoryManager.FetchDetails?, error: Swift.Error?, duration: DispatchTimeInterval)

--- a/Sources/Workspace/ToolsVersionSpecificationRewriter.swift
+++ b/Sources/Workspace/ToolsVersionSpecificationRewriter.swift
@@ -106,7 +106,7 @@ public func rewriteToolsVersionSpecification(toDefaultManifestIn manifestDirecto
     let toolsVersionSpecificationComponents = manifestComponents.toolsVersionSpecificationComponents
     
     // Replace the Swift tools version specification line if and only if it's well-formed up to the version specifier.
-    // This matches the behaviour of the old (now removed) [`ToolsVersionLoader.split(:_)`](https://github.com/WowbaggersLiquidLunch/swift-package-manager/blob/49cfc46bc5defd3ce8e0c0261e3e2cb475bcdb91/Sources/PackageLoading/ToolsVersionLoader.swift#L160).
+    // This matches the behavior of the old (now removed) [`ToolsVersionLoader.split(:_)`](https://github.com/WowbaggersLiquidLunch/swift-package-manager/blob/49cfc46bc5defd3ce8e0c0261e3e2cb475bcdb91/Sources/PackageLoading/ToolsVersionLoader.swift#L160).
     if toolsVersionSpecificationComponents.everythingUpToVersionSpecifierIsWellFormed {
         stream <<< ByteString(encodingAsUTF8: String(manifestComponents.contentsAfterToolsVersionSpecification))
     } else {

--- a/Sources/Workspace/WorkspaceConfiguration.swift
+++ b/Sources/Workspace/WorkspaceConfiguration.swift
@@ -116,6 +116,10 @@ extension Workspace {
             self.sharedCacheDirectory.map { $0.appending(component: "repositories") }
         }
 
+        /// Path to the shared registry download cache.
+        public var sharedRegistryDownloadsCacheDirectory: AbsolutePath? {
+            self.sharedCacheDirectory.map { $0.appending(components: "registry", "downloads") }
+        }
 
         /// Create a new workspace location.
         ///
@@ -519,8 +523,8 @@ public struct WorkspaceConfiguration {
     /// File rules to determine resource handling behavior.
     public var additionalFileRules: [FileRuleDescription]
 
-    /// Enables the shared repository cache. Enabled by default.
-    public var sharedRepositoriesCacheEnabled: Bool
+    /// Enables the shared dependencies cache. Enabled by default.
+    public var sharedDependenciesCacheEnabled: Bool
 
     ///  Fingerprint checking mode. Defaults to warn.
     public var fingerprintCheckingMode: FingerprintCheckingMode
@@ -529,13 +533,13 @@ public struct WorkspaceConfiguration {
         skipDependenciesUpdates: Bool,
         prefetchBasedOnResolvedFile: Bool,
         additionalFileRules: [FileRuleDescription],
-        sharedRepositoriesCacheEnabled: Bool,
+        sharedDependenciesCacheEnabled: Bool,
         fingerprintCheckingMode: FingerprintCheckingMode
     ) {
         self.skipDependenciesUpdates = skipDependenciesUpdates
         self.prefetchBasedOnResolvedFile = prefetchBasedOnResolvedFile
         self.additionalFileRules = additionalFileRules
-        self.sharedRepositoriesCacheEnabled = sharedRepositoriesCacheEnabled
+        self.sharedDependenciesCacheEnabled = sharedDependenciesCacheEnabled
         self.fingerprintCheckingMode = fingerprintCheckingMode
     }
 
@@ -545,7 +549,7 @@ public struct WorkspaceConfiguration {
             skipDependenciesUpdates: false,
             prefetchBasedOnResolvedFile: true,
             additionalFileRules: [],
-            sharedRepositoriesCacheEnabled: true,
+            sharedDependenciesCacheEnabled: true,
             fingerprintCheckingMode: .warn
         )
     }

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -124,7 +124,7 @@ final class PackageToolTests: CommandsTestCase {
                 _ = try execute(["reset"], packagePath: packageRoot)
                 try localFileSystem.removeFileTree(cachePath)
 
-                try self.execute(["resolve", "--enable-dependencies-cache", "--cache-path", cachePath.pathString], packagePath: packageRoot)
+                try self.execute(["resolve", "--enable-dependency-cache", "--cache-path", cachePath.pathString], packagePath: packageRoot)
 
                 // we have to check for the prefix here since the hash value changes because spm sees the `prefix`
                 // directory `/var/...` as `/private/var/...`.
@@ -135,7 +135,7 @@ final class PackageToolTests: CommandsTestCase {
                 _ = try execute(["reset"], packagePath: packageRoot)
 
                 // Perform another cache this time from the cache
-                _ = try execute(["resolve", "--enable-dependencies-cache", "--cache-path", cachePath.pathString], packagePath: packageRoot)
+                _ = try execute(["resolve", "--enable-dependency-cache", "--cache-path", cachePath.pathString], packagePath: packageRoot)
                 XCTAssert(try localFileSystem.getDirectoryContents(repositoriesPath).contains { $0.hasPrefix("Foo-") })
 
                 // Remove .build and cache folder
@@ -143,7 +143,7 @@ final class PackageToolTests: CommandsTestCase {
                 try localFileSystem.removeFileTree(cachePath)
 
                 // Perfom another fetch
-                _ = try execute(["resolve", "--enable-dependencies-cache", "--cache-path", cachePath.pathString], packagePath: packageRoot)
+                _ = try execute(["resolve", "--enable-dependency-cache", "--cache-path", cachePath.pathString], packagePath: packageRoot)
                 XCTAssert(try localFileSystem.getDirectoryContents(repositoriesPath).contains { $0.hasPrefix("Foo-") })
                 XCTAssert(try localFileSystem.getDirectoryContents(repositoriesCachePath).contains { $0.hasPrefix("Foo-") })
             }
@@ -153,7 +153,7 @@ final class PackageToolTests: CommandsTestCase {
                 _ = try execute(["reset"], packagePath: packageRoot)
                 try localFileSystem.removeFileTree(cachePath)
 
-                try self.execute(["resolve", "--disable-dependencies-cache", "--cache-path", cachePath.pathString], packagePath: packageRoot)
+                try self.execute(["resolve", "--disable-dependency-cache", "--cache-path", cachePath.pathString], packagePath: packageRoot)
 
                 // we have to check for the prefix here since the hash value changes because spm sees the `prefix`
                 // directory `/var/...` as `/private/var/...`.
@@ -167,7 +167,7 @@ final class PackageToolTests: CommandsTestCase {
                 try localFileSystem.removeFileTree(cachePath)
 
                 let (_, stderr) = try self.execute(["resolve", "--enable-repository-cache", "--cache-path", cachePath.pathString], packagePath: packageRoot)
-                XCTAssertMatch(stderr, .contains("'--disable-repository-cache'/'--enable-repository-cache' flags are deprecated; use '--disable-dependencies-cache'/'--enable-dependencies-cache' instead"))
+                XCTAssertMatch(stderr, .contains("'--disable-repository-cache'/'--enable-repository-cache' flags are deprecated; use '--disable-dependency-cache'/'--enable-dependency-cache' instead"))
 
                 // we have to check for the prefix here since the hash value changes because spm sees the `prefix`
                 // directory `/var/...` as `/private/var/...`.
@@ -197,7 +197,7 @@ final class PackageToolTests: CommandsTestCase {
                 try localFileSystem.removeFileTree(cachePath)
 
                 let (_, stderr) = try self.execute(["resolve", "--disable-repository-cache", "--cache-path", cachePath.pathString], packagePath: packageRoot)
-                XCTAssertMatch(stderr, .contains("'--disable-repository-cache'/'--enable-repository-cache' flags are deprecated; use '--disable-dependencies-cache'/'--enable-dependencies-cache' instead"))
+                XCTAssertMatch(stderr, .contains("'--disable-repository-cache'/'--enable-repository-cache' flags are deprecated; use '--disable-dependency-cache'/'--enable-dependency-cache' instead"))
 
                 // we have to check for the prefix here since the hash value changes because spm sees the `prefix`
                 // directory `/var/...` as `/private/var/...`.

--- a/Tests/PackageRegistryTests/RegistryClientTests.swift
+++ b/Tests/PackageRegistryTests/RegistryClientTests.swift
@@ -501,7 +501,6 @@ final class RegistryClientTests: XCTestCase {
         ])
         let registryClient = RegistryClient(
             configuration: configuration,
-            identityResolver: DefaultIdentityResolver(),
             fingerprintStorage: fingerprintStorage,
             fingerprintCheckingMode: .strict,
             customHTTPClient: httpClient,
@@ -580,7 +579,6 @@ final class RegistryClientTests: XCTestCase {
         ])
         let registryClient = RegistryClient(
             configuration: configuration,
-            identityResolver: DefaultIdentityResolver(),
             fingerprintStorage: fingerprintStorage,
             fingerprintCheckingMode: .strict,
             customHTTPClient: httpClient,
@@ -613,9 +611,8 @@ final class RegistryClientTests: XCTestCase {
             }
         }
 
-        // Unzip didn't take place so directory is empty
-        let contents = try fileSystem.getDirectoryContents(path)
-        XCTAssertEqual(contents, [])
+        // download did not succeed so directory does not exist
+        XCTAssertFalse(fileSystem.exists(path))
     }
 
     func testDownloadSourceArchive_nonMatchingChecksumInStorage_fingerprintChecking_warn() throws {
@@ -665,7 +662,6 @@ final class RegistryClientTests: XCTestCase {
         ])
         let registryClient = RegistryClient(
             configuration: configuration,
-            identityResolver: DefaultIdentityResolver(),
             fingerprintStorage: fingerprintStorage,
             fingerprintCheckingMode: .warn,
             customHTTPClient: httpClient,
@@ -781,7 +777,6 @@ final class RegistryClientTests: XCTestCase {
         let fingerprintStorage = MockPackageFingerprintStorage()
         let registryClient = RegistryClient(
             configuration: configuration,
-            identityResolver: DefaultIdentityResolver(),
             fingerprintStorage: fingerprintStorage,
             fingerprintCheckingMode: .strict,
             customHTTPClient: httpClient,
@@ -970,7 +965,6 @@ private func makeRegistryClient(
 ) -> RegistryClient {
     RegistryClient(
         configuration: configuration,
-        identityResolver: DefaultIdentityResolver(),
         fingerprintStorage: fingerprintStorage,
         fingerprintCheckingMode: fingerprintCheckingMode,
         customHTTPClient: httpClient,

--- a/Tests/PackageRegistryTests/RegistryDownloadsManagerTests.swift
+++ b/Tests/PackageRegistryTests/RegistryDownloadsManagerTests.swift
@@ -1,0 +1,434 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import Basics
+import PackageModel
+import PackageLoading
+@testable import PackageRegistry
+import SPMTestSupport
+import TSCBasic
+import XCTest
+import SwiftDriver
+
+class RegistryDownloadsManagerTests: XCTestCase {
+    func testNoCache() throws {
+        let observability = ObservabilitySystem.makeForTesting()
+        let fs = InMemoryFileSystem()
+
+        let registry = MockRegistry(
+            filesystem: fs,
+            identityResolver: DefaultIdentityResolver(),
+            checksumAlgorithm: MockHashAlgorithm(),
+            fingerprintStorage: MockPackageFingerprintStorage()
+        )
+
+        let package: PackageIdentity = .plain("test.\(UUID().uuidString)")
+        let packageVersion: Version = "1.0.0"
+        let packageSource = InMemoryRegistryPackageSource(fileSystem: fs, path: .root.appending(components: "registry", "server", package.description))
+        try packageSource.writePackageContent()
+
+        registry.addPackage(
+            identity: package,
+            versions: [packageVersion],
+            source: packageSource
+        )
+
+        let delegate = MockRegistryDownloadsManagerDelegate()
+        let downloadsPath = AbsolutePath.root.appending(components: "registry", "downloads")
+        let manager = RegistryDownloadsManager(
+            fileSystem: fs,
+            path: downloadsPath,
+            cachePath: .none, // cache disabled
+            registryClient: registry.registryClient,
+            checksumAlgorithm: MockHashAlgorithm(),
+            delegate: delegate
+        )
+
+        // try to get a package
+
+        do {
+            delegate.prepare(fetchExpected: true)
+            let path = try manager.lookup(package: package, version: packageVersion, observabilityScope: observability.topScope)
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertEqual(path, try downloadsPath.appending(package.downloadPath(version: packageVersion)))
+            XCTAssertTrue(fs.isDirectory(path))
+
+            try delegate.wait(timeout: .now() + 2)
+            XCTAssertEqual(delegate.willFetch.count, 1)
+            XCTAssertEqual(delegate.willFetch.first?.packageVersion, .init(package: package, version: packageVersion))
+            XCTAssertEqual(delegate.willFetch.first?.fetchDetails, .init(fromCache: false, updatedCache: false))
+
+            XCTAssertEqual(delegate.didFetch.count, 1)
+            XCTAssertEqual(delegate.didFetch.first?.packageVersion, .init(package: package, version: packageVersion))
+            XCTAssertEqual(try! delegate.didFetch.first?.result.get(), .init(fromCache: false, updatedCache: false))
+        }
+
+        // try to get a package that does not exist
+
+        let unknownPackage: PackageIdentity = .plain("unknown.\(UUID().uuidString)")
+        let unknownPackageVersion: Version = "1.0.0"
+
+        do {
+            delegate.prepare(fetchExpected: true)
+            XCTAssertThrowsError(try manager.lookup(package: unknownPackage, version: unknownPackageVersion, observabilityScope: observability.topScope)) { error in
+                XCTAssertNotNil(error as? RegistryError)
+            }
+
+            try delegate.wait(timeout: .now() + 2)
+            XCTAssertEqual(delegate.willFetch.map { ($0.packageVersion) },
+                           [
+                            (PackageVersion(package: package, version: packageVersion)),
+                            (PackageVersion(package: unknownPackage, version: unknownPackageVersion))
+                           ]
+            )
+            XCTAssertEqual(delegate.didFetch.map { ($0.packageVersion) },
+                           [
+                            (PackageVersion(package: package, version: packageVersion)),
+                            (PackageVersion(package: unknownPackage, version: unknownPackageVersion))
+                           ]
+            )
+        }
+
+        // try to get the existing package again, no fetching expected this time
+
+        do {
+            delegate.prepare(fetchExpected: false)
+            let path = try manager.lookup(package: package, version: packageVersion, observabilityScope: observability.topScope)
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertEqual(path, try downloadsPath.appending(package.downloadPath(version: packageVersion)))
+            XCTAssertTrue(fs.isDirectory(path))
+
+            try delegate.wait(timeout: .now() + 2)
+            XCTAssertEqual(delegate.willFetch.map { ($0.packageVersion) },
+                           [
+                            (PackageVersion(package: package, version: packageVersion)),
+                            (PackageVersion(package: unknownPackage, version: unknownPackageVersion))
+                           ]
+            )
+            XCTAssertEqual(delegate.didFetch.map { ($0.packageVersion) },
+                           [
+                            (PackageVersion(package: package, version: packageVersion)),
+                            (PackageVersion(package: unknownPackage, version: unknownPackageVersion))
+                           ]
+            )
+        }
+
+        // remove the package
+
+        do {
+            try manager.remove(package: package)
+
+            delegate.prepare(fetchExpected: true)
+            let path = try manager.lookup(package: package, version: packageVersion, observabilityScope: observability.topScope)
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertEqual(path, try downloadsPath.appending(package.downloadPath(version: packageVersion)))
+            XCTAssertTrue(fs.isDirectory(path))
+
+            try delegate.wait(timeout: .now() + 2)
+            XCTAssertEqual(delegate.willFetch.map { ($0.packageVersion) },
+                           [
+                            (PackageVersion(package: package, version: packageVersion)),
+                            (PackageVersion(package: unknownPackage, version: unknownPackageVersion)),
+                            (PackageVersion(package: package, version: packageVersion))
+                           ]
+            )
+            XCTAssertEqual(delegate.didFetch.map { ($0.packageVersion) },
+                           [
+                            (PackageVersion(package: package, version: packageVersion)),
+                            (PackageVersion(package: unknownPackage, version: unknownPackageVersion)),
+                            (PackageVersion(package: package, version: packageVersion))
+                           ]
+            )
+        }
+    }
+
+    func testCache() throws {
+        let observability = ObservabilitySystem.makeForTesting()
+        let fs = InMemoryFileSystem()
+
+        let registry = MockRegistry(
+            filesystem: fs,
+            identityResolver: DefaultIdentityResolver(),
+            checksumAlgorithm: MockHashAlgorithm(),
+            fingerprintStorage: MockPackageFingerprintStorage()
+        )
+
+        let package: PackageIdentity = .plain("test.\(UUID().uuidString)")
+        let packageVersion: Version = "1.0.0"
+        let packageSource = InMemoryRegistryPackageSource(fileSystem: fs, path: .root.appending(components: "registry", "server", package.description))
+        try packageSource.writePackageContent()
+
+        registry.addPackage(
+            identity: package,
+            versions: [packageVersion],
+            source: packageSource
+        )
+
+        let delegate = MockRegistryDownloadsManagerDelegate()
+        let downloadsPath = AbsolutePath.root.appending(components: "registry", "downloads")
+        let cachePath = AbsolutePath.root.appending(components: "registry", "cache")
+        let manager = RegistryDownloadsManager(
+            fileSystem: fs,
+            path: downloadsPath,
+            cachePath: cachePath, // cache enabled
+            registryClient: registry.registryClient,
+            checksumAlgorithm: MockHashAlgorithm(),
+            delegate: delegate
+        )
+
+        // try to get a package
+
+        do {
+            delegate.prepare(fetchExpected: true)
+            let path = try manager.lookup(package: package, version: packageVersion, observabilityScope: observability.topScope)
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertEqual(path, try downloadsPath.appending(package.downloadPath(version: packageVersion)))
+            XCTAssertTrue(fs.isDirectory(path))
+            XCTAssertTrue(fs.isDirectory(cachePath.appending(components: package.scopeAndName!.scope.description, package.scopeAndName!.name.description, packageVersion.description)))
+
+            try delegate.wait(timeout: .now() + 2)
+
+            XCTAssertEqual(delegate.willFetch.count, 1)
+            XCTAssertEqual(delegate.willFetch.first?.packageVersion, .init(package: package, version: packageVersion))
+            XCTAssertEqual(delegate.willFetch.first?.fetchDetails, .init(fromCache: false, updatedCache: false))
+
+            XCTAssertEqual(delegate.didFetch.count, 1)
+            XCTAssertEqual(delegate.didFetch.first?.packageVersion, .init(package: package, version: packageVersion))
+            XCTAssertEqual(try! delegate.didFetch.first?.result.get(), .init(fromCache: true, updatedCache: true))
+        }
+
+        // remove the "local" package, should come from cache
+
+        do {
+            try manager.remove(package: package)
+
+            delegate.prepare(fetchExpected: true)
+            let path = try manager.lookup(package: package, version: packageVersion, observabilityScope: observability.topScope)
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertEqual(path, try downloadsPath.appending(package.downloadPath(version: packageVersion)))
+            XCTAssertTrue(fs.isDirectory(path))
+
+            try delegate.wait(timeout: .now() + 2)
+
+            XCTAssertEqual(delegate.willFetch.count, 2)
+            XCTAssertEqual(delegate.willFetch.last?.packageVersion, .init(package: package, version: packageVersion))
+            XCTAssertEqual(delegate.willFetch.last?.fetchDetails, .init(fromCache: true, updatedCache: false))
+
+            XCTAssertEqual(delegate.didFetch.count, 2)
+            XCTAssertEqual(delegate.didFetch.last?.packageVersion, .init(package: package, version: packageVersion))
+            XCTAssertEqual(try! delegate.didFetch.last?.result.get(), .init(fromCache: true, updatedCache: false))
+        }
+
+        // remove the "local" package, and purge cache
+
+        do {
+            try manager.remove(package: package)
+            try manager.purgeCache()
+
+            delegate.prepare(fetchExpected: true)
+            let path = try manager.lookup(package: package, version: packageVersion, observabilityScope: observability.topScope)
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertEqual(path, try downloadsPath.appending(package.downloadPath(version: packageVersion)))
+            XCTAssertTrue(fs.isDirectory(path))
+
+            try delegate.wait(timeout: .now() + 2)
+
+            XCTAssertEqual(delegate.willFetch.count, 3)
+            XCTAssertEqual(delegate.willFetch.last?.packageVersion, .init(package: package, version: packageVersion))
+            XCTAssertEqual(delegate.willFetch.last?.fetchDetails, .init(fromCache: false, updatedCache: false))
+
+            XCTAssertEqual(delegate.didFetch.count, 3)
+            XCTAssertEqual(delegate.didFetch.last?.packageVersion, .init(package: package, version: packageVersion))
+            XCTAssertEqual(try! delegate.didFetch.last?.result.get(), .init(fromCache: true, updatedCache: true))
+        }
+    }
+
+    func testConcurrency() throws {
+        let observability = ObservabilitySystem.makeForTesting()
+        let fs = InMemoryFileSystem()
+
+        let registry = MockRegistry(
+            filesystem: fs,
+            identityResolver: DefaultIdentityResolver(),
+            checksumAlgorithm: MockHashAlgorithm(),
+            fingerprintStorage: MockPackageFingerprintStorage()
+        )
+
+        let downloadsPath = AbsolutePath.root.appending(components: "registry", "downloads")
+        let delegate = MockRegistryDownloadsManagerDelegate()
+        let manager = RegistryDownloadsManager(
+            fileSystem: fs,
+            path: downloadsPath,
+            cachePath: .none, // cache disabled
+            registryClient: registry.registryClient,
+            checksumAlgorithm: MockHashAlgorithm(),
+            delegate: delegate
+        )
+
+        // many different versions
+
+        do {
+            let concurrency = 100
+            let package: PackageIdentity = .plain("test.\(UUID().uuidString)")
+            let packageVersions = (0 ..< concurrency).map { Version($0, 0 , 0) }
+            let packageSource = InMemoryRegistryPackageSource(fileSystem: fs, path: .root.appending(components: "registry", "server", package.description))
+            try packageSource.writePackageContent()
+
+            registry.addPackage(
+                identity: package,
+                versions: packageVersions,
+                source: packageSource
+            )
+
+            let group = DispatchGroup()
+            let results = ThreadSafeKeyValueStore<Version, Result<AbsolutePath, Error>>()
+            for packageVersion in packageVersions {
+                group.enter()
+                delegate.prepare(fetchExpected: true)
+                manager.lookup(package: package, version: packageVersion, observabilityScope: observability.topScope, delegateQueue: .sharedConcurrent, callbackQueue: .sharedConcurrent) { result in
+                    results[packageVersion] = result
+                    group.leave()
+                }
+            }
+
+            if case .timedOut = group.wait(timeout: .now() + 10) {
+                return XCTFail("timeout")
+            }
+
+            try delegate.wait(timeout: .now() + 2)
+            XCTAssertEqual(delegate.willFetch.count, concurrency)
+            XCTAssertEqual(delegate.didFetch.count, concurrency)
+
+            XCTAssertEqual(results.count, concurrency)
+            for packageVersion in packageVersions {
+                let expectedPath = try downloadsPath.appending(package.downloadPath(version: packageVersion))
+                XCTAssertEqual(try results[packageVersion]?.get(), expectedPath)
+            }
+        }
+
+        // same versions
+
+        do {
+            let concurrency = 1000
+            let repeatRatio = 10
+            let package: PackageIdentity = .plain("test.\(UUID().uuidString)")
+            let packageVersions = (0 ..< concurrency / 10).map { Version($0, 0 , 0) }
+            let packageSource = InMemoryRegistryPackageSource(fileSystem: fs, path: .root.appending(components: "registry", "server", package.description))
+            try packageSource.writePackageContent()
+
+            registry.addPackage(
+                identity: package,
+                versions: packageVersions,
+                source: packageSource
+            )
+
+            delegate.reset()
+            let group = DispatchGroup()
+            let results = ThreadSafeKeyValueStore<Version, Result<AbsolutePath, Error>>()
+            for index in 0 ..< concurrency {
+                group.enter()
+                delegate.prepare(fetchExpected: index < concurrency / repeatRatio)
+                let packageVersion = Version(index % (concurrency / repeatRatio), 0 , 0)
+                manager.lookup(package: package, version: packageVersion, observabilityScope: observability.topScope, delegateQueue: .sharedConcurrent, callbackQueue: .sharedConcurrent) { result in
+                    results[packageVersion] = result
+                    group.leave()
+                }
+            }
+
+            if case .timedOut = group.wait(timeout: .now() + 10) {
+                return XCTFail("timeout")
+            }
+
+            try delegate.wait(timeout: .now() + 2)
+            XCTAssertEqual(delegate.willFetch.count, concurrency / repeatRatio)
+            XCTAssertEqual(delegate.didFetch.count, concurrency / repeatRatio)
+
+            XCTAssertEqual(results.count, concurrency / repeatRatio)
+            for packageVersion in packageVersions {
+                let expectedPath = try downloadsPath.appending(package.downloadPath(version: packageVersion))
+                XCTAssertEqual(try results[packageVersion]?.get(), expectedPath)
+            }
+        }
+    }
+}
+
+private class MockRegistryDownloadsManagerDelegate: RegistryDownloadsManagerDelegate {
+    private var _willFetch = [(packageVersion: PackageVersion, fetchDetails: RegistryDownloadsManager.FetchDetails)]()
+    private var _didFetch = [(packageVersion: PackageVersion, result: Result<RegistryDownloadsManager.FetchDetails, Error>)]()
+
+    private let lock = Lock()
+    private var group = DispatchGroup()
+
+    public func prepare(fetchExpected: Bool) {
+        if fetchExpected {
+            group.enter() // will fetch
+            group.enter() // did fetch
+        }
+    }
+
+    public func reset() {
+        self.group = DispatchGroup()
+        self._willFetch = []
+        self._didFetch = []
+    }
+
+    public func wait(timeout: DispatchTime) throws {
+        switch group.wait(timeout: timeout) {
+        case .success:
+            return
+        case .timedOut:
+            throw StringError("timeout")
+        }
+    }
+
+    var willFetch: [(packageVersion: PackageVersion, fetchDetails: RegistryDownloadsManager.FetchDetails)] {
+        return self.lock.withLock { _willFetch }
+    }
+
+    var didFetch: [(packageVersion: PackageVersion, result: Result<RegistryDownloadsManager.FetchDetails, Error>)] {
+        return self.lock.withLock { _didFetch }
+    }
+
+    func willFetch(package: PackageIdentity, version: Version, fetchDetails: RegistryDownloadsManager.FetchDetails) {
+        self.lock.withLock {
+            _willFetch += [(PackageVersion(package: package, version: version), fetchDetails: fetchDetails)]
+        }
+        self.group.leave()
+    }
+
+    func didFetch(package: PackageIdentity, version: Version, result: Result<RegistryDownloadsManager.FetchDetails, Error>, duration: DispatchTimeInterval) {
+        self.lock.withLock {
+            _didFetch += [(PackageVersion(package: package, version: version), result: result)]
+        }
+        self.group.leave()
+    }
+
+    func fetching(package: PackageIdentity, version: Version, downloaded: Int64, total: Int64?) {
+    }
+}
+
+extension RegistryDownloadsManager {
+    fileprivate func lookup(package: PackageIdentity, version: Version, observabilityScope: ObservabilityScope) throws -> AbsolutePath {
+        return try tsc_await {
+            self.lookup(
+                package: package,
+                version: version,
+                observabilityScope: observabilityScope,
+                delegateQueue: .sharedConcurrent,
+                callbackQueue: .sharedConcurrent, completion: $0
+            )
+        }
+    }
+}
+
+fileprivate struct PackageVersion: Hashable, Equatable {
+    let package: PackageIdentity
+    let version: Version
+}

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -195,7 +195,7 @@ private class DummyRepositoryProvider: RepositoryProvider {
 }
 
 private class DummyRepositoryManagerDelegate: RepositoryManagerDelegate {
-    private var _willFetch = [(repository: RepositorySpecifier, fetchDetails: RepositoryManager.FetchDetails?)]()
+    private var _willFetch = [(repository: RepositorySpecifier, fetchDetails: RepositoryManager.FetchDetails)]()
     private var _didFetch = [(repository: RepositorySpecifier, fetchDetails: RepositoryManager.FetchDetails?)]()
 
     private var _willUpdate = [RepositorySpecifier]()
@@ -208,7 +208,7 @@ private class DummyRepositoryManagerDelegate: RepositoryManagerDelegate {
     var willUpdateGroup: DispatchGroup?
     var didUpdateGroup: DispatchGroup?
 
-    var willFetch: [(repository: RepositorySpecifier, fetchDetails: RepositoryManager.FetchDetails?)] {
+    var willFetch: [(repository: RepositorySpecifier, fetchDetails: RepositoryManager.FetchDetails)] {
         self.willFetchGroup?.wait()
         return self.fetchedLock.withLock { _willFetch }
     }
@@ -228,7 +228,7 @@ private class DummyRepositoryManagerDelegate: RepositoryManagerDelegate {
         return self.fetchedLock.withLock { _didUpdate }
     }
 
-    func fetchingWillBegin(handle: RepositoryManager.RepositoryHandle, fetchDetails: RepositoryManager.FetchDetails?) {
+    func fetchingWillBegin(handle: RepositoryManager.RepositoryHandle, fetchDetails: RepositoryManager.FetchDetails) {
         self.fetchedLock.withLock {
             _willFetch += [(repository: handle.repository, fetchDetails: fetchDetails)]
         }

--- a/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
@@ -317,8 +317,6 @@ class RegistryPackageContainerTests: XCTestCase {
         archiver: Archiver? = .none
     ) throws -> RegistryClient {
         let jsonEncoder = JSONEncoder.makeWithDefaults()
-
-        let identityResolver = DefaultIdentityResolver()
         let fingerprintStorage = MockPackageFingerprintStorage()
 
         guard let (packageScope, packageName) = packageIdentity.scopeAndName else {
@@ -416,7 +414,6 @@ class RegistryPackageContainerTests: XCTestCase {
 
         return RegistryClient(
             configuration: configuration!,
-            identityResolver: identityResolver,
             fingerprintStorage: fingerprintStorage,
             fingerprintCheckingMode: .strict,
             authorizationProvider: .none,

--- a/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
@@ -145,7 +145,7 @@ private class MockRepositories: RepositoryProvider {
 private class MockResolverDelegate: RepositoryManagerDelegate {
     var fetched = [RepositorySpecifier]()
 
-    func fetchingWillBegin(handle: RepositoryManager.RepositoryHandle, fetchDetails: RepositoryManager.FetchDetails?) {
+    func fetchingWillBegin(handle: RepositoryManager.RepositoryHandle, fetchDetails: RepositoryManager.FetchDetails) {
         self.fetched += [handle.repository]
     }
 


### PR DESCRIPTION
motivation: better performance when using registry

cached:
* introduce RegistryDownloadsManager which manages the downloads across the local and cache
* integrate RegistryDownloadsManager into Workspace, which now uses it to download from registry instead of the registry client directly
* update workspace delegate to handle callback from registry downloads, and propogate them to workspace delegates
* improve / generalize the workspace fetching delegate methods such that they are appropriate to both repositories and registry downloads
* deprecate --enable-repository-cache/--disable-repository-cache in favor of --enable-dependency-cache/--disable-dependency-cache
* fix several download and unzip edge cases which came to bear now that a cache is in place
* add and adjust tests
