### PR TITLE
Revert "improve example created by package init --type executable"

### DIFF
--- a/IntegrationTests/Package.swift
+++ b/IntegrationTests/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.1
 
 import PackageDescription
 
@@ -6,8 +6,8 @@ let package = Package(
     name: "IntegrationTests",
     targets: [
         .testTarget(name: "IntegrationTests", dependencies: [
-            .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
-            .product(name: "TSCTestSupport", package: "swift-tools-support-core")
+            "SwiftToolsSupport-auto",
+            "TSCTestSupport"
         ]),
     ]
 )
@@ -20,6 +20,6 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     ]
 } else {
     package.dependencies += [
-        .package(name: "swift-tools-support-core", path: "../TSC"),
+        .package(path: "../TSC"),
     ]
 }

--- a/IntegrationTests/Tests/IntegrationTests/BasicTests.swift
+++ b/IntegrationTests/Tests/IntegrationTests/BasicTests.swift
@@ -1,12 +1,12 @@
 /*
- This source file is part of the Swift.org open source project
+This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
- Licensed under Apache License v2.0 with Runtime Library Exception
+Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
 
- See http://swift.org/LICENSE.txt for license information
- See http://swift.org/CONTRIBUTORS.txt for Swift project authors
- */
+See http://swift.org/LICENSE.txt for license information
+See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
 
 import XCTest
 import TSCBasic
@@ -20,35 +20,38 @@ final class BasicTests: XCTestCase {
     func testExamplePackageDealer() throws {
         try XCTSkipIf(isSelfHosted, "These packages don't use the latest runtime library, which doesn't work with self-hosted builds.")
 
-        try withTemporaryDirectory { tempDir in
-            let packagePath = tempDir.appending(component: "dealer")
-            try sh("git", "clone", "https://github.com/apple/example-package-dealer", packagePath)
-            let build1Output = try sh(swiftBuild, "--package-path", packagePath).stdout
-            // Check the build log.
-            XCTAssertMatch(build1Output, .contains("Build complete"))
+        try withTemporaryDirectory { dir in
+            let dealerDir = dir.appending(component: "dealer")
+            try sh("git", "clone", "https://github.com/apple/example-package-dealer", dealerDir)
+            let build1Output = try sh(swiftBuild, "--package-path", dealerDir).stdout
 
-            // Verify that the app works.
-            let dealerOutput = try sh(packagePath.appending(RelativePath(".build/debug/dealer")), "10").stdout
-            XCTAssertEqual(dealerOutput.filter(\.isPlayingCardSuit).count, 10)
+            // Check the build log.
+            XCTAssertContents(build1Output) { checker in
+                checker.check(.contains("Merging module FisherYates"))
+                checker.check(.contains("Merging module Dealer"))
+            }
+
+            // Verify that the build worked.
+            let dealerOutput = try sh(dealerDir.appending(RelativePath(".build/debug/Dealer"))).stdout
+            XCTAssertMatch(dealerOutput, .regex("(?:(♡|♠|♢|♣)\\s([0-9JQKA]|10)\\n)+"))
 
             // Verify that the 'git status' is clean after a build.
-            try localFileSystem.changeCurrentWorkingDirectory(to: packagePath)
+            try localFileSystem.changeCurrentWorkingDirectory(to: dealerDir)
             let gitOutput = try sh("git", "status").stdout
             XCTAssertMatch(gitOutput, .contains("nothing to commit, working tree clean"))
 
             // Verify that another 'swift build' does nothing.
-            let build2Output = try sh(swiftBuild, "--package-path", packagePath).stdout
-            XCTAssertMatch(build2Output, .contains("Build complete"))
+            let build2Output = try sh(swiftBuild, "--package-path", dealerDir).stdout
             XCTAssertNoMatch(build2Output, .contains("Compiling"))
         }
     }
 
     func testSwiftBuild() throws {
-        try withTemporaryDirectory { tempDir in
-            let packagePath = tempDir.appending(component: "tool")
-            try localFileSystem.createDirectory(packagePath)
+        try withTemporaryDirectory { dir in
+            let toolDir = dir.appending(component: "tool")
+            try localFileSystem.createDirectory(toolDir)
             try localFileSystem.writeFileContents(
-                packagePath.appending(component: "Package.swift"),
+                toolDir.appending(component: "Package.swift"),
                 bytes: ByteString(encodingAsUTF8: """
                     // swift-tools-version:4.2
                     import PackageDescription
@@ -61,26 +64,26 @@ final class BasicTests: XCTestCase {
                     )
                     """))
             try localFileSystem.writeFileContents(
-                packagePath.appending(component: "main.swift"),
+                toolDir.appending(component: "main.swift"),
                 bytes: ByteString(encodingAsUTF8: #"print("HI")"#))
 
             // Check the build.
-            let buildOutput = try sh(swiftBuild, "--package-path", packagePath, "-v").stdout
+            let buildOutput = try sh(swiftBuild, "--package-path", toolDir, "-v").stdout
             XCTAssertMatch(buildOutput, .regex("swiftc.* -module-name tool"))
 
             // Verify that the tool exists and works.
-            let toolOutput = try sh(packagePath.appending(components: ".build", "debug", "tool")).stdout
+            let toolOutput = try sh(toolDir.appending(components: ".build", "debug", "tool")).stdout
             XCTAssertEqual(toolOutput, "HI\n")
         }
     }
 
     func testSwiftCompiler() throws {
-        try withTemporaryDirectory { tempDir in
-            let helloSourcePath = tempDir.appending(component: "hello.swift")
+        try withTemporaryDirectory { dir in
+            let helloSourcePath = dir.appending(component: "hello.swift")
             try localFileSystem.writeFileContents(
                 helloSourcePath,
                 bytes: ByteString(encodingAsUTF8: #"print("hello")"#))
-            let helloBinaryPath = tempDir.appending(component: "hello")
+            let helloBinaryPath = dir.appending(component: "hello")
             try sh(swiftc, helloSourcePath, "-o", helloBinaryPath)
 
             // Check the file exists.
@@ -93,88 +96,44 @@ final class BasicTests: XCTestCase {
     }
 
     func testSwiftPackageInitExec() throws {
-        #if swift(<5.5)
-        try XCTSkipIf(true, "skipping because host compiler doesn't support '-entry-point-function-name'")
-        #endif
-
-        try withTemporaryDirectory { tempDir in
+        try XCTSkipUnless(swiftcSupportsRenamingMainSymbol(), "skipping because host compiler doesn't support `-entry-point-function-name`")
+        
+        try withTemporaryDirectory { dir in
             // Create a new package with an executable target.
-            let packagePath = tempDir.appending(component: "Project")
-            try localFileSystem.createDirectory(packagePath)
-            try sh(swiftPackage, "--package-path", packagePath, "init", "--type", "executable")
-            let buildOutput = try sh(swiftBuild, "--package-path", packagePath).stdout
+            let projectDir = dir.appending(component: "Project")
+            try localFileSystem.createDirectory(projectDir)
+            try sh(swiftPackage, "--package-path", projectDir, "init", "--type", "executable")
+            let buildOutput = try sh(swiftBuild, "--package-path", projectDir).stdout
 
             // Check the build log.
             XCTAssertContents(buildOutput) { checker in
                 checker.check(.regex("Compiling .*Project.*"))
                 checker.check(.regex("Linking .*Project"))
-                checker.check(.contains("Build complete"))
             }
 
             // Verify that the tool was built and works.
-            let toolOutput = try sh(packagePath.appending(components: ".build", "debug", "Project")).stdout
-            XCTAssertMatch(toolOutput.lowercased(), .contains("hello, world!"))
+            let toolOutput = try sh(projectDir.appending(components: ".build", "debug", "Project")).stdout
+            XCTAssertEqual(toolOutput, "Hello, world!\n")
 
             // Check there were no compile errors or warnings.
             XCTAssertNoMatch(buildOutput, .contains("error"))
             XCTAssertNoMatch(buildOutput, .contains("warning"))
-        }
-    }
-
-    func testSwiftPackageInitExecTests() throws {
-        #if swift(<5.5)
-        try XCTSkipIf(true, "skipping because host compiler doesn't support '-entry-point-function-name'")
-        #endif
-
-        try XCTSkip("FIXME: swift-test invocations are timing out in Xcode and self-hosted CI")
-
-        try withTemporaryDirectory { tempDir in
-            // Create a new package with an executable target.
-            let packagePath = tempDir.appending(component: "Project")
-            try localFileSystem.createDirectory(packagePath)
-            try sh(swiftPackage, "--package-path", packagePath, "init", "--type", "executable")
-            let testOutput = try sh(swiftTest, "--package-path", packagePath).stdout
-
-            // Check the test log.
-            XCTAssertContents(testOutput) { checker in
-                checker.check(.regex("Compiling .*ProjectTests.*"))
-                checker.check("Test Suite 'All tests' passed")
-                checker.checkNext("Executed 1 test")
-            }
-
-            // Check there were no compile errors or warnings.
-            XCTAssertNoMatch(testOutput, .contains("error"))
-            XCTAssertNoMatch(testOutput, .contains("warning"))
         }
     }
 
     func testSwiftPackageInitLib() throws {
-        try withTemporaryDirectory { tempDir in
+        try XCTSkip("FIXME: swift-test invocations are timing out in Xcode and self-hosted CI")
+
+        try withTemporaryDirectory { dir in
             // Create a new package with an executable target.
-            let packagePath = tempDir.appending(component: "Project")
-            try localFileSystem.createDirectory(packagePath)
-            try sh(swiftPackage, "--package-path", packagePath, "init", "--type", "library")
-            let buildOutput = try sh(swiftBuild, "--package-path", packagePath).stdout
+            let projectDir = dir.appending(component: "Project")
+            try localFileSystem.createDirectory(projectDir)
+            try sh(swiftPackage, "--package-path", projectDir, "init", "--type", "library")
+            let buildOutput = try sh(swiftBuild, "--package-path", projectDir).stdout
+            let testOutput = try sh(swiftTest, "--package-path", projectDir).stdout
 
             // Check the build log.
             XCTAssertMatch(buildOutput, .regex("Compiling .*Project.*"))
-            XCTAssertMatch(buildOutput, .contains("Build complete"))
-
-            // Check there were no compile errors or warnings.
-            XCTAssertNoMatch(buildOutput, .contains("error"))
-            XCTAssertNoMatch(buildOutput, .contains("warning"))
-        }
-    }
-
-    func testSwiftPackageLibsTests() throws {
-        try XCTSkip("FIXME: swift-test invocations are timing out in Xcode and self-hosted CI")
-
-        try withTemporaryDirectory { tempDir in
-            // Create a new package with an executable target.
-            let packagePath = tempDir.appending(component: "Project")
-            try localFileSystem.createDirectory(packagePath)
-            try sh(swiftPackage, "--package-path", packagePath, "init", "--type", "library")
-            let testOutput = try sh(swiftTest, "--package-path", packagePath).stdout
 
             // Check the test log.
             XCTAssertContents(testOutput) { checker in
@@ -184,17 +143,17 @@ final class BasicTests: XCTestCase {
             }
 
             // Check there were no compile errors or warnings.
-            XCTAssertNoMatch(testOutput, .contains("error"))
-            XCTAssertNoMatch(testOutput, .contains("warning"))
+            XCTAssertNoMatch(buildOutput, .contains("error"))
+            XCTAssertNoMatch(buildOutput, .contains("warning"))
         }
     }
 
     func testSwiftPackageWithSpaces() throws {
-        try withTemporaryDirectory { tempDir in
-            let packagePath = tempDir.appending(components: "more spaces", "special tool")
-            try localFileSystem.createDirectory(packagePath, recursive: true)
+        try withTemporaryDirectory { dir in
+            let toolDir = dir.appending(components: "more spaces", "special tool")
+            try localFileSystem.createDirectory(toolDir, recursive: true)
             try localFileSystem.writeFileContents(
-                packagePath.appending(component: "Package.swift"),
+                toolDir.appending(component: "Package.swift"),
                 bytes: ByteString(encodingAsUTF8: """
                     // swift-tools-version:4.2
                     import PackageDescription
@@ -207,49 +166,41 @@ final class BasicTests: XCTestCase {
                     )
                     """))
             try localFileSystem.writeFileContents(
-                packagePath.appending(component: "main.swift"),
+                toolDir.appending(component: "main.swift"),
                 bytes: ByteString(encodingAsUTF8: #"foo()"#))
             try localFileSystem.writeFileContents(
-                packagePath.appending(component: "some file.swift"),
+                toolDir.appending(component: "some file.swift"),
                 bytes: ByteString(encodingAsUTF8: #"func foo() { print("HI") }"#))
 
             // Check the build.
-            let buildOutput = try sh(swiftBuild, "--package-path", packagePath, "-v").stdout
+            let buildOutput = try sh(swiftBuild, "--package-path", toolDir, "-v").stdout
             XCTAssertMatch(buildOutput, .regex(#"swiftc.* -module-name special_tool .* ".*/more spaces/special tool/some file.swift""#))
-            XCTAssertMatch(buildOutput, .contains("Build complete"))
 
             // Verify that the tool exists and works.
-            let toolOutput = try sh(packagePath.appending(components: ".build", "debug", "special tool")).stdout
+            let toolOutput = try sh(toolDir.appending(components: ".build", "debug", "special tool")).stdout
             XCTAssertEqual(toolOutput, "HI\n")
         }
     }
 
     func testSwiftRun() throws {
-        #if swift(<5.5)
-        try XCTSkipIf(true, "skipping because host compiler doesn't support '-entry-point-function-name'")
-        #endif
+        try XCTSkipUnless(swiftcSupportsRenamingMainSymbol(), "skipping because host compiler doesn't support `-entry-point-function-name`")
 
-        try withTemporaryDirectory { tempDir in
-            let packagePath = tempDir.appending(component: "secho")
-            try localFileSystem.createDirectory(packagePath)
-            try sh(swiftPackage, "--package-path", packagePath, "init", "--type", "executable")
-            // delete any files generated
-            for entry in try localFileSystem.getDirectoryContents(packagePath.appending(components: "Sources", "secho")) {
-                try localFileSystem.removeFileTree(packagePath.appending(components: "Sources", "secho", entry))
-            }
+        try withTemporaryDirectory { dir in
+            let toolDir = dir.appending(component: "secho")
+            try localFileSystem.createDirectory(toolDir)
+            try sh(swiftPackage, "--package-path", toolDir, "init", "--type", "executable")
             try localFileSystem.writeFileContents(
-                packagePath.appending(components: "Sources", "secho", "main.swift"),
+                toolDir.appending(components: "Sources", "secho", "main.swift"),
                 bytes: ByteString(encodingAsUTF8: """
                     import Foundation
                     print(CommandLine.arguments.dropFirst().joined(separator: " "))
                     """))
-            let (runOutput, runError) = try sh(swiftRun, "--package-path", packagePath, "secho", "1", #""two""#)
+            let (runOutput, runError) = try sh(swiftRun, "--package-path", toolDir, "secho", "1", #""two""#)
 
             // Check the run log.
             XCTAssertContents(runError) { checker in
                 checker.check(.regex("Compiling .*secho.*"))
                 checker.check(.regex("Linking .*secho"))
-                checker.check(.contains("Build complete"))
             }
             XCTAssertEqual(runOutput, "1 \"two\"\n")
         }
@@ -258,12 +209,12 @@ final class BasicTests: XCTestCase {
     func testSwiftTest() throws {
         try XCTSkip("FIXME: swift-test invocations are timing out in Xcode and self-hosted CI")
 
-        try withTemporaryDirectory { tempDir in
-            let packagePath = tempDir.appending(component: "swiftTest")
-            try localFileSystem.createDirectory(packagePath)
-            try sh(swiftPackage, "--package-path", packagePath, "init", "--type", "library")
+        try withTemporaryDirectory { dir in
+            let toolDir = dir.appending(component: "swiftTest")
+            try localFileSystem.createDirectory(toolDir)
+            try sh(swiftPackage, "--package-path", toolDir, "init", "--type", "library")
             try localFileSystem.writeFileContents(
-                packagePath.appending(components: "Tests", "swiftTestTests", "MyTests.swift"),
+                toolDir.appending(components: "Tests", "swiftTestTests", "MyTests.swift"),
                 bytes: ByteString(encodingAsUTF8: """
                     import XCTest
 
@@ -277,7 +228,7 @@ final class BasicTests: XCTestCase {
                         func testBaz() { }
                     }
                     """))
-            let testOutput = try sh(swiftTest, "--package-path", packagePath, "--filter", "MyTests.*", "--skip", "testBaz").stderr
+            let testOutput = try sh(swiftTest, "--package-path", toolDir, "--filter", "MyTests.*", "--skip", "testBaz").stderr
 
             // Check the test log.
             XCTAssertContents(testOutput) { checker in
@@ -287,16 +238,16 @@ final class BasicTests: XCTestCase {
             }
         }
     }
-
+  
     func testSwiftTestWithResources() throws {
         try XCTSkip("FIXME: swift-test invocations are timing out in Xcode and self-hosted CI")
 
-        try withTemporaryDirectory { tempDir in
-            let packagePath = tempDir.appending(component: "swiftTestResources")
-            try localFileSystem.createDirectory(packagePath)
+        try withTemporaryDirectory { dir in
+            let toolDir = dir.appending(component: "swiftTestResources")
+            try localFileSystem.createDirectory(toolDir)
             try localFileSystem.writeFileContents(
-                packagePath.appending(component: "Package.swift"),
-                bytes: ByteString(encodingAsUTF8: """
+              toolDir.appending(component: "Package.swift"),
+              bytes: ByteString(encodingAsUTF8: """
                     // swift-tools-version:5.3
                     import PackageDescription
 
@@ -309,11 +260,11 @@ final class BasicTests: XCTestCase {
                     )
                     """)
             )
-            try localFileSystem.createDirectory(packagePath.appending(component: "Sources"))
-            try localFileSystem.createDirectory(packagePath.appending(components: "Sources", "AwesomeResources"))
+            try localFileSystem.createDirectory(toolDir.appending(component: "Sources"))
+            try localFileSystem.createDirectory(toolDir.appending(components: "Sources", "AwesomeResources"))
             try localFileSystem.writeFileContents(
-                packagePath.appending(components: "Sources", "AwesomeResources", "AwesomeResource.swift"),
-                bytes: ByteString(encodingAsUTF8: """
+              toolDir.appending(components: "Sources", "AwesomeResources", "AwesomeResource.swift"),
+              bytes: ByteString(encodingAsUTF8: """
                     import Foundation
 
                     public struct AwesomeResource {
@@ -325,20 +276,20 @@ final class BasicTests: XCTestCase {
             )
 
             try localFileSystem.writeFileContents(
-                packagePath.appending(components: "Sources", "AwesomeResources", "hello.txt"),
-                bytes: ByteString(encodingAsUTF8: "hello")
+              toolDir.appending(components: "Sources", "AwesomeResources", "hello.txt"),
+              bytes: ByteString(encodingAsUTF8: "hello")
             )
 
-            try localFileSystem.createDirectory(packagePath.appending(component: "Tests"))
-            try localFileSystem.createDirectory(packagePath.appending(components: "Tests", "AwesomeResourcesTest"))
+            try localFileSystem.createDirectory(toolDir.appending(component: "Tests"))
+            try localFileSystem.createDirectory(toolDir.appending(components: "Tests", "AwesomeResourcesTest"))
 
             try localFileSystem.writeFileContents(
-                packagePath.appending(components: "Tests", "AwesomeResourcesTest", "world.txt"),
-                bytes: ByteString(encodingAsUTF8: "world")
+              toolDir.appending(components: "Tests", "AwesomeResourcesTest", "world.txt"),
+              bytes: ByteString(encodingAsUTF8: "world")
             )
 
             try localFileSystem.writeFileContents(
-                packagePath.appending(components: "Tests", "AwesomeResourcesTest", "MyTests.swift"),
+                toolDir.appending(components: "Tests", "AwesomeResourcesTest", "MyTests.swift"),
                 bytes: ByteString(encodingAsUTF8: """
                     import XCTest
                     import Foundation
@@ -354,26 +305,15 @@ final class BasicTests: XCTestCase {
                         }
                     }
                     """))
+          
+            let testOutput = try sh(swiftTest, "--package-path", toolDir, "--filter", "MyTests.*").stderr
 
-            let testOutput = try sh(swiftTest, "--package-path", packagePath, "--filter", "MyTests.*").stderr
-
-            // Check the test log.
-            XCTAssertContents(testOutput) { checker in
-                checker.check(.contains("Test Suite 'MyTests' started"))
-                checker.check(.contains("Test Suite 'MyTests' passed"))
-                checker.check(.contains("Executed 2 tests, with 0 failures"))
-            }
-        }
-    }
-}
-
-private extension Character {
-    var isPlayingCardSuit: Bool {
-        switch self {
-        case "♠︎", "♡", "♢", "♣︎":
-            return true
-        default:
-            return false
+//             Check the test log.
+              XCTAssertContents(testOutput) { checker in
+                  checker.check(.contains("Test Suite 'MyTests' started"))
+                  checker.check(.contains("Test Suite 'MyTests' passed"))
+                  checker.check(.contains("Executed 2 tests, with 0 failures"))
+              }
         }
     }
 }

--- a/IntegrationTests/Tests/IntegrationTests/Helpers.swift
+++ b/IntegrationTests/Tests/IntegrationTests/Helpers.swift
@@ -286,9 +286,9 @@ func initGitRepo(
 }
 
 func binaryTargetsFixture(_ closure: (AbsolutePath) throws -> Void) throws {
-    fixture(name: "BinaryTargets") { fixturePath in
-        let inputsPath = fixturePath.appending(component: "Inputs")
-        let packagePath = fixturePath.appending(component: "TestBinary")
+    fixture(name: "BinaryTargets") { prefix in
+        let inputsPath = prefix.appending(component: "Inputs")
+        let packagePath = prefix.appending(component: "TestBinary")
 
         // Generating StaticLibrary.xcframework.
         try withTemporaryDirectory { tmpDir in
@@ -341,5 +341,13 @@ extension ProcessResult {
         stderr:
         \((try? utf8stderrOutput()) ?? "")
         """
+    }
+}
+
+func swiftcSupportsRenamingMainSymbol() throws -> Bool {
+    try withTemporaryDirectory { tmpDir in
+        FileManager.default.createFile(atPath: "\(tmpDir)/foo.swift", contents: Data())
+        let result = try Process.popen(args: swiftc.pathString, "-c", "-Xfrontend", "-entry-point-function-name", "-Xfrontend", "foo", "\(tmpDir)/foo.swift", "-o", "\(tmpDir)/foo.o")
+        return try !result.utf8stderrOutput().contains("unknown argument: '-entry-point-function-name'")
     }
 }

--- a/IntegrationTests/Tests/IntegrationTests/SwiftPMTests.swift
+++ b/IntegrationTests/Tests/IntegrationTests/SwiftPMTests.swift
@@ -1,12 +1,12 @@
 /*
- This source file is part of the Swift.org open source project
+This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
- Licensed under Apache License v2.0 with Runtime Library Exception
+Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
 
- See http://swift.org/LICENSE.txt for license information
- See http://swift.org/CONTRIBUTORS.txt for Swift project authors
- */
+See http://swift.org/LICENSE.txt for license information
+See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
 
 import XCTest
 import TSCBasic
@@ -16,13 +16,13 @@ final class SwiftPMTests: XCTestCase {
     func testBinaryTargets() throws {
         try XCTSkip("FIXME: ld: warning: dylib (/../BinaryTargets.6YVYK4/TestBinary/.build/x86_64-apple-macosx/debug/SwiftFramework.framework/SwiftFramework) was built for newer macOS version (10.15) than being linked (10.10)")
 
-#if !os(macOS)
-        try XCTSkip("Test requires macOS")
-#endif
+        #if !os(macOS)
+            try XCTSkip("Test requires macOS")
+        #endif
 
-        try binaryTargetsFixture { fixturePath in
+        try binaryTargetsFixture { prefix in
             do {
-                let (stdout, stderr) = try sh(swiftRun, "--package-path", fixturePath, "exe")
+                let (stdout, stderr) = try sh(swiftRun, "--package-path", prefix, "exe")
                 XCTAssertNoMatch(stderr, .contains("warning: "))
                 XCTAssertEqual(stdout, """
                     SwiftFramework()
@@ -32,18 +32,18 @@ final class SwiftPMTests: XCTestCase {
             }
 
             do {
-                let (stdout, stderr) = try sh(swiftRun, "--package-path", fixturePath, "cexe")
+                let (stdout, stderr) = try sh(swiftRun, "--package-path", prefix, "cexe")
                 XCTAssertNoMatch(stderr, .contains("warning: "))
                 XCTAssertMatch(stdout, .contains("<CLibrary: "))
             }
 
             do {
-                let invalidPath = fixturePath.appending(component: "SwiftFramework.xcframework")
-                let (_, stderr) = try shFails(swiftPackage, "--package-path", fixturePath, "compute-checksum", invalidPath)
+                let invalidPath = prefix.appending(component: "SwiftFramework.xcframework")
+                let (_, stderr) = try shFails(swiftPackage, "--package-path", prefix, "compute-checksum", invalidPath)
                 XCTAssertMatch(stderr, .contains("error: unexpected file type; supported extensions are: zip"))
 
-                let validPath = fixturePath.appending(component: "SwiftFramework.zip")
-                let (stdout, _) = try sh(swiftPackage, "--package-path", fixturePath, "compute-checksum", validPath)
+                let validPath = prefix.appending(component: "SwiftFramework.zip")
+                let (stdout, _) = try sh(swiftPackage, "--package-path", prefix, "compute-checksum", validPath)
                 XCTAssertEqual(stdout.spm_chomp(), "d1f202b1bfe04dea30b2bc4038f8059dcd75a5a176f1d81fcaedb6d3597d1158")
             }
         }
@@ -51,35 +51,33 @@ final class SwiftPMTests: XCTestCase {
 
     func testArchCustomization() throws {
         #if !os(macOS)
-        try XCTSkip("Test requires macOS")
+            try XCTSkip("Test requires macOS")
         #endif
 
         try withTemporaryDirectory { tmpDir in
-            let packagePath = tmpDir.appending(component: "foo")
-            try localFileSystem.createDirectory(packagePath)
-            try sh(swiftPackage, "--package-path", packagePath, "init", "--type", "executable")
-            // delete any files generated
-            for entry in try localFileSystem.getDirectoryContents(packagePath.appending(components: "Sources", "foo")) {
-                try localFileSystem.removeFileTree(packagePath.appending(components: "Sources", "foo", entry))
-            }
-            try localFileSystem.writeFileContents(packagePath.appending(RelativePath("Sources/foo/main.m"))) {
+            let foo = tmpDir.appending(component: "foo")
+            try localFileSystem.createDirectory(foo)
+            try sh(swiftPackage, "--package-path", foo, "init", "--type", "executable")
+
+            try localFileSystem.removeFileTree(foo.appending(RelativePath("Sources/foo/main.swift")))
+            try localFileSystem.writeFileContents(foo.appending(RelativePath("Sources/foo/main.m"))) {
                 $0 <<< "int main() {}"
             }
             let archs = ["x86_64", "arm64"]
 
             for arch in archs {
-                try sh(swiftBuild, "--package-path", packagePath, "--arch", arch)
-                let fooPath = packagePath.appending(RelativePath(".build/\(arch)-apple-macosx/debug/foo"))
+                try sh(swiftBuild, "--package-path", foo, "--arch", arch)
+                let fooPath = foo.appending(RelativePath(".build/\(arch)-apple-macosx/debug/foo"))
                 XCTAssertFileExists(fooPath)
             }
 
-            let args = [swiftBuild.pathString, "--package-path", packagePath.pathString] + archs.flatMap{ ["--arch", $0] }
+            let args = [swiftBuild.pathString, "--package-path", foo.pathString] + archs.flatMap{ ["--arch", $0] }
             try _sh(args)
 
-            let fooPath = packagePath.appending(RelativePath(".build/apple/Products/Debug/foo"))
+            let fooPath = foo.appending(RelativePath(".build/apple/Products/Debug/foo"))
             XCTAssertFileExists(fooPath)
 
-            let objectsDir = packagePath.appending(RelativePath(".build/apple/Intermediates.noindex/foo.build/Debug/foo.build/Objects-normal"))
+            let objectsDir = foo.appending(RelativePath(".build/apple/Intermediates.noindex/foo.build/Debug/foo.build/Objects-normal"))
             for arch in archs {
                 XCTAssertDirectoryExists(objectsDir.appending(component: arch))
             }

--- a/IntegrationTests/Tests/IntegrationTests/XCBuildTests.swift
+++ b/IntegrationTests/Tests/IntegrationTests/XCBuildTests.swift
@@ -6,7 +6,7 @@
 
  See http://swift.org/LICENSE.txt for license information
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
- */
+*/
 
 import XCTest
 import TSCBasic
@@ -15,7 +15,7 @@ import TSCTestSupport
 final class XCBuildTests: XCTestCase {
     func testExecutableProducts() throws {
         #if !os(macOS)
-        try XCTSkip("Test requires macOS")
+            try XCTSkip("Test requires macOS")
         #endif
 
         fixture(name: "XCBuild/ExecutableProducts") { path in
@@ -118,7 +118,7 @@ final class XCBuildTests: XCTestCase {
         try XCTSkip("FIXME: /.../XCBuild_TestProducts.551ajO/Foo/.build/apple/Intermediates.noindex/GeneratedModuleMaps/macosx/FooLib.modulemap:2:12: error: header 'FooLib-Swift.h' not found")
 
         #if !os(macOS)
-        try XCTSkip("Test requires macOS")
+            try XCTSkip("Test requires macOS")
         #endif
 
         fixture(name: "XCBuild/TestProducts") { path in
@@ -200,7 +200,7 @@ final class XCBuildTests: XCTestCase {
 
     func testLibraryProductsAndTargets() throws {
         #if !os(macOS)
-        try XCTSkip("Test requires macOS")
+            try XCTSkip("Test requires macOS")
         #endif
 
         fixture(name: "XCBuild/Libraries") { path in
@@ -276,7 +276,7 @@ final class XCBuildTests: XCTestCase {
         try XCTSkip("FIXME: ld: warning: ignoring file /../XCBuild_SystemTargets.b38QoO/Inputs/libsys.a, building for macOS-arm64 but attempting to link with file built for unknown-x86_64\n\nUndefined symbols for architecture arm64:\n  \"_GetSystemLibName\", referenced from:\n      _main in main.o\n\nld: symbol(s) not found for architecture arm64\n\nclang: error: linker command failed with exit code 1 (use -v to see invocation)\n\nBuild cancelled\n")
 
         #if !os(macOS)
-        try XCTSkip("Test requires macOS")
+            try XCTSkip("Test requires macOS")
         #endif
 
         fixture(name: "XCBuild/SystemTargets") { path in
@@ -312,7 +312,7 @@ final class XCBuildTests: XCTestCase {
         try XCTSkip("FIXME: swift-test invocations are timing out in Xcode and self-hosted CI")
 
         #if !os(macOS) || Xcode
-        try XCTSkip("Test requires macOS")
+            try XCTSkip("Test requires macOS")
         #endif
 
         fixture(name: "XCBuild/TestProducts") { path in

--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -286,7 +286,7 @@ public final class InitPackage {
         let moduleDir = sources.appending(component: "\(pkgname)")
         try makeDirectories(moduleDir)
         
-        let sourceFileName = "\(typeName).swift"
+        let sourceFileName = (packageType == .executable) ? "main.swift" : "\(typeName).swift"
         let sourceFile = moduleDir.appending(RelativePath(sourceFileName))
 
         let content: String
@@ -303,14 +303,7 @@ public final class InitPackage {
                 """
         case .executable:
             content = """
-                @main
-                public struct \(typeName) {
-                    public private(set) var text = "Hello, World!"
-
-                    public static func main() {
-                        print(\(typeName)().text)
-                    }
-                }
+                print("Hello, world!")
 
                 """
         case .systemModule, .empty, .manifest, .`extension`:
@@ -384,14 +377,50 @@ public final class InitPackage {
         try writePackageFile(path) { stream in
             stream <<< """
                 import XCTest
-                @testable import \(moduleName)
+                import class Foundation.Bundle
 
                 final class \(moduleName)Tests: XCTestCase {
                     func testExample() throws {
                         // This is an example of a functional test case.
                         // Use XCTAssert and related functions to verify your tests produce the correct
                         // results.
-                        XCTAssertEqual(\(typeName)().text, "Hello, World!")
+
+                        // Some of the APIs that we use below are available in macOS 10.13 and above.
+                        guard #available(macOS 10.13, *) else {
+                            return
+                        }
+
+                        // Mac Catalyst won't have `Process`, but it is supported for executables.
+                        #if !targetEnvironment(macCatalyst)
+
+                        let fooBinary = productsDirectory.appendingPathComponent("\(pkgname)")
+
+                        let process = Process()
+                        process.executableURL = fooBinary
+
+                        let pipe = Pipe()
+                        process.standardOutput = pipe
+
+                        try process.run()
+                        process.waitUntilExit()
+
+                        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                        let output = String(data: data, encoding: .utf8)
+
+                        XCTAssertEqual(output, "Hello, world!\\n")
+                        #endif
+                    }
+
+                    /// Returns path to the built products directory.
+                    var productsDirectory: URL {
+                      #if os(macOS)
+                        for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
+                            return bundle.bundleURL.deletingLastPathComponent()
+                        }
+                        fatalError("couldn't find the products directory")
+                      #else
+                        return Bundle.main.bundleURL
+                      #endif
                     }
                 }
 

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -673,7 +673,7 @@ final class PackageToolTests: CommandsTestCase {
             XCTAssertMatch(contents, .prefix("// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"))
 
             XCTAssertFileExists(manifest)
-            XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources").appending(component: "Foo")), ["Foo.swift"])
+            XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources").appending(component: "Foo")), ["main.swift"])
             XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Tests")).sorted(), ["FooTests"])
         }
     }
@@ -705,7 +705,7 @@ final class PackageToolTests: CommandsTestCase {
             XCTAssertMatch(contents, .prefix("// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"))
 
             XCTAssertFileExists(manifest)
-            XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources").appending(component: "CustomName")), ["CustomName.swift"])
+            XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources").appending(component: "CustomName")), ["main.swift"])
             XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Tests")).sorted(), ["CustomNameTests"])
         }
     }

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -81,7 +81,7 @@ class InitTests: XCTestCase {
             let readmeContents: String = try localFileSystem.readFileContents(readme)
             XCTAssertMatch(readmeContents, .prefix("# Foo\n"))
 
-            XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources").appending(component: "Foo")), ["Foo.swift"])
+            XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources").appending(component: "Foo")), ["main.swift"])
             XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Tests")).sorted(), ["FooTests"])
             
             // If we have a compiler that supports `-entry-point-function-name`, we try building it (we need that flag now).


### PR DESCRIPTION
Reverts apple/swift-package-manager#4122

```
********************
Failed Tests (2):
  swift-package-tests :: swift-package-init-exec.md
  swift-package-tests :: swift-run.md
```
