### PR TITLE
Add support for -X* flags when building with Xcode

### DIFF
--- a/Fixtures/ValidLayouts/SingleModule/ExecutableMixed/.gitignore
+++ b/Fixtures/ValidLayouts/SingleModule/ExecutableMixed/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj

--- a/Fixtures/ValidLayouts/SingleModule/ExecutableMixed/Package.swift
+++ b/Fixtures/ValidLayouts/SingleModule/ExecutableMixed/Package.swift
@@ -1,0 +1,11 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "ExecutableNew",
+    targets: [
+        .target(name: "ExecutableSwift"),
+        .target(name: "ExecutableC"),
+        .target(name: "ExecutableCxx"),
+    ]
+)

--- a/Fixtures/ValidLayouts/SingleModule/ExecutableMixed/README.md
+++ b/Fixtures/ValidLayouts/SingleModule/ExecutableMixed/README.md
@@ -1,0 +1,3 @@
+# ExecutableMixed
+
+A description of this package.

--- a/Fixtures/ValidLayouts/SingleModule/ExecutableMixed/Sources/ExecutableC/c.c
+++ b/Fixtures/ValidLayouts/SingleModule/ExecutableMixed/Sources/ExecutableC/c.c
@@ -1,0 +1,4 @@
+int main() {
+  return 0;
+}
+

--- a/Fixtures/ValidLayouts/SingleModule/ExecutableMixed/Sources/ExecutableCxx/cxx.cpp
+++ b/Fixtures/ValidLayouts/SingleModule/ExecutableMixed/Sources/ExecutableCxx/cxx.cpp
@@ -1,0 +1,4 @@
+int main() {
+  return 0;
+}
+

--- a/Fixtures/ValidLayouts/SingleModule/ExecutableMixed/Sources/ExecutableSwift/main.swift
+++ b/Fixtures/ValidLayouts/SingleModule/ExecutableMixed/Sources/ExecutableSwift/main.swift
@@ -1,0 +1,1 @@
+print("Hello, world!")

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -171,9 +171,19 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
         // Always specify the path of the effective Swift compiler, which was determined in the same way as for the native build system.
         settings["SWIFT_EXEC"] = buildParameters.toolchain.swiftCompiler.pathString
         settings["LIBRARY_SEARCH_PATHS"] = "$(inherited) \(buildParameters.toolchain.toolchainLibDir.pathString)"
-        settings["OTHER_CFLAGS"] = "$(inherited) \(buildParameters.toolchain.extraCCFlags.joined(separator: " "))"
-        settings["OTHER_CPLUSPLUSFLAGS"] = "$(inherited) \(buildParameters.toolchain.extraCPPFlags.joined(separator: " "))"
-        settings["OTHER_SWIFT_FLAGS"] = "$(inherited) \(buildParameters.toolchain.extraSwiftCFlags.joined(separator: " "))"
+        settings["OTHER_CFLAGS"] = (
+            ["$(inherited)"] + buildParameters.toolchain.extraCCFlags + buildParameters.flags.cCompilerFlags
+        ).joined(separator: " ")
+        settings["OTHER_CPLUSPLUSFLAGS"] = (
+            ["$(inherited)"] + buildParameters.toolchain.extraCPPFlags + buildParameters.flags.cxxCompilerFlags
+        ).joined(separator: " ")
+        settings["OTHER_SWIFT_FLAGS"] = (
+            ["$(inherited)"] + buildParameters.toolchain.extraSwiftCFlags + buildParameters.flags.swiftCompilerFlags
+        ).joined(separator: " ")
+        settings["OTHER_LDFLAGS"] = (
+            ["$(inherited)"] + buildParameters.flags.linkerFlags
+        ).joined(separator: " ")
+
         // Optionally also set the list of architectures to build for.
         if !buildParameters.archs.isEmpty {
             settings["ARCHS"] = buildParameters.archs.joined(separator: " ")

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -172,16 +172,23 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
         settings["SWIFT_EXEC"] = buildParameters.toolchain.swiftCompiler.pathString
         settings["LIBRARY_SEARCH_PATHS"] = "$(inherited) \(buildParameters.toolchain.toolchainLibDir.pathString)"
         settings["OTHER_CFLAGS"] = (
-            ["$(inherited)"] + buildParameters.toolchain.extraCCFlags + buildParameters.flags.cCompilerFlags
+            ["$(inherited)"]
+            + buildParameters.toolchain.extraCCFlags
+            + buildParameters.flags.cCompilerFlags.map { $0.spm_shellEscaped() }
         ).joined(separator: " ")
         settings["OTHER_CPLUSPLUSFLAGS"] = (
-            ["$(inherited)"] + buildParameters.toolchain.extraCPPFlags + buildParameters.flags.cxxCompilerFlags
+            ["$(inherited)"]
+            + buildParameters.toolchain.extraCPPFlags
+            + buildParameters.flags.cxxCompilerFlags.map { $0.spm_shellEscaped() }
         ).joined(separator: " ")
         settings["OTHER_SWIFT_FLAGS"] = (
-            ["$(inherited)"] + buildParameters.toolchain.extraSwiftCFlags + buildParameters.flags.swiftCompilerFlags
+            ["$(inherited)"]
+            + buildParameters.toolchain.extraSwiftCFlags
+            + buildParameters.flags.swiftCompilerFlags.map { $0.spm_shellEscaped() }
         ).joined(separator: " ")
         settings["OTHER_LDFLAGS"] = (
-            ["$(inherited)"] + buildParameters.flags.linkerFlags
+            ["$(inherited)"]
+            + buildParameters.flags.linkerFlags.map { $0.spm_shellEscaped() }
         ).joined(separator: " ")
 
         // Optionally also set the list of architectures to build for.

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -314,6 +314,32 @@ final class BuildToolTests: CommandsTestCase {
         }
     }
 
+    func testXcodeBuildSystemWithAdditionalBuildFlags() throws {
+        #if !os(macOS)
+        try XCTSkipIf(true, "test requires `xcbuild` and is therefore only supported on macOS")
+        #endif
+        fixture(name: "ValidLayouts/SingleModule/ExecutableMixed") { path in
+            // Try building using XCBuild with additional flags.  This should succeed.  We build verbosely so we get full command lines.
+            let defaultOutput = try execute(
+                [
+                    "--build-system", "xcode",
+                    "-c", "debug", "-v",
+                    "-Xlinker", "-rpath", "-Xlinker", "/fakerpath",
+                    "-Xcc", "-I/cfakepath",
+                    "-Xcxx", "-I/cxxfakepath",
+                    "-Xswiftc", "-I/swiftfakepath",
+                ],
+                packagePath: path
+            ).stdout
+
+            // Look for certain things in the output from XCBuild.
+            XCTAssertMatch(defaultOutput, .contains("/fakerpath"))
+            XCTAssertMatch(defaultOutput, .contains("-I/cfakepath"))
+            XCTAssertMatch(defaultOutput, .contains("-I/cxxfakepath"))
+            XCTAssertMatch(defaultOutput, .contains("-I/swiftfakepath"))
+        }
+    }
+
     func testXcodeBuildSystemOverrides() throws {
         #if !os(macOS)
         try XCTSkipIf(true, "test requires `xcbuild` and is therefore only supported on macOS")


### PR DESCRIPTION
This forwards the -Xlinker, -Xcc, -Xcxx and -Xswiftc flags to the
xcbuild invocation.

### Motivation:

This use case appeared when creating universal binaries by specifying
the arm64 and x86_64 and needing to specify the rpath flag. Since the
change is small, decided to add all of the BuildFlags as well.

### Modifications:

Changes in how the XcodeBuildSystem is configured using the BuildFlags already available in `buildParameters`.

### Result:

This command will work as expected when building universal binaries:

```swift
swift build --arch arm64 --arch x86_64 -Xlinker -rpath -Xlinker -/some/rpath
```
