### PR TITLE
refactor workspace delegates

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -166,7 +166,10 @@ let package = Package(
         .target(
             /** Source control operations */
             name: "SourceControl",
-            dependencies: ["Basics"],
+            dependencies: [
+                "Basics",
+                "PackageModel"
+            ],
             exclude: ["CMakeLists.txt"]
         ),
 

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -755,47 +755,47 @@ public final class MockWorkspaceDelegate: WorkspaceDelegate {
 
     public init() {}
 
-    public func repositoryWillUpdate(_ repository: String) {
-        self.append("updating repo: \(repository)")
+    public func willUpdateRepository(package: PackageIdentity, repository url: String) {
+        self.append("updating repo: \(url)")
     }
 
-    public func repositoryDidUpdate(_ repository: String, duration: DispatchTimeInterval) {
-        self.append("finished updating repo: \(repository)")
+    public func didUpdateRepository(package: PackageIdentity, repository url: String, duration: DispatchTimeInterval) {
+        self.append("finished updating repo: \(url)")
     }
 
     public func dependenciesUpToDate() {
         self.append("Everything is already up-to-date")
     }
 
-    public func willFetchPackage(package: String, fetchDetails: PackageFetchDetails) {
-        self.append("fetching package: \(package)")
+    public func willFetchPackage(package: PackageIdentity, packageLocation: String?, fetchDetails: PackageFetchDetails) {
+        self.append("fetching package: \(packageLocation ?? package.description)")
     }
 
-    public func fetchingPackage(package: String, progress: Int64, total: Int64?) {
+    public func fetchingPackage(package: PackageIdentity, packageLocation: String?, progress: Int64, total: Int64?) {
     }
 
-    public func didFetchPackage(package: String, result: Result<PackageFetchDetails, Error>, duration: DispatchTimeInterval) {
-        self.append("finished fetching package: \(package)")
+    public func didFetchPackage(package: PackageIdentity, packageLocation: String?, result: Result<PackageFetchDetails, Error>, duration: DispatchTimeInterval) {
+        self.append("finished fetching package: \(packageLocation ?? package.description)")
     }
 
-    public func willCreateWorkingCopy(repository url: String, at path: AbsolutePath) {
+    public func willCreateWorkingCopy(package: PackageIdentity, repository url: String, at path: AbsolutePath) {
         self.append("creating working copy for: \(url)")
     }
 
-    public func didCreateWorkingCopy(repository url: String, at path: AbsolutePath, error: Basics.Diagnostic?) {
+    public func didCreateWorkingCopy(package: PackageIdentity, repository url: String, at path: AbsolutePath) {
         self.append("finished creating working copy for: \(url)")
     }
 
-    public func willCheckOut(repository url: String, revision: String, at path: AbsolutePath) {
+    public func willCheckOut(package: PackageIdentity, repository url: String, revision: String, at path: AbsolutePath) {
         self.append("checking out repo: \(url)")
     }
 
-    public func didCheckOut(repository url: String, revision: String, at path: AbsolutePath, error: Basics.Diagnostic?) {
+    public func didCheckOut(package: PackageIdentity, repository url: String, revision: String, at path: AbsolutePath) {
         self.append("finished checking out repo: \(url)")
     }
 
-    public func removing(repository: String) {
-        self.append("removing repo: \(repository)")
+    public func removing(package: PackageIdentity, packageLocation: String?) {
+        self.append("removing repo: \(packageLocation ?? package.description)")
     }
 
     public func willResolveDependencies(reason: WorkspaceResolveReason) {

--- a/Sources/SourceControl/CMakeLists.txt
+++ b/Sources/SourceControl/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(SourceControl
 
 target_link_libraries(SourceControl PUBLIC
   Basics
+  PackageModel
   TSCBasic
   TSCUtility
   Basics)

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -9,6 +9,7 @@
  */
 
 import Basics
+import PackageModel
 import SPMTestSupport
 @testable import SourceControl
 import TSCBasic
@@ -347,6 +348,7 @@ class RepositoryManagerTests: XCTestCase {
                 group.enter()
                 delegate.prepare(fetchExpected: index == 0, updateExpected: index > 0)
                 manager.lookup(
+                    package: .init(url: dummyRepo.url),
                     repository: dummyRepo,
                     skipUpdate: false,
                     observabilityScope: observability.topScope,
@@ -452,6 +454,7 @@ extension RepositoryManager {
     fileprivate func lookup(repository: RepositorySpecifier, skipUpdate: Bool = false, observabilityScope: ObservabilityScope) throws -> RepositoryHandle {
         return try tsc_await {
             self.lookup(
+                package: .init(url: repository.url),
                 repository: repository,
                 skipUpdate: skipUpdate,
                 observabilityScope: observabilityScope,
@@ -705,25 +708,25 @@ private class DummyRepositoryManagerDelegate: RepositoryManager.Delegate {
         return self._didUpdate.get()
     }
 
-    func willFetch(repository: RepositorySpecifier, details: RepositoryManager.FetchDetails) {
+    func willFetch(package: PackageIdentity, repository: RepositorySpecifier, details: RepositoryManager.FetchDetails) {
         self._willFetch.append((repository: repository, details: details))
         self.group.leave()
     }
 
-    func fetching(repository: RepositorySpecifier, objectsFetched: Int, totalObjectsToFetch: Int) {
+    func fetching(package: PackageIdentity, repository: RepositorySpecifier, objectsFetched: Int, totalObjectsToFetch: Int) {
     }
 
-    func didFetch(repository: RepositorySpecifier, result: Result<RepositoryManager.FetchDetails, Error>, duration: DispatchTimeInterval) {
+    func didFetch(package: PackageIdentity, repository: RepositorySpecifier, result: Result<RepositoryManager.FetchDetails, Error>, duration: DispatchTimeInterval) {
         self._didFetch.append((repository: repository, result: result))
         self.group.leave()
     }
 
-    func willUpdate(repository: RepositorySpecifier) {
+    func willUpdate(package: PackageIdentity, repository: RepositorySpecifier) {
         self._willUpdate.append(repository)
         self.group.leave()
     }
 
-    func didUpdate(repository: RepositorySpecifier, duration: DispatchTimeInterval) {
+    func didUpdate(package: PackageIdentity, repository: RepositorySpecifier, duration: DispatchTimeInterval) {
         self._didUpdate.append(repository)
         self.group.leave()
     }

--- a/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
@@ -150,17 +150,17 @@ private class MockRepositories: RepositoryProvider {
 private class MockResolverDelegate: RepositoryManager.Delegate {
     var fetched = ThreadSafeArrayStore<RepositorySpecifier>()
 
-    func willFetch(repository: RepositorySpecifier, details: RepositoryManager.FetchDetails) {
+    func willFetch(package: PackageIdentity, repository: RepositorySpecifier, details: RepositoryManager.FetchDetails) {
         self.fetched.append(repository)
     }
 
-    func fetching(repository: RepositorySpecifier, objectsFetched: Int, totalObjectsToFetch: Int) {}
+    func fetching(package: PackageIdentity, repository: RepositorySpecifier, objectsFetched: Int, totalObjectsToFetch: Int) {}
 
-    func didFetch(repository: RepositorySpecifier, result: Result<RepositoryManager.FetchDetails, Error>, duration: DispatchTimeInterval) {}
+    func didFetch(package: PackageIdentity, repository: RepositorySpecifier, result: Result<RepositoryManager.FetchDetails, Error>, duration: DispatchTimeInterval) {}
 
-    func willUpdate(repository: RepositorySpecifier) {}
+    func willUpdate(package: PackageIdentity, repository: RepositorySpecifier) {}
 
-    func didUpdate(repository: RepositorySpecifier, duration: DispatchTimeInterval) {}
+    func didUpdate(package: PackageIdentity, repository: RepositorySpecifier, duration: DispatchTimeInterval) {}
 }
 
 // Some handy versions & ranges.


### PR DESCRIPTION
motivaton: SwiftPM clients now need to reverse engineer the package identity from the url

changes:
* add PackageIdentity to WorkspaceDelegate::willFetchPackage
* add PackageIdentity to WorkspaceDelegate::fetchingPackage
* add PackageIdentity to WorkspaceDelegate::didFetchPackage
* rename WorkspaceDelegate::repositoryWillUpdate to WorkspaceDelegate::willUpdateRepository and add PackageIdentity
* rename WorkspaceDelegate::repositoryDidUpdate to WorkspaceDelegate::didUpdateRepository and add PackageIdentity
* add PackageIdentity to WorkspaceDelegate::willCreateWorkingCopy
* add PackageIdentity to WorkspaceDelegate::didCreateWorkingCopy
* add PackageIdentity to WorkspaceDelegate::willCheckOut
* add PackageIdentity to WorkspaceDelegate::didCheckOut
* add PackageIdentity to WorkspaceDelegate::removing
* remove redundant (not in use) Diagnostics argument from WorkspaceDelegate::didCreateWorkingCopy
* remove redundant (not in use) Diagnostics argument from WorkspaceDelegate::didCheckOut
* update call sites and test