### PR TITLE
Test parent directory of .netrc file is writable before using it

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -609,6 +609,13 @@ public class SwiftTool {
             // User didn't tell us to use these .netrc files so be more lenient with errors
             func loadNetrcNoThrows(at path: AbsolutePath) -> NetrcAuthorizationProvider? {
                 guard localFileSystem.exists(path) else { return nil }
+                
+                do {
+                    try withTemporaryFile(dir: path.parentDirectory) { _ in }
+                } catch {
+                    self.observabilityScope.emit(warning: "\(path.parentDirectory) is not accessible or not writable, not using .netrc file in it: \(error)")
+                    return nil
+                }
 
                 do {
                     return try NetrcAuthorizationProvider(path: path, fileSystem: localFileSystem)

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -4085,9 +4085,10 @@ extension Workspace.Location {
 
         // check that shared configuration directory is accessible, or warn + reset if not
         if let sharedConfigurationDirectory = self.sharedConfigurationDirectory {
-            // it may not always be possible to create default location (for example de to restricted sandbox)
+            // It may not always be possible to create default location (for example de to restricted sandbox),
+            // in which case defaultDirectory would be nil.
             let defaultDirectory = try? fileSystem.getOrCreateSwiftPMConfigurationDirectory(warningHandler: warningHandler)
-            if sharedConfigurationDirectory != defaultDirectory {
+            if defaultDirectory != nil, sharedConfigurationDirectory != defaultDirectory {
                 // custom location must be writable, throw if we cannot access it
                 try withTemporaryFile(dir: sharedConfigurationDirectory) { _ in }
             } else {
@@ -4103,9 +4104,10 @@ extension Workspace.Location {
 
         // check that shared configuration directory is accessible, or warn + reset if not
         if let sharedSecurityDirectory = self.sharedSecurityDirectory {
-            // it may not always be possible to create default location (for example de to restricted sandbox)
+            // It may not always be possible to create default location (for example de to restricted sandbox),
+            // in which case defaultDirectory would be nil.
             let defaultDirectory = try? fileSystem.getOrCreateSwiftPMSecurityDirectory()
-            if sharedSecurityDirectory != defaultDirectory {
+            if defaultDirectory != nil, sharedSecurityDirectory != defaultDirectory {
                 // custom location must be writable, throw if we cannot access it
                 try withTemporaryFile(dir: sharedSecurityDirectory) { _ in }
             } else {
@@ -4121,9 +4123,10 @@ extension Workspace.Location {
 
         // check that shared configuration directory is accessible, or warn + reset if not
         if let sharedCacheDirectory = self.sharedCacheDirectory {
-            // it may not always be possible to create default location (for example de to restricted sandbox)
+            // It may not always be possible to create default location (for example de to restricted sandbox),
+            // in which case defaultDirectory would be nil.
             let defaultDirectory = try? fileSystem.getOrCreateSwiftPMCacheDirectory()
-            if sharedCacheDirectory != defaultDirectory {
+            if defaultDirectory != nil, sharedCacheDirectory != defaultDirectory {
                 // custom location must be writable, throw if we cannot access it
                 try withTemporaryFile(dir: sharedCacheDirectory) { _ in }
             } else {


### PR DESCRIPTION
https://ci.swift.org/job/swift-PR-source-compat-suite-debug/4058/

```
$ sandbox-exec -f /Users/buildnode/jenkins/workspace-private/swift-source-compat-suite-sandbox/sandbox_package.sb /Users/buildnode/jenkins/workspace-private/swift-PR-source-compat-suite-debug/build/compat_macos/install/toolchain/usr/bin/swift package --disable-sandbox -C /Users/buildnode/jenkins/workspace/swift-PR-source-compat-suite-debug/swift-source-compat-suite/project_cache/GRDB.swift clean
warning: '--chdir/-C' option is deprecated; use '--package-path' instead
warning: Failed to load .netrc file at /Users/buildnode/.netrc. Error: unreadableFile(<AbsolutePath:"/Users/buildnode/.netrc">)
error: other(1)
```

Not sure if the `other(1)` error is `.netrc` related. Trying to see if
this code change will fix it.
