### PR TITLE
add flag to disable building with testablity when running tests

### DIFF
--- a/Fixtures/Miscellaneous/TestableExe/Tests/TestableExeTests/TestableExeTests.swift
+++ b/Fixtures/Miscellaneous/TestableExe/Tests/TestableExeTests/TestableExeTests.swift
@@ -1,6 +1,6 @@
 import XCTest
-import TestableExe1
-import TestableExe2
+@testable import TestableExe1
+@testable import TestableExe2
 // import TestableExe3
 import class Foundation.Bundle
 
@@ -9,7 +9,7 @@ final class TestableExeTests: XCTestCase {
         // This is an example of a functional test case.
         // Use XCTAssert and related functions to verify your tests produce the correct
         // results.
-        
+
         print(GetGreeting1())
         XCTAssertEqual(GetGreeting1(), "Hello, world")
         print(GetGreeting2())

--- a/Sources/Build/LLBuildManifestBuilder.swift
+++ b/Sources/Build/LLBuildManifestBuilder.swift
@@ -823,7 +823,7 @@ extension LLBuildManifestBuilder {
         for target in plan.targets {
             guard case .swift(let target) = target,
                 target.isTestTarget,
-                target.testDiscoveryTarget else { continue }
+                target.isTestDiscoveryTarget else { continue }
 
             let testDiscoveryTarget = target
 

--- a/Sources/Commands/TestingSupport.swift
+++ b/Sources/Commands/TestingSupport.swift
@@ -134,10 +134,12 @@ enum TestingSupport {
 }
 
 extension SwiftTool {
-    func buildParametersForTest() throws -> BuildParameters {
+    func buildParametersForTest(
+        enableTestability: Bool? = nil
+    ) throws -> BuildParameters {
         var parameters = try self.buildParameters()
-        // for test commands, alway enable building with testability enabled
-        parameters.enableTestability = true
+        // for test commands, we normally enable building with testability
+        parameters.enableTestability = enableTestability ?? true
         return parameters
     }
 }

--- a/Sources/Commands/TestingSupport.swift
+++ b/Sources/Commands/TestingSupport.swift
@@ -139,6 +139,7 @@ extension SwiftTool {
     ) throws -> BuildParameters {
         var parameters = try self.buildParameters()
         // for test commands, we normally enable building with testability
+        // but we let users override this with a flag
         parameters.enableTestability = enableTestability ?? true
         return parameters
     }

--- a/Sources/LLBuildManifest/BuildManifest.swift
+++ b/Sources/LLBuildManifest/BuildManifest.swift
@@ -51,7 +51,7 @@ public struct BuildManifest {
         inputs: [Node],
         outputs: [Node]
     ) {
-        assert(commands[name] == nil, "aleady had a command named '\(name)'")
+        assert(commands[name] == nil, "already had a command named '\(name)'")
         let tool = PhonyTool(inputs: inputs, outputs: outputs)
         commands[name] = Command(name: name, tool: tool)
     }
@@ -61,7 +61,7 @@ public struct BuildManifest {
         inputs: [Node],
         outputs: [Node]
     ) {
-        assert(commands[name] == nil, "aleady had a command named '\(name)'")
+        assert(commands[name] == nil, "already had a command named '\(name)'")
         let tool = TestDiscoveryTool(inputs: inputs, outputs: outputs)
         commands[name] = Command(name: name, tool: tool)
     }
@@ -71,7 +71,7 @@ public struct BuildManifest {
         inputs: [Node],
         outputs: [Node]
     ) {
-        assert(commands[name] == nil, "aleady had a command named '\(name)'")
+        assert(commands[name] == nil, "already had a command named '\(name)'")
         let tool = CopyTool(inputs: inputs, outputs: outputs)
         commands[name] = Command(name: name, tool: tool)
     }
@@ -81,7 +81,7 @@ public struct BuildManifest {
         inputs: [Node],
         outputs: [Node]
     ) {
-        assert(commands[name] == nil, "aleady had a command named '\(name)'")
+        assert(commands[name] == nil, "already had a command named '\(name)'")
         let tool = PackageStructureTool(inputs: inputs, outputs: outputs)
         commands[name] = Command(name: name, tool: tool)
     }
@@ -91,7 +91,7 @@ public struct BuildManifest {
         inputs: [Node],
         outputs: [Node]
     ) {
-        assert(commands[name] == nil, "aleady had a command named '\(name)'")
+        assert(commands[name] == nil, "already had a command named '\(name)'")
         let tool = ArchiveTool(inputs: inputs, outputs: outputs)
         commands[name] = Command(name: name, tool: tool)
     }
@@ -106,7 +106,7 @@ public struct BuildManifest {
         workingDirectory: String? = nil,
         allowMissingInputs: Bool = false
     ) {
-        assert(commands[name] == nil, "aleady had a command named '\(name)'")
+        assert(commands[name] == nil, "already had a command named '\(name)'")
         let tool = ShellTool(
             description: description,
             inputs: inputs,
@@ -127,7 +127,7 @@ public struct BuildManifest {
         outputs: [Node],
         arguments: [String]
     ) {
-        assert(commands[name] == nil, "aleady had a command named '\(name)'")
+        assert(commands[name] == nil, "already had a command named '\(name)'")
         let tool = SwiftFrontendTool(
                 moduleName: moduleName,
                 description: description,
@@ -146,7 +146,7 @@ public struct BuildManifest {
         arguments: [String],
         dependencies: String? = nil
     ) {
-        assert(commands[name] == nil, "aleady had a command named '\(name)'")
+        assert(commands[name] == nil, "already had a command named '\(name)'")
         let tool = ClangTool(
             description: description,
             inputs: inputs,
@@ -173,7 +173,7 @@ public struct BuildManifest {
         isLibrary: Bool,
         wholeModuleOptimization: Bool
     ) {
-        assert(commands[name] == nil, "aleady had a command named '\(name)'")
+        assert(commands[name] == nil, "already had a command named '\(name)'")
         let tool = SwiftCompilerTool(
             inputs: inputs,
             outputs: outputs,

--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -228,6 +228,12 @@ public struct BuildParameters: Encodable {
         self.isXcodeBuildSystemEnabled = isXcodeBuildSystemEnabled
         self.printManifestGraphviz = printManifestGraphviz
         // decide on testability based on debug/release config
+        // the goals of this being based on the build configuration is
+        // that `swift build` followed by a `swift test` will need to do minimal rebuilding
+        // given that the default configuration for `swift build` is debug
+        // and that `swift test` normally requires building with testable enabled.
+        // when building and testing in release mode, one can use the '--disable-testable-imports' flag
+        // to disable testability in `swift test`, but that requires that the tests do not use the testable imports feature
         self.enableTestability = enableTestability ?? (.debug == configuration)
         // decide if to enable the use of test manifests based on platform. this is likely to change in the future
         self.testDiscoveryStrategy = triple.isDarwin() ? .objectiveC : .manifest(generate: forceTestDiscovery)

--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -8,15 +8,15 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import XCTest
-
-import SPMTestSupport
 import Commands
+import SPMTestSupport
+import TSCBasic
+import XCTest
 
 final class TestToolTests: CommandsTestCase {
     
-    private func execute(_ args: [String]) throws -> (stdout: String, stderr: String) {
-        return try SwiftPMProduct.SwiftTest.execute(args)
+    private func execute(_ args: [String], packagePath: AbsolutePath? = nil) throws -> (stdout: String, stderr: String) {
+        return try SwiftPMProduct.SwiftTest.execute(args, packagePath: packagePath)
     }
     
     func testUsage() throws {
@@ -57,5 +57,27 @@ final class TestToolTests: CommandsTestCase {
             }
         }
         #endif
+    }
+
+    func testEnableDisableTestability() {
+        fixture(name: "Miscellaneous/TestableExe") { path in
+            do {
+                let result = try execute(["--vv"], packagePath: path)
+                // default should run with testability
+                XCTAssertMatch(result.stdout, .contains("-enable-testing"))
+            }
+
+            do {
+                // disable
+                let result = try execute(["--disable-testable-imports", "--vv"], packagePath: path)
+                XCTAssertNoMatch(result.stdout, .contains("-enable-testing"))
+            }
+
+            do {
+                // enable
+                let result = try execute(["--enable-testable-imports", "--vv"], packagePath: path)
+                XCTAssertMatch(result.stdout, .contains("-enable-testing"))
+            }
+        }
     }
 }

--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -61,20 +61,22 @@ final class TestToolTests: CommandsTestCase {
 
     func testEnableDisableTestability() {
         fixture(name: "Miscellaneous/TestableExe") { path in
+            // default should run with testability
             do {
                 let result = try execute(["--vv"], packagePath: path)
-                // default should run with testability
                 XCTAssertMatch(result.stdout, .contains("-enable-testing"))
             }
 
+            // disabled
             do {
-                // disable
                 let result = try execute(["--disable-testable-imports", "--vv"], packagePath: path)
-                XCTAssertNoMatch(result.stdout, .contains("-enable-testing"))
+            } catch SwiftPMProductError.executionFailure(_, let stdout, _) {
+                XCTAssertNoMatch(stdout, .contains("-enable-testing"))
+                XCTAssertMatch(stdout, .contains("was not compiled for testing"))
             }
 
+            // enabled
             do {
-                // enable
                 let result = try execute(["--enable-testable-imports", "--vv"], packagePath: path)
                 XCTAssertMatch(result.stdout, .contains("-enable-testing"))
             }

--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -69,9 +69,8 @@ final class TestToolTests: CommandsTestCase {
 
             // disabled
             do {
-                let result = try execute(["--disable-testable-imports", "--vv"], packagePath: path)
+                _ = try execute(["--disable-testable-imports", "--vv"], packagePath: path)
             } catch SwiftPMProductError.executionFailure(_, let stdout, _) {
-                XCTAssertNoMatch(stdout, .contains("-enable-testing"))
                 XCTAssertMatch(stdout, .contains("was not compiled for testing"))
             }
 


### PR DESCRIPTION
motivation: give users an option to build the tests without testability (testable imports). this can increase build / test cycles when tests do not require the testable imports feature, so build artifacts are more is cachable

changes:
* add a `--disable-testable-imports` flag to `swift test` with which tests are build without the testability feature
* always use `-enable-testing` when building test modules as it is required for test discovery 
* add tests

rdar://82448144

