### PR TITLE
make XCTest optional on macOS for operations that do not require testing

### DIFF
--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -580,10 +580,10 @@ final class TestRunner {
     private func args(forTestAt testPath: AbsolutePath) throws -> [String] {
         var args: [String] = []
       #if os(macOS)
-        guard let xctest = self.toolchain.xctest else {
+        guard let xctestPath = self.toolchain.configuration.xctestPath else {
             throw TestError.testsExecutableNotFound
         }
-        args = [xctest.pathString]
+        args = [xctestPath.pathString]
         if let xctestArg = xctestArg {
             args += ["-XCTest", xctestArg]
         }

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -26,6 +26,7 @@ private enum TestError: Swift.Error {
     case invalidListTestJSONData
     case testsExecutableNotFound
     case multipleTestProducts([String])
+    case xctestNotAvailable
 }
 
 extension TestError: CustomStringConvertible {
@@ -37,6 +38,8 @@ extension TestError: CustomStringConvertible {
             return "invalid list test JSON structure"
         case .multipleTestProducts(let products):
             return "found multiple test products: \(products.joined(separator: ", ")); use --test-product to select one"
+        case .xctestNotAvailable:
+            return "XCTest not available"
         }
     }
 }
@@ -210,8 +213,19 @@ public struct SwiftTestTool: SwiftCommand {
     }
 
     public func run(_ swiftTool: SwiftTool) throws {
-        // Validate commands arguments
-        try self.validateArguments(observabilityScope: swiftTool.observabilityScope)
+        do {
+            // Validate commands arguments
+            try self.validateArguments(observabilityScope: swiftTool.observabilityScope)
+
+            // validate XCTest available on darwin based systems
+            let toolchain = try swiftTool.getToolchain()
+            if toolchain.triple.isDarwin() && toolchain.configuration.xctestPath == nil {
+                throw TestError.xctestNotAvailable
+            }
+        } catch {
+            swiftTool.observabilityScope.emit(error)
+            throw ExitCode.failure
+        }
 
         switch options.mode {
         case .listTests:
@@ -481,13 +495,11 @@ public struct SwiftTestTool: SwiftCommand {
 
             // The --num-worker option should be called with --parallel.
             guard options.mode == .runParallel else {
-                observabilityScope.emit(error: "--num-workers must be used with --parallel")
-                throw ExitCode.failure
+                throw StringError("--num-workers must be used with --parallel")
             }
 
             guard workers > 0 else {
-                observabilityScope.emit(error: "'--num-workers' must be greater than zero")
-                throw ExitCode.failure
+                throw StringError("'--num-workers' must be greater than zero")
             }
         }
 
@@ -579,21 +591,21 @@ final class TestRunner {
     /// Constructs arguments to execute XCTest.
     private func args(forTestAt testPath: AbsolutePath) throws -> [String] {
         var args: [String] = []
-      #if os(macOS)
+        #if os(macOS)
         guard let xctestPath = self.toolchain.configuration.xctestPath else {
-            throw TestError.testsExecutableNotFound
+            throw TestError.xctestNotAvailable
         }
         args = [xctestPath.pathString]
         if let xctestArg = xctestArg {
             args += ["-XCTest", xctestArg]
         }
         args += [testPath.pathString]
-      #else
+        #else
         args += [testPath.description]
         if let xctestArg = xctestArg {
             args += [xctestArg]
         }
-      #endif
+        #endif
         return args
     }
 

--- a/Sources/PackageModel/ToolchainConfiguration.swift
+++ b/Sources/PackageModel/ToolchainConfiguration.swift
@@ -33,7 +33,9 @@ public struct ToolchainConfiguration {
     /// If provided, it will be passed to the swift interpreter.
     public var sdkRootPath: AbsolutePath?
 
-    /// XCTest Location
+    /// Path to the XCTest utility.
+    ///
+    /// This is optional for example on macOS w/o Xcode.
     public var xctestPath: AbsolutePath?
 
     /// Creates the set of manifest resources associated with a `swiftc` executable.

--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -64,11 +64,6 @@ public final class UserToolchain: Toolchain {
         return self.swiftInterpreterPath
     }
 
-    /// Path to the xctest utility.
-    ///
-    /// This is only present on macOS.
-    public let xctest: AbsolutePath?
-
     /// The compilation destination object.
     public let destination: Destination
 
@@ -333,17 +328,6 @@ public final class UserToolchain: Toolchain {
 
         self.triple = triple
 
-        // We require xctest to exist on macOS.
-        if triple.isDarwin() {
-            // FIXME: We should have some general utility to find tools.
-            let xctestFindArgs = ["/usr/bin/xcrun", "--sdk", "macosx", "--find", "xctest"]
-            self.xctest = try AbsolutePath(
-                validating: Process.checkNonZeroExit(arguments: xctestFindArgs, environment: environment
-                                                    ).spm_chomp())
-        } else {
-            self.xctest = nil
-        }
-
         self.extraSwiftCFlags = Self.deriveSwiftCFlags(triple: triple, destination: destination)
 
         if let sdk = destination.sdk {
@@ -388,7 +372,7 @@ public final class UserToolchain: Toolchain {
 
         let swiftPMLibrariesLocation = try Self.deriveSwiftPMLibrariesLocation(swiftCompilerPath: swiftCompilerPath, destination: destination)
 
-        let xctestPath = Self.deriveXCTestPath()
+        let xctestPath = try Self.deriveXCTestPath(triple: triple, environment: environment)
 
         self.configuration = .init(
             swiftCompilerPath: swiftCompilers.manifest,
@@ -461,24 +445,30 @@ public final class UserToolchain: Toolchain {
         return .init(swiftCompilerPath: swiftCompilerPath)
     }
 
-    // TODO: why is this only required on Windows? is there something better we can do?
-    private static func deriveXCTestPath() -> AbsolutePath? {
-#if os(Windows)
-        if let DEVELOPER_DIR = ProcessEnv.vars["DEVELOPER_DIR"],
-           let root = try? AbsolutePath(validating: DEVELOPER_DIR)
-            .appending(component: "Platforms")
-            .appending(component: "Windows.platform") {
-            if let info = WindowsPlatformInfo(reading: root.appending(component: "Info.plist"),
-                                              diagnostics: nil,
-                                              filesystem: localFileSystem) {
-                return root.appending(component: "Developer")
-                    .appending(component: "Library")
-                    .appending(component: "XCTest-\(info.defaults.xctestVersion)")
-                    .appending(component: "usr")
-                    .appending(component: "bin")
+    // TODO: We should have some general utility to find tools.
+    private static func deriveXCTestPath(triple: Triple, environment: EnvironmentVariables) throws -> AbsolutePath? {
+        if triple.isDarwin() {
+            // XCTest is optional on macOS, for example with Xcode is not installed
+            let xctestFindArgs = ["/usr/bin/xcrun", "--sdk", "macosx", "--find", "xctest"]
+            if let path = try? Process.checkNonZeroExit(arguments: xctestFindArgs, environment: environment).spm_chomp() {
+                return try AbsolutePath(validating: path)
+            }
+        } else if triple.isWindows() {
+            if let DEVELOPER_DIR = ProcessEnv.vars["DEVELOPER_DIR"],
+               let root = try? AbsolutePath(validating: DEVELOPER_DIR)
+                .appending(component: "Platforms")
+                .appending(component: "Windows.platform") {
+                if let info = WindowsPlatformInfo(reading: root.appending(component: "Info.plist"),
+                                                  diagnostics: nil,
+                                                  filesystem: localFileSystem) {
+                    return root.appending(component: "Developer")
+                        .appending(component: "Library")
+                        .appending(component: "XCTest-\(info.defaults.xctestVersion)")
+                        .appending(component: "usr")
+                        .appending(component: "bin")
+                }
             }
         }
-#endif
-        return nil
+        return .none
     }
 }

--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -448,7 +448,7 @@ public final class UserToolchain: Toolchain {
     // TODO: We should have some general utility to find tools.
     private static func deriveXCTestPath(triple: Triple, environment: EnvironmentVariables) throws -> AbsolutePath? {
         if triple.isDarwin() {
-            // XCTest is optional on macOS, for example with Xcode is not installed
+            // XCTest is optional on macOS, for example when Xcode is not installed
             let xctestFindArgs = ["/usr/bin/xcrun", "--sdk", "macosx", "--find", "xctest"]
             if let path = try? Process.checkNonZeroExit(arguments: xctestFindArgs, environment: environment).spm_chomp() {
                 return try AbsolutePath(validating: path)


### PR DESCRIPTION
motivation: users should be able to use SwiftPM on macOS without Xcode installed (with the exception of testing for now)

changes:
* in UserToolchain make xctest lookup optional on macOS and only validate its exists when trying to perform tests
* consolidate two different representations of xctest path (one was for Windows and the other for macOS)

rdar://88651484
