### PR TITLE
Add `products(ofType:)`, `targets(ofType:)`, and `sourceFiles(withSuffix:)` utilities to PackagePlugin API

### DIFF
--- a/Sources/PackagePlugin/Utilities.swift
+++ b/Sources/PackagePlugin/Utilities.swift
@@ -54,3 +54,23 @@ extension Target {
         return self.dependencies.flatMap{ dependencyClosure(for: $0) }
     }
 }
+
+extension Package {
+    /// The products in this package that conform to a specific type.
+    public func products<T: Product>(ofType: T.Type) -> [T] {
+        return self.products.compactMap { $0 as? T }
+    }
+
+    /// The targets in this package that conform to a specific type.
+    public func targets<T: Target>(ofType: T.Type) -> [T] {
+        return self.targets.compactMap { $0 as? T }
+    }
+}
+
+extension SourceModuleTarget {
+    /// A possibly empty list of source files in the target that have the given
+    /// filename suffix.
+    public func sourceFiles(withSuffix suffix: String) -> FileList {
+        return FileList(self.sourceFiles.filter{ $0.path.lastComponent.hasSuffix(suffix) })
+    }
+}


### PR DESCRIPTION
This continues expanding the set of utility methods based on feedback from early use of plugins.  This makes it easier to write simpler and briefer plugin code.

The extensions are:
```
extension Package {
    /// The products in this package that conform to a specific type.
    public func products<T: Product>(ofType: T.Type) -> [T]

    /// The targets in this package that conform to a specific type.
    public func targets<T: Target>(ofType: T.Type) -> [T]
}

extension SourceModuleTarget {
    /// A possibly empty list of source files in the target that have the given
    /// filename suffix.
    public func sourceFiles(withSuffix suffix: String) -> FileList
}
```

The last of these was documented in SE-0325, and the other two added based on feedback.