### PR TITLE
[5.6] Cancelling `swift package` with Control-C doesn't stop any running plugins

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -361,6 +361,7 @@ public class SwiftTool {
             SwiftTool.shutdownRegistry = (processSet: processSet, buildSystemRef: buildSystemRef)
             _ = SetConsoleCtrlHandler({ _ in
                 // Terminate all processes on receiving an interrupt signal.
+                DefaultPluginScriptRunner.cancelAllRunningPlugins()
                 SwiftTool.shutdownRegistry?.processSet.terminate()
                 SwiftTool.shutdownRegistry?.buildSystemRef.buildSystem?.cancel()
 
@@ -381,6 +382,7 @@ public class SwiftTool {
                 interruptSignalSource.cancel()
 
                 // Terminate all processes on receiving an interrupt signal.
+                DefaultPluginScriptRunner.cancelAllRunningPlugins()
                 processSet.terminate()
                 buildSystemRef.buildSystem?.cancel()
 

--- a/Sources/Workspace/DefaultPluginScriptRunner.swift
+++ b/Sources/Workspace/DefaultPluginScriptRunner.swift
@@ -503,8 +503,18 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner {
         }
         process.standardError = stderrPipe
         
+        // Add it to the list of currently running plugin processes, so it can be cancelled if the host is interrupted.
+        DefaultPluginScriptRunner.currentlyRunningPlugins.lock.withLock {
+            _ = DefaultPluginScriptRunner.currentlyRunningPlugins.processes.insert(process)
+        }
+
         // Set up a handler to deal with the exit of the plugin process.
         process.terminationHandler = { process in
+            // Remove the process from the list of currently running ones.
+            DefaultPluginScriptRunner.currentlyRunningPlugins.lock.withLock {
+                _ = DefaultPluginScriptRunner.currentlyRunningPlugins.processes.remove(process)
+            }
+
             // Close the output handle through which we talked to the plugin.
             try? outputHandle.close()
 
@@ -554,6 +564,22 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner {
         }
 #endif
     }
+    
+    /// Cancels all currently running plugins, resulting in an error code indicating that they were interrupted. This is intended for use when the host process is interrupted.
+    public static func cancelAllRunningPlugins() {
+#if !os(iOS) && !os(watchOS) && !os(tvOS)
+        currentlyRunningPlugins.lock.withLock {
+            currentlyRunningPlugins.processes.forEach{
+                $0.terminate()
+            }
+            currentlyRunningPlugins.processes = []
+        }
+#endif
+    }
+    /// Private list of currently running plugin processes and the lock that protects the list.
+#if !os(iOS) && !os(watchOS) && !os(tvOS)
+    private static var currentlyRunningPlugins: (processes: Set<Foundation.Process>, lock: Lock) = (.init(), .init())
+#endif
 }
 
 /// An error encountered by the default plugin runner.


### PR DESCRIPTION
This is a SwiftPM 5.6 cherry-pick of https://github.com/apple/swift-package-manager/pull/4104.

**Explanation:**  This makes sure that any running package plugins are killed as part of the shutdown procedure that runs when `swift` `package` receives a Control-C.

**Scope of Issue:**  This affects long-running package command plugins which a user may want to cancel by using Control-C on `swift` `package`.  Using Control-C causes SwiftPM to do some cleanup and exit, and does not reliably cause the subprocess to exit (killing `swift` `package` directly, outside of Control-C, does seem to always cause the subprocess to exit).

**Reason for Nominating to 5.6:**  This is an issue in new functionality (command plugins) that affects the user experience with long-running plugin processes. In particular it affects the new .docc plugin, which has a preview mode in which it stays running and vends the generated documentation.

**Risk:**  Low — this affects the Control-C behavior and not the normal running of plugins.  The risk when the plugin is running is minimal (process objects are being added and removed from a locked set but no other action is taken outside of handling Control-C).

**Reviewed By:**  @tomerd

**Automated Testing:**  A new unit test covers this new property, using a never-ending test plugin and checking for the absence of the subprocess after cancelling.

**Dependencies:**  None

**Impact on CI:**  None

**How to Verify:**  Run a long-running command plugin and use Control-C to interrupt the  `swift` `package` invocation.  Verify that the plugin subprocess is no longer running.

rdar://87280309
