### PR TITLE
Build: enable the swift-driver on Windows

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -728,10 +728,6 @@ public final class SwiftTargetBuildDescription {
     }
     
     public static func checkSupportedFrontendFlags(flags: Set<String>, fileSystem: FileSystem) -> Bool {
-        // The new driver is not supported on Windows, yet, so we should avoid calling into it there.
-        #if os(Windows)
-        return false
-        #else
         do {
             let executor = try SPMSwiftDriverExecutor(resolver: ArgsResolver(fileSystem: fileSystem), fileSystem: fileSystem, env: [:])
             let driver = try Driver(args: ["swiftc"], executor: executor)
@@ -739,7 +735,6 @@ public final class SwiftTargetBuildDescription {
         } catch {
             return false
         }
-        #endif
     }
     
     /// The arguments needed to compile this target.


### PR DESCRIPTION
The swift-driver works on Windows is in the process of becoming the
default driver on Windows.  This enable the last piece of the
swift-driver support in SPM.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
