### PR TITLE
fix flaky test

### DIFF
--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -326,8 +326,6 @@ class RepositoryManagerTests: XCTestCase {
     }
 
     func testConcurrency() throws {
-        throw XCTSkip("Skipping test due to rdar://88453312")
-
         let fs = localFileSystem
         let observability = ObservabilitySystem.makeForTesting()
 
@@ -356,8 +354,8 @@ class RepositoryManagerTests: XCTestCase {
                     delegateQueue: .sharedConcurrent,
                     callbackQueue: .sharedConcurrent
                 ) { result in
-                    group.leave()
                     results[index] = result
+                    group.leave()
                 }
             }
 


### PR DESCRIPTION
motivation: stable ci

changes: leave sync group only after recording results

rdar://88453312