### PR TITLE
Refactor and clean up plugin communication and wire messages

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -1064,8 +1064,7 @@ extension SwiftPackageTool {
             // Run the command plugin.
             let buildEnvironment = try swiftTool.buildParameters().buildEnvironment
             let _ = try tsc_await { plugin.invoke(
-                action: .performCommand(arguments: arguments),
-                package: package,
+                action: .performCommand(package: package, arguments: arguments),
                 buildEnvironment: buildEnvironment,
                 scriptRunner: pluginScriptRunner,
                 workingDirectory: swiftTool.originalWorkingDirectory,

--- a/Sources/PackagePlugin/CMakeLists.txt
+++ b/Sources/PackagePlugin/CMakeLists.txt
@@ -16,7 +16,8 @@ add_library(PackagePlugin
   PackageModel.swift
   Path.swift
   Plugin.swift
-  PluginInput.swift
+  PluginContextDeserializer.swift
+  PluginMessages.swift
   Protocols.swift
   Utilities.swift)
 

--- a/Sources/PackagePlugin/PluginContextDeserializer.swift
+++ b/Sources/PackagePlugin/PluginContextDeserializer.swift
@@ -10,53 +10,23 @@
 
 @_implementationOnly import Foundation
 
-/// Input information to the plugin, constructed by decoding and deserializing
-/// the JSON data received from SwiftPM.
-struct PluginInput {
-    let package: Package
-    let pluginWorkDirectory: Path
-    let toolSearchDirectories: [Path]
-    let toolNamesToPaths: [String: Path]
-    let pluginAction: PluginAction
-    enum PluginAction {
-        case createBuildToolCommands(target: Target)
-        case performCommand(arguments: [String])
-    }
-    
-    internal init(from input: WireInput) throws {
-        // Create a deserializer to unpack the input structures.
-        var deserializer = PluginInputDeserializer(with: input)
-        
-        // Unpack the individual pieces from which we'll create the plugin context.
-        self.package = try deserializer.package(for: input.rootPackageId)
-        self.pluginWorkDirectory = try deserializer.path(for: input.pluginWorkDirId)
-        self.toolSearchDirectories = try input.toolSearchDirIds.map { try deserializer.path(for: $0) }
-        self.toolNamesToPaths = try input.toolNamesToPathIds.mapValues { try deserializer.path(for: $0) }
-        
-        // Unpack the plugin action, which will determine which plugin functionality to invoke.
-        switch input.pluginAction {
-        case .createBuildToolCommands(let targetId):
-            self.pluginAction = .createBuildToolCommands(target: try deserializer.target(for: targetId))
-        case .performCommand(let arguments):
-            self.pluginAction = .performCommand(arguments: arguments)
-        }
-    }
-}
+typealias WireInput = HostToPluginMessage.InputContext
 
 /// Deserializer for constructing a plugin input from the wire representation
 /// received from SwiftPM, which consists of a set of flat lists of entities,
 /// referenced by array index in all cross-references. The deserialized data
-/// structure forms a directed acyclic graph.
-fileprivate struct PluginInputDeserializer {
-    let input: WireInput
+/// structure forms a directed acyclic graph. This information is provided to
+/// the plugin in the `PluginContext` struct.
+internal struct PluginContextDeserializer {
+    let wireInput: WireInput
     var pathsById: [WireInput.Path.Id: Path] = [:]
     var packagesById: [WireInput.Package.Id: Package] = [:]
     var productsById: [WireInput.Product.Id: Product] = [:]
     var targetsById: [WireInput.Target.Id: Target] = [:]
     
     /// Initializes the deserializer with the given wire input.
-    fileprivate init(with input: WireInput) {
-        self.input = input
+    init(_ input: WireInput) {
+        self.wireInput = input
     }
     
     /// Returns the `Path` that corresponds to the given ID (a small integer),
@@ -64,13 +34,13 @@ fileprivate struct PluginInputDeserializer {
     /// demand if it hasn't already been deserialized.
     mutating func path(for id: WireInput.Path.Id) throws -> Path {
         if let path = pathsById[id] { return path }
-        guard id < input.paths.count else {
+        guard id < wireInput.paths.count else {
             throw PluginDeserializationError.malformedInputJSON("invalid path id (\(id))")
         }
         
         // Compose a path based on an optional base path and a subpath.
-        let wirePath = input.paths[id]
-        let basePath = try input.paths[id].basePathId.map{ try self.path(for: $0) } ?? Path("/")
+        let wirePath = wireInput.paths[id]
+        let basePath = try wireInput.paths[id].basePathId.map{ try self.path(for: $0) } ?? Path("/")
         let path = basePath.appending(subpath: wirePath.subpath)
         
         // Store it for the next look up.
@@ -83,11 +53,11 @@ fileprivate struct PluginInputDeserializer {
     /// demand if it hasn't already been deserialized.
     mutating func target(for id: WireInput.Target.Id) throws -> Target {
         if let target = targetsById[id] { return target }
-        guard id < input.targets.count else {
+        guard id < wireInput.targets.count else {
             throw PluginDeserializationError.malformedInputJSON("invalid target id (\(id))")
         }
 
-        let wireTarget = input.targets[id]
+        let wireTarget = wireInput.targets[id]
         let dependencies: [TargetDependency] = try wireTarget.dependencies.map {
             switch $0 {
             case .target(let targetId):
@@ -206,11 +176,11 @@ fileprivate struct PluginInputDeserializer {
     /// demand if it hasn't already been deserialized.
     mutating func product(for id: WireInput.Product.Id) throws -> Product {
         if let product = productsById[id] { return product }
-        guard id < input.products.count else {
+        guard id < wireInput.products.count else {
             throw PluginDeserializationError.malformedInputJSON("invalid product id (\(id))")
         }
 
-        let wireProduct = input.products[id]
+        let wireProduct = wireInput.products[id]
         let targets: [Target] = try wireProduct.targetIds.map{ try self.target(for: $0) }
         let product: Product
         switch wireProduct.info {
@@ -249,10 +219,10 @@ fileprivate struct PluginInputDeserializer {
     /// demand if it hasn't already been deserialized.
     mutating func package(for id: WireInput.Product.Id) throws -> Package {
         if let package = packagesById[id] { return package }
-        guard id < input.packages.count else {
+        guard id < wireInput.packages.count else {
             throw PluginDeserializationError.malformedInputJSON("invalid package id (\(id))") }
         
-        let wirePackage = input.packages[id]
+        let wirePackage = wireInput.packages[id]
         let directory = try self.path(for: wirePackage.directoryId)
         let toolsVersion = ToolsVersion(
             major: wirePackage.toolsVersion.major,
@@ -275,190 +245,6 @@ fileprivate struct PluginInputDeserializer {
         
         packagesById[id] = package
         return package
-    }
-}
-
-/// The input structure received as JSON from SwiftPM, consisting of an array
-/// of flat structures for each kind of entity. All references to entities use
-/// ID numbers that correspond to the indices into these arrays. The directed
-/// acyclic graph is then deserialized from this structure.
-internal struct WireInput: Decodable {
-    let paths: [Path]
-    let targets: [Target]
-    let products: [Product]
-    let packages: [Package]
-    let rootPackageId: Package.Id
-    let pluginWorkDirId: Path.Id
-    let toolSearchDirIds: [Path.Id]
-    let toolNamesToPathIds: [String: Path.Id]
-    let pluginAction: PluginAction
-
-    /// An action that SwiftPM can ask the plugin to take. This corresponds to
-    /// the capabilities declared for the plugin.
-    enum PluginAction: Decodable {
-        case createBuildToolCommands(targetId: Target.Id)
-        case performCommand(arguments: [String])
-    }
-
-    /// A single absolute path in the wire structure, represented as a tuple
-    /// consisting of the ID of the base path and subpath off of that path.
-    /// This avoids repetition of path components in the wire representation.
-    struct Path: Decodable {
-        typealias Id = Int
-        let basePathId: Path.Id?
-        let subpath: String
-    }
-
-    /// A package in the wire structure. All references to other entities are
-    /// their ID numbers.
-    struct Package: Decodable {
-        typealias Id = Int
-        let identity: String
-        let displayName: String
-        let directoryId: Path.Id
-        let origin: Origin
-        let toolsVersion: ToolsVersion
-        let dependencies: [Dependency]
-        let productIds: [Product.Id]
-        let targetIds: [Target.Id]
-
-        /// The origin of the package (root, local, repository, registry, etc).
-        enum Origin: Decodable {
-            case root
-            case local(
-                path: Path.Id)
-            case repository(
-                url: String,
-                displayVersion: String,
-                scmRevision: String)
-            case registry(
-                identity: String,
-                displayVersion: String)
-        }
-        
-        /// Represents a version of SwiftPM on whose semantics a package relies.
-        struct ToolsVersion: Decodable {
-            let major: Int
-            let minor: Int
-            let patch: Int
-        }
-
-        /// A dependency on a package in the wire structure. All references to
-        /// other entities are ID numbers.
-        struct Dependency: Decodable {
-            let packageId: Package.Id
-        }
-    }
-
-    /// A product in the wire structure. All references to other entities are
-    /// their ID numbers.
-    struct Product: Decodable {
-        typealias Id = Int
-        let name: String
-        let targetIds: [Target.Id]
-        let info: ProductInfo
-
-        /// Information for each type of product in the wire structure. All
-        /// references to other entities are their ID numbers.
-        enum ProductInfo: Decodable {
-            case executable(
-                mainTargetId: Target.Id)
-            case library(
-                kind: LibraryKind)
-
-            /// A type of library in the wire structure, as SwiftPM sees it.
-            enum LibraryKind: Decodable {
-                case `static`
-                case `dynamic`
-                case automatic
-            }
-        }
-    }
-
-    /// A target in the wire structure. All references to other entities are
-    /// their ID numbers.
-    struct Target: Decodable {
-        typealias Id = Int
-        let name: String
-        let directoryId: Path.Id
-        let dependencies: [Dependency]
-        let info: TargetInfo
-
-        /// A dependency on either a target or a product in the wire structure.
-        /// All references to other entities are ID their numbers.
-        enum Dependency: Decodable {
-            case target(
-                targetId: Target.Id)
-            case product(
-                productId: Product.Id)
-        }
-        
-        /// Type-specific information for a target in the wire structure. All
-        /// references to other entities are their ID numbers.
-        enum TargetInfo: Decodable {
-            /// Information about a Swift source module target.
-            case swiftSourceModuleInfo(
-                moduleName: String,
-                kind: SourceModuleKind,
-                sourceFiles: [File],
-                compilationConditions: [String],
-                linkedLibraries: [String],
-                linkedFrameworks: [String])
-            
-            /// Information about a Clang source module target.
-            case clangSourceModuleInfo(
-                moduleName: String,
-                kind: SourceModuleKind,
-                sourceFiles: [File],
-                preprocessorDefinitions: [String],
-                headerSearchPaths: [String],
-                publicHeadersDirId: Path.Id?,
-                linkedLibraries: [String],
-                linkedFrameworks: [String])
-            
-            /// Information about a binary artifact target.
-            case binaryArtifactInfo(
-                kind: BinaryArtifactKind,
-                origin: BinaryArtifactOrigin,
-                artifactId: Path.Id)
-            
-            /// Information about a system library target.
-            case systemLibraryInfo(
-                pkgConfig: String?,
-                compilerFlags: [String],
-                linkerFlags: [String])
-
-            /// A file in the wire structure.
-            struct File: Decodable {
-                let basePathId: Path.Id
-                let name: String
-                let type: FileType
-
-                /// A type of file in the wire structure, as SwiftPM sees it.
-                enum FileType: String, Decodable {
-                    case source
-                    case header
-                    case resource
-                    case unknown
-                }
-            }
-
-            enum SourceModuleKind: String, Decodable {
-                case generic
-                case executable
-                case test
-            }
-
-            enum BinaryArtifactKind: Decodable {
-                case xcframework
-                case artifactsArchive
-            }
-
-            enum BinaryArtifactOrigin: Decodable {
-                case local
-                case remote(url: String)
-            }
-        }
     }
 }
 

--- a/Sources/PackagePlugin/PluginMessages.swift
+++ b/Sources/PackagePlugin/PluginMessages.swift
@@ -1,0 +1,316 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+/// A message that the host can send to the plugin, including definitions of the corresponding serializable data structures.
+enum HostToPluginMessage: Codable {
+    
+    /// The host requests that the plugin create build commands (corresponding to a `.buildTool` capability) for a target in the package graph.
+    case createBuildToolCommands(context: InputContext, rootPackageId: InputContext.Package.Id, targetId: InputContext.Target.Id)
+    
+    /// The host requests that the plugin perform a user command (corresponding to a `.command` capability) on a package in the graph.
+    case performCommand(context: InputContext, rootPackageId: InputContext.Package.Id, arguments: [String])
+
+        struct InputContext: Codable {
+            let paths: [Path]
+            let targets: [Target]
+            let products: [Product]
+            let packages: [Package]
+            let pluginWorkDirId: Path.Id
+            let toolSearchDirIds: [Path.Id]
+            let toolNamesToPathIds: [String: Path.Id]
+
+            /// A single absolute path in the wire structure, represented as a tuple
+            /// consisting of the ID of the base path and subpath off of that path.
+            /// This avoids repetition of path components in the wire representation.
+            struct Path: Codable {
+                typealias Id = Int
+                let basePathId: Path.Id?
+                let subpath: String
+            }
+
+            /// A package in the wire structure. All references to other entities are
+            /// their ID numbers.
+            struct Package: Codable {
+                typealias Id = Int
+                let identity: String
+                let displayName: String
+                let directoryId: Path.Id
+                let origin: Origin
+                let toolsVersion: ToolsVersion
+                let dependencies: [Dependency]
+                let productIds: [Product.Id]
+                let targetIds: [Target.Id]
+
+                enum Origin: Codable {
+                    case root
+                    case local(
+                        path: Path.Id)
+                    case repository(
+                        url: String,
+                        displayVersion: String,
+                        scmRevision: String)
+                    case registry(
+                        identity: String,
+                        displayVersion: String)
+                }
+                
+                struct ToolsVersion: Codable {
+                    let major: Int
+                    let minor: Int
+                    let patch: Int
+                }
+
+                /// A dependency on a package in the wire structure. All references to
+                /// other entities are ID numbers.
+                struct Dependency: Codable {
+                    let packageId: Package.Id
+                }
+            }
+
+            /// A product in the wire structure. All references to other entities are
+            /// their ID numbers.
+            struct Product: Codable {
+                typealias Id = Int
+                let name: String
+                let targetIds: [Target.Id]
+                let info: ProductInfo
+
+                /// Information for each type of product in the wire structure. All
+                /// references to other entities are their ID numbers.
+                enum ProductInfo: Codable {
+                    case executable(
+                        mainTargetId: Target.Id)
+                    case library(
+                        kind: LibraryKind)
+
+                    enum LibraryKind: Codable {
+                        case `static`
+                        case `dynamic`
+                        case automatic
+                    }
+                }
+            }
+
+            /// A target in the wire structure. All references to other entities are
+            /// their ID numbers.
+            struct Target: Codable {
+                typealias Id = Int
+                let name: String
+                let directoryId: Path.Id
+                let dependencies: [Dependency]
+                let info: TargetInfo
+
+                /// A dependency on either a target or a product in the wire structure.
+                /// All references to other entities are ID their numbers.
+                enum Dependency: Codable {
+                    case target(
+                        targetId: Target.Id)
+                    case product(
+                        productId: Product.Id)
+                }
+                
+                /// Type-specific information for a target in the wire structure. All
+                /// references to other entities are their ID numbers.
+                enum TargetInfo: Codable {
+                    case swiftSourceModuleInfo(
+                        moduleName: String,
+                        kind: SourceModuleKind,
+                        sourceFiles: [File],
+                        compilationConditions: [String],
+                        linkedLibraries: [String],
+                        linkedFrameworks: [String])
+                    
+                    case clangSourceModuleInfo(
+                        moduleName: String,
+                        kind: SourceModuleKind,
+                        sourceFiles: [File],
+                        preprocessorDefinitions: [String],
+                        headerSearchPaths: [String],
+                        publicHeadersDirId: Path.Id?,
+                        linkedLibraries: [String],
+                        linkedFrameworks: [String])
+                    
+                    case binaryArtifactInfo(
+                        kind: BinaryArtifactKind,
+                        origin: BinaryArtifactOrigin,
+                        artifactId: Path.Id)
+                    
+                    case systemLibraryInfo(
+                        pkgConfig: String?,
+                        compilerFlags: [String],
+                        linkerFlags: [String])
+
+                    struct File: Codable {
+                        let basePathId: Path.Id
+                        let name: String
+                        let type: FileType
+
+                        enum FileType: String, Codable {
+                            case source
+                            case header
+                            case resource
+                            case unknown
+                        }
+                    }
+
+                    enum SourceModuleKind: String, Codable {
+                        case generic
+                        case executable
+                        case test
+                    }
+
+                    enum BinaryArtifactKind: Codable {
+                        case xcframework
+                        case artifactsArchive
+                    }
+
+                    enum BinaryArtifactOrigin: Codable {
+                        case local
+                        case remote(url: String)
+                    }
+                }
+            }
+        }
+    
+    /// A response to a request to run a build operation.
+    case buildOperationResponse(result: BuildResult)
+
+        struct BuildResult: Codable {
+            var succeeded: Bool
+            var logText: String
+            var builtArtifacts: [BuiltArtifact]
+            
+            struct BuiltArtifact: Codable {
+                var path: String
+                var kind: Kind
+                
+                enum Kind: String, Codable {
+                    case executable
+                    case dynamicLibrary
+                    case staticLibrary
+                }
+            }
+        }
+
+    /// A response to a request to run a test operation.
+    case testOperationResponse(result: TestResult)
+
+        struct TestResult: Codable {
+            var succeeded: Bool
+            var testTargets: [TestTarget]
+            var codeCoverageDataFile: String?
+
+            struct TestTarget: Codable {
+                var name: String
+                var testCases: [TestCase]
+                
+                struct TestCase: Codable {
+                    var name: String
+                    var tests: [Test]
+                                       
+                    struct Test: Codable {
+                        var name: String
+                        var result: Result
+                        var duration: Double
+                        
+                        enum Result: String, Codable {
+                            case succeeded
+                            case skipped
+                            case failed
+                        }
+                    }
+                }
+            }
+        }
+    
+    /// A response to a request for symbol graph information for a target.
+    case symbolGraphResponse(result: SymbolGraphResult)
+    
+        struct SymbolGraphResult: Codable {
+            var directoryPath: String
+        }
+    
+    /// A response of an error while trying to complete a request.
+    case errorResponse(error: String)
+}
+
+
+/// A message that the plugin can send to the host.
+enum PluginToHostMessage: Codable {
+    
+    /// The plugin emits a diagnostic.
+    case emitDiagnostic(severity: DiagnosticSeverity, message: String, file: String?, line: Int?)
+
+        enum DiagnosticSeverity: String, Codable {
+            case error, warning, remark
+        }
+    
+    /// The plugin defines a build command.
+    case defineBuildCommand(configuration: CommandConfiguration, inputFiles: [String], outputFiles: [String])
+    
+    /// The plugin defines a prebuild command.
+    case definePrebuildCommand(configuration: CommandConfiguration, outputFilesDirectory: String)
+    
+        struct CommandConfiguration: Codable {
+            var displayName: String?
+            var executable: String
+            var arguments: [String]
+            var environment: [String: String]
+            var workingDirectory: String?
+        }
+    
+    /// The plugin is requesting that a build operation be run.
+    case buildOperationRequest(subset: BuildSubset, parameters: BuildParameters)
+    
+        enum BuildSubset: Codable {
+            case all(includingTests: Bool)
+            case product(String)
+            case target(String)
+        }
+
+        struct BuildParameters: Codable {
+            var configuration: Configuration
+            enum Configuration: String, Codable {
+                case debug, release
+            }
+            var logging: LogVerbosity
+            enum LogVerbosity: String, Codable {
+                case concise, verbose, debug
+            }
+            var otherCFlags: [String]
+            var otherCxxFlags: [String]
+            var otherSwiftcFlags: [String]
+            var otherLinkerFlags: [String]
+        }
+
+    /// The plugin is requesting that a test operation be run.
+    case testOperationRequest(subset: TestSubset, parameters: TestParameters)
+
+        enum TestSubset: Codable {
+            case all
+            case filtered([String])
+        }
+
+        struct TestParameters: Codable {
+            var enableCodeCoverage: Bool
+        }
+
+    /// The plugin is requesting symbol graph information for a given target and set of options.
+    case symbolGraphRequest(targetName: String, options: SymbolGraphOptions)
+
+        struct SymbolGraphOptions: Codable {
+            var minimumAccessLevel: AccessLevel
+            enum AccessLevel: String, Codable {
+                case `private`, `fileprivate`, `internal`, `public`, `open`
+            }
+            var includeSynthesized: Bool
+            var includeSPI: Bool
+        }
+}

--- a/Sources/SPMBuildCore/CMakeLists.txt
+++ b/Sources/SPMBuildCore/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See http://swift.org/LICENSE.txt for license information
@@ -14,7 +14,10 @@ add_library(SPMBuildCore
   BuildSystemCommand.swift
   BuildSystemDelegate.swift
   BuiltTestProduct.swift
+  PluginContextSerializer.swift
   PluginInvocation.swift
+  PluginMessages.swift
+  PluginScriptRunner.swift
   PrebuildCommandResult.swift
   Sanitizers.swift
   Toolchain.swift

--- a/Sources/SPMBuildCore/PluginContextSerializer.swift
+++ b/Sources/SPMBuildCore/PluginContextSerializer.swift
@@ -1,0 +1,277 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Basics
+import Foundation
+import PackageGraph
+import PackageLoading
+import PackageModel
+import TSCBasic
+
+typealias WireInput = HostToPluginMessage.InputContext
+
+/// Creates the serialized input structure for the plugin script based on all
+/// the input information to a plugin.
+internal struct PluginContextSerializer {
+    let fileSystem: FileSystem
+    let buildEnvironment: BuildEnvironment
+    var paths: [WireInput.Path] = []
+    var pathsToIds: [AbsolutePath: WireInput.Path.Id] = [:]
+    var targets: [WireInput.Target] = []
+    var targetsToIds: [ResolvedTarget: WireInput.Target.Id] = [:]
+    var products: [WireInput.Product] = []
+    var productsToIds: [ResolvedProduct: WireInput.Product.Id] = [:]
+    var packages: [WireInput.Package] = []
+    var packagesToIds: [ResolvedPackage: WireInput.Package.Id] = [:]
+    
+    /// Adds a path to the serialized structure, if it isn't already there.
+    /// Either way, this function returns the path's wire ID.
+    mutating func serialize(path: AbsolutePath) throws -> WireInput.Path.Id {
+        // If we've already seen the path, just return the wire ID we already assigned to it.
+        if let id = pathsToIds[path] { return id }
+        
+        // Split up the path into a base path and a subpath (currently always with the last path component as the
+        // subpath, but this can be optimized where there are sequences of path components with a valence of one).
+        let basePathId = (path.parentDirectory.isRoot ? nil : try serialize(path: path.parentDirectory))
+        let subpathString = path.basename
+        
+        // Finally assign the next wire ID to the path, and append a serialized Path record.
+        let id = paths.count
+        paths.append(.init(basePathId: basePathId, subpath: subpathString))
+        pathsToIds[path] = id
+        return id
+    }
+
+    // Adds a target to the serialized structure, if it isn't already there and
+    // if it is of a kind that should be passed to the plugin. If so, this func-
+    // tion returns the target's wire ID. If not, it returns nil.
+    mutating func serialize(target: ResolvedTarget) throws -> WireInput.Target.Id? {
+        // If we've already seen the target, just return the wire ID we already assigned to it.
+        if let id = targetsToIds[target] { return id }
+        
+        // Construct the FileList
+        var targetFiles: [WireInput.Target.TargetInfo.File] = []
+        targetFiles.append(contentsOf: try target.underlyingTarget.sources.paths.map {
+            .init(basePathId: try serialize(path: $0.parentDirectory), name: $0.basename, type: .source)
+        })
+        targetFiles.append(contentsOf: try target.underlyingTarget.resources.map {
+            .init(basePathId: try serialize(path: $0.path.parentDirectory), name: $0.path.basename, type: .resource)
+        })
+        targetFiles.append(contentsOf: try target.underlyingTarget.ignored.map {
+            .init(basePathId: try serialize(path: $0.parentDirectory), name: $0.basename, type: .unknown)
+        })
+        targetFiles.append(contentsOf: try target.underlyingTarget.others.map {
+            .init(basePathId: try serialize(path: $0.parentDirectory), name: $0.basename, type: .unknown)
+        })
+        
+        // Create a scope for evaluating build settings.
+        let scope = BuildSettings.Scope(target.underlyingTarget.buildSettings, environment: buildEnvironment)
+        
+        // Look at the target and decide what to serialize. At this point we may decide to not serialize it at all.
+        let targetInfo: WireInput.Target.TargetInfo
+        switch target.underlyingTarget {
+            
+        case let target as SwiftTarget:
+            targetInfo = .swiftSourceModuleInfo(
+                moduleName: target.c99name,
+                kind: try .init(target.type),
+                sourceFiles: targetFiles,
+                compilationConditions: scope.evaluate(.SWIFT_ACTIVE_COMPILATION_CONDITIONS),
+                linkedLibraries: scope.evaluate(.LINK_LIBRARIES),
+                linkedFrameworks: scope.evaluate(.LINK_FRAMEWORKS))
+
+        case let target as ClangTarget:
+            targetInfo = .clangSourceModuleInfo(
+                moduleName: target.c99name,
+                kind: try .init(target.type),
+                sourceFiles: targetFiles,
+                preprocessorDefinitions: scope.evaluate(.GCC_PREPROCESSOR_DEFINITIONS),
+                headerSearchPaths: scope.evaluate(.HEADER_SEARCH_PATHS),
+                publicHeadersDirId: try serialize(path: target.includeDir),
+                linkedLibraries: scope.evaluate(.LINK_LIBRARIES),
+                linkedFrameworks: scope.evaluate(.LINK_FRAMEWORKS))
+
+        case let target as SystemLibraryTarget:
+            var cFlags: [String] = []
+            var ldFlags: [String] = []
+            // FIXME: What do we do with any diagnostics here?
+            let observabilityScope = ObservabilitySystem({ _, _ in }).topScope
+            for result in pkgConfigArgs(for: target, fileSystem: self.fileSystem, observabilityScope: observabilityScope) {
+                if let error = result.error {
+                    observabilityScope.emit(
+                        warning: "\(error)",
+                        metadata: .pkgConfig(pcFile: result.pkgConfigName, targetName: target.name)
+                    )
+                }
+                else {
+                    cFlags += result.cFlags
+                    ldFlags += result.libs
+                }
+            }
+
+            targetInfo = .systemLibraryInfo(
+                pkgConfig: target.pkgConfig,
+                compilerFlags: cFlags,
+                linkerFlags: ldFlags)
+            
+        case let target as BinaryTarget:
+            let artifactKind: WireInput.Target.TargetInfo.BinaryArtifactKind
+            switch target.kind {
+            case .artifactsArchive:
+                artifactKind = .artifactsArchive
+            case .xcframework:
+                artifactKind = .xcframework
+            case .unknown:
+                // Skip unknown binary targets.
+                return nil
+            }
+            let artifactOrigin: WireInput.Target.TargetInfo.BinaryArtifactOrigin
+            switch target.origin {
+            case .local:
+                artifactOrigin = .local
+            case .remote(let url):
+                artifactOrigin = .remote(url: url)
+            }
+            targetInfo = .binaryArtifactInfo(
+                kind: artifactKind,
+                origin: artifactOrigin,
+                artifactId: try serialize(path: target.artifactPath))
+            
+        default:
+            // It's not a type of target that we pass through to the plugin.
+            return nil
+        }
+        
+        // We only get this far if we are serializing the target. If so we also serialize its dependencies. This needs to be done before assigning the next wire ID for the target we're serializing, to make sure we end up with the correct one.
+        let dependencies: [WireInput.Target.Dependency] = try target.dependencies(satisfying: buildEnvironment).compactMap {
+            switch $0 {
+            case .target(let target, _):
+                return try serialize(target: target).map { .target(targetId: $0) }
+            case .product(let product, _):
+                return try serialize(product: product).map { .product(productId: $0) }
+            }
+        }
+
+        // Finally assign the next wire ID to the target, and append a serialized Target record.
+        let id = targets.count
+        targets.append(.init(
+            name: target.name,
+            directoryId: try serialize(path: target.sources.root),
+            dependencies: dependencies,
+            info: targetInfo))
+        targetsToIds[target] = id
+        return id
+    }
+
+    // Adds a product to the serialized structure, if it isn't already there and
+    // if it is of a kind that should be passed to the plugin. If so, this func-
+    // tion returns the product's wire ID. If not, it returns nil.
+    mutating func serialize(product: ResolvedProduct) throws -> WireInput.Product.Id? {
+        // If we've already seen the product, just return the wire ID we already assigned to it.
+        if let id = productsToIds[product] { return id }
+        
+        // Look at the product and decide what to serialize. At this point we may decide to not serialize it at all.
+        let productInfo: WireInput.Product.ProductInfo
+        switch product.type {
+            
+        case .executable:
+            guard let mainExecTarget = product.targets.first(where: { $0.type == .executable }) else {
+                throw InternalError("could not determine main executable target for product \(product)")
+            }
+            guard let mainExecTargetId = try serialize(target: mainExecTarget) else {
+                throw InternalError("unable to serialize main executable target \(mainExecTarget) for product \(product)")
+            }
+            productInfo = .executable(mainTargetId: mainExecTargetId)
+
+        case .library(let kind):
+            switch kind {
+            case .static:
+                productInfo = .library(kind: .static)
+            case .dynamic:
+                productInfo = .library(kind: .dynamic)
+            case .automatic:
+                productInfo = .library(kind: .automatic)
+            }
+
+        default:
+            // It's not a type of product that we pass through to the plugin.
+            return nil
+        }
+        
+        // Finally assign the next wire ID to the product, and append a serialized Product record.
+        let id = products.count
+        products.append(.init(
+            name: product.name,
+            targetIds: try product.targets.compactMap{ try serialize(target: $0) },
+            info: productInfo))
+        productsToIds[product] = id
+        return id
+    }
+
+    // Adds a package to the serialized structure, if it isn't already there.
+    // Either way, this function returns the package's wire ID.
+    mutating func serialize(package: ResolvedPackage) throws -> WireInput.Package.Id {
+        // If we've already seen the package, just return the wire ID we already assigned to it.
+        if let id = packagesToIds[package] { return id }
+        
+        // Determine how we should represent the origin of the package to the plugin.
+        func origin(for package: ResolvedPackage) throws -> WireInput.Package.Origin {
+            switch package.manifest.packageKind {
+            case .root(_):
+                return .root
+            case .fileSystem(let path):
+                return .local(path: try serialize(path: path))
+            case .localSourceControl(let path):
+                return .repository(url: path.asURL.absoluteString, displayVersion: String(describing: package.manifest.version), scmRevision: String(describing: package.manifest.revision))
+            case .remoteSourceControl(let url):
+                return .repository(url: url.absoluteString, displayVersion: String(describing: package.manifest.version), scmRevision: String(describing: package.manifest.revision))
+            case .registry(let identity):
+                return .registry(identity: identity.description, displayVersion: String(describing: package.manifest.version))
+            }
+        }
+
+        // Serialize the dependencies. It is important to do this before the `let id = package.count` below so the correct wire ID gets assigned.
+        let dependencies = try package.dependencies.map {
+            WireInput.Package.Dependency(packageId: try serialize(package: $0))
+        }
+
+        // Assign the next wire ID to the package, and append a serialized Package record.
+        let id = packages.count
+        packages.append(.init(
+            identity: package.identity.description,
+            displayName: package.manifest.displayName,
+            directoryId: try serialize(path: package.path),
+            origin: try origin(for: package),
+            toolsVersion: .init(
+                major: package.manifest.toolsVersion.major,
+                minor: package.manifest.toolsVersion.minor,
+                patch: package.manifest.toolsVersion.patch),
+            dependencies: dependencies,
+            productIds: try package.products.compactMap{ try serialize(product: $0) },
+            targetIds: try package.targets.compactMap{ try serialize(target: $0) }))
+        packagesToIds[package] = id
+        return id
+    }
+}
+
+fileprivate extension WireInput.Target.TargetInfo.SourceModuleKind {
+    init(_ kind: Target.Kind) throws {
+        switch kind {
+        case .library:
+            self = .generic
+        case .executable:
+            self = .executable
+        case .test:
+            self = .test
+        case .binary, .plugin, .snippet, .systemModule:
+            throw StringError("unexpected target kind \(kind) for source module")
+        }
+    }
+}

--- a/Sources/SPMBuildCore/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/PluginInvocation.swift
@@ -17,11 +17,9 @@ import TSCBasic
 
 import struct TSCUtility.Triple
 
-public typealias Diagnostic = Basics.Diagnostic
-
 public enum PluginAction {
-    case createBuildToolCommands(target: ResolvedTarget)
-    case performCommand(arguments: [String])
+    case createBuildToolCommands(package: ResolvedPackage, target: ResolvedTarget)
+    case performCommand(package: ResolvedPackage, arguments: [String])
 }
 
 extension PluginTarget {
@@ -49,7 +47,6 @@ extension PluginTarget {
     /// - Returns: A PluginInvocationResult that contains the results of invoking the plugin.
     public func invoke(
         action: PluginAction,
-        package: ResolvedPackage,
         buildEnvironment: BuildEnvironment,
         scriptRunner: PluginScriptRunner,
         workingDirectory: AbsolutePath,
@@ -64,7 +61,7 @@ extension PluginTarget {
         delegate: PluginInvocationDelegate,
         completion: @escaping (Result<Bool, Error>) -> Void
     ) {
-        // Create the plugin working directory if needed (but don't do anything with it if it already exists).
+        // Create the plugin's output directory if needed (but don't do anything with it if it already exists).
         do {
             try fileSystem.createDirectory(outputDirectory, recursive: true)
         }
@@ -72,25 +69,173 @@ extension PluginTarget {
             return callbackQueue.async { completion(.failure(PluginEvaluationError.couldNotCreateOuputDirectory(path: outputDirectory, underlyingError: error))) }
         }
 
-        // Create the input context to send to the plugin.
-        var serializer = PluginScriptRunnerInputSerializer(fileSystem: fileSystem, buildEnvironment: buildEnvironment)
-        let inputStruct: PluginScriptRunnerInput
+        // Serialize the plugin action to send as the initial message.
+        let initialMessage: Data
         do {
-            inputStruct = try serializer.makePluginScriptRunnerInput(
-                rootPackage: package,
-                pluginWorkDir: outputDirectory,
-                toolSearchDirs: toolSearchDirectories,
-                toolNamesToPaths: toolNamesToPaths,
-                pluginAction: action)
+            var serializer = PluginContextSerializer(fileSystem: fileSystem, buildEnvironment: buildEnvironment)
+            let pluginWorkDirId = try serializer.serialize(path: outputDirectory)
+            let toolSearchDirIds = try toolSearchDirectories.map{ try serializer.serialize(path: $0) }
+            let toolNamesToPathIds = try toolNamesToPaths.mapValues{ try serializer.serialize(path: $0) }
+            let actionMessage: HostToPluginMessage
+            switch action {
+                
+            case .createBuildToolCommands(let package, let target):
+                let rootPackageId = try serializer.serialize(package: package)
+                guard let targetId = try serializer.serialize(target: target) else {
+                    throw StringError("unexpectedly was unable to serialize target \(target)")
+                }
+                let wireInput = WireInput(
+                    paths: serializer.paths,
+                    targets: serializer.targets,
+                    products: serializer.products,
+                    packages: serializer.packages,
+                    pluginWorkDirId: pluginWorkDirId,
+                    toolSearchDirIds: toolSearchDirIds,
+                    toolNamesToPathIds: toolNamesToPathIds)
+                actionMessage = .createBuildToolCommands(
+                    context: wireInput,
+                    rootPackageId: rootPackageId,
+                    targetId: targetId)
+            
+            case .performCommand(let package, let arguments):
+                let rootPackageId = try serializer.serialize(package: package)
+                let wireInput = WireInput(
+                    paths: serializer.paths,
+                    targets: serializer.targets,
+                    products: serializer.products,
+                    packages: serializer.packages,
+                    pluginWorkDirId: pluginWorkDirId,
+                    toolSearchDirIds: toolSearchDirIds,
+                    toolNamesToPathIds: toolNamesToPathIds)
+                actionMessage = .performCommand(
+                    context: wireInput,
+                    rootPackageId: rootPackageId,
+                    arguments: arguments)
+            }
+            initialMessage = try actionMessage.toData()
         }
         catch {
             return callbackQueue.async { completion(.failure(PluginEvaluationError.couldNotSerializePluginInput(underlyingError: error))) }
         }
+        
+        // Handle messages and output from the plugin.
+        class ScriptRunnerDelegate: PluginScriptRunnerDelegate {
+            /// Delegate that should be told about events involving the plugin.
+            let invocationDelegate: PluginInvocationDelegate
+            
+            /// Observability scope for the invoking of the plugin. Diagnostics from the plugin itself are sent through the delegate.
+            let observabilityScope: ObservabilityScope
+            
+            /// Whether at least one error has been reported; this is used to make sure there is at least one error if the plugin fails.
+            var hasReportedError = false
+            
+            init(invocationDelegate: PluginInvocationDelegate, observabilityScope: ObservabilityScope) {
+                self.invocationDelegate = invocationDelegate
+                self.observabilityScope = observabilityScope
+            }
+            
+            /// Invoked when the plugin emits arbtirary data on its stdout/stderr. There is no guarantee that the data is split on UTF-8 character encoding boundaries etc.  The script runner delegate just passes it on to the invocation delegate.
+            func handleOutput(data: Data) {
+                invocationDelegate.pluginEmittedOutput(data)
+            }
 
+            /// Invoked when the plugin emits a message. The `responder` closure can be used to send any reply messages.
+            func handleMessage(data: Data, responder: @escaping (Data) -> Void) throws {
+                let message = try PluginToHostMessage(data)
+                switch message {
+                    
+                case .emitDiagnostic(let severity, let message, let file, let line):
+                    let metadata: ObservabilityMetadata? = file.map {
+                        var metadata = ObservabilityMetadata()
+                        // FIXME: We should probably report some kind of protocol error if the path isn't valid.
+                        metadata.fileLocation = try? .init(.init(validating: $0), line: line)
+                        return metadata
+                    }
+                    let diagnostic: Basics.Diagnostic
+                    switch severity {
+                    case .error:
+                        diagnostic = .error(message, metadata: metadata)
+                        hasReportedError = true
+                    case .warning:
+                        diagnostic = .warning(message, metadata: metadata)
+                    case .remark:
+                        diagnostic = .info(message, metadata: metadata)
+                    }
+                    self.invocationDelegate.pluginEmittedDiagnostic(diagnostic)
+                    
+                case .defineBuildCommand(let config, let inputFiles, let outputFiles):
+                    self.invocationDelegate.pluginDefinedBuildCommand(
+                        displayName: config.displayName,
+                        executable: try AbsolutePath(validating: config.executable),
+                        arguments: config.arguments,
+                        environment: config.environment,
+                        workingDirectory: try config.workingDirectory.map{ try AbsolutePath(validating: $0) },
+                        inputFiles: try inputFiles.map{ try AbsolutePath(validating: $0) },
+                        outputFiles: try outputFiles.map{ try AbsolutePath(validating: $0) })
+                    
+                case .definePrebuildCommand(let config, let outputFilesDir):
+                    self.invocationDelegate.pluginDefinedPrebuildCommand(
+                        displayName: config.displayName,
+                        executable: try AbsolutePath(validating: config.executable),
+                        arguments: config.arguments,
+                        environment: config.environment,
+                        workingDirectory: try config.workingDirectory.map{ try AbsolutePath(validating: $0) },
+                        outputFilesDirectory: try AbsolutePath(validating: outputFilesDir))
+
+                case .buildOperationRequest(let subset, let parameters):
+                    self.invocationDelegate.pluginRequestedBuildOperation(subset: .init(subset), parameters: .init(parameters)) {
+                        do {
+                            switch $0 {
+                            case .success(let result):
+                                responder(try HostToPluginMessage.buildOperationResponse(result: .init(result)).toData())
+                            case .failure(let error):
+                                responder(try HostToPluginMessage.errorResponse(error: String(describing: error)).toData())
+                            }
+                        }
+                        catch {
+                            self.observabilityScope.emit(debug: "couldn't send reply to plugin \(error)")
+                        }
+                    }
+
+                case .testOperationRequest(let subset, let parameters):
+                    self.invocationDelegate.pluginRequestedTestOperation(subset: .init(subset), parameters: .init(parameters)) {
+                        do {
+                            switch $0 {
+                            case .success(let result):
+                                responder(try HostToPluginMessage.testOperationResponse(result: .init(result)).toData())
+                            case .failure(let error):
+                                responder(try HostToPluginMessage.errorResponse(error: String(describing: error)).toData())
+                            }
+                        }
+                        catch {
+                            self.observabilityScope.emit(debug: "couldn't send reply to plugin \(error)")
+                        }
+                    }
+
+                case .symbolGraphRequest(let targetName, let options):
+                    // The plugin requested symbol graph information for a target. We ask the delegate and then send a response.
+                    self.invocationDelegate.pluginRequestedSymbolGraph(forTarget: .init(targetName), options: .init(options)) {
+                        do {
+                            switch $0 {
+                            case .success(let result):
+                                responder(try HostToPluginMessage.symbolGraphResponse(result: .init(result)).toData())
+                            case .failure(let error):
+                                responder(try HostToPluginMessage.errorResponse(error: String(describing: error)).toData())
+                            }
+                        }
+                        catch {
+                            self.observabilityScope.emit(debug: "couldn't send reply to plugin \(error)")
+                        }
+                    }
+                }
+            }
+        }
+        let runnerDelegate = ScriptRunnerDelegate(invocationDelegate: delegate, observabilityScope: observabilityScope)
+        
         // Call the plugin script runner to actually invoke the plugin.
         scriptRunner.runPluginScript(
             sources: sources,
-            input: inputStruct,
+            initialMessage: initialMessage,
             toolsVersion: self.apiVersion,
             workingDirectory: workingDirectory,
             writableDirectories: writableDirectories,
@@ -98,10 +243,36 @@ extension PluginTarget {
             fileSystem: fileSystem,
             observabilityScope: observabilityScope,
             callbackQueue: callbackQueue,
-            delegate: delegate,
-            completion: completion)
+            delegate: runnerDelegate) { result in
+                dispatchPrecondition(condition: .onQueue(callbackQueue))
+                completion(result.map { exitCode in
+                    // Return a result based on the exit code. If the plugin
+                    // exits with an error but hasn't already emitted an error,
+                    // we do so for it.
+                    let exitedCleanly = (exitCode == 0)
+                    if !exitedCleanly && !runnerDelegate.hasReportedError {
+                        delegate.pluginEmittedDiagnostic(
+                            .error("Plugin ended with exit code \(exitCode)")
+                        )
+                    }
+                    return exitedCleanly
+                })
+        }
     }
 }
+
+fileprivate extension HostToPluginMessage {
+    func toData() throws -> Data {
+        return try JSONEncoder.makeWithDefaults().encode(self)
+    }
+}
+
+fileprivate extension PluginToHostMessage {
+    init(_ data: Data) throws {
+        self = try JSONDecoder.makeWithDefaults().decode(Self.self, from: data)
+    }
+}
+
 
 extension PackageGraph {
 
@@ -194,7 +365,7 @@ extension PackageGraph {
                 class PluginDelegate: PluginInvocationDelegate {
                     let delegateQueue: DispatchQueue
                     var outputData = Data()
-                    var diagnostics = [Diagnostic]()
+                    var diagnostics = [Basics.Diagnostic]()
                     var buildCommands = [BuildToolPluginInvocationResult.BuildCommand]()
                     var prebuildCommands = [BuildToolPluginInvocationResult.PrebuildCommand]()
                     
@@ -207,7 +378,7 @@ extension PackageGraph {
                         outputData.append(contentsOf: data)
                     }
                     
-                    func pluginEmittedDiagnostic(_ diagnostic: Diagnostic) {
+                    func pluginEmittedDiagnostic(_ diagnostic: Basics.Diagnostic) {
                         dispatchPrecondition(condition: .onQueue(delegateQueue))
                         diagnostics.append(diagnostic)
                     }
@@ -242,8 +413,7 @@ extension PackageGraph {
                 // Invoke the build tool plugin with the input parameters and the delegate that will collect outputs.
                 let startTime = DispatchTime.now()
                 let success = try tsc_await { pluginTarget.invoke(
-                    action: .createBuildToolCommands(target: target),
-                    package: package,
+                    action: .createBuildToolCommands(package: package, target: target),
                     buildEnvironment: buildEnvironment,
                     scriptRunner: pluginScriptRunner,
                     workingDirectory: package.path,
@@ -338,7 +508,7 @@ public struct BuildToolPluginInvocationResult {
     public var duration: DispatchTimeInterval
 
     /// Any diagnostics emitted by the plugin.
-    public var diagnostics: [Diagnostic]
+    public var diagnostics: [Basics.Diagnostic]
 
     /// Any textual output emitted by the plugin.
     public var textOutput: String
@@ -393,102 +563,12 @@ public enum PluginEvaluationError: Swift.Error {
 }
 
 
-/// Implements the mechanics of running a plugin script (implemented as a set of Swift source files) as a process.
-public protocol PluginScriptRunner {
-    
-    /// Public protocol function that starts compiling the plugin script to an exectutable. The tools version controls the availability of APIs in PackagePlugin, and should be set to the tools version of the package that defines the plugin (not of the target to which it is being applied). This function returns immediately and then calls the completion handler on the callbackq queue when compilation ends.
-    func compilePluginScript(
-        sources: Sources,
-        toolsVersion: ToolsVersion,
-        observabilityScope: ObservabilityScope
-    ) throws -> PluginCompilationResult
-
-    /// Implements the mechanics of running a plugin script implemented as a set of Swift source files, for use
-    /// by the package graph when it is evaluating package plugins.
-    ///
-    /// The `sources` refer to the Swift source files and are accessible in the provided `fileSystem`. The input is
-    /// a PluginScriptRunnerInput structure, and the output will be a PluginScriptRunnerOutput structure.
-    ///
-    /// The text output callback handler will receive free-form output from the script as it's running. Structured
-    /// diagnostics emitted by the plugin will be added to the observability scope.
-    ///
-    /// Every concrete implementation should cache any intermediates as necessary to avoid redundant work.
-    func runPluginScript(
-        sources: Sources,
-        input: PluginScriptRunnerInput,
-        toolsVersion: ToolsVersion,
-        workingDirectory: AbsolutePath,
-        writableDirectories: [AbsolutePath],
-        readOnlyDirectories: [AbsolutePath],
-        fileSystem: FileSystem,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        delegate: PluginInvocationDelegate,
-        completion: @escaping (Result<Bool, Error>) -> Void
-    )
-
-    /// Returns the Triple that represents the host for which plugin script tools should be built, or for which binary
-    /// tools should be selected.
-    var hostTriple: Triple { get }
-}
-
-
-/// The result of compiling a plugin. The executable path will only be present if the compilation succeeds, while the other properties are present in all cases.
-public struct PluginCompilationResult {
-    /// Process result of invoking the Swift compiler to produce the executable (contains command line, environment, exit status, and any output).
-    public var compilerResult: ProcessResult?
-    
-    /// Path of the libClang diagnostics file emitted by the compiler (even if compilation succeded, it might contain warnings).
-    public var diagnosticsFile: AbsolutePath
-    
-    /// Path of the compiled executable.
-    public var compiledExecutable: AbsolutePath
-
-    /// Whether the compilation result was cached.
-    public var wasCached: Bool
-
-    public init(compilerResult: ProcessResult?, diagnosticsFile: AbsolutePath, compiledExecutable: AbsolutePath, wasCached: Bool) {
-        self.compilerResult = compilerResult
-        self.diagnosticsFile = diagnosticsFile
-        self.compiledExecutable = compiledExecutable
-        self.wasCached = wasCached
-    }
-    
-    /// Returns true if and only if the compilation succeeded or was cached
-    public var succeeded: Bool {
-        return self.wasCached || self.compilerResult?.exitStatus == .terminated(code: 0)
-    }
-}
-
-extension PluginCompilationResult: CustomStringConvertible {
-    public var description: String {
-        let stdout = (try? compilerResult?.utf8Output()) ?? ""
-        let stderr = (try? compilerResult?.utf8stderrOutput()) ?? ""
-        let output = (stdout + stderr).spm_chomp()
-        return output + (output.isEmpty || output.hasSuffix("\n") ? "" : "\n")
-    }
-}
-
-extension PluginCompilationResult: CustomDebugStringConvertible {
-    public var debugDescription: String {
-        return """
-            <PluginCompilationResult(
-                exitStatus: \(compilerResult.map{ "\($0.exitStatus)" } ?? "-"),
-                stdout: \((try? compilerResult?.utf8Output()) ?? ""),
-                stderr: \((try? compilerResult?.utf8stderrOutput()) ?? ""),
-                executable: \(compiledExecutable.prettyPath())
-            )>
-            """
-    }
-}
-
-
 public protocol PluginInvocationDelegate {
     /// Called for each piece of textual output data emitted by the plugin. Note that there is no guarantee that the data begins and ends on a UTF-8 byte sequence boundary (much less on a line boundary) so the delegate should buffer partial data as appropriate.
     func pluginEmittedOutput(_: Data)
     
     /// Called when a plugin emits a diagnostic through the PackagePlugin APIs.
-    func pluginEmittedDiagnostic(_: Diagnostic)
+    func pluginEmittedDiagnostic(_: Basics.Diagnostic)
 
     /// Called when a plugin defines a build command through the PackagePlugin APIs.
     func pluginDefinedBuildCommand(displayName: String?, executable: AbsolutePath, arguments: [String], environment: [String: String], workingDirectory: AbsolutePath?, inputFiles: [AbsolutePath], outputFiles: [AbsolutePath])
@@ -506,35 +586,35 @@ public protocol PluginInvocationDelegate {
     func pluginRequestedSymbolGraph(forTarget name: String, options: PluginInvocationSymbolGraphOptions, completion: @escaping (Result<PluginInvocationSymbolGraphResult, Error>) -> Void)
 }
 
-public struct PluginInvocationSymbolGraphOptions: Decodable {
+public struct PluginInvocationSymbolGraphOptions {
     public var minimumAccessLevel: AccessLevel
-    public enum AccessLevel: String, Decodable {
+    public enum AccessLevel: String {
         case `private`, `fileprivate`, `internal`, `public`, `open`
     }
     public var includeSynthesized: Bool
     public var includeSPI: Bool
 }
 
-public struct PluginInvocationSymbolGraphResult: Encodable {
+public struct PluginInvocationSymbolGraphResult {
     public var directoryPath: String
     public init(directoryPath: String) {
         self.directoryPath = directoryPath
     }
 }
 
-public enum PluginInvocationBuildSubset: Decodable {
+public enum PluginInvocationBuildSubset {
     case all(includingTests: Bool)
     case product(String)
     case target(String)
 }
 
-public struct PluginInvocationBuildParameters: Decodable {
+public struct PluginInvocationBuildParameters {
     public var configuration: Configuration
-    public enum Configuration: String, Decodable {
+    public enum Configuration: String {
         case debug, release
     }
     public var logging: LogVerbosity
-    public enum LogVerbosity: String, Decodable {
+    public enum LogVerbosity: String {
         case concise, verbose, debug
     }
     public var otherCFlags: [String]
@@ -543,14 +623,14 @@ public struct PluginInvocationBuildParameters: Decodable {
     public var otherLinkerFlags: [String]
 }
 
-public struct PluginInvocationBuildResult: Encodable {
+public struct PluginInvocationBuildResult {
     public var succeeded: Bool
     public var logText: String
     public var builtArtifacts: [BuiltArtifact]
-    public struct BuiltArtifact: Encodable {
+    public struct BuiltArtifact {
         public var path: String
         public var kind: Kind
-        public enum Kind: String, Encodable {
+        public enum Kind: String {
             case executable, dynamicLibrary, staticLibrary
         }
         public init(path: String, kind: Kind) {
@@ -565,31 +645,31 @@ public struct PluginInvocationBuildResult: Encodable {
     }
 }
 
-public enum PluginInvocationTestSubset: Decodable {
+public enum PluginInvocationTestSubset {
     case all
     case filtered([String])
 }
 
-public struct PluginInvocationTestParameters: Decodable {
+public struct PluginInvocationTestParameters {
     public var enableCodeCoverage: Bool
 }
 
-public struct PluginInvocationTestResult: Encodable {
+public struct PluginInvocationTestResult {
     public var succeeded: Bool
     public var testTargets: [TestTarget]
     public var codeCoverageDataFile: String?
 
-    public struct TestTarget: Encodable {
+    public struct TestTarget {
         public var name: String
         public var testCases: [TestCase]
-        public struct TestCase: Encodable {
+        public struct TestCase {
             public var name: String
             public var tests: [Test]
-            public struct Test: Encodable {
+            public struct Test {
                 public var name: String
                 public var result: Result
                 public var duration: Double
-                public enum Result: String, Encodable {
+                public enum Result: String {
                     case succeeded, skipped, failed
                 }
                 public init(name: String, result: Result, duration: Double) {
@@ -631,526 +711,170 @@ public extension PluginInvocationDelegate {
     }
 }
 
-/// Serializable context that's passed as input to an invocation of a plugin.
-/// This is the transport data to a particular invocation of a plugin for a
-/// particular purpose; everything we can communicate to the plugin is here.
-///
-/// It consists mainly of a flattened package graph, with each kind of entity
-/// referenced by an array that is indexed by an ID (a small integer). This
-/// structure is serialized from the package model (a directed acyclic graph).
-/// All references in the flattened graph are ID numbers.
-///
-/// Other information includes a mapping from names of command line tools that
-/// are available to the plugin to their corresponding paths, and a serialized
-/// representation of the plugin action.
-public struct PluginScriptRunnerInput: Codable {
-    let paths: [Path]
-    let targets: [Target]
-    let products: [Product]
-    let packages: [Package]
-    let rootPackageId: Package.Id
-    let pluginWorkDirId: Path.Id
-    let toolSearchDirIds: [Path.Id]
-    let toolNamesToPathIds: [String: Path.Id]
-    let pluginAction: PluginAction
-
-    /// An action that SwiftPM can ask the plugin to take. This corresponds to
-    /// the capabilities declared for the plugin.
-    enum PluginAction: Codable {
-        case createBuildToolCommands(targetId: Target.Id)
-        case performCommand(arguments: [String])
-    }
-
-    /// A single absolute path in the wire structure, represented as a tuple
-    /// consisting of the ID of the base path and subpath off of that path.
-    /// This avoids repetition of path components in the wire representation.
-    struct Path: Codable {
-        typealias Id = Int
-        let basePathId: Path.Id?
-        let subpath: String
-    }
-
-    /// A package in the wire structure. All references to other entities are
-    /// their ID numbers.
-    struct Package: Codable {
-        typealias Id = Int
-        let identity: String
-        let displayName: String
-        let directoryId: Path.Id
-        let origin: Origin
-        let toolsVersion: ToolsVersion
-        let dependencies: [Dependency]
-        let productIds: [Product.Id]
-        let targetIds: [Target.Id]
-
-        /// The origin of the package (root, local, repository, registry, etc).
-        enum Origin: Codable {
-            case root
-            case local(
-                path: Path.Id)
-            case repository(
-                url: String,
-                displayVersion: String,
-                scmRevision: String)
-            case registry(
-                identity: String,
-                displayVersion: String)
-        }
-
-        /// Represents a version of SwiftPM on whose semantics a package relies.
-        struct ToolsVersion: Codable {
-            let major: Int
-            let minor: Int
-            let patch: Int
-        }
-
-        /// A dependency on a package in the wire structure. All references to
-        /// other entities are ID numbers.
-        struct Dependency: Codable {
-            let packageId: Package.Id
-        }
-    }
-
-    /// A product in the wire structure. All references to other entities are
-    /// their ID numbers.
-    struct Product: Codable {
-        typealias Id = Int
-        let name: String
-        let targetIds: [Target.Id]
-        let info: ProductInfo
-
-        /// Information for each type of product in the wire structure. All
-        /// references to other entities are their ID numbers.
-        enum ProductInfo: Codable {
-            case executable(
-                mainTargetId: Target.Id)
-            case library(
-                kind: LibraryKind)
-
-            /// A type of library in the wire structure, as SwiftPM sees it.
-            enum LibraryKind: Codable {
-                case `static`
-                case `dynamic`
-                case automatic
-            }
-        }
-    }
-
-    /// A target in the wire structure. All references to other entities are
-    /// their ID numbers.
-    struct Target: Codable {
-        typealias Id = Int
-        let name: String
-        let directoryId: Path.Id
-        let dependencies: [Dependency]
-        let info: TargetInfo
-
-        /// A dependency on either a target or a product in the wire structure.
-        /// All references to other entities are ID their numbers.
-        enum Dependency: Codable {
-            case target(
-                targetId: Target.Id)
-            case product(
-                productId: Product.Id)
-        }
-        
-        /// Type-specific information for a target in the wire structure. All
-        /// references to other entities are their ID numbers.
-        enum TargetInfo: Codable {
-            /// Information about a Swift source module target.
-            case swiftSourceModuleInfo(
-                moduleName: String,
-                kind: SourceModuleKind,
-                sourceFiles: [File],
-                compilationConditions: [String],
-                linkedLibraries: [String],
-                linkedFrameworks: [String])
-            
-            /// Information about a Clang source module target.
-            case clangSourceModuleInfo(
-                moduleName: String,
-                kind: SourceModuleKind,
-                sourceFiles: [File],
-                preprocessorDefinitions: [String],
-                headerSearchPaths: [String],
-                publicHeadersDirId: Path.Id?,
-                linkedLibraries: [String],
-                linkedFrameworks: [String])
-            
-            /// Information about a binary artifact target.
-            case binaryArtifactInfo(
-                kind: BinaryArtifactKind,
-                origin: BinaryArtifactOrigin,
-                artifactId: Path.Id)
-            
-            /// Information about a system library target.
-            case systemLibraryInfo(
-                pkgConfig: String?,
-                compilerFlags: [String],
-                linkerFlags: [String])
-
-            /// A file in the wire structure.
-            struct File: Codable {
-                let basePathId: Path.Id
-                let name: String
-                let type: FileType
-
-                /// A type of file in the wire structure, as SwiftPM sees it.
-                enum FileType: String, Codable {
-                    case source
-                    case header
-                    case resource
-                    case unknown
-                }
-            }
-            
-            /// A kind of source module.
-            enum SourceModuleKind: String, Codable {
-                case generic
-                case executable
-                case test
-            }
-
-            /// A kind of binary artifact.
-            enum BinaryArtifactKind: Codable {
-                case xcframework
-                case artifactsArchive
-                case unknown
-            }
-            
-            /// The origin of a binary artifact.
-            enum BinaryArtifactOrigin: Codable {
-                case local
-                case remote(url: String)
-            }
+fileprivate extension PluginInvocationBuildSubset {
+    init(_ subset: PluginToHostMessage.BuildSubset) {
+        switch subset {
+        case .all(let includingTests):
+            self = .all(includingTests: includingTests)
+        case .product(let name):
+            self = .product(name)
+        case .target(let name):
+            self = .target(name)
         }
     }
 }
 
-/// Creates the serialized input structure for the plugin script based on all
-/// the input information to a plugin.
-struct PluginScriptRunnerInputSerializer {
-    let fileSystem: FileSystem
-    let buildEnvironment: BuildEnvironment
-    var paths: [PluginScriptRunnerInput.Path] = []
-    var pathsToIds: [AbsolutePath: PluginScriptRunnerInput.Path.Id] = [:]
-    var targets: [PluginScriptRunnerInput.Target] = []
-    var targetsToIds: [ResolvedTarget: PluginScriptRunnerInput.Target.Id] = [:]
-    var products: [PluginScriptRunnerInput.Product] = []
-    var productsToIds: [ResolvedProduct: PluginScriptRunnerInput.Product.Id] = [:]
-    var packages: [PluginScriptRunnerInput.Package] = []
-    var packagesToIds: [ResolvedPackage: PluginScriptRunnerInput.Package.Id] = [:]
-    
-    mutating func makePluginScriptRunnerInput(
-        rootPackage: ResolvedPackage,
-        pluginWorkDir: AbsolutePath,
-        toolSearchDirs: [AbsolutePath],
-        toolNamesToPaths: [String: AbsolutePath],
-        pluginAction: PluginAction
-    ) throws -> PluginScriptRunnerInput {
-        let rootPackageId = try serialize(package: rootPackage)
-        let pluginWorkDirId = try serialize(path: pluginWorkDir)
-        let toolSearchDirIds = try toolSearchDirs.map{ try serialize(path: $0) }
-        let toolNamesToPathIds = try toolNamesToPaths.mapValues{ try serialize(path: $0) }
-        let serializedPluginAction: PluginScriptRunnerInput.PluginAction
-        switch pluginAction {
-        case .createBuildToolCommands(let target):
-            guard let targetId = try serialize(target: target) else {
-                throw StringError("unexpectedly was unable to serialize target \(target)")
-            }
-            serializedPluginAction = .createBuildToolCommands(targetId: targetId)
-        case .performCommand(let arguments):
-            serializedPluginAction = .performCommand(arguments: arguments)
-        }
-        return PluginScriptRunnerInput(
-            paths: paths,
-            targets: targets,
-            products: products,
-            packages: packages,
-            rootPackageId: rootPackageId,
-            pluginWorkDirId: pluginWorkDirId,
-            toolSearchDirIds: toolSearchDirIds,
-            toolNamesToPathIds: toolNamesToPathIds,
-            pluginAction: serializedPluginAction)
-    }
-    
-    /// Adds a path to the serialized structure, if it isn't already there.
-    /// Either way, this function returns the path's wire ID.
-    mutating func serialize(path: AbsolutePath) throws -> PluginScriptRunnerInput.Path.Id {
-        // If we've already seen the path, just return the wire ID we already assigned to it.
-        if let id = pathsToIds[path] { return id }
-        
-        // Split up the path into a base path and a subpath (currently always with the last path component as the
-        // subpath, but this can be optimized where there are sequences of path components with a valence of one).
-        let basePathId = (path.parentDirectory.isRoot ? nil : try serialize(path: path.parentDirectory))
-        let subpathString = path.basename
-        
-        // Finally assign the next wire ID to the path and append a serialized Path record.
-        let id = paths.count
-        paths.append(.init(basePathId: basePathId, subpath: subpathString))
-        pathsToIds[path] = id
-        return id
-    }
-
-    // Adds a target to the serialized structure, if it isn't already there and
-    // if it is of a kind that should be passed to the plugin. If so, this func-
-    // tion returns the target's wire ID. If not, it returns nil.
-    mutating func serialize(target: ResolvedTarget) throws -> PluginScriptRunnerInput.Target.Id? {
-        // If we've already seen the target, just return the wire ID we already assigned to it.
-        if let id = targetsToIds[target] { return id }
-        
-        // Construct the FileList
-        var targetFiles: [PluginScriptRunnerInput.Target.TargetInfo.File] = []
-        targetFiles.append(contentsOf: try target.underlyingTarget.sources.paths.map {
-            .init(basePathId: try serialize(path: $0.parentDirectory), name: $0.basename, type: .source)
-        })
-        targetFiles.append(contentsOf: try target.underlyingTarget.resources.map {
-            .init(basePathId: try serialize(path: $0.path.parentDirectory), name: $0.path.basename, type: .resource)
-        })
-        targetFiles.append(contentsOf: try target.underlyingTarget.ignored.map {
-            .init(basePathId: try serialize(path: $0.parentDirectory), name: $0.basename, type: .unknown)
-        })
-        targetFiles.append(contentsOf: try target.underlyingTarget.others.map {
-            .init(basePathId: try serialize(path: $0.parentDirectory), name: $0.basename, type: .unknown)
-        })
-        
-        // Create a scope for evaluating build settings.
-        let scope = BuildSettings.Scope(target.underlyingTarget.buildSettings, environment: buildEnvironment)
-        
-        // Look at the target and decide what to serialize. At this point we may decide to not serialize it at all.
-        let targetInfo: PluginScriptRunnerInput.Target.TargetInfo
-        switch target.underlyingTarget {
-            
-        case let target as SwiftTarget:
-            targetInfo = .swiftSourceModuleInfo(
-                moduleName: target.c99name,
-                kind: try .init(target.type),
-                sourceFiles: targetFiles,
-                compilationConditions: scope.evaluate(.SWIFT_ACTIVE_COMPILATION_CONDITIONS),
-                linkedLibraries: scope.evaluate(.LINK_LIBRARIES),
-                linkedFrameworks: scope.evaluate(.LINK_FRAMEWORKS))
-
-        case let target as ClangTarget:
-            targetInfo = .clangSourceModuleInfo(
-                moduleName: target.c99name,
-                kind: try .init(target.type),
-                sourceFiles: targetFiles,
-                preprocessorDefinitions: scope.evaluate(.GCC_PREPROCESSOR_DEFINITIONS),
-                headerSearchPaths: scope.evaluate(.HEADER_SEARCH_PATHS),
-                publicHeadersDirId: try serialize(path: target.includeDir),
-                linkedLibraries: scope.evaluate(.LINK_LIBRARIES),
-                linkedFrameworks: scope.evaluate(.LINK_FRAMEWORKS))
-
-        case let target as SystemLibraryTarget:
-            var cFlags: [String] = []
-            var ldFlags: [String] = []
-            // FIXME: What do we do with any diagnostics here?
-            let observabilityScope = ObservabilitySystem({ _, _ in }).topScope
-            for result in pkgConfigArgs(for: target, fileSystem: self.fileSystem, observabilityScope: observabilityScope) {
-                if let error = result.error {
-                    observabilityScope.emit(
-                        warning: "\(error)",
-                        metadata: .pkgConfig(pcFile: result.pkgConfigName, targetName: target.name)
-                    )
-                }
-                else {
-                    cFlags += result.cFlags
-                    ldFlags += result.libs
-                }
-            }
-
-            targetInfo = .systemLibraryInfo(
-                pkgConfig: target.pkgConfig,
-                compilerFlags: cFlags,
-                linkerFlags: ldFlags)
-            
-        case let target as BinaryTarget:
-            let artifactKind: PluginScriptRunnerInput.Target.TargetInfo.BinaryArtifactKind
-            switch target.kind {
-            case .artifactsArchive:
-                artifactKind = .artifactsArchive
-            case .xcframework:
-                artifactKind = .xcframework
-            case .unknown:
-                artifactKind = .unknown
-            }
-            let artifactOrigin: PluginScriptRunnerInput.Target.TargetInfo.BinaryArtifactOrigin
-            switch target.origin {
-            case .local:
-                artifactOrigin = .local
-            case .remote(let url):
-                artifactOrigin = .remote(url: url)
-            }
-            targetInfo = .binaryArtifactInfo(
-                kind: artifactKind,
-                origin: artifactOrigin,
-                artifactId: try serialize(path: target.artifactPath))
-            
-        default:
-            // It's not a type of target that we pass through to the plugin.
-            return nil
-        }
-        
-        // We only get this far if we are serializing the target. If so we also serialize its dependencies. This needs to be done before assigning the next wire ID for the target we're serializing, to make sure we end up with the correct one.
-        let dependencies: [PluginScriptRunnerInput.Target.Dependency] = try target.dependencies(satisfying: buildEnvironment).compactMap {
-            switch $0 {
-            case .target(let target, _):
-                return try serialize(target: target).map { .target(targetId: $0) }
-            case .product(let product, _):
-                return try serialize(product: product).map { .product(productId: $0) }
-            }
-        }
-
-        // Finally assign the next wire ID to the target and append a serialized Target record.
-        let id = targets.count
-        targets.append(.init(
-            name: target.name,
-            directoryId: try serialize(path: target.sources.root),
-            dependencies: dependencies,
-            info: targetInfo))
-        targetsToIds[target] = id
-        return id
-    }
-
-    // Adds a product to the serialized structure, if it isn't already there and
-    // if it is of a kind that should be passed to the plugin. If so, this func-
-    // tion returns the product's wire ID. If not, it returns nil.
-    mutating func serialize(product: ResolvedProduct) throws -> PluginScriptRunnerInput.Product.Id? {
-        // If we've already seen the product, just return the wire ID we already assigned to it.
-        if let id = productsToIds[product] { return id }
-        
-        // Look at the product and decide what to serialize. At this point we may decide to not serialize it at all.
-        let productInfo: PluginScriptRunnerInput.Product.ProductInfo
-        switch product.type {
-            
-        case .executable:
-            guard let mainExecTarget = product.targets.first(where: { $0.type == .executable }) else {
-                throw InternalError("could not determine main executable target for product \(product)")
-            }
-            guard let mainExecTargetId = try serialize(target: mainExecTarget) else {
-                throw InternalError("unable to serialize main executable target \(mainExecTarget) for product \(product)")
-            }
-            productInfo = .executable(mainTargetId: mainExecTargetId)
-
-        case .library(let kind):
-            switch kind {
-            case .static:
-                productInfo = .library(kind: .static)
-            case .dynamic:
-                productInfo = .library(kind: .dynamic)
-            case .automatic:
-                productInfo = .library(kind: .automatic)
-            }
-
-        default:
-            // It's not a type of product that we pass through to the plugin.
-            return nil
-        }
-        
-        // Finally assign the next wire ID to the product and append a serialized Product record.
-        let id = products.count
-        products.append(.init(
-            name: product.name,
-            targetIds: try product.targets.compactMap{ try serialize(target: $0) },
-            info: productInfo))
-        productsToIds[product] = id
-        return id
-    }
-
-    // Adds a package to the serialized structure, if it isn't already there.
-    // Either way, this function returns the target's wire ID.
-    mutating func serialize(package: ResolvedPackage) throws -> PluginScriptRunnerInput.Package.Id {
-        // If we've already seen the package, just return the wire ID we already assigned to it.
-        if let id = packagesToIds[package] { return id }
-        
-        // Determine how we should represent the origin of the package to the plugin.
-        func origin(for package: ResolvedPackage) throws -> PluginScriptRunnerInput.Package.Origin {
-            switch package.manifest.packageKind {
-            case .root(_):
-                return .root
-            case .fileSystem(let path):
-                return .local(path: try serialize(path: path))
-            case .localSourceControl(let path):
-                return .repository(url: path.asURL.absoluteString, displayVersion: String(describing: package.manifest.version), scmRevision: String(describing: package.manifest.revision))
-            case .remoteSourceControl(let url):
-                return .repository(url: url.absoluteString, displayVersion: String(describing: package.manifest.version), scmRevision: String(describing: package.manifest.revision))
-            case .registry(let identity):
-                return .registry(identity: identity.description, displayVersion: String(describing: package.manifest.version))
-            }
-        }
-
-        // Serialize the dependency packages. This needs to be done assigning the next wire ID to the package we're serializing, to make sure we end up with the correct one.
-        let dependencies = try package.dependencies.map {
-            PluginScriptRunnerInput.Package.Dependency(packageId: try serialize(package: $0))
-        }
-
-        // Assign the next wire ID to the package and append a serialized Package record.
-        let id = packages.count
-        packages.append(.init(
-            identity: package.identity.description,
-            displayName: package.manifest.displayName,
-            directoryId: try serialize(path: package.path),
-            origin: try origin(for: package),
-            toolsVersion: .init(
-                major: package.manifest.toolsVersion.major,
-                minor: package.manifest.toolsVersion.minor,
-                patch: package.manifest.toolsVersion.patch),
-            dependencies: dependencies,
-            productIds: try package.products.compactMap{ try serialize(product: $0) },
-            targetIds: try package.targets.compactMap{ try serialize(target: $0) }))
-        packagesToIds[package] = id
-        return id
+fileprivate extension PluginInvocationBuildParameters {
+    init(_ parameters: PluginToHostMessage.BuildParameters) {
+        self.configuration = .init(parameters.configuration)
+        self.logging = .init(parameters.logging)
+        self.otherCFlags = parameters.otherCFlags
+        self.otherCxxFlags = parameters.otherCxxFlags
+        self.otherSwiftcFlags = parameters.otherSwiftcFlags
+        self.otherLinkerFlags = parameters.otherLinkerFlags
     }
 }
 
-fileprivate extension PluginScriptRunnerInput.Target.TargetInfo.SourceModuleKind {
-    init(_ kind: Target.Kind) throws {
+fileprivate extension PluginInvocationBuildParameters.Configuration {
+    init(_ configuration: PluginToHostMessage.BuildParameters.Configuration) {
+        switch configuration {
+        case .debug:
+            self = .debug
+        case .release:
+            self = .release
+        }
+    }
+}
+
+fileprivate extension PluginInvocationBuildParameters.LogVerbosity {
+    init(_ verbosity: PluginToHostMessage.BuildParameters.LogVerbosity) {
+        switch verbosity {
+        case .concise:
+            self = .concise
+        case .verbose:
+            self = .verbose
+        case .debug:
+            self = .debug
+        }
+    }
+}
+
+fileprivate extension HostToPluginMessage.BuildResult {
+    init(_ result: PluginInvocationBuildResult) {
+        self.succeeded = result.succeeded
+        self.logText = result.logText
+        self.builtArtifacts = result.builtArtifacts.map { .init($0) }
+    }
+}
+
+fileprivate extension HostToPluginMessage.BuildResult.BuiltArtifact {
+    init(_ artifact: PluginInvocationBuildResult.BuiltArtifact) {
+        self.path = .init(artifact.path)
+        self.kind = .init(artifact.kind)
+    }
+}
+
+fileprivate extension HostToPluginMessage.BuildResult.BuiltArtifact.Kind {
+    init(_ kind: PluginInvocationBuildResult.BuiltArtifact.Kind) {
         switch kind {
-        case .library:
-            self = .generic
         case .executable:
             self = .executable
-        case .test:
-            self = .test
-        case .binary, .plugin, .snippet, .systemModule:
-            throw StringError("unexpected target kind \(kind) for source module")
+        case .dynamicLibrary:
+            self = .dynamicLibrary
+        case .staticLibrary:
+            self = .staticLibrary
         }
     }
 }
 
-
-
-/// Deserializable result that's received as output from the invocation of the plugin. This is the transport data from
-/// the invocation of the plugin for a particular target; everything the plugin can commuicate to us is here.
-public struct PluginScriptRunnerOutput: Codable {
-    var diagnostics: [Diagnostic]
-    struct Diagnostic: Codable {
-        enum Severity: String, Codable {
-            case error, warning, remark
+fileprivate extension PluginInvocationTestSubset {
+    init(_ subset: PluginToHostMessage.TestSubset) {
+        switch subset {
+        case .all:
+            self = .all
+        case .filtered(let regexes):
+            self = .filtered(regexes)
         }
-        let severity: Severity
-        let message: String
-        let file: String?
-        let line: Int?
     }
-    let buildCommands: [BuildCommand]
-    struct BuildCommand: Codable {
-        let displayName: String
-        let executable: String
-        let arguments: [String]
-        let environment: [String: String]
-        let workingDirectory: String?
-        let inputFiles: [String]
-        let outputFiles: [String]
+}
+
+fileprivate extension PluginInvocationTestParameters {
+    init(_ parameters: PluginToHostMessage.TestParameters) {
+        self.enableCodeCoverage = parameters.enableCodeCoverage
     }
-    let prebuildCommands: [PrebuildCommand]
-    struct PrebuildCommand: Codable {
-        let displayName: String
-        let executable: String
-        let arguments: [String]
-        let environment: [String: String]
-        let workingDirectory: String?
-        let outputFilesDirectory: String
+}
+
+fileprivate extension HostToPluginMessage.TestResult {
+    init(_ result: PluginInvocationTestResult) {
+        self.succeeded = result.succeeded
+        self.testTargets = result.testTargets.map{ .init($0) }
+        self.codeCoverageDataFile = result.codeCoverageDataFile.map{ .init($0) }
+    }
+}
+
+fileprivate extension HostToPluginMessage.TestResult.TestTarget {
+    init(_ testTarget: PluginInvocationTestResult.TestTarget) {
+        self.name = testTarget.name
+        self.testCases = testTarget.testCases.map{ .init($0) }
+    }
+}
+
+fileprivate extension HostToPluginMessage.TestResult.TestTarget.TestCase {
+    init(_ testCase: PluginInvocationTestResult.TestTarget.TestCase) {
+        self.name = testCase.name
+        self.tests = testCase.tests.map{ .init($0) }
+    }
+}
+
+fileprivate extension HostToPluginMessage.TestResult.TestTarget.TestCase.Test {
+    init(_ test: PluginInvocationTestResult.TestTarget.TestCase.Test) {
+        self.name = test.name
+        self.result = .init(test.result)
+        self.duration = test.duration
+    }
+}
+
+fileprivate extension HostToPluginMessage.TestResult.TestTarget.TestCase.Test.Result {
+    init(_ result: PluginInvocationTestResult.TestTarget.TestCase.Test.Result) {
+        switch result {
+        case .succeeded:
+            self = .succeeded
+        case .skipped:
+            self = .skipped
+        case .failed:
+            self = .failed
+        }
+    }
+}
+
+fileprivate extension PluginInvocationSymbolGraphOptions {
+    init(_ options: PluginToHostMessage.SymbolGraphOptions) {
+        self.minimumAccessLevel = .init(options.minimumAccessLevel)
+        self.includeSynthesized = options.includeSynthesized
+        self.includeSPI = options.includeSPI
+    }
+}
+
+fileprivate extension PluginInvocationSymbolGraphOptions.AccessLevel {
+    init(_ accessLevel: PluginToHostMessage.SymbolGraphOptions.AccessLevel) {
+        switch accessLevel {
+        case .private:
+            self = .private
+        case .fileprivate:
+            self = .fileprivate
+        case .internal:
+            self = .internal
+        case .public:
+            self = .public
+        case .open:
+            self = .open
+        }
+    }
+}
+
+fileprivate extension HostToPluginMessage.SymbolGraphResult {
+    init(_ result: PluginInvocationSymbolGraphResult) {
+        self.directoryPath = .init(result.directoryPath)
     }
 }
 
@@ -1198,4 +922,3 @@ extension ObservabilityMetadata {
         typealias Value = String
     }
 }
-

--- a/Sources/SPMBuildCore/PluginMessages.swift
+++ b/Sources/SPMBuildCore/PluginMessages.swift
@@ -1,0 +1,1 @@
+../PackagePlugin/PluginMessages.swift

--- a/Sources/SPMBuildCore/PluginScriptRunner.swift
+++ b/Sources/SPMBuildCore/PluginScriptRunner.swift
@@ -1,0 +1,115 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Basics
+import Foundation
+import PackageModel
+import PackageLoading
+import PackageGraph
+import TSCBasic
+import struct TSCUtility.Triple
+
+/// Implements the mechanics of running and communicating with a plugin (implemented as a set of Swift source files). In most environments this is done by compiling the code to an executable, invoking it as a sandboxed subprocess, and communicating with it using pipes. Specific implementations are free to implement things differently, however.
+public protocol PluginScriptRunner {
+    
+    /// Public protocol function that starts compiling the plugin script to an exectutable. The tools version controls the availability of APIs in PackagePlugin, and should be set to the tools version of the package that defines the plugin (not of the target to which it is being applied). This function returns immediately and then calls the completion handler on the callbackq queue when compilation ends.
+    func compilePluginScript(
+        sources: Sources,
+        toolsVersion: ToolsVersion,
+        observabilityScope: ObservabilityScope
+    ) throws -> PluginCompilationResult
+
+    /// Implements the mechanics of running a plugin script implemented as a set of Swift source files, for use
+    /// by the package graph when it is evaluating package plugins.
+    ///
+    /// The `sources` refer to the Swift source files and are accessible in the provided `fileSystem`. The input is
+    /// a PluginScriptRunnerInput structure.
+    ///
+    /// The text output callback handler will receive free-form output from the script as it's running. Structured
+    /// diagnostics emitted by the plugin will be added to the observability scope.
+    ///
+    /// Every concrete implementation should cache any intermediates as necessary to avoid redundant work.
+    func runPluginScript(
+        sources: Sources,
+        initialMessage: Data,
+        toolsVersion: ToolsVersion,
+        workingDirectory: AbsolutePath,
+        writableDirectories: [AbsolutePath],
+        readOnlyDirectories: [AbsolutePath],
+        fileSystem: FileSystem,
+        observabilityScope: ObservabilityScope,
+        callbackQueue: DispatchQueue,
+        delegate: PluginScriptRunnerDelegate,
+        completion: @escaping (Result<Int32, Error>) -> Void
+    )
+
+    /// Returns the Triple that represents the host for which plugin script tools should be built, or for which binary
+    /// tools should be selected.
+    var hostTriple: Triple { get }
+}
+
+/// Protocol by which `PluginScriptRunner.runPluginScript()` communicates back to the caller.
+public protocol PluginScriptRunnerDelegate {
+    /// Called for each piece of textual output data emitted by the plugin. Note that there is no guarantee that the data begins and ends on a UTF-8 byte sequence boundary (much less on a line boundary) so the delegate should buffer partial data as appropriate.
+    func handleOutput(data: Data)
+    
+    /// Called for each length-delimited message received from the plugin. The `responder` is closure that can be used to send one or more messages in reply.
+    func handleMessage(data: Data, responder: @escaping (Data) -> Void) throws
+}
+
+
+/// The result of compiling a plugin. The executable path will only be present if the compilation succeeds, while the other properties are present in all cases.
+public struct PluginCompilationResult {
+    /// Process result of invoking the Swift compiler to produce the executable (contains command line, environment, exit status, and any output).
+    public var compilerResult: ProcessResult?
+    
+    /// Path of the libClang diagnostics file emitted by the compiler (even if compilation succeded, it might contain warnings).
+    public var diagnosticsFile: AbsolutePath
+    
+    /// Path of the compiled executable.
+    public var compiledExecutable: AbsolutePath
+
+    /// Whether the compilation result was cached.
+    public var wasCached: Bool
+
+    public init(compilerResult: ProcessResult?, diagnosticsFile: AbsolutePath, compiledExecutable: AbsolutePath, wasCached: Bool) {
+        self.compilerResult = compilerResult
+        self.diagnosticsFile = diagnosticsFile
+        self.compiledExecutable = compiledExecutable
+        self.wasCached = wasCached
+    }
+    
+    /// Returns true if and only if the compilation succeeded or was cached
+    public var succeeded: Bool {
+        return self.wasCached || self.compilerResult?.exitStatus == .terminated(code: 0)
+    }
+}
+
+extension PluginCompilationResult: CustomStringConvertible {
+    public var description: String {
+        let stdout = (try? compilerResult?.utf8Output()) ?? ""
+        let stderr = (try? compilerResult?.utf8stderrOutput()) ?? ""
+        let output = (stdout + stderr).spm_chomp()
+        return output + (output.isEmpty || output.hasSuffix("\n") ? "" : "\n")
+    }
+}
+
+extension PluginCompilationResult: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        return """
+            <PluginCompilationResult(
+                exitStatus: \(compilerResult.map{ "\($0.exitStatus)" } ?? "-"),
+                stdout: \((try? compilerResult?.utf8Output()) ?? ""),
+                stderr: \((try? compilerResult?.utf8stderrOutput()) ?? ""),
+                executable: \(compiledExecutable.prettyPath())
+            )>
+            """
+    }
+}

--- a/Sources/Workspace/DefaultPluginScriptRunner.swift
+++ b/Sources/Workspace/DefaultPluginScriptRunner.swift
@@ -72,7 +72,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner {
     /// Public protocol function that starts evaluating a plugin by compiling it and running it as a subprocess. The tools version controls the availability of APIs in PackagePlugin, and should be set to the tools version of the package that defines the plugin (not the package containing the target to which it is being applied). This function returns immediately and then repeated calls the output handler on the given callback queue as plain-text output is received from the plugin, and then eventually calls the completion handler on the given callback queue once the plugin is done.
     public func runPluginScript(
         sources: Sources,
-        input: PluginScriptRunnerInput,
+        initialMessage: Data,
         toolsVersion: ToolsVersion,
         workingDirectory: AbsolutePath,
         writableDirectories: [AbsolutePath],
@@ -80,8 +80,8 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner {
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue,
-        delegate: PluginInvocationDelegate,
-        completion: @escaping (Result<Bool, Error>) -> Void
+        delegate: PluginScriptRunnerDelegate,
+        completion: @escaping (Result<Int32, Error>) -> Void
     ) {
         // If needed, compile the plugin script to an executable (asynchronously). Compilation is skipped if the plugin hasn't changed since it was last compiled.
         self.compile(
@@ -102,7 +102,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner {
                             workingDirectory: workingDirectory,
                             writableDirectories: writableDirectories,
                             readOnlyDirectories: readOnlyDirectories,
-                            input: input,
+                            initialMessage: initialMessage,
                             observabilityScope: observabilityScope,
                             callbackQueue: callbackQueue,
                             delegate: delegate,
@@ -371,11 +371,11 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner {
         workingDirectory: AbsolutePath,
         writableDirectories: [AbsolutePath],
         readOnlyDirectories: [AbsolutePath],
-        input: PluginScriptRunnerInput,
+        initialMessage: Data,
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue,
-        delegate: PluginInvocationDelegate,
-        completion: @escaping (Result<Bool, Error>) -> Void
+        delegate: PluginScriptRunnerDelegate,
+        completion: @escaping (Result<Int32, Error>) -> Void
     ) {
 #if os(iOS) || os(watchOS) || os(tvOS)
         callbackQueue.async {
@@ -403,92 +403,36 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner {
         let outputQueue = DispatchQueue(label: "plugin-send-queue")
         process.standardInput = stdinPipe
 
-        // Private message handler method. Always invoked on the callback queue.
-        var emittedAtLeastOneError = false
-        func handle(message: PluginToHostMessage) throws {
-            dispatchPrecondition(condition: .onQueue(callbackQueue))
-            switch message {
-                
-            case .emitDiagnostic(let severity, let message, let file, let line):
-                let metadata: ObservabilityMetadata? = file.map {
-                    var metadata = ObservabilityMetadata()
-                    // FIXME: We should probably report some kind of protocol error if the path isn't valid.
-                    metadata.fileLocation = try? .init(.init(validating: $0), line: line)
-                    return metadata
-                }
-                let diagnostic: Basics.Diagnostic
-                switch severity {
-                case .error:
-                    emittedAtLeastOneError = true
-                    diagnostic = .error(message, metadata: metadata)
-                case .warning:
-                    diagnostic = .warning(message, metadata: metadata)
-                case .remark:
-                    diagnostic = .info(message, metadata: metadata)
-                }
-                delegate.pluginEmittedDiagnostic(diagnostic)
-                
-            case .defineBuildCommand(let config, let inputFiles, let outputFiles):
-                delegate.pluginDefinedBuildCommand(
-                    displayName: config.displayName,
-                    executable: try AbsolutePath(validating: config.executable),
-                    arguments: config.arguments,
-                    environment: config.environment,
-                    workingDirectory: try config.workingDirectory.map{ try AbsolutePath(validating: $0) },
-                    inputFiles: try inputFiles.map{ try AbsolutePath(validating: $0) },
-                    outputFiles: try outputFiles.map{ try AbsolutePath(validating: $0) })
-                
-            case .definePrebuildCommand(let config, let outputFilesDir):
-                delegate.pluginDefinedPrebuildCommand(
-                    displayName: config.displayName,
-                    executable: try AbsolutePath(validating: config.executable),
-                    arguments: config.arguments,
-                    environment: config.environment,
-                    workingDirectory: try config.workingDirectory.map{ try AbsolutePath(validating: $0) },
-                    outputFilesDirectory: try AbsolutePath(validating: outputFilesDir))
-
-            case .buildOperationRequest(let subset, let parameters):
-                delegate.pluginRequestedBuildOperation(subset: subset, parameters: parameters) {
-                    switch $0 {
-                    case .success(let result):
-                        outputQueue.async { try? outputHandle.writePluginMessage(.buildOperationResponse(result: result)) }
-                    case .failure(let error):
-                        outputQueue.async { try? outputHandle.writePluginMessage(.errorResponse(error: String(describing: error))) }
-                    }
-                }
-
-            case .testOperationRequest(let subset, let parameters):
-                delegate.pluginRequestedTestOperation(subset: subset, parameters: parameters) {
-                    switch $0 {
-                    case .success(let result):
-                        outputQueue.async { try? outputHandle.writePluginMessage(.testOperationResponse(result: result)) }
-                    case .failure(let error):
-                        outputQueue.async { try? outputHandle.writePluginMessage(.errorResponse(error: String(describing: error))) }
-                    }
-                }
-
-            case .symbolGraphRequest(let targetName, let options):
-                // The plugin requested symbol graph information for a target. We ask the delegate and then send a response.
-                delegate.pluginRequestedSymbolGraph(forTarget: targetName, options: options) {
-                    switch $0 {
-                    case .success(let result):
-                        outputQueue.async { try? outputHandle.writePluginMessage(.symbolGraphResponse(result: result)) }
-                    case .failure(let error):
-                        outputQueue.async { try? outputHandle.writePluginMessage(.errorResponse(error: String(describing: error))) }
-                    }
-                }
-            }
-        }
-
-        // Set up a pipe for receiving structured messages from the plugin on its stdout.
+        // Set up a pipe for receiving messages from the plugin on its stdout.
         let stdoutPipe = Pipe()
         let stdoutLock = Lock()
         stdoutPipe.fileHandleForReading.readabilityHandler = { fileHandle in
-            // Parse the next message and pass it on to the delegate.
+            // Receive the next message and pass it on to the delegate.
             stdoutLock.withLock {
-                while let message = try? fileHandle.readPluginMessage() {
-                    // FIXME: We should handle errors here.
-                    callbackQueue.async { try? handle(message: message) }
+                do {
+                    while let message = try fileHandle.readPluginMessage() {
+                        // FIXME: We should handle errors here.
+                        callbackQueue.async {
+                            do {
+                                try delegate.handleMessage(data: message, responder: { data in
+                                    outputQueue.async {
+                                        do {
+                                            try outputHandle.writePluginMessage(data)
+                                        }
+                                        catch {
+                                            print("error while trying to send message to plugin: \(error)")
+                                        }
+                                    }
+                                })
+                            }
+                            catch {
+                                print("error while trying to handle message from plugin: \(error)")
+                            }
+                        }
+                    }
+                }
+                catch {
+                    print("error while trying to read message from plugin: \(error)")
                 }
             }
         }
@@ -501,10 +445,10 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner {
         stderrPipe.fileHandleForReading.readabilityHandler = { fileHandle in
             // Pass on any available data to the delegate.
             stderrLock.withLock {
-                let newData = fileHandle.availableData
-                if newData.isEmpty { return }
-                stderrData.append(contentsOf: newData)
-                callbackQueue.async { delegate.pluginEmittedOutput(newData) }
+                let data = fileHandle.availableData
+                if data.isEmpty { return }
+                stderrData.append(contentsOf: data)
+                callbackQueue.async { delegate.handleOutput(data: data) }
             }
         }
         process.standardError = stderrPipe
@@ -540,16 +484,8 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner {
                             command: command,
                             output: String(decoding: stderrData, as: UTF8.self))
                     }
-                    // Otherwise we return a result based on its exit code. If
-                    // the plugin exits with an error but hasn't already emitted
-                    // an error, we do so for it.
-                    let success = (process.terminationStatus == 0)
-                    if !success && !emittedAtLeastOneError {
-                        delegate.pluginEmittedDiagnostic(
-                            .error("Plugin ended with exit code \(process.terminationStatus)")
-                        )
-                    }
-                    return success
+                    // Otherwise return the termination satatus.
+                    return process.terminationStatus
                 })
             }
         }
@@ -564,9 +500,9 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner {
             }
         }
 
-        /// Send an initial message to the plugin to ask it to perform its action based on the input data.
+        /// Send the initial message to the plugin.
         outputQueue.async {
-            try? outputHandle.writePluginMessage(.performAction(input: input))
+            try? outputHandle.writePluginMessage(initialMessage)
         }
 #endif
     }
@@ -635,93 +571,35 @@ public enum DefaultPluginScriptRunnerError: Error, CustomStringConvertible {
     }
 }
 
-/// A message that the host can send to the plugin.
-enum HostToPluginMessage: Encodable {
-    /// The host is requesting that the plugin perform one of its declared plugin actions.
-    case performAction(input: PluginScriptRunnerInput)
-    
-    /// A response to a request to run a build operation.
-    case buildOperationResponse(result: PluginInvocationBuildResult)
-
-    /// A response to a request to run a test.
-    case testOperationResponse(result: PluginInvocationTestResult)
-
-    /// A response to a request for symbol graph information for a target.
-    case symbolGraphResponse(result: PluginInvocationSymbolGraphResult)
-    
-    /// A response of an error while trying to complete a request.
-    case errorResponse(error: String)
-}
-
-/// A message that the plugin can send to the host.
-enum PluginToHostMessage: Decodable {
-    /// The plugin emits a diagnostic.
-    case emitDiagnostic(severity: DiagnosticSeverity, message: String, file: String?, line: Int?)
-
-    enum DiagnosticSeverity: String, Decodable {
-        case error, warning, remark
-    }
-    
-    /// The plugin defines a build command.
-    case defineBuildCommand(configuration: CommandConfiguration, inputFiles: [String], outputFiles: [String])
-
-    /// The plugin defines a prebuild command.
-    case definePrebuildCommand(configuration: CommandConfiguration, outputFilesDirectory: String)
-    
-    struct CommandConfiguration: Decodable {
-        var displayName: String?
-        var executable: String
-        var arguments: [String]
-        var environment: [String: String]
-        var workingDirectory: String?
-    }
-
-    /// The plugin is requesting that a build operation be run.
-    case buildOperationRequest(subset: PluginInvocationBuildSubset, parameters: PluginInvocationBuildParameters)
-    
-    /// The plugin is requesting that a test operation be run.
-    case testOperationRequest(subset: PluginInvocationTestSubset, parameters: PluginInvocationTestParameters)
-
-    /// The plugin is requesting symbol graph information for a given target and set of options.
-    case symbolGraphRequest(targetName: String, options: PluginInvocationSymbolGraphOptions)
-}
-
 fileprivate extension FileHandle {
     
-    func writePluginMessage(_ message: HostToPluginMessage) throws {
-        // Encode the message as JSON.
-        let payload = try JSONEncoder().encode(message)
-        
+    func writePluginMessage(_ message: Data) throws {
         // Write the header (a 64-bit length field in little endian byte order).
-        var count = UInt64(littleEndian: UInt64(payload.count))
-        let header = Swift.withUnsafeBytes(of: &count) { Data($0) }
+        var length = UInt64(littleEndian: UInt64(message.count))
+        let header = Swift.withUnsafeBytes(of: &length) { Data($0) }
         assert(header.count == 8)
         try self.write(contentsOf: header)
         
         // Write the payload.
-        try self.write(contentsOf: payload)
+        try self.write(contentsOf: message)
     }
     
-    func readPluginMessage() throws -> PluginToHostMessage? {
+    func readPluginMessage() throws -> Data? {
         // Read the header (a 64-bit length field in little endian byte order).
         guard let header = try self.read(upToCount: 8) else { return nil }
         guard header.count == 8 else {
             throw PluginMessageError.truncatedHeader
         }
-        
-        // Decode the count.
-        let count = header.withUnsafeBytes{ $0.load(as: UInt64.self).littleEndian }
-        guard count >= 2 else {
+        let length = header.withUnsafeBytes{ $0.load(as: UInt64.self).littleEndian }
+        guard length >= 2 else {
             throw PluginMessageError.invalidPayloadSize
         }
 
-        // Read the JSON payload.
-        guard let payload = try self.read(upToCount: Int(count)), payload.count == count else {
+        // Read and return the message.
+        guard let message = try self.read(upToCount: Int(length)), message.count == length else {
             throw PluginMessageError.truncatedPayload
         }
-
-        // Decode and return the message.
-        return try JSONDecoder().decode(PluginToHostMessage.self, from: payload)
+        return message
     }
 
     enum PluginMessageError: Swift.Error {

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -401,8 +401,7 @@ class PluginTests: XCTestCase {
                 let delegate = PluginDelegate(delegateQueue: delegateQueue)
                 do {
                     let success = try tsc_await { plugin.invoke(
-                        action: .performCommand(arguments: arguments),
-                        package: package,
+                        action: .performCommand(package: package, arguments: arguments),
                         buildEnvironment: BuildEnvironment(platform: .macOS, configuration: .debug),
                         scriptRunner: scriptRunner,
                         workingDirectory: package.path,
@@ -613,8 +612,7 @@ class PluginTests: XCTestCase {
             let delegate = PluginDelegate(delegateQueue: delegateQueue)
             let sync = DispatchSemaphore(value: 0)
             plugin.invoke(
-                action: .performCommand(arguments: []),
-                package: package,
+                action: .performCommand(package: package, arguments: []),
                 buildEnvironment: BuildEnvironment(platform: .macOS, configuration: .debug),
                 scriptRunner: scriptRunner,
                 workingDirectory: package.path,

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -87,6 +87,7 @@ class PluginInvocationTests: XCTestCase {
 
         // A fake PluginScriptRunner that just checks the input conditions and returns canned output.
         struct MockPluginScriptRunner: PluginScriptRunner {
+            
             var hostTriple: Triple {
                 return UserToolchain.default.triple
             }
@@ -97,7 +98,7 @@ class PluginInvocationTests: XCTestCase {
             
             func runPluginScript(
                 sources: Sources,
-                input: PluginScriptRunnerInput,
+                initialMessage: Data,
                 toolsVersion: ToolsVersion,
                 workingDirectory: AbsolutePath,
                 writableDirectories: [AbsolutePath],
@@ -105,54 +106,67 @@ class PluginInvocationTests: XCTestCase {
                 fileSystem: FileSystem,
                 observabilityScope: ObservabilityScope,
                 callbackQueue: DispatchQueue,
-                delegate: PluginInvocationDelegate,
-                completion: @escaping (Result<Bool, Error>) -> Void
+                delegate: PluginScriptRunnerDelegate,
+                completion: @escaping (Result<Int32, Error>) -> Void
             ) {
                 // Check that we were given the right sources.
                 XCTAssertEqual(sources.root, AbsolutePath("/Foo/Plugins/FooPlugin"))
                 XCTAssertEqual(sources.relativePaths, [RelativePath("source.swift")])
 
-                // Check the input structure we received.
-                XCTAssertEqual(input.products.count, 2, "unexpected products: \(dump(input.products))")
-                XCTAssertEqual(input.products[0].name, "Foo", "unexpected products: \(dump(input.products))")
-                XCTAssertEqual(input.products[0].targetIds.count, 1, "unexpected product targets: \(dump(input.products[0].targetIds))")
-                XCTAssertEqual(input.products[1].name, "FooTool", "unexpected products: \(dump(input.products))")
-                XCTAssertEqual(input.products[1].targetIds.count, 1, "unexpected product targets: \(dump(input.products[1].targetIds))")
-                XCTAssertEqual(input.targets.count, 2, "unexpected targets: \(dump(input.targets))")
-                XCTAssertEqual(input.targets[0].name, "Foo", "unexpected targets: \(dump(input.targets))")
-                XCTAssertEqual(input.targets[0].dependencies.count, 0, "unexpected target dependencies: \(dump(input.targets[0].dependencies))")
-                XCTAssertEqual(input.targets[1].name, "FooTool", "unexpected targets: \(dump(input.targets))")
-                XCTAssertEqual(input.targets[1].dependencies.count, 0, "unexpected target dependencies: \(dump(input.targets[1].dependencies))")
+                do {
+                    // Pretend the plugin emitted some output.
+                    callbackQueue.sync {
+                        delegate.handleOutput(data: Data("Hello Plugin!".utf8))
+                    }
+                    
+                    // Pretend it emitted a warning.
+                    try callbackQueue.sync {
+                        let message = Data("""
+                        {   "emitDiagnostic": {
+                                "severity": "warning",
+                                "message": "A warning",
+                                "file": "/Foo/Sources/Foo/SomeFile.abc",
+                                "line": 42
+                            }
+                        }
+                        """.utf8)
+                        try delegate.handleMessage(data: message, responder: { _ in })
+                    }
 
-                // Pretend the plugin emitted some output.
-                callbackQueue.sync {
-                    delegate.pluginEmittedOutput(Data("Hello Plugin!".utf8))
+                    // Pretend it defined a build command.
+                    try callbackQueue.sync {
+                        let message = Data("""
+                        {   "defineBuildCommand": {
+                                "configuration": {
+                                    "displayName": "Do something",
+                                    "executable": "/bin/FooTool",
+                                    "arguments": [
+                                        "-c", "/Foo/Sources/Foo/SomeFile.abc"
+                                    ],
+                                    "workingDirectory": "/Foo/Sources/Foo",
+                                    "environment": {
+                                        "X": "Y"
+                                    },
+                                },
+                                "inputFiles": [
+                                ],
+                                "outputFiles": [
+                                ]
+                            }
+                        }
+                        """.utf8)
+                        try delegate.handleMessage(data: message, responder: { _ in })
+                    }
                 }
-                
-                // Pretend it emitted a warning.
-                callbackQueue.sync {
-                    var locationMetadata = ObservabilityMetadata()
-                    locationMetadata.fileLocation = .init(AbsolutePath("/Foo/Sources/Foo/SomeFile.abc"), line: 42)
-                    delegate.pluginEmittedDiagnostic(.warning("A warning", metadata: locationMetadata))
+                catch {
+                    callbackQueue.sync {
+                        completion(.failure(error))
+                    }
                 }
-                
-                // Pretend it defined a build command.
+
+                // If we get this far we succeded, so invoke the completion handler.
                 callbackQueue.sync {
-                    delegate.pluginDefinedBuildCommand(
-                        displayName: "Do something",
-                        executable: AbsolutePath("/bin/FooTool"),
-                        arguments: ["-c", "/Foo/Sources/Foo/SomeFile.abc"],
-                        environment: [
-                            "X": "Y"
-                        ],
-                        workingDirectory: AbsolutePath("/Foo/Sources/Foo"),
-                        inputFiles: [],
-                        outputFiles: [])
-                }
-                
-                // Finally, invoke the completion handler.
-                callbackQueue.sync {
-                    completion(.success(true))
+                    completion(.success(0))
                 }
             }
         }


### PR DESCRIPTION
Motivation:

Refactor the plugin machinery for better maintainability, consolidation of wire protocol struct definitions, and groundwork for extending the plugin functionality (such as adding new capabilities or new plugin messages such as dynamic querying of capabilities).

Changes:

- factor out the Codable declarations of enums and struct for the plugin wire protocol into a PluginMessage file that can be shared between the plugin and plugin host; this gets us compile-time checking so that the host and plugin are always in sync
- separate out the functionality of DefaultPluginScriptRunner to only handle the mechanics to talking to the plugin and not be concerned with what the messages are (this is factored back down into PluginInvocation)
- hoist the different kinds of plugin action messages up to top-level messages, allowing each to have a separate set of parameters
- factor the plugin input context serializer and deserializer out into their own source files and better separating from the semantics
- better separation of the structures for the plugin request structures (for building, testing, etc) to not reference any part of the plugin API; this will allow separate representations when/if necessary
- pull the package parameter into the plugin action, to support actions that don't operate on packages (such as querying the plugin for information, etc)

No functional changes.
