### PR TITLE
Conditionalize references to `Foundation.Process` to allow building on iOS, tvOS, watchOS

### DIFF
--- a/Sources/Workspace/DefaultPluginScriptRunner.swift
+++ b/Sources/Workspace/DefaultPluginScriptRunner.swift
@@ -567,15 +567,19 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner {
     
     /// Cancels all currently running plugins, resulting in an error code indicating that they were interrupted. This is intended for use when the host process is interrupted.
     public static func cancelAllRunningPlugins() {
+#if !os(iOS) && !os(watchOS) && !os(tvOS)
         currentlyRunningPlugins.lock.withLock {
             currentlyRunningPlugins.processes.forEach{
                 $0.terminate()
             }
             currentlyRunningPlugins.processes = []
         }
+#endif
     }
     /// Private list of currently running plugin processes and the lock that protects the list.
+#if !os(iOS) && !os(watchOS) && !os(tvOS)
     private static var currentlyRunningPlugins: (processes: Set<Foundation.Process>, lock: Lock) = (.init(), .init())
+#endif
 }
 
 /// An error encountered by the default plugin runner.


### PR DESCRIPTION
Code added in https://github.com/apple/swift-package-manager/pull/4104 unintentionally assumed the existence of `Foundation.Process`, which isn't the case on iOS, tvOS, watchOS.  This conditionalizes the use of that type — plugins aren't available on those platforms in any case, throwing an "unavailable" error.  Cancelling all running plugins on iOS, tvOS, watchOS is a no-op, since by definition, none are running.
