### PR TITLE
[5.6] Add `products(ofType:)`, `targets(ofType:)`, and `sourceFiles(withSuffix:)` utilities to PackagePlugin API

### DIFF
--- a/Sources/PackagePlugin/Utilities.swift
+++ b/Sources/PackagePlugin/Utilities.swift
@@ -54,3 +54,23 @@ extension Target {
         return self.dependencies.flatMap{ dependencyClosure(for: $0) }
     }
 }
+
+extension Package {
+    /// The products in this package that conform to a specific type.
+    public func products<T: Product>(ofType: T.Type) -> [T] {
+        return self.products.compactMap { $0 as? T }
+    }
+
+    /// The targets in this package that conform to a specific type.
+    public func targets<T: Target>(ofType: T.Type) -> [T] {
+        return self.targets.compactMap { $0 as? T }
+    }
+}
+
+extension SourceModuleTarget {
+    /// A possibly empty list of source files in the target that have the given
+    /// filename suffix.
+    public func sourceFiles(withSuffix suffix: String) -> FileList {
+        return FileList(self.sourceFiles.filter{ $0.path.lastComponent.hasSuffix(suffix) })
+    }
+}

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -2048,6 +2048,13 @@ final class PackageToolTests: CommandsTestCase {
                                 .product(name: "HelperLibrary", package: "HelperPackage"),
                             ]
                         ),
+                        .executableTarget(
+                            name: "FifthTarget",
+                            dependencies: [
+                                "FirstTarget",
+                                "ThirdTarget",
+                            ]
+                        ),
                         .plugin(
                             name: "PrintTargetDependencies",
                             capability: .command(
@@ -2082,6 +2089,14 @@ final class PackageToolTests: CommandsTestCase {
                 public func FourthFunc() { }
                 """)
 
+            let fifthTargetDir = packageDir.appending(components: "Sources", "FifthTarget")
+            try localFileSystem.createDirectory(fifthTargetDir, recursive: true)
+            try localFileSystem.writeFileContents(fifthTargetDir.appending(component: "main.swift"), string: """
+                @main struct MyExec {
+                    func run() throws {}
+                }
+                """)
+
             let pluginTargetTargetDir = packageDir.appending(components: "Plugins", "PrintTargetDependencies")
             try localFileSystem.createDirectory(pluginTargetTargetDir, recursive: true)
             try localFileSystem.writeFileContents(pluginTargetTargetDir.appending(component: "plugin.swift"), string: """
@@ -2100,6 +2115,13 @@ final class PackageToolTests: CommandsTestCase {
                             throw "No target found with the name '\\(targetName)'"
                         }
                         print("Recursive dependencies of '\\(target.name)': \\(target.recursiveTargetDependencies.map(\\.name))")
+                
+                        let execProducts = context.package.products(ofType: ExecutableProduct.self)
+                        print("execProducts: \\(execProducts.map{ $0.name })")
+                        let swiftTargets = context.package.targets(ofType: SwiftSourceModuleTarget.self)
+                        print("swiftTargets: \\(swiftTargets.map{ $0.name })")
+                        let swiftSources = swiftTargets.flatMap{ $0.sourceFiles(withSuffix: ".swift") }
+                        print("swiftSources: \\(swiftSources.map{ $0.path.lastComponent })")
                     }
                 }
                 extension String: Error {}
@@ -2151,6 +2173,16 @@ final class PackageToolTests: CommandsTestCase {
                 let output = try result.utf8Output() + result.utf8stderrOutput()
                 XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
                 XCTAssertMatch(output, .contains("of 'FourthTarget': [\"FirstTarget\", \"SecondTarget\", \"ThirdTarget\", \"HelperLibrary\"]"))
+            }
+
+            // Check some of the other utility APIs.
+            do {
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["print-target-dependencies", "--target", "FifthTarget"], packagePath: packageDir)
+                let output = try result.utf8Output() + result.utf8stderrOutput()
+                XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
+                XCTAssertMatch(output, .contains("execProducts: [\"FifthTarget\"]"))
+                XCTAssertMatch(output, .contains("swiftTargets: [\"ThirdTarget\", \"SecondTarget\", \"FourthTarget\", \"FirstTarget\", \"FifthTarget\"]"))
+                XCTAssertMatch(output, .contains("swiftSources: [\"library.swift\", \"library.swift\", \"library.swift\", \"library.swift\", \"main.swift\"]"))
             }
         }
     }


### PR DESCRIPTION
SwiftPM 5.6 nomination of https://github.com/apple/swift-package-manager/pull/4094