### PR TITLE
update netrc auth provider to read file "live"

### DIFF
--- a/Sources/Basics/AuthorizationProvider.swift
+++ b/Sources/Basics/AuthorizationProvider.swift
@@ -17,7 +17,7 @@ import Security
 import TSCBasic
 
 public protocol AuthorizationProvider {
-    func authentication(for url: Foundation.URL) -> (user: String, password: String)?
+    func authentication(for url: URL) -> (user: String, password: String)?
 }
 
 public enum AuthorizationProviderError: Error {
@@ -28,7 +28,7 @@ public enum AuthorizationProviderError: Error {
 }
 
 public extension AuthorizationProvider {
-    func httpAuthorizationHeader(for url: Foundation.URL) -> String? {
+    func httpAuthorizationHeader(for url: URL) -> String? {
         guard let (user, password) = self.authentication(for: url) else {
             return nil
         }
@@ -40,7 +40,7 @@ public extension AuthorizationProvider {
     }
 }
 
-private extension Foundation.URL {
+private extension URL {
     var authenticationID: String? {
         guard let host = host?.lowercased() else {
             return nil
@@ -52,29 +52,26 @@ private extension Foundation.URL {
 // MARK: - netrc
 
 public struct NetrcAuthorizationProvider: AuthorizationProvider {
-    let path: AbsolutePath
+    // marked internal for testing
+    internal let path: AbsolutePath
     private let fileSystem: FileSystem
-
-    private var underlying: Netrc?
-
-    var machines: [Netrc.Machine] {
-        self.underlying?.machines ?? []
-    }
 
     public init(path: AbsolutePath, fileSystem: FileSystem) throws {
         self.path = path
         self.fileSystem = fileSystem
-        self.underlying = try Self.load(fileSystem: fileSystem, path: path)
+        // validate file is okay at the time of initializing the provider
+        _ = try Self.load(fileSystem: fileSystem, path: path)
     }
 
-    public mutating func addOrUpdate(for url: Foundation.URL, user: String, password: String, callback: @escaping (Result<Void, Error>) -> Void) {
+    public mutating func addOrUpdate(for url: URL, user: String, password: String, callback: @escaping (Result<Void, Error>) -> Void) {
         guard let machine = url.authenticationID else {
             return callback(.failure(AuthorizationProviderError.invalidURLHost))
         }
 
         // Same entry already exists, no need to add or update
-        guard self.machines.first(where: { $0.name.lowercased() == machine && $0.login == user && $0.password == password }) == nil else {
-            return
+        let netrc = try? Self.load(fileSystem: self.fileSystem, path: self.path)
+        guard netrc?.machines.first(where: { $0.name.lowercased() == machine && $0.login == user && $0.password == password }) == nil else {
+            return callback(.success(()))
         }
 
         do {
@@ -92,19 +89,13 @@ public struct NetrcAuthorizationProvider: AuthorizationProvider {
                 }
             }
 
-            // At this point the netrc file should exist and non-empty
-            guard let netrc = try Self.load(fileSystem: self.fileSystem, path: self.path) else {
-                throw AuthorizationProviderError.other("Failed to update netrc file at \(self.path)")
-            }
-            self.underlying = netrc
-
             callback(.success(()))
         } catch {
             callback(.failure(AuthorizationProviderError.other("Failed to update netrc file at \(self.path): \(error)")))
         }
     }
 
-    public func authentication(for url: Foundation.URL) -> (user: String, password: String)? {
+    public func authentication(for url: URL) -> (user: String, password: String)? {
         self.machine(for: url).map { (user: $0.login, password: $0.password) }
     }
 
@@ -118,17 +109,21 @@ public struct NetrcAuthorizationProvider: AuthorizationProvider {
         return .none
     }
 
+    // marked internal for testing
+    internal var machines: [Basics.Netrc.Machine] {
+        // this ignores any errors reading the file
+        // initial validation is done at the time of initializing the provider
+        // and if the file becomes corrupt at runtime it will handle it gracefully
+        let netrc = try? Self.load(fileSystem: self.fileSystem, path: self.path)
+        return netrc?.machines ?? []
+    }
+
     private static func load(fileSystem: FileSystem, path: AbsolutePath) throws -> Netrc? {
         do {
             return try NetrcParser.parse(fileSystem: fileSystem, path: path)
-        } catch {
-            switch error {
-            case NetrcError.fileNotFound, NetrcError.machineNotFound:
-                // These are recoverable errors. We will just create the file and append entry to it.
-                return .none
-            default:
-                throw error
-            }
+        } catch NetrcError.fileNotFound, NetrcError.machineNotFound {
+            // These are recoverable errors.
+            return .none
         }
     }
 }
@@ -143,7 +138,7 @@ public struct KeychainAuthorizationProvider: AuthorizationProvider {
         self.observabilityScope = observabilityScope
     }
 
-    public func addOrUpdate(for url: Foundation.URL, user: String, password: String, callback: @escaping (Result<Void, Error>) -> Void) {
+    public func addOrUpdate(for url: URL, user: String, password: String, callback: @escaping (Result<Void, Error>) -> Void) {
         guard let server = url.authenticationID else {
             return callback(.failure(AuthorizationProviderError.invalidURLHost))
         }
@@ -162,7 +157,7 @@ public struct KeychainAuthorizationProvider: AuthorizationProvider {
         }
     }
 
-    public func authentication(for url: Foundation.URL) -> (user: String, password: String)? {
+    public func authentication(for url: URL) -> (user: String, password: String)? {
         guard let server = url.authenticationID else {
             return nil
         }
@@ -240,7 +235,7 @@ public struct KeychainAuthorizationProvider: AuthorizationProvider {
         return item
     }
 
-    private func `protocol`(for url: Foundation.URL) -> CFString {
+    private func `protocol`(for url: URL) -> CFString {
         // See https://developer.apple.com/documentation/security/keychain_services/keychain_items/item_attribute_keys_and_values?language=swift
         // for a list of possible values for the `kSecAttrProtocol` attribute.
         switch url.scheme?.lowercased() {
@@ -268,7 +263,7 @@ public struct CompositeAuthorizationProvider: AuthorizationProvider {
         self.observabilityScope = observabilityScope
     }
 
-    public func authentication(for url: Foundation.URL) -> (user: String, password: String)? {
+    public func authentication(for url: URL) -> (user: String, password: String)? {
         for provider in self.providers {
             if let authentication = provider.authentication(for: url) {
                 switch provider {


### PR DESCRIPTION
motivation: providers may live for a long time (together with workspace) so cannot cache the content of the file

changes:
* read the netrc file content every time data is requested
* adjust call sites
