### PR TITLE
adjust to TSC verbosity API changes

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -56,7 +56,9 @@ extension BuildParameters {
     public var swiftCompilerFlags: [String] {
         var flags = self.flags.cCompilerFlags.flatMap({ ["-Xcc", $0] })
         flags += self.flags.swiftCompilerFlags
-        flags += verbosity.ccArgs
+        if self.verboseOutput {
+            flags.append("-v")
+        }
         return flags
     }
 
@@ -812,7 +814,7 @@ public final class SwiftTargetBuildDescription {
         }
 
         // Add arguments to colorize output if stdout is tty
-        if buildParameters.isTTY {
+        if buildParameters.colorizedOutput {
             args += ["-color-diagnostics"]
         }
 

--- a/Sources/Commands/APIDigester.swift
+++ b/Sources/Commands/APIDigester.swift
@@ -236,8 +236,7 @@ public struct SwiftAPIDigester {
         let arguments = [tool.pathString] + args
         let process = Process(
             arguments: arguments,
-            outputRedirection: .collect,
-            verbose: verbosity != .concise
+            outputRedirection: .collect
         )
         try process.launch()
         try process.waitUntilExit()

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -584,8 +584,9 @@ extension SwiftPackageTool {
                 try symbolGraphExtractor.extractSymbolGraph(
                     target: target,
                     buildPlan: buildPlan,
-                    logLevel: swiftTool.logLevel,
-                    outputDirectory: symbolGraphDirectory)
+                    outputDirectory: symbolGraphDirectory,
+                    verboseOutput: swiftTool.logLevel <= .info
+                )
             }
 
             print("Files written to", symbolGraphDirectory.pathString)
@@ -1409,8 +1410,9 @@ final class PluginDelegate: PluginInvocationDelegate {
             target: target,
             buildPlan: buildPlan,
             outputRedirection: .collect,
-            logLevel: .warning,
-            outputDirectory: outputDir)
+            outputDirectory: outputDir,
+            verboseOutput: self.swiftTool.logLevel <= .info
+        )
 
         // Return the results to the plugin.
         return PluginInvocationSymbolGraphResult(directoryPath: outputDir.pathString)

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -461,17 +461,8 @@ public class SwiftTool {
         self.sharedConfigurationDirectory = try getSharedConfigurationDirectory(options: self.options, observabilityScope: self.observabilityScope)
         self.sharedCacheDirectory = try getSharedCacheDirectory(options: self.options, observabilityScope: self.observabilityScope)
 
-        // set verbosity globals.
-        // TODO: get rid of this global settings in TSC
-        switch self.logLevel {
-        case .debug:
-            TSCUtility.verbosity = .debug
-        case .info:
-            TSCUtility.verbosity = .verbose
-        case .warning, .error:
-            TSCUtility.verbosity = .concise
-        }
-        Process.verbose = TSCUtility.verbosity != .concise
+        // set global process logging handler
+        Process.loggingHandler = { self.observabilityScope.emit(debug: $0) }
     }
 
     static func postprocessArgParserResult(options: SwiftToolOptions, observabilityScope: ObservabilityScope) throws {
@@ -843,7 +834,8 @@ public class SwiftTool {
                 printManifestGraphviz: options.printManifestGraphviz,
                 forceTestDiscovery: options.enableTestDiscovery, // backwards compatibility, remove with --enable-test-discovery
                 linkerDeadStrip: options.linkerDeadStrip,
-                isTTY: isTTY
+                colorizedOutput: isTTY,
+                verboseOutput: self.logLevel <= .info
             )
         })
     }()
@@ -914,6 +906,10 @@ public class SwiftTool {
             // Disable the implicit concurrency import if the compiler in use supports it to avoid warnings if we are building against an older SDK that does not contain a Concurrency module.
             if SwiftTargetBuildDescription.checkSupportedFrontendFlags(flags: ["disable-implicit-concurrency-module-import"], fileSystem: localFileSystem) {
                 extraManifestFlags += ["-Xfrontend", "-disable-implicit-concurrency-module-import"]
+            }
+
+            if self.logLevel <= .info {
+                extraManifestFlags.append("-v")
             }
 
             return try ManifestLoader(

--- a/Sources/Commands/SymbolGraphExtract.swift
+++ b/Sources/Commands/SymbolGraphExtract.swift
@@ -43,8 +43,8 @@ public struct SymbolGraphExtract {
         target: ResolvedTarget,
         buildPlan: BuildPlan,
         outputRedirection: Process.OutputRedirection = .none,
-        logLevel: Basics.Diagnostic.Severity,
-        outputDirectory: AbsolutePath
+        outputDirectory: AbsolutePath,
+        verboseOutput: Bool
     ) throws {
         let buildParameters = buildPlan.buildParameters
         try localFileSystem.createDirectory(outputDirectory, recursive: true)
@@ -55,7 +55,7 @@ public struct SymbolGraphExtract {
         commandLine += try buildParameters.targetTripleArgs(for: target)
         commandLine += buildPlan.createAPIToolCommonArgs(includeLibrarySearchPaths: true)
         commandLine += ["-module-cache-path", buildParameters.moduleCache.pathString]
-        if logLevel <= .info {
+        if verboseOutput {
             commandLine += ["-v"]
         }
         commandLine += ["-minimum-access-level", minimumAccessLevel.rawValue]
@@ -79,8 +79,8 @@ public struct SymbolGraphExtract {
         // Run the extraction.
         let process = Process(
             arguments: commandLine,
-            outputRedirection: outputRedirection,
-            verbose: logLevel <= .info)
+            outputRedirection: outputRedirection
+        )
         try process.launch()
         try process.waitUntilExit()
     }

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -822,7 +822,6 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 
         var cmd: [String] = []
         cmd += [self.toolchain.swiftCompilerPath.pathString]
-        cmd += verbosity.ccArgs
 
         let macOSPackageDescriptionPath: AbsolutePath
         // if runtimePath is set to "PackageFrameworks" that means we could be developing SwiftPM in Xcode

--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -175,7 +175,9 @@ public struct BuildParameters: Encodable {
     /// Whether to disable dead code stripping by the linker
     public var linkerDeadStrip: Bool
 
-    public var isTTY: Bool
+    public var colorizedOutput: Bool
+
+    public var verboseOutput: Bool
 
     public init(
         dataPath: AbsolutePath,
@@ -204,7 +206,8 @@ public struct BuildParameters: Encodable {
         enableTestability: Bool? = nil,
         forceTestDiscovery: Bool = false,
         linkerDeadStrip: Bool = true,
-        isTTY: Bool = false
+        colorizedOutput: Bool = false,
+        verboseOutput: Bool = false
     ) {
         let triple = destinationTriple ?? .getHostTriple(usingSwiftCompiler: toolchain.swiftCompiler)
 
@@ -242,7 +245,8 @@ public struct BuildParameters: Encodable {
         // decide if to enable the use of test manifests based on platform. this is likely to change in the future
         self.testDiscoveryStrategy = triple.isDarwin() ? .objectiveC : .manifest(generate: forceTestDiscovery)
         self.linkerDeadStrip = linkerDeadStrip
-        self.isTTY = isTTY
+        self.colorizedOutput = colorizedOutput
+        self.verboseOutput = verboseOutput
     }
 
     /// The path to the build directory (inside the data directory).

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -347,19 +347,19 @@ final class BuildToolTests: CommandsTestCase {
         #endif
         try fixture(name: "ValidLayouts/SingleModule/ExecutableNew") { fixturePath in
             // Try building using XCBuild without specifying overrides.  This should succeed, and should use the default compiler path.
-            let defaultOutput = try execute(["-c", "debug", "-v"], packagePath: fixturePath).stdout
+            let defaultOutput = try execute(["-c", "debug", "--vv"], packagePath: fixturePath).stdout
             XCTAssertMatch(defaultOutput, .contains(ToolchainConfiguration.default.swiftCompilerPath.pathString))
 
             // Now try building using XCBuild while specifying a faulty compiler override.  This should fail.  Note that we need to set the executable to use for the manifest itself to the default one, since it defaults to SWIFT_EXEC if not provided.
             var overriddenOutput = ""
             do {
-                overriddenOutput = try execute(["-c", "debug", "-v"], environment: ["SWIFT_EXEC": "/usr/bin/false", "SWIFT_EXEC_MANIFEST": ToolchainConfiguration.default.swiftCompilerPath.pathString], packagePath: fixturePath).stdout
+                overriddenOutput = try execute(["-c", "debug", "--vv"], environment: ["SWIFT_EXEC": "/usr/bin/false", "SWIFT_EXEC_MANIFEST": ToolchainConfiguration.default.swiftCompilerPath.pathString], packagePath: fixturePath).stdout
                 XCTFail("unexpected success (was SWIFT_EXEC not overridden properly?)")
             }
-            catch SwiftPMProductError.executionFailure(let error, let stdout, _) {
+            catch SwiftPMProductError.executionFailure(let error, _, let stderr) {
                 switch error {
                 case ProcessResult.Error.nonZeroExit(let result) where result.exitStatus != .terminated(code: 0):
-                    overriddenOutput = stdout
+                    overriddenOutput = stderr
                     break
                 default:
                     XCTFail("`swift build' failed in an unexpected manner")


### PR DESCRIPTION
motivation: deprecate global and process verbosity

changes:
* stop using TSC global verbosity flags
* set a logging handler on Process to funnel debug information to observability handler
* adjust call sites
