### PR TITLE
[5.6] Increment SwiftArgumentParser dependency to 1.0.3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -566,7 +566,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         // The 'swift-argument-parser' version declared here must match that
         // used by 'swift-driver' and 'sourcekit-lsp'. Please coordinate
         // dependency version changes here with those projects.
-        .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.0.1")),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.0.3")),
         .package(url: "https://github.com/apple/swift-driver.git", .branch(relatedDependenciesBranch)),
         .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: minimumCryptoVersion)),
     ]


### PR DESCRIPTION
Increment SwiftArgumentParser dependency to 1.0.3 to pull in a bug fix that would cause subcommand arguments to be folded into the parent command

Motivation:

We'd like to get the fix in apple/swift-argument-parser#397 in order to fix issues with swift run and swift plugin arguments. For example, swift package plugin foo --verbose would cause the --verbose to be applied to the parent command and not the plugin.

rdar://88097258
