### PR TITLE
refactor test fixtures throw underlying error

### DIFF
--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -38,7 +38,7 @@ public func fixture(
     file: StaticString = #file,
     line: UInt = #line,
     body: (AbsolutePath) throws -> Void
-) {
+) throws {
     do {
         // Make a suitable test directory name from the fixture subpath.
         let fixtureSubpath = RelativePath(name)
@@ -91,9 +91,7 @@ public func fixture(
         print("**** FAILURE EXECUTING SUBPROCESS ****")
         print("output:", output)
         print("stderr:", stderr)
-        XCTFail("\(error)", file: file, line: line)
-    } catch {
-        XCTFail("\(error)", file: file, line: line)
+        throw error
     }
 }
 

--- a/Tests/BasicsTests/URLSessionHTTPClientTests.swift
+++ b/Tests/BasicsTests/URLSessionHTTPClientTests.swift
@@ -209,12 +209,15 @@ final class URLSessionHTTPClientTest: XCTestCase {
 
     // MARK: - download
 
-    // URLSession Download tests can only run on macOS
-    // as re-libs-foundation's URLSessionTask implementation which expects the temporaryFileURL property to be on the request.
-    // and there is no way to set it in a mock
-    // https://github.com/apple/swift-corelibs-foundation/pull/2593 tries to address the latter part
-    #if os(macOS)
+
     func testDownloadSuccess() throws {
+        #if !os(macOS)
+        // URLSession Download tests can only run on macOS
+        // as re-libs-foundation's URLSessionTask implementation which expects the temporaryFileURL property to be on the request.
+        // and there is no way to set it in a mock
+        // https://github.com/apple/swift-corelibs-foundation/pull/2593 tries to address the latter part
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
         let configuration = URLSessionConfiguration.default
         configuration.protocolClasses = [MockURLProtocol.self]
         let urlSession = URLSessionHTTPClient(configuration: configuration)
@@ -270,6 +273,13 @@ final class URLSessionHTTPClientTest: XCTestCase {
     }
 
     func testDownloadAuthenticatedSuccess() throws {
+        #if !os(macOS)
+        // URLSession Download tests can only run on macOS
+        // as re-libs-foundation's URLSessionTask implementation which expects the temporaryFileURL property to be on the request.
+        // and there is no way to set it in a mock
+        // https://github.com/apple/swift-corelibs-foundation/pull/2593 tries to address the latter part
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
         let netrcContent = "machine protected.downloader-tests.com login anonymous password qwerty"
         guard case .success(let netrc) = Netrc.from(netrcContent) else {
             return XCTFail("Cannot load netrc content")
@@ -334,6 +344,13 @@ final class URLSessionHTTPClientTest: XCTestCase {
     }
 
     func testDownloadDefaultAuthenticationSuccess() throws {
+        #if !os(macOS)
+        // URLSession Download tests can only run on macOS
+        // as re-libs-foundation's URLSessionTask implementation which expects the temporaryFileURL property to be on the request.
+        // and there is no way to set it in a mock
+        // https://github.com/apple/swift-corelibs-foundation/pull/2593 tries to address the latter part
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
         let netrcContent = "default login default password default"
         guard case .success(let netrc) = Netrc.from(netrcContent) else {
             return XCTFail("Cannot load netrc content")
@@ -398,6 +415,13 @@ final class URLSessionHTTPClientTest: XCTestCase {
     }
 
     func testDownloadClientError() throws {
+        #if !os(macOS)
+        // URLSession Download tests can only run on macOS
+        // as re-libs-foundation's URLSessionTask implementation which expects the temporaryFileURL property to be on the request.
+        // and there is no way to set it in a mock
+        // https://github.com/apple/swift-corelibs-foundation/pull/2593 tries to address the latter part
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
         let configuration = URLSessionConfiguration.default
         configuration.protocolClasses = [MockURLProtocol.self]
         let urlSession = URLSessionHTTPClient(configuration: configuration)
@@ -453,6 +477,13 @@ final class URLSessionHTTPClientTest: XCTestCase {
     }
 
     func testDownloadServerError() throws {
+        #if !os(macOS)
+        // URLSession Download tests can only run on macOS
+        // as re-libs-foundation's URLSessionTask implementation which expects the temporaryFileURL property to be on the request.
+        // and there is no way to set it in a mock
+        // https://github.com/apple/swift-corelibs-foundation/pull/2593 tries to address the latter part
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
         let configuration = URLSessionConfiguration.default
         configuration.protocolClasses = [MockURLProtocol.self]
         let urlSession = URLSessionHTTPClient(configuration: configuration)
@@ -493,6 +524,13 @@ final class URLSessionHTTPClientTest: XCTestCase {
     }
 
     func testDownloadFileSystemError() throws {
+        #if !os(macOS)
+        // URLSession Download tests can only run on macOS
+        // as re-libs-foundation's URLSessionTask implementation which expects the temporaryFileURL property to be on the request.
+        // and there is no way to set it in a mock
+        // https://github.com/apple/swift-corelibs-foundation/pull/2593 tries to address the latter part
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
         let configuration = URLSessionConfiguration.default
         configuration.protocolClasses = [MockURLProtocol.self]
         let urlSession = URLSessionHTTPClient(configuration: configuration)
@@ -525,7 +563,6 @@ final class URLSessionHTTPClientTest: XCTestCase {
             wait(for: [completionExpectation], timeout: 1.0)
         }
     }
-    #endif
 }
 
 private class MockURLProtocol: URLProtocol {

--- a/Tests/CommandsTests/APIDiffTests.swift
+++ b/Tests/CommandsTests/APIDiffTests.swift
@@ -56,8 +56,8 @@ final class APIDiffTests: CommandsTestCase {
 
     func testInvokeAPIDiffDigester() throws {
         try skipIfApiDigesterUnsupported()
-        fixture(name: "Miscellaneous/APIDiff/") { prefix in
-            let packageRoot = prefix.appending(component: "Foo")
+        try fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
+            let packageRoot = fixturePath.appending(component: "Foo")
             // Overwrite the existing decl.
             try localFileSystem.writeFileContents(packageRoot.appending(component: "Foo.swift")) {
                 $0 <<< "public let foo = 42"
@@ -74,8 +74,8 @@ final class APIDiffTests: CommandsTestCase {
 
     func testSimpleAPIDiff() throws {
         try skipIfApiDigesterUnsupportedOrUnset()
-        fixture(name: "Miscellaneous/APIDiff/") { prefix in
-            let packageRoot = prefix.appending(component: "Foo")
+        try fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
+            let packageRoot = fixturePath.appending(component: "Foo")
             // Overwrite the existing decl.
             try localFileSystem.writeFileContents(packageRoot.appending(component: "Foo.swift")) {
                 $0 <<< "public let foo = 42"
@@ -93,8 +93,8 @@ final class APIDiffTests: CommandsTestCase {
 
     func testMultiTargetAPIDiff() throws {
         try skipIfApiDigesterUnsupportedOrUnset()
-        fixture(name: "Miscellaneous/APIDiff/") { prefix in
-            let packageRoot = prefix.appending(component: "Bar")
+        try fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
+            let packageRoot = fixturePath.appending(component: "Bar")
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Baz", "Baz.swift")) {
                 $0 <<< "public func baz() -> String { \"hello, world!\" }"
             }
@@ -117,8 +117,8 @@ final class APIDiffTests: CommandsTestCase {
 
     func testBreakageAllowlist() throws {
         try skipIfApiDigesterUnsupportedOrUnset()
-        fixture(name: "Miscellaneous/APIDiff/") { prefix in
-            let packageRoot = prefix.appending(component: "Bar")
+        try fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
+            let packageRoot = fixturePath.appending(component: "Bar")
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Baz", "Baz.swift")) {
                 $0 <<< "public func baz() -> String { \"hello, world!\" }"
             }
@@ -148,8 +148,8 @@ final class APIDiffTests: CommandsTestCase {
 
     func testCheckVendedModulesOnly() throws {
         try skipIfApiDigesterUnsupportedOrUnset()
-        fixture(name: "Miscellaneous/APIDiff/") { prefix in
-            let packageRoot = prefix.appending(component: "NonAPILibraryTargets")
+        try fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
+            let packageRoot = fixturePath.appending(component: "NonAPILibraryTargets")
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Foo", "Foo.swift")) {
                 $0 <<< "public func baz() -> String { \"hello, world!\" }"
             }
@@ -184,8 +184,8 @@ final class APIDiffTests: CommandsTestCase {
 
     func testFilters() throws {
         try skipIfApiDigesterUnsupportedOrUnset()
-        fixture(name: "Miscellaneous/APIDiff/") { prefix in
-            let packageRoot = prefix.appending(component: "NonAPILibraryTargets")
+        try fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
+            let packageRoot = fixturePath.appending(component: "NonAPILibraryTargets")
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Foo", "Foo.swift")) {
                 $0 <<< "public func baz() -> String { \"hello, world!\" }"
             }
@@ -256,8 +256,8 @@ final class APIDiffTests: CommandsTestCase {
 
     func testAPIDiffOfModuleWithCDependency() throws {
         try skipIfApiDigesterUnsupportedOrUnset()
-        fixture(name: "Miscellaneous/APIDiff/") { prefix in
-            let packageRoot = prefix.appending(component: "CTargetDep")
+        try fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
+            let packageRoot = fixturePath.appending(component: "CTargetDep")
             // Overwrite the existing decl.
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Bar", "Bar.swift")) {
                 $0 <<< """
@@ -292,8 +292,8 @@ final class APIDiffTests: CommandsTestCase {
 
     func testNoBreakingChanges() throws {
         try skipIfApiDigesterUnsupportedOrUnset()
-        fixture(name: "Miscellaneous/APIDiff/") { prefix in
-            let packageRoot = prefix.appending(component: "Bar")
+        try fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
+            let packageRoot = fixturePath.appending(component: "Bar")
             // Introduce an API-compatible change
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Baz", "Baz.swift")) {
                 $0 <<< "public func bar() -> Int { 100 }"
@@ -306,8 +306,8 @@ final class APIDiffTests: CommandsTestCase {
 
     func testAPIDiffAfterAddingNewTarget() throws {
         try skipIfApiDigesterUnsupportedOrUnset()
-        fixture(name: "Miscellaneous/APIDiff/") { prefix in
-            let packageRoot = prefix.appending(component: "Bar")
+        try fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
+            let packageRoot = fixturePath.appending(component: "Bar")
             try localFileSystem.createDirectory(packageRoot.appending(components: "Sources", "Foo"))
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Foo", "Foo.swift")) {
                 $0 <<< "public let foo = \"All new module!\""
@@ -340,8 +340,8 @@ final class APIDiffTests: CommandsTestCase {
 
     func testBadTreeish() throws {
         try skipIfApiDigesterUnsupportedOrUnset()
-        fixture(name: "Miscellaneous/APIDiff/") { prefix in
-            let packageRoot = prefix.appending(component: "Foo")
+        try fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
+            let packageRoot = fixturePath.appending(component: "Foo")
             XCTAssertThrowsError(try execute(["diagnose-api-breaking-changes", "7.8.9"], packagePath: packageRoot)) { error in
                 guard case SwiftPMProductError.executionFailure(error: _, output: _, stderr: let stderr) = error else {
                     XCTFail("Unexpected error")
@@ -355,8 +355,8 @@ final class APIDiffTests: CommandsTestCase {
     func testBranchUpdate() throws {
         try skipIfApiDigesterUnsupportedOrUnset()
         try withTemporaryDirectory { baselineDir in
-            fixture(name: "Miscellaneous/APIDiff/") { prefix in
-                let packageRoot = prefix.appending(component: "Foo")
+            try fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
+                let packageRoot = fixturePath.appending(component: "Foo")
                 let repo = GitRepository(path: packageRoot)
                 try repo.checkout(newBranch: "feature")
                 // Overwrite the existing decl.
@@ -392,14 +392,14 @@ final class APIDiffTests: CommandsTestCase {
 
     func testBaselineDirOverride() throws {
         try skipIfApiDigesterUnsupportedOrUnset()
-        fixture(name: "Miscellaneous/APIDiff/") { prefix in
-            let packageRoot = prefix.appending(component: "Foo")
+        try fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
+            let packageRoot = fixturePath.appending(component: "Foo")
             // Overwrite the existing decl.
             try localFileSystem.writeFileContents(packageRoot.appending(component: "Foo.swift")) {
                 $0 <<< "public let foo = 42"
             }
 
-            let baselineDir = prefix.appending(component: "Baselines")
+            let baselineDir = fixturePath.appending(component: "Baselines")
             let repo = GitRepository(path: packageRoot)
             let revision = try repo.resolveRevision(identifier: "1.2.3")
 
@@ -419,8 +419,8 @@ final class APIDiffTests: CommandsTestCase {
 
     func testRegenerateBaseline() throws {
        try skipIfApiDigesterUnsupportedOrUnset()
-        fixture(name: "Miscellaneous/APIDiff/") { prefix in
-            let packageRoot = prefix.appending(component: "Foo")
+        try fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
+            let packageRoot = fixturePath.appending(component: "Foo")
             // Overwrite the existing decl.
             try localFileSystem.writeFileContents(packageRoot.appending(component: "Foo.swift")) {
                 $0 <<< "public let foo = 42"
@@ -429,7 +429,7 @@ final class APIDiffTests: CommandsTestCase {
             let repo = GitRepository(path: packageRoot)
             let revision = try repo.resolveRevision(identifier: "1.2.3")
 
-            let baselineDir = prefix.appending(component: "Baselines")
+            let baselineDir = fixturePath.appending(component: "Baselines")
             let fooBaselinePath = baselineDir.appending(components: revision.identifier, "Foo.json")
 
             try localFileSystem.createDirectory(fooBaselinePath.parentDirectory, recursive: true)

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -74,8 +74,8 @@ final class BuildToolTests: CommandsTestCase {
     }
 
     func testBinPathAndSymlink() throws {
-        fixture(name: "ValidLayouts/SingleModule/ExecutableNew") { path in
-            let fullPath = resolveSymlinks(path)
+        try fixture(name: "ValidLayouts/SingleModule/ExecutableNew") { fixturePath in
+            let fullPath = resolveSymlinks(fixturePath)
             let targetPath = fullPath.appending(components: ".build", UserToolchain.default.triple.platformBuildPathComponent())
             let xcbuildTargetPath = fullPath.appending(components: ".build", "apple")
             XCTAssertEqual(try execute(["--show-bin-path"], packagePath: fullPath).stdout,
@@ -105,8 +105,8 @@ final class BuildToolTests: CommandsTestCase {
     }
 
     func testProductAndTarget() throws {
-        fixture(name: "Miscellaneous/MultipleExecutables") { path in
-            let fullPath = resolveSymlinks(path)
+        try fixture(name: "Miscellaneous/MultipleExecutables") { fixturePath in
+            let fullPath = resolveSymlinks(fixturePath)
 
             do {
                 let result = try build(["--product", "exec1"], packagePath: fullPath)
@@ -131,42 +131,42 @@ final class BuildToolTests: CommandsTestCase {
             }
 
             do {
-                _ = try execute(["--product", "exec1", "--target", "exec2"], packagePath: path)
+                _ = try execute(["--product", "exec1", "--target", "exec2"], packagePath: fixturePath)
                 XCTFail("Expected to fail")
             } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
                 XCTAssertMatch(stderr, .contains("error: '--product' and '--target' are mutually exclusive"))
             }
 
             do {
-                _ = try execute(["--product", "exec1", "--build-tests"], packagePath: path)
+                _ = try execute(["--product", "exec1", "--build-tests"], packagePath: fixturePath)
                 XCTFail("Expected to fail")
             } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
                 XCTAssertMatch(stderr, .contains("error: '--product' and '--build-tests' are mutually exclusive"))
             }
 
             do {
-                _ = try execute(["--build-tests", "--target", "exec2"], packagePath: path)
+                _ = try execute(["--build-tests", "--target", "exec2"], packagePath: fixturePath)
                 XCTFail("Expected to fail")
             } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
                 XCTAssertMatch(stderr, .contains("error: '--target' and '--build-tests' are mutually exclusive"))
             }
 
             do {
-                _ = try execute(["--build-tests", "--target", "exec2", "--product", "exec1"], packagePath: path)
+                _ = try execute(["--build-tests", "--target", "exec2", "--product", "exec1"], packagePath: fixturePath)
                 XCTFail("Expected to fail")
             } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
                 XCTAssertMatch(stderr, .contains("error: '--product', '--target', and '--build-tests' are mutually exclusive"))
             }
 
             do {
-                _ = try execute(["--product", "UnkownProduct"], packagePath: path)
+                _ = try execute(["--product", "UnkownProduct"], packagePath: fixturePath)
                 XCTFail("Expected to fail")
             } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
                 XCTAssertMatch(stderr, .contains("error: no product named 'UnkownProduct'"))
             }
 
             do {
-                _ = try execute(["--target", "UnkownTarget"], packagePath: path)
+                _ = try execute(["--target", "UnkownTarget"], packagePath: fixturePath)
                 XCTFail("Expected to fail")
             } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
                 XCTAssertMatch(stderr, .contains("error: no target named 'UnkownTarget'"))
@@ -174,9 +174,9 @@ final class BuildToolTests: CommandsTestCase {
         }
     }
     
-    func testAtMainSupport() {
-        fixture(name: "Miscellaneous/AtMainSupport") { path in
-            let fullPath = resolveSymlinks(path)
+    func testAtMainSupport() throws {
+        try fixture(name: "Miscellaneous/AtMainSupport") { fixturePath in
+            let fullPath = resolveSymlinks(fixturePath)
             do {
                 let result = try build(["--product", "ClangExecSingleFile"], packagePath: fullPath)
                 XCTAssertMatch(result.binContents, ["ClangExecSingleFile"])
@@ -200,9 +200,9 @@ final class BuildToolTests: CommandsTestCase {
         }
     }
 
-    func testNonReachableProductsAndTargetsFunctional() {
-        fixture(name: "Miscellaneous/UnreachableTargets") { path in
-            let aPath = path.appending(component: "A")
+    func testNonReachableProductsAndTargetsFunctional() throws {
+        try fixture(name: "Miscellaneous/UnreachableTargets") { fixturePath in
+            let aPath = fixturePath.appending(component: "A")
 
             do {
                 let result = try build([], packagePath: aPath)
@@ -243,10 +243,10 @@ final class BuildToolTests: CommandsTestCase {
         }
     }
 
-    func testParseableInterfaces() {
-        fixture(name: "Miscellaneous/ParseableInterfaces") { path in
+    func testParseableInterfaces() throws {
+        try fixture(name: "Miscellaneous/ParseableInterfaces") { fixturePath in
             do {
-                let result = try build(["--enable-parseable-module-interfaces"], packagePath: path)
+                let result = try build(["--enable-parseable-module-interfaces"], packagePath: fixturePath)
                 XCTAssertMatch(result.binContents, ["A.swiftinterface"])
                 XCTAssertMatch(result.binContents, ["B.swiftinterface"])
             } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
@@ -255,10 +255,10 @@ final class BuildToolTests: CommandsTestCase {
         }
     }
 
-    func testAutomaticParseableInterfacesWithLibraryEvolution() {
-        fixture(name: "Miscellaneous/LibraryEvolution") { path in
+    func testAutomaticParseableInterfacesWithLibraryEvolution() throws {
+        try fixture(name: "Miscellaneous/LibraryEvolution") { fixturePath in
             do {
-                let result = try build([], packagePath: path)
+                let result = try build([], packagePath: fixturePath)
                 XCTAssertMatch(result.binContents, ["A.swiftinterface"])
                 XCTAssertMatch(result.binContents, ["B.swiftinterface"])
             } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
@@ -267,10 +267,10 @@ final class BuildToolTests: CommandsTestCase {
         }
     }
 
-    func testBuildCompleteMessage() {
-        fixture(name: "DependencyResolution/Internal/Simple") { path in
+    func testBuildCompleteMessage() throws {
+        try fixture(name: "DependencyResolution/Internal/Simple") { fixturePath in
             do {
-                let result = try execute([], packagePath: path)
+                let result = try execute([], packagePath: fixturePath)
                 XCTAssertMatch(result.stdout, .regex("\\[[1-9][0-9]*\\/[1-9][0-9]*\\] Compiling"))
                 let lines = result.stdout.split(separator: "\n")
                 XCTAssertMatch(String(lines.last!), .regex("Build complete! \\([0-9]*\\.[0-9]*s\\)"))
@@ -278,7 +278,7 @@ final class BuildToolTests: CommandsTestCase {
 
             do {
                 // test second time, to make sure message is presented even when nothing to build (cached)
-                let result = try execute([], packagePath: path)
+                let result = try execute([], packagePath: fixturePath)
                 XCTAssertNoMatch(result.stdout, .regex("\\[[1-9][0-9]*\\/[1-9][0-9]*\\] Compiling"))
                 let lines = result.stdout.split(separator: "\n")
                 XCTAssertMatch(String(lines.last!), .regex("Build complete! \\([0-9]*\\.[0-9]*s\\)"))
@@ -286,15 +286,15 @@ final class BuildToolTests: CommandsTestCase {
         }
     }
 
-    func testBuildStartMessage() {
-        fixture(name: "DependencyResolution/Internal/Simple") { path in
+    func testBuildStartMessage() throws {
+        try fixture(name: "DependencyResolution/Internal/Simple") { fixturePath in
             do {
-                let result = try execute(["-c", "debug"], packagePath: path)
+                let result = try execute(["-c", "debug"], packagePath: fixturePath)
                 XCTAssertMatch(result.stdout, .prefix("Building for debugging"))
             }
 
             do {
-                let result = try execute(["-c", "release"], packagePath: path)
+                let result = try execute(["-c", "release"], packagePath: fixturePath)
                 XCTAssertMatch(result.stdout, .prefix("Building for production"))
             }
         }
@@ -304,9 +304,9 @@ final class BuildToolTests: CommandsTestCase {
         #if !os(macOS)
         try XCTSkipIf(true, "test requires `xcbuild` and is therefore only supported on macOS")
         #endif
-        fixture(name: "ValidLayouts/SingleModule/ExecutableNew") { path in
+        try fixture(name: "ValidLayouts/SingleModule/ExecutableNew") { fixturePath in
             // Try building using XCBuild with default parameters.  This should succeed.  We build verbosely so we get full command lines.
-            let defaultOutput = try execute(["-c", "debug", "-v"], packagePath: path).stdout
+            let defaultOutput = try execute(["-c", "debug", "-v"], packagePath: fixturePath).stdout
             
             // Look for certain things in the output from XCBuild.
             XCTAssertMatch(defaultOutput, .contains("-target \(UserToolchain.default.triple.tripleString(forPlatformVersion: ""))"))
@@ -317,7 +317,7 @@ final class BuildToolTests: CommandsTestCase {
         #if !os(macOS)
         try XCTSkipIf(true, "test requires `xcbuild` and is therefore only supported on macOS")
         #endif
-        fixture(name: "ValidLayouts/SingleModule/ExecutableMixed") { path in
+        try fixture(name: "ValidLayouts/SingleModule/ExecutableMixed") { fixturePath in
             // Try building using XCBuild with additional flags.  This should succeed.  We build verbosely so we get full command lines.
             let defaultOutput = try execute(
                 [
@@ -328,7 +328,7 @@ final class BuildToolTests: CommandsTestCase {
                     "-Xcxx", "-I/cxxfakepath",
                     "-Xswiftc", "-I/swiftfakepath",
                 ],
-                packagePath: path
+                packagePath: fixturePath
             ).stdout
 
             // Look for certain things in the output from XCBuild.
@@ -343,15 +343,15 @@ final class BuildToolTests: CommandsTestCase {
         #if !os(macOS)
         try XCTSkipIf(true, "test requires `xcbuild` and is therefore only supported on macOS")
         #endif
-        fixture(name: "ValidLayouts/SingleModule/ExecutableNew") { path in
+        try fixture(name: "ValidLayouts/SingleModule/ExecutableNew") { fixturePath in
             // Try building using XCBuild without specifying overrides.  This should succeed, and should use the default compiler path.
-            let defaultOutput = try execute(["-c", "debug", "-v"], packagePath: path).stdout
+            let defaultOutput = try execute(["-c", "debug", "-v"], packagePath: fixturePath).stdout
             XCTAssertMatch(defaultOutput, .contains(ToolchainConfiguration.default.swiftCompilerPath.pathString))
 
             // Now try building using XCBuild while specifying a faulty compiler override.  This should fail.  Note that we need to set the executable to use for the manifest itself to the default one, since it defaults to SWIFT_EXEC if not provided.
             var overriddenOutput = ""
             do {
-                overriddenOutput = try execute(["-c", "debug", "-v"], environment: ["SWIFT_EXEC": "/usr/bin/false", "SWIFT_EXEC_MANIFEST": ToolchainConfiguration.default.swiftCompilerPath.pathString], packagePath: path).stdout
+                overriddenOutput = try execute(["-c", "debug", "-v"], environment: ["SWIFT_EXEC": "/usr/bin/false", "SWIFT_EXEC_MANIFEST": ToolchainConfiguration.default.swiftCompilerPath.pathString], packagePath: fixturePath).stdout
                 XCTFail("unexpected success (was SWIFT_EXEC not overridden properly?)")
             }
             catch SwiftPMProductError.executionFailure(let error, let stdout, _) {

--- a/Tests/CommandsTests/PackageRegistryToolTests.swift
+++ b/Tests/CommandsTests/PackageRegistryToolTests.swift
@@ -48,8 +48,8 @@ final class PackageRegistryToolTests: CommandsTestCase {
     }
 
     func testLocalConfiguration() throws {
-        fixture(name: "DependencyResolution/External/Simple") { prefix in
-            let packageRoot = prefix.appending(component: "Bar")
+        try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
+            let packageRoot = fixturePath.appending(component: "Bar")
             let configurationFilePath = packageRoot.appending(RelativePath(".swiftpm/configuration/registries.json"))
 
             XCTAssertFalse(localFileSystem.exists(configurationFilePath))
@@ -127,8 +127,8 @@ final class PackageRegistryToolTests: CommandsTestCase {
     // TODO: Test global configuration
 
     func testSetMissingURL() throws {
-        fixture(name: "DependencyResolution/External/Simple") { prefix in
-            let packageRoot = prefix.appending(component: "Bar")
+        try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
+            let packageRoot = fixturePath.appending(component: "Bar")
             let configurationFilePath = packageRoot.appending(RelativePath(".swiftpm/configuration/registries.json"))
 
             XCTAssertFalse(localFileSystem.exists(configurationFilePath))
@@ -144,8 +144,8 @@ final class PackageRegistryToolTests: CommandsTestCase {
     }
 
     func testSetInvalidURL() throws {
-        fixture(name: "DependencyResolution/External/Simple") { prefix in
-            let packageRoot = prefix.appending(component: "Bar")
+        try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
+            let packageRoot = fixturePath.appending(component: "Bar")
             let configurationFilePath = packageRoot.appending(RelativePath(".swiftpm/configuration/registries.json"))
 
             XCTAssertFalse(localFileSystem.exists(configurationFilePath))
@@ -161,8 +161,8 @@ final class PackageRegistryToolTests: CommandsTestCase {
     }
 
     func testSetInvalidScope() throws {
-        fixture(name: "DependencyResolution/External/Simple") { prefix in
-            let packageRoot = prefix.appending(component: "Bar")
+        try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
+            let packageRoot = fixturePath.appending(component: "Bar")
             let configurationFilePath = packageRoot.appending(RelativePath(".swiftpm/configuration/registries.json"))
 
             XCTAssertFalse(localFileSystem.exists(configurationFilePath))
@@ -178,8 +178,8 @@ final class PackageRegistryToolTests: CommandsTestCase {
     }
 
     func testUnsetMissingEntry() throws {
-        fixture(name: "DependencyResolution/External/Simple") { prefix in
-            let packageRoot = prefix.appending(component: "Bar")
+        try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
+            let packageRoot = fixturePath.appending(component: "Bar")
             let configurationFilePath = packageRoot.appending(RelativePath(".swiftpm/configuration/registries.json"))
 
             XCTAssertFalse(localFileSystem.exists(configurationFilePath))

--- a/Tests/CommandsTests/RunToolTests.swift
+++ b/Tests/CommandsTests/RunToolTests.swift
@@ -39,10 +39,10 @@ final class RunToolTests: CommandsTestCase {
     }
 
     func testUnknownProductAndArgumentPassing() throws {
-        fixture(name: "Miscellaneous/EchoExecutable") { path in
+        try fixture(name: "Miscellaneous/EchoExecutable") { fixturePath in
 
             let result = try SwiftPMProduct.SwiftRun.executeProcess(
-                ["secho", "1", "--hello", "world"], packagePath: path)
+                ["secho", "1", "--hello", "world"], packagePath: fixturePath)
 
             // We only expect tool's output on the stdout stream.
             XCTAssertMatch(try result.utf8Output(), .contains("""
@@ -54,7 +54,7 @@ final class RunToolTests: CommandsTestCase {
             XCTAssertMatch(try result.utf8stderrOutput(), .contains("Linking"))
 
             do {
-                _ = try execute(["unknown"], packagePath: path)
+                _ = try execute(["unknown"], packagePath: fixturePath)
                 XCTFail("Unexpected success")
             } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
                 XCTAssertMatch(stderr, .contains("error: no executable product named 'unknown'"))
@@ -63,44 +63,44 @@ final class RunToolTests: CommandsTestCase {
     }
 
     func testMultipleExecutableAndExplicitExecutable() throws {
-        fixture(name: "Miscellaneous/MultipleExecutables") { path in
+        try fixture(name: "Miscellaneous/MultipleExecutables") { fixturePath in
             do {
-                _ = try execute([], packagePath: path)
+                _ = try execute([], packagePath: fixturePath)
                 XCTFail("Unexpected success")
             } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
                 XCTAssertMatch(stderr, .contains("error: multiple executable products available: exec1, exec2"))
             }
             
-            var (runOutput, _) = try execute(["exec1"], packagePath: path)
+            var (runOutput, _) = try execute(["exec1"], packagePath: fixturePath)
             XCTAssertMatch(runOutput, .contains("1"))
 
-            (runOutput, _) = try execute(["exec2"], packagePath: path)
+            (runOutput, _) = try execute(["exec2"], packagePath: fixturePath)
             XCTAssertMatch(runOutput, .contains("2"))
         }
     }
 
     func testUnreachableExecutable() throws {
-        fixture(name: "Miscellaneous/UnreachableTargets") { path in
-            let (output, _) = try execute(["bexec"], packagePath: path.appending(component: "A"))
+        try fixture(name: "Miscellaneous/UnreachableTargets") { fixturePath in
+            let (output, _) = try execute(["bexec"], packagePath: fixturePath.appending(component: "A"))
             let outputLines = output.split(separator: "\n")
             XCTAssertMatch(String(outputLines[0]), .contains("BTarget2"))
         }
     }
 
     func testFileDeprecation() throws {
-        fixture(name: "Miscellaneous/EchoExecutable") { path in
-            let filePath = AbsolutePath(path, "Sources/secho/main.swift").pathString
+        try fixture(name: "Miscellaneous/EchoExecutable") { fixturePath in
+            let filePath = AbsolutePath(fixturePath, "Sources/secho/main.swift").pathString
             let cwd = localFileSystem.currentWorkingDirectory!
-            let (stdout, stderr) = try execute([filePath, "1", "2"], packagePath: path)
+            let (stdout, stderr) = try execute([filePath, "1", "2"], packagePath: fixturePath)
             XCTAssertMatch(stdout, .contains(#""\#(cwd)" "1" "2""#))
             XCTAssertMatch(stderr, .contains("warning: 'swift run file.swift' command to interpret swift files is deprecated; use 'swift file.swift' instead"))
         }
     }
 
     func testMutualExclusiveFlags() throws {
-        fixture(name: "Miscellaneous/EchoExecutable") { path in
+        try fixture(name: "Miscellaneous/EchoExecutable") { fixturePath in
             do {
-                _ = try execute(["--build-tests", "--skip-build"], packagePath: path)
+                _ = try execute(["--build-tests", "--skip-build"], packagePath: fixturePath)
                 XCTFail("Expected to fail")
             } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
                 XCTAssertMatch(stderr, .contains("error: '--build-tests' and '--skip-build' are mutually exclusive"))

--- a/Tests/CommandsTests/SwiftToolTests.swift
+++ b/Tests/CommandsTests/SwiftToolTests.swift
@@ -17,9 +17,9 @@ import XCTest
 final class SwiftToolTests: CommandsTestCase {
     
     func testVerbosityLogLevel() throws {
-        fixture(name: "Miscellaneous/Simple") { packageRoot in
+        try fixture(name: "Miscellaneous/Simple") { fixturePath in
             do {
-                let options = try SwiftToolOptions.parse(["--package-path", packageRoot.pathString])
+                let options = try SwiftToolOptions.parse(["--package-path", fixturePath.pathString])
                 let tool = try SwiftTool(options: options)
                 XCTAssertEqual(tool.logLevel, .warning)
 
@@ -30,7 +30,7 @@ final class SwiftToolTests: CommandsTestCase {
             }
 
             do {
-                let options = try SwiftToolOptions.parse(["--package-path", packageRoot.pathString, "--verbose"])
+                let options = try SwiftToolOptions.parse(["--package-path", fixturePath.pathString, "--verbose"])
                 let tool = try SwiftTool(options: options)
                 XCTAssertEqual(tool.logLevel, .info)
 
@@ -41,13 +41,13 @@ final class SwiftToolTests: CommandsTestCase {
             }
 
             do {
-                let options = try SwiftToolOptions.parse(["--package-path", packageRoot.pathString, "-v"])
+                let options = try SwiftToolOptions.parse(["--package-path", fixturePath.pathString, "-v"])
                 let tool = try SwiftTool(options: options)
                 XCTAssertEqual(tool.logLevel, .info)
             }
 
             do {
-                let options = try SwiftToolOptions.parse(["--package-path", packageRoot.pathString, "--very-verbose"])
+                let options = try SwiftToolOptions.parse(["--package-path", fixturePath.pathString, "--very-verbose"])
                 let tool = try SwiftTool(options: options)
                 XCTAssertEqual(tool.logLevel, .debug)
 
@@ -58,7 +58,7 @@ final class SwiftToolTests: CommandsTestCase {
             }
 
             do {
-                let options = try SwiftToolOptions.parse(["--package-path", packageRoot.pathString, "--vv"])
+                let options = try SwiftToolOptions.parse(["--package-path", fixturePath.pathString, "--vv"])
                 let tool = try SwiftTool(options: options)
                 XCTAssertEqual(tool.logLevel, .debug)
             }
@@ -66,9 +66,9 @@ final class SwiftToolTests: CommandsTestCase {
     }
 
     func testNetrcAuthorizationProviders() throws {
-        fixture(name: "DependencyResolution/External/XCFramework") { packageRoot in
+        try fixture(name: "DependencyResolution/External/XCFramework") { fixturePath in
             let fs = localFileSystem
-            let localPath = packageRoot.appending(component: ".netrc")
+            let localPath = fixturePath.appending(component: ".netrc")
 
             // custom .netrc file
             do {
@@ -77,7 +77,7 @@ final class SwiftToolTests: CommandsTestCase {
                     "machine mymachine.labkey.org login custom@labkey.org password custom"
                 }
 
-                let options = try SwiftToolOptions.parse(["--package-path", packageRoot.pathString, "--netrc-file", customPath.pathString])
+                let options = try SwiftToolOptions.parse(["--package-path", fixturePath.pathString, "--netrc-file", customPath.pathString])
                 let tool = try SwiftTool(options: options)
 
                 let authorizationProvider = try tool.getAuthorizationProvider() as? CompositeAuthorizationProvider
@@ -102,7 +102,7 @@ final class SwiftToolTests: CommandsTestCase {
                     return "machine mymachine.labkey.org login local@labkey.org password local"
                 }
 
-                let options = try SwiftToolOptions.parse(["--package-path", packageRoot.pathString])
+                let options = try SwiftToolOptions.parse(["--package-path", fixturePath.pathString])
                 let tool = try SwiftTool(options: options)
 
                 let authorizationProvider = try tool.getAuthorizationProvider() as? CompositeAuthorizationProvider

--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -35,48 +35,51 @@ final class TestToolTests: CommandsTestCase {
     }
 
     func testNumWorkersParallelRequirement() throws {
+        #if !os(macOS)
         // Running swift-test fixtures on linux is not yet possible.
-        #if os(macOS)
-        fixture(name: "Miscellaneous/EchoExecutable") { path in
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
+        try fixture(name: "Miscellaneous/EchoExecutable") { fixturePath in
             do {
                 _ = try execute(["--num-workers", "1"])
             } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
                 XCTAssertMatch(stderr, .contains("error: --num-workers must be used with --parallel"))
             }
         }
-        #endif
     }
     
     func testNumWorkersValue() throws {
-        #if os(macOS)
-        fixture(name: "Miscellaneous/EchoExecutable") { path in
+        #if !os(macOS)
+        // Running swift-test fixtures on linux is not yet possible.
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
+        try fixture(name: "Miscellaneous/EchoExecutable") { fixturePath in
             do {
                 _ = try execute(["--parallel", "--num-workers", "0"])
             } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
                 XCTAssertMatch(stderr, .contains("error: '--num-workers' must be greater than zero"))
             }
         }
-        #endif
     }
 
-    func testEnableDisableTestability() {
-        fixture(name: "Miscellaneous/TestableExe") { path in
+    func testEnableDisableTestability() throws {
+        try fixture(name: "Miscellaneous/TestableExe") { fixturePath in
             // default should run with testability
             do {
-                let result = try execute(["--vv"], packagePath: path)
+                let result = try execute(["--vv"], packagePath: fixturePath)
                 XCTAssertMatch(result.stdout, .contains("-enable-testing"))
             }
 
             // disabled
             do {
-                _ = try execute(["--disable-testable-imports", "--vv"], packagePath: path)
+                _ = try execute(["--disable-testable-imports", "--vv"], packagePath: fixturePath)
             } catch SwiftPMProductError.executionFailure(_, let stdout, _) {
                 XCTAssertMatch(stdout, .contains("was not compiled for testing"))
             }
 
             // enabled
             do {
-                let result = try execute(["--enable-testable-imports", "--vv"], packagePath: path)
+                let result = try execute(["--enable-testable-imports", "--vv"], packagePath: fixturePath)
                 XCTAssertMatch(result.stdout, .contains("-enable-testing"))
             }
         }

--- a/Tests/FunctionalPerformanceTests/BuildPerfTests.swift
+++ b/Tests/FunctionalPerformanceTests/BuildPerfTests.swift
@@ -27,33 +27,37 @@ class BuildPerfTests: XCTestCasePerf {
         _ = try SwiftPMProduct.SwiftPackage.execute(["clean"], packagePath: packagePath)
     }
 
-    func testTrivialPackageFullBuild() {
-      #if os(macOS)
-        runFullBuildTest(for: "DependencyResolution/Internal/Simple", product: "foo")
-      #endif
+    func testTrivialPackageFullBuild() throws {
+        #if !os(macOS)
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
+        try runFullBuildTest(for: "DependencyResolution/Internal/Simple", product: "foo")
     }
 
-    func testTrivialPackageNullBuild() {
-      #if os(macOS)
-        runNullBuildTest(for: "DependencyResolution/Internal/Simple", product: "foo")
-      #endif
+    func testTrivialPackageNullBuild() throws {
+        #if !os(macOS)
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
+        try runNullBuildTest(for: "DependencyResolution/Internal/Simple", product: "foo")
     }
 
-    func testComplexPackageFullBuild() {
-      #if os(macOS)
-        runFullBuildTest(for: "DependencyResolution/External/Complex", app: "app", product: "Dealer")
-      #endif
+    func testComplexPackageFullBuild() throws {
+        #if !os(macOS)
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
+        try runFullBuildTest(for: "DependencyResolution/External/Complex", app: "app", product: "Dealer")
     }
 
-    func testComplexPackageNullBuild() {
-      #if os(macOS)
-        runNullBuildTest(for: "DependencyResolution/External/Complex", app: "app", product: "Dealer")
-      #endif
+    func testComplexPackageNullBuild() throws {
+        #if !os(macOS)
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
+        try runNullBuildTest(for: "DependencyResolution/External/Complex", app: "app", product: "Dealer")
     }
 
-    func runFullBuildTest(for name: String, app appString: String? = nil, product productString: String) {
-        fixture(name: name) { prefix in
-            let app = prefix.appending(components: (appString ?? ""))
+    func runFullBuildTest(for name: String, app appString: String? = nil, product productString: String) throws {
+        try fixture(name: name) { fixturePath in
+            let app = fixturePath.appending(components: (appString ?? ""))
             let triple = UserToolchain.default.triple
             let product = app.appending(components: ".build", triple.platformBuildPathComponent(), "debug", productString)
             try self.execute(packagePath: app)
@@ -65,9 +69,9 @@ class BuildPerfTests: XCTestCasePerf {
         }
     }
 
-    func runNullBuildTest(for name: String, app appString: String? = nil, product productString: String) {
-        fixture(name: name) { prefix in
-            let app = prefix.appending(components: (appString ?? ""))
+    func runNullBuildTest(for name: String, app appString: String? = nil, product productString: String) throws {
+        try fixture(name: name) { fixturePath in
+            let app = fixturePath.appending(components: (appString ?? ""))
             let triple = UserToolchain.default.triple
             let product = app.appending(components: ".build", triple.platformBuildPathComponent(), "debug", productString)
             try self.execute(packagePath: app)

--- a/Tests/FunctionalTests/CFamilyTargetTests.swift
+++ b/Tests/FunctionalTests/CFamilyTargetTests.swift
@@ -6,7 +6,7 @@
 
  See http://swift.org/LICENSE.txt for license information
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
-*/
+ */
 
 import Commands
 import PackageGraph
@@ -34,20 +34,20 @@ private func XCTAssertDirectoryContainsFile(dir: AbsolutePath, filename: String,
 
 class CFamilyTargetTestCase: XCTestCase {
 
-    func testCLibraryWithSpaces() {
-        fixture(name: "CFamilyTargets/CLibraryWithSpaces") { prefix in
-            XCTAssertBuilds(prefix)
-            let debugPath = prefix.appending(components: ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug")
+    func testCLibraryWithSpaces() throws {
+        try fixture(name: "CFamilyTargets/CLibraryWithSpaces") { fixturePath in
+            XCTAssertBuilds(fixturePath)
+            let debugPath = fixturePath.appending(components: ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Bar.c.o")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Foo.c.o")
         }
     }
 
-    func testCUsingCAndSwiftDep() {
-        fixture(name: "DependencyResolution/External/CUsingCDep") { prefix in
-            let packageRoot = prefix.appending(component: "Bar")
+    func testCUsingCAndSwiftDep() throws {
+        try fixture(name: "DependencyResolution/External/CUsingCDep") { fixturePath in
+            let packageRoot = fixturePath.appending(component: "Bar")
             XCTAssertBuilds(packageRoot)
-            let debugPath = prefix.appending(components: "Bar", ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug")
+            let debugPath = fixturePath.appending(components: "Bar", ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Sea.c.o")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Foo.c.o")
             let path = try SwiftPMProduct.packagePath(for: "Foo", packageRoot: packageRoot)
@@ -55,10 +55,10 @@ class CFamilyTargetTestCase: XCTestCase {
         }
     }
 
-    func testModuleMapGenerationCases() {
-        fixture(name: "CFamilyTargets/ModuleMapGenerationCases") { prefix in
-            XCTAssertBuilds(prefix)
-            let debugPath = prefix.appending(components: ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug")
+    func testModuleMapGenerationCases() throws {
+        try fixture(name: "CFamilyTargets/ModuleMapGenerationCases") { fixturePath in
+            XCTAssertBuilds(fixturePath)
+            let debugPath = fixturePath.appending(components: ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Jaz.c.o")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "main.swift.o")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "FlatInclude.c.o")
@@ -66,9 +66,9 @@ class CFamilyTargetTestCase: XCTestCase {
         }
     }
     
-    func testNoIncludeDirCheck() {
-        fixture(name: "CFamilyTargets/CLibraryNoIncludeDir") { prefix in
-            XCTAssertThrowsError(try executeSwiftBuild(prefix), "This build should throw an error") { err in
+    func testNoIncludeDirCheck() throws {
+        try fixture(name: "CFamilyTargets/CLibraryNoIncludeDir") { fixturePath in
+            XCTAssertThrowsError(try executeSwiftBuild(fixturePath), "This build should throw an error") { err in
                 // The err.localizedDescription doesn't capture the detailed error string so interpolate
                 let errStr = "\(err)"
                 let missingIncludeDirStr = "\(ModuleError.invalidPublicHeadersDirectory("Cfactorial"))"
@@ -77,24 +77,25 @@ class CFamilyTargetTestCase: XCTestCase {
         }
     }
 
-    func testCanForwardExtraFlagsToClang() {
+    func testCanForwardExtraFlagsToClang() throws {
         // Try building a fixture which needs extra flags to be able to build.
-        fixture(name: "CFamilyTargets/CDynamicLookup") { prefix in
-            XCTAssertBuilds(prefix, Xld: ["-undefined", "dynamic_lookup"])
-            let debugPath = prefix.appending(components: ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug")
+        try fixture(name: "CFamilyTargets/CDynamicLookup") { fixturePath in
+            XCTAssertBuilds(fixturePath, Xld: ["-undefined", "dynamic_lookup"])
+            let debugPath = fixturePath.appending(components: ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Foo.c.o")
         }
     }
 
     func testObjectiveCPackageWithTestTarget() throws {
-      #if os(macOS)
-        fixture(name: "CFamilyTargets/ObjCmacOSPackage") { prefix in
+        #if !os(macOS)
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
+        try fixture(name: "CFamilyTargets/ObjCmacOSPackage") { fixturePath in
             // Build the package.
-            XCTAssertBuilds(prefix)
-            XCTAssertDirectoryContainsFile(dir: prefix.appending(components: ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug"), filename: "HelloWorldExample.m.o")
+            XCTAssertBuilds(fixturePath)
+            XCTAssertDirectoryContainsFile(dir: fixturePath.appending(components: ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug"), filename: "HelloWorldExample.m.o")
             // Run swift-test on package.
-            XCTAssertSwiftTest(prefix)
+            XCTAssertSwiftTest(fixturePath)
         }
-      #endif
     }
 }

--- a/Tests/FunctionalTests/DependencyResolutionTests.swift
+++ b/Tests/FunctionalTests/DependencyResolutionTests.swift
@@ -17,67 +17,67 @@ import Workspace
 import XCTest
 
 class DependencyResolutionTests: XCTestCase {
-    func testInternalSimple() {
-        fixture(name: "DependencyResolution/Internal/Simple") { prefix in
-            XCTAssertBuilds(prefix)
+    func testInternalSimple() throws {
+        try fixture(name: "DependencyResolution/Internal/Simple") { fixturePath in
+            XCTAssertBuilds(fixturePath)
 
-            let output = try Process.checkNonZeroExit(args: prefix.appending(components: ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Foo").pathString)
+            let output = try Process.checkNonZeroExit(args: fixturePath.appending(components: ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Foo").pathString)
             XCTAssertEqual(output, "Foo\nBar\n")
         }
     }
 
-    func testInternalExecAsDep() {
-        fixture(name: "DependencyResolution/Internal/InternalExecutableAsDependency") { prefix in
-            XCTAssertBuildFails(prefix)
+    func testInternalExecAsDep() throws {
+        try fixture(name: "DependencyResolution/Internal/InternalExecutableAsDependency") { fixturePath in
+            XCTAssertBuildFails(fixturePath)
         }
     }
 
-    func testInternalComplex() {
-        fixture(name: "DependencyResolution/Internal/Complex") { prefix in
-            XCTAssertBuilds(prefix)
+    func testInternalComplex() throws {
+        try fixture(name: "DependencyResolution/Internal/Complex") { fixturePath in
+            XCTAssertBuilds(fixturePath)
 
-            let output = try Process.checkNonZeroExit(args: prefix.appending(components: ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Foo").pathString)
+            let output = try Process.checkNonZeroExit(args: fixturePath.appending(components: ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Foo").pathString)
             XCTAssertEqual(output, "meiow Baz\n")
         }
     }
 
     /// Check resolution of a trivial package with one dependency.
-    func testExternalSimple() {
-        fixture(name: "DependencyResolution/External/Simple") { prefix in
+    func testExternalSimple() throws {
+        try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
             // Add several other tags to check version selection.
-            let repo = GitRepository(path: prefix.appending(components: "Foo"))
+            let repo = GitRepository(path: fixturePath.appending(components: "Foo"))
             for tag in ["1.1.0", "1.2.0"] {
                 try repo.tag(name: tag)
             }
 
-            let packageRoot = prefix.appending(component: "Bar")
+            let packageRoot = fixturePath.appending(component: "Bar")
             XCTAssertBuilds(packageRoot)
-            XCTAssertFileExists(prefix.appending(components: "Bar", ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Bar"))
+            XCTAssertFileExists(fixturePath.appending(components: "Bar", ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Bar"))
             let path = try SwiftPMProduct.packagePath(for: "Foo", packageRoot: packageRoot)
             XCTAssert(try GitRepository(path: path).getTags().contains("1.2.3"))
         }
     }
 
-    func testExternalComplex() {
-        fixture(name: "DependencyResolution/External/Complex") { prefix in
-            XCTAssertBuilds(prefix.appending(component: "app"))
-            let output = try Process.checkNonZeroExit(args: prefix.appending(components: "app", ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Dealer").pathString)
+    func testExternalComplex() throws {
+        try fixture(name: "DependencyResolution/External/Complex") { fixturePath in
+            XCTAssertBuilds(fixturePath.appending(component: "app"))
+            let output = try Process.checkNonZeroExit(args: fixturePath.appending(components: "app", ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Dealer").pathString)
             XCTAssertEqual(output, "♣︎K\n♣︎Q\n♣︎J\n♣︎10\n♣︎9\n♣︎8\n♣︎7\n♣︎6\n♣︎5\n♣︎4\n")
         }
     }
     
     func testConvenienceBranchInit() throws {
-        fixture(name: "DependencyResolution/External/Branch") { prefix in
+        try fixture(name: "DependencyResolution/External/Branch") { fixturePath in
             // Tests the convenience init .package(url: , branch: )
-            let app = prefix.appending(component: "Bar")
+            let app = fixturePath.appending(component: "Bar")
             let result = try SwiftPMProduct.SwiftBuild.executeProcess([], packagePath: app)
             XCTAssertEqual(result.exitStatus, .terminated(code: 0))
         }
     }
 
-    func testMirrors() {
-        fixture(name: "DependencyResolution/External/Mirror") { prefix in
-            let prefix = resolveSymlinks(prefix)
+    func testMirrors() throws {
+        try fixture(name: "DependencyResolution/External/Mirror") { fixturePath in
+            let prefix = resolveSymlinks(fixturePath)
             let appPath = prefix.appending(component: "App")
             let appPinsPath = appPath.appending(component: "Package.resolved")
 
@@ -138,8 +138,8 @@ class DependencyResolutionTests: XCTestCase {
     }
 
     func testPackageLookupCaseInsensitive() throws {
-        fixture(name: "DependencyResolution/External/PackageLookupCaseInsensitive") { path in
-            let result = try SwiftPMProduct.SwiftPackage.executeProcess(["update"], packagePath: path.appending(component: "pkg"))
+        try fixture(name: "DependencyResolution/External/PackageLookupCaseInsensitive") { fixturePath in
+            let result = try SwiftPMProduct.SwiftPackage.executeProcess(["update"], packagePath: fixturePath.appending(component: "pkg"))
             XCTAssert(result.exitStatus == .terminated(code: 0), try! result.utf8Output() + result.utf8stderrOutput())
         }
     }

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -20,13 +20,13 @@ typealias ProcessID = TSCBasic.Process.ProcessID
 
 class MiscellaneousTestCase: XCTestCase {
 
-    func testPrintsSelectedDependencyVersion() {
+    func testPrintsSelectedDependencyVersion() throws {
 
         // verifies the stdout contains information about
         // the selected version of the package
 
-        fixture(name: "DependencyResolution/External/Simple") { prefix in
-            let (output, _) = try executeSwiftBuild(prefix.appending(component: "Bar"))
+        try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
+            let (output, _) = try executeSwiftBuild(fixturePath.appending(component: "Bar"))
             XCTAssertMatch(output, .regex("Computed .* at 1\\.2\\.3"))
             XCTAssertMatch(output, .contains("Compiling Foo Foo.swift"))
             XCTAssertMatch(output, .or(.contains("Merging module Foo"),
@@ -38,34 +38,34 @@ class MiscellaneousTestCase: XCTestCase {
         }
     }
 
-    func testPassExactDependenciesToBuildCommand() {
+    func testPassExactDependenciesToBuildCommand() throws {
 
         // regression test to ensure that dependencies of other dependencies
         // are not passed into the build-command.
 
-        fixture(name: "Miscellaneous/ExactDependencies") { prefix in
-            XCTAssertBuilds(prefix.appending(component: "app"))
-            let buildDir = prefix.appending(components: "app", ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug")
+        try fixture(name: "Miscellaneous/ExactDependencies") { fixturePath in
+            XCTAssertBuilds(fixturePath.appending(component: "app"))
+            let buildDir = fixturePath.appending(components: "app", ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug")
             XCTAssertFileExists(buildDir.appending(component: "FooExec"))
             XCTAssertFileExists(buildDir.appending(component: "FooLib1.swiftmodule"))
             XCTAssertFileExists(buildDir.appending(component: "FooLib2.swiftmodule"))
         }
     }
 
-    func testCanBuildMoreThanTwiceWithExternalDependencies() {
+    func testCanBuildMoreThanTwiceWithExternalDependencies() throws {
 
         // running `swift build` multiple times should not fail
         // subsequent executions to an unmodified source tree
         // should immediately exit with exit-status: `0`
 
-        fixture(name: "DependencyResolution/External/Complex") { prefix in
-            XCTAssertBuilds(prefix.appending(component: "app"))
-            XCTAssertBuilds(prefix.appending(component: "app"))
-            XCTAssertBuilds(prefix.appending(component: "app"))
+        try fixture(name: "DependencyResolution/External/Complex") { fixturePath in
+            XCTAssertBuilds(fixturePath.appending(component: "app"))
+            XCTAssertBuilds(fixturePath.appending(component: "app"))
+            XCTAssertBuilds(fixturePath.appending(component: "app"))
         }
     }
 
-    func testNoArgumentsExitsWithOne() {
+    func testNoArgumentsExitsWithOne() throws {
         var foo = false
         do {
             try executeSwiftBuild(AbsolutePath("/"))
@@ -84,10 +84,10 @@ class MiscellaneousTestCase: XCTestCase {
         XCTAssertTrue(foo)
     }
 
-    func testCompileFailureExitsGracefully() {
-        fixture(name: "Miscellaneous/CompileFails") { prefix in
+    func testCompileFailureExitsGracefully() throws {
+        try fixture(name: "Miscellaneous/CompileFails") { fixturePath in
             do {
-                try executeSwiftBuild(prefix)
+                try executeSwiftBuild(fixturePath)
                 XCTFail()
             } catch SwiftPMProductError.executionFailure(let error, let output, let stderr) {
                 XCTAssertMatch(stderr + output, .contains("Compiling CompileFails Foo.swift"))
@@ -105,10 +105,10 @@ class MiscellaneousTestCase: XCTestCase {
         }
     }
 
-    func testPackageManagerDefineAndXArgs() {
-        fixture(name: "Miscellaneous/-DSWIFT_PACKAGE") { prefix in
-            XCTAssertBuildFails(prefix)
-            XCTAssertBuilds(prefix, Xcc: ["-DEXTRA_C_DEFINE=2"], Xswiftc: ["-DEXTRA_SWIFTC_DEFINE"])
+    func testPackageManagerDefineAndXArgs() throws {
+        try fixture(name: "Miscellaneous/-DSWIFT_PACKAGE") { fixturePath in
+            XCTAssertBuildFails(fixturePath)
+            XCTAssertBuilds(fixturePath, Xcc: ["-DEXTRA_C_DEFINE=2"], Xswiftc: ["-DEXTRA_SWIFTC_DEFINE"])
         }
     }
 
@@ -116,11 +116,11 @@ class MiscellaneousTestCase: XCTestCase {
      Tests that modules that are rebuilt causes
      any executables that link to that module to be relinked.
     */
-    func testInternalDependencyEdges() {
-        fixture(name: "Miscellaneous/DependencyEdges/Internal") { prefix in
-            let execpath = prefix.appending(components: ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Foo").pathString
+    func testInternalDependencyEdges() throws {
+        try fixture(name: "Miscellaneous/DependencyEdges/Internal") { fixturePath in
+            let execpath = fixturePath.appending(components: ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Foo").pathString
 
-            XCTAssertBuilds(prefix)
+            XCTAssertBuilds(fixturePath)
             var output = try Process.checkNonZeroExit(args: execpath)
             XCTAssertEqual(output, "Hello\n")
 
@@ -128,9 +128,9 @@ class MiscellaneousTestCase: XCTestCase {
             // llbuild does not realize the file has changed
             Thread.sleep(forTimeInterval: 1)
 
-            try localFileSystem.writeFileContents(prefix.appending(components: "Bar", "Bar.swift"), bytes: "public let bar = \"Goodbye\"\n")
+            try localFileSystem.writeFileContents(fixturePath.appending(components: "Bar", "Bar.swift"), bytes: "public let bar = \"Goodbye\"\n")
 
-            XCTAssertBuilds(prefix)
+            XCTAssertBuilds(fixturePath)
             output = try Process.checkNonZeroExit(args: execpath)
             XCTAssertEqual(output, "Goodbye\n")
         }
@@ -140,11 +140,11 @@ class MiscellaneousTestCase: XCTestCase {
      Tests that modules from other packages that are rebuilt causes
      any executables that link to that module in the root package.
     */
-    func testExternalDependencyEdges1() {
-        fixture(name: "DependencyResolution/External/Complex") { prefix in
-            let execpath = prefix.appending(components: "app", ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Dealer").pathString
+    func testExternalDependencyEdges1() throws {
+        try fixture(name: "DependencyResolution/External/Complex") { fixturePath in
+            let execpath = fixturePath.appending(components: "app", ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Dealer").pathString
 
-            let packageRoot = prefix.appending(component: "app")
+            let packageRoot = fixturePath.appending(component: "app")
             XCTAssertBuilds(packageRoot)
             var output = try Process.checkNonZeroExit(args: execpath)
             XCTAssertEqual(output, "♣︎K\n♣︎Q\n♣︎J\n♣︎10\n♣︎9\n♣︎8\n♣︎7\n♣︎6\n♣︎5\n♣︎4\n")
@@ -157,7 +157,7 @@ class MiscellaneousTestCase: XCTestCase {
             try localFileSystem.chmod(.userWritable, path: path, options: [.recursive])
             try localFileSystem.writeFileContents(path.appending(components: "src", "Fisher-Yates_Shuffle.swift"), bytes: "public extension Collection{ func shuffle() -> [Iterator.Element] {return []} }\n\npublic extension MutableCollection where Index == Int { mutating func shuffleInPlace() { for (i, _) in enumerated() { self[i] = self[0] } }}\n\npublic let shuffle = true")
 
-            XCTAssertBuilds(prefix.appending(component: "app"))
+            XCTAssertBuilds(fixturePath.appending(component: "app"))
             output = try Process.checkNonZeroExit(args: execpath)
             XCTAssertEqual(output, "♠︎A\n♠︎A\n♠︎A\n♠︎A\n♠︎A\n♠︎A\n♠︎A\n♠︎A\n♠︎A\n♠︎A\n")
         }
@@ -167,12 +167,12 @@ class MiscellaneousTestCase: XCTestCase {
      Tests that modules from other packages that are rebuilt causes
      any executables for another external package to be rebuilt.
      */
-    func testExternalDependencyEdges2() {
-        fixture(name: "Miscellaneous/DependencyEdges/External") { prefix in
-            let execpath = [prefix.appending(components: "root", ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug", "dep2").pathString]
+    func testExternalDependencyEdges2() throws {
+        try fixture(name: "Miscellaneous/DependencyEdges/External") { fixturePath in
+            let execpath = [fixturePath.appending(components: "root", ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug", "dep2").pathString]
 
-            let packageRoot = prefix.appending(component: "root")
-            XCTAssertBuilds(prefix.appending(component: "root"))
+            let packageRoot = fixturePath.appending(component: "root")
+            XCTAssertBuilds(fixturePath.appending(component: "root"))
             var output = try Process.checkNonZeroExit(arguments: execpath)
             XCTAssertEqual(output, "Hello\n")
 
@@ -184,16 +184,16 @@ class MiscellaneousTestCase: XCTestCase {
             try localFileSystem.chmod(.userWritable, path: path, options: [.recursive])
             try localFileSystem.writeFileContents(path.appending(components: "Foo.swift"), bytes: "public let foo = \"Goodbye\"")
 
-            XCTAssertBuilds(prefix.appending(component: "root"))
+            XCTAssertBuilds(fixturePath.appending(component: "root"))
             output = try Process.checkNonZeroExit(arguments: execpath)
             XCTAssertEqual(output, "Goodbye\n")
         }
     }
 
-    func testSpaces() {
-        fixture(name: "Miscellaneous/Spaces Fixture") { prefix in
-            XCTAssertBuilds(prefix)
-            XCTAssertFileExists(prefix.appending(components: ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Module_Name_1.build", "Foo.swift.o"))
+    func testSpaces() throws {
+        try fixture(name: "Miscellaneous/Spaces Fixture") { fixturePath in
+            XCTAssertBuilds(fixturePath)
+            XCTAssertFileExists(fixturePath.appending(components: ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Module_Name_1.build", "Foo.swift.o"))
         }
     }
 
@@ -201,7 +201,7 @@ class MiscellaneousTestCase: XCTestCase {
         // This has been failing on the Swift CI sometimes, need to investigate.
       #if false
         // Make sure that swiftpm doesn't rebuild second time if the modulemap is being generated.
-        fixture(name: "CFamilyTargets/SwiftCMixed") { prefix in
+        try fixture(name: "CFamilyTargets/SwiftCMixed") { fixturePath in
             var output = try executeSwiftBuild(prefix)
             XCTAssertFalse(output.isEmpty, output)
             output = try executeSwiftBuild(prefix)
@@ -211,10 +211,10 @@ class MiscellaneousTestCase: XCTestCase {
     }
 
     func testSwiftTestParallel() throws {
-        fixture(name: "Miscellaneous/ParallelTestsPkg") { prefix in
+        try fixture(name: "Miscellaneous/ParallelTestsPkg") { fixturePath in
             // First try normal serial testing.
             do {
-                _ = try SwiftPMProduct.SwiftTest.execute([], packagePath: prefix)
+                _ = try SwiftPMProduct.SwiftTest.execute([], packagePath: fixturePath)
             } catch SwiftPMProductError.executionFailure(_, let output, let stderr) {
                 #if os(macOS)
                 XCTAssertMatch(stderr, .contains("Executed 2 tests"))
@@ -225,7 +225,7 @@ class MiscellaneousTestCase: XCTestCase {
 
             do {
                 // Run tests in parallel.
-                _ = try SwiftPMProduct.SwiftTest.execute(["--parallel"], packagePath: prefix)
+                _ = try SwiftPMProduct.SwiftTest.execute(["--parallel"], packagePath: fixturePath)
             } catch SwiftPMProductError.executionFailure(_, let output, _) {
                 XCTAssertMatch(output, .contains("testExample1"))
                 XCTAssertMatch(output, .contains("testExample2"))
@@ -234,12 +234,12 @@ class MiscellaneousTestCase: XCTestCase {
                 XCTAssertMatch(output, .contains("[3/3]"))
             }
 
-            let xUnitOutput = prefix.appending(component: "result.xml")
+            let xUnitOutput = fixturePath.appending(component: "result.xml")
             do {
                 // Run tests in parallel with verbose output.
                 _ = try SwiftPMProduct.SwiftTest.execute(
                     ["--parallel", "--verbose", "--xunit-output", xUnitOutput.pathString],
-                    packagePath: prefix)
+                    packagePath: fixturePath)
             } catch SwiftPMProductError.executionFailure(_, let output, _) {
                 XCTAssertMatch(output, .contains("testExample1"))
                 XCTAssertMatch(output, .contains("testExample2"))
@@ -256,15 +256,15 @@ class MiscellaneousTestCase: XCTestCase {
     }
 
     func testSwiftTestFilter() throws {
-        fixture(name: "Miscellaneous/ParallelTestsPkg") { prefix in
-            let (stdout, _) = try SwiftPMProduct.SwiftTest.execute(["--filter", ".*1", "-l"], packagePath: prefix)
+        try fixture(name: "Miscellaneous/ParallelTestsPkg") { fixturePath in
+            let (stdout, _) = try SwiftPMProduct.SwiftTest.execute(["--filter", ".*1", "-l"], packagePath: fixturePath)
             XCTAssertMatch(stdout, .contains("testExample1"))
             XCTAssertNoMatch(stdout, .contains("testExample2"))
             XCTAssertNoMatch(stdout, .contains("testSureFailure"))
         }
 
-        fixture(name: "Miscellaneous/ParallelTestsPkg") { prefix in
-            let (stdout, _) = try SwiftPMProduct.SwiftTest.execute(["--filter", "ParallelTestsTests", "--skip", ".*1", "--filter", "testSureFailure", "-l"], packagePath: prefix)
+        try fixture(name: "Miscellaneous/ParallelTestsPkg") { fixturePath in
+            let (stdout, _) = try SwiftPMProduct.SwiftTest.execute(["--filter", "ParallelTestsTests", "--skip", ".*1", "--filter", "testSureFailure", "-l"], packagePath: fixturePath)
             XCTAssertNoMatch(stdout, .contains("testExample1"))
             XCTAssertMatch(stdout, .contains("testExample2"))
             XCTAssertMatch(stdout, .contains("testSureFailure"))
@@ -272,22 +272,22 @@ class MiscellaneousTestCase: XCTestCase {
     }
 
     func testSwiftTestSkip() throws {
-        fixture(name: "Miscellaneous/ParallelTestsPkg") { prefix in
-            let (stdout, _) = try SwiftPMProduct.SwiftTest.execute(["--skip", "ParallelTestsTests", "-l"], packagePath: prefix)
+        try fixture(name: "Miscellaneous/ParallelTestsPkg") { fixturePath in
+            let (stdout, _) = try SwiftPMProduct.SwiftTest.execute(["--skip", "ParallelTestsTests", "-l"], packagePath: fixturePath)
             XCTAssertNoMatch(stdout, .contains("testExample1"))
             XCTAssertNoMatch(stdout, .contains("testExample2"))
             XCTAssertMatch(stdout, .contains("testSureFailure"))
         }
 
-        fixture(name: "Miscellaneous/ParallelTestsPkg") { prefix in
-            let (stdout, _) = try SwiftPMProduct.SwiftTest.execute(["--filter", "ParallelTestsTests", "--skip", ".*2", "--filter", "TestsFailure", "--skip", "testSureFailure", "-l"], packagePath: prefix)
+        try fixture(name: "Miscellaneous/ParallelTestsPkg") { fixturePath in
+            let (stdout, _) = try SwiftPMProduct.SwiftTest.execute(["--filter", "ParallelTestsTests", "--skip", ".*2", "--filter", "TestsFailure", "--skip", "testSureFailure", "-l"], packagePath: fixturePath)
             XCTAssertMatch(stdout, .contains("testExample1"))
             XCTAssertNoMatch(stdout, .contains("testExample2"))
             XCTAssertNoMatch(stdout, .contains("testSureFailure"))
         }
 
-        fixture(name: "Miscellaneous/ParallelTestsPkg") { prefix in
-            let (stdout, stderr) = try SwiftPMProduct.SwiftTest.execute(["--skip", "Tests"], packagePath: prefix)
+        try fixture(name: "Miscellaneous/ParallelTestsPkg") { fixturePath in
+            let (stdout, stderr) = try SwiftPMProduct.SwiftTest.execute(["--skip", "Tests"], packagePath: fixturePath)
             XCTAssertNoMatch(stdout, .contains("testExample1"))
             XCTAssertNoMatch(stdout, .contains("testExample2"))
             XCTAssertNoMatch(stdout, .contains("testSureFailure"))
@@ -296,24 +296,25 @@ class MiscellaneousTestCase: XCTestCase {
     }
 
     func testOverridingDeploymentTargetUsingSwiftCompilerArgument() throws {
-      #if os(macOS)
-        fixture(name: "Miscellaneous/DistantFutureDeploymentTarget") { prefix in
+        #if !os(macOS)
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
+        try fixture(name: "Miscellaneous/DistantFutureDeploymentTarget") { fixturePath in
             let hostTriple = UserToolchain.default.triple
-            try executeSwiftBuild(prefix, Xswiftc: ["-target", "\(hostTriple.arch)-apple-macosx41.0"])
+            try executeSwiftBuild(fixturePath, Xswiftc: ["-target", "\(hostTriple.arch)-apple-macosx41.0"])
         }
-      #endif
     }
 
     func testPkgConfigCFamilyTargets() throws {
-        fixture(name: "Miscellaneous/PkgConfig") { prefix in
-            let systemModule = prefix.appending(component: "SystemModule")
+        try fixture(name: "Miscellaneous/PkgConfig") { fixturePath in
+            let systemModule = fixturePath.appending(component: "SystemModule")
             // Create a shared library.
             let input = systemModule.appending(components: "Sources", "SystemModule.c")
             let triple = UserToolchain.default.triple
             let output =  systemModule.appending(component: "libSystemModule\(triple.dynamicLibraryExtension)")
             try systemQuietly(["clang", "-shared", input.pathString, "-o", output.pathString])
 
-            let pcFile = prefix.appending(component: "libSystemModule.pc")
+            let pcFile = fixturePath.appending(component: "libSystemModule.pc")
 
             let stream = BufferedOutputByteStream()
             stream <<< """
@@ -331,8 +332,8 @@ class MiscellaneousTestCase: XCTestCase {
                 """
             try localFileSystem.writeFileContents(pcFile, bytes: stream.bytes)
 
-            let moduleUser = prefix.appending(component: "SystemModuleUserClang")
-            let env = ["PKG_CONFIG_PATH": prefix.pathString]
+            let moduleUser = fixturePath.appending(component: "SystemModuleUserClang")
+            let env = ["PKG_CONFIG_PATH": fixturePath.pathString]
             _ = try executeSwiftBuild(moduleUser, env: env)
 
             XCTAssertFileExists(moduleUser.appending(components: ".build", triple.platformBuildPathComponent(), "debug", "SystemModuleUserClang"))
@@ -342,10 +343,10 @@ class MiscellaneousTestCase: XCTestCase {
     func testCanKillSubprocessOnSigInt() throws {
         // <rdar://problem/31890371> swift-pm: Spurious? failures of MiscellaneousTestCase.testCanKillSubprocessOnSigInt on linux
       #if false
-        fixture(name: "DependencyResolution/External/Simple") { prefix in
+        try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
 
-            let fakeGit = prefix.appending(components: "bin", "git")
-            let waitFile = prefix.appending(components: "waitfile")
+            let fakeGit = fixturePath.appending(components: "bin", "git")
+            let waitFile = fixturePath.appending(components: "waitfile")
 
             try localFileSystem.createDirectory(fakeGit.parentDirectory)
 
@@ -372,7 +373,7 @@ class MiscellaneousTestCase: XCTestCase {
             }
 
             // Launch swift-build.
-            let app = prefix.appending(component: "Bar")
+            let app = fixturePath.appending(component: "Bar")
             let process = Process(args: SwiftPMProduct.SwiftBuild.path.pathString, "--package-path", app.pathString, environment: env)
             try process.launch()
 
@@ -395,12 +396,12 @@ class MiscellaneousTestCase: XCTestCase {
     }
 
     func testReportingErrorFromGitCommand() throws {
-        fixture(name: "Miscellaneous/MissingDependency") { prefix in
+        try fixture(name: "Miscellaneous/MissingDependency") { fixturePath in
             // This fixture has a setup that is intentionally missing a local
             // dependency to induce a failure.
 
             // Launch swift-build.
-            let app = prefix.appending(component: "Bar")
+            let app = fixturePath.appending(component: "Bar")
 
             let result = try SwiftPMProduct.SwiftBuild.executeProcess([], packagePath: app)
 
@@ -413,10 +414,10 @@ class MiscellaneousTestCase: XCTestCase {
     }
 
     func testLocalPackageUsedAsURLValidation() throws {
-        fixture(name: "Miscellaneous/LocalPackageAsURL", createGitRepo: false) { path in
+        try fixture(name: "Miscellaneous/LocalPackageAsURL", createGitRepo: false) { fixturePath in
             // This fixture has a setup that is trying to use a local package
             // as a url that hasn't been initialized as a repo
-            let result = try SwiftPMProduct.SwiftBuild.executeProcess([], packagePath: path.appending(component: "Bar"))
+            let result = try SwiftPMProduct.SwiftBuild.executeProcess([], packagePath: fixturePath.appending(component: "Bar"))
             XCTAssert(result.exitStatus != .terminated(code: 0))
             let output = try result.utf8stderrOutput()
             XCTAssert(output.contains("Cannot clone from local directory"), "Didn't find expected output: \(output)")
@@ -424,15 +425,15 @@ class MiscellaneousTestCase: XCTestCase {
     }
 
     func testInvalidRefsValidation() throws {
-        fixture(name: "Miscellaneous/InvalidRefs", createGitRepo: false) { path in
+        try fixture(name: "Miscellaneous/InvalidRefs", createGitRepo: false) { fixturePath in
             do {
-                let result = try SwiftPMProduct.SwiftBuild.executeProcess([], packagePath: path.appending(component: "InvalidBranch"))
+                let result = try SwiftPMProduct.SwiftBuild.executeProcess([], packagePath: fixturePath.appending(component: "InvalidBranch"))
                 XCTAssert(result.exitStatus != .terminated(code: 0))
                 let output = try result.utf8stderrOutput()
                 XCTAssert(output.contains("Invalid branch name: "), "Didn't find expected output: \(output)")
             }
             do {
-                let result = try SwiftPMProduct.SwiftBuild.executeProcess([], packagePath: path.appending(component: "InvalidRevision"))
+                let result = try SwiftPMProduct.SwiftBuild.executeProcess([], packagePath: fixturePath.appending(component: "InvalidRevision"))
                 XCTAssert(result.exitStatus != .terminated(code: 0))
                 let output = try result.utf8stderrOutput()
                 XCTAssert(output.contains("Invalid revision: "), "Didn't find expected output: \(output)")
@@ -440,9 +441,9 @@ class MiscellaneousTestCase: XCTestCase {
         }
     }
 
-    func testUnicode() {
+    func testUnicode() throws {
         #if !os(Linux) && !os(Android) // TODO: - Linux has trouble with this and needs investigation.
-        fixture(name: "Miscellaneous/Unicode") { prefix in
+        try fixture(name: "Miscellaneous/Unicode") { fixturePath in
             // See the fixture manifest for an explanation of this string.
             let complicatedString = "πשּׁµ𝄞🇺🇳🇮🇱x̱̱̱̱̱̄̄̄̄̄"
             let verify = "\u{03C0}\u{0FB2C}\u{00B5}\u{1D11E}\u{1F1FA}\u{1F1F3}\u{1F1EE}\u{1F1F1}\u{0078}\u{0331}\u{0304}\u{0331}\u{0304}\u{0331}\u{0304}\u{0331}\u{0304}\u{0331}\u{0304}"
@@ -456,7 +457,7 @@ class MiscellaneousTestCase: XCTestCase {
                 .appending(component: "Fixtures")
                 .appending(component: "Miscellaneous")
                 .appending(component: dependencyName)
-            let dependencyDestination = prefix.parentDirectory.appending(component: dependencyName)
+            let dependencyDestination = fixturePath.parentDirectory.appending(component: dependencyName)
             try? FileManager.default.removeItem(atPath: dependencyDestination.pathString)
             defer { try? FileManager.default.removeItem(atPath: dependencyDestination.pathString) }
             try FileManager.default.copyItem(
@@ -470,8 +471,8 @@ class MiscellaneousTestCase: XCTestCase {
             // •••••
 
             // Attempt several operations.
-            try SwiftPMProduct.SwiftTest.execute([], packagePath: prefix)
-            try SwiftPMProduct.SwiftRun.execute([complicatedString + "‐tool"], packagePath: prefix)
+            try SwiftPMProduct.SwiftTest.execute([], packagePath: fixturePath)
+            try SwiftPMProduct.SwiftRun.execute([complicatedString + "‐tool"], packagePath: fixturePath)
         }
         #endif
     }
@@ -480,47 +481,49 @@ class MiscellaneousTestCase: XCTestCase {
         let compilerDiagnosticFlags = ["-Xswiftc", "-Xfrontend", "-Xswiftc", "-Rmodule-interface-rebuild"]
         #if canImport(Darwin)
         // should emit when LinuxMain is present
-        fixture(name: "Miscellaneous/TestDiscovery/Simple") { path in
-            let (_, stderr) = try SwiftPMProduct.SwiftTest.execute(["--enable-test-discovery"] + compilerDiagnosticFlags, packagePath: path)
+        try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
+            let (_, stderr) = try SwiftPMProduct.SwiftTest.execute(["--enable-test-discovery"] + compilerDiagnosticFlags, packagePath: fixturePath)
             XCTAssertMatch(stderr, .contains("warning: '--enable-test-discovery' option is deprecated"))
         }
 
         // should emit when LinuxMain is not present
-        fixture(name: "Miscellaneous/TestDiscovery/Simple") { path in
-            try localFileSystem.writeFileContents(path.appending(components: "Tests", SwiftTarget.testManifestNames.first!), bytes: "fatalError(\"boom\")")
-            let (_, stderr) = try SwiftPMProduct.SwiftTest.execute(["--enable-test-discovery"] + compilerDiagnosticFlags, packagePath: path)
+        try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
+            try localFileSystem.writeFileContents(fixturePath.appending(components: "Tests", SwiftTarget.testManifestNames.first!), bytes: "fatalError(\"boom\")")
+            let (_, stderr) = try SwiftPMProduct.SwiftTest.execute(["--enable-test-discovery"] + compilerDiagnosticFlags, packagePath: fixturePath)
             XCTAssertMatch(stderr, .contains("warning: '--enable-test-discovery' option is deprecated"))
         }
         #else
         // should emit when LinuxMain is present
-        fixture(name: "Miscellaneous/TestDiscovery/Simple") { path in
-            let (_, stderr) = try SwiftPMProduct.SwiftTest.execute(["--enable-test-discovery"] + compilerDiagnosticFlags, packagePath: path)
+        try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
+            let (_, stderr) = try SwiftPMProduct.SwiftTest.execute(["--enable-test-discovery"] + compilerDiagnosticFlags, packagePath: fixturePath)
             XCTAssertMatch(stderr, .contains("warning: '--enable-test-discovery' option is deprecated"))
         }
         // should not emit when LinuxMain is present
-        fixture(name: "Miscellaneous/TestDiscovery/Simple") { path in
-            try localFileSystem.writeFileContents(path.appending(components: "Tests", SwiftTarget.testManifestNames.first!), bytes: "fatalError(\"boom\")")
-            let (_, stderr) = try SwiftPMProduct.SwiftTest.execute(["--enable-test-discovery"] + compilerDiagnosticFlags, packagePath: path)
+        try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
+            try localFileSystem.writeFileContents(fixturePath.appending(components: "Tests", SwiftTarget.testManifestNames.first!), bytes: "fatalError(\"boom\")")
+            let (_, stderr) = try SwiftPMProduct.SwiftTest.execute(["--enable-test-discovery"] + compilerDiagnosticFlags, packagePath: fixturePath)
             XCTAssertNoMatch(stderr, .contains("warning: '--enable-test-discovery' option is deprecated"))
         }
         #endif
     }
 
-    func testGenerateLinuxMainDeprecation() {
-        fixture(name: "Miscellaneous/TestDiscovery/Simple") { path in
-            let (_, stderr) = try SwiftPMProduct.SwiftTest.execute(["--generate-linuxmain"], packagePath: path)
+    func testGenerateLinuxMainDeprecation() throws {
+        try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
+            let (_, stderr) = try SwiftPMProduct.SwiftTest.execute(["--generate-linuxmain"], packagePath: fixturePath)
             // test deprecation warning
             XCTAssertMatch(stderr, .contains("warning: '--generate-linuxmain' option is deprecated"))
         }
     }
 
-    func testGenerateLinuxMain() {
-        #if os(macOS)
-        fixture(name: "Miscellaneous/TestDiscovery/Simple") { path in
-            _ = try SwiftPMProduct.SwiftTest.execute(["--generate-linuxmain"], packagePath: path)
+    func testGenerateLinuxMain() throws {
+        #if !os(macOS)
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
+        try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
+            _ = try SwiftPMProduct.SwiftTest.execute(["--generate-linuxmain"], packagePath: fixturePath)
 
             // Check LinuxMain
-            let linuxMain = path.appending(components: "Tests", "LinuxMain.swift")
+            let linuxMain = fixturePath.appending(components: "Tests", "LinuxMain.swift")
              XCTAssertEqual(try localFileSystem.readFileContents(linuxMain), """
                  import XCTest
 
@@ -534,7 +537,7 @@ class MiscellaneousTestCase: XCTestCase {
                  """)
 
             // Check test manifest
-            let testManifest = path.appending(components: "Tests", "SimpleTests", "XCTestManifests.swift")
+            let testManifest = fixturePath.appending(components: "Tests", "SimpleTests", "XCTestManifests.swift")
             XCTAssertEqual(try localFileSystem.readFileContents(testManifest), """
                 #if !canImport(ObjectiveC)
                 import XCTest
@@ -559,7 +562,6 @@ class MiscellaneousTestCase: XCTestCase {
 
                 """)
         }
-        #endif
     }
 
     func testTestsCanLinkAgainstExecutable() throws {
@@ -568,9 +570,9 @@ class MiscellaneousTestCase: XCTestCase {
         try XCTSkipIf(true, "skipping because host compiler doesn't support '-entry-point-function-name'")
         #endif
 
-        fixture(name: "Miscellaneous/TestableExe") { prefix in
+        try fixture(name: "Miscellaneous/TestableExe") { fixturePath in
             do {
-                let (stdout, _) = try executeSwiftTest(prefix)
+                let (stdout, _) = try executeSwiftTest(fixturePath)
                 XCTAssertMatch(stdout, .contains("Linking TestableExe1"))
                 XCTAssertMatch(stdout, .contains("Linking TestableExe2"))
                 XCTAssertMatch(stdout, .contains("Linking TestableExePackageTests"))
@@ -594,8 +596,8 @@ class MiscellaneousTestCase: XCTestCase {
         }
     }
 
-    func testExecutableTargetMismatch() {
-        fixture(name: "Miscellaneous/TargetMismatch") { path in
+    func testExecutableTargetMismatch() throws {
+        try fixture(name: "Miscellaneous/TargetMismatch") { path in
             do {
                 let output = try executeSwiftBuild(path)
                 XCTAssertMatch(output.stdout, .contains("Compiling Sample main.swift"))
@@ -606,14 +608,14 @@ class MiscellaneousTestCase: XCTestCase {
         }
     }
 
-    func testEditModeEndToEnd() {
-        fixture(name: "Miscellaneous/Edit") { prefix in
-            let prefix = resolveSymlinks(prefix)
-            let appPath = prefix.appending(component: "App")
+    func testEditModeEndToEnd() throws {
+        try fixture(name: "Miscellaneous/Edit") { fixturePath in
+            let prefix = resolveSymlinks(fixturePath)
+            let appPath = fixturePath.appending(component: "App")
 
             // prepare the dependencies as git repos
             try ["Foo", "Bar"].forEach { directory in
-                let path = prefix.appending(component: directory)
+                let path = fixturePath.appending(component: directory)
                 _ = try Process.checkNonZeroExit(args: "git", "-C", path.pathString, "init")
             }
 
@@ -650,8 +652,8 @@ class MiscellaneousTestCase: XCTestCase {
         }
     }
 
-    func testCustomCachePath() {
-        fixture(name: "Miscellaneous/Simple") { path in
+    func testCustomCachePath() throws {
+        try fixture(name: "Miscellaneous/Simple") { path in
             let customCachePath = path.appending(components: "custom", "cache")
             XCTAssertNoSuchPath(customCachePath)
             try SwiftPMProduct.SwiftBuild.execute(["--cache-path", customCachePath.pathString], packagePath: path)
@@ -660,7 +662,7 @@ class MiscellaneousTestCase: XCTestCase {
 
         // `FileSystem` does not support `chmod` on Linux
         #if os(macOS)
-        fixture(name: "Miscellaneous/Simple") { path in
+        try fixture(name: "Miscellaneous/Simple") { path in
             try localFileSystem.chmod(.userUnWritable, path: path)
             let customCachePath = path.appending(components: "custom", "cache")
             XCTAssertNoSuchPath(customCachePath)
@@ -673,8 +675,8 @@ class MiscellaneousTestCase: XCTestCase {
         #endif
     }
 
-    func testCustomConfigPath() {
-        fixture(name: "Miscellaneous/Simple") { path in
+    func testCustomConfigPath() throws {
+        try fixture(name: "Miscellaneous/Simple") { path in
             let customConfigPath = path.appending(components: "custom", "config")
             XCTAssertNoSuchPath(customConfigPath)
             try SwiftPMProduct.SwiftBuild.execute(["--config-path", customConfigPath.pathString], packagePath: path)
@@ -683,7 +685,7 @@ class MiscellaneousTestCase: XCTestCase {
 
         // `FileSystem` does not support `chmod` on Linux
         #if os(macOS)
-        fixture(name: "Miscellaneous/Simple") { path in
+        try fixture(name: "Miscellaneous/Simple") { path in
             try localFileSystem.chmod(.userUnWritable, path: path)
             let customConfigPath = path.appending(components: "custom", "config")
             XCTAssertNoSuchPath(customConfigPath)
@@ -696,8 +698,8 @@ class MiscellaneousTestCase: XCTestCase {
         #endif
     }
 
-    func testCustomSecurityPath() {
-        fixture(name: "Miscellaneous/Simple") { path in
+    func testCustomSecurityPath() throws {
+        try fixture(name: "Miscellaneous/Simple") { path in
             let customSecurityPath = path.appending(components: "custom", "security")
             XCTAssertNoSuchPath(customSecurityPath)
             try SwiftPMProduct.SwiftBuild.execute(["--security-path", customSecurityPath.pathString], packagePath: path)
@@ -706,7 +708,7 @@ class MiscellaneousTestCase: XCTestCase {
 
         // `FileSystem` does not support `chmod` on Linux
         #if os(macOS)
-        fixture(name: "Miscellaneous/Simple") { path in
+        try fixture(name: "Miscellaneous/Simple") { path in
             try localFileSystem.chmod(.userUnWritable, path: path)
             let customSecurityPath = path.appending(components: "custom", "security")
             XCTAssertNoSuchPath(customSecurityPath)

--- a/Tests/FunctionalTests/ModuleAliasingTests.swift
+++ b/Tests/FunctionalTests/ModuleAliasingTests.swift
@@ -25,15 +25,15 @@ class ModuleAliasingTests: XCTestCase {
 
         try XCTSkipIf(true, "rdar://88722540")
 
-        fixture(name: "Miscellaneous/ModuleAliasing/DirectDeps") { prefix in
-            let app = prefix.appending(components: "AppPkg")
+        try fixture(name: "Miscellaneous/ModuleAliasing/DirectDeps") { fixturePath in
+            let app = fixturePath.appending(components: "AppPkg")
             XCTAssertBuilds(app)
-            XCTAssertFileExists(prefix.appending(components: "AppPkg", ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug", "App"))
-            XCTAssertFileExists(prefix.appending(components: "AppPkg", ".build", UserToolchain.default.triple.platformBuildPathComponent(), "release", "App"))
-            XCTAssertFileExists(prefix.appending(components: "AppPkg", ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug", "GameUtils.swiftmodule"))
-            XCTAssertFileExists(prefix.appending(components: "AppPkg", ".build", UserToolchain.default.triple.platformBuildPathComponent(), "release", "GameUtils.swiftmodule"))
-            XCTAssertFileExists(prefix.appending(components: "AppPkg", ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Utils.swiftmodule"))
-            XCTAssertFileExists(prefix.appending(components: "AppPkg", ".build", UserToolchain.default.triple.platformBuildPathComponent(), "release", "Utils.swiftmodule"))
+            XCTAssertFileExists(fixturePath.appending(components: "AppPkg", ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug", "App"))
+            XCTAssertFileExists(fixturePath.appending(components: "AppPkg", ".build", UserToolchain.default.triple.platformBuildPathComponent(), "release", "App"))
+            XCTAssertFileExists(fixturePath.appending(components: "AppPkg", ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug", "GameUtils.swiftmodule"))
+            XCTAssertFileExists(fixturePath.appending(components: "AppPkg", ".build", UserToolchain.default.triple.platformBuildPathComponent(), "release", "GameUtils.swiftmodule"))
+            XCTAssertFileExists(fixturePath.appending(components: "AppPkg", ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Utils.swiftmodule"))
+            XCTAssertFileExists(fixturePath.appending(components: "AppPkg", ".build", UserToolchain.default.triple.platformBuildPathComponent(), "release", "Utils.swiftmodule"))
             
             let result = try SwiftPMProduct.SwiftBuild.executeProcess([], packagePath: app)
             let output = try result.utf8Output() + result.utf8stderrOutput()

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -24,9 +24,9 @@ class PluginTests: XCTestCase {
         // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
 
-        fixture(name: "Miscellaneous/Plugins") { path in
+        try fixture(name: "Miscellaneous/Plugins") { fixturePath in
             do {
-                let (stdout, _) = try executeSwiftBuild(path.appending(component: "MySourceGenPlugin"), configuration: .Debug, extraArgs: ["--product", "MyLocalTool"])
+                let (stdout, _) = try executeSwiftBuild(fixturePath.appending(component: "MySourceGenPlugin"), configuration: .Debug, extraArgs: ["--product", "MyLocalTool"])
                 XCTAssert(stdout.contains("Linking MySourceGenBuildTool"), "stdout:\n\(stdout)")
                 XCTAssert(stdout.contains("Generating foo.swift from foo.dat"), "stdout:\n\(stdout)")
                 XCTAssert(stdout.contains("Linking MyLocalTool"), "stdout:\n\(stdout)")
@@ -43,9 +43,9 @@ class PluginTests: XCTestCase {
         // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
 
-        fixture(name: "Miscellaneous/Plugins") { path in
+        try fixture(name: "Miscellaneous/Plugins") { fixturePath in
             do {
-                let (stdout, _) = try executeSwiftBuild(path.appending(component: "MySourceGenClient"), configuration: .Debug, extraArgs: ["--product", "MyTool"])
+                let (stdout, _) = try executeSwiftBuild(fixturePath.appending(component: "MySourceGenClient"), configuration: .Debug, extraArgs: ["--product", "MyTool"])
                 XCTAssert(stdout.contains("Linking MySourceGenBuildTool"), "stdout:\n\(stdout)")
                 XCTAssert(stdout.contains("Generating foo.swift from foo.dat"), "stdout:\n\(stdout)")
                 XCTAssert(stdout.contains("Linking MyTool"), "stdout:\n\(stdout)")
@@ -62,9 +62,9 @@ class PluginTests: XCTestCase {
         // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
 
-        fixture(name: "Miscellaneous/Plugins") { path in
+        try fixture(name: "Miscellaneous/Plugins") { fixturePath in
             do {
-                let (stdout, _) = try executeSwiftBuild(path.appending(component: "MySourceGenPlugin"), configuration: .Debug, extraArgs: ["--product", "MyOtherLocalTool"])
+                let (stdout, _) = try executeSwiftBuild(fixturePath.appending(component: "MySourceGenPlugin"), configuration: .Debug, extraArgs: ["--product", "MyOtherLocalTool"])
                 XCTAssert(stdout.contains("Compiling MyOtherLocalTool bar.swift"), "stdout:\n\(stdout)")
                 XCTAssert(stdout.contains("Compiling MyOtherLocalTool baz.swift"), "stdout:\n\(stdout)")
                 XCTAssert(stdout.contains("Linking MyOtherLocalTool"), "stdout:\n\(stdout)")
@@ -81,8 +81,8 @@ class PluginTests: XCTestCase {
         // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
         
-        fixture(name: "Miscellaneous/Plugins") { path in
-            let (stdout, _) = try executeSwiftBuild(path.appending(component: "ClientOfPluginWithInternalExecutable"))
+        try fixture(name: "Miscellaneous/Plugins") { fixturePath in
+            let (stdout, _) = try executeSwiftBuild(fixturePath.appending(component: "ClientOfPluginWithInternalExecutable"))
             XCTAssert(stdout.contains("Compiling PluginExecutable main.swift"), "stdout:\n\(stdout)")
             XCTAssert(stdout.contains("Linking PluginExecutable"), "stdout:\n\(stdout)")
             XCTAssert(stdout.contains("Generating foo.swift from foo.dat"), "stdout:\n\(stdout)")
@@ -96,9 +96,9 @@ class PluginTests: XCTestCase {
         // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
 
-        fixture(name: "Miscellaneous/Plugins") { path in
+        try fixture(name: "Miscellaneous/Plugins") { fixturePath in
             do {
-                let (stdout, _) = try executeSwiftBuild(path.appending(component: "InvalidUseOfInternalPluginExecutable"))
+                let (stdout, _) = try executeSwiftBuild(fixturePath.appending(component: "InvalidUseOfInternalPluginExecutable"))
                 XCTFail("Illegally used internal executable.\nstdout:\n\(stdout)")
             }
             catch SwiftPMProductError.executionFailure(_, _, let stderr) {
@@ -116,9 +116,9 @@ class PluginTests: XCTestCase {
         // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
 
-        fixture(name: "Miscellaneous/Plugins") { path in
+        try fixture(name: "Miscellaneous/Plugins") { fixturePath in
             do {
-                let (stdout, _) = try executeSwiftBuild(path.appending(component: "ContrivedTestPlugin"), configuration: .Debug, extraArgs: ["--product", "MyLocalTool"])
+                let (stdout, _) = try executeSwiftBuild(fixturePath.appending(component: "ContrivedTestPlugin"), configuration: .Debug, extraArgs: ["--product", "MyLocalTool"])
                 XCTAssert(stdout.contains("Linking MySourceGenBuildTool"), "stdout:\n\(stdout)")
                 XCTAssert(stdout.contains("Generating foo.swift from foo.dat"), "stdout:\n\(stdout)")
                 XCTAssert(stdout.contains("Linking MyLocalTool"), "stdout:\n\(stdout)")
@@ -132,13 +132,14 @@ class PluginTests: XCTestCase {
     }
 
     func testPluginScriptSandbox() throws {
+        #if !os(macOS)
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
         // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
-
-        #if os(macOS)
-        fixture(name: "Miscellaneous/Plugins") { path in
+        try fixture(name: "Miscellaneous/Plugins") { fixturePath in
             do {
-                let (stdout, _) = try executeSwiftBuild(path.appending(component: "SandboxTesterPlugin"), configuration: .Debug, extraArgs: ["--product", "MyLocalTool"])
+                let (stdout, _) = try executeSwiftBuild(fixturePath.appending(component: "SandboxTesterPlugin"), configuration: .Debug, extraArgs: ["--product", "MyLocalTool"])
                 XCTAssert(stdout.contains("Linking MyLocalTool"), "stdout:\n\(stdout)")
                 XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
             }
@@ -147,17 +148,17 @@ class PluginTests: XCTestCase {
                 throw error
             }
         }
-        #endif
     }
 
     func testUseOfVendedBinaryTool() throws {
+        #if !os(macOS)
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
         // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
-
-        #if os(macOS)
-        fixture(name: "Miscellaneous/Plugins") { path in
+        try fixture(name: "Miscellaneous/Plugins") { fixturePath in
             do {
-                let (stdout, _) = try executeSwiftBuild(path.appending(component: "MyBinaryToolPlugin"), configuration: .Debug, extraArgs: ["--product", "MyLocalTool"])
+                let (stdout, _) = try executeSwiftBuild(fixturePath.appending(component: "MyBinaryToolPlugin"), configuration: .Debug, extraArgs: ["--product", "MyLocalTool"])
                 XCTAssert(stdout.contains("Linking MyLocalTool"), "stdout:\n\(stdout)")
                 XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
             }
@@ -166,7 +167,6 @@ class PluginTests: XCTestCase {
                 throw error
             }
         }
-        #endif
     }
     
     func testCommandPluginInvocation() throws {

--- a/Tests/FunctionalTests/ResourcesTests.swift
+++ b/Tests/FunctionalTests/ResourcesTests.swift
@@ -14,8 +14,8 @@ import SPMTestSupport
 import TSCBasic
 
 class ResourcesTests: XCTestCase {
-    func testSimpleResources() {
-        fixture(name: "Resources/Simple") { prefix in
+    func testSimpleResources() throws {
+        try fixture(name: "Resources/Simple") { fixturePath in
             var executables = ["SwiftyResource"]
 
             // Objective-C module requires macOS
@@ -25,17 +25,17 @@ class ResourcesTests: XCTestCase {
             #endif
 
             for execName in executables {
-                let (output, _) = try executeSwiftRun(prefix, execName)
+                let (output, _) = try executeSwiftRun(fixturePath, execName)
                 XCTAssertTrue(output.contains("foo"), output)
             }
         }
     }
 
-    func testLocalizedResources() {
-        fixture(name: "Resources/Localized") { prefix in
-            try executeSwiftBuild(prefix)
+    func testLocalizedResources() throws {
+        try fixture(name: "Resources/Localized") { fixturePath in
+            try executeSwiftBuild(fixturePath)
 
-            let exec = prefix.appending(RelativePath(".build/debug/exe"))
+            let exec = fixturePath.appending(RelativePath(".build/debug/exe"))
             // Note: <rdar://problem/59738569> Source from LANG and -AppleLanguages on command line for Linux resources
             let output = try Process.checkNonZeroExit(args: exec.pathString, "-AppleLanguages", "(en_US)")
             XCTAssertEqual(output, """
@@ -47,8 +47,8 @@ class ResourcesTests: XCTestCase {
         }
     }
 
-    func testMovedBinaryResources() {
-        fixture(name: "Resources/Moved") { prefix in
+    func testMovedBinaryResources() throws {
+        try fixture(name: "Resources/Moved") { fixturePath in
             var executables = ["SwiftyResource"]
 
             // Objective-C module requires macOS
@@ -57,12 +57,12 @@ class ResourcesTests: XCTestCase {
             #endif
 
             let binPath = try AbsolutePath(
-                executeSwiftBuild(prefix, configuration: .Release, extraArgs: ["--show-bin-path"]).stdout
+                executeSwiftBuild(fixturePath, configuration: .Release, extraArgs: ["--show-bin-path"]).stdout
                     .trimmingCharacters(in: .whitespacesAndNewlines)
             )
 
             for execName in executables {
-                _ = try executeSwiftBuild(prefix, configuration: .Release, extraArgs: ["--product", execName])
+                _ = try executeSwiftBuild(fixturePath, configuration: .Release, extraArgs: ["--product", execName])
 
                 try withTemporaryDirectory(prefix: execName) { tmpDirPath in
                     defer {

--- a/Tests/FunctionalTests/SwiftPMXCTestHelperTests.swift
+++ b/Tests/FunctionalTests/SwiftPMXCTestHelperTests.swift
@@ -17,14 +17,16 @@ import XCTest
 
 class SwiftPMXCTestHelperTests: XCTestCase {
     func testBasicXCTestHelper() throws {
-      #if os(macOS)
-        fixture(name: "Miscellaneous/SwiftPMXCTestHelper") { prefix in
+        #if !os(macOS)
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
+        try fixture(name: "Miscellaneous/SwiftPMXCTestHelper") { fixturePath in
             // Build the package.
-            XCTAssertBuilds(prefix)
+            XCTAssertBuilds(fixturePath)
             let triple = UserToolchain.default.triple
-            XCTAssertFileExists(prefix.appending(components: ".build", triple.platformBuildPathComponent(), "debug", "SwiftPMXCTestHelper.swiftmodule"))
+            XCTAssertFileExists(fixturePath.appending(components: ".build", triple.platformBuildPathComponent(), "debug", "SwiftPMXCTestHelper.swiftmodule"))
             // Run swift-test on package.
-            XCTAssertSwiftTest(prefix)
+            XCTAssertSwiftTest(fixturePath)
             // Expected output dictionary.
             let testCases = ["name": "All Tests", "tests": [["name" : "SwiftPMXCTestHelperPackageTests.xctest",
                 "tests": [
@@ -39,16 +41,12 @@ class SwiftPMXCTestHelperTests: XCTestCase {
               ] as Array<Dictionary<String, Any>>]] as Array<Dictionary<String, Any>>
             ] as Dictionary<String, Any> as NSDictionary
             // Run the XCTest helper tool and check result.
-            XCTAssertXCTestHelper(prefix.appending(components: ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug", "SwiftPMXCTestHelperPackageTests.xctest"), testCases: testCases)
+            try XCTAssertXCTestHelper(fixturePath.appending(components: ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug", "SwiftPMXCTestHelperPackageTests.xctest"), testCases: testCases)
         }
-      #endif
     }
-}
 
-
-#if os(macOS)
-func XCTAssertXCTestHelper(_ bundlePath: AbsolutePath, testCases: NSDictionary) {
-    do {
+    func XCTAssertXCTestHelper(_ bundlePath: AbsolutePath, testCases: NSDictionary) throws {
+        #if os(macOS)
         let env = ["DYLD_FRAMEWORK_PATH": ToolchainConfiguration.default.sdkPlatformFrameworksPath.pathString]
         let outputFile = bundlePath.parentDirectory.appending(component: "tests.txt")
         let _ = try SwiftPMProduct.XCTestHelper.execute([bundlePath.pathString, outputFile.pathString], env: env)
@@ -57,8 +55,8 @@ func XCTAssertXCTestHelper(_ bundlePath: AbsolutePath, testCases: NSDictionary) 
         }
         let json = try JSONSerialization.jsonObject(with: data as Data, options: []) as AnyObject
         XCTAssertTrue(json.isEqual(testCases), "\(json) is not equal to \(testCases)")
-    } catch {
-        XCTFail("Failed with error: \(error)")
+        #else
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
     }
 }
-#endif

--- a/Tests/FunctionalTests/TestDiscoveryTests.swift
+++ b/Tests/FunctionalTests/TestDiscoveryTests.swift
@@ -15,8 +15,8 @@ import XCTest
 
 class TestDiscoveryTests: XCTestCase {
     func testBuild() throws {
-        fixture(name: "Miscellaneous/TestDiscovery/Simple") { path in
-            let (stdout, _) = try executeSwiftBuild(path)
+        try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
+            let (stdout, _) = try executeSwiftBuild(fixturePath)
             #if os(macOS)
             XCTAssertMatch(stdout, .contains("module Simple"))
             #else
@@ -26,8 +26,8 @@ class TestDiscoveryTests: XCTestCase {
     }
 
     func testDiscovery() throws {
-        fixture(name: "Miscellaneous/TestDiscovery/Simple") { path in
-            let (stdout, stderr) = try executeSwiftTest(path)
+        try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
+            let (stdout, stderr) = try executeSwiftTest(fixturePath)
             #if os(macOS)
             XCTAssertMatch(stdout, .contains("module Simple"))
             XCTAssertMatch(stderr, .contains("Executed 3 tests"))
@@ -39,8 +39,8 @@ class TestDiscoveryTests: XCTestCase {
     }
 
     func testNonStandardName() throws {
-        fixture(name: "Miscellaneous/TestDiscovery/hello world") { path in
-            let (stdout, stderr) = try executeSwiftTest(path)
+        try fixture(name: "Miscellaneous/TestDiscovery/hello world") { fixturePath in
+            let (stdout, stderr) = try executeSwiftTest(fixturePath)
             #if os(macOS)
             XCTAssertMatch(stdout, .contains("module hello_world"))
             XCTAssertMatch(stderr, .contains("Executed 1 test"))
@@ -52,8 +52,8 @@ class TestDiscoveryTests: XCTestCase {
     }
 
     func testAsyncMethods() throws {
-        fixture(name: "Miscellaneous/TestDiscovery/Async") { path in
-            let (stdout, stderr) = try executeSwiftTest(path)
+        try fixture(name: "Miscellaneous/TestDiscovery/Async") { fixturePath in
+            let (stdout, stderr) = try executeSwiftTest(fixturePath)
             #if os(macOS)
             XCTAssertMatch(stdout, .contains("module Async"))
             XCTAssertMatch(stderr, .contains("Executed 4 tests"))
@@ -67,42 +67,40 @@ class TestDiscoveryTests: XCTestCase {
     func testManifestOverride() throws {
         #if os(macOS)
         try XCTSkipIf(true)
-        #else
-        SwiftTarget.testManifestNames.forEach { name in
-            fixture(name: "Miscellaneous/TestDiscovery/Simple") { path in
+        #endif
+        try SwiftTarget.testManifestNames.forEach { name in
+            try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
                 let random = UUID().uuidString
-                let manifestPath = path.appending(components: "Tests", name)
+                let manifestPath = fixturePath.appending(components: "Tests", name)
                 try localFileSystem.writeFileContents(manifestPath, bytes: ByteString("print(\"\(random)\")".utf8))
-                let (stdout, _) = try executeSwiftTest(path)
+                let (stdout, _) = try executeSwiftTest(fixturePath)
                 XCTAssertMatch(stdout, .contains("module Simple"))
                 XCTAssertNoMatch(stdout, .contains("Executed 1 test"))
                 XCTAssertMatch(stdout, .contains(random))
             }
         }
-        #endif
     }
 
     func testManifestOverrideIgnored() throws {
         #if os(macOS)
         try XCTSkipIf(true)
-        #else
+        #endif
         let name = SwiftTarget.testManifestNames.first!
-        fixture(name: "Miscellaneous/TestDiscovery/Simple") { path in
-            let manifestPath = path.appending(components: "Tests", name)
+        try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
+            let manifestPath = fixturePath.appending(components: "Tests", name)
             try localFileSystem.writeFileContents(manifestPath, bytes: ByteString("fatalError(\"should not be called\")".utf8))
-            let (stdout, _) = try executeSwiftTest(path, extraArgs: ["--enable-test-discovery"])
+            let (stdout, _) = try executeSwiftTest(fixturePath, extraArgs: ["--enable-test-discovery"])
             XCTAssertMatch(stdout, .contains("module Simple"))
             XCTAssertNoMatch(stdout, .contains("Executed 1 test"))
         }
-        #endif
     }
 
     func testTestExtensions() throws {
         #if os(macOS)
         try XCTSkipIf(true)
-        #else
-        fixture(name: "Miscellaneous/TestDiscovery/Extensions") { path in
-            let (stdout, _) = try executeSwiftTest(path, extraArgs: ["--enable-test-discovery"])
+        #endif
+        try fixture(name: "Miscellaneous/TestDiscovery/Extensions") { fixturePath in
+            let (stdout, _) = try executeSwiftTest(fixturePath, extraArgs: ["--enable-test-discovery"])
             XCTAssertMatch(stdout, .contains("module Simple"))
             XCTAssertMatch(stdout, .contains("SimpleTests1.testExample1"))
             XCTAssertMatch(stdout, .contains("SimpleTests1.testExample1_a"))
@@ -113,18 +111,16 @@ class TestDiscoveryTests: XCTestCase {
             XCTAssertMatch(stdout, .contains("SimpleTests4.testExample2"))
             XCTAssertMatch(stdout, .contains("Executed 7 tests"))
         }
-        #endif
     }
 
     func testDeprecatedTests() throws {
         #if os(macOS)
         try XCTSkipIf(true)
-        #else
-        fixture(name: "Miscellaneous/TestDiscovery/Deprecation") { path in
-            let (stdout, _) = try executeSwiftTest(path, extraArgs: ["--enable-test-discovery"])
+        #endif
+        try fixture(name: "Miscellaneous/TestDiscovery/Deprecation") { fixturePath in
+            let (stdout, _) = try executeSwiftTest(fixturePath, extraArgs: ["--enable-test-discovery"])
             XCTAssertMatch(stdout, .contains("Executed 2 tests"))
             XCTAssertNoMatch(stdout, .contains("is deprecated"))
         }
-        #endif
     }
 }

--- a/Tests/PackageCollectionsSigningTests/CertificatePolicyTests.swift
+++ b/Tests/PackageCollectionsSigningTests/CertificatePolicyTests.swift
@@ -20,14 +20,14 @@ class CertificatePolicyTests: XCTestCase {
     func test_RSA_validate_happyCase() throws {
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
-            let certPath = directoryPath.appending(components: "Signing", "Test_rsa.cer")
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
+            let certPath = fixturePath.appending(components: "Signing", "Test_rsa.cer")
             let certificate = try Certificate(derEncoded: try localFileSystem.readFileContents(certPath))
 
-            let intermediateCAPath = directoryPath.appending(components: "Signing", "TestIntermediateCA.cer")
+            let intermediateCAPath = fixturePath.appending(components: "Signing", "TestIntermediateCA.cer")
             let intermediateCA = try Certificate(derEncoded: try localFileSystem.readFileContents(intermediateCAPath))
 
-            let rootCAPath = directoryPath.appending(components: "Signing", "TestRootCA.cer")
+            let rootCAPath = fixturePath.appending(components: "Signing", "TestRootCA.cer")
             let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath))
 
             let certChain = [certificate, intermediateCA, rootCA]
@@ -40,14 +40,14 @@ class CertificatePolicyTests: XCTestCase {
     func test_EC_validate_happyCase() throws {
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
-            let certPath = directoryPath.appending(components: "Signing", "Test_ec.cer")
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
+            let certPath = fixturePath.appending(components: "Signing", "Test_ec.cer")
             let certificate = try Certificate(derEncoded: try localFileSystem.readFileContents(certPath))
 
-            let intermediateCAPath = directoryPath.appending(components: "Signing", "TestIntermediateCA.cer")
+            let intermediateCAPath = fixturePath.appending(components: "Signing", "TestIntermediateCA.cer")
             let intermediateCA = try Certificate(derEncoded: try localFileSystem.readFileContents(intermediateCAPath))
 
-            let rootCAPath = directoryPath.appending(components: "Signing", "TestRootCA.cer")
+            let rootCAPath = fixturePath.appending(components: "Signing", "TestRootCA.cer")
             let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath))
 
             let certChain = [certificate, intermediateCA, rootCA]
@@ -60,14 +60,14 @@ class CertificatePolicyTests: XCTestCase {
     func test_validate_untrustedRoot() throws {
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
-            let certPath = directoryPath.appending(components: "Signing", "Test_rsa.cer")
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
+            let certPath = fixturePath.appending(components: "Signing", "Test_rsa.cer")
             let certificate = try Certificate(derEncoded: try localFileSystem.readFileContents(certPath))
 
-            let intermediateCAPath = directoryPath.appending(components: "Signing", "TestIntermediateCA.cer")
+            let intermediateCAPath = fixturePath.appending(components: "Signing", "TestIntermediateCA.cer")
             let intermediateCA = try Certificate(derEncoded: try localFileSystem.readFileContents(intermediateCAPath))
 
-            let rootCAPath = directoryPath.appending(components: "Signing", "TestRootCA.cer")
+            let rootCAPath = fixturePath.appending(components: "Signing", "TestRootCA.cer")
             let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath))
 
             let certChain = [certificate, intermediateCA, rootCA]
@@ -91,14 +91,14 @@ class CertificatePolicyTests: XCTestCase {
     func test_validate_expiredCert() throws {
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
-            let certPath = directoryPath.appending(components: "Signing", "Test_rsa.cer")
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
+            let certPath = fixturePath.appending(components: "Signing", "Test_rsa.cer")
             let certificate = try Certificate(derEncoded: try localFileSystem.readFileContents(certPath))
 
-            let intermediateCAPath = directoryPath.appending(components: "Signing", "TestIntermediateCA.cer")
+            let intermediateCAPath = fixturePath.appending(components: "Signing", "TestIntermediateCA.cer")
             let intermediateCA = try Certificate(derEncoded: try localFileSystem.readFileContents(intermediateCAPath))
 
-            let rootCAPath = directoryPath.appending(components: "Signing", "TestRootCA.cer")
+            let rootCAPath = fixturePath.appending(components: "Signing", "TestRootCA.cer")
             let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath))
 
             let certChain = [certificate, intermediateCA, rootCA]
@@ -121,14 +121,14 @@ class CertificatePolicyTests: XCTestCase {
 
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
-            let certPath = directoryPath.appending(components: "Signing", "development-revoked.cer")
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
+            let certPath = fixturePath.appending(components: "Signing", "development-revoked.cer")
             let certificate = try Certificate(derEncoded: try localFileSystem.readFileContents(certPath))
 
-            let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCAG3.cer")
+            let intermediateCAPath = fixturePath.appending(components: "Signing", "AppleWWDRCAG3.cer")
             let intermediateCA = try Certificate(derEncoded: try localFileSystem.readFileContents(intermediateCAPath))
 
-            let rootCAPath = directoryPath.appending(components: "Signing", "AppleIncRoot.cer")
+            let rootCAPath = fixturePath.appending(components: "Signing", "AppleIncRoot.cer")
             let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath))
 
             let certChain = [certificate, intermediateCA, rootCA]
@@ -168,14 +168,14 @@ class CertificatePolicyTests: XCTestCase {
 
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
-            let certPath = directoryPath.appending(components: "Signing", "development.cer")
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
+            let certPath = fixturePath.appending(components: "Signing", "development.cer")
             let certificate = try Certificate(derEncoded: try localFileSystem.readFileContents(certPath))
 
-            let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCAG3.cer")
+            let intermediateCAPath = fixturePath.appending(components: "Signing", "AppleWWDRCAG3.cer")
             let intermediateCA = try Certificate(derEncoded: try localFileSystem.readFileContents(intermediateCAPath))
 
-            let rootCAPath = directoryPath.appending(components: "Signing", "AppleIncRoot.cer")
+            let rootCAPath = fixturePath.appending(components: "Signing", "AppleIncRoot.cer")
             let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath))
 
             let certChain = [certificate, intermediateCA, rootCA]
@@ -236,15 +236,15 @@ class CertificatePolicyTests: XCTestCase {
 
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             // This must be an Apple Swift Package Collection cert
-            let certPath = directoryPath.appending(components: "Signing", "swift_package_collection.cer")
+            let certPath = fixturePath.appending(components: "Signing", "swift_package_collection.cer")
             let certificate = try Certificate(derEncoded: try localFileSystem.readFileContents(certPath))
 
-            let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCA.cer")
+            let intermediateCAPath = fixturePath.appending(components: "Signing", "AppleWWDRCA.cer")
             let intermediateCA = try Certificate(derEncoded: try localFileSystem.readFileContents(intermediateCAPath))
 
-            let rootCAPath = directoryPath.appending(components: "Signing", "AppleIncRoot.cer")
+            let rootCAPath = fixturePath.appending(components: "Signing", "AppleIncRoot.cer")
             let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath))
 
             let certChain = [certificate, intermediateCA, rootCA]
@@ -305,15 +305,15 @@ class CertificatePolicyTests: XCTestCase {
 
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             // This must be an Apple Distribution cert
-            let certPath = directoryPath.appending(components: "Signing", "development.cer")
+            let certPath = fixturePath.appending(components: "Signing", "development.cer")
             let certificate = try Certificate(derEncoded: try localFileSystem.readFileContents(certPath))
 
-            let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCAG3.cer")
+            let intermediateCAPath = fixturePath.appending(components: "Signing", "AppleWWDRCAG3.cer")
             let intermediateCA = try Certificate(derEncoded: try localFileSystem.readFileContents(intermediateCAPath))
 
-            let rootCAPath = directoryPath.appending(components: "Signing", "AppleIncRoot.cer")
+            let rootCAPath = fixturePath.appending(components: "Signing", "AppleIncRoot.cer")
             let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath))
 
             let certChain = [certificate, intermediateCA, rootCA]
@@ -374,14 +374,14 @@ class CertificatePolicyTests: XCTestCase {
 
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
-            let certPath = directoryPath.appending(components: "Signing", "development.cer")
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
+            let certPath = fixturePath.appending(components: "Signing", "development.cer")
             let certificate = try Certificate(derEncoded: try localFileSystem.readFileContents(certPath))
 
-            let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCAG3.cer")
+            let intermediateCAPath = fixturePath.appending(components: "Signing", "AppleWWDRCAG3.cer")
             let intermediateCA = try Certificate(derEncoded: try localFileSystem.readFileContents(intermediateCAPath))
 
-            let rootCAPath = directoryPath.appending(components: "Signing", "AppleIncRoot.cer")
+            let rootCAPath = fixturePath.appending(components: "Signing", "AppleIncRoot.cer")
             let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath))
 
             let certChain = [certificate, intermediateCA, rootCA]
@@ -449,15 +449,15 @@ class CertificatePolicyTests: XCTestCase {
 
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             // This must be an Apple Swift Package Collection cert
-            let certPath = directoryPath.appending(components: "Signing", "swift_package_collection.cer")
+            let certPath = fixturePath.appending(components: "Signing", "swift_package_collection.cer")
             let certificate = try Certificate(derEncoded: try localFileSystem.readFileContents(certPath))
 
-            let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCA.cer")
+            let intermediateCAPath = fixturePath.appending(components: "Signing", "AppleWWDRCA.cer")
             let intermediateCA = try Certificate(derEncoded: try localFileSystem.readFileContents(intermediateCAPath))
 
-            let rootCAPath = directoryPath.appending(components: "Signing", "AppleIncRoot.cer")
+            let rootCAPath = fixturePath.appending(components: "Signing", "AppleIncRoot.cer")
             let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath))
 
             let certChain = [certificate, intermediateCA, rootCA]
@@ -527,15 +527,15 @@ class CertificatePolicyTests: XCTestCase {
 
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             // This must be an Apple Distribution cert
-            let certPath = directoryPath.appending(components: "Signing", "development.cer")
+            let certPath = fixturePath.appending(components: "Signing", "development.cer")
             let certificate = try Certificate(derEncoded: try localFileSystem.readFileContents(certPath))
 
-            let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCAG3.cer")
+            let intermediateCAPath = fixturePath.appending(components: "Signing", "AppleWWDRCAG3.cer")
             let intermediateCA = try Certificate(derEncoded: try localFileSystem.readFileContents(intermediateCAPath))
 
-            let rootCAPath = directoryPath.appending(components: "Signing", "AppleIncRoot.cer")
+            let rootCAPath = fixturePath.appending(components: "Signing", "AppleIncRoot.cer")
             let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath))
 
             let certChain = [certificate, intermediateCA, rootCA]

--- a/Tests/PackageCollectionsSigningTests/CertificateTests.swift
+++ b/Tests/PackageCollectionsSigningTests/CertificateTests.swift
@@ -19,8 +19,8 @@ class CertificateTests: XCTestCase {
     func test_withRSAKey_fromDER() throws {
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
-            let path = directoryPath.appending(components: "Signing", "Test_rsa.cer")
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
+            let path = fixturePath.appending(components: "Signing", "Test_rsa.cer")
             let data: Data = try localFileSystem.readFileContents(path)
 
             let certificate = try Certificate(derEncoded: data)
@@ -42,8 +42,8 @@ class CertificateTests: XCTestCase {
     func test_withECKey_fromDER() throws {
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
-            let path = directoryPath.appending(components: "Signing", "Test_ec.cer")
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
+            let path = fixturePath.appending(components: "Signing", "Test_ec.cer")
             let data: Data = try localFileSystem.readFileContents(path)
 
             let certificate = try Certificate(derEncoded: data)

--- a/Tests/PackageCollectionsSigningTests/KeyTests+EC.swift
+++ b/Tests/PackageCollectionsSigningTests/KeyTests+EC.swift
@@ -19,8 +19,8 @@ class ECKeyTests: XCTestCase {
     func testPublicKeyFromCertificate() throws {
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
-            let path = directoryPath.appending(components: "Signing", "Test_ec.cer")
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
+            let path = fixturePath.appending(components: "Signing", "Test_ec.cer")
             let data: Data = try localFileSystem.readFileContents(path)
 
             let certificate = try Certificate(derEncoded: data)

--- a/Tests/PackageCollectionsSigningTests/KeyTests+RSA.swift
+++ b/Tests/PackageCollectionsSigningTests/KeyTests+RSA.swift
@@ -19,8 +19,8 @@ class RSAKeyTests: XCTestCase {
     func testPublicKeyFromCertificate() throws {
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
-            let path = directoryPath.appending(components: "Signing", "Test_rsa.cer")
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
+            let path = fixturePath.appending(components: "Signing", "Test_rsa.cer")
             let data: Data = try localFileSystem.readFileContents(path)
 
             let certificate = try Certificate(derEncoded: data)

--- a/Tests/PackageCollectionsSigningTests/PackageCollectionSigningTest.swift
+++ b/Tests/PackageCollectionsSigningTests/PackageCollectionSigningTest.swift
@@ -21,19 +21,19 @@ class PackageCollectionSigningTests: XCTestCase {
     func test_RSA_signAndValidate_happyCase() throws {
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let jsonDecoder = JSONDecoder.makeWithDefaults()
 
-            let collectionPath = directoryPath.appending(components: "JSON", "good.json")
+            let collectionPath = fixturePath.appending(components: "JSON", "good.json")
             let collectionData: Data = try localFileSystem.readFileContents(collectionPath)
             let collection = try jsonDecoder.decode(PackageCollectionModel.V1.Collection.self, from: collectionData)
 
-            let certPath = directoryPath.appending(components: "Signing", "Test_rsa.cer")
-            let intermediateCAPath = directoryPath.appending(components: "Signing", "TestIntermediateCA.cer")
-            let rootCAPath = directoryPath.appending(components: "Signing", "TestRootCA.cer")
+            let certPath = fixturePath.appending(components: "Signing", "Test_rsa.cer")
+            let intermediateCAPath = fixturePath.appending(components: "Signing", "TestIntermediateCA.cer")
+            let rootCAPath = fixturePath.appending(components: "Signing", "TestRootCA.cer")
             let certChainPaths = [certPath, intermediateCAPath, rootCAPath].map { $0.asURL }
 
-            let privateKeyPath = directoryPath.appending(components: "Signing", "Test_rsa_key.pem")
+            let privateKeyPath = fixturePath.appending(components: "Signing", "Test_rsa_key.pem")
 
             let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath))
             // Trust the self-signed root cert
@@ -53,7 +53,7 @@ class PackageCollectionSigningTests: XCTestCase {
     func test_RSA_signAndValidate_collectionMismatch() throws {
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let collection1 = PackageCollectionModel.V1.Collection(
                 name: "Test Package Collection 1",
                 overview: nil,
@@ -75,12 +75,12 @@ class PackageCollectionSigningTests: XCTestCase {
                 generatedBy: nil
             )
 
-            let certPath = directoryPath.appending(components: "Signing", "Test_rsa.cer")
-            let intermediateCAPath = directoryPath.appending(components: "Signing", "TestIntermediateCA.cer")
-            let rootCAPath = directoryPath.appending(components: "Signing", "TestRootCA.cer")
+            let certPath = fixturePath.appending(components: "Signing", "Test_rsa.cer")
+            let intermediateCAPath = fixturePath.appending(components: "Signing", "TestIntermediateCA.cer")
+            let rootCAPath = fixturePath.appending(components: "Signing", "TestRootCA.cer")
             let certChainPaths = [certPath, intermediateCAPath, rootCAPath].map { $0.asURL }
 
-            let privateKeyPath = directoryPath.appending(components: "Signing", "Test_rsa_key.pem")
+            let privateKeyPath = fixturePath.appending(components: "Signing", "Test_rsa_key.pem")
 
             let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath))
             // Trust the self-signed root cert
@@ -109,19 +109,19 @@ class PackageCollectionSigningTests: XCTestCase {
     func test_EC_signAndValidate_happyCase() throws {
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let jsonDecoder = JSONDecoder.makeWithDefaults()
 
-            let collectionPath = directoryPath.appending(components: "JSON", "good.json")
+            let collectionPath = fixturePath.appending(components: "JSON", "good.json")
             let collectionData: Data = try localFileSystem.readFileContents(collectionPath)
             let collection = try jsonDecoder.decode(PackageCollectionModel.V1.Collection.self, from: collectionData)
 
-            let certPath = directoryPath.appending(components: "Signing", "Test_ec.cer")
-            let intermediateCAPath = directoryPath.appending(components: "Signing", "TestIntermediateCA.cer")
-            let rootCAPath = directoryPath.appending(components: "Signing", "TestRootCA.cer")
+            let certPath = fixturePath.appending(components: "Signing", "Test_ec.cer")
+            let intermediateCAPath = fixturePath.appending(components: "Signing", "TestIntermediateCA.cer")
+            let rootCAPath = fixturePath.appending(components: "Signing", "TestRootCA.cer")
             let certChainPaths = [certPath, intermediateCAPath, rootCAPath].map { $0.asURL }
 
-            let privateKeyPath = directoryPath.appending(components: "Signing", "Test_ec_key.pem")
+            let privateKeyPath = fixturePath.appending(components: "Signing", "Test_ec_key.pem")
 
             let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath))
             // Trust the self-signed root cert
@@ -141,7 +141,7 @@ class PackageCollectionSigningTests: XCTestCase {
     func test_EC_signAndValidate_collectionMismatch() throws {
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let collection1 = PackageCollectionModel.V1.Collection(
                 name: "Test Package Collection 1",
                 overview: nil,
@@ -163,12 +163,12 @@ class PackageCollectionSigningTests: XCTestCase {
                 generatedBy: nil
             )
 
-            let certPath = directoryPath.appending(components: "Signing", "Test_ec.cer")
-            let intermediateCAPath = directoryPath.appending(components: "Signing", "TestIntermediateCA.cer")
-            let rootCAPath = directoryPath.appending(components: "Signing", "TestRootCA.cer")
+            let certPath = fixturePath.appending(components: "Signing", "Test_ec.cer")
+            let intermediateCAPath = fixturePath.appending(components: "Signing", "TestIntermediateCA.cer")
+            let rootCAPath = fixturePath.appending(components: "Signing", "TestRootCA.cer")
             let certChainPaths = [certPath, intermediateCAPath, rootCAPath].map { $0.asURL }
 
-            let privateKeyPath = directoryPath.appending(components: "Signing", "Test_ec_key.pem")
+            let privateKeyPath = fixturePath.appending(components: "Signing", "Test_ec_key.pem")
 
             let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath))
             // Trust the self-signed root cert
@@ -202,20 +202,20 @@ class PackageCollectionSigningTests: XCTestCase {
 
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let jsonDecoder = JSONDecoder.makeWithDefaults()
 
-            let collectionPath = directoryPath.appending(components: "JSON", "good.json")
+            let collectionPath = fixturePath.appending(components: "JSON", "good.json")
             let collectionData: Data = try localFileSystem.readFileContents(collectionPath)
             let collection = try jsonDecoder.decode(PackageCollectionModel.V1.Collection.self, from: collectionData)
 
-            let certPath = directoryPath.appending(components: "Signing", "development.cer")
-            let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCAG3.cer")
-            let rootCAPath = directoryPath.appending(components: "Signing", "AppleIncRoot.cer")
+            let certPath = fixturePath.appending(components: "Signing", "development.cer")
+            let intermediateCAPath = fixturePath.appending(components: "Signing", "AppleWWDRCAG3.cer")
+            let rootCAPath = fixturePath.appending(components: "Signing", "AppleIncRoot.cer")
             let rootCAData: Data = try localFileSystem.readFileContents(rootCAPath)
             let certChainPaths = [certPath, intermediateCAPath, rootCAPath].map { $0.asURL }
 
-            let privateKeyPath = directoryPath.appending(components: "Signing", "development-key.pem")
+            let privateKeyPath = fixturePath.appending(components: "Signing", "development-key.pem")
             let certPolicyKey: CertificatePolicyKey = .default
 
             #if os(macOS)
@@ -311,21 +311,21 @@ class PackageCollectionSigningTests: XCTestCase {
 
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let jsonDecoder = JSONDecoder.makeWithDefaults()
 
-            let collectionPath = directoryPath.appending(components: "JSON", "good.json")
+            let collectionPath = fixturePath.appending(components: "JSON", "good.json")
             let collectionData: Data = try localFileSystem.readFileContents(collectionPath)
             let collection = try jsonDecoder.decode(PackageCollectionModel.V1.Collection.self, from: collectionData)
 
             // This must be an Apple Distribution cert
-            let certPath = directoryPath.appending(components: "Signing", "development.cer")
-            let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCAG3.cer")
-            let rootCAPath = directoryPath.appending(components: "Signing", "AppleIncRoot.cer")
+            let certPath = fixturePath.appending(components: "Signing", "development.cer")
+            let intermediateCAPath = fixturePath.appending(components: "Signing", "AppleWWDRCAG3.cer")
+            let rootCAPath = fixturePath.appending(components: "Signing", "AppleIncRoot.cer")
             let rootCAData: Data = try localFileSystem.readFileContents(rootCAPath)
             let certChainPaths = [certPath, intermediateCAPath, rootCAPath].map { $0.asURL }
 
-            let privateKeyPath = directoryPath.appending(components: "Signing", "development-key.pem")
+            let privateKeyPath = fixturePath.appending(components: "Signing", "development-key.pem")
             let certPolicyKey: CertificatePolicyKey = .appleDistribution
 
             #if os(macOS)
@@ -405,21 +405,21 @@ class PackageCollectionSigningTests: XCTestCase {
 
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let jsonDecoder = JSONDecoder.makeWithDefaults()
 
-            let collectionPath = directoryPath.appending(components: "JSON", "good.json")
+            let collectionPath = fixturePath.appending(components: "JSON", "good.json")
             let collectionData: Data = try localFileSystem.readFileContents(collectionPath)
             let collection = try jsonDecoder.decode(PackageCollectionModel.V1.Collection.self, from: collectionData)
 
             // This must be an Apple Swift Package Collection cert
-            let certPath = directoryPath.appending(components: "Signing", "swift_package_collection.cer")
-            let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCA.cer")
-            let rootCAPath = directoryPath.appending(components: "Signing", "AppleIncRoot.cer")
+            let certPath = fixturePath.appending(components: "Signing", "swift_package_collection.cer")
+            let intermediateCAPath = fixturePath.appending(components: "Signing", "AppleWWDRCA.cer")
+            let rootCAPath = fixturePath.appending(components: "Signing", "AppleIncRoot.cer")
             let rootCAData: Data = try localFileSystem.readFileContents(rootCAPath)
             let certChainPaths = [certPath, intermediateCAPath, rootCAPath].map { $0.asURL }
 
-            let privateKeyPath = directoryPath.appending(components: "Signing", "development-key.pem")
+            let privateKeyPath = fixturePath.appending(components: "Signing", "development-key.pem")
             let certPolicyKey: CertificatePolicyKey = .appleSwiftPackageCollection
 
             #if os(macOS)
@@ -499,19 +499,19 @@ class PackageCollectionSigningTests: XCTestCase {
 
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let jsonDecoder = JSONDecoder.makeWithDefaults()
 
-            let collectionPath = directoryPath.appending(components: "JSON", "good.json")
+            let collectionPath = fixturePath.appending(components: "JSON", "good.json")
             let collectionData: Data = try localFileSystem.readFileContents(collectionPath)
             let collection = try jsonDecoder.decode(PackageCollectionModel.V1.Collection.self, from: collectionData)
 
-            let certPath = directoryPath.appending(components: "Signing", "development.cer")
-            let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCAG3.cer")
-            let rootCAPath = directoryPath.appending(components: "Signing", "AppleIncRoot.cer")
+            let certPath = fixturePath.appending(components: "Signing", "development.cer")
+            let intermediateCAPath = fixturePath.appending(components: "Signing", "AppleWWDRCAG3.cer")
+            let rootCAPath = fixturePath.appending(components: "Signing", "AppleIncRoot.cer")
             let certChainPaths = [certPath, intermediateCAPath, rootCAPath].map { $0.asURL }
 
-            let privateKeyPath = directoryPath.appending(components: "Signing", "development-key.pem")
+            let privateKeyPath = fixturePath.appending(components: "Signing", "development-key.pem")
             let certPolicyKey: CertificatePolicyKey = .default(subjectUserID: expectedSubjectUserID)
 
             #if os(macOS)
@@ -553,20 +553,20 @@ class PackageCollectionSigningTests: XCTestCase {
 
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let jsonDecoder = JSONDecoder.makeWithDefaults()
 
-            let collectionPath = directoryPath.appending(components: "JSON", "good.json")
+            let collectionPath = fixturePath.appending(components: "JSON", "good.json")
             let collectionData: Data = try localFileSystem.readFileContents(collectionPath)
             let collection = try jsonDecoder.decode(PackageCollectionModel.V1.Collection.self, from: collectionData)
 
             // This must be an Apple Distribution cert
-            let certPath = directoryPath.appending(components: "Signing", "development.cer")
-            let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCAG3.cer")
-            let rootCAPath = directoryPath.appending(components: "Signing", "AppleIncRoot.cer")
+            let certPath = fixturePath.appending(components: "Signing", "development.cer")
+            let intermediateCAPath = fixturePath.appending(components: "Signing", "AppleWWDRCAG3.cer")
+            let rootCAPath = fixturePath.appending(components: "Signing", "AppleIncRoot.cer")
             let certChainPaths = [certPath, intermediateCAPath, rootCAPath].map { $0.asURL }
 
-            let privateKeyPath = directoryPath.appending(components: "Signing", "development-key.pem")
+            let privateKeyPath = fixturePath.appending(components: "Signing", "development-key.pem")
             let certPolicyKey: CertificatePolicyKey = .appleDistribution(subjectUserID: expectedSubjectUserID)
 
             #if os(macOS)
@@ -618,20 +618,20 @@ class PackageCollectionSigningTests: XCTestCase {
 
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let jsonDecoder = JSONDecoder.makeWithDefaults()
 
-            let collectionPath = directoryPath.appending(components: "JSON", "good.json")
+            let collectionPath = fixturePath.appending(components: "JSON", "good.json")
             let collectionData: Data = try localFileSystem.readFileContents(collectionPath)
             let collection = try jsonDecoder.decode(PackageCollectionModel.V1.Collection.self, from: collectionData)
 
             // This must be an Apple Distribution cert
-            let certPath = directoryPath.appending(components: "Signing", "swift_package_collection.cer")
-            let intermediateCAPath = directoryPath.appending(components: "Signing", "AppleWWDRCA.cer")
-            let rootCAPath = directoryPath.appending(components: "Signing", "AppleIncRoot.cer")
+            let certPath = fixturePath.appending(components: "Signing", "swift_package_collection.cer")
+            let intermediateCAPath = fixturePath.appending(components: "Signing", "AppleWWDRCA.cer")
+            let rootCAPath = fixturePath.appending(components: "Signing", "AppleIncRoot.cer")
             let certChainPaths = [certPath, intermediateCAPath, rootCAPath].map { $0.asURL }
 
-            let privateKeyPath = directoryPath.appending(components: "Signing", "development-key.pem")
+            let privateKeyPath = fixturePath.appending(components: "Signing", "development-key.pem")
             let certPolicyKey: CertificatePolicyKey = .appleSwiftPackageCollection(subjectUserID: expectedSubjectUserID)
 
             #if os(macOS)

--- a/Tests/PackageCollectionsSigningTests/SignatureTests.swift
+++ b/Tests/PackageCollectionsSigningTests/SignatureTests.swift
@@ -19,13 +19,13 @@ class SignatureTests: XCTestCase {
     func test_RS256_generateAndValidate_happyCase() throws {
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let jsonEncoder = JSONEncoder()
             let jsonDecoder = JSONDecoder()
 
             let payload = ["foo": "bar"]
 
-            let certPath = directoryPath.appending(components: "Signing", "Test_rsa.cer")
+            let certPath = fixturePath.appending(components: "Signing", "Test_rsa.cer")
             let certData: Data = try localFileSystem.readFileContents(certPath)
             let base64EncodedCert = certData.base64EncodedString()
             let certificate = try Certificate(derEncoded: certData)
@@ -45,13 +45,13 @@ class SignatureTests: XCTestCase {
     func test_RS256_generateAndValidate_keyMismatch() throws {
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let jsonEncoder = JSONEncoder()
             let jsonDecoder = JSONDecoder()
 
             let payload = ["foo": "bar"]
 
-            let certPath = directoryPath.appending(components: "Signing", "Test_rsa.cer")
+            let certPath = fixturePath.appending(components: "Signing", "Test_rsa.cer")
             let certData: Data = try localFileSystem.readFileContents(certPath)
             let base64EncodedCert = certData.base64EncodedString()
             let certificate = try Certificate(derEncoded: certData)
@@ -74,13 +74,13 @@ class SignatureTests: XCTestCase {
     func test_ES256_generateAndValidate_happyCase() throws {
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let jsonEncoder = JSONEncoder()
             let jsonDecoder = JSONDecoder()
 
             let payload = ["foo": "bar"]
 
-            let certPath = directoryPath.appending(components: "Signing", "Test_ec.cer")
+            let certPath = fixturePath.appending(components: "Signing", "Test_ec.cer")
             let certData: Data = try localFileSystem.readFileContents(certPath)
             let base64EncodedCert = certData.base64EncodedString()
             let certificate = try Certificate(derEncoded: certData)
@@ -100,13 +100,13 @@ class SignatureTests: XCTestCase {
     func test_ES256_generateAndValidate_keyMismatch() throws {
         try skipIfUnsupportedPlatform()
 
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let jsonEncoder = JSONEncoder()
             let jsonDecoder = JSONDecoder()
 
             let payload = ["foo": "bar"]
 
-            let certPath = directoryPath.appending(components: "Signing", "Test_ec.cer")
+            let certPath = fixturePath.appending(components: "Signing", "Test_ec.cer")
             let certData: Data = try localFileSystem.readFileContents(certPath)
             let base64EncodedCert = certData.base64EncodedString()
             let certificate = try Certificate(derEncoded: certData)

--- a/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
+++ b/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
@@ -46,41 +46,41 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
             let apiURL = URL(string: "https://api.github.com/repos/octocat/Hello-World")!
             let releasesURL = URL(string: "https://api.github.com/repos/octocat/Hello-World/releases?per_page=20")!
 
-            fixture(name: "Collections", createGitRepo: false) { directoryPath in
+            try fixture(name: "Collections", createGitRepo: false) { fixturePath in
                 let handler: HTTPClient.Handler = { request, _, completion in
                     switch (request.method, request.url) {
                     case (.get, apiURL):
-                        let path = directoryPath.appending(components: "GitHub", "metadata.json")
+                        let path = fixturePath.appending(components: "GitHub", "metadata.json")
                         let data: Data = try! localFileSystem.readFileContents(path)
                         completion(.success(.init(statusCode: 200,
                                                   headers: .init([.init(name: "Content-Length", value: "\(data.count)")]),
                                                   body: data)))
                     case (.get, releasesURL):
-                        let path = directoryPath.appending(components: "GitHub", "releases.json")
+                        let path = fixturePath.appending(components: "GitHub", "releases.json")
                         let data: Data = try! localFileSystem.readFileContents(path)
                         completion(.success(.init(statusCode: 200,
                                                   headers: .init([.init(name: "Content-Length", value: "\(data.count)")]),
                                                   body: data)))
                     case (.get, apiURL.appendingPathComponent("contributors")):
-                        let path = directoryPath.appending(components: "GitHub", "contributors.json")
+                        let path = fixturePath.appending(components: "GitHub", "contributors.json")
                         let data: Data = try! localFileSystem.readFileContents(path)
                         completion(.success(.init(statusCode: 200,
                                                   headers: .init([.init(name: "Content-Length", value: "\(data.count)")]),
                                                   body: data)))
                     case (.get, apiURL.appendingPathComponent("readme")):
-                        let path = directoryPath.appending(components: "GitHub", "readme.json")
+                        let path = fixturePath.appending(components: "GitHub", "readme.json")
                         let data: Data = try! localFileSystem.readFileContents(path)
                         completion(.success(.init(statusCode: 200,
                                                   headers: .init([.init(name: "Content-Length", value: "\(data.count)")]),
                                                   body: data)))
                     case (.get, apiURL.appendingPathComponent("license")):
-                        let path = directoryPath.appending(components: "GitHub", "license.json")
+                        let path = fixturePath.appending(components: "GitHub", "license.json")
                         let data: Data = try! localFileSystem.readFileContents(path)
                         completion(.success(.init(statusCode: 200,
                                                   headers: .init([.init(name: "Content-Length", value: "\(data.count)")]),
                                                   body: data)))
                     case (.get, apiURL.appendingPathComponent("languages")):
-                        let path = directoryPath.appending(components: "GitHub", "languages.json")
+                        let path = fixturePath.appending(components: "GitHub", "languages.json")
                         let data: Data = try! localFileSystem.readFileContents(path)
                         completion(.success(.init(statusCode: 200,
                                                   headers: .init([.init(name: "Content-Length", value: "\(data.count)")]),
@@ -147,8 +147,8 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
             let repoURL = URL(string: "https://github.com/octocat/Hello-World.git")!
             let apiURL = URL(string: "https://api.github.com/repos/octocat/Hello-World")!
 
-            fixture(name: "Collections", createGitRepo: false) { directoryPath in
-                let path = directoryPath.appending(components: "GitHub", "metadata.json")
+            try fixture(name: "Collections", createGitRepo: false) { fixturePath in
+                let path = fixturePath.appending(components: "GitHub", "metadata.json")
                 let data = try Data(localFileSystem.readFileContents(path).contents)
                 let handler: HTTPClient.Handler = { request, _, completion in
                     switch (request.method, request.url) {
@@ -241,8 +241,8 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
             let total = 5
             var remaining = total
 
-            fixture(name: "Collections", createGitRepo: false) { directoryPath in
-                let path = directoryPath.appending(components: "GitHub", "metadata.json")
+            try fixture(name: "Collections", createGitRepo: false) { fixturePath in
+                let path = fixturePath.appending(components: "GitHub", "metadata.json")
                 let data = try Data(localFileSystem.readFileContents(path).contents)
                 let handler: HTTPClient.Handler = { request, _, completion in
                     var headers = HTTPClientHeaders()
@@ -286,7 +286,7 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
 
     func testInvalidURL() throws {
         try testWithTemporaryDirectory { tmpPath in
-            fixture(name: "Collections", createGitRepo: false) { _ in
+            try fixture(name: "Collections", createGitRepo: false) { _ in
                 var configuration = GitHubPackageMetadataProvider.Configuration()
                 configuration.cacheDir = tmpPath
                 let provider = GitHubPackageMetadataProvider(configuration: configuration)
@@ -303,7 +303,7 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
 
     func testInvalidURL2() throws {
         try testWithTemporaryDirectory { tmpPath in
-            fixture(name: "Collections", createGitRepo: false) { _ in
+            try fixture(name: "Collections", createGitRepo: false) { _ in
                 var configuration = GitHubPackageMetadataProvider.Configuration()
                 configuration.cacheDir = tmpPath
                 let provider = GitHubPackageMetadataProvider(configuration: configuration)

--- a/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
+++ b/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
@@ -21,8 +21,8 @@ import TSCBasic
 
 class JSONPackageCollectionProviderTests: XCTestCase {
     func testGood() throws {
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
-            let path = directoryPath.appending(components: "JSON", "good.json")
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
+            let path = fixturePath.appending(components: "JSON", "good.json")
             let url = URL(string: "https://www.test.com/collection.json")!
             let data: Data = try localFileSystem.readFileContents(path)
 
@@ -83,8 +83,8 @@ class JSONPackageCollectionProviderTests: XCTestCase {
     }
 
     func testLocalFile() throws {
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
-            let path = directoryPath.appending(components: "JSON", "good.json")
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
+            let path = fixturePath.appending(components: "JSON", "good.json")
 
             var httpClient = HTTPClient(handler: { (_, _, _) -> Void in fatalError("should not be called") })
             httpClient.configuration.circuitBreakerStrategy = .none
@@ -360,8 +360,8 @@ class JSONPackageCollectionProviderTests: XCTestCase {
     func testSignedGood() throws {
         try skipIfSignatureCheckNotSupported()
 
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
-            let path = directoryPath.appending(components: "JSON", "good_signed.json")
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
+            let path = fixturePath.appending(components: "JSON", "good_signed.json")
             let url = URL(string: "https://www.test.com/collection.json")!
             let data: Data = try localFileSystem.readFileContents(path)
 
@@ -429,8 +429,8 @@ class JSONPackageCollectionProviderTests: XCTestCase {
     }
 
     func testSigned_skipSignatureCheck() throws {
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
-            let path = directoryPath.appending(components: "JSON", "good_signed.json")
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
+            let path = fixturePath.appending(components: "JSON", "good_signed.json")
             let url = URL(string: "https://www.test.com/collection.json")!
             let data: Data = try localFileSystem.readFileContents(path)
 
@@ -496,8 +496,8 @@ class JSONPackageCollectionProviderTests: XCTestCase {
     func testSigned_noTrustedRootCertsConfigured() throws {
         try skipIfSignatureCheckNotSupported()
 
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
-            let path = directoryPath.appending(components: "JSON", "good_signed.json")
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
+            let path = fixturePath.appending(components: "JSON", "good_signed.json")
             let url = URL(string: "https://www.test.com/collection.json")!
             let data: Data = try localFileSystem.readFileContents(path)
 
@@ -538,8 +538,8 @@ class JSONPackageCollectionProviderTests: XCTestCase {
     func testSignedBad() throws {
         try skipIfSignatureCheckNotSupported()
 
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
-            let path = directoryPath.appending(components: "JSON", "good_signed.json")
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
+            let path = fixturePath.appending(components: "JSON", "good_signed.json")
             let url = URL(string: "https://www.test.com/collection.json")!
             let data: Data = try localFileSystem.readFileContents(path)
 
@@ -581,8 +581,8 @@ class JSONPackageCollectionProviderTests: XCTestCase {
     func testSignedLocalFile() throws {
         try skipIfSignatureCheckNotSupported()
 
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
-            let path = directoryPath.appending(components: "JSON", "good_signed.json")
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
+            let path = fixturePath.appending(components: "JSON", "good_signed.json")
 
             var httpClient = HTTPClient(handler: { (_, _, _) -> Void in fatalError("should not be called") })
             httpClient.configuration.circuitBreakerStrategy = .none
@@ -628,8 +628,8 @@ class JSONPackageCollectionProviderTests: XCTestCase {
     }
 
     func testRequiredSigningGood() throws {
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
-            let path = directoryPath.appending(components: "JSON", "good_signed.json")
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
+            let path = fixturePath.appending(components: "JSON", "good_signed.json")
             let url = URL(string: "https://www.test.com/collection.json")!
             let data: Data = try localFileSystem.readFileContents(path)
 
@@ -698,8 +698,8 @@ class JSONPackageCollectionProviderTests: XCTestCase {
     }
 
     func testRequiredSigningMultiplePoliciesGood() throws {
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
-            let path = directoryPath.appending(components: "JSON", "good_signed.json")
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
+            let path = fixturePath.appending(components: "JSON", "good_signed.json")
             let url = URL(string: "https://www.test.com/collection.json")!
             let data: Data = try localFileSystem.readFileContents(path)
 
@@ -773,8 +773,8 @@ class JSONPackageCollectionProviderTests: XCTestCase {
     }
 
     func testMissingRequiredSignature() throws {
-        fixture(name: "Collections", createGitRepo: false) { directoryPath in
-            let path = directoryPath.appending(components: "JSON", "good.json")
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
+            let path = fixturePath.appending(components: "JSON", "good.json")
             let url = URL(string: "https://www.test.com/collection.json")!
             let data: Data = try localFileSystem.readFileContents(path)
 

--- a/Tests/PackageCollectionsTests/PackageCollectionsModelTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsModelTests.swift
@@ -88,28 +88,24 @@ final class PackageCollectionsModelTests: XCTestCase {
     }
 
     func testSourceValidation_localFile() throws {
-        do {
-            fixture(name: "Collections", createGitRepo: false) { directoryPath in
-                // File must exist in local FS
-                let path = directoryPath.appending(components: "JSON", "good.json")
+        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
+            // File must exist in local FS
+            let path = fixturePath.appending(components: "JSON", "good.json")
 
-                let source = PackageCollectionsModel.CollectionSource(type: .json, url: path.asURL)
-                XCTAssertNil(source.validate())
-            }
+            let source = PackageCollectionsModel.CollectionSource(type: .json, url: path.asURL)
+            XCTAssertNil(source.validate())
         }
     }
 
     func testSourceValidation_localFileDoesNotExist() throws {
-        do {
-            let source = PackageCollectionsModel.CollectionSource(type: .json, url: URL(fileURLWithPath: "/foo/bar"))
+        let source = PackageCollectionsModel.CollectionSource(type: .json, url: URL(fileURLWithPath: "/foo/bar"))
 
-            let messages = source.validate()!
-            XCTAssertEqual(1, messages.count)
+        let messages = source.validate()!
+        XCTAssertEqual(1, messages.count)
 
-            guard case .error = messages[0].level else {
-                return XCTFail("Expected .error")
-            }
-            XCTAssertNotNil(messages[0].message.range(of: "either a non-local path or the file does not exist", options: .caseInsensitive))
+        guard case .error = messages[0].level else {
+            return XCTFail("Expected .error")
         }
+        XCTAssertNotNil(messages[0].message.range(of: "either a non-local path or the file does not exist", options: .caseInsensitive))
     }
 }

--- a/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
@@ -23,27 +23,31 @@ private let v1Range: VersionSetSpecifier = .range("1.0.0" ..< "2.0.0")
 
 class DependencyResolverRealWorldPerfTests: XCTestCasePerf {
     func testKituraPubGrub_X100() throws {
-#if os(macOS)
+        #if !os(macOS)
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
         try runPackageTestPubGrub(name: "kitura.json", N: 100)
-#endif
     }
 
     func testZewoPubGrub_X100() throws {
-#if os(macOS)
+        #if !os(macOS)
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
         try runPackageTestPubGrub(name: "ZewoHTTPServer.json", N: 100)
-#endif
     }
 
     func testPerfectPubGrub_X100() throws {
-#if os(macOS)
+        #if !os(macOS)
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
         try runPackageTestPubGrub(name: "PerfectHTTPServer.json", N: 100)
-#endif
     }
 
     func testSourceKittenPubGrub_X100() throws {
-#if os(macOS)
+        #if !os(macOS)
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
         try runPackageTestPubGrub(name: "SourceKitten.json", N: 100)
-#endif
     }
 
     func runPackageTestPubGrub(name: String, N: Int = 1) throws {

--- a/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
@@ -20,7 +20,10 @@ import XCTest
 class PackageGraphPerfTests: XCTestCasePerf {
 
     func testLoading100Packages() throws {
-      #if os(macOS)
+        #if !os(macOS)
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
+
         let N = 100
         let files = (1...N).map { "/Foo\($0)/source.swift" }
         let fs = InMemoryFileSystem(emptyFiles: files)
@@ -80,6 +83,5 @@ class PackageGraphPerfTests: XCTestCasePerf {
             XCTAssertEqual(g.packages.count, N)
             XCTAssertNoDiagnostics(observability.diagnostics)
         }
-      #endif
     }
 }

--- a/Tests/PackageLoadingPerformanceTests/ManifestLoadingTests.swift
+++ b/Tests/PackageLoadingPerformanceTests/ManifestLoadingTests.swift
@@ -27,7 +27,9 @@ class ManifestLoadingPerfTests: XCTestCasePerf {
     }
 
     func testTrivialManifestLoading_X1() throws {
-      #if os(macOS)
+        #if !os(macOS)
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
         let N = 1
         let trivialManifest = ByteString(encodingAsUTF8: ("""
             import PackageDescription
@@ -47,11 +49,12 @@ class ManifestLoadingPerfTests: XCTestCasePerf {
                 }
             }
         }
-      #endif
     }
 
     func testNonTrivialManifestLoading_X1() throws {
-      #if os(macOS)
+        #if !os(macOS)
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
         let N = 1
         let manifest = ByteString(encodingAsUTF8: """
             import PackageDescription
@@ -81,6 +84,5 @@ class ManifestLoadingPerfTests: XCTestCasePerf {
                 }
             }
         }
-      #endif
     }
 }

--- a/Tests/PackageLoadingTests/MinimumDeploymentTargetTests.swift
+++ b/Tests/PackageLoadingTests/MinimumDeploymentTargetTests.swift
@@ -14,8 +14,11 @@ import XCTest
 @testable import PackageLoading
 
 class MinimumDeploymentTargetTests: XCTestCase {
-#if os(macOS) // these tests eventually call `xcrun`.
     func testDoesNotAssertWithNoOutput() throws {
+        #if !os(macOS)
+        // these tests eventually call `xcrun`.
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
         let result = ProcessResult(arguments: [],
                                    environment: [:],
                                    exitStatus: .terminated(code: 0),
@@ -26,6 +29,10 @@ class MinimumDeploymentTargetTests: XCTestCase {
     }
 
     func testThrowsWithNonPathOutput() throws {
+        #if !os(macOS)
+        // these tests eventually call `xcrun`.
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
         let result = ProcessResult(arguments: [],
                                    environment: [:],
                                    exitStatus: .terminated(code: 0),
@@ -36,6 +43,10 @@ class MinimumDeploymentTargetTests: XCTestCase {
     }
 
     func testThrowsWithErrorForOutput() throws {
+        #if !os(macOS)
+        // these tests eventually call `xcrun`.
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
         let result = ProcessResult(arguments: [],
                                    environment: [:],
                                    exitStatus: .terminated(code: 0),
@@ -44,7 +55,6 @@ class MinimumDeploymentTargetTests: XCTestCase {
 
         XCTAssertThrowsError(try MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(with: result, platform: .macOS))
     }
-#endif
 }
 
 private struct DummyError: Error {

--- a/Tests/PackageLoadingTests/PD_5_2_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_2_LoadingTests.swift
@@ -418,7 +418,10 @@ class PackageDescription5_2LoadingTests: PackageDescriptionLoadingTests {
     }
 
     func testManifestLoadingIsSandboxed() throws {
-        #if os(macOS) // Sandboxing is only done on macOS today.
+        #if !os(macOS)
+        // Sandboxing is only done on macOS today.
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
         let content = """
             import Foundation
 
@@ -441,6 +444,5 @@ class PackageDescription5_2LoadingTests: PackageDescriptionLoadingTests {
                 XCTFail("unexpected error: \(error)")
             }
         }
-        #endif
     }
 }

--- a/Tests/PackageLoadingTests/PD_5_3_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_3_LoadingTests.swift
@@ -455,7 +455,10 @@ class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
     }
 
     func testManifestLoadingIsSandboxed() throws {
-        #if os(macOS) // Sandboxing is only done on macOS today.
+        #if !os(macOS)
+        // Sandboxing is only done on macOS today.
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
         let content = """
             import Foundation
 
@@ -478,6 +481,5 @@ class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
                 XCTFail("unexpected error: \(error)")
             }
         }
-        #endif
     }
 }

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -133,10 +133,10 @@ class RepositoryManagerTests: XCTestCase {
         let fs = localFileSystem
         let observability = ObservabilitySystem.makeForTesting()
 
-        fixture(name: "DependencyResolution/External/Simple") { prefix in
-            let cachePath = prefix.appending(component: "cache")
-            let repositoriesPath = prefix.appending(component: "repositories")
-            let repo = RepositorySpecifier(path: prefix.appending(component: "Foo"))
+        try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
+            let cachePath = fixturePath.appending(component: "cache")
+            let repositoriesPath = fixturePath.appending(component: "repositories")
+            let repo = RepositorySpecifier(path: fixturePath.appending(component: "Foo"))
 
             let provider = GitRepositoryProvider()
             let delegate = DummyRepositoryManagerDelegate()

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -6,7 +6,7 @@
 
  See http://swift.org/LICENSE.txt for license information
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
-*/
+ */
 
 import Basics
 import Foundation
@@ -22,16 +22,18 @@ import XCTest
 class PIFBuilderTests: XCTestCase {
     let inputsDir = AbsolutePath(#file).parentDirectory.appending(components: "Inputs")
 
-  #if os(macOS)
     func testOrdering() throws {
+        #if !os(macOS)
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
         // Repeat multiple times to detect non-deterministic shuffling due to sets.
         for _ in 0..<10 {
             let fs = InMemoryFileSystem(emptyFiles:
-                "/A/Sources/A1/main.swift",
-                "/A/Sources/A2/lib.swift",
-                "/A/Sources/A3/lib.swift",
-                "/B/Sources/B1/main.swift",
-                "/B/Sources/B2/lib.swift"
+                                            "/A/Sources/A1/main.swift",
+                                        "/A/Sources/A2/lib.swift",
+                                        "/A/Sources/A3/lib.swift",
+                                        "/B/Sources/B1/main.swift",
+                                        "/B/Sources/B2/lib.swift"
             )
 
             let observability = ObservabilitySystem.makeForTesting()
@@ -87,19 +89,22 @@ class PIFBuilderTests: XCTestCase {
             let targetAExeDependencies = pif.workspace.projects[0].targets[0].dependencies
             XCTAssertEqual(targetAExeDependencies.map{ $0.targetGUID }, ["PACKAGE-PRODUCT:blib", "PACKAGE-TARGET:A2", "PACKAGE-TARGET:A3"])
             let projectBTargetNames = pif.workspace.projects[1].targets.map({ $0.name })
-            #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
+#if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
             XCTAssertEqual(projectBTargetNames, ["blib_7AE74026D_PackageProduct", "B2"])
-            #else
+#else
             XCTAssertEqual(projectBTargetNames, ["bexe_7ADFD1428_PackageProduct", "blib_7AE74026D_PackageProduct", "B2"])
-            #endif
+#endif
         }
     }
 
     func testProject() throws {
+        #if !os(macOS)
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
         let fs = InMemoryFileSystem(emptyFiles:
-            "/Foo/Sources/foo/main.swift",
-            "/Foo/Tests/FooTests/tests.swift",
-            "/Bar/Sources/BarLib/lib.swift"
+                                        "/Foo/Sources/foo/main.swift",
+                                    "/Foo/Tests/FooTests/tests.swift",
+                                    "/Bar/Sources/BarLib/lib.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -372,14 +377,17 @@ class PIFBuilderTests: XCTestCase {
     }
 
     func testExecutableProducts() throws {
+        #if !os(macOS)
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
         let fs = InMemoryFileSystem(emptyFiles:
-            "/Foo/Sources/foo/main.swift",
-            "/Foo/Sources/cfoo/main.c",
-            "/Foo/Sources/FooLib/lib.swift",
-            "/Foo/Sources/SystemLib/module.modulemap",
-            "/Bar/Sources/bar/main.swift",
-            "/Bar/Sources/cbar/main.c",
-            "/Bar/Sources/BarLib/lib.swift"
+                                        "/Foo/Sources/foo/main.swift",
+                                    "/Foo/Sources/cfoo/main.c",
+                                    "/Foo/Sources/FooLib/lib.swift",
+                                    "/Foo/Sources/SystemLib/module.modulemap",
+                                    "/Bar/Sources/bar/main.swift",
+                                    "/Bar/Sources/cbar/main.c",
+                                    "/Bar/Sources/BarLib/lib.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -700,17 +708,20 @@ class PIFBuilderTests: XCTestCase {
     }
 
     func testTestProducts() throws {
+        #if !os(macOS)
+                try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
         let fs = InMemoryFileSystem(emptyFiles:
-            "/Foo/Sources/FooTests/FooTests.swift",
-            "/Foo/Sources/CFooTests/CFooTests.m",
-            "/Foo/Sources/foo/main.swift",
-            "/Foo/Sources/FooLib/lib.swift",
-            "/Foo/Sources/SystemLib/module.modulemap",
-            "/Bar/Sources/bar/main.swift",
-            "/Bar/Sources/BarTests/BarTests.swift",
-            "/Bar/Sources/CBarTests/CBarTests.m",
-            "/Bar/Sources/BarLib/lib.swift",
-            inputsDir.appending(component: "Foo.pc").pathString
+                                        "/Foo/Sources/FooTests/FooTests.swift",
+                                    "/Foo/Sources/CFooTests/CFooTests.m",
+                                    "/Foo/Sources/foo/main.swift",
+                                    "/Foo/Sources/FooLib/lib.swift",
+                                    "/Foo/Sources/SystemLib/module.modulemap",
+                                    "/Bar/Sources/bar/main.swift",
+                                    "/Bar/Sources/BarTests/BarTests.swift",
+                                    "/Bar/Sources/CBarTests/CBarTests.m",
+                                    "/Bar/Sources/BarLib/lib.swift",
+                                    inputsDir.appending(component: "Foo.pc").pathString
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -951,11 +962,14 @@ class PIFBuilderTests: XCTestCase {
     }
 
     func testLibraryProducts() throws {
+        #if !os(macOS)
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
         let fs = InMemoryFileSystem(emptyFiles:
-            "/Foo/Sources/FooLib1/lib.swift",
-            "/Foo/Sources/FooLib2/lib.swift",
-            "/Foo/Sources/SystemLib/module.modulemap",
-            "/Bar/Sources/BarLib/lib.swift"
+                                        "/Foo/Sources/FooLib1/lib.swift",
+                                    "/Foo/Sources/FooLib2/lib.swift",
+                                    "/Foo/Sources/SystemLib/module.modulemap",
+                                    "/Bar/Sources/BarLib/lib.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -1099,8 +1113,8 @@ class PIFBuilderTests: XCTestCase {
                         XCTAssertEqual(configuration.guid, "PACKAGE-PRODUCT:BarLib::BUILDCONFIG_Debug")
                         XCTAssertEqual(configuration.name, "Debug")
                         configuration.checkAllBuildSettings { settings in
-                        XCTAssertEqual(settings[.USES_SWIFTPM_UNSAFE_FLAGS], "NO")
-                        XCTAssertEqual(settings[.APPLICATION_EXTENSION_API_ONLY], "YES")
+                            XCTAssertEqual(settings[.USES_SWIFTPM_UNSAFE_FLAGS], "NO")
+                            XCTAssertEqual(settings[.APPLICATION_EXTENSION_API_ONLY], "YES")
                             XCTAssertEqual(settings[.BUILT_PRODUCTS_DIR], "$(BUILT_PRODUCTS_DIR)/PackageFrameworks")
                             XCTAssertEqual(settings[.CLANG_ENABLE_MODULES], "YES")
                             XCTAssertEqual(settings[.CURRENT_PROJECT_VERSION], "1")
@@ -1150,11 +1164,14 @@ class PIFBuilderTests: XCTestCase {
     }
 
     func testLibraryTargets() throws {
+        #if !os(macOS)
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
         let fs = InMemoryFileSystem(emptyFiles:
-            "/Foo/Sources/FooLib1/lib.swift",
-            "/Foo/Sources/FooLib2/lib.cpp",
-            "/Foo/Sources/SystemLib/module.modulemap",
-            "/Bar/Sources/BarLib/lib.c"
+                                        "/Foo/Sources/FooLib1/lib.swift",
+                                    "/Foo/Sources/FooLib2/lib.cpp",
+                                    "/Foo/Sources/SystemLib/module.modulemap",
+                                    "/Bar/Sources/BarLib/lib.c"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -1444,8 +1461,11 @@ class PIFBuilderTests: XCTestCase {
     }
 
     func testLibraryTargetsAsDylib() throws {
+        #if !os(macOS)
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
         let fs = InMemoryFileSystem(emptyFiles:
-            "/Bar/Sources/BarLib/lib.c"
+                                        "/Bar/Sources/BarLib/lib.c"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -1493,9 +1513,12 @@ class PIFBuilderTests: XCTestCase {
     }
 
     func testLibraryTargetWithModuleMap() throws {
+        #if !os(macOS)
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
         let fs = InMemoryFileSystem(emptyFiles:
-            "/Bar/Sources/BarLib/lib.c",
-            "/Bar/Sources/BarLib/module.modulemap"
+                                        "/Bar/Sources/BarLib/lib.c",
+                                    "/Bar/Sources/BarLib/module.modulemap"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -1548,9 +1571,12 @@ class PIFBuilderTests: XCTestCase {
     }
 
     func testSystemLibraryTargets() throws {
+        #if !os(macOS)
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
         let fs = InMemoryFileSystem(emptyFiles:
-            "/Foo/Sources/SystemLib1/module.modulemap",
-            "/Foo/Sources/SystemLib2/module.modulemap"
+                                        "/Foo/Sources/SystemLib1/module.modulemap",
+                                    "/Foo/Sources/SystemLib2/module.modulemap"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -1662,11 +1688,14 @@ class PIFBuilderTests: XCTestCase {
     }
 
     func testBinaryTargets() throws {
+        #if !os(macOS)
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
         let fs = InMemoryFileSystem(emptyFiles:
-            "/Foo/Sources/foo/main.swift",
-            "/Foo/Sources/FooLib/lib.swift",
-            "/Foo/Sources/FooTests/FooTests.swift",
-            "/Foo/BinaryLibrary.xcframework/Info.plist"
+                                        "/Foo/Sources/foo/main.swift",
+                                    "/Foo/Sources/FooLib/lib.swift",
+                                    "/Foo/Sources/FooTests/FooTests.swift",
+                                    "/Foo/BinaryLibrary.xcframework/Info.plist"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -1726,16 +1755,19 @@ class PIFBuilderTests: XCTestCase {
     }
 
     func testResources() throws {
+        #if !os(macOS)
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
         let fs = InMemoryFileSystem(emptyFiles:
-            "/Foo/Sources/foo/main.swift",
-            "/Foo/Sources/foo/Resources/Data.plist",
-            "/Foo/Sources/foo/Resources/Database.xcdatamodel",
-            "/Foo/Sources/FooLib/lib.swift",
-            "/Foo/Sources/FooLib/Resources/Data.plist",
-            "/Foo/Sources/FooLib/Resources/Database.xcdatamodel",
-            "/Foo/Sources/FooTests/FooTests.swift",
-            "/Foo/Sources/FooTests/Resources/Data.plist",
-            "/Foo/Sources/FooTests/Resources/Database.xcdatamodel"
+                                        "/Foo/Sources/foo/main.swift",
+                                    "/Foo/Sources/foo/Resources/Data.plist",
+                                    "/Foo/Sources/foo/Resources/Database.xcdatamodel",
+                                    "/Foo/Sources/FooLib/lib.swift",
+                                    "/Foo/Sources/FooLib/Resources/Data.plist",
+                                    "/Foo/Sources/FooLib/Resources/Database.xcdatamodel",
+                                    "/Foo/Sources/FooTests/FooTests.swift",
+                                    "/Foo/Sources/FooTests/Resources/Data.plist",
+                                    "/Foo/Sources/FooTests/Resources/Database.xcdatamodel"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -1945,10 +1977,13 @@ class PIFBuilderTests: XCTestCase {
     }
 
     func testBuildSettings() throws {
+        #if !os(macOS)
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
         let fs = InMemoryFileSystem(emptyFiles:
-            "/Foo/Sources/foo/main.swift",
-            "/Foo/Sources/FooLib/lib.swift",
-            "/Foo/Sources/FooTests/FooTests.swift"
+                                        "/Foo/Sources/foo/main.swift",
+                                    "/Foo/Sources/FooLib/lib.swift",
+                                    "/Foo/Sources/FooTests/FooTests.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -2167,11 +2202,14 @@ class PIFBuilderTests: XCTestCase {
     }
 
     func testConditionalDependencies() throws {
+        #if !os(macOS)
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
         let fs = InMemoryFileSystem(emptyFiles:
-            "/Foo/Sources/foo/main.swift",
-            "/Foo/Sources/FooLib1/lib.swift",
-            "/Foo/Sources/FooLib2/lib.swift",
-            "/Foo/Sources/FooTests/FooTests.swift"
+                                        "/Foo/Sources/foo/main.swift",
+                                    "/Foo/Sources/FooLib1/lib.swift",
+                                    "/Foo/Sources/FooLib2/lib.swift",
+                                    "/Foo/Sources/FooTests/FooTests.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -2236,8 +2274,11 @@ class PIFBuilderTests: XCTestCase {
     }
 
     func testSDKOptions() throws {
+        #if !os(macOS)
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
         let fs = InMemoryFileSystem(emptyFiles:
-            "/Foo/Sources/foo/main.swift"
+                                        "/Foo/Sources/foo/main.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -2283,8 +2324,11 @@ class PIFBuilderTests: XCTestCase {
     /// Tests that the inference of XCBuild build settings based on the package manifest's declared unsafe settings
     /// works as expected.
     func testUnsafeFlagsBuildSettingInference() throws {
+        #if !os(macOS)
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
         let fs = InMemoryFileSystem(emptyFiles:
-            "/MyLib/Sources/MyLib/Foo.swift"
+                                        "/MyLib/Sources/MyLib/Foo.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -2343,8 +2387,6 @@ class PIFBuilderTests: XCTestCase {
             }
         }
     }
-
-  #endif
 }
 
 extension PIFBuilderParameters {


### PR DESCRIPTION
motivation: test fixtures currently swallow the original error and hide it with XCTFail which does not allow using XCTSkip inside a fixture block

changes:
* update the fixture function to be throwing
* adjust call sites (lots of them!)
* cleanup use of XCTSkip for platform checks
