### PR TITLE
move netrc parser into SwiftPM (from TSC)

### DIFF
--- a/Sources/Basics/CMakeLists.txt
+++ b/Sources/Basics/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(Basics
   HTTPClient.swift
   JSON+Extensions.swift
   JSONDecoder+Extensions.swift
+  Netrc.swift
   Observability.swift
   Sandbox.swift
   String+Extensions.swift

--- a/Sources/Basics/Netrc.swift
+++ b/Sources/Basics/Netrc.swift
@@ -1,0 +1,166 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import Foundation
+import TSCBasic
+
+/// Representation of Netrc configuration
+@available (macOS 10.13, iOS 11, tvOS 11, watchOS 4, *)
+public struct Netrc {
+    /// Representation of `machine` connection settings & `default` connection settings.
+    /// If `default` connection settings present, they will be last element.
+    public let machines: [Machine]
+
+    fileprivate init(machines: [Machine]) {
+        self.machines = machines
+    }
+
+    /// Returns auth information
+    ///
+    /// - Parameters:
+    ///   - url: The url to retrieve authorization information for.
+    public func authorization(for url: URL) -> Authorization? {
+        guard let index = machines.firstIndex(where: { $0.name == url.host }) ?? machines.firstIndex(where: { $0.isDefault }) else {
+            return .none
+        }
+        let machine = machines[index]
+        return Authorization(login: machine.login, password: machine.password)
+    }
+
+
+    /// Representation of connection settings
+    public struct Machine: Equatable {
+        public let name: String
+        public let login: String
+        public let password: String
+
+        public var isDefault: Bool {
+            return name == "default"
+        }
+
+        public init(name: String, login: String, password: String) {
+            self.name = name
+            self.login = login
+            self.password = password
+        }
+
+        init?(for match: NSTextCheckingResult, string: String, variant: String = "") {
+            guard let name = RegexUtil.Token.machine.capture(in: match, string: string) ?? RegexUtil.Token.default.capture(in: match, string: string),
+                  let login = RegexUtil.Token.login.capture(prefix: variant, in: match, string: string),
+                  let password = RegexUtil.Token.password.capture(prefix: variant, in: match, string: string) else {
+                      return nil
+                  }
+            self = Machine(name: name, login: login, password: password)
+        }
+    }
+
+    /// Representation of authorization information
+    public struct Authorization: Equatable {
+        public let login: String
+        public let password: String
+
+        public init(login: String, password: String) {
+            self.login = login
+            self.password = password
+        }
+    }
+}
+
+public struct NetrcParser {
+    /// Parses a netrc file at the give location
+    ///
+    /// - Parameters:
+    ///   - fileSystem: The file system to use.
+    ///   - path: The file to parse
+    public static func parse(fileSystem: FileSystem, path: AbsolutePath) throws -> Netrc {
+        guard fileSystem.exists(path) else {
+            throw NetrcError.fileNotFound(path)
+        }
+        guard fileSystem.isReadable(path) else {
+            throw NetrcError.unreadableFile(path)
+        }
+        let content: String = try fileSystem.readFileContents(path)
+        return try Self.parse(content)
+    }
+
+    /// Parses strnigified netrc content
+    ///
+    /// - Parameters:
+    ///   - content: The content to parse
+    public static func parse(_ content: String) throws -> Netrc {
+        let content = trimComments(from: content)
+        let regex = try! NSRegularExpression(pattern: RegexUtil.netrcPattern, options: [])
+        let matches = regex.matches(in: content, options: [], range: NSRange(content.startIndex..<content.endIndex, in: content))
+
+        let machines: [Netrc.Machine] = matches.compactMap {
+            return Netrc.Machine(for: $0, string: content, variant: "lp") ?? Netrc.Machine(for: $0, string: content, variant: "pl")
+        }
+
+        if let defIndex = machines.firstIndex(where: { $0.isDefault }) {
+            guard defIndex == machines.index(before: machines.endIndex) else {
+                throw NetrcError.invalidDefaultMachinePosition
+            }
+        }
+        guard machines.count > 0 else {
+            throw NetrcError.machineNotFound
+        }
+        return Netrc(machines: machines)
+    }
+
+    /// Utility method to trim comments from netrc content
+    /// - Parameter text: String text of netrc file
+    /// - Returns: String text of netrc file *sans* comments
+    private static func trimComments(from text: String) -> String {
+        let regex = try! NSRegularExpression(pattern: RegexUtil.comments, options: .anchorsMatchLines)
+        let nsString = text as NSString
+        let range = NSRange(location: 0, length: nsString.length)
+        let matches = regex.matches(in: text, range: range)
+        var trimmedCommentsText = text
+        matches.forEach {
+            trimmedCommentsText = trimmedCommentsText
+                .replacingOccurrences(of: nsString.substring(with: $0.range), with: "")
+        }
+        return trimmedCommentsText
+    }
+}
+
+public enum NetrcError: Error, Equatable {
+    case fileNotFound(AbsolutePath)
+    case unreadableFile(AbsolutePath)
+    case machineNotFound
+    case invalidDefaultMachinePosition
+}
+
+@available (macOS 10.13, iOS 11, tvOS 11, watchOS 4, *)
+fileprivate enum RegexUtil {
+    @frozen fileprivate enum Token: String, CaseIterable {
+        case machine, login, password, account, macdef, `default`
+
+        func capture(prefix: String = "", in match: NSTextCheckingResult, string: String) -> String? {
+            guard let range = Range(match.range(withName: prefix + rawValue), in: string) else { return nil }
+            return String(string[range])
+        }
+    }
+
+    static let comments: String = "\\#[\\s\\S]*?.*$"
+    static let `default`: String = #"(?:\s*(?<default>default))"#
+    static let accountOptional: String = #"(?:\s*account\s+\S++)?"#
+    static let loginPassword: String = #"\#(namedTrailingCapture("login", prefix: "lp"))\#(accountOptional)\#(namedTrailingCapture("password", prefix: "lp"))"#
+    static let passwordLogin: String = #"\#(namedTrailingCapture("password", prefix: "pl"))\#(accountOptional)\#(namedTrailingCapture("login", prefix: "pl"))"#
+    static let netrcPattern = #"(?:(?:(\#(namedTrailingCapture("machine"))|\#(namedMatch("default"))))(?:\#(loginPassword)|\#(passwordLogin)))"#
+
+    static func namedMatch(_ string: String) -> String {
+        return #"(?:\s*(?<\#(string)>\#(string)))"#
+    }
+
+    static func namedTrailingCapture(_ string: String, prefix: String = "") -> String {
+        return #"\s*\#(string)\s+(?<\#(prefix + string)>\S++)"#
+    }
+}

--- a/Tests/BasicsTests/NetrcTests.swift
+++ b/Tests/BasicsTests/NetrcTests.swift
@@ -1,0 +1,436 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import Basics
+import XCTest
+
+/// Netrc feature depends upon `NSTextCheckingResult.range(withName name: String) -> NSRange`,
+/// which is only available in macOS 10.13+ at this time.
+@available(macOS 10.13, iOS 11, tvOS 11, watchOS 4, *)
+class NetrcTests: XCTestCase {
+    /// should load machines for a given inline format
+    func testLoadMachinesInline() throws {
+        let content = "machine example.com login anonymous password qwerty"
+
+        let netrc = try NetrcParser.parse(content)
+        XCTAssertEqual(netrc.machines.count, 1)
+
+        let machine = netrc.machines.first
+        XCTAssertEqual(machine?.name, "example.com")
+        XCTAssertEqual(machine?.login, "anonymous")
+        XCTAssertEqual(machine?.password, "qwerty")
+
+        let authorization = netrc.authorization(for: URL(string: "http://example.com/resource.zip")!)
+        XCTAssertEqual(authorization, Netrc.Authorization(login: "anonymous", password: "qwerty"))
+
+        XCTAssertNil(netrc.authorization(for: URL(string: "http://example2.com/resource.zip")!))
+        XCTAssertNil(netrc.authorization(for: URL(string: "http://www.example2.com/resource.zip")!))
+    }
+
+    /// should load machines for a given multi-line format
+    func testLoadMachinesMultiLine() throws {
+        let content = """
+                    machine example.com
+                    login anonymous
+                    password qwerty
+                    """
+
+        let netrc = try NetrcParser.parse(content)
+        XCTAssertEqual(netrc.machines.count, 1)
+
+        let machine = netrc.machines.first
+        XCTAssertEqual(machine?.name, "example.com")
+        XCTAssertEqual(machine?.login, "anonymous")
+        XCTAssertEqual(machine?.password, "qwerty")
+
+        let authorization = netrc.authorization(for: URL(string: "http://example.com/resource.zip")!)
+        XCTAssertEqual(authorization, Netrc.Authorization(login: "anonymous", password: "qwerty"))
+
+        XCTAssertNil(netrc.authorization(for: URL(string: "http://example2.com/resource.zip")!))
+        XCTAssertNil(netrc.authorization(for: URL(string: "http://www.example2.com/resource.zip")!))
+    }
+
+    /// Should fall back to default machine when not matching host
+    func testLoadDefaultMachine() throws {
+        let content = """
+                    machine example.com
+                    login anonymous
+                    password qwerty
+
+                    default
+                    login id
+                    password secret
+                    """
+
+        let netrc = try NetrcParser.parse(content)
+        XCTAssertEqual(netrc.machines.count, 2)
+
+        let machine = netrc.machines.first
+        XCTAssertEqual(machine?.name, "example.com")
+        XCTAssertEqual(machine?.login, "anonymous")
+        XCTAssertEqual(machine?.password, "qwerty")
+
+        let machine2 = netrc.machines.last
+        XCTAssertEqual(machine2?.name, "default")
+        XCTAssertEqual(machine2?.login, "id")
+        XCTAssertEqual(machine2?.password, "secret")
+
+        let authorization = netrc.authorization(for: URL(string: "http://example2.com/resource.zip")!)
+        XCTAssertEqual(authorization, Netrc.Authorization(login: "id", password: "secret"))
+    }
+
+    func testRegexParsing() throws {
+        let content = """
+                    machine machine
+                    login login
+                    password password
+
+                    machine login
+                    password machine
+                    login password
+
+                    default machine
+                    login id
+                    password secret
+
+                    machinemachine machine
+                    loginlogin id
+                    passwordpassword secret
+
+                    default
+                    login id
+                    password secret
+                    """
+
+        let netrc = try NetrcParser.parse(content)
+        XCTAssertEqual(netrc.machines.count, 3)
+
+        XCTAssertEqual(netrc.machines[0].name, "machine")
+        XCTAssertEqual(netrc.machines[0].login, "login")
+        XCTAssertEqual(netrc.machines[0].password, "password")
+
+        XCTAssertEqual(netrc.machines[1].name, "login")
+        XCTAssertEqual(netrc.machines[1].login, "password")
+        XCTAssertEqual(netrc.machines[1].password, "machine")
+
+        XCTAssertEqual(netrc.machines[2].name, "default")
+        XCTAssertEqual(netrc.machines[2].login, "id")
+        XCTAssertEqual(netrc.machines[2].password, "secret")
+
+        let authorization = netrc.authorization(for: URL(string: "http://example2.com/resource.zip")!)
+        XCTAssertEqual(authorization, Netrc.Authorization(login: "id", password: "secret"))
+    }
+
+    func testOutOfOrderDefault() {
+        let content = """
+                    machine machine
+                    login login
+                    password password
+
+                    machine login
+                    password machine
+                    login password
+
+                    default
+                    login id
+                    password secret
+
+                    machine machine
+                    login id
+                    password secret
+                    """
+
+        XCTAssertThrowsError(try NetrcParser.parse(content)) { error in
+            XCTAssertEqual(error as? NetrcError, .invalidDefaultMachinePosition)
+        }
+    }
+
+    func testErrorOnMultipleDefault() {
+        let content = """
+                    machine machine
+                    login login
+                    password password
+
+                    machine login
+                    password machine
+                    login password
+
+                    default
+                    login id
+                    password secret
+
+                    machine machine
+                    login id
+                    password secret
+
+                    default
+                    login di
+                    password terces
+                    """
+
+        XCTAssertThrowsError(try NetrcParser.parse(content)) { error in
+            XCTAssertEqual(error as? NetrcError, .invalidDefaultMachinePosition)
+        }
+    }
+
+    /// should load machines for a given multi-line format with comments
+    func testLoadMachinesMultilineComments() throws {
+        let content = """
+                    ## This is a comment
+                    # This is another comment
+                    machine example.com # This is an inline comment
+                    login anonymous
+                    password qwerty # and # another #one
+                    """
+
+        let machines = try NetrcParser.parse(content).machines
+        XCTAssertEqual(machines.count, 1)
+
+        let machine = machines.first
+        XCTAssertEqual(machine?.name, "example.com")
+        XCTAssertEqual(machine?.login, "anonymous")
+        XCTAssertEqual(machine?.password, "qwerty")
+    }
+
+    /// should load machines for a given multi-line + whitespaces format
+    func testLoadMachinesMultilineWhitespaces() throws {
+        let content = """
+                    machine  example.com login     anonymous
+                    password                  qwerty
+                    """
+
+        let machines = try NetrcParser.parse(content).machines
+        XCTAssertEqual(machines.count, 1)
+
+        let machine = machines.first
+        XCTAssertEqual(machine?.name, "example.com")
+        XCTAssertEqual(machine?.login, "anonymous")
+        XCTAssertEqual(machine?.password, "qwerty")
+    }
+
+    /// should load multiple machines for a given inline format
+    func testLoadMultipleMachinesInline() throws {
+        let content = "machine example.com login anonymous password qwerty machine example2.com login anonymous2 password qwerty2"
+
+        let netrc = try NetrcParser.parse(content)
+        XCTAssertEqual(netrc.machines.count, 2)
+
+        XCTAssertEqual(netrc.machines[0].name, "example.com")
+        XCTAssertEqual(netrc.machines[0].login, "anonymous")
+        XCTAssertEqual(netrc.machines[0].password, "qwerty")
+
+        XCTAssertEqual(netrc.machines[1].name, "example2.com")
+        XCTAssertEqual(netrc.machines[1].login, "anonymous2")
+        XCTAssertEqual(netrc.machines[1].password, "qwerty2")
+    }
+
+    /// should load multiple machines for a given multi-line format
+    func testLoadMultipleMachinesMultiline() throws {
+        let content = """
+                    machine  example.com login     anonymous
+                    password                  qwerty
+                    machine example2.com
+                    login anonymous2
+                    password qwerty2
+                    """
+
+        let machines = try NetrcParser.parse(content).machines
+        XCTAssertEqual(machines.count, 2)
+
+        var machine = machines[0]
+        XCTAssertEqual(machine.name, "example.com")
+        XCTAssertEqual(machine.login, "anonymous")
+        XCTAssertEqual(machine.password, "qwerty")
+
+        machine = machines[1]
+        XCTAssertEqual(machine.name, "example2.com")
+        XCTAssertEqual(machine.login, "anonymous2")
+        XCTAssertEqual(machine.password, "qwerty2")
+    }
+
+    /// should throw error when machine parameter is missing
+    func testErrorMachineParameterMissing() throws {
+        let content = "login anonymous password qwerty"
+
+        XCTAssertThrowsError(try NetrcParser.parse(content)) { error in
+            XCTAssertEqual(error as? NetrcError, .machineNotFound)
+        }
+    }
+
+    /// should throw error for an empty machine values
+    func testErrorEmptyMachineValue() throws {
+        let content = "machine"
+
+        XCTAssertThrowsError(try NetrcParser.parse(content)) { error in
+            XCTAssertEqual(error as? NetrcError, .machineNotFound)
+        }
+    }
+
+    /// should throw error for an empty machine values
+    func testEmptyMachineValueFollowedByDefaultNoError() throws {
+        let content = "machine default login id password secret"
+        let netrc = try NetrcParser.parse(content)
+        let authorization = netrc.authorization(for: URL(string: "http://example.com/resource.zip")!)
+        XCTAssertEqual(authorization, Netrc.Authorization(login: "id", password: "secret"))
+    }
+
+    /// should return authorization when config contains a given machine
+    func testReturnAuthorizationForMachineMatch() throws {
+        let content = "machine example.com login anonymous password qwerty"
+
+        let netrc = try NetrcParser.parse(content)
+        let authorization = netrc.authorization(for: URL(string: "http://example.com/resource.zip")!)
+        XCTAssertEqual(authorization, Netrc.Authorization(login: "anonymous", password: "qwerty"))
+    }
+
+    func testReturnNoAuthorizationForUnmatched() throws {
+        let content = "machine example.com login anonymous password qwerty"
+        let netrc = try NetrcParser.parse(content)
+        XCTAssertNil(netrc.authorization(for: URL(string: "http://www.example.com/resource.zip")!))
+        XCTAssertNil(netrc.authorization(for: URL(string: "ftp.example.com/resource.zip")!))
+        XCTAssertNil(netrc.authorization(for: URL(string: "http://example2.com/resource.zip")!))
+        XCTAssertNil(netrc.authorization(for: URL(string: "http://www.example2.com/resource.zip")!))
+    }
+
+    /// should not return authorization when config does not contain a given machine
+    func testNoReturnAuthorizationForNoMachineMatch() throws {
+        let content = "machine example.com login anonymous password qwerty"
+
+        let netrc = try NetrcParser.parse(content)
+        XCTAssertNil(netrc.authorization(for: URL(string: "https://example99.com")!))
+        XCTAssertNil(netrc.authorization(for: URL(string: "http://www.example.com/resource.zip")!))
+        XCTAssertNil(netrc.authorization(for: URL(string: "ftp.example.com/resource.zip")!))
+        XCTAssertNil(netrc.authorization(for: URL(string: "http://example2.com/resource.zip")!))
+        XCTAssertNil(netrc.authorization(for: URL(string: "http://www.example2.com/resource.zip")!))
+    }
+
+    /// Test case: https://www.ibm.com/support/knowledgecenter/en/ssw_aix_72/filesreference/netrc.html
+    func testIBMDocumentation() throws {
+        let content = "machine host1.austin.century.com login fred password bluebonnet"
+
+        let netrc = try NetrcParser.parse(content)
+
+        let machine = netrc.machines.first
+        XCTAssertEqual(machine?.name, "host1.austin.century.com")
+        XCTAssertEqual(machine?.login, "fred")
+        XCTAssertEqual(machine?.password, "bluebonnet")
+    }
+
+    /// Should not fail on presence of `account`, `macdef`, `default`
+    /// test case: https://gist.github.com/tpope/4247721
+    func testNoErrorTrailingAccountMacdefDefault() throws {
+        let content = """
+            machine api.heroku.com
+              login my@email.com
+              password 01230123012301230123012301230123
+
+            machine api.github.com password something login somebody
+
+            machine ftp.server login abc password def account ghi macdef somemacro
+            cd somehwhere
+            continues until end of paragraph
+
+            default login anonymous password my@email.com
+            """
+
+        let netrc = try NetrcParser.parse(content)
+
+        XCTAssertEqual(netrc.machines.count, 4)
+
+        XCTAssertEqual(netrc.machines[0].name, "api.heroku.com")
+        XCTAssertEqual(netrc.machines[0].login, "my@email.com")
+        XCTAssertEqual(netrc.machines[0].password, "01230123012301230123012301230123")
+
+        XCTAssertEqual(netrc.machines[1].name, "api.github.com")
+        XCTAssertEqual(netrc.machines[1].login, "somebody")
+        XCTAssertEqual(netrc.machines[1].password, "something")
+
+        XCTAssertEqual(netrc.machines[2].name, "ftp.server")
+        XCTAssertEqual(netrc.machines[2].login, "abc")
+        XCTAssertEqual(netrc.machines[2].password, "def")
+
+        XCTAssertEqual(netrc.machines[3].name, "default")
+        XCTAssertEqual(netrc.machines[3].login, "anonymous")
+        XCTAssertEqual(netrc.machines[3].password, "my@email.com")
+    }
+
+    /// Should not fail on presence of `account`, `macdef`, `default`
+    /// test case: https://gist.github.com/tpope/4247721
+    func testNoErrorMixedAccount() throws {
+        let content = """
+            machine api.heroku.com
+              login my@email.com
+              password 01230123012301230123012301230123
+
+            machine api.github.com password something account ghi login somebody
+
+            machine ftp.server login abc account ghi password def macdef somemacro
+            cd somehwhere
+            continues until end of paragraph
+
+            default login anonymous password my@email.com
+            """
+
+        let netrc = try NetrcParser.parse(content)
+
+        XCTAssertEqual(netrc.machines.count, 4)
+
+        XCTAssertEqual(netrc.machines[0].name, "api.heroku.com")
+        XCTAssertEqual(netrc.machines[0].login, "my@email.com")
+        XCTAssertEqual(netrc.machines[0].password, "01230123012301230123012301230123")
+
+        XCTAssertEqual(netrc.machines[1].name, "api.github.com")
+        XCTAssertEqual(netrc.machines[1].login, "somebody")
+        XCTAssertEqual(netrc.machines[1].password, "something")
+
+        XCTAssertEqual(netrc.machines[2].name, "ftp.server")
+        XCTAssertEqual(netrc.machines[2].login, "abc")
+        XCTAssertEqual(netrc.machines[2].password, "def")
+
+        XCTAssertEqual(netrc.machines[3].name, "default")
+        XCTAssertEqual(netrc.machines[3].login, "anonymous")
+        XCTAssertEqual(netrc.machines[3].password, "my@email.com")
+    }
+
+    /// Should not fail on presence of `account`, `macdef`, `default`
+    /// test case: https://renenyffenegger.ch/notes/Linux/fhs/home/username/_netrc
+    func testNoErrorMultipleMacdefAndComments() throws {
+        let content = """
+            machine  ftp.foobar.baz
+            login    john
+            password 5ecr3t
+
+            macdef   getmyfile       # define a macro (here named 'getmyfile')
+            cd /abc/defghi/jklm      # The macro can be executed in ftp client
+            get myFile.txt           # by prepending macro name with $ sign
+            quit
+
+            macdef   init            # macro init is searched for when
+            binary                   # ftp connects to server.
+
+            machine  other.server.org
+            login    fred
+            password sunshine4ever
+            """
+
+        let netrc = try NetrcParser.parse(content)
+
+        XCTAssertEqual(netrc.machines.count, 2)
+
+        XCTAssertEqual(netrc.machines[0].name, "ftp.foobar.baz")
+        XCTAssertEqual(netrc.machines[0].login, "john")
+        XCTAssertEqual(netrc.machines[0].password, "5ecr3t")
+
+        XCTAssertEqual(netrc.machines[1].name, "other.server.org")
+        XCTAssertEqual(netrc.machines[1].login, "fred")
+        XCTAssertEqual(netrc.machines[1].password, "sunshine4ever")
+    }
+}
+


### PR DESCRIPTION
motivation: the Netrc parser is only used by SwiftPM and can be moved into, which brings us closer to reducing TSC codebase

changes:
* migrate netrc parser from TSC into SwiftPM
* clean up the API a bit, e.g. use throwing instead of returning Result in non-async methods
* spelit netrc utility to parser and model vs. one monolithic utility
* migrate and clean up the tests
* update call sites