### PR TITLE
cleanup use of FileSystem::readFileContents

### DIFF
--- a/Sources/Basics/JSON+Extensions.swift
+++ b/Sources/Basics/JSON+Extensions.swift
@@ -9,6 +9,7 @@
  */
 
 import class Foundation.DateFormatter
+import struct Foundation.Data
 import class Foundation.JSONDecoder
 import class Foundation.JSONEncoder
 import TSCBasic
@@ -116,8 +117,7 @@ extension JSONEncoder {
 
 extension JSONDecoder {
     public func decode<T: Decodable>(path: AbsolutePath, fileSystem: FileSystem, `as` kind: T.Type) throws -> T {
-        try fileSystem.readFileContents(path).withData { data in
-            try self.decode(kind, from: data)
-        }
+        let data: Data = try fileSystem.readFileContents(path)
+        return try self.decode(kind, from: data)
     }
 }

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -259,9 +259,9 @@ public struct BuildDescription: Codable {
     }
 
     public static func load(from path: AbsolutePath) throws -> BuildDescription {
-        let contents = try localFileSystem.readFileContents(path).contents
+        let contents: Data = try localFileSystem.readFileContents(path)
         let decoder = JSONDecoder.makeWithDefaults()
-        return try decoder.decode(BuildDescription.self, from: Data(contents))
+        return try decoder.decode(BuildDescription.self, from: contents)
     }
 }
 

--- a/Sources/Commands/MultiRootSupport.swift
+++ b/Sources/Commands/MultiRootSupport.swift
@@ -44,7 +44,7 @@ public struct XcodeWorkspaceLoader {
     /// Load the given workspace and return the file ref paths from it.
     public func load(workspace: AbsolutePath) throws -> [AbsolutePath] {
         let path = workspace.appending(component: "contents.xcworkspacedata")
-        let contents = try Data(self.fileSystem.readFileContents(path).contents)
+        let contents: Data = try self.fileSystem.readFileContents(path)
 
         let delegate = ParserDelegate(observabilityScope: self.observabilityScope)
         let parser = XMLParser(data: contents)

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -148,7 +148,7 @@ struct TestToolOptions: ParsableArguments {
             let skipTests: [String.SubSequence]
             // Read from the file if it exists.
             if let path = try? AbsolutePath(validating: override), localFileSystem.exists(path) {
-                let contents = try localFileSystem.readFileContents(path).cString
+                let contents: String = try localFileSystem.readFileContents(path)
                 skipTests = contents.split(separator: "\n", omittingEmptySubsequences: true)
             } else {
                 // Otherwise, read the env variable.

--- a/Sources/Commands/TestingSupport.swift
+++ b/Sources/Commands/TestingSupport.swift
@@ -73,7 +73,7 @@ enum TestingSupport {
             }
             try Process.checkNonZeroExit(arguments: args, environment: env)
             // Read the temporary file's content.
-            return try localFileSystem.readFileContents(tempFile.path).validDescription ?? ""
+            return try localFileSystem.readFileContents(tempFile.path)
         }
         #else
         let env = try constructTestEnvironment(toolchain: try swiftTool.getToolchain(), options: swiftOptions, buildParameters: swiftTool.buildParametersForTest())

--- a/Sources/PackageCollections/PackageIndex+Configuration.swift
+++ b/Sources/PackageCollections/PackageIndex+Configuration.swift
@@ -55,11 +55,11 @@ public struct PackageIndexConfigurationStorage {
         guard self.fileSystem.exists(self.path) else {
             return .init()
         }
-        let buffer = try self.fileSystem.readFileContents(self.path).contents
-        guard buffer.count > 0 else {
+        let data: Data = try self.fileSystem.readFileContents(self.path)
+        guard data.count > 0 else {
             return .init()
         }
-        let container = try decoder.decode(StorageModel.Container.self, from: Data(buffer))
+        let container = try decoder.decode(StorageModel.Container.self, from: data)
         return try PackageIndexConfiguration(container.index)
     }
 

--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -75,10 +75,8 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
         // Source is a local file
         if let absolutePath = source.absolutePath {
             do {
-                let fileContents = try localFileSystem.readFileContents(absolutePath)
-                return fileContents.withData { data in
-                    self.decodeAndRunSignatureCheck(source: source, data: data, certPolicyKeys: Self.defaultCertPolicyKeys, callback: callback)
-                }
+                let data: Data = try localFileSystem.readFileContents(absolutePath)
+                return self.decodeAndRunSignatureCheck(source: source, data: data, certPolicyKeys: Self.defaultCertPolicyKeys, callback: callback)
             } catch {
                 return callback(.failure(error))
             }

--- a/Sources/PackageCollections/Storage/FilePackageCollectionsSourcesStorage.swift
+++ b/Sources/PackageCollections/Storage/FilePackageCollectionsSourcesStorage.swift
@@ -134,11 +134,11 @@ struct FilePackageCollectionsSourcesStorage: PackageCollectionsSourcesStorage {
         guard self.fileSystem.exists(self.path) else {
             return .init()
         }
-        let buffer = try fileSystem.readFileContents(self.path).contents
-        guard buffer.count > 0 else {
+        let data: Data = try fileSystem.readFileContents(self.path)
+        guard data.count > 0 else {
             return .init()
         }
-        let container = try decoder.decode(StorageModel.Container.self, from: Data(buffer))
+        let container = try decoder.decode(StorageModel.Container.self, from: data)
         return try container.sources()
     }
 

--- a/Sources/PackageFingerprint/FilePackageFingerprintStorage.swift
+++ b/Sources/PackageFingerprint/FilePackageFingerprintStorage.swift
@@ -93,12 +93,12 @@ public struct FilePackageFingerprintStorage: PackageFingerprintStorage {
             return .init()
         }
 
-        let buffer = try fileSystem.readFileContents(path).contents
-        guard buffer.count > 0 else {
+        let data: Data = try fileSystem.readFileContents(path)
+        guard data.count > 0 else {
             return .init()
         }
 
-        let container = try self.decoder.decode(StorageModel.Container.self, from: Data(buffer))
+        let container = try self.decoder.decode(StorageModel.Container.self, from: data)
         return try container.packageFingerprints()
     }
 

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -942,9 +942,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                             }
 
                             // Read the JSON output that was emitted by libPackageDescription.
-                            guard let jsonOutput = try localFileSystem.readFileContents(jsonOutputFile).validDescription else {
-                                return completion(.failure(StringError("the manifest's JSON output has invalid encoding")))
-                            }
+                            let jsonOutput: String = try localFileSystem.readFileContents(jsonOutputFile)
                             evaluationResult.manifestJSON = jsonOutput
                             
                             completion(.success(evaluationResult))

--- a/Sources/PackageLoading/PkgConfig.swift
+++ b/Sources/PackageLoading/PkgConfig.swift
@@ -172,9 +172,9 @@ internal struct PkgConfigParser {
         // Add pc_sysrootdir variable. This is the path of the sysroot directory for pc files.
         variables["pc_sysrootdir"] = ProcessEnv.vars["PKG_CONFIG_SYSROOT_DIR"] ?? "/"
 
-        let fileContents = try fileSystem.readFileContents(pcFile)
+        let fileContents: String = try fileSystem.readFileContents(pcFile)
         // FIXME: Should we error out instead if content is not UTF8 representable?
-        for line in fileContents.validDescription?.components(separatedBy: "\n") ?? [] {
+        for line in fileContents.components(separatedBy: "\n") {
             // Remove commented or any trailing comment from the line.
             let uncommentedLine = removeComment(line: line)
             // Ignore any empty or whitespace line.

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -342,7 +342,9 @@ public struct ToolsVersionLoader: ToolsVersionLoaderProtocol {
     fileprivate func load(file: AbsolutePath, fileSystem: FileSystem) throws -> ToolsVersion {
         // FIXME: We don't need the entire file, just the first line.
         let manifestContents: ByteString
-        do { manifestContents = try fileSystem.readFileContents(file) } catch {
+        do {
+            manifestContents = try fileSystem.readFileContents(file)
+        } catch {
             throw Error.inaccessibleManifest(path: file, reason: String(describing: error))
         }
         

--- a/Sources/SPMBuildCore/ArtifactsArchiveMetadata.swift
+++ b/Sources/SPMBuildCore/ArtifactsArchiveMetadata.swift
@@ -61,11 +61,9 @@ extension ArtifactsArchiveMetadata {
         }
 
         do {
-            let bytes = try fileSystem.readFileContents(path)
-            return try bytes.withData { data in
-                let decoder = JSONDecoder.makeWithDefaults()
-                return try decoder.decode(ArtifactsArchiveMetadata.self, from: data)
-            }
+            let data: Data = try fileSystem.readFileContents(path)
+            let decoder = JSONDecoder.makeWithDefaults()
+            return try decoder.decode(ArtifactsArchiveMetadata.self, from: data)
         } catch {
             throw StringError("failed parsing ArtifactsArchive info.json at '\(path)': \(error)")
         }

--- a/Sources/SPMBuildCore/XCFrameworkMetadata.swift
+++ b/Sources/SPMBuildCore/XCFrameworkMetadata.swift
@@ -52,11 +52,9 @@ extension XCFrameworkMetadata {
         }
 
         do {
-            let bytes = try fileSystem.readFileContents(path)
-            return try bytes.withData { data in
-                let decoder = PropertyListDecoder()
-                return try decoder.decode(XCFrameworkMetadata.self, from: data)
-            }
+            let data: Data = try fileSystem.readFileContents(path)
+            let decoder = PropertyListDecoder()
+            return try decoder.decode(XCFrameworkMetadata.self, from: data)
         } catch {
             throw StringError("failed parsing XCFramework Info.plist at '\(path)': \(error)")
         }

--- a/Sources/SPMPackageEditor/PackageEditor.swift
+++ b/Sources/SPMPackageEditor/PackageEditor.swift
@@ -90,7 +90,7 @@ public final class PackageEditor {
         }
 
         // Add the package dependency.
-        let manifestContents = try fs.readFileContents(options.manifestPath).cString
+        let manifestContents: String = try fs.readFileContents(options.manifestPath)
         let editor = try ManifestRewriter(manifestContents)
         try editor.addPackageDependency(url: options.url, requirement: requirement)
 
@@ -120,7 +120,7 @@ public final class PackageEditor {
             throw StringError("Already has a target named \(targetName)")
         }
 
-        let manifestContents = try fs.readFileContents(options.manifestPath).cString
+        let manifestContents: String = try fs.readFileContents(options.manifestPath)
         let editor = try ManifestRewriter(manifestContents)
         try editor.addTarget(targetName: targetName)
         try editor.addTarget(targetName: testTargetName, type: .test)

--- a/Sources/SPMTestSupport/MockRegistry.swift
+++ b/Sources/SPMTestSupport/MockRegistry.swift
@@ -181,7 +181,7 @@ public class MockRegistry {
             filename = Manifest.basename + ".swift"
         }
 
-        let content = try package.fileSystem.readFileContents(package.path.appending(component: filename))
+        let content: Data = try package.fileSystem.readFileContents(package.path.appending(component: filename))
 
         var headers = HTTPClientHeaders()
         headers.add(name: "Content-Version", value: "1")
@@ -190,7 +190,7 @@ public class MockRegistry {
         return HTTPClientResponse(
             statusCode: 200,
             headers: headers,
-            body: Data(content.contents)
+            body: content
         )
     }
 
@@ -288,9 +288,7 @@ private struct MockRegistryArchiver: Archiver {
 
     func extract(from archivePath: AbsolutePath, to destinationPath: AbsolutePath, completion: @escaping (Result<Void, Error>) -> Void) {
         do {
-            guard let content = try String(bytes: self.fileSystem.readFileContents(archivePath).contents, encoding: .utf8) else {
-                throw StringError("invalid mock zip format")
-            }
+            let content: String = try self.fileSystem.readFileContents(archivePath)
             let lines = content.split(separator: "\n").map(String.init)
             guard lines.count >= 2 else {
                 throw StringError("invalid mock zip format, not enough lines")

--- a/Sources/Workspace/WindowsToolchainInfo.swift
+++ b/Sources/Workspace/WindowsToolchainInfo.swift
@@ -58,10 +58,8 @@ extension WindowsSDKSettings {
         }
 
         do {
-            let contents = try filesystem.readFileContents(path)
-            self = try contents.withData {
-                try PropertyListDecoder().decode(WindowsSDKSettings.self, from: $0)
-            }
+            let data: Data = try filesystem.readFileContents(path)
+            self = try PropertyListDecoder().decode(WindowsSDKSettings.self, from: data)
         } catch {
             diagnostics?.emit(error: "failed to load SDKSettings.plist at '\(path)': \(error)")
             return nil
@@ -104,10 +102,8 @@ extension WindowsPlatformInfo {
         }
 
         do {
-            let contents = try filesystem.readFileContents(path)
-            self = try contents.withData {
-                try PropertyListDecoder().decode(WindowsPlatformInfo.self, from: $0)
-            }
+            let data: Data = try filesystem.readFileContents(path)
+            self = try PropertyListDecoder().decode(WindowsPlatformInfo.self, from: data)
         } catch {
             diagnostics?.emit(error: "failed to load Info.plist at '\(path)': \(error)")
             return nil

--- a/Sources/swiftpm-manifest-tool/main.swift
+++ b/Sources/swiftpm-manifest-tool/main.swift
@@ -68,8 +68,8 @@ final class PackageIndex {
             return
         }
 
-        let bytes = try localFileSystem.readFileContents(indexFile).contents
-        let entries = try JSONDecoder.makeWithDefaults().decode(Array<Entry>.self, from: Data(bytes: bytes, count: bytes.count))
+        let data: Data = try localFileSystem.readFileContents(indexFile)
+        let entries = try JSONDecoder.makeWithDefaults().decode(Array<Entry>.self, from: data)
 
         self.index = try Dictionary(throwingUniqueKeysWithValues: entries.map{($0.name, $0.url)})
     }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -252,7 +252,7 @@ final class BuildPlanTests: XCTestCase {
                 let yaml = buildDirPath.appending(component: "release.yaml")
                 let llbuild = LLBuildManifestBuilder(plan, fileSystem: localFileSystem, observabilityScope: observability.topScope)
                 try llbuild.generateManifest(at: yaml)
-                let contents = try localFileSystem.readFileContents(yaml).description
+                let contents: String = try localFileSystem.readFileContents(yaml)
 
                 // A few basic checks
                 XCTAssertMatch(contents, .contains("-disable-implicit-swift-modules"))
@@ -330,15 +330,15 @@ final class BuildPlanTests: XCTestCase {
                 observabilityScope: observability.topScope
             )
 
-            let linkedFileList = try fs.readFileContents(AbsolutePath("/path/to/build/release/exe.product/Objects.LinkFileList"))
-            XCTAssertMatch(linkedFileList.description, .contains("PkgLib"))
-            XCTAssertNoMatch(linkedFileList.description, .contains("ExtLib"))
+            let linkedFileList: String = try fs.readFileContents(AbsolutePath("/path/to/build/release/exe.product/Objects.LinkFileList"))
+            XCTAssertMatch(linkedFileList, .contains("PkgLib"))
+            XCTAssertNoMatch(linkedFileList, .contains("ExtLib"))
 
             try testWithTemporaryDirectory { path in
                 let yaml = path.appending(component: "release.yaml")
                 let llbuild = LLBuildManifestBuilder(plan, fileSystem: fs, observabilityScope: observability.topScope)
                 try llbuild.generateManifest(at: yaml)
-                let contents = try localFileSystem.readFileContents(yaml).description
+                let contents: String = try localFileSystem.readFileContents(yaml)
                 XCTAssertMatch(contents, .contains("""
                         inputs: ["/Pkg/Sources/exe/main.swift","/path/to/build/release/PkgLib.swiftmodule"]
                     """))
@@ -356,15 +356,15 @@ final class BuildPlanTests: XCTestCase {
                 observabilityScope: observability.topScope
             )
 
-            let linkedFileList = try fs.readFileContents(AbsolutePath("/path/to/build/debug/exe.product/Objects.LinkFileList"))
-            XCTAssertNoMatch(linkedFileList.description, .contains("PkgLib"))
-            XCTAssertNoMatch(linkedFileList.description, .contains("ExtLib"))
+            let linkedFileList: String = try fs.readFileContents(AbsolutePath("/path/to/build/debug/exe.product/Objects.LinkFileList"))
+            XCTAssertNoMatch(linkedFileList, .contains("PkgLib"))
+            XCTAssertNoMatch(linkedFileList, .contains("ExtLib"))
 
             try testWithTemporaryDirectory { path in
                 let yaml = path.appending(component: "debug.yaml")
                 let llbuild = LLBuildManifestBuilder(plan, fileSystem: fs, observabilityScope: observability.topScope)
                 try llbuild.generateManifest(at: yaml)
-                let contents = try localFileSystem.readFileContents(yaml).description
+                let contents: String = try localFileSystem.readFileContents(yaml)
                 XCTAssertMatch(contents, .contains("""
                         inputs: ["/Pkg/Sources/exe/main.swift"]
                     """))
@@ -586,7 +586,7 @@ final class BuildPlanTests: XCTestCase {
         ])
       #endif
 
-      let linkedFileList = try fs.readFileContents(AbsolutePath("/path/to/build/debug/exe.product/Objects.LinkFileList"))
+      let linkedFileList: String = try fs.readFileContents(AbsolutePath("/path/to/build/debug/exe.product/Objects.LinkFileList"))
       XCTAssertEqual(linkedFileList, """
           /path/to/build/debug/exe.build/main.c.o
           /path/to/build/debug/extlib.build/extlib.c.o
@@ -743,7 +743,7 @@ final class BuildPlanTests: XCTestCase {
             let yaml = path.appending(component: "debug.yaml")
             let llbuild = LLBuildManifestBuilder(plan, fileSystem: fs, observabilityScope: observability.topScope)
             try llbuild.generateManifest(at: yaml)
-            let contents = try localFileSystem.readFileContents(yaml).description
+            let contents: String = try localFileSystem.readFileContents(yaml)
             XCTAssertMatch(contents, .contains(#"-std=gnu99","-c","/Pkg/Sources/lib/lib.c"#))
             XCTAssertMatch(contents, .contains(#"-std=c++1z","-c","/Pkg/Sources/lib/libx.cpp"#))
         }
@@ -2388,7 +2388,7 @@ final class BuildPlanTests: XCTestCase {
             let yaml = path.appending(component: "debug.yaml")
             let llbuild = LLBuildManifestBuilder(plan, fileSystem: fs, observabilityScope: observability.topScope)
             try llbuild.generateManifest(at: yaml)
-            let contents = try localFileSystem.readFileContents(yaml).description
+            let contents: String = try localFileSystem.readFileContents(yaml)
             XCTAssertMatch(contents, .contains("""
                     inputs: ["/PkgA/Sources/swiftlib/lib.swift","/path/to/build/debug/exe"]
                     outputs: ["/path/to/build/debug/swiftlib.build/lib.swift.o","/path/to/build/debug/
@@ -2445,7 +2445,7 @@ final class BuildPlanTests: XCTestCase {
             let yaml = path.appending(component: "debug.yaml")
             let llbuild = LLBuildManifestBuilder(plan, fileSystem: fs, observabilityScope: observability.topScope)
             try llbuild.generateManifest(at: yaml)
-            let contents = try localFileSystem.readFileContents(yaml).description
+            let contents: String = try localFileSystem.readFileContents(yaml)
             XCTAssertMatch(contents, .contains("""
                   "/path/to/build/debug/Bar.build/main.m.o":
                     tool: clang
@@ -2516,7 +2516,7 @@ final class BuildPlanTests: XCTestCase {
              let yaml = path.appending(component: "debug.yaml")
              let llbuild = LLBuildManifestBuilder(plan, fileSystem: fs, observabilityScope: observability.topScope)
              try llbuild.generateManifest(at: yaml)
-             let contents = try localFileSystem.readFileContents(yaml).description
+             let contents: String = try localFileSystem.readFileContents(yaml)
              XCTAssertMatch(contents, .contains("""
                    "/path/to/build/debug/Bar.build/main.m.o":
                      tool: clang
@@ -2588,7 +2588,7 @@ final class BuildPlanTests: XCTestCase {
              let yaml = path.appending(component: "debug.yaml")
              let llbuild = LLBuildManifestBuilder(plan, fileSystem: fs, observabilityScope: observability.topScope)
              try llbuild.generateManifest(at: yaml)
-             let contents = try localFileSystem.readFileContents(yaml).description
+             let contents: String = try localFileSystem.readFileContents(yaml)
              XCTAssertMatch(contents, .contains("""
                    "/path/to/build/debug/Bar.build/main.m.o":
                      tool: clang
@@ -2637,7 +2637,7 @@ final class BuildPlanTests: XCTestCase {
             let yaml = path.appending(component: "debug.yaml")
             let llbuild = LLBuildManifestBuilder(result.plan, fileSystem: fs, observabilityScope: observability.topScope)
             try llbuild.generateManifest(at: yaml)
-            let contents = try localFileSystem.readFileContents(yaml).description
+            let contents: String = try localFileSystem.readFileContents(yaml)
             XCTAssertMatch(contents, .contains("""
                   "/path/to/build/debug/exe.build/exe.swiftmodule.o":
                     tool: shell
@@ -2709,7 +2709,7 @@ final class BuildPlanTests: XCTestCase {
         ])
 
         let resourceAccessor = fooTarget.sources.first{ $0.basename == "resource_bundle_accessor.swift" }!
-        let contents = try fs.readFileContents(resourceAccessor).cString
+        let contents: String = try fs.readFileContents(resourceAccessor)
         XCTAssertMatch(contents, .contains("extension Foundation.Bundle"))
         // Assert that `Bundle.main` is executed in the compiled binary (and not during compilation)
         // See https://bugs.swift.org/browse/SR-14555 and https://github.com/apple/swift-package-manager/pull/2972/files#r623861646
@@ -2773,7 +2773,7 @@ final class BuildPlanTests: XCTestCase {
         ])
 
         let resourceAccessor = fooTarget.sources.first{ $0.basename == "resource_bundle_accessor.swift" }!
-        let contents = try fs.readFileContents(resourceAccessor).cString
+        let contents: String = try fs.readFileContents(resourceAccessor)
         XCTAssertMatch(contents, .contains("extension Foundation.Bundle"))
         // Assert that `Bundle.main` is executed in the compiled binary (and not during compilation)
         // See https://bugs.swift.org/browse/SR-14555 and https://github.com/apple/swift-package-manager/pull/2972/files#r623861646

--- a/Tests/BuildTests/IncrementalBuildTests.swift
+++ b/Tests/BuildTests/IncrementalBuildTests.swift
@@ -56,14 +56,14 @@ final class IncrementalBuildTests: XCTestCase {
             try localFileSystem.writeFileContents(sourceFile, bytes: sourceStream.bytes)
 
             // Read the first llbuild manifest.
-            let llbuildContents1 = try localFileSystem.readFileContents(llbuildManifest)
+            let llbuildContents1: String = try localFileSystem.readFileContents(llbuildManifest)
 
             // Now build again.  This should be an incremental build.
             let (log2, _) = try executeSwiftBuild(prefix)
             XCTAssertMatch(log2, .contains("Compiling CLibrarySources Foo.c"))
 
             // Read the second llbuild manifest.
-            let llbuildContents2 = try localFileSystem.readFileContents(llbuildManifest)
+            let llbuildContents2: String = try localFileSystem.readFileContents(llbuildManifest)
 
             // Now build again without changing anything.  This should be a null
             // build.
@@ -71,7 +71,7 @@ final class IncrementalBuildTests: XCTestCase {
             XCTAssertNoMatch(log3, .contains("Compiling CLibrarySources Foo.c"))
 
             // Read the third llbuild manifest.
-            let llbuildContents3 = try localFileSystem.readFileContents(llbuildManifest)
+            let llbuildContents3: String = try localFileSystem.readFileContents(llbuildManifest)
 
             XCTAssertEqual(llbuildContents1, llbuildContents2)
             XCTAssertEqual(llbuildContents2, llbuildContents3)

--- a/Tests/BuildTests/LLBuildManifestTests.swift
+++ b/Tests/BuildTests/LLBuildManifestTests.swift
@@ -34,7 +34,7 @@ final class LLBuildManifestTests: XCTestCase {
         let fs = InMemoryFileSystem()
         try ManifestWriter(fs).write(manifest, at: AbsolutePath("/manifest.yaml"))
 
-        let contents = try fs.readFileContents(AbsolutePath("/manifest.yaml"))
+        let contents: String = try fs.readFileContents(AbsolutePath("/manifest.yaml"))
 
         XCTAssertEqual(contents, """
             client:
@@ -85,7 +85,7 @@ final class LLBuildManifestTests: XCTestCase {
         let fs = InMemoryFileSystem()
         try ManifestWriter(fs).write(manifest, at: AbsolutePath("/manifest.yaml"))
 
-        let contents = try fs.readFileContents(AbsolutePath("/manifest.yaml"))
+        let contents: String = try fs.readFileContents(AbsolutePath("/manifest.yaml"))
 
         XCTAssertEqual(contents, """
             client:

--- a/Tests/CommandsTests/APIDiffTests.swift
+++ b/Tests/CommandsTests/APIDiffTests.swift
@@ -448,7 +448,8 @@ final class APIDiffTests: CommandsTestCase {
                 XCTAssertMatch(output, .contains("1 breaking change detected in Foo"))
                 XCTAssertMatch(output, .contains("💔 API breakage: func foo() has been removed"))
                 XCTAssertFileExists(fooBaselinePath)
-                XCTAssertNotEqual((try! localFileSystem.readFileContents(fooBaselinePath)).description, "Old Baseline")
+                let content: String = try! localFileSystem.readFileContents(fooBaselinePath)
+                XCTAssertNotEqual(content, "Old Baseline")
             }
         }
     }

--- a/Tests/CommandsTests/PackageRegistryToolTests.swift
+++ b/Tests/CommandsTests/PackageRegistryToolTests.swift
@@ -59,7 +59,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
                 let result = try execute(["set", "\(defaultRegistryBaseURL)"], packagePath: packageRoot)
                 XCTAssertEqual(result.exitStatus, .terminated(code: 0))
 
-                let json = try JSON(bytes: localFileSystem.readFileContents(configurationFilePath))
+                let json = try JSON(data: localFileSystem.readFileContents(configurationFilePath))
                 XCTAssertEqual(json["registries"]?.dictionary?.count, 1)
                 XCTAssertEqual(json["registries"]?.dictionary?["[default]"]?.dictionary?["url"]?.string, "\(defaultRegistryBaseURL)")
                 XCTAssertEqual(json["version"], .int(1))
@@ -70,7 +70,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
                 let result = try execute(["set", "\(customRegistryBaseURL)"], packagePath: packageRoot)
                 XCTAssertEqual(result.exitStatus, .terminated(code: 0))
 
-                let json = try JSON(bytes: localFileSystem.readFileContents(configurationFilePath))
+                let json = try JSON(data: localFileSystem.readFileContents(configurationFilePath))
                 XCTAssertEqual(json["registries"]?.dictionary?.count, 1)
                 XCTAssertEqual(json["registries"]?.dictionary?["[default]"]?.dictionary?["url"]?.string, "\(customRegistryBaseURL)")
                 XCTAssertEqual(json["version"], .int(1))
@@ -81,7 +81,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
                 let result = try execute(["unset"], packagePath: packageRoot)
                 XCTAssertEqual(result.exitStatus, .terminated(code: 0))
 
-                let json = try JSON(bytes: localFileSystem.readFileContents(configurationFilePath))
+                let json = try JSON(data: localFileSystem.readFileContents(configurationFilePath))
                 XCTAssertEqual(json["registries"]?.dictionary?.count, 0)
                 XCTAssertEqual(json["version"], .int(1))
             }
@@ -91,7 +91,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
                 let result = try execute(["set", "\(customRegistryBaseURL)", "--scope", "foo"], packagePath: packageRoot)
                 XCTAssertEqual(result.exitStatus, .terminated(code: 0))
 
-                let json = try JSON(bytes: localFileSystem.readFileContents(configurationFilePath))
+                let json = try JSON(data: localFileSystem.readFileContents(configurationFilePath))
                 XCTAssertEqual(json["registries"]?.dictionary?.count, 1)
                 XCTAssertEqual(json["registries"]?.dictionary?["foo"]?.dictionary?["url"]?.string, "\(customRegistryBaseURL)")
                 XCTAssertEqual(json["version"], .int(1))
@@ -102,7 +102,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
                 let result = try execute(["set", "\(customRegistryBaseURL)", "--scope", "bar"], packagePath: packageRoot)
                 XCTAssertEqual(result.exitStatus, .terminated(code: 0))
 
-                let json = try JSON(bytes: localFileSystem.readFileContents(configurationFilePath))
+                let json = try JSON(data: localFileSystem.readFileContents(configurationFilePath))
                 XCTAssertEqual(json["registries"]?.dictionary?.count, 2)
                 XCTAssertEqual(json["registries"]?.dictionary?["foo"]?.dictionary?["url"]?.string, "\(customRegistryBaseURL)")
                 XCTAssertEqual(json["registries"]?.dictionary?["bar"]?.dictionary?["url"]?.string, "\(customRegistryBaseURL)")
@@ -114,7 +114,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
                 let result = try execute(["unset", "--scope", "foo"], packagePath: packageRoot)
                 XCTAssertEqual(result.exitStatus, .terminated(code: 0))
 
-                let json = try JSON(bytes: localFileSystem.readFileContents(configurationFilePath))
+                let json = try JSON(data: localFileSystem.readFileContents(configurationFilePath))
                 XCTAssertEqual(json["registries"]?.dictionary?.count, 1)
                 XCTAssertEqual(json["registries"]?.dictionary?["bar"]?.dictionary?["url"]?.string, "\(customRegistryBaseURL)")
                 XCTAssertEqual(json["version"], .int(1))
@@ -189,7 +189,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
                 let result = try execute(["set", "\(defaultRegistryBaseURL)"], packagePath: packageRoot)
                 XCTAssertEqual(result.exitStatus, .terminated(code: 0))
 
-                let json = try JSON(bytes: localFileSystem.readFileContents(configurationFilePath))
+                let json = try JSON(data: localFileSystem.readFileContents(configurationFilePath))
                 XCTAssertEqual(json["registries"]?.dictionary?.count, 1)
                 XCTAssertEqual(json["registries"]?.dictionary?["[default]"]?.dictionary?["url"]?.string, "\(defaultRegistryBaseURL)")
                 XCTAssertEqual(json["version"], .int(1))
@@ -200,7 +200,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
                 let result = try execute(["unset", "--scope", "baz"], packagePath: packageRoot)
                 XCTAssertNotEqual(result.exitStatus, .terminated(code: 0))
 
-                let json = try JSON(bytes: localFileSystem.readFileContents(configurationFilePath))
+                let json = try JSON(data: localFileSystem.readFileContents(configurationFilePath))
                 XCTAssertEqual(json["registries"]?.dictionary?.count, 1)
                 XCTAssertEqual(json["registries"]?.dictionary?["[default]"]?.dictionary?["url"]?.string, "\(defaultRegistryBaseURL)")
                 XCTAssertEqual(json["version"], .int(1))

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -638,8 +638,8 @@ final class PackageToolTests: CommandsTestCase {
             _ = try execute(["show-dependencies", "--format", "json", "--output-path", resultPath.pathString ], packagePath: root)
 
             XCTAssertFileExists(resultPath)
-            let jsonOutput = try fs.readFileContents(resultPath)
-            let json = try JSON(bytes: jsonOutput)
+            let jsonOutput: Data = try fs.readFileContents(resultPath)
+            let json = try JSON(data: jsonOutput)
 
             XCTAssertEqual(json["name"]?.string, "root")
             XCTAssertEqual(json["dependencies"]?[0]?["name"]?.string, "dep")
@@ -667,7 +667,7 @@ final class PackageToolTests: CommandsTestCase {
             _ = try execute(["init", "--type", "executable"], packagePath: path)
 
             let manifest = path.appending(component: "Package.swift")
-            let contents = try localFileSystem.readFileContents(manifest).description
+            let contents: String = try localFileSystem.readFileContents(manifest)
             let version = InitPackage.newPackageToolsVersion
             let versionSpecifier = "\(version.major).\(version.minor)"
             XCTAssertMatch(contents, .prefix("// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"))
@@ -699,7 +699,7 @@ final class PackageToolTests: CommandsTestCase {
             _ = try execute(["init", "--name", "CustomName", "--type", "executable"], packagePath: path)
 
             let manifest = path.appending(component: "Package.swift")
-            let contents = try localFileSystem.readFileContents(manifest).description
+            let contents: String = try localFileSystem.readFileContents(manifest)
             let version = InitPackage.newPackageToolsVersion
             let versionSpecifier = "\(version.major).\(version.minor)"
             XCTAssertMatch(contents, .prefix("// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"))
@@ -896,8 +896,8 @@ final class PackageToolTests: CommandsTestCase {
 
             // Checks the content of checked out bar.swift.
             func checkBar(_ value: Int, file: StaticString = #file, line: UInt = #line) throws {
-                let contents = try localFileSystem.readFileContents(barPath.appending(components:"Sources", "bar.swift")).validDescription?.spm_chomp()
-                XCTAssert(contents?.hasSuffix("\(value)") ?? false, file: file, line: line)
+                let contents: String = try localFileSystem.readFileContents(barPath.appending(components:"Sources", "bar.swift"))
+                XCTAssertTrue(contents.spm_chomp().hasSuffix("\(value)"), file: file, line: line)
             }
 
             // We should see a pin file now.
@@ -1092,7 +1092,8 @@ final class PackageToolTests: CommandsTestCase {
             // Test env override.
             try execute(["config", "set-mirror", "--original-url", "https://github.com/foo/bar", "--mirror-url", "https://mygithub.com/foo/bar"], packagePath: packageRoot, env: ["SWIFTPM_MIRROR_CONFIG": configOverride.pathString])
             XCTAssertTrue(fs.isFile(configOverride))
-            XCTAssertTrue(try fs.readFileContents(configOverride).description.contains("mygithub"))
+            let content: String = try fs.readFileContents(configOverride)
+            XCTAssertMatch(content, .contains("mygithub"))
 
             // Test reading.
             (stdout, stderr) = try execute(["config", "get-mirror", "--package-url", "https://github.com/foo/bar"], packagePath: packageRoot)

--- a/Tests/FunctionalTests/DependencyResolutionTests.swift
+++ b/Tests/FunctionalTests/DependencyResolutionTests.swift
@@ -96,7 +96,7 @@ class DependencyResolutionTests: XCTestCase {
                 XCTAssertMatch(output.stdout, .contains("foo<\(prefix.pathString)/Foo@unspecified"))
                 XCTAssertMatch(output.stdout, .contains("bar<\(prefix.pathString)/Bar@unspecified"))
 
-                let pins = try String(bytes: localFileSystem.readFileContents(appPinsPath).contents, encoding: .utf8)!
+                let pins: String = try localFileSystem.readFileContents(appPinsPath)
                 XCTAssertMatch(pins, .contains("\"\(prefix.pathString)/Foo\""))
                 XCTAssertMatch(pins, .contains("\"\(prefix.pathString)/Bar\""))
 
@@ -124,7 +124,7 @@ class DependencyResolutionTests: XCTestCase {
                 XCTAssertNoMatch(output.stdout, .contains("bar<\(prefix.pathString)/Bar@unspecified"))
 
                 // rdar://52529014 mirrors should not be reflected in pins file
-                let pins = try String(bytes: localFileSystem.readFileContents(appPinsPath).contents, encoding: .utf8)!
+                let pins: String = try localFileSystem.readFileContents(appPinsPath)
                 XCTAssertMatch(pins, .contains("\"\(prefix.pathString)/Foo\""))
                 XCTAssertMatch(pins, .contains("\"\(prefix.pathString)/Bar\""))
                 XCTAssertNoMatch(pins, .contains("\"\(prefix.pathString)/BarMirror\""))

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -212,46 +212,46 @@ class MiscellaneousTestCase: XCTestCase {
 
     func testSwiftTestParallel() throws {
         fixture(name: "Miscellaneous/ParallelTestsPkg") { prefix in
-          // First try normal serial testing.
-          do {
-            _ = try SwiftPMProduct.SwiftTest.execute([], packagePath: prefix)
-          } catch SwiftPMProductError.executionFailure(_, let output, let stderr) {
-            #if os(macOS)
-              XCTAssertMatch(stderr, .contains("Executed 2 tests"))
-            #else
-              XCTAssertMatch(output, .contains("Executed 2 tests"))
-            #endif
-          }
+            // First try normal serial testing.
+            do {
+                _ = try SwiftPMProduct.SwiftTest.execute([], packagePath: prefix)
+            } catch SwiftPMProductError.executionFailure(_, let output, let stderr) {
+                #if os(macOS)
+                XCTAssertMatch(stderr, .contains("Executed 2 tests"))
+                #else
+                XCTAssertMatch(output, .contains("Executed 2 tests"))
+                #endif
+            }
 
-          do {
-            // Run tests in parallel.
-            _ = try SwiftPMProduct.SwiftTest.execute(["--parallel"], packagePath: prefix)
-          } catch SwiftPMProductError.executionFailure(_, let output, _) {
-            XCTAssertMatch(output, .contains("testExample1"))
-            XCTAssertMatch(output, .contains("testExample2"))
-            XCTAssertNoMatch(output, .contains("'ParallelTestsTests' passed"))
-            XCTAssertMatch(output, .contains("'ParallelTestsFailureTests' failed"))
-            XCTAssertMatch(output, .contains("[3/3]"))
-          }
+            do {
+                // Run tests in parallel.
+                _ = try SwiftPMProduct.SwiftTest.execute(["--parallel"], packagePath: prefix)
+            } catch SwiftPMProductError.executionFailure(_, let output, _) {
+                XCTAssertMatch(output, .contains("testExample1"))
+                XCTAssertMatch(output, .contains("testExample2"))
+                XCTAssertNoMatch(output, .contains("'ParallelTestsTests' passed"))
+                XCTAssertMatch(output, .contains("'ParallelTestsFailureTests' failed"))
+                XCTAssertMatch(output, .contains("[3/3]"))
+            }
 
-          let xUnitOutput = prefix.appending(component: "result.xml")
-          do {
-            // Run tests in parallel with verbose output.
-            _ = try SwiftPMProduct.SwiftTest.execute(
-                ["--parallel", "--verbose", "--xunit-output", xUnitOutput.pathString],
-                packagePath: prefix)
-          } catch SwiftPMProductError.executionFailure(_, let output, _) {
-            XCTAssertMatch(output, .contains("testExample1"))
-            XCTAssertMatch(output, .contains("testExample2"))
-            XCTAssertMatch(output, .contains("'ParallelTestsTests' passed"))
-            XCTAssertMatch(output, .contains("'ParallelTestsFailureTests' failed"))
-            XCTAssertMatch(output, .contains("[3/3]"))
-          }
+            let xUnitOutput = prefix.appending(component: "result.xml")
+            do {
+                // Run tests in parallel with verbose output.
+                _ = try SwiftPMProduct.SwiftTest.execute(
+                    ["--parallel", "--verbose", "--xunit-output", xUnitOutput.pathString],
+                    packagePath: prefix)
+            } catch SwiftPMProductError.executionFailure(_, let output, _) {
+                XCTAssertMatch(output, .contains("testExample1"))
+                XCTAssertMatch(output, .contains("testExample2"))
+                XCTAssertMatch(output, .contains("'ParallelTestsTests' passed"))
+                XCTAssertMatch(output, .contains("'ParallelTestsFailureTests' failed"))
+                XCTAssertMatch(output, .contains("[3/3]"))
+            }
 
-          // Check the xUnit output.
-          XCTAssertFileExists(xUnitOutput)
-          let contents = try localFileSystem.readFileContents(xUnitOutput).description
-          XCTAssertMatch(contents, .contains("tests=\"3\" failures=\"1\""))
+            // Check the xUnit output.
+            XCTAssertFileExists(xUnitOutput)
+            let contents: String = try localFileSystem.readFileContents(xUnitOutput)
+            XCTAssertMatch(contents, .contains("tests=\"3\" failures=\"1\""))
         }
     }
 
@@ -387,7 +387,7 @@ class MiscellaneousTestCase: XCTestCase {
             XCTAssert(result.exitStatus != .terminated(code: 0))
 
             // Process and subprocesses should be dead.
-            let contents = try localFileSystem.readFileContents(waitFile).description
+            let contents: String = try localFileSystem.readFileContents(waitFile)
             XCTAssertFalse(try Process.running(process.processID))
             XCTAssertFalse(try Process.running(ProcessID(contents)!))
         }

--- a/Tests/PackageCollectionsSigningTests/CertificatePolicyTests.swift
+++ b/Tests/PackageCollectionsSigningTests/CertificatePolicyTests.swift
@@ -22,13 +22,13 @@ class CertificatePolicyTests: XCTestCase {
 
         fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let certPath = directoryPath.appending(components: "Signing", "Test_rsa.cer")
-            let certificate = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(certPath).contents))
+            let certificate = try Certificate(derEncoded: try localFileSystem.readFileContents(certPath))
 
             let intermediateCAPath = directoryPath.appending(components: "Signing", "TestIntermediateCA.cer")
-            let intermediateCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(intermediateCAPath).contents))
+            let intermediateCA = try Certificate(derEncoded: try localFileSystem.readFileContents(intermediateCAPath))
 
             let rootCAPath = directoryPath.appending(components: "Signing", "TestRootCA.cer")
-            let rootCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(rootCAPath).contents))
+            let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath))
 
             let certChain = [certificate, intermediateCA, rootCA]
 
@@ -42,13 +42,13 @@ class CertificatePolicyTests: XCTestCase {
 
         fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let certPath = directoryPath.appending(components: "Signing", "Test_ec.cer")
-            let certificate = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(certPath).contents))
+            let certificate = try Certificate(derEncoded: try localFileSystem.readFileContents(certPath))
 
             let intermediateCAPath = directoryPath.appending(components: "Signing", "TestIntermediateCA.cer")
-            let intermediateCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(intermediateCAPath).contents))
+            let intermediateCA = try Certificate(derEncoded: try localFileSystem.readFileContents(intermediateCAPath))
 
             let rootCAPath = directoryPath.appending(components: "Signing", "TestRootCA.cer")
-            let rootCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(rootCAPath).contents))
+            let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath))
 
             let certChain = [certificate, intermediateCA, rootCA]
 
@@ -62,13 +62,13 @@ class CertificatePolicyTests: XCTestCase {
 
         fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let certPath = directoryPath.appending(components: "Signing", "Test_rsa.cer")
-            let certificate = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(certPath).contents))
+            let certificate = try Certificate(derEncoded: try localFileSystem.readFileContents(certPath))
 
             let intermediateCAPath = directoryPath.appending(components: "Signing", "TestIntermediateCA.cer")
-            let intermediateCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(intermediateCAPath).contents))
+            let intermediateCA = try Certificate(derEncoded: try localFileSystem.readFileContents(intermediateCAPath))
 
             let rootCAPath = directoryPath.appending(components: "Signing", "TestRootCA.cer")
-            let rootCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(rootCAPath).contents))
+            let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath))
 
             let certChain = [certificate, intermediateCA, rootCA]
 
@@ -93,13 +93,13 @@ class CertificatePolicyTests: XCTestCase {
 
         fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let certPath = directoryPath.appending(components: "Signing", "Test_rsa.cer")
-            let certificate = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(certPath).contents))
+            let certificate = try Certificate(derEncoded: try localFileSystem.readFileContents(certPath))
 
             let intermediateCAPath = directoryPath.appending(components: "Signing", "TestIntermediateCA.cer")
-            let intermediateCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(intermediateCAPath).contents))
+            let intermediateCA = try Certificate(derEncoded: try localFileSystem.readFileContents(intermediateCAPath))
 
             let rootCAPath = directoryPath.appending(components: "Signing", "TestRootCA.cer")
-            let rootCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(rootCAPath).contents))
+            let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath))
 
             let certChain = [certificate, intermediateCA, rootCA]
 
@@ -123,13 +123,13 @@ class CertificatePolicyTests: XCTestCase {
 
         fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let certPath = directoryPath.appending(components: "Signing", "development-revoked.cer")
-            let certificate = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(certPath).contents))
+            let certificate = try Certificate(derEncoded: try localFileSystem.readFileContents(certPath))
 
             let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCAG3.cer")
-            let intermediateCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(intermediateCAPath).contents))
+            let intermediateCA = try Certificate(derEncoded: try localFileSystem.readFileContents(intermediateCAPath))
 
             let rootCAPath = directoryPath.appending(components: "Signing", "AppleIncRoot.cer")
-            let rootCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(rootCAPath).contents))
+            let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath))
 
             let certChain = [certificate, intermediateCA, rootCA]
 
@@ -170,13 +170,13 @@ class CertificatePolicyTests: XCTestCase {
 
         fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let certPath = directoryPath.appending(components: "Signing", "development.cer")
-            let certificate = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(certPath).contents))
+            let certificate = try Certificate(derEncoded: try localFileSystem.readFileContents(certPath))
 
             let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCAG3.cer")
-            let intermediateCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(intermediateCAPath).contents))
+            let intermediateCA = try Certificate(derEncoded: try localFileSystem.readFileContents(intermediateCAPath))
 
             let rootCAPath = directoryPath.appending(components: "Signing", "AppleIncRoot.cer")
-            let rootCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(rootCAPath).contents))
+            let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath))
 
             let certChain = [certificate, intermediateCA, rootCA]
 
@@ -239,13 +239,13 @@ class CertificatePolicyTests: XCTestCase {
         fixture(name: "Collections", createGitRepo: false) { directoryPath in
             // This must be an Apple Swift Package Collection cert
             let certPath = directoryPath.appending(components: "Signing", "swift_package_collection.cer")
-            let certificate = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(certPath).contents))
+            let certificate = try Certificate(derEncoded: try localFileSystem.readFileContents(certPath))
 
             let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCA.cer")
-            let intermediateCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(intermediateCAPath).contents))
+            let intermediateCA = try Certificate(derEncoded: try localFileSystem.readFileContents(intermediateCAPath))
 
             let rootCAPath = directoryPath.appending(components: "Signing", "AppleIncRoot.cer")
-            let rootCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(rootCAPath).contents))
+            let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath))
 
             let certChain = [certificate, intermediateCA, rootCA]
 
@@ -308,13 +308,13 @@ class CertificatePolicyTests: XCTestCase {
         fixture(name: "Collections", createGitRepo: false) { directoryPath in
             // This must be an Apple Distribution cert
             let certPath = directoryPath.appending(components: "Signing", "development.cer")
-            let certificate = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(certPath).contents))
+            let certificate = try Certificate(derEncoded: try localFileSystem.readFileContents(certPath))
 
             let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCAG3.cer")
-            let intermediateCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(intermediateCAPath).contents))
+            let intermediateCA = try Certificate(derEncoded: try localFileSystem.readFileContents(intermediateCAPath))
 
             let rootCAPath = directoryPath.appending(components: "Signing", "AppleIncRoot.cer")
-            let rootCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(rootCAPath).contents))
+            let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath))
 
             let certChain = [certificate, intermediateCA, rootCA]
 
@@ -376,13 +376,13 @@ class CertificatePolicyTests: XCTestCase {
 
         fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let certPath = directoryPath.appending(components: "Signing", "development.cer")
-            let certificate = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(certPath).contents))
+            let certificate = try Certificate(derEncoded: try localFileSystem.readFileContents(certPath))
 
             let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCAG3.cer")
-            let intermediateCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(intermediateCAPath).contents))
+            let intermediateCA = try Certificate(derEncoded: try localFileSystem.readFileContents(intermediateCAPath))
 
             let rootCAPath = directoryPath.appending(components: "Signing", "AppleIncRoot.cer")
-            let rootCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(rootCAPath).contents))
+            let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath))
 
             let certChain = [certificate, intermediateCA, rootCA]
 
@@ -452,13 +452,13 @@ class CertificatePolicyTests: XCTestCase {
         fixture(name: "Collections", createGitRepo: false) { directoryPath in
             // This must be an Apple Swift Package Collection cert
             let certPath = directoryPath.appending(components: "Signing", "swift_package_collection.cer")
-            let certificate = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(certPath).contents))
+            let certificate = try Certificate(derEncoded: try localFileSystem.readFileContents(certPath))
 
             let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCA.cer")
-            let intermediateCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(intermediateCAPath).contents))
+            let intermediateCA = try Certificate(derEncoded: try localFileSystem.readFileContents(intermediateCAPath))
 
             let rootCAPath = directoryPath.appending(components: "Signing", "AppleIncRoot.cer")
-            let rootCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(rootCAPath).contents))
+            let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath))
 
             let certChain = [certificate, intermediateCA, rootCA]
 
@@ -530,13 +530,13 @@ class CertificatePolicyTests: XCTestCase {
         fixture(name: "Collections", createGitRepo: false) { directoryPath in
             // This must be an Apple Distribution cert
             let certPath = directoryPath.appending(components: "Signing", "development.cer")
-            let certificate = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(certPath).contents))
+            let certificate = try Certificate(derEncoded: try localFileSystem.readFileContents(certPath))
 
             let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCAG3.cer")
-            let intermediateCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(intermediateCAPath).contents))
+            let intermediateCA = try Certificate(derEncoded: try localFileSystem.readFileContents(intermediateCAPath))
 
             let rootCAPath = directoryPath.appending(components: "Signing", "AppleIncRoot.cer")
-            let rootCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(rootCAPath).contents))
+            let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath))
 
             let certChain = [certificate, intermediateCA, rootCA]
 

--- a/Tests/PackageCollectionsSigningTests/CertificateTests.swift
+++ b/Tests/PackageCollectionsSigningTests/CertificateTests.swift
@@ -21,7 +21,7 @@ class CertificateTests: XCTestCase {
 
         fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let path = directoryPath.appending(components: "Signing", "Test_rsa.cer")
-            let data = Data(try localFileSystem.readFileContents(path).contents)
+            let data: Data = try localFileSystem.readFileContents(path)
 
             let certificate = try Certificate(derEncoded: data)
 
@@ -44,7 +44,7 @@ class CertificateTests: XCTestCase {
 
         fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let path = directoryPath.appending(components: "Signing", "Test_ec.cer")
-            let data = Data(try localFileSystem.readFileContents(path).contents)
+            let data: Data = try localFileSystem.readFileContents(path)
 
             let certificate = try Certificate(derEncoded: data)
 

--- a/Tests/PackageCollectionsSigningTests/KeyTests+EC.swift
+++ b/Tests/PackageCollectionsSigningTests/KeyTests+EC.swift
@@ -21,7 +21,7 @@ class ECKeyTests: XCTestCase {
 
         fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let path = directoryPath.appending(components: "Signing", "Test_ec.cer")
-            let data = Data(try localFileSystem.readFileContents(path).contents)
+            let data: Data = try localFileSystem.readFileContents(path)
 
             let certificate = try Certificate(derEncoded: data)
             XCTAssertNoThrow(try certificate.publicKey())

--- a/Tests/PackageCollectionsSigningTests/KeyTests+RSA.swift
+++ b/Tests/PackageCollectionsSigningTests/KeyTests+RSA.swift
@@ -21,7 +21,7 @@ class RSAKeyTests: XCTestCase {
 
         fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let path = directoryPath.appending(components: "Signing", "Test_rsa.cer")
-            let data = Data(try localFileSystem.readFileContents(path).contents)
+            let data: Data = try localFileSystem.readFileContents(path)
 
             let certificate = try Certificate(derEncoded: data)
             XCTAssertNoThrow(try certificate.publicKey())

--- a/Tests/PackageCollectionsSigningTests/PackageCollectionSigningTest.swift
+++ b/Tests/PackageCollectionsSigningTests/PackageCollectionSigningTest.swift
@@ -25,7 +25,7 @@ class PackageCollectionSigningTests: XCTestCase {
             let jsonDecoder = JSONDecoder.makeWithDefaults()
 
             let collectionPath = directoryPath.appending(components: "JSON", "good.json")
-            let collectionData = Data(try localFileSystem.readFileContents(collectionPath).contents)
+            let collectionData: Data = try localFileSystem.readFileContents(collectionPath)
             let collection = try jsonDecoder.decode(PackageCollectionModel.V1.Collection.self, from: collectionData)
 
             let certPath = directoryPath.appending(components: "Signing", "Test_rsa.cer")
@@ -35,7 +35,7 @@ class PackageCollectionSigningTests: XCTestCase {
 
             let privateKeyPath = directoryPath.appending(components: "Signing", "Test_rsa_key.pem")
 
-            let rootCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(rootCAPath).contents))
+            let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath))
             // Trust the self-signed root cert
             let certPolicy = TestCertificatePolicy(anchorCerts: [rootCA])
             let signing = PackageCollectionSigning(certPolicy: certPolicy, callbackQueue: callbackQueue)
@@ -82,7 +82,7 @@ class PackageCollectionSigningTests: XCTestCase {
 
             let privateKeyPath = directoryPath.appending(components: "Signing", "Test_rsa_key.pem")
 
-            let rootCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(rootCAPath).contents))
+            let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath))
             // Trust the self-signed root cert
             let certPolicy = TestCertificatePolicy(anchorCerts: [rootCA])
             let signing = PackageCollectionSigning(certPolicy: certPolicy, callbackQueue: callbackQueue)
@@ -113,7 +113,7 @@ class PackageCollectionSigningTests: XCTestCase {
             let jsonDecoder = JSONDecoder.makeWithDefaults()
 
             let collectionPath = directoryPath.appending(components: "JSON", "good.json")
-            let collectionData = Data(try localFileSystem.readFileContents(collectionPath).contents)
+            let collectionData: Data = try localFileSystem.readFileContents(collectionPath)
             let collection = try jsonDecoder.decode(PackageCollectionModel.V1.Collection.self, from: collectionData)
 
             let certPath = directoryPath.appending(components: "Signing", "Test_ec.cer")
@@ -123,7 +123,7 @@ class PackageCollectionSigningTests: XCTestCase {
 
             let privateKeyPath = directoryPath.appending(components: "Signing", "Test_ec_key.pem")
 
-            let rootCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(rootCAPath).contents))
+            let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath))
             // Trust the self-signed root cert
             let certPolicy = TestCertificatePolicy(anchorCerts: [rootCA])
             let signing = PackageCollectionSigning(certPolicy: certPolicy, callbackQueue: callbackQueue)
@@ -170,7 +170,7 @@ class PackageCollectionSigningTests: XCTestCase {
 
             let privateKeyPath = directoryPath.appending(components: "Signing", "Test_ec_key.pem")
 
-            let rootCA = try Certificate(derEncoded: Data(try localFileSystem.readFileContents(rootCAPath).contents))
+            let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath))
             // Trust the self-signed root cert
             let certPolicy = TestCertificatePolicy(anchorCerts: [rootCA])
             let signing = PackageCollectionSigning(certPolicy: certPolicy, callbackQueue: callbackQueue)
@@ -206,13 +206,13 @@ class PackageCollectionSigningTests: XCTestCase {
             let jsonDecoder = JSONDecoder.makeWithDefaults()
 
             let collectionPath = directoryPath.appending(components: "JSON", "good.json")
-            let collectionData = Data(try localFileSystem.readFileContents(collectionPath).contents)
+            let collectionData: Data = try localFileSystem.readFileContents(collectionPath)
             let collection = try jsonDecoder.decode(PackageCollectionModel.V1.Collection.self, from: collectionData)
 
             let certPath = directoryPath.appending(components: "Signing", "development.cer")
             let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCAG3.cer")
             let rootCAPath = directoryPath.appending(components: "Signing", "AppleIncRoot.cer")
-            let rootCAData = Data(try localFileSystem.readFileContents(rootCAPath).contents)
+            let rootCAData: Data = try localFileSystem.readFileContents(rootCAPath)
             let certChainPaths = [certPath, intermediateCAPath, rootCAPath].map { $0.asURL }
 
             let privateKeyPath = directoryPath.appending(components: "Signing", "development-key.pem")
@@ -315,14 +315,14 @@ class PackageCollectionSigningTests: XCTestCase {
             let jsonDecoder = JSONDecoder.makeWithDefaults()
 
             let collectionPath = directoryPath.appending(components: "JSON", "good.json")
-            let collectionData = Data(try localFileSystem.readFileContents(collectionPath).contents)
+            let collectionData: Data = try localFileSystem.readFileContents(collectionPath)
             let collection = try jsonDecoder.decode(PackageCollectionModel.V1.Collection.self, from: collectionData)
 
             // This must be an Apple Distribution cert
             let certPath = directoryPath.appending(components: "Signing", "development.cer")
             let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCAG3.cer")
             let rootCAPath = directoryPath.appending(components: "Signing", "AppleIncRoot.cer")
-            let rootCAData = Data(try localFileSystem.readFileContents(rootCAPath).contents)
+            let rootCAData: Data = try localFileSystem.readFileContents(rootCAPath)
             let certChainPaths = [certPath, intermediateCAPath, rootCAPath].map { $0.asURL }
 
             let privateKeyPath = directoryPath.appending(components: "Signing", "development-key.pem")
@@ -409,14 +409,14 @@ class PackageCollectionSigningTests: XCTestCase {
             let jsonDecoder = JSONDecoder.makeWithDefaults()
 
             let collectionPath = directoryPath.appending(components: "JSON", "good.json")
-            let collectionData = Data(try localFileSystem.readFileContents(collectionPath).contents)
+            let collectionData: Data = try localFileSystem.readFileContents(collectionPath)
             let collection = try jsonDecoder.decode(PackageCollectionModel.V1.Collection.self, from: collectionData)
 
             // This must be an Apple Swift Package Collection cert
             let certPath = directoryPath.appending(components: "Signing", "swift_package_collection.cer")
             let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCA.cer")
             let rootCAPath = directoryPath.appending(components: "Signing", "AppleIncRoot.cer")
-            let rootCAData = Data(try localFileSystem.readFileContents(rootCAPath).contents)
+            let rootCAData: Data = try localFileSystem.readFileContents(rootCAPath)
             let certChainPaths = [certPath, intermediateCAPath, rootCAPath].map { $0.asURL }
 
             let privateKeyPath = directoryPath.appending(components: "Signing", "development-key.pem")
@@ -503,7 +503,7 @@ class PackageCollectionSigningTests: XCTestCase {
             let jsonDecoder = JSONDecoder.makeWithDefaults()
 
             let collectionPath = directoryPath.appending(components: "JSON", "good.json")
-            let collectionData = Data(try localFileSystem.readFileContents(collectionPath).contents)
+            let collectionData: Data = try localFileSystem.readFileContents(collectionPath)
             let collection = try jsonDecoder.decode(PackageCollectionModel.V1.Collection.self, from: collectionData)
 
             let certPath = directoryPath.appending(components: "Signing", "development.cer")
@@ -557,7 +557,7 @@ class PackageCollectionSigningTests: XCTestCase {
             let jsonDecoder = JSONDecoder.makeWithDefaults()
 
             let collectionPath = directoryPath.appending(components: "JSON", "good.json")
-            let collectionData = Data(try localFileSystem.readFileContents(collectionPath).contents)
+            let collectionData: Data = try localFileSystem.readFileContents(collectionPath)
             let collection = try jsonDecoder.decode(PackageCollectionModel.V1.Collection.self, from: collectionData)
 
             // This must be an Apple Distribution cert
@@ -622,7 +622,7 @@ class PackageCollectionSigningTests: XCTestCase {
             let jsonDecoder = JSONDecoder.makeWithDefaults()
 
             let collectionPath = directoryPath.appending(components: "JSON", "good.json")
-            let collectionData = Data(try localFileSystem.readFileContents(collectionPath).contents)
+            let collectionData: Data = try localFileSystem.readFileContents(collectionPath)
             let collection = try jsonDecoder.decode(PackageCollectionModel.V1.Collection.self, from: collectionData)
 
             // This must be an Apple Distribution cert

--- a/Tests/PackageCollectionsSigningTests/SignatureTests.swift
+++ b/Tests/PackageCollectionsSigningTests/SignatureTests.swift
@@ -26,7 +26,7 @@ class SignatureTests: XCTestCase {
             let payload = ["foo": "bar"]
 
             let certPath = directoryPath.appending(components: "Signing", "Test_rsa.cer")
-            let certData = Data(try localFileSystem.readFileContents(certPath).contents)
+            let certData: Data = try localFileSystem.readFileContents(certPath)
             let base64EncodedCert = certData.base64EncodedString()
             let certificate = try Certificate(derEncoded: certData)
 
@@ -52,7 +52,7 @@ class SignatureTests: XCTestCase {
             let payload = ["foo": "bar"]
 
             let certPath = directoryPath.appending(components: "Signing", "Test_rsa.cer")
-            let certData = Data(try localFileSystem.readFileContents(certPath).contents)
+            let certData: Data = try localFileSystem.readFileContents(certPath)
             let base64EncodedCert = certData.base64EncodedString()
             let certificate = try Certificate(derEncoded: certData)
 
@@ -81,7 +81,7 @@ class SignatureTests: XCTestCase {
             let payload = ["foo": "bar"]
 
             let certPath = directoryPath.appending(components: "Signing", "Test_ec.cer")
-            let certData = Data(try localFileSystem.readFileContents(certPath).contents)
+            let certData: Data = try localFileSystem.readFileContents(certPath)
             let base64EncodedCert = certData.base64EncodedString()
             let certificate = try Certificate(derEncoded: certData)
 
@@ -107,7 +107,7 @@ class SignatureTests: XCTestCase {
             let payload = ["foo": "bar"]
 
             let certPath = directoryPath.appending(components: "Signing", "Test_ec.cer")
-            let certData = Data(try localFileSystem.readFileContents(certPath).contents)
+            let certData: Data = try localFileSystem.readFileContents(certPath)
             let base64EncodedCert = certData.base64EncodedString()
             let certificate = try Certificate(derEncoded: certData)
 

--- a/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
+++ b/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
@@ -51,37 +51,37 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
                     switch (request.method, request.url) {
                     case (.get, apiURL):
                         let path = directoryPath.appending(components: "GitHub", "metadata.json")
-                        let data = Data(try! localFileSystem.readFileContents(path).contents)
+                        let data: Data = try! localFileSystem.readFileContents(path)
                         completion(.success(.init(statusCode: 200,
                                                   headers: .init([.init(name: "Content-Length", value: "\(data.count)")]),
                                                   body: data)))
                     case (.get, releasesURL):
                         let path = directoryPath.appending(components: "GitHub", "releases.json")
-                        let data = Data(try! localFileSystem.readFileContents(path).contents)
+                        let data: Data = try! localFileSystem.readFileContents(path)
                         completion(.success(.init(statusCode: 200,
                                                   headers: .init([.init(name: "Content-Length", value: "\(data.count)")]),
                                                   body: data)))
                     case (.get, apiURL.appendingPathComponent("contributors")):
                         let path = directoryPath.appending(components: "GitHub", "contributors.json")
-                        let data = Data(try! localFileSystem.readFileContents(path).contents)
+                        let data: Data = try! localFileSystem.readFileContents(path)
                         completion(.success(.init(statusCode: 200,
                                                   headers: .init([.init(name: "Content-Length", value: "\(data.count)")]),
                                                   body: data)))
                     case (.get, apiURL.appendingPathComponent("readme")):
                         let path = directoryPath.appending(components: "GitHub", "readme.json")
-                        let data = Data(try! localFileSystem.readFileContents(path).contents)
+                        let data: Data = try! localFileSystem.readFileContents(path)
                         completion(.success(.init(statusCode: 200,
                                                   headers: .init([.init(name: "Content-Length", value: "\(data.count)")]),
                                                   body: data)))
                     case (.get, apiURL.appendingPathComponent("license")):
                         let path = directoryPath.appending(components: "GitHub", "license.json")
-                        let data = Data(try! localFileSystem.readFileContents(path).contents)
+                        let data: Data = try! localFileSystem.readFileContents(path)
                         completion(.success(.init(statusCode: 200,
                                                   headers: .init([.init(name: "Content-Length", value: "\(data.count)")]),
                                                   body: data)))
                     case (.get, apiURL.appendingPathComponent("languages")):
                         let path = directoryPath.appending(components: "GitHub", "languages.json")
-                        let data = Data(try! localFileSystem.readFileContents(path).contents)
+                        let data: Data = try! localFileSystem.readFileContents(path)
                         completion(.success(.init(statusCode: 200,
                                                   headers: .init([.init(name: "Content-Length", value: "\(data.count)")]),
                                                   body: data)))

--- a/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
+++ b/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
@@ -24,7 +24,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let path = directoryPath.appending(components: "JSON", "good.json")
             let url = URL(string: "https://www.test.com/collection.json")!
-            let data = Data(try localFileSystem.readFileContents(path).contents)
+            let data: Data = try localFileSystem.readFileContents(path)
 
             let handler: HTTPClient.Handler = { request, _, completion in
                 XCTAssertEqual(request.url, url, "url should match")
@@ -363,7 +363,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let path = directoryPath.appending(components: "JSON", "good_signed.json")
             let url = URL(string: "https://www.test.com/collection.json")!
-            let data = Data(try localFileSystem.readFileContents(path).contents)
+            let data: Data = try localFileSystem.readFileContents(path)
 
             let handler: HTTPClient.Handler = { request, _, completion in
                 XCTAssertEqual(request.url, url, "url should match")
@@ -432,7 +432,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let path = directoryPath.appending(components: "JSON", "good_signed.json")
             let url = URL(string: "https://www.test.com/collection.json")!
-            let data = Data(try localFileSystem.readFileContents(path).contents)
+            let data: Data = try localFileSystem.readFileContents(path)
 
             let handler: HTTPClient.Handler = { request, _, completion in
                 XCTAssertEqual(request.url, url, "url should match")
@@ -499,7 +499,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let path = directoryPath.appending(components: "JSON", "good_signed.json")
             let url = URL(string: "https://www.test.com/collection.json")!
-            let data = Data(try localFileSystem.readFileContents(path).contents)
+            let data: Data = try localFileSystem.readFileContents(path)
 
             let handler: HTTPClient.Handler = { request, _, completion in
                 XCTAssertEqual(request.url, url, "url should match")
@@ -541,7 +541,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let path = directoryPath.appending(components: "JSON", "good_signed.json")
             let url = URL(string: "https://www.test.com/collection.json")!
-            let data = Data(try localFileSystem.readFileContents(path).contents)
+            let data: Data = try localFileSystem.readFileContents(path)
 
             let handler: HTTPClient.Handler = { request, _, completion in
                 XCTAssertEqual(request.url, url, "url should match")
@@ -631,7 +631,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let path = directoryPath.appending(components: "JSON", "good_signed.json")
             let url = URL(string: "https://www.test.com/collection.json")!
-            let data = Data(try localFileSystem.readFileContents(path).contents)
+            let data: Data = try localFileSystem.readFileContents(path)
 
             let handler: HTTPClient.Handler = { request, _, completion in
                 XCTAssertEqual(request.url, url, "url should match")
@@ -701,7 +701,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let path = directoryPath.appending(components: "JSON", "good_signed.json")
             let url = URL(string: "https://www.test.com/collection.json")!
-            let data = Data(try localFileSystem.readFileContents(path).contents)
+            let data: Data = try localFileSystem.readFileContents(path)
 
             let handler: HTTPClient.Handler = { request, _, completion in
                 XCTAssertEqual(request.url, url, "url should match")
@@ -776,7 +776,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         fixture(name: "Collections", createGitRepo: false) { directoryPath in
             let path = directoryPath.appending(components: "JSON", "good.json")
             let url = URL(string: "https://www.test.com/collection.json")!
-            let data = Data(try localFileSystem.readFileContents(path).contents)
+            let data: Data = try localFileSystem.readFileContents(path)
 
             let handler: HTTPClient.Handler = { request, _, completion in
                 XCTAssertEqual(request.url, url, "url should match")

--- a/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
@@ -73,8 +73,8 @@ class DependencyResolverRealWorldPerfTests: XCTestCasePerf {
 
     func mockGraph(for name: String) throws -> MockDependencyGraph {
         let input = AbsolutePath(#file).parentDirectory.appending(component: "Inputs").appending(component: name)
-        let jsonString = try localFileSystem.readFileContents(input)
-        let json = try JSON(bytes: jsonString)
+        let jsonString: Data = try localFileSystem.readFileContents(input)
+        let json = try JSON(data: jsonString)
         return MockDependencyGraph(json)
     }
 }

--- a/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
+++ b/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
@@ -207,7 +207,7 @@ final class ModuleMapResult {
         XCTAssertEqual(isCreated, false, "unexpected modulemap created: \(contents)", file: (file), line: line)
     }
 
-    private var contents: ByteString {
+    private var contents: String {
         return try! fs.readFileContents(path)
     }
 
@@ -219,6 +219,6 @@ final class ModuleMapResult {
         guard isCreated else {
             return XCTFail("Can't compare values, modulemap not generated.", file: (file), line: line)
         }
-        XCTAssertEqual(ByteString(encodingAsUTF8: contents), self.contents, file: (file), line: line)
+        XCTAssertEqual(contents, self.contents, file: (file), line: line)
     }
 }

--- a/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
@@ -617,7 +617,7 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
             XCTAssertNoDiagnostics(observability.diagnostics)
             XCTAssertEqual(manifest.displayName, "Trivial")
 
-            let moduleTraceJSON = try XCTUnwrap(try localFileSystem.readFileContents(moduleTraceFilePath).validDescription)
+            let moduleTraceJSON: String = try localFileSystem.readFileContents(moduleTraceFilePath)
             XCTAssertMatch(moduleTraceJSON, .contains("PackageDescription"))
         }
     }

--- a/Tests/SPMPackageEditorTests/PackageEditorTests.swift
+++ b/Tests/SPMPackageEditorTests/PackageEditorTests.swift
@@ -61,7 +61,7 @@ final class PackageEditorTests: XCTestCase {
         try editor.addTarget(options:
             .init(manifestPath: manifestPath, targetName: "baz"))
 
-        let newManifest = try fs.readFileContents(manifestPath).cString
+        let newManifest: String = try fs.readFileContents(manifestPath)
         XCTAssertEqual(newManifest, """
             // swift-tools-version:5.0
             import PackageDescription

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -39,7 +39,7 @@ class InitTests: XCTestCase {
             // Verify basic file system content that we expect in the package
             let manifest = path.appending(component: "Package.swift")
             XCTAssertFileExists(manifest)
-            let manifestContents = try localFileSystem.readFileContents(manifest).description
+            let manifestContents: String = try localFileSystem.readFileContents(manifest)
             let version = InitPackage.newPackageToolsVersion
             let versionSpecifier = "\(version.major).\(version.minor)"
             XCTAssertMatch(manifestContents, .prefix("// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"))
@@ -71,14 +71,14 @@ class InitTests: XCTestCase {
             // Verify basic file system content that we expect in the package
             let manifest = path.appending(component: "Package.swift")
             XCTAssertFileExists(manifest)
-            let manifestContents = try localFileSystem.readFileContents(manifest).description
+            let manifestContents: String = try localFileSystem.readFileContents(manifest)
             let version = InitPackage.newPackageToolsVersion
             let versionSpecifier = "\(version.major).\(version.minor)"
             XCTAssertMatch(manifestContents, .prefix("// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"))
             
             let readme = path.appending(component: "README.md")
             XCTAssertFileExists(readme)
-            let readmeContents = try localFileSystem.readFileContents(readme).description
+            let readmeContents: String = try localFileSystem.readFileContents(readme)
             XCTAssertMatch(readmeContents, .prefix("# Foo\n"))
 
             XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources").appending(component: "Foo")), ["main.swift"])
@@ -116,14 +116,14 @@ class InitTests: XCTestCase {
             // Verify basic file system content that we expect in the package
             let manifest = path.appending(component: "Package.swift")
             XCTAssertFileExists(manifest)
-            let manifestContents = try localFileSystem.readFileContents(manifest).description
+            let manifestContents: String = try localFileSystem.readFileContents(manifest)
             let version = InitPackage.newPackageToolsVersion
             let versionSpecifier = "\(version.major).\(version.minor)"
             XCTAssertMatch(manifestContents, .prefix("// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"))
 
             let readme = path.appending(component: "README.md")
             XCTAssertFileExists(readme)
-            let readmeContents = try localFileSystem.readFileContents(readme).description
+            let readmeContents: String = try localFileSystem.readFileContents(readme)
             XCTAssertMatch(readmeContents, .prefix("# Foo\n"))
 
             XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources").appending(component: "Foo")), ["Foo.swift"])
@@ -132,7 +132,7 @@ class InitTests: XCTestCase {
             XCTAssertEqual(try fs.getDirectoryContents(tests).sorted(), ["FooTests"])
 
             let testFile = tests.appending(component: "FooTests").appending(component: "FooTests.swift")
-            let testFileContents = try localFileSystem.readFileContents(testFile).description
+            let testFileContents: String = try localFileSystem.readFileContents(testFile)
             XCTAssertTrue(testFileContents.hasPrefix("import XCTest"), """
                           Validates formatting of XCTest source file, in particular that it does not contain leading whitespace:
                           \(testFileContents)
@@ -167,7 +167,7 @@ class InitTests: XCTestCase {
             // Verify basic file system content that we expect in the package
             let manifest = path.appending(component: "Package.swift")
             XCTAssertFileExists(manifest)
-            let manifestContents = try localFileSystem.readFileContents(manifest).description
+            let manifestContents: String = try localFileSystem.readFileContents(manifest)
             let version = InitPackage.newPackageToolsVersion
             let versionSpecifier = "\(version.major).\(version.minor)"
             XCTAssertMatch(manifestContents, .prefix("// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"))
@@ -198,7 +198,7 @@ class InitTests: XCTestCase {
             // Verify basic file system content that we expect in the package
             let manifest = path.appending(component: "Package.swift")
             XCTAssertFileExists(manifest)
-            let manifestContents = try localFileSystem.readFileContents(manifest).description
+            let manifestContents: String = try localFileSystem.readFileContents(manifest)
             let version = InitPackage.newPackageToolsVersion
             let versionSpecifier = "\(version.major).\(version.minor)"
             XCTAssertMatch(manifestContents, .prefix("// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"))
@@ -270,7 +270,7 @@ class InitTests: XCTestCase {
             )
             try initPackage.writePackageStructure()
 
-            let contents = try localFileSystem.readFileContents(packageRoot.appending(component: "Package.swift")).cString
+            let contents: String = try localFileSystem.readFileContents(packageRoot.appending(component: "Package.swift"))
             XCTAssertMatch(contents, .contains(#"platforms: [.macOS(.v10_15), .iOS(.v12), .watchOS("2.1"), .tvOS("999.0")],"#))
         }
     }

--- a/Tests/WorkspaceTests/ToolsVersionSpecificationRewriterTests.swift
+++ b/Tests/WorkspaceTests/ToolsVersionSpecificationRewriterTests.swift
@@ -184,7 +184,7 @@ class ToolsVersionSpecificationRewriterTests: XCTestCase {
     func rewriteToolsVersionSpecificationToDefaultManifest(
         stream: BufferedOutputByteStream,
         version: ToolsVersion = ToolsVersion(version: "4.1.2"),
-        resultHandler: (ByteString) -> Void
+        resultHandler: (String) -> Void
     ) {
         do {
             let inMemoryFileSystem = InMemoryFileSystem()

--- a/Tests/WorkspaceTests/WorkspaceStateTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceStateTests.swift
@@ -293,7 +293,7 @@ final class WorkspaceStateTests: XCTestCase {
         let state = WorkspaceState(fileSystem: fs, storageDirectory: buildDir)
         try state.save()
 
-        let serialized = try fs.readFileContents(statePath).description
+        let serialized: String = try fs.readFileContents(statePath)
 
         let argpRange = try XCTUnwrap(serialized.range(of: "swift-argument-parser"))
         let yamsRange = try XCTUnwrap(serialized.range(of: "yams"))


### PR DESCRIPTION
motivation: use common APIs to read file content and reduce use of ByteString (which we want to deprecate)

changes:
* update call sites that convert readFileContents ByteString result to Data or String to use the overloads that return these types directly
* adjust test and other call sites
