### PR TITLE
improve error message when using invalid path for local binary artifacts

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -76,7 +76,7 @@ public protocol ManifestLoaderProtocol {
 }
 
 public extension ManifestLoaderProtocol {
-    var supportedArchiveExtension: String { "zip" }
+    var supportedArchiveExtensions: [String] { ["zip"] }
 }
 
 public protocol ManifestLoaderDelegate {
@@ -408,30 +408,69 @@ public final class ManifestLoader: ManifestLoaderProtocol {
     private func validateBinaryTargets(_ manifest: Manifest, observabilityScope: ObservabilityScope) throws {
         // Check that binary targets point to the right file type.
         for target in manifest.targets where target.type == .binary {
-            guard let location = URL(string: target.url ?? target.path ?? "") else {
+            if target.isLocal {
+                guard let path = target.path else {
+                    observabilityScope.emit(.invalidBinaryLocation(targetName: target.name))
+                    continue
+                }
+
+                guard let path = path.spm_chuzzle(), !path.isEmpty else {
+                    observabilityScope.emit(.invalidLocalBinaryPath(path: path, targetName: target.name))
+                    continue
+                }
+
+                guard let relativePath = try? RelativePath(validating: path) else {
+                    observabilityScope.emit(.invalidLocalBinaryPath(path: path, targetName: target.name))
+                    continue
+                }
+
+                let validExtensions = self.supportedArchiveExtensions + BinaryTarget.Kind.allCases.filter{ $0 != .unknown }.map { $0.fileExtension }
+                guard let fileExtension = relativePath.extension, validExtensions.contains(fileExtension) else {
+                    observabilityScope.emit(.unsupportedBinaryLocationExtension(
+                        targetName: target.name,
+                        validExtensions: validExtensions
+                    ))
+                    continue
+                }
+            } else if target.isRemote {
+                guard let url = target.url else {
+                    observabilityScope.emit(.invalidBinaryLocation(targetName: target.name))
+                    continue
+                }
+
+                guard let url = url.spm_chuzzle(), !url.isEmpty else {
+                    observabilityScope.emit(.invalidBinaryURL(url: url, targetName: target.name))
+                    continue
+                }
+
+                guard let url = URL(string: url) else {
+                    observabilityScope.emit(.invalidBinaryURL(url: url, targetName: target.name))
+                    continue
+                }
+
+                let validSchemes = ["https"]
+                guard url.scheme.map({ validSchemes.contains($0) }) ?? false else {
+                    observabilityScope.emit(.invalidBinaryURLScheme(
+                        targetName: target.name,
+                        validSchemes: validSchemes
+                    ))
+                    continue
+                }
+
+                guard self.supportedArchiveExtensions.contains(url.pathExtension) else {
+                    observabilityScope.emit(.unsupportedBinaryLocationExtension(
+                        targetName: target.name,
+                        validExtensions: self.supportedArchiveExtensions
+                    ))
+                    continue
+                }
+
+            } else {
                 observabilityScope.emit(.invalidBinaryLocation(targetName: target.name))
                 continue
             }
 
-            let validSchemes = ["https"]
-            if target.isRemote && (location.scheme.map({ !validSchemes.contains($0) }) ?? true) {
-                observabilityScope.emit(.invalidBinaryURLScheme(
-                    targetName: target.name,
-                    validSchemes: validSchemes
-                ))
-            }
 
-            var validExtensions = [self.supportedArchiveExtension]
-            if target.isLocal {
-                validExtensions += BinaryTarget.Kind.allCases.filter{ $0 != .unknown }.map { $0.fileExtension }
-            }
-
-            if !validExtensions.contains(location.pathExtension) {
-                observabilityScope.emit(.unsupportedBinaryLocationExtension(
-                    targetName: target.name,
-                    validExtensions: validExtensions
-                ))
-            }
         }
     }
 
@@ -1068,6 +1107,14 @@ extension Basics.Diagnostic {
 
     static func invalidBinaryLocation(targetName: String) -> Self {
         .error("invalid location for binary target '\(targetName)'")
+    }
+
+    static func invalidBinaryURL(url: String, targetName: String) -> Self {
+        .error("invalid URL '\(url)' for binary target '\(targetName)'")
+    }
+
+    static func invalidLocalBinaryPath(path: String, targetName: String) -> Self {
+        .error("invalid local path '\(path)' for binary target '\(targetName)', path expected to be relative to package root.")
     }
 
     static func invalidBinaryURLScheme(targetName: String, validSchemes: [String]) -> Self {

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -2282,7 +2282,7 @@ extension Workspace {
         addedOrUpdatedPackages: [PackageReference],
         observabilityScope: ObservabilityScope
     ) throws {
-        let manifestArtifacts = try self.parseArtifacts(from: manifests)
+        let manifestArtifacts = try self.parseArtifacts(from: manifests, observabilityScope: observabilityScope)
 
         var artifactsToRemove: [ManagedArtifact] = []
         var artifactsToAdd: [ManagedArtifact] = []
@@ -2302,7 +2302,7 @@ extension Workspace {
                 targetName: artifact.targetName
             ]
 
-            if artifact.path.extension == self.manifestLoader.supportedArchiveExtension {
+            if let fileExtension = artifact.path.extension, self.manifestLoader.supportedArchiveExtensions.contains(fileExtension) {
                 // If we already have an artifact that was extracted from an archive with the same checksum,
                 // we don't need to extract the artifact again.
                 if case .local(let existingChecksum) = existingArtifact?.source, existingChecksum == (try self.checksum(forBinaryArtifactAt: artifact.path)) {
@@ -2393,7 +2393,7 @@ extension Workspace {
         }
     }
 
-    private func parseArtifacts(from manifests: DependencyManifests) throws -> (local: [ManagedArtifact], remote: [RemoteArtifact]) {
+    private func parseArtifacts(from manifests: DependencyManifests, observabilityScope: ObservabilityScope) throws -> (local: [ManagedArtifact], remote: [RemoteArtifact]) {
         let packageAndManifests: [(reference: PackageReference, manifest: Manifest)] =
             manifests.root.packages.values + // Root package and manifests.
             manifests.dependencies.map({ manifest, managed, _, _ in (managed.packageRef, manifest) }) // Dependency package and manifests.
@@ -2436,7 +2436,7 @@ extension Workspace {
         // zip files to download
         // stored in a thread-safe way as we may fetch more from "artifactbundleindex" files
         let zipArtifacts = ThreadSafeArrayStore<RemoteArtifact>(artifacts.filter {
-            $0.url.pathExtension.lowercased() == self.manifestLoader.supportedArchiveExtension
+            self.manifestLoader.supportedArchiveExtensions.contains($0.url.pathExtension.lowercased())
         })
 
         // fetch and parse "artifactbundleindex" files, if any

--- a/Tests/PackageLoadingTests/PD_5_3_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_3_LoadingTests.swift
@@ -234,7 +234,7 @@ class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
             let observability = ObservabilitySystem.makeForTesting()
             XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error")
             testDiagnostics(observability.diagnostics) { result in
-                result.check(diagnostic: "invalid location for binary target 'Foo'", severity: .error)
+                result.check(diagnostic: "invalid local path ' ' for binary target 'Foo', path expected to be relative to package root.", severity: .error)
             }
         }
 
@@ -346,6 +346,77 @@ class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
             XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error")
             testDiagnostics(observability.diagnostics) { result in
                 result.check(diagnostic: "unsupported extension for binary target 'Foo'; valid extensions are: 'zip'", severity: .error)
+            }
+        }
+
+        do {
+            let content = """
+                import PackageDescription
+                let package = Package(
+                    name: "Foo",
+                    products: [
+                        .library(name: "Foo", targets: ["Foo"]),
+                    ],
+                    targets: [
+                        .binaryTarget(
+                            name: "Foo",
+                            url: "ssh://foo/bar",
+                            checksum: "839F9F30DC13C30795666DD8F6FB77DD0E097B83D06954073E34FE5154481F7A"),
+                    ]
+                )
+                """
+
+            let observability = ObservabilitySystem.makeForTesting()
+            XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error")
+            testDiagnostics(observability.diagnostics) { result in
+                result.check(diagnostic: "invalid URL scheme for binary target 'Foo'; valid schemes are: 'https'", severity: .error)
+            }
+        }
+
+        do {
+            let content = """
+                import PackageDescription
+                let package = Package(
+                    name: "Foo",
+                    products: [
+                        .library(name: "Foo", targets: ["Foo"]),
+                    ],
+                    targets: [
+                        .binaryTarget(
+                            name: "Foo",
+                            url: " ",
+                            checksum: "839F9F30DC13C30795666DD8F6FB77DD0E097B83D06954073E34FE5154481F7A"),
+                    ]
+                )
+                """
+
+            let observability = ObservabilitySystem.makeForTesting()
+            XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error")
+            testDiagnostics(observability.diagnostics) { result in
+                result.check(diagnostic: "invalid URL ' ' for binary target 'Foo'", severity: .error)
+            }
+        }
+
+        do {
+            let content = """
+                import PackageDescription
+                let package = Package(
+                    name: "Foo",
+                    products: [
+                        .library(name: "Foo", targets: ["Foo"]),
+                    ],
+                    targets: [
+                        .binaryTarget(
+                            name: "Foo",
+                            path: "/tmp/foo/bar")
+                    ]
+                )
+                """
+
+            let observability = ObservabilitySystem.makeForTesting()
+            XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error")
+            testDiagnostics(observability.diagnostics) { result in
+                result.check(diagnostic: "invalid local path '/tmp/foo/bar' for binary target 'Foo', path expected to be relative to package root.", severity: .error)
             }
         }
     }

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -9333,13 +9333,13 @@ final class WorkspaceTests: XCTestCase {
                 delegate: MockWorkspaceDelegate()
             )
 
-            do {
-                try workspace.resolve(root: .init(packages: [foo]), observabilityScope: observability.topScope)
-            } catch {
-                XCTAssertEqual(error.localizedDescription, "invalid relative path '/best.xcframework'; relative path should not begin with '/' or '~'")
-                return
+            try workspace.resolve(root: .init(packages: [foo]), observabilityScope: observability.topScope)
+            testDiagnostics(observability.diagnostics) { result in
+                result.check(
+                    diagnostic: "invalid local path '/best.xcframework' for binary target 'best', path expected to be relative to package root.",
+                    severity: .error
+                )
             }
-            XCTFail("unexpected success")
         }
     }
 


### PR DESCRIPTION
motivation: clearer, more actionable error message

changes:
* catch invalid relative path for binary artifacts and emit a clear diagnostics
* overall improve validation of binary targets path and urls
* add tests

rdar://84365161
