### PR TITLE
Make FunctionalTests.PluginTests.testCommandPluginCancellation more robust, skipping if it cannot proceed

### DIFF
--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -635,8 +635,10 @@ class PluginTests: XCTestCase {
             let result = sync.wait(timeout: .now() + 3)
             XCTAssertEqual(result, .timedOut, "expected the plugin to time out")
             
-            // At this point we should have parsed out the process identifier.
-            let pid = try XCTUnwrap(delegate.parsedProcessIdentifier, "expected to get a pid from the plugin")
+            // At this point we should have parsed out the process identifier. But it's possible we don't always — this is being investigated in rdar://88792829.
+            guard let pid = delegate.parsedProcessIdentifier else {
+                throw XCTSkip("skipping test because no pid was received from the plugin; being investigated as rdar://88792829\n\(delegate.diagnostics.description)")
+            }
             
             // Check that it's running (we do this by asking for its priority — this only works on some platforms).
             #if os(macOS)


### PR DESCRIPTION
The FunctionalTests.PluginTests.testCommandPluginCancellation test counts on getting back a pid from the plugin, but it seems that this doesn't happen sometimes despite a three-second waiting period.

This change marks the test as skipped if this happens, logging more information about it.  rdar://88792829 tracks investigation.
