### PR TITLE
Reenable the `PackageToolTests.testPluginCompilationBeforeBuilding`

### DIFF
--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -2282,9 +2282,6 @@ final class PackageToolTests: CommandsTestCase {
     }
 
     func testPluginCompilationBeforeBuilding() throws {
-        // Temporarily disabled while fixing rdar://88453397
-        throw XCTSkip("Skipping test due to rdar://88453397")
-        
         // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
         


### PR DESCRIPTION
This reverts commit eb198dd878ae0c29b62ce34bf48a121b3853891c now that the underlying issue has been fixed in ffd0759fffdbff6ad95dd7dbde039a33fd37b612.
