### PR TITLE
Fix issues caused by having the `plugin` subcommand be the default subcommand

### DIFF
--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -35,6 +35,11 @@ final class PackageToolTests: CommandsTestCase {
         return try SwiftPMProduct.SwiftPackage.execute(args, packagePath: packagePath, env: environment)
     }
 
+    func testNoParameters() throws {
+        let stdout = try execute([]).stdout
+        XCTAssertMatch(stdout, .contains("USAGE: swift package"))
+    }
+
     func testUsage() throws {
         let stdout = try execute(["-help"]).stdout
         XCTAssertMatch(stdout, .contains("USAGE: swift package"))
@@ -48,6 +53,35 @@ final class PackageToolTests: CommandsTestCase {
     func testVersion() throws {
         let stdout = try execute(["--version"]).stdout
         XCTAssertMatch(stdout, .contains("Swift Package Manager"))
+    }
+
+    func testPlugin() throws {
+        do {
+            try execute(["plugin"])
+            XCTFail("This should have been an error")
+        } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
+            XCTAssertMatch(stderr, .contains("error: Missing expected plugin command"))
+        }
+    }
+
+    func testUnknownOption() throws {
+        do {
+            try execute(["--foo"])
+            XCTFail("This should have been an error")
+        } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
+            XCTAssertMatch(stderr, .contains("error: Unknown option '--foo'"))
+        }
+    }
+
+    func testUnknownSubommand() throws {
+        fixture(name: "Miscellaneous/ExeTest") { pkgDir in
+            do {
+                try execute(["foo"], packagePath: pkgDir)
+                XCTFail("This should have been an error")
+            } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
+                XCTAssertMatch(stderr, .contains("error: Unknown subcommand or plugin name 'foo'"))
+            }
+        }
     }
 
     func testNetrc() throws {
@@ -1467,12 +1501,12 @@ final class PackageToolTests: CommandsTestCase {
                 let result = try SwiftPMProduct.SwiftPackage.executeProcess(["my-nonexistent-cmd"], packagePath: packageDir)
                 let output = try result.utf8Output() + result.utf8stderrOutput()
                 XCTAssertNotEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
-                XCTAssertMatch(output, .contains("No command plugins found for ‘my-nonexistent-cmd’"))
+                XCTAssertMatch(output, .contains("error: Unknown subcommand or plugin name 'my-nonexistent-cmd'"))
             }
 
             // Check that the .docc file was properly vended to the plugin.
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["--target", "MyLibrary", "mycmd"], packagePath: packageDir)
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["mycmd", "--target", "MyLibrary"], packagePath: packageDir)
                 let output = try result.utf8Output() + result.utf8stderrOutput()
                 XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
                 XCTAssertMatch(output, .contains("Sources/MyLibrary/library.swift: source"))
@@ -1664,7 +1698,7 @@ final class PackageToolTests: CommandsTestCase {
 
             // Check that if we pass a target, we successfully get symbol graph information for just the target we asked for.
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["--target", "MyLibrary", "generate-documentation"], packagePath: packageDir)
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["generate-documentation", "--target", "MyLibrary"], packagePath: packageDir)
                 let output = try result.utf8Output() + result.utf8stderrOutput()
                 XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
                 XCTAssertMatch(output, .and(.contains("MyLibrary:"), .contains("mypackage/MyLibrary")))


### PR DESCRIPTION
There were a few undesirable issues caused by a combination of a `swift-argument-parser` issue and making the `plugin` subcommand be the default subcommand so that the `plugin` subcommand could be omitted:
 - when you invoke `swift package` without any arguments it starts resolving the package graph
 - when you make a typo like `swift package resove` it emits an error that it did not find any plugin (`error: No command plugins found for ‘resove’`)
 - the `--list` option of the `plugin` subcommand incorrectly applied even when `plugin` was omitted
 - `swift package plugin --help` yields no help
 - `swift package plugin` yields `error: No plugin command name specified`

This change introduces a new separate default subcommand that has behavior suitable for omitting the `plugin` subcommand:
 - if there are no parameters, it prints the help
 - if there is an unknown parameter, it prints an error message that takes into account that it might not be a command
 - it doesn't define options like `--list` that only make sense in the context of a `plugin` subcommand
 - it removes the definitions of `--target` and `--product` from `swift package plugin` since they are no longer treated specially, and this prevents them from being folded into `swift package` arguments even when they are on the right side of the plugin verb
 - add a unit test to check that invoking `swift package` without arguments prints help

This still leaves the problem of having options defined by `swift package`, such as `--verbose`, getting "stolen" even if they are on the right hand side of the plugin name.  Fixing that depends on a fix in `swift-argument-parser` that is planned to be included in an upcoming bugfix tag, but this is still incremental progress.