### PR TITLE
Temporary disable `testXcodeBuildSystemWithAdditionalBuildFlags`

### DIFF
--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -314,6 +314,8 @@ final class BuildToolTests: CommandsTestCase {
     }
 
     func testXcodeBuildSystemWithAdditionalBuildFlags() throws {
+        try XCTSkipIf(true, "Disabled for now because it is hitting 'IR generation failure: Cannot read legacy layout file' in CI (rdar://88828632)")
+
         #if !os(macOS)
         try XCTSkipIf(true, "test requires `xcbuild` and is therefore only supported on macOS")
         #endif


### PR DESCRIPTION
This seems to be failing in CI on Apple Silicon because we can't build universal with the inferior toolchain there. On the one hand, that seems fair enough and most of our XCBuild tests are not part of the main test suite but they are in integration tests. On the other hand, there's `testXcodeBuildSystemOverrides` which should be hitting the same issue and it is present since last year. So I am disabling the test here to get more signal on whether this is a problem with the new test somehow or a new issue outside of SwiftPM / this particular test.