### PR TITLE
Ensure checkouts get updated when enforcing resolved versions

### DIFF
--- a/Sources/SPMTestSupport/GitRepositoryExtensions.swift
+++ b/Sources/SPMTestSupport/GitRepositoryExtensions.swift
@@ -27,6 +27,12 @@ public extension GitRepository {
             args: Git.tool, "-C", path.pathString, "rev-parse", "--abbrev-ref", "HEAD").spm_chomp()
     }
 
+    /// Returns the revision for a given tag.
+    func revision(forTag tag: String) throws -> String {
+        return try Process.checkNonZeroExit(
+            args: Git.tool, "-C", path.pathString, "rev-parse", tag).spm_chomp()
+    }
+
     /// Stage a file.
     func stage(file: String) throws {
         try systemQuietly([Git.tool, "-C", self.path.pathString, "add", file])

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -2757,9 +2757,14 @@ extension Workspace {
         //
         // We just request the packages here, repository manager will
         // automatically manage the parallelism.
+        let group = DispatchGroup()
         for pin in pinsStore.pins {
-            packageContainerProvider.getContainer(for: pin.packageRef, skipUpdate: true, observabilityScope: observabilityScope, on: .sharedConcurrent, completion: { _ in })
+            group.enter()
+            packageContainerProvider.getContainer(for: pin.packageRef, skipUpdate: self.configuration.skipDependenciesUpdates, observabilityScope: observabilityScope, on: .sharedConcurrent, completion: { _ in
+                group.leave()
+            })
         }
+        group.wait()
 
         // Compute the pins that we need to actually clone.
         //

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -987,6 +987,97 @@ final class PackageToolTests: CommandsTestCase {
         }
     }
 
+    func testOnlyUseVersionsFromResolvedFileFetchesWithExistingState() throws {
+        func writeResolvedFile(packageDir: AbsolutePath, repositoryURL: String, revision: String, version: String) throws {
+            try localFileSystem.writeFileContents(packageDir.appending(component: "Package.resolved")) {
+                $0 <<< """
+                    {
+                      "object": {
+                        "pins": [
+                          {
+                            "package": "library",
+                            "repositoryURL": "\(repositoryURL)",
+                            "state": {
+                              "branch": null,
+                              "revision": "\(revision)",
+                              "version": "\(version)"
+                            }
+                          }
+                        ]
+                      },
+                      "version": 1
+                    }
+                """
+            }
+        }
+
+        try testWithTemporaryDirectory { tmpPath in
+            let packageDir = tmpPath.appending(components: "library")
+            try localFileSystem.writeFileContents(packageDir.appending(component: "Package.swift")) {
+                $0 <<< """
+                // swift-tools-version:5.0
+                import PackageDescription
+                let package = Package(
+                    name: "library",
+                    products: [ .library(name: "library", targets: ["library"]) ],
+                    targets: [ .target(name: "library") ]
+                )
+                """
+            }
+            try localFileSystem.writeFileContents(packageDir.appending(components: "Sources", "library", "library.swift")) {
+                $0 <<< """
+                    public func Foo() { }
+                """
+            }
+
+            let depGit = GitRepository(path: packageDir)
+            try depGit.create()
+            try depGit.stageEverything()
+            try depGit.commit()
+            try depGit.tag(name: "1.0.0")
+
+            let initialRevision = try depGit.revision(forTag: "1.0.0")
+            let repositoryURL = "file://\(packageDir.pathString)"
+
+            let clientDir = tmpPath.appending(components: "client")
+            try localFileSystem.writeFileContents(clientDir.appending(component: "Package.swift")) {
+                $0 <<< """
+                // swift-tools-version:5.0
+                import PackageDescription
+                let package = Package(
+                    name: "client",
+                    dependencies: [ .package(url: "\(repositoryURL)", from: "1.0.0") ],
+                    targets: [ .target(name: "client", dependencies: [ "library" ]) ]
+                )
+                """
+            }
+            try localFileSystem.writeFileContents(clientDir.appending(components: "Sources", "client", "main.swift")) {
+                $0 <<< """
+                    print("hello")
+                """
+            }
+
+            // Initial resolution with clean state.
+            try writeResolvedFile(packageDir: clientDir, repositoryURL: repositoryURL, revision: initialRevision, version: "1.0.0")
+            _ = try execute(["resolve", "--only-use-versions-from-resolved-file"], packagePath: clientDir)
+
+            // Make a change to the dependency and tag a new version.
+            try localFileSystem.writeFileContents(packageDir.appending(components: "Sources", "library", "library.swift")) {
+                $0 <<< """
+                    public func Best() { }
+                """
+            }
+            try depGit.stageEverything()
+            try depGit.commit()
+            try depGit.tag(name: "1.0.1")
+            let updatedRevision = try depGit.revision(forTag: "1.0.1")
+
+            // Require new version but re-use existing state that hasn't fetched the latest revision, yet.
+            try writeResolvedFile(packageDir: clientDir, repositoryURL: repositoryURL, revision: updatedRevision, version: "1.0.1")
+            _ = try execute(["resolve", "--only-use-versions-from-resolved-file"], packagePath: clientDir)
+        }
+    }
+
     func testSymlinkedDependency() throws {
         try testWithTemporaryDirectory { path in
             let fs = localFileSystem


### PR DESCRIPTION
Honor `skipDependenciesUpdates` when enforcing resolved versions.

### Motivation:

Previously there could be cases where an existing checkout won't be updated from the remote even if `--skip-update` hasn't been passed.

### Modifications:

Pass in the correct value from `WorkspaceConfiguration` when calling `getContainer` and ensure we wait for all `getContainer` calls to complete before proceeding.

### Result:

We won't update with stale checkouts that could break builds because the resolved file is requiring newer revisions than what we have in the existing local checkouts.
