### PR TITLE
Remove unnecessary `TSCLibc` dependency

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -19,13 +19,17 @@ import PackageModel
 import SourceControl
 import SPMBuildCore
 import TSCBasic
-import TSCLibc
+
 import TSCUtility
 import Workspace
 import XCBuildSupport
 
 #if os(Windows)
 import WinSDK
+#elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+import Darwin
+#else
+import Glibc
 #endif
 
 typealias Diagnostic = Basics.Diagnostic

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -12,7 +12,7 @@ import PackageModel
 import SourceControl
 import SPMTestSupport
 import TSCBasic
-import TSCLibc
+
 import TSCUtility
 import Workspace
 import XCTest


### PR DESCRIPTION
Remove the `TSCLibc` dependency as we do not depend on any of the
interfaces from the module.  This matters particularly on Windows
where static linking Swift content is not available, so this will
reduce the amount of dirty memory due to the dynamic library link
that cannot be removed.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
