### PR TITLE
Fix missing prefix rename to fixturePath in MiscellaneousTests.swift

### DIFF
--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -581,7 +581,7 @@ class MiscellaneousTestCase: XCTestCase {
             } catch {
                 #if os(macOS) && arch(arm64)
                 // Add some logging but ignore the failure for an environment being investigated.
-                let (stdout, stderr) = try executeSwiftTest(prefix, extraArgs: ["-v"])
+                let (stdout, stderr) = try executeSwiftTest(fixturePath, extraArgs: ["-v"])
                 print("testTestsCanLinkAgainstExecutable failed")
                 print("ENV:\n")
                 for (k, v) in ProcessEnv.vars.sorted(by: { $0.key < $1.key }) {


### PR DESCRIPTION
```
[80/83] Compiling FunctionalTests CFamilyTargetTests.swift
/Users/ec2-user/jenkins/workspace/oss-swift-incremental-RA-macos-apple-silicon/swiftpm/Tests/FunctionalTests/MiscellaneousTests.swift:584:61: error: cannot find 'prefix' in scope
                let (stdout, stderr) = try executeSwiftTest(prefix, extraArgs: ["-v"])
                                                            ^~~~~~
error: fatalError
```