### PR TITLE
Cancelling `swift package` with Control-C doesn't stop any running plugins

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -360,6 +360,7 @@ public class SwiftTool {
             SwiftTool.shutdownRegistry = (processSet: processSet, buildSystemRef: buildSystemRef)
             _ = SetConsoleCtrlHandler({ _ in
                 // Terminate all processes on receiving an interrupt signal.
+                DefaultPluginScriptRunner.cancelAllRunningPlugins()
                 SwiftTool.shutdownRegistry?.processSet.terminate()
                 SwiftTool.shutdownRegistry?.buildSystemRef.buildSystem?.cancel()
 
@@ -380,6 +381,7 @@ public class SwiftTool {
                 interruptSignalSource.cancel()
 
                 // Terminate all processes on receiving an interrupt signal.
+                DefaultPluginScriptRunner.cancelAllRunningPlugins()
                 processSet.terminate()
                 buildSystemRef.buildSystem?.cancel()
 


### PR DESCRIPTION
*Motivation:*

Cancelling the plugin host (such as `swift package`) should also cancel any running plugins.

*Changes:*

Add a registry that keeps track of running plugin processes, and an API to cancel them.  We can't use `ProcessSet()` since it's tied to ToolsSupportCore's implementation of a subprocess and doesn't use Foundation.  In this case we don't need such a general solution in any case.

Added a unit test that goes to some length to try to determine that process is really gone after cancelling.

rdar://87280309
