### PR TITLE
improve output stream handling in CLI

### DIFF
--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -88,6 +88,10 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         fileSystem: TSCBasic.FileSystem,
         observabilityScope: ObservabilityScope
     ) {
+        /// Checks if stdout stream is tty.
+        var buildParameters = buildParameters
+        buildParameters.colorizedOutput = outputStream.isTTY
+
         self.buildParameters = buildParameters
         self.cacheBuildManifest = cacheBuildManifest
         self.packageGraphLoader = packageGraphLoader
@@ -561,6 +565,21 @@ extension BuildSubset {
             }
             return target.getLLBuildTargetName(config: config)
         }
+    }
+}
+
+extension OutputByteStream {
+    fileprivate var isTTY: Bool {
+        let stream: OutputByteStream
+        if let threadSafeStream = self as? ThreadSafeOutputByteStream {
+            stream = threadSafeStream.stream
+        } else {
+            stream = self
+        }
+        guard let fileStream = stream as? LocalFileOutputByteStream else {
+            return false
+        }
+        return TerminalController.isTTY(fileStream)
     }
 }
 

--- a/Sources/Commands/APIDigester.swift
+++ b/Sources/Commands/APIDigester.swift
@@ -61,7 +61,6 @@ struct APIDigesterBaselineDumper {
         for modulesToDiff: Set<String>,
         at baselineDir: AbsolutePath?,
         force: Bool,
-        outputStream: OutputByteStream,
         logLevel: Diagnostic.Severity,
         swiftTool: SwiftTool
     ) throws -> AbsolutePath {
@@ -124,18 +123,11 @@ struct APIDigesterBaselineDumper {
 
         // Build the baseline module.
         // FIXME: We need to implement the build tool invocation closure here so that build tool plugins work with the APIDigester. rdar://86112934
-        let buildOp = BuildOperation(
-            buildParameters: buildParameters,
+        let buildOp = try swiftTool.createBuildOperation(
             cacheBuildManifest: false,
-            packageGraphLoader: { graph },
-            pluginScriptRunner: try swiftTool.getPluginScriptRunner(),
-            pluginWorkDirectory: try swiftTool.getActiveWorkspace().location.pluginWorkingDirectory,
-            outputStream: outputStream,
-            logLevel: logLevel,
-            fileSystem: localFileSystem,
-            observabilityScope: observabilityScope
+            customBuildParameters: buildParameters,
+            customPackageGraphLoader: { graph }
         )
-
         try buildOp.build()
 
         // Dump the SDK JSON.

--- a/Sources/Commands/Snippets/CardStack.swift
+++ b/Sources/Commands/Snippets/CardStack.swift
@@ -36,7 +36,8 @@ struct CardStack {
     private var needsToClearScreen = true
 
     init(package: ResolvedPackage, snippetGroups: [SnippetGroup], swiftTool: SwiftTool) {
-        self.terminal = TerminalController(stream: swiftTool.outputStream)!
+        // this interaction is done on stdout
+        self.terminal = TerminalController(stream: TSCBasic.stdoutStream)!
         self.cards = [TopCard(package: package, snippetGroups: snippetGroups, swiftTool: swiftTool)]
         self.swiftTool = swiftTool
     }

--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -107,7 +107,12 @@ public struct SwiftBuildTool: SwiftCommand {
         guard let subset = options.buildSubset(observabilityScope: swiftTool.observabilityScope) else {
             throw ExitCode.failure
         }
-        let buildSystem = try swiftTool.createBuildSystem(explicitProduct: options.product)
+        let buildSystem = try swiftTool.createBuildSystem(
+            explicitProduct: options.product,
+            // command result output goes on stdout
+            // ie "swift build" should output to stdout
+            customOutputStream: TSCBasic.stdoutStream
+        )
         do {
             try buildSystem.build(subset: subset)
         } catch _ as Diagnostics {

--- a/Sources/Commands/SwiftRunTool.swift
+++ b/Sources/Commands/SwiftRunTool.swift
@@ -114,26 +114,18 @@ public struct SwiftRunTool: SwiftCommand {
             let graphLoader = {
                 try swiftTool.loadPackageGraph(
                     explicitProduct: self.options.executable,
-                    createREPLProduct: true)
+                    createREPLProduct: true
+                )
             }
             let buildParameters = try swiftTool.buildParameters()
 
             // Construct the build operation.
             // FIXME: We need to implement the build tool invocation closure here so that build tool plugins work with the REPL. rdar://86112934
-            let buildOp = BuildOperation(
-                buildParameters: buildParameters,
+            let buildOp = try swiftTool.createBuildOperation(
                 cacheBuildManifest: false,
-                packageGraphLoader: graphLoader,
-                pluginScriptRunner: try swiftTool.getPluginScriptRunner(),
-                pluginWorkDirectory: try swiftTool.getActiveWorkspace().location.pluginWorkingDirectory,
-                outputStream: swiftTool.outputStream,
-                logLevel: swiftTool.logLevel,
-                fileSystem: localFileSystem,
-                observabilityScope: swiftTool.observabilityScope
+                customBuildParameters: buildParameters,
+                customPackageGraphLoader: graphLoader
             )
-
-            // Save the instance so it can be cancelled from the int handler.
-            swiftTool.buildSystemRef.buildSystem = buildOp
 
             // Perform build.
             try buildOp.build()
@@ -186,10 +178,6 @@ public struct SwiftRunTool: SwiftCommand {
                     arguments: arguments)
                 return
             }
-
-            // Redirect stdout to stderr because swift-run clients usually want
-            // to ignore swiftpm's output and only care about the tool's output.
-            swiftTool.redirectStdoutToStderr()
 
             do {
                 let buildSystem = try swiftTool.createBuildSystem(explicitProduct: options.executable)

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -31,7 +31,9 @@ import Darwin
 import Glibc
 #endif
 
+import protocol TSCUtility.ProgressAnimationProtocol
 import class TSCUtility.NinjaProgressAnimation
+import class TSCUtility.PercentProgressAnimation
 import var TSCUtility.verbosity
 
 typealias Diagnostic = Basics.Diagnostic
@@ -342,28 +344,39 @@ public class SwiftTool {
     /// The execution status of the tool.
     var executionStatus: ExecutionStatus = .success
 
-    /// The stream to print standard output on.
-    fileprivate(set) var outputStream: OutputByteStream = TSCBasic.stdoutStream
-
     /// Holds the currently active workspace.
     ///
     /// It is not initialized in init() because for some of the commands like package init , usage etc,
-    /// workspace is not needed, infact it would be an error to ask for the workspace object
+    /// workspace is not needed, in-fact it would be an error to ask for the workspace object
     /// for package init because the Manifest file should *not* present.
     private var _workspace: Workspace?
     private var _workspaceDelegate: ToolWorkspaceDelegate?
+
+    private let observabilityHandler: SwiftToolObservabilityHandler
 
     let observabilityScope: ObservabilityScope
 
     let logLevel: Diagnostic.Severity
 
+
     /// Create an instance of this tool.
     ///
-    /// - parameter args: The command line arguments to be passed to this tool.
-    public init(options: SwiftToolOptions) throws {
-        // first, bootstrap the observability syste
+    /// - parameter options: The command line options to be passed to this tool.
+    public convenience init(options: SwiftToolOptions) throws {
+        // output from background activities goes to stderr, this includes diagnostics and output from build operations,
+        // package resolution that take place as part of another action
+        // CLI commands that have user facing output, use stdout directly to emit the final result
+        // this means that the build output from "swift build" goes to stdout
+        // but the build output from "swift test" goes to stderr, while the tests output go to stdout
+        try self.init(outputStream: TSCBasic.stderrStream, options: options)
+    }
+
+    // marked internal for testing
+    internal init(outputStream: OutputByteStream, options: SwiftToolOptions) throws {
+        // first, bootstrap the observability system
         self.logLevel = options.logLevel
-        let observabilitySystem = ObservabilitySystem.init(SwiftToolObservability(logLevel: self.logLevel))
+        self.observabilityHandler = SwiftToolObservabilityHandler(outputStream: outputStream, logLevel: self.logLevel)
+        let observabilitySystem = ObservabilitySystem(self.observabilityHandler)
         self.observabilityScope = observabilitySystem.topScope
 
         // Capture the original working directory ASAP.
@@ -619,11 +632,6 @@ public class SwiftTool {
         return try authorization.makeAuthorizationProvider(fileSystem: localFileSystem, observabilityScope: self.observabilityScope)
     }
 
-    /// Start redirecting the standard output stream to the standard error stream.
-    func redirectStdoutToStderr() {
-        self.outputStream = TSCBasic.stderrStream
-    }
-
     /// Resolve the dependencies.
     func resolve() throws {
         let workspace = try getActiveWorkspace()
@@ -724,22 +732,32 @@ public class SwiftTool {
         return true
     }
 
-    func createBuildOperation(explicitProduct: String? = nil, cacheBuildManifest: Bool = true) throws -> BuildOperation {
-        // Load a custom package graph which has a special product for REPL.
+    // note: do not customize the OutputStream unless absolutely necessary
+    // "customOutputStream" is designed to support build output redirection
+    // but it is only expected to be used when invoking builds from "swift build" command.
+    // in all other cases, the build output should go to the default which is stderr
+    func createBuildOperation(
+        explicitProduct: String? = .none,
+        cacheBuildManifest: Bool = true,
+        customBuildParameters: BuildParameters? = .none,
+        customPackageGraphLoader: (() throws -> PackageGraph)? = .none,
+        customOutputStream: OutputByteStream? = .none,
+        customObservabilityScope: ObservabilityScope? = .none
+    ) throws -> BuildOperation {
         let graphLoader = { try self.loadPackageGraph(explicitProduct: explicitProduct) }
 
         // Construct the build operation.
         // FIXME: We need to implement the build tool invocation closure here so that build tool plugins work with dumping the symbol graph (the only case that currently goes through this path, as far as I can tell). rdar://86112934
         let buildOp = try BuildOperation(
-            buildParameters: buildParameters(),
+            buildParameters: customBuildParameters ?? self.buildParameters(),
             cacheBuildManifest: cacheBuildManifest && self.canUseCachedBuildManifest(),
-            packageGraphLoader: graphLoader,
+            packageGraphLoader: customPackageGraphLoader ?? graphLoader,
             pluginScriptRunner: self.getPluginScriptRunner(),
             pluginWorkDirectory: try self.getActiveWorkspace().location.pluginWorkingDirectory,
-            outputStream: self.outputStream,
+            outputStream: customOutputStream ?? self.outputStream,
             logLevel: self.logLevel,
             fileSystem: localFileSystem,
-            observabilityScope: self.observabilityScope
+            observabilityScope: customObservabilityScope ?? self.observabilityScope
         )
 
         // Save the instance so it can be cancelled from the int handler.
@@ -747,33 +765,44 @@ public class SwiftTool {
         return buildOp
     }
 
-    func createBuildSystem(explicitProduct: String? = nil, buildParameters: BuildParameters? = nil) throws -> BuildSystem {
+    // note: do not customize the OutputStream unless absolutely necessary
+    // "customOutputStream" is designed to support build output redirection
+    // but it is only expected to be used when invoking builds from "swift build" command.
+    // in all other cases, the build output should go to the default which is stderr
+    func createBuildSystem(
+        explicitProduct: String? = .none,
+        customBuildParameters: BuildParameters? = .none,
+        customPackageGraphLoader: (() throws -> PackageGraph)? = .none,
+        customOutputStream: OutputByteStream? = .none,
+        customObservabilityScope: ObservabilityScope? = .none
+    ) throws -> BuildSystem {
         let buildSystem: BuildSystem
         switch options.buildSystem {
         case .native:
             let graphLoader = { try self.loadPackageGraph(explicitProduct: explicitProduct) }
+
             buildSystem = try BuildOperation(
-                buildParameters: buildParameters ?? self.buildParameters(),
+                buildParameters: customBuildParameters ?? self.buildParameters(),
                 cacheBuildManifest: self.canUseCachedBuildManifest(),
-                packageGraphLoader: graphLoader,
+                packageGraphLoader: customPackageGraphLoader ?? graphLoader,
                 pluginScriptRunner: self.getPluginScriptRunner(),
                 pluginWorkDirectory: try self.getActiveWorkspace().location.pluginWorkingDirectory,
                 disableSandboxForPluginCommands: self.options.shouldDisableSandbox,
-                outputStream: self.outputStream,
+                outputStream: customOutputStream ?? self.outputStream,
                 logLevel: self.logLevel,
                 fileSystem: localFileSystem,
-                observabilityScope: self.observabilityScope
+                observabilityScope: customObservabilityScope ?? self.observabilityScope
             )
         case .xcode:
             let graphLoader = { try self.loadPackageGraph(explicitProduct: explicitProduct, createMultipleTestProducts: true) }
             // FIXME: Implement the custom build command provider also.
             buildSystem = try XcodeBuildSystem(
-                buildParameters: buildParameters ?? self.buildParameters(),
-                packageGraphLoader: graphLoader,
-                outputStream: self.outputStream,
+                buildParameters: customBuildParameters ?? self.buildParameters(),
+                packageGraphLoader: customPackageGraphLoader ??  graphLoader,
+                outputStream: customOutputStream ?? self.outputStream,
                 logLevel: self.logLevel,
                 fileSystem: localFileSystem,
-                observabilityScope: self.observabilityScope
+                observabilityScope: customObservabilityScope ?? self.observabilityScope
             )
         }
 
@@ -791,20 +820,6 @@ public class SwiftTool {
         return Result(catching: {
             let toolchain = try self.getToolchain()
             let triple = toolchain.triple
-
-            /// Checks if stdout stream is tty.
-            let isTTY: Bool = {
-                let stream: OutputByteStream
-                if let threadSafeStream = self.outputStream as? ThreadSafeOutputByteStream {
-                    stream = threadSafeStream.stream
-                } else {
-                    stream = self.outputStream
-                }
-                guard let fileStream = stream as? LocalFileOutputByteStream else {
-                    return false
-                }
-                return TerminalController.isTTY(fileStream)
-            }()
 
             // Use "apple" as the subdirectory because in theory Xcode build system
             // can be used to build for any Apple platform and it has it's own
@@ -835,7 +850,6 @@ public class SwiftTool {
                 printManifestGraphviz: options.printManifestGraphviz,
                 forceTestDiscovery: options.enableTestDiscovery, // backwards compatibility, remove with --enable-test-discovery
                 linkerDeadStrip: options.linkerDeadStrip,
-                colorizedOutput: isTTY,
                 verboseOutput: self.logLevel <= .info
             )
         })
@@ -1009,27 +1023,53 @@ extension Basics.Diagnostic {
 
 // MARK: - Diagnostics
 
-private struct SwiftToolObservability: ObservabilityHandlerProvider, DiagnosticsHandler {
-    private let logLevel: Diagnostic.Severity
+private struct SwiftToolObservabilityHandler: ObservabilityHandlerProvider {
+    private let outputHandler: OutputHandler
 
-    var diagnosticsHandler: DiagnosticsHandler { self }
-
-    init(logLevel: Diagnostic.Severity) {
-        self.logLevel = logLevel
+    var diagnosticsHandler: DiagnosticsHandler {
+        self.outputHandler
     }
 
-    func handleDiagnostic(scope: ObservabilityScope, diagnostic: Basics.Diagnostic) {
-        // TODO: do something useful with scope
-        if diagnostic.severity >= self.logLevel {
-            diagnostic.print()
+    init(outputStream: OutputByteStream, logLevel: Diagnostic.Severity) {
+        let threadSafeOutputByteStream = outputStream as? ThreadSafeOutputByteStream ?? ThreadSafeOutputByteStream(outputStream)
+        self.outputHandler = OutputHandler(logLevel: logLevel, outputStream: threadSafeOutputByteStream)
+    }
+
+    // FIXME: deprecate this one we are further along refactoring the call sites that use it
+    var outputStream: OutputByteStream {
+        self.outputHandler.outputStream
+    }
+
+    struct OutputHandler: DiagnosticsHandler {
+        let logLevel: Diagnostic.Severity
+        let outputStream: ThreadSafeOutputByteStream
+        let writer: InteractiveWriter
+
+        init(logLevel: Diagnostic.Severity, outputStream: ThreadSafeOutputByteStream) {
+            self.logLevel = logLevel
+            self.outputStream = outputStream
+            self.writer = InteractiveWriter(stream: outputStream)
+        }
+
+        func handleDiagnostic(scope: ObservabilityScope, diagnostic: Basics.Diagnostic) {
+            // TODO: do something useful with scope
+            if diagnostic.severity >= self.logLevel {
+                diagnostic.print(with: self.writer)
+            }
         }
     }
 }
 
-extension Basics.Diagnostic {
-    func print() {
-        let writer = InteractiveWriter.stderr
+extension SwiftTool {
+    // FIXME: deprecate these one we are further along refactoring the call sites that use it
+    /// The stream to print standard output on.
+    var outputStream: OutputByteStream {
+        self.observabilityHandler.outputStream
+    }
+}
 
+extension Basics.Diagnostic {
+    fileprivate func print(with writer: InteractiveWriter) {
         var message: String
         switch self.severity {
         case .error:
@@ -1060,14 +1100,7 @@ extension Basics.Diagnostic {
 ///
 /// If underlying stream is a not tty, the string will be written in without any
 /// formatting.
-private final class InteractiveWriter {
-
-    /// The standard error writer.
-    static let stderr = InteractiveWriter(stream: TSCBasic.stderrStream)
-
-    /// The standard output writer.
-    static let stdout = InteractiveWriter(stream: TSCBasic.stdoutStream)
-
+private struct InteractiveWriter {
     /// The terminal controller, if present.
     let term: TerminalController?
 

--- a/Tests/CommandsTests/SwiftToolTests.swift
+++ b/Tests/CommandsTests/SwiftToolTests.swift
@@ -19,48 +19,88 @@ final class SwiftToolTests: CommandsTestCase {
     func testVerbosityLogLevel() throws {
         try fixture(name: "Miscellaneous/Simple") { fixturePath in
             do {
+                let outputStream = BufferedOutputByteStream()
                 let options = try SwiftToolOptions.parse(["--package-path", fixturePath.pathString])
-                let tool = try SwiftTool(options: options)
+                let tool = try SwiftTool(outputStream: outputStream, options: options)
                 XCTAssertEqual(tool.logLevel, .warning)
 
                 tool.observabilityScope.emit(error: "error")
                 tool.observabilityScope.emit(warning: "warning")
                 tool.observabilityScope.emit(info: "info")
                 tool.observabilityScope.emit(debug: "debug")
+
+                XCTAssertMatch(outputStream.bytes.validDescription, .contains("error: error"))
+                XCTAssertMatch(outputStream.bytes.validDescription, .contains("warning: warning"))
+                XCTAssertNoMatch(outputStream.bytes.validDescription, .contains("info: info"))
+                XCTAssertNoMatch(outputStream.bytes.validDescription, .contains("debug: debug"))
             }
 
             do {
+                let outputStream = BufferedOutputByteStream()
                 let options = try SwiftToolOptions.parse(["--package-path", fixturePath.pathString, "--verbose"])
-                let tool = try SwiftTool(options: options)
+                let tool = try SwiftTool(outputStream: outputStream, options: options)
                 XCTAssertEqual(tool.logLevel, .info)
 
                 tool.observabilityScope.emit(error: "error")
                 tool.observabilityScope.emit(warning: "warning")
                 tool.observabilityScope.emit(info: "info")
                 tool.observabilityScope.emit(debug: "debug")
+
+                XCTAssertMatch(outputStream.bytes.validDescription, .contains("error: error"))
+                XCTAssertMatch(outputStream.bytes.validDescription, .contains("warning: warning"))
+                XCTAssertMatch(outputStream.bytes.validDescription, .contains("info: info"))
+                XCTAssertNoMatch(outputStream.bytes.validDescription, .contains("debug: debug"))
             }
 
             do {
+                let outputStream = BufferedOutputByteStream()
                 let options = try SwiftToolOptions.parse(["--package-path", fixturePath.pathString, "-v"])
-                let tool = try SwiftTool(options: options)
+                let tool = try SwiftTool(outputStream: outputStream, options: options)
                 XCTAssertEqual(tool.logLevel, .info)
+
+                tool.observabilityScope.emit(error: "error")
+                tool.observabilityScope.emit(warning: "warning")
+                tool.observabilityScope.emit(info: "info")
+                tool.observabilityScope.emit(debug: "debug")
+
+                XCTAssertMatch(outputStream.bytes.validDescription, .contains("error: error"))
+                XCTAssertMatch(outputStream.bytes.validDescription, .contains("warning: warning"))
+                XCTAssertMatch(outputStream.bytes.validDescription, .contains("info: info"))
+                XCTAssertNoMatch(outputStream.bytes.validDescription, .contains("debug: debug"))
             }
 
             do {
+                let outputStream = BufferedOutputByteStream()
                 let options = try SwiftToolOptions.parse(["--package-path", fixturePath.pathString, "--very-verbose"])
-                let tool = try SwiftTool(options: options)
+                let tool = try SwiftTool(outputStream: outputStream, options: options)
                 XCTAssertEqual(tool.logLevel, .debug)
 
                 tool.observabilityScope.emit(error: "error")
                 tool.observabilityScope.emit(warning: "warning")
                 tool.observabilityScope.emit(info: "info")
                 tool.observabilityScope.emit(debug: "debug")
+
+                XCTAssertMatch(outputStream.bytes.validDescription, .contains("error: error"))
+                XCTAssertMatch(outputStream.bytes.validDescription, .contains("warning: warning"))
+                XCTAssertMatch(outputStream.bytes.validDescription, .contains("info: info"))
+                XCTAssertMatch(outputStream.bytes.validDescription, .contains("debug: debug"))
             }
 
             do {
+                let outputStream = BufferedOutputByteStream()
                 let options = try SwiftToolOptions.parse(["--package-path", fixturePath.pathString, "--vv"])
-                let tool = try SwiftTool(options: options)
+                let tool = try SwiftTool(outputStream: outputStream, options: options)
                 XCTAssertEqual(tool.logLevel, .debug)
+
+                tool.observabilityScope.emit(error: "error")
+                tool.observabilityScope.emit(warning: "warning")
+                tool.observabilityScope.emit(info: "info")
+                tool.observabilityScope.emit(debug: "debug")
+
+                XCTAssertMatch(outputStream.bytes.validDescription, .contains("error: error"))
+                XCTAssertMatch(outputStream.bytes.validDescription, .contains("warning: warning"))
+                XCTAssertMatch(outputStream.bytes.validDescription, .contains("info: info"))
+                XCTAssertMatch(outputStream.bytes.validDescription, .contains("debug: debug"))
             }
         }
     }

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -26,15 +26,18 @@ class MiscellaneousTestCase: XCTestCase {
         // the selected version of the package
 
         try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
-            let (output, _) = try executeSwiftBuild(fixturePath.appending(component: "Bar"))
-            XCTAssertMatch(output, .regex("Computed .* at 1\\.2\\.3"))
-            XCTAssertMatch(output, .contains("Compiling Foo Foo.swift"))
-            XCTAssertMatch(output, .or(.contains("Merging module Foo"),
+            let (stdout, stderr) = try executeSwiftBuild(fixturePath.appending(component: "Bar"))
+            // package resolution output goes to stderr
+            XCTAssertMatch(stderr, .regex("Computed .* at 1\\.2\\.3"))
+            // in "swift build" build output goes to stdout
+            XCTAssertMatch(stdout, .contains("Compiling Foo Foo.swift"))
+            XCTAssertMatch(stdout, .or(.contains("Merging module Foo"),
                                        .contains("Emitting module Foo")))
-            XCTAssertMatch(output, .contains("Compiling Bar main.swift"))
-            XCTAssertMatch(output, .or(.contains("Merging module Bar"),
+            XCTAssertMatch(stdout, .contains("Compiling Bar main.swift"))
+            XCTAssertMatch(stdout, .or(.contains("Merging module Bar"),
                                       .contains("Emitting module Bar")))
-            XCTAssertMatch(output, .contains("Linking Bar"))
+            XCTAssertMatch(stdout, .contains("Linking Bar"))
+            XCTAssertMatch(stdout, .contains("Build complete!"))
         }
     }
 
@@ -215,23 +218,21 @@ class MiscellaneousTestCase: XCTestCase {
             // First try normal serial testing.
             do {
                 _ = try SwiftPMProduct.SwiftTest.execute([], packagePath: fixturePath)
-            } catch SwiftPMProductError.executionFailure(_, let output, let stderr) {
-                #if os(macOS)
-                XCTAssertMatch(stderr, .contains("Executed 2 tests"))
-                #else
-                XCTAssertMatch(output, .contains("Executed 2 tests"))
-                #endif
+            } catch SwiftPMProductError.executionFailure(_, let stdout, _) {
+                // in "swift test" test output goes to stdout
+                XCTAssertMatch(stdout, .contains("Executed 2 tests"))
             }
 
             do {
                 // Run tests in parallel.
                 _ = try SwiftPMProduct.SwiftTest.execute(["--parallel"], packagePath: fixturePath)
-            } catch SwiftPMProductError.executionFailure(_, let output, _) {
-                XCTAssertMatch(output, .contains("testExample1"))
-                XCTAssertMatch(output, .contains("testExample2"))
-                XCTAssertNoMatch(output, .contains("'ParallelTestsTests' passed"))
-                XCTAssertMatch(output, .contains("'ParallelTestsFailureTests' failed"))
-                XCTAssertMatch(output, .contains("[3/3]"))
+            } catch SwiftPMProductError.executionFailure(_, let stdout, _) {
+                // in "swift test" test output goes to stdout
+                XCTAssertMatch(stdout, .contains("testExample1"))
+                XCTAssertMatch(stdout, .contains("testExample2"))
+                XCTAssertNoMatch(stdout, .contains("'ParallelTestsTests' passed"))
+                XCTAssertMatch(stdout, .contains("'ParallelTestsFailureTests' failed"))
+                XCTAssertMatch(stdout, .contains("[3/3]"))
             }
 
             let xUnitOutput = fixturePath.appending(component: "result.xml")
@@ -240,12 +241,13 @@ class MiscellaneousTestCase: XCTestCase {
                 _ = try SwiftPMProduct.SwiftTest.execute(
                     ["--parallel", "--verbose", "--xunit-output", xUnitOutput.pathString],
                     packagePath: fixturePath)
-            } catch SwiftPMProductError.executionFailure(_, let output, _) {
-                XCTAssertMatch(output, .contains("testExample1"))
-                XCTAssertMatch(output, .contains("testExample2"))
-                XCTAssertMatch(output, .contains("'ParallelTestsTests' passed"))
-                XCTAssertMatch(output, .contains("'ParallelTestsFailureTests' failed"))
-                XCTAssertMatch(output, .contains("[3/3]"))
+            } catch SwiftPMProductError.executionFailure(_, let stdout, _) {
+                // in "swift test" test output goes to stdout
+                XCTAssertMatch(stdout, .contains("testExample1"))
+                XCTAssertMatch(stdout, .contains("testExample2"))
+                XCTAssertMatch(stdout, .contains("'ParallelTestsTests' passed"))
+                XCTAssertMatch(stdout, .contains("'ParallelTestsFailureTests' failed"))
+                XCTAssertMatch(stdout, .contains("[3/3]"))
             }
 
             // Check the xUnit output.
@@ -258,6 +260,7 @@ class MiscellaneousTestCase: XCTestCase {
     func testSwiftTestFilter() throws {
         try fixture(name: "Miscellaneous/ParallelTestsPkg") { fixturePath in
             let (stdout, _) = try SwiftPMProduct.SwiftTest.execute(["--filter", ".*1", "-l"], packagePath: fixturePath)
+            // in "swift test" test output goes to stdout
             XCTAssertMatch(stdout, .contains("testExample1"))
             XCTAssertNoMatch(stdout, .contains("testExample2"))
             XCTAssertNoMatch(stdout, .contains("testSureFailure"))
@@ -265,6 +268,7 @@ class MiscellaneousTestCase: XCTestCase {
 
         try fixture(name: "Miscellaneous/ParallelTestsPkg") { fixturePath in
             let (stdout, _) = try SwiftPMProduct.SwiftTest.execute(["--filter", "ParallelTestsTests", "--skip", ".*1", "--filter", "testSureFailure", "-l"], packagePath: fixturePath)
+            // in "swift test" test output goes to stdout
             XCTAssertNoMatch(stdout, .contains("testExample1"))
             XCTAssertMatch(stdout, .contains("testExample2"))
             XCTAssertMatch(stdout, .contains("testSureFailure"))
@@ -274,6 +278,7 @@ class MiscellaneousTestCase: XCTestCase {
     func testSwiftTestSkip() throws {
         try fixture(name: "Miscellaneous/ParallelTestsPkg") { fixturePath in
             let (stdout, _) = try SwiftPMProduct.SwiftTest.execute(["--skip", "ParallelTestsTests", "-l"], packagePath: fixturePath)
+            // in "swift test" test output goes to stdout
             XCTAssertNoMatch(stdout, .contains("testExample1"))
             XCTAssertNoMatch(stdout, .contains("testExample2"))
             XCTAssertMatch(stdout, .contains("testSureFailure"))
@@ -281,6 +286,7 @@ class MiscellaneousTestCase: XCTestCase {
 
         try fixture(name: "Miscellaneous/ParallelTestsPkg") { fixturePath in
             let (stdout, _) = try SwiftPMProduct.SwiftTest.execute(["--filter", "ParallelTestsTests", "--skip", ".*2", "--filter", "TestsFailure", "--skip", "testSureFailure", "-l"], packagePath: fixturePath)
+            // in "swift test" test output goes to stdout
             XCTAssertMatch(stdout, .contains("testExample1"))
             XCTAssertNoMatch(stdout, .contains("testExample2"))
             XCTAssertNoMatch(stdout, .contains("testSureFailure"))
@@ -288,6 +294,7 @@ class MiscellaneousTestCase: XCTestCase {
 
         try fixture(name: "Miscellaneous/ParallelTestsPkg") { fixturePath in
             let (stdout, stderr) = try SwiftPMProduct.SwiftTest.execute(["--skip", "Tests"], packagePath: fixturePath)
+            // in "swift test" test output goes to stdout
             XCTAssertNoMatch(stdout, .contains("testExample1"))
             XCTAssertNoMatch(stdout, .contains("testExample2"))
             XCTAssertNoMatch(stdout, .contains("testSureFailure"))
@@ -572,10 +579,14 @@ class MiscellaneousTestCase: XCTestCase {
 
         try fixture(name: "Miscellaneous/TestableExe") { fixturePath in
             do {
-                let (stdout, _) = try executeSwiftTest(fixturePath)
-                XCTAssertMatch(stdout, .contains("Linking TestableExe1"))
-                XCTAssertMatch(stdout, .contains("Linking TestableExe2"))
-                XCTAssertMatch(stdout, .contains("Linking TestableExePackageTests"))
+                let (stdout, stderr) = try executeSwiftTest(fixturePath)
+                // in "swift test" build output goes to stderr
+                XCTAssertMatch(stderr, .contains("Linking TestableExe1"))
+                XCTAssertMatch(stderr, .contains("Linking TestableExe2"))
+                XCTAssertMatch(stderr, .contains("Linking TestableExePackageTests"))
+                XCTAssertMatch(stderr, .contains("Build complete!"))
+                // in "swift test" test output goes to stdout
+                XCTAssertMatch(stdout, .contains("Executed 1 test"))
                 XCTAssertMatch(stdout, .contains("Hello, world"))
                 XCTAssertMatch(stdout, .contains("Hello, planet"))
             } catch {
@@ -600,6 +611,7 @@ class MiscellaneousTestCase: XCTestCase {
         try fixture(name: "Miscellaneous/TargetMismatch") { path in
             do {
                 let output = try executeSwiftBuild(path)
+                // in "swift build" build output goes to stdout
                 XCTAssertMatch(output.stdout, .contains("Compiling Sample main.swift"))
                 XCTAssertMatch(output.stderr, .contains("The target named 'Sample' was identified as an executable target but a non-executable product with this name already exists."))
             } catch {
@@ -622,8 +634,10 @@ class MiscellaneousTestCase: XCTestCase {
             do {
                 // make sure it builds
                 let output = try executeSwiftBuild(appPath)
-                XCTAssertTrue(output.stdout.contains("Fetching \(prefix)/Foo"), output.stdout)
-                XCTAssertTrue(output.stdout.contains("Creating working copy for \(prefix)/Foo"), output.stdout)
+                // package resolution output goes to stderr
+                XCTAssertTrue(output.stderr.contains("Fetching \(prefix)/Foo"), output.stderr)
+                XCTAssertTrue(output.stderr.contains("Creating working copy for \(prefix)/Foo"), output.stderr)
+                // in "swift build" build output goes to stdout
                 XCTAssertTrue(output.stdout.contains("Build complete!"), output.stdout)
             }
 
@@ -640,13 +654,15 @@ class MiscellaneousTestCase: XCTestCase {
             do {
                 // take foo out of edit mode
                 let output = try executeSwiftPackage(appPath, extraArgs: ["unedit", "Foo"])
-                XCTAssertTrue(output.stdout.contains("Creating working copy for \(prefix)/Foo"), output.stdout)
+                // package resolution output goes to stderr
+                XCTAssertTrue(output.stderr.contains("Creating working copy for \(prefix)/Foo"), output.stderr)
                 XCTAssertNoSuchPath(appPath.appending(components: ["Packages", "Foo"]))
             }
 
             // build again in edit mode
             do {
                 let output = try executeSwiftBuild(appPath)
+                // in "swift build" build output goes to stdout
                 XCTAssertTrue(output.stdout.contains("Build complete!"), output.stdout)
             }
         }

--- a/Tests/FunctionalTests/TestDiscoveryTests.swift
+++ b/Tests/FunctionalTests/TestDiscoveryTests.swift
@@ -17,50 +17,38 @@ class TestDiscoveryTests: XCTestCase {
     func testBuild() throws {
         try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
             let (stdout, _) = try executeSwiftBuild(fixturePath)
-            #if os(macOS)
-            XCTAssertMatch(stdout, .contains("module Simple"))
-            #else
-            XCTAssertMatch(stdout, .contains("module Simple"))
-            #endif
+            // in "swift build" build output goes to stdout
+            XCTAssertMatch(stdout, .contains("Build complete!"))
         }
     }
 
     func testDiscovery() throws {
         try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
             let (stdout, stderr) = try executeSwiftTest(fixturePath)
-            #if os(macOS)
-            XCTAssertMatch(stdout, .contains("module Simple"))
-            XCTAssertMatch(stderr, .contains("Executed 3 tests"))
-            #else
-            XCTAssertMatch(stdout, .contains("module Simple"))
+            // in "swift test" build output goes to stderr
+            XCTAssertMatch(stderr, .contains("Build complete!"))
+            // in "swift test" test output goes to stdout
             XCTAssertMatch(stdout, .contains("Executed 3 tests"))
-            #endif
         }
     }
 
     func testNonStandardName() throws {
         try fixture(name: "Miscellaneous/TestDiscovery/hello world") { fixturePath in
             let (stdout, stderr) = try executeSwiftTest(fixturePath)
-            #if os(macOS)
-            XCTAssertMatch(stdout, .contains("module hello_world"))
-            XCTAssertMatch(stderr, .contains("Executed 1 test"))
-            #else
-            XCTAssertMatch(stdout, .contains("module hello_world"))
+            // in "swift test" build output goes to stderr
+            XCTAssertMatch(stderr, .contains("Build complete!"))
+            // in "swift test" test output goes to stdout
             XCTAssertMatch(stdout, .contains("Executed 1 test"))
-            #endif
         }
     }
 
     func testAsyncMethods() throws {
         try fixture(name: "Miscellaneous/TestDiscovery/Async") { fixturePath in
             let (stdout, stderr) = try executeSwiftTest(fixturePath)
-            #if os(macOS)
-            XCTAssertMatch(stdout, .contains("module Async"))
-            XCTAssertMatch(stderr, .contains("Executed 4 tests"))
-            #else
-            XCTAssertMatch(stdout, .contains("module Async"))
+            // in "swift test" build output goes to stderr
+            XCTAssertMatch(stderr, .contains("Build complete!"))
+            // in "swift test" test output goes to stdout
             XCTAssertMatch(stdout, .contains("Executed 4 tests"))
-            #endif
         }
     }
 
@@ -73,8 +61,10 @@ class TestDiscoveryTests: XCTestCase {
                 let random = UUID().uuidString
                 let manifestPath = fixturePath.appending(components: "Tests", name)
                 try localFileSystem.writeFileContents(manifestPath, bytes: ByteString("print(\"\(random)\")".utf8))
-                let (stdout, _) = try executeSwiftTest(fixturePath)
-                XCTAssertMatch(stdout, .contains("module Simple"))
+                let (stdout, stderr) = try executeSwiftTest(fixturePath)
+                // in "swift test" build output goes to stderr
+                XCTAssertMatch(stderr, .contains("Build complete!"))
+                // in "swift test" test output goes to stdout
                 XCTAssertNoMatch(stdout, .contains("Executed 1 test"))
                 XCTAssertMatch(stdout, .contains(random))
             }
@@ -89,8 +79,10 @@ class TestDiscoveryTests: XCTestCase {
         try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
             let manifestPath = fixturePath.appending(components: "Tests", name)
             try localFileSystem.writeFileContents(manifestPath, bytes: ByteString("fatalError(\"should not be called\")".utf8))
-            let (stdout, _) = try executeSwiftTest(fixturePath, extraArgs: ["--enable-test-discovery"])
-            XCTAssertMatch(stdout, .contains("module Simple"))
+            let (stdout, stderr) = try executeSwiftTest(fixturePath, extraArgs: ["--enable-test-discovery"])
+            // in "swift test" build output goes to stderr
+            XCTAssertMatch(stderr, .contains("Build complete!"))
+            // in "swift test" test output goes to stdout
             XCTAssertNoMatch(stdout, .contains("Executed 1 test"))
         }
     }
@@ -100,8 +92,10 @@ class TestDiscoveryTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
         try fixture(name: "Miscellaneous/TestDiscovery/Extensions") { fixturePath in
-            let (stdout, _) = try executeSwiftTest(fixturePath, extraArgs: ["--enable-test-discovery"])
-            XCTAssertMatch(stdout, .contains("module Simple"))
+            let (stdout, stderr) = try executeSwiftTest(fixturePath)
+            // in "swift test" build output goes to stderr
+            XCTAssertMatch(stderr, .contains("Build complete!"))
+            // in "swift test" test output goes to stdout
             XCTAssertMatch(stdout, .contains("SimpleTests1.testExample1"))
             XCTAssertMatch(stdout, .contains("SimpleTests1.testExample1_a"))
             XCTAssertMatch(stdout, .contains("SimpleTests2.testExample2"))
@@ -118,9 +112,10 @@ class TestDiscoveryTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
         try fixture(name: "Miscellaneous/TestDiscovery/Deprecation") { fixturePath in
-            let (stdout, _) = try executeSwiftTest(fixturePath, extraArgs: ["--enable-test-discovery"])
+            let (stdout, stderr) = try executeSwiftTest(fixturePath)
+            // in "swift test" test output goes to stdout
             XCTAssertMatch(stdout, .contains("Executed 2 tests"))
-            XCTAssertNoMatch(stdout, .contains("is deprecated"))
+            XCTAssertNoMatch(stderr, .contains("is deprecated"))
         }
     }
 }


### PR DESCRIPTION
motivation: better handling of what neds to go to stdout vs stderr

changes:
* update all CLI commands to use stdout for the final result. this means "swift build" and "swift test" output goes to stdout
* update all other background activities to output to stderr, this includes output from build operations and pacakge resolution that take place as part of another action
* set SwiftTool default output stream to sdterr instead of stdout
* update "swift test" to emit its output to stdout
* refactor all instance creation sites of BuildOperation to use a standard factory method which uses the appropriate output stream (normally stderr), whith a customization point for "swift build" to direct the output to stdout
* add and adjust tests
