### PR TITLE
[5.6] Disable a flaky part of the unit test `PackageToolTests.testPluginCompilationBeforeBuilding`

### DIFF
--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -2315,7 +2315,9 @@ final class PackageToolTests: CommandsTestCase {
                 XCTAssertNotEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
                 XCTAssertMatch(output, .contains("Compiling plugin MyCommandPlugin..."))
                 XCTAssertMatch(output, .contains("Compiling plugin MyBuildToolPlugin..."))
-                XCTAssertMatch(output, .contains("MyCommandPlugin/plugin.swift:7:19: error: consecutive statements on a line must be separated by ';'"))
+                #if false // sometimes this line isn't emitted; being investigated in https://bugs.swift.org/browse/SR-15831
+                    XCTAssertMatch(output, .contains("MyCommandPlugin/plugin.swift:7:19: error: consecutive statements on a line must be separated by ';'"))
+                #endif
                 XCTAssertNoMatch(output, .contains("Building for debugging..."))
             }
         }


### PR DESCRIPTION
This is a 5.6 cherry-pick of https://github.com/apple/swift-package-manager/pull/4103 after being asked to cherry-pick this change since it's also affecting 5.6 CI.  It was already merged in main.

As in main, we don't want to skip the entire test since there are other good things being tested here that are not flaky, such as some of the other output as well as the exit code of the subprocess.

**Explanation:**  Temporarily disable a what is reported to be a flaky condition in a unit test that is causing occasional CI failures.  This is test-only change.  Investigation of the underlying cause is tracked by https://bugs.swift.org/browse/SR-15831.

**Scope of Issue:**  This is limited to one condition in a unit test, which checks the compiler output being printed by SwiftPM.  This hasn't been seen in direct usage and may be a problem with the test.

**Reason for Nominating to 5.6:**  This is reported to be affecting CI.

**Risk:**  Extremely low.  This disables a single condition in a test.

**Automated Testing:**  This is part of a unit test.

**Dependencies:**  None

**Impact on CI:**  None

**How to Verify:**  Verify that CI passes consistently.

(cherry picked from commit 9cad76e765436ed580d459c66dbf980a4323b5e6)