### PR TITLE
improve binary downlaods delegate handers

### DIFF
--- a/Sources/PackageRegistry/RegistryDownloadsManager.swift
+++ b/Sources/PackageRegistry/RegistryDownloadsManager.swift
@@ -227,8 +227,8 @@ public class RegistryDownloadsManager {
                 self.delegate?.fetching(
                     package: package,
                     version: version,
-                    downloaded: downloaded,
-                    total: total
+                    bytesDownloaded: downloaded,
+                    totalBytesToDownload: total
                 )
             }
         }
@@ -272,7 +272,7 @@ public protocol RegistryDownloadsManagerDelegate {
     func didFetch(package: PackageIdentity, version: Version, result: Result<RegistryDownloadsManager.FetchDetails, Error>, duration: DispatchTimeInterval)
 
     /// Called every time the progress of a repository fetch operation updates.
-    func fetching(package: PackageIdentity, version: Version, downloaded: Int64, total: Int64?)
+    func fetching(package: PackageIdentity, version: Version, bytesDownloaded: Int64, totalBytesToDownload: Int64?)
 }
 
 extension RegistryDownloadsManager {

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -826,11 +826,19 @@ public final class MockWorkspaceDelegate: WorkspaceDelegate {
         // noop
     }
 
+    public func willDownloadBinaryArtifact(from url: String) {
+        self.append("downloading binary artifact package: \(url)")
+    }
+
+    public func didDownloadBinaryArtifact(from url: String, result: Result<AbsolutePath, Error>, duration: DispatchTimeInterval) {
+        self.append("finished downloading binary artifact package: \(url)")
+    }
+
     public func downloadingBinaryArtifact(from url: String, bytesDownloaded: Int64, totalBytesToDownload: Int64?) {
         // noop
     }
 
-    public func didDownloadBinaryArtifacts() {
+    public func didDownloadAllBinaryArtifacts() {
         // noop
     }
 

--- a/Tests/PackageRegistryTests/RegistryDownloadsManagerTests.swift
+++ b/Tests/PackageRegistryTests/RegistryDownloadsManagerTests.swift
@@ -410,7 +410,7 @@ private class MockRegistryDownloadsManagerDelegate: RegistryDownloadsManagerDele
         self.group.leave()
     }
 
-    func fetching(package: PackageIdentity, version: Version, downloaded: Int64, total: Int64?) {
+    func fetching(package: PackageIdentity, version: Version, bytesDownloaded downloaded: Int64, totalBytesToDownload total: Int64?) {
     }
 }
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -5753,6 +5753,13 @@ final class WorkspaceTests: XCTestCase {
                          path: workspace.artifactsDir.appending(components: "b", "B.xcframework")
             )
         }
+
+        XCTAssertMatch(workspace.delegate.events, ["downloading binary artifact package: https://a.com/a1.zip"])
+        XCTAssertMatch(workspace.delegate.events, ["downloading binary artifact package: https://a.com/a2.zip"])
+        XCTAssertMatch(workspace.delegate.events, ["downloading binary artifact package: https://b.com/b.zip"])
+        XCTAssertMatch(workspace.delegate.events, ["finished downloading binary artifact package: https://a.com/a1.zip"])
+        XCTAssertMatch(workspace.delegate.events, ["finished downloading binary artifact package: https://a.com/a2.zip"])
+        XCTAssertMatch(workspace.delegate.events, ["finished downloading binary artifact package: https://b.com/b.zip"])
     }
 
     func testArtifactDownloadWithPreviousState() throws {
@@ -7261,6 +7268,13 @@ final class WorkspaceTests: XCTestCase {
                          path: workspace.artifactsDir.appending(components: "b", "B.artifactbundle")
             )
         }
+
+        XCTAssertMatch(workspace.delegate.events, ["downloading binary artifact package: https://a.com/a1.zip"])
+        XCTAssertMatch(workspace.delegate.events, ["downloading binary artifact package: https://a.com/a2/a2.zip"])
+        XCTAssertMatch(workspace.delegate.events, ["downloading binary artifact package: https://b.com/b.zip"])
+        XCTAssertMatch(workspace.delegate.events, ["finished downloading binary artifact package: https://a.com/a1.zip"])
+        XCTAssertMatch(workspace.delegate.events, ["finished downloading binary artifact package: https://a.com/a2/a2.zip"])
+        XCTAssertMatch(workspace.delegate.events, ["finished downloading binary artifact package: https://b.com/b.zip"])
     }
 
     func testDownloadArchiveIndexServerError() throws {


### PR DESCRIPTION
motivation: provide more fine grained information on binary downlads

changes:
* add willDownloadBinaryArtifact, didDownloadBinaryArtifact methods to the Workspace delegate
* update binary artifacts handling code to call the new delegates methods in the approproate time
* update ToolWorkspaceDelegate to handle new delegate calls for artifact downloads
* improve ToolWorkspaceDelegate handling of package doownloads along the same lines of artifacts downloads
* update RegistryDownloadsManagerDelegate to use same sematics as artifacts download (bytesDownloaded: Int64, totalBytesToDownload: Int64?)
* update and adjust tests
