### PR TITLE
Fix llbuild package name for SWIFTCI_USE_LOCAL_DEPS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -568,10 +568,10 @@ if ProcessInfo.processInfo.environment["SWIFTPM_LLBUILD_FWK"] == nil {
         // In Swift CI, use a local path to llbuild to interoperate with tools
         // like `update-checkout`, which control the sources externally.
         package.dependencies += [
-            .package(name: "swift-llbuild", path: "../llbuild"),
+            .package(name: "llbuild", path: "../llbuild"),
         ]
     }
-    package.targets.first(where: { $0.name == "SPMLLBuild" })!.dependencies += [.product(name: "llbuildSwift", package: "swift-llbuild")]
+    package.targets.first(where: { $0.name == "SPMLLBuild" })!.dependencies += [.product(name: "llbuildSwift", package: "llbuild")]
 }
 
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {


### PR DESCRIPTION
Without this fix when this var is set I see:

```
'SwiftPM' /path/to/oss-swift/swiftpm: error: 'swiftpm' dependency on '/path/to/oss-swift/llbuild' has an explicit name 'swift-llbuild' which does not match the name 'llbuild' set for '/path/to/oss-swift/llbuild'
```