### PR TITLE
Fix warning about unhandled files

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -416,7 +416,11 @@ let package = Package(
 
         .testTarget(
             name: "BasicsTests",
-            dependencies: ["Basics", "SPMTestSupport", "tsan_utils"]
+            dependencies: ["Basics", "SPMTestSupport", "tsan_utils"],
+            exclude: [
+                "Inputs/archive.zip",
+                "Inputs/invalid_archive.zip",
+            ]
         ),
         .testTarget(
             name: "BuildTests",


### PR DESCRIPTION
```
'SwiftPM' /Users/ylee/apple/swift-package-manager: warning: found 2 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    /Users/ylee/apple/swift-package-manager/Tests/BasicsTests/Inputs/archive.zip
    /Users/ylee/apple/swift-package-manager/Tests/BasicsTests/Inputs/invalid_archive.zip
```
