### PR TITLE
test that downloaded binary artifacts are valid archives before computing checksum

### DIFF
--- a/Sources/Basics/Archiver+Zip.swift
+++ b/Sources/Basics/Archiver+Zip.swift
@@ -44,8 +44,21 @@ public struct ZipArchiver: Archiver {
         Process.popen(arguments: ["unzip", archivePath.pathString, "-d", destinationPath.pathString], queue: .sharedConcurrent) { result in
             completion(result.tryMap { processResult in
                 guard processResult.exitStatus == .terminated(code: 0) else {
-                    throw try  StringError(processResult.utf8stderrOutput())
+                    throw try StringError(processResult.utf8stderrOutput())
                 }
+            })
+        }
+    }
+
+    public func validate(path: AbsolutePath, completion: @escaping (Result<Bool, Error>) -> Void) {
+        guard fileSystem.exists(path) else {
+            completion(.failure(FileSystemError(.noEntry, path)))
+            return
+        }
+
+        Process.popen(arguments: ["unzip", "-t", path.pathString], queue: .sharedConcurrent) { result in
+            completion(result.tryMap { processResult in
+                return processResult.exitStatus == .terminated(code: 0)
             })
         }
     }

--- a/Sources/Basics/Archiver.swift
+++ b/Sources/Basics/Archiver.swift
@@ -26,4 +26,14 @@ public protocol Archiver {
         to destinationPath: AbsolutePath,
         completion: @escaping (Result<Void, Error>) -> Void
     )
+
+    /// Asynchronously validates if a file is an archive.
+    ///
+    /// - Parameters:
+    ///   - path: The `AbsolutePath` to the archive to validate.
+    ///   - completion: The completion handler that will be called when the operation finishes to notify of its success.
+    func validate(
+        path: AbsolutePath,
+        completion: @escaping (Result<Bool, Error>) -> Void
+    )
 }

--- a/Sources/SPMTestSupport/MockArchiver.swift
+++ b/Sources/SPMTestSupport/MockArchiver.swift
@@ -12,7 +12,8 @@ import Basics
 import TSCBasic
 
 public class MockArchiver: Archiver {
-    public typealias Handler = (MockArchiver, AbsolutePath, AbsolutePath, (Result<Void, Error>) -> Void) throws -> Void
+    public typealias ExtractionHandler = (MockArchiver, AbsolutePath, AbsolutePath, (Result<Void, Error>) -> Void) throws -> Void
+    public typealias ValidationHandler = (MockArchiver, AbsolutePath, (Result<Bool, Error>) -> Void) throws -> Void
 
     public struct Extraction: Equatable {
         public let archivePath: AbsolutePath
@@ -26,10 +27,16 @@ public class MockArchiver: Archiver {
 
     public let supportedExtensions: Set<String> = ["zip"]
     public let extractions = ThreadSafeArrayStore<Extraction>()
-    public let handler: Handler?
+    public let extractionHandler: ExtractionHandler?
+    public let validationHandler: ValidationHandler?
 
-    public init(handler: Handler? = nil) {
-        self.handler = handler
+    public convenience init(handler: ExtractionHandler? = nil) {
+        self.init(extractionHandler: handler, validationHandler: nil)
+    }
+
+    public init(extractionHandler: ExtractionHandler? = nil, validationHandler: ValidationHandler? = nil) {
+        self.extractionHandler = extractionHandler
+        self.validationHandler = validationHandler
     }
 
     public func extract(
@@ -38,11 +45,23 @@ public class MockArchiver: Archiver {
         completion: @escaping (Result<Void, Error>) -> Void
     ) {
         do {
-            if let handler = self.handler {
+            if let handler = self.extractionHandler {
                 try handler(self, archivePath, destinationPath, completion)
             } else {
                 self.extractions.append(Extraction(archivePath: archivePath, destinationPath: destinationPath))
                 completion(.success(()))
+            }
+        } catch {
+            completion(.failure(error))
+        }
+    }
+
+    public func validate(path: AbsolutePath, completion: @escaping (Result<Bool, Error>) -> Void) {
+        do {
+            if let handler = self.validationHandler {
+                try handler(self, path, completion)
+            } else {
+                completion(.success(true))
             }
         } catch {
             completion(.failure(error))

--- a/Sources/SPMTestSupport/MockRegistry.swift
+++ b/Sources/SPMTestSupport/MockRegistry.swift
@@ -288,12 +288,10 @@ private struct MockRegistryArchiver: Archiver {
 
     func extract(from archivePath: AbsolutePath, to destinationPath: AbsolutePath, completion: @escaping (Result<Void, Error>) -> Void) {
         do {
-            let content: String = try self.fileSystem.readFileContents(archivePath)
-            let lines = content.split(separator: "\n").map(String.init)
+            let lines = try self.readFileContents(archivePath)
             guard lines.count >= 2 else {
                 throw StringError("invalid mock zip format, not enough lines")
             }
-
             let rootPath = lines[1]
             for path in lines[2..<lines.count] {
                 let relativePath = String(path.dropFirst(rootPath.count + 1))
@@ -307,5 +305,19 @@ private struct MockRegistryArchiver: Archiver {
         } catch {
             completion(.failure(error))
         }
+    }
+
+    func validate(path: AbsolutePath, completion: @escaping (Result<Bool, Error>) -> Void) {
+        do {
+            let lines = try self.readFileContents(path)
+            completion(.success(lines.count >= 2))
+        } catch {
+            completion(.failure(error))
+        }
+    }
+
+    private func readFileContents(_ path: AbsolutePath) throws -> [String] {
+        let content: String = try self.fileSystem.readFileContents(path)
+        return content.split(separator: "\n").map(String.init)
     }
 }

--- a/Sources/Workspace/Diagnostics.swift
+++ b/Sources/Workspace/Diagnostics.swift
@@ -130,6 +130,10 @@ extension Basics.Diagnostic {
         .warning("dependency '\(packageName)' is missing; retrieving again")
     }
 
+    static func artifactInvalidArchive(artifactURL: Foundation.URL, targetName: String) -> Self {
+        .error("invalid archive returned from '\(artifactURL.absoluteString)' which is required by binary target '\(targetName)'")
+    }
+
     static func artifactChecksumChanged(targetName: String) -> Self {
         .error("artifact of binary target '\(targetName)' has changed checksum; this is a potential security risk so the new artifact won't be downloaded")
     }
@@ -140,6 +144,10 @@ extension Basics.Diagnostic {
 
     static func artifactFailedDownload(artifactURL: Foundation.URL, targetName: String, reason: String) -> Self {
         .error("failed downloading '\(artifactURL.absoluteString)' which is required by binary target '\(targetName)': \(reason)")
+    }
+
+    static func artifactFailedValidation(artifactURL: Foundation.URL, targetName: String, reason: String) -> Self {
+        .error("failed validating archive from '\(artifactURL.absoluteString)' which is required by binary target '\(targetName)': \(reason)")
     }
 
     static func artifactFailedExtraction(artifactURL: Foundation.URL, targetName: String, reason: String) -> Self {


### PR DESCRIPTION
motivation: a web server may return an invalid archive file (say as a result of a redirect) which should emit a nicer error message instead of checksm mismatch

changes:
* add an Archiver::validate API
* implement the validate API uzing unzip -t
* add adjust tests

rdar://73225887
