### PR TITLE
resolve source control dependencies via the registry when available

### DIFF
--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -376,11 +376,22 @@ public struct SwiftToolOptions: ParsableArguments {
         static func name(for value: Self) -> NameSpecification {
             switch value {
             case .disabled:
-                return .customLong("disable-scm-to-regsitry-lookup")
+                return .customLong("disable-scm-to-registry-transformation")
             case .identity:
                 return .customLong("use-registry-identity-for-scm")
             case .swizzle:
-                return .customLong("raplace-scm-with-registry")
+                return .customLong("replace-scm-with-registry")
+            }
+        }
+
+        static func help(for value: SwiftToolOptions.SourceControlToRegistryDependencyTransformation) -> ArgumentHelp? {
+            switch value {
+            case .disabled:
+                return "disable source control to registry transformation"
+            case .identity:
+                return "look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins"
+            case .swizzle:
+                return "look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible"
             }
         }
     }

--- a/Sources/PackageGraph/PackageModel+Extensions.swift
+++ b/Sources/PackageGraph/PackageModel+Extensions.swift
@@ -34,7 +34,7 @@ extension PackageDependency {
 extension Manifest {
     /// Constructs constraints of the dependencies in the raw package.
     public func dependencyConstraints(productFilter: ProductFilter) throws -> [PackageContainerConstraint] {
-        return try dependenciesRequired(for: productFilter).map({
+        return try self.dependenciesRequired(for: productFilter).map({
             return PackageContainerConstraint(
                 package: $0.createPackageRef(),
                 requirement: try $0.toConstraintRequirement(),

--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -191,17 +191,16 @@ public final class Manifest {
             return self.dependencies
         }
 
-        var requiredDependencyURLs: Set<PackageIdentity> = []
-
+        var requiredDependencies: Set<PackageIdentity> = []
         for target in self.targetsRequired(for: products) {
             for targetDependency in target.dependencies {
                 if let dependency = self.packageDependency(referencedBy: targetDependency) {
-                    requiredDependencyURLs.insert(dependency.identity)
+                    requiredDependencies.insert(dependency.identity)
                 }
             }
         }
 
-        return self.dependencies.filter { requiredDependencyURLs.contains($0.identity) }
+        return self.dependencies.filter { requiredDependencies.contains($0.identity) }
         #endif
     }
 

--- a/Sources/PackageModel/Manifest/PackageDependencyDescription.swift
+++ b/Sources/PackageModel/Manifest/PackageDependencyDescription.swift
@@ -12,19 +12,19 @@ import Foundation
 import TSCBasic
 
 /// Represents a package dependency.
-public enum PackageDependency: Equatable {
+public enum PackageDependency: Equatable, Hashable {
     case fileSystem(FileSystem)
     case sourceControl(SourceControl)
     case registry(Registry)
     
-    public struct FileSystem: Equatable, Encodable {
+    public struct FileSystem: Equatable, Hashable, Encodable {
         public let identity: PackageIdentity
         public let nameForTargetDependencyResolutionOnly: String?
         public let path: AbsolutePath
         public let productFilter: ProductFilter
     }
 
-    public struct SourceControl: Equatable, Encodable {
+    public struct SourceControl: Equatable, Hashable, Encodable {
         public let identity: PackageIdentity
         public let nameForTargetDependencyResolutionOnly: String?
         public let location: Location
@@ -38,13 +38,13 @@ public enum PackageDependency: Equatable {
             case branch(String)
         }
 
-        public enum Location: Equatable {
+        public enum Location: Equatable, Hashable {
             case local(AbsolutePath)
             case remote(URL)
         }
     }
 
-    public struct Registry: Equatable, Encodable {
+    public struct Registry: Equatable, Hashable, Encodable {
         public let identity: PackageIdentity
         public let requirement: Requirement
         public let productFilter: ProductFilter

--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -46,6 +46,10 @@ public final class RegistryClient {
         self.jsonDecoder = JSONDecoder.makeWithDefaults()
     }
 
+    public var configured: Bool {
+        return !self.configuration.isEmpty
+    }
+
     public func getPackageMetadata(
         package: PackageIdentity,
         timeout: DispatchTimeInterval? = .none,

--- a/Sources/SPMTestSupport/MockPackage.swift
+++ b/Sources/SPMTestSupport/MockPackage.swift
@@ -73,6 +73,7 @@ public struct MockPackage {
         name: String,
         platforms: [PlatformDescription] = [],
         identity: String,
+        alternativeURLs: [String]? = .none,
         targets: [MockTarget],
         products: [MockProduct],
         dependencies: [MockDependency] = [],
@@ -82,7 +83,7 @@ public struct MockPackage {
     ) {
         self.name = name
         self.platforms = platforms
-        self.location = .registry(identity: .plain(identity))
+        self.location = .registry(identity: .plain(identity), alternativeURLs: alternativeURLs?.compactMap{ URL(string: $0) })
         self.targets = targets
         self.products = products
         self.dependencies = dependencies
@@ -107,6 +108,6 @@ public struct MockPackage {
     public enum Location {
         case fileSystem(path: RelativePath)
         case sourceControl(url: URL)
-        case registry(identity: PackageIdentity)
+        case registry(identity: PackageIdentity, alternativeURLs: [URL]?)
     }
 }

--- a/Sources/Workspace/FileSystemPackageContainer.swift
+++ b/Sources/Workspace/FileSystemPackageContainer.swift
@@ -99,7 +99,8 @@ public struct FileSystemPackageContainer: PackageContainer {
     }
 
     public func getUnversionedDependencies(productFilter: ProductFilter) throws -> [PackageContainerConstraint] {
-        return try loadManifest().dependencyConstraints(productFilter: productFilter)
+        let manifest = try self.loadManifest()
+        return try manifest.dependencyConstraints(productFilter: productFilter)
     }
 
     public func loadPackageReference(at boundVersion: BoundVersion) throws -> PackageReference {

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -4460,7 +4460,7 @@ extension Workspace {
                 case .success(let identities):
                     // FIXME: returns first result... need to consider how to address multiple ones
                     let identity = identities.first
-                    self.identitiesCache[url] = identity.map { (identity: $0, expirationTime: .now().advanced(by: self.cacheTTL)) }
+                    self.identitiesCache[url] = identity.map { (identity: $0, expirationTime: .now() + self.cacheTTL) }
                     completion(.success(identity))
                 }
             }

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -459,7 +459,8 @@ public class Workspace {
             prefetchBasedOnResolvedFile: resolverPrefetchingEnabled ?? WorkspaceConfiguration.default.prefetchBasedOnResolvedFile,
             additionalFileRules: additionalFileRules ?? WorkspaceConfiguration.default.additionalFileRules,
             sharedDependenciesCacheEnabled: sharedRepositoriesCacheEnabled ?? WorkspaceConfiguration.default.sharedDependenciesCacheEnabled,
-            fingerprintCheckingMode: resolverFingerprintCheckingMode
+            fingerprintCheckingMode: resolverFingerprintCheckingMode,
+            sourceControlToRegistryDependencyTransformation: WorkspaceConfiguration.default.sourceControlToRegistryDependencyTransformation
         )
         try self.init(
             fileSystem: fileSystem,
@@ -660,7 +661,7 @@ public class Workspace {
         let currentToolsVersion = customToolsVersion ?? ToolsVersion.currentToolsVersion
         let toolsVersionLoader = ToolsVersionLoader(currentToolsVersion: currentToolsVersion)
         let hostToolchain = try customHostToolchain ?? UserToolchain(destination: .hostDestination())
-        let manifestLoader = customManifestLoader ?? ManifestLoader(
+        var manifestLoader = customManifestLoader ?? ManifestLoader(
             toolchain: hostToolchain.configuration,
             cacheDir: location.sharedManifestsCacheDirectory
         )
@@ -674,6 +675,8 @@ public class Workspace {
         ).mirrors
 
         let identityResolver = customIdentityResolver ?? DefaultIdentityResolver(locationMapper: mirrors.effectiveURL(for:))
+        let checksumAlgorithm = customChecksumAlgorithm ?? SHA256()
+
         let repositoryProvider = customRepositoryProvider ?? GitRepositoryProvider()
         let repositoryManager = customRepositoryManager ?? RepositoryManager(
             fileSystem: fileSystem,
@@ -704,7 +707,6 @@ public class Workspace {
             authorizationProvider: authorizationProvider?.httpAuthorizationHeader(for:)
         )
 
-        let checksumAlgorithm = customChecksumAlgorithm ?? SHA256()
         let registryDownloadsManager = RegistryDownloadsManager(
             fileSystem: fileSystem,
             path: location.registryDownloadDirectory,
@@ -713,6 +715,14 @@ public class Workspace {
             checksumAlgorithm: checksumAlgorithm,
             delegate: delegate.map(WorkspaceRegistryDownloadsManagerDelegate.init(workspaceDelegate:))
         )
+
+        if registryClient.configured, let transformationMode = RegistryAwareManifestLoader.TransformationMode(configuration.sourceControlToRegistryDependencyTransformation) {
+            manifestLoader = RegistryAwareManifestLoader(
+                underlying: manifestLoader,
+                registryClient: registryClient,
+                transformationMode: transformationMode
+            )
+        }
 
         let httpClient = customHTTPClient ?? HTTPClient()
         let archiver = customArchiver ?? ZipArchiver()
@@ -967,17 +977,17 @@ extension Workspace {
     ///     - observabilityScope: The observability scope that reports errors, warnings, etc
     public func reset(observabilityScope: ObservabilityScope) {
         let removed = observabilityScope.trap { () -> Bool in
-            try fileSystem.chmod(.userWritable, path: self.location.repositoriesCheckoutsDirectory, options: [.recursive, .onlyFiles])
+            try self.fileSystem.chmod(.userWritable, path: self.location.repositoriesCheckoutsDirectory, options: [.recursive, .onlyFiles])
             // Reset state.
             try self.resetState()
             return true
         }
 
         guard (removed ?? false) else { return }
-        try? repositoryManager.reset()
-        try? registryDownloadsManager.reset()
-        try? manifestLoader.resetCache()
-        try? fileSystem.removeFileTree(self.location.workingDirectory)
+        try? self.repositoryManager.reset()
+        try? self.registryDownloadsManager.reset()
+        try? self.manifestLoader.resetCache()
+        try? self.fileSystem.removeFileTree(self.location.workingDirectory)
     }
 
     // FIXME: @testable internal
@@ -2148,7 +2158,7 @@ extension Workspace {
                     .packageMetadata(identity: packageIdentity, kind: packageKind)
                 }
 
-                manifestLoader.load(
+                self.manifestLoader.load(
                     at: packagePath,
                     packageIdentity: packageIdentity,
                     packageKind: packageKind,
@@ -2219,7 +2229,6 @@ extension Workspace {
                 }
             }
         }
-
     }
 
 
@@ -4186,6 +4195,290 @@ extension Workspace.Location {
             }
         }
         return location
+    }
+}
+
+extension Workspace {
+    // the goal of this code is to help align dependency identities across source control and registry origins
+    // the issue this solves is that dependencies will have different identities across the origins
+    // for example, source control based dependency on http://github.com/apple/swift-nio would have an identifier of "swift-nio"
+    // while in the registry, the same package will [likely] have an identifier of "apple.swift-nio"
+    // since there is not generally fire sure way to translate one system to the other (urls can vary widely, so the best we would be able to do is guess)
+    // what this code does is query the registry of it "knows" what the registry identity of URL is, and then use the registry identity instead of the URL bases one
+    // the code also supports a "full swizzle" mode in which it _replaces_ the source control dependency with a registry one which encourages the transition
+    // from source control based dependencies to registry based ones
+
+    // TODO
+    // 1. handle mixed situation when some versions on the registry but some on source control. we need a second lookup to make sure the version exists
+    // 2. handle registry returning multiple identifiers, how do we choose the right one?
+    fileprivate struct RegistryAwareManifestLoader: ManifestLoaderProtocol {
+        private let underlying: ManifestLoaderProtocol
+        private let registryClient: RegistryClient
+        private let transformationMode: TransformationMode
+
+        init(underlying: ManifestLoaderProtocol, registryClient: RegistryClient, transformationMode: TransformationMode) {
+            self.underlying = underlying
+            self.registryClient = registryClient
+            self.transformationMode = transformationMode
+        }
+
+        func load(
+            at path: AbsolutePath,
+            packageIdentity: PackageIdentity,
+            packageKind: PackageReference.Kind,
+            packageLocation: String,
+            version: Version?,
+            revision: String?,
+            toolsVersion: ToolsVersion,
+            identityResolver: IdentityResolver,
+            fileSystem: FileSystem,
+            observabilityScope: ObservabilityScope,
+            on queue: DispatchQueue,
+            completion: @escaping (Result<Manifest, Error>) -> Void
+        ) {
+            self.underlying.load(
+                at: path,
+                packageIdentity: packageIdentity,
+                packageKind: packageKind,
+                packageLocation: packageLocation,
+                version: version,
+                revision: revision,
+                toolsVersion: toolsVersion,
+                identityResolver: identityResolver,
+                fileSystem: fileSystem,
+                observabilityScope: observabilityScope,
+                on: queue
+            ) { result in
+                switch result {
+                case .failure(let error):
+                    completion(.failure(error))
+                case .success(let manifest):
+                    self.transformSourceControlDependenciesToRegistry(
+                        manifest: manifest,
+                        transformationMode: transformationMode,
+                        observabilityScope: observabilityScope,
+                        callbackQueue: queue,
+                        completion: completion
+                    )
+                }
+            }
+        }
+
+        func resetCache() throws {
+            try self.underlying.resetCache()
+        }
+
+        func purgeCache() throws {
+            try self.underlying.purgeCache()
+        }
+
+        private func transformSourceControlDependenciesToRegistry(
+            manifest: Manifest,
+            transformationMode: TransformationMode,
+            observabilityScope: ObservabilityScope,
+            callbackQueue: DispatchQueue,
+            completion: @escaping (Result<Manifest, Error>) -> Void
+        ) {
+            let sync = DispatchGroup()
+            let transformations = ThreadSafeKeyValueStore<PackageDependency, PackageIdentity>()
+            for dependency in manifest.dependencies {
+                if case .sourceControl(let settings) = dependency, case .remote(let url) = settings.location  {
+                    sync.enter()
+                    self.mapRegistryIdentity(url: url, observabilityScope: observabilityScope, callbackQueue: callbackQueue) { result in
+                        defer { sync.leave() }
+                        switch result {
+                        case .failure(let error):
+                            // do not raise error, only report it as warning
+                            observabilityScope.emit(warning: "failed querying registry identity for '\(url)': \(error)")
+                        case .success(.some(let identity)):
+                            transformations[dependency] = identity
+                        case .success(.none):
+                            // no identity found
+                            break
+                        }
+                    }
+                }
+            }
+
+            // update the manifest with the transformed dependencies
+            sync.notify(queue: .sharedConcurrent) {
+                do {
+                    let updatedManifest = try self.transformManifest(
+                        manifest: manifest,
+                        transformations: transformations.get(),
+                        transformationMode: transformationMode,
+                        observabilityScope: observabilityScope
+                    )
+                    completion(.success(updatedManifest))
+                }
+                catch {
+                    return completion(.failure(error))
+                }
+            }
+        }
+
+        private func transformManifest(
+            manifest: Manifest,
+            transformations: [PackageDependency: PackageIdentity],
+            transformationMode: TransformationMode,
+            observabilityScope: ObservabilityScope
+        ) throws -> Manifest {
+            var targetDependencyPackageNameTransformations = [String: String]()
+
+            var modifiedDependencies = [PackageDependency]()
+            for dependency in manifest.dependencies {
+                var modifiedDependency = dependency
+                if let registryIdentity = transformations[dependency] {
+                    guard case .sourceControl(let settings) = dependency, case .remote = settings.location else {
+                        // an implementation mistake
+                        throw InternalError("unexpected non-source-control dependency")
+                    }
+                    switch transformationMode {
+                    case .identity:
+                        // we replace the *identity* of the dependency in order to align the identities
+                        // and de-dupe across source control and registry origins
+                        observabilityScope.emit(info: "adjusting '\(dependency.locationString)' identity to registry identity of '\(registryIdentity)'.")
+                        modifiedDependency = .sourceControl(
+                            identity: registryIdentity,
+                            nameForTargetDependencyResolutionOnly: settings.nameForTargetDependencyResolutionOnly,
+                            location: settings.location,
+                            requirement: settings.requirement,
+                            productFilter: settings.productFilter
+                        )
+                    case .swizzle:
+                        // we replace the *entire* source control dependency with a registry one
+                        // this helps de-dupe across source control and registry dependencies
+                        // and also encourages use of registry over source control
+                        switch settings.requirement {
+                        case .exact, .range:
+                            let requirement = try settings.requirement.asRegistryRequirement()
+                            observabilityScope.emit(info: "swizzling '\(dependency.locationString)' with registry dependency '\(registryIdentity)'.")
+                            targetDependencyPackageNameTransformations[dependency.nameForTargetDependencyResolutionOnly] = registryIdentity.description
+                            modifiedDependency = .registry(
+                                identity: registryIdentity,
+                                requirement: requirement,
+                                productFilter: settings.productFilter
+                            )
+                        case .branch, .revision:
+                            // branch and revision dependencies are not supported by the registry
+                            // in such case, the best we can do is to replace the *identity* of the
+                            // source control dependency in order to align the identities
+                            // and de-dupe across source control and registry origins
+                            observabilityScope.emit(info: "adjusting '\(dependency.locationString)' identity to registry identity of '\(registryIdentity)'.")
+                            modifiedDependency = .sourceControl(
+                                identity: registryIdentity,
+                                nameForTargetDependencyResolutionOnly: settings.nameForTargetDependencyResolutionOnly,
+                                location: settings.location,
+                                requirement: settings.requirement,
+                                productFilter: settings.productFilter
+                            )
+                        }
+                    }
+                }
+                modifiedDependencies.append(modifiedDependency)
+            }
+
+            var modifiedTargets = manifest.targets
+            if !transformations.isEmpty {
+                modifiedTargets = []
+                for target in manifest.targets {
+                    var modifiedDependencies = [TargetDescription.Dependency]()
+                    for dependency in target.dependencies {
+                        var modifiedDependency = dependency
+                        if case .product(let name, let packageName, let moduleAliases, let condition) = dependency, let packageName = packageName {
+                            // makes sure we use the updated package name for target based dependencies
+                            if let modifiedPackageName = targetDependencyPackageNameTransformations[packageName] {
+                                modifiedDependency = .product(name: name, package: modifiedPackageName, moduleAliases: moduleAliases, condition: condition)
+                            }
+                        }
+                        modifiedDependencies.append(modifiedDependency)
+                    }
+
+                    modifiedTargets.append(
+                        try TargetDescription(
+                            name: target.name,
+                            dependencies: modifiedDependencies,
+                            path: target.path,
+                            url: target.url,
+                            exclude: target.exclude,
+                            sources: target.sources,
+                            resources: target.resources,
+                            publicHeadersPath: target.publicHeadersPath,
+                            type: target.type,
+                            pkgConfig: target.pkgConfig,
+                            providers: target.providers,
+                            pluginCapability: target.pluginCapability,
+                            settings: target.settings,
+                            checksum: target.checksum,
+                            pluginUsages: target.pluginUsages
+                        )
+                    )
+                }
+            }
+
+            let modifiedManifest = Manifest(
+                displayName: manifest.displayName,
+                path: manifest.path,
+                packageKind: manifest.packageKind,
+                packageLocation: manifest.packageLocation,
+                defaultLocalization: manifest.defaultLocalization,
+                platforms: manifest.platforms,
+                version: manifest.version,
+                revision: manifest.revision,
+                toolsVersion: manifest.toolsVersion,
+                pkgConfig: manifest.pkgConfig,
+                providers: manifest.providers,
+                cLanguageStandard: manifest.cLanguageStandard,
+                cxxLanguageStandard: manifest.cxxLanguageStandard,
+                swiftLanguageVersions: manifest.swiftLanguageVersions,
+                dependencies: modifiedDependencies,
+                products: manifest.products,
+                targets: modifiedTargets
+            )
+
+            return modifiedManifest
+        }
+
+        private func mapRegistryIdentity(
+            url: URL,
+            observabilityScope: ObservabilityScope,
+            callbackQueue: DispatchQueue,
+            completion: @escaping (Result<PackageIdentity?, Error>) -> Void
+        ) {
+            self.registryClient.lookupIdentities(url: url, observabilityScope: observabilityScope, callbackQueue: callbackQueue) { result in
+                // FIXME: returns first result... need to consider how to address multuiple ones
+                completion(result.map{ $0.first })
+            }
+        }
+
+        enum TransformationMode {
+            case identity
+            case swizzle
+
+            init?(_ seed: WorkspaceConfiguration.SourceControlToRegistryDependencyTransformation) {
+                switch seed {
+                case .identity:
+                    self = .identity
+                case .swizzle:
+                    self = .swizzle
+                case .disabled:
+                    return nil
+                }
+            }
+        }
+    }
+}
+
+fileprivate extension PackageDependency.SourceControl.Requirement {
+    func asRegistryRequirement() throws -> PackageDependency.Registry.Requirement {
+        switch self {
+        case .range(let versions):
+            return .range(versions)
+        case .exact(let version):
+            return .exact(version)
+        case .branch, .revision:
+            throw InternalError("invalid source control to registry requirement tranformation")
+        }
     }
 }
 

--- a/Sources/Workspace/WorkspaceConfiguration.swift
+++ b/Sources/Workspace/WorkspaceConfiguration.swift
@@ -633,18 +633,23 @@ public struct WorkspaceConfiguration {
     ///  Fingerprint checking mode. Defaults to warn.
     public var fingerprintCheckingMode: FingerprintCheckingMode
 
+    ///  Attempt to transform source control based dependencies to registry ones
+    public var sourceControlToRegistryDependencyTransformation: SourceControlToRegistryDependencyTransformation
+
     public init(
         skipDependenciesUpdates: Bool,
         prefetchBasedOnResolvedFile: Bool,
         additionalFileRules: [FileRuleDescription],
         sharedDependenciesCacheEnabled: Bool,
-        fingerprintCheckingMode: FingerprintCheckingMode
+        fingerprintCheckingMode: FingerprintCheckingMode,
+        sourceControlToRegistryDependencyTransformation: SourceControlToRegistryDependencyTransformation
     ) {
         self.skipDependenciesUpdates = skipDependenciesUpdates
         self.prefetchBasedOnResolvedFile = prefetchBasedOnResolvedFile
         self.additionalFileRules = additionalFileRules
         self.sharedDependenciesCacheEnabled = sharedDependenciesCacheEnabled
         self.fingerprintCheckingMode = fingerprintCheckingMode
+        self.sourceControlToRegistryDependencyTransformation = sourceControlToRegistryDependencyTransformation
     }
 
     /// Default instance of WorkspaceConfiguration
@@ -654,8 +659,15 @@ public struct WorkspaceConfiguration {
             prefetchBasedOnResolvedFile: true,
             additionalFileRules: [],
             sharedDependenciesCacheEnabled: true,
-            fingerprintCheckingMode: .warn
+            fingerprintCheckingMode: .warn,
+            sourceControlToRegistryDependencyTransformation: .disabled
         )
+    }
+
+    public enum SourceControlToRegistryDependencyTransformation {
+        case disabled
+        case identity
+        case swizzle
     }
 }
 


### PR DESCRIPTION
motivation: support mixed dependencies graphs where some dependencies come from source control while other from registry, and encourage the transition to the registry

changes:
* introduce new CLI flag to determine the source control to registry transformation mode (disabled, identity only, swizzle)
* wrap manifest loading with a transformer that translates source control dependencies to registry ones when the dependency is found in the registry, based on the mode
* add a bunch of tests