### PR TITLE
Make the order in which targets (including plugin targets) are processed consistent

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -1616,7 +1616,7 @@ public class BuildPlan {
         // given to LLBuild.
         var targetMap = [ResolvedTarget: TargetBuildDescription]()
         var pluginDescriptions = [PluginDescription]()
-        for target in graph.allTargets {
+        for target in graph.allTargets.sorted(by: { $0.name < $1.name }) {
 
             // Validate the product dependencies of this target.
             for dependency in target.dependencies {

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -2355,13 +2355,13 @@ final class PackageToolTests: CommandsTestCase {
                 XCTAssertNoMatch(output, .contains("Building for debugging..."))
             }
             
-            // Deliberately break the build plugin.
-            try localFileSystem.writeFileContents(myBuildToolPluginTargetDir.appending(component: "plugin.swift"), string: """
+            // Deliberately break the command plugin.
+            try localFileSystem.writeFileContents(myCommandPluginTargetDir.appending(component: "plugin.swift"), string: """
                 import PackagePlugin
                 @main struct MyBuildToolPlugin: BuildToolPlugin {
-                    func createBuildCommands(
+                    func performCommand(
                         context: PluginContext,
-                        target: Target
+                        arguments: [String]
                     ) throws -> [Command] {
                         this is an error
                     }
@@ -2370,12 +2370,14 @@ final class PackageToolTests: CommandsTestCase {
             )
 
             // Check that building stops after compiling the plugin and doesn't proceed.
-            do {
+            // Run this test a number of times to try to catch any race conditions.
+            for _ in 1...5 {
                 let result = try SwiftPMProduct.SwiftBuild.executeProcess([], packagePath: packageDir)
                 let output = try result.utf8Output() + result.utf8stderrOutput()
                 XCTAssertNotEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
                 XCTAssertMatch(output, .contains("Compiling plugin MyCommandPlugin..."))
-                XCTAssertMatch(output, .contains("MyBuildToolPlugin/plugin.swift:7:19: error: consecutive statements on a line must be separated by ';'"))
+                XCTAssertMatch(output, .contains("Compiling plugin MyBuildToolPlugin..."))
+                XCTAssertMatch(output, .contains("MyCommandPlugin/plugin.swift:7:19: error: consecutive statements on a line must be separated by ';'"))
                 XCTAssertNoMatch(output, .contains("Building for debugging..."))
             }
         }


### PR DESCRIPTION
The code that processes targets in a BuildPlan was traversing a Set without any particular order, result in different order of processing each time (due to collection enumeration randomization).

The new code that collects lists of plugin descriptions became dependent on this order, causing plugins to be compiled in different order, which would sometimes cause a unit test to fail.

Rather than just imposing the order later, it seems prudent to make sure that the initial code that traverses the targets in the graph runs in a well-defined order, if nothing else to make debuggability easier.  There is no advantage to randomizing this order, and so this PR sorts them by name.  Ideally SwiftPM would preserve the order in which targets were declared, on the theory that the user had some purpose for organizing them that way in the manifest, but since that information has been lost at this point in the code, traversing them in alphabetical order by name seems like the next best thing.  We should consider using ordered sets in the future, if nothing else to make the output more predictable to the user.

rdar://88453397