### PR TITLE
[5.6] Add module kind enum to the package plugin API

### DIFF
--- a/Sources/PackagePlugin/PackageModel.swift
+++ b/Sources/PackagePlugin/PackageModel.swift
@@ -192,6 +192,10 @@ public protocol SourceModuleTarget: Target {
     /// The name of the module produced by the target (derived from the target
     /// name, though future SwiftPM versions may allow this to be customized).
     var moduleName: String { get }
+    
+    /// The kind of module, describing whether it contains unit tests, contains
+    /// the main entry point of an executable, or neither.
+    var kind: ModuleKind { get }
 
     /// The source files that are associated with this target (any files that
     /// have been excluded in the manifest have already been filtered out).
@@ -206,6 +210,16 @@ public protocol SourceModuleTarget: Target {
     var linkedFrameworks: [String] { get }
 }
 
+/// Represents the kind of module.
+public enum ModuleKind {
+    /// A module that contains generic code (not a test nor an executable).
+    case generic
+    /// A module that contains code for an executable's main module.
+    case executable
+    /// A module that contains unit tests.
+    case test
+}
+
 /// Represents a target consisting of a source code module compiled using Swift.
 public struct SwiftSourceModuleTarget: SourceModuleTarget {
     /// Unique identifier for the target.
@@ -215,6 +229,10 @@ public struct SwiftSourceModuleTarget: SourceModuleTarget {
     /// is unique among the targets of the package in which it is defined.
     public let name: String
     
+    /// The kind of module, describing whether it contains unit tests, contains
+    /// the main entry point of an executable, or neither.
+    public let kind: ModuleKind
+
     /// The absolute path of the target directory in the local file system.
     public let directory: Path
     
@@ -253,6 +271,10 @@ public struct ClangSourceModuleTarget: SourceModuleTarget {
     /// is unique among the targets of the package in which it is defined.
     public let name: String
     
+    /// The kind of module, describing whether it contains unit tests, contains
+    /// the main entry point of an executable, or neither.
+    public let kind: ModuleKind
+
     /// The absolute path of the target directory in the local file system.
     public let directory: Path
     

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -2055,6 +2055,12 @@ final class PackageToolTests: CommandsTestCase {
                                 "ThirdTarget",
                             ]
                         ),
+                        .testTarget(
+                            name: "TestTarget",
+                            dependencies: [
+                                "SecondTarget",
+                            ]
+                        ),
                         .plugin(
                             name: "PrintTargetDependencies",
                             capability: .command(
@@ -2097,6 +2103,14 @@ final class PackageToolTests: CommandsTestCase {
                 }
                 """)
 
+            let testTargetDir = packageDir.appending(components: "Tests", "TestTarget")
+            try localFileSystem.createDirectory(testTargetDir, recursive: true)
+            try localFileSystem.writeFileContents(testTargetDir.appending(component: "tests.swift"), string: """
+                import XCTest
+                class MyTestCase: XCTestCase {
+                }
+                """)
+
             let pluginTargetTargetDir = packageDir.appending(components: "Plugins", "PrintTargetDependencies")
             try localFileSystem.createDirectory(pluginTargetTargetDir, recursive: true)
             try localFileSystem.writeFileContents(pluginTargetTargetDir.appending(component: "plugin.swift"), string: """
@@ -2122,6 +2136,10 @@ final class PackageToolTests: CommandsTestCase {
                         print("swiftTargets: \\(swiftTargets.map{ $0.name })")
                         let swiftSources = swiftTargets.flatMap{ $0.sourceFiles(withSuffix: ".swift") }
                         print("swiftSources: \\(swiftSources.map{ $0.path.lastComponent })")
+                        
+                        if let target = target as? SourceModuleTarget {
+                            print("Module kind of '\\(target.name)': \\(target.kind)")
+                        }
                     }
                 }
                 extension String: Error {}
@@ -2156,7 +2174,8 @@ final class PackageToolTests: CommandsTestCase {
                 let result = try SwiftPMProduct.SwiftPackage.executeProcess(["print-target-dependencies", "--target", "SecondTarget"], packagePath: packageDir)
                 let output = try result.utf8Output() + result.utf8stderrOutput()
                 XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
-                XCTAssertMatch(output, .contains("of 'SecondTarget': [\"FirstTarget\"]"))
+                XCTAssertMatch(output, .contains("Recursive dependencies of 'SecondTarget': [\"FirstTarget\"]"))
+                XCTAssertMatch(output, .contains("Module kind of 'SecondTarget': generic"))
             }
 
             // Check that targets are not included twice in recursive dependencies.
@@ -2164,7 +2183,8 @@ final class PackageToolTests: CommandsTestCase {
                 let result = try SwiftPMProduct.SwiftPackage.executeProcess(["print-target-dependencies", "--target", "ThirdTarget"], packagePath: packageDir)
                 let output = try result.utf8Output() + result.utf8stderrOutput()
                 XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
-                XCTAssertMatch(output, .contains("of 'ThirdTarget': [\"FirstTarget\"]"))
+                XCTAssertMatch(output, .contains("Recursive dependencies of 'ThirdTarget': [\"FirstTarget\"]"))
+                XCTAssertMatch(output, .contains("Module kind of 'ThirdTarget': generic"))
             }
 
             // Check that product dependencies work in recursive dependencies.
@@ -2172,7 +2192,8 @@ final class PackageToolTests: CommandsTestCase {
                 let result = try SwiftPMProduct.SwiftPackage.executeProcess(["print-target-dependencies", "--target", "FourthTarget"], packagePath: packageDir)
                 let output = try result.utf8Output() + result.utf8stderrOutput()
                 XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
-                XCTAssertMatch(output, .contains("of 'FourthTarget': [\"FirstTarget\", \"SecondTarget\", \"ThirdTarget\", \"HelperLibrary\"]"))
+                XCTAssertMatch(output, .contains("Recursive dependencies of 'FourthTarget': [\"FirstTarget\", \"SecondTarget\", \"ThirdTarget\", \"HelperLibrary\"]"))
+                XCTAssertMatch(output, .contains("Module kind of 'FourthTarget': generic"))
             }
 
             // Check some of the other utility APIs.
@@ -2181,8 +2202,18 @@ final class PackageToolTests: CommandsTestCase {
                 let output = try result.utf8Output() + result.utf8stderrOutput()
                 XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
                 XCTAssertMatch(output, .contains("execProducts: [\"FifthTarget\"]"))
-                XCTAssertMatch(output, .contains("swiftTargets: [\"ThirdTarget\", \"SecondTarget\", \"FourthTarget\", \"FirstTarget\", \"FifthTarget\"]"))
-                XCTAssertMatch(output, .contains("swiftSources: [\"library.swift\", \"library.swift\", \"library.swift\", \"library.swift\", \"main.swift\"]"))
+                XCTAssertMatch(output, .contains("swiftTargets: [\"ThirdTarget\", \"TestTarget\", \"SecondTarget\", \"FourthTarget\", \"FirstTarget\", \"FifthTarget\"]"))
+                XCTAssertMatch(output, .contains("swiftSources: [\"library.swift\", \"tests.swift\", \"library.swift\", \"library.swift\", \"library.swift\", \"main.swift\"]"))
+                XCTAssertMatch(output, .contains("Module kind of 'FifthTarget': executable"))
+            }
+
+            // Check a test target.
+            do {
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["print-target-dependencies", "--target", "TestTarget"], packagePath: packageDir)
+                let output = try result.utf8Output() + result.utf8stderrOutput()
+                XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
+                XCTAssertMatch(output, .contains("Recursive dependencies of 'TestTarget': [\"FirstTarget\", \"SecondTarget\"]"))
+                XCTAssertMatch(output, .contains("Module kind of 'TestTarget': test"))
             }
         }
     }


### PR DESCRIPTION
SwfitPM 5.6 nomination of #4098.

Although the different basic kinds of targets were expressed through types, the module kind (executable, test, or regular) for a source module target was not expressed in the API.  This adds that property.

**Explanation:**  This adds a property to the `SourceModuleTarget` type in `PackagePlugin` to let plugins identify the kind of target:  executable, test, or generic.  This is useful for some plugins such as docc, which may want to skip test targets when generating documentation.

**Scope of Issue:**  This affects some package plugins that need a way to filter out different purposes of targets.

**Reason for Nominating to 5.6:**  This is a refinement requested by the .docc plugin (and useful to other plugins) in new functionality in 5.6 (command plugins).  It is not part of the evolution proposal API but is intended to be included in the next proposal for expanded functionality.

**Risk:**  Very low — this vends a property that is already present in the SwiftPM data model so that it can be used by a plugin.  The risk of getting it wrong would primarily be that this new property would be incorrect but wouldn't break existing functionality.

**Reviewed By:**  @tomerd

**Automated Testing:**  A new unit test covers this new property, and checks for all three possible values using test fixtures.

**Dependencies:**  None

**Impact on CI:**  None

**How to Verify:**  Write a command plugin and verify the value of the `kind` property on an instance of the `SourceModuleTarget`.

rdar://86786080

(cherry picked from commit b7c299105592451cde264b3965aa41f0bbc3c3fc)
