### PR TITLE
build: remove `-DYams_DIR=` from s-p-m build

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -565,7 +565,6 @@ def build_swiftpm_with_cmake(args):
     cmake_flags = [
         get_llbuild_cmake_arg(args),
         "-DTSC_DIR="              + os.path.join(args.build_dirs["tsc"],                   "cmake/modules"),
-        "-DYams_DIR="             + os.path.join(args.build_dirs["yams"],                  "cmake/modules"),
         "-DArgumentParser_DIR="   + os.path.join(args.build_dirs["swift-argument-parser"], "cmake/modules"),
         "-DSwiftDriver_DIR="      + os.path.join(args.build_dirs["swift-driver"],          "cmake/modules"),
         "-DSwiftCrypto_DIR="      + os.path.join(args.build_dirs["swift-crypto"],          "cmake/modules"),


### PR DESCRIPTION
swift-package-manager does not use Yams, remove the unnecessary flag
being passed to the build.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
