### PR TITLE
tests cleanup

### DIFF
--- a/Sources/SPMTestSupport/XCTAssertHelpers.swift
+++ b/Sources/SPMTestSupport/XCTAssertHelpers.swift
@@ -22,16 +22,16 @@ public func XCTAssertBuilds(
     _ path: AbsolutePath,
     configurations: Set<Configuration> = [.Debug, .Release],
     extraArgs: [String] = [],
-    file: StaticString = #file,
-    line: UInt = #line,
     Xcc: [String] = [],
     Xld: [String] = [],
     Xswiftc: [String] = [],
-    env: EnvironmentVariables? = nil
+    env: EnvironmentVariables? = nil,
+    file: StaticString = #file,
+    line: UInt = #line
 ) {
     for conf in configurations {
-        do {
-            _ = try executeSwiftBuild(
+        XCTAssertNoThrow(
+            try executeSwiftBuild(
                 path,
                 configuration: conf,
                 extraArgs: extraArgs,
@@ -39,72 +39,75 @@ public func XCTAssertBuilds(
                 Xld: Xld,
                 Xswiftc: Xswiftc,
                 env: env
-            )
-        } catch {
-            XCTFail("""
-            `swift build -c \(conf)' failed:
-
-            \(error)
-
-            """, file: file, line: line)
-        }
+            ),
+            file: file,
+            line: line
+        )
     }
 }
 
 public func XCTAssertSwiftTest(
     _ path: AbsolutePath,
+    env: EnvironmentVariables? = nil,
     file: StaticString = #file,
-    line: UInt = #line,
-    env: EnvironmentVariables? = nil
+    line: UInt = #line
 ) {
-    do {
-        _ = try SwiftPMProduct.SwiftTest.execute([], packagePath: path, env: env)
-    } catch {
-        XCTFail("""
-        `swift test' failed:
-
-        \(error)
-
-        """, file: file, line: line)
-    }
+    XCTAssertNoThrow(
+        try SwiftPMProduct.SwiftTest.execute([], packagePath: path, env: env),
+        file: file,
+        line: line
+    )
 }
 
+@discardableResult
 public func XCTAssertBuildFails(
     _ path: AbsolutePath,
-    file: StaticString = #file,
-    line: UInt = #line,
     Xcc: [String] = [],
     Xld: [String] = [],
     Xswiftc: [String] = [],
-    env: EnvironmentVariables? = nil
-) {
-    do {
-        _ = try executeSwiftBuild(path, Xcc: Xcc, Xld: Xld, Xswiftc: Xswiftc)
-
-        XCTFail("`swift build' succeeded but should have failed", file: file, line: line)
-
-    } catch SwiftPMProductError.executionFailure(let error, _, _) {
-        switch error {
-        case ProcessResult.Error.nonZeroExit(let result) where result.exitStatus != .terminated(code: 0):
-            break
-        default:
-            XCTFail("`swift build' failed in an unexpected manner")
-        }
-    } catch {
-        XCTFail("`swift build' failed in an unexpected manner")
+    env: EnvironmentVariables? = nil,
+    file: StaticString = #file,
+    line: UInt = #line
+) -> CommandExecutionError? {
+    var failure: CommandExecutionError? = nil
+    XCTAssertThrowsCommandExecutionError(try executeSwiftBuild(path, Xcc: Xcc, Xld: Xld, Xswiftc: Xswiftc), file: file, line: line) { error in
+        failure = error
     }
+    return failure
 }
 
 public func XCTAssertEqual<T: CustomStringConvertible>(
     _ assignment: [(container: T, version: Version)],
     _ expected: [T: Version],
-    file: StaticString = #file, line: UInt = #line
-)
-    where T: Hashable
-{
+    file: StaticString = #file,
+    line: UInt = #line
+) where T: Hashable {
     var actual = [T: Version]()
     for (identifier, binding) in assignment {
         actual[identifier] = binding
     }
     XCTAssertEqual(actual, expected, file: file, line: line)
+}
+
+public func XCTAssertThrowsCommandExecutionError<T>(
+    _ expression: @autoclosure () throws -> T,
+    _ message: @autoclosure () -> String = "",
+    file: StaticString = #filePath,
+    line: UInt = #line,
+    _ errorHandler: (_ error: CommandExecutionError) -> Void = { _ in }
+) {
+    XCTAssertThrowsError(try expression(), message(), file: file, line: line) { error in
+        guard case SwiftPMProductError.executionFailure(let processError, let stdout, let stderr) = error,
+              case ProcessResult.Error.nonZeroExit(let processResult) = processError,
+              processResult.exitStatus != .terminated(code: 0) else {
+            return XCTFail("Unexpected error type: \(error)", file: file, line: line)
+        }
+        errorHandler(CommandExecutionError(result: processResult, stdout: stdout, stderr: stderr))
+    }
+}
+
+public struct CommandExecutionError: Error {
+    public let result: ProcessResult
+    public let stdout: String
+    public let stderr: String
 }

--- a/Tests/CommandsTests/APIDiffTests.swift
+++ b/Tests/CommandsTests/APIDiffTests.swift
@@ -62,12 +62,8 @@ final class APIDiffTests: CommandsTestCase {
             try localFileSystem.writeFileContents(packageRoot.appending(component: "Foo.swift")) {
                 $0 <<< "public let foo = 42"
             }
-            XCTAssertThrowsError(try execute(["diagnose-api-breaking-changes", "1.2.3"], packagePath: packageRoot)) { error in
-                guard case SwiftPMProductError.executionFailure(error: _, output: let output, stderr: _) = error else {
-                    XCTFail("Unexpected error")
-                    return
-                }
-                XCTAssertFalse(output.isEmpty)
+            XCTAssertThrowsCommandExecutionError(try execute(["diagnose-api-breaking-changes", "1.2.3"], packagePath: packageRoot)) { error in
+                XCTAssertFalse(error.stdout.isEmpty)
             }
         }
     }
@@ -80,13 +76,9 @@ final class APIDiffTests: CommandsTestCase {
             try localFileSystem.writeFileContents(packageRoot.appending(component: "Foo.swift")) {
                 $0 <<< "public let foo = 42"
             }
-            XCTAssertThrowsError(try execute(["diagnose-api-breaking-changes", "1.2.3"], packagePath: packageRoot)) { error in
-                guard case SwiftPMProductError.executionFailure(error: _, output: let output, stderr: _) = error else {
-                    XCTFail("Unexpected error")
-                    return
-                }
-                XCTAssertMatch(output, .contains("1 breaking change detected in Foo"))
-                XCTAssertMatch(output, .contains("💔 API breakage: func foo() has been removed"))
+            XCTAssertThrowsCommandExecutionError(try execute(["diagnose-api-breaking-changes", "1.2.3"], packagePath: packageRoot)) { error in
+                XCTAssertMatch(error.stdout, .contains("1 breaking change detected in Foo"))
+                XCTAssertMatch(error.stdout, .contains("💔 API breakage: func foo() has been removed"))
             }
         }
     }
@@ -101,16 +93,12 @@ final class APIDiffTests: CommandsTestCase {
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Qux", "Qux.swift")) {
                 $0 <<< "public class Qux<T, U> { private let x = 1 }"
             }
-            XCTAssertThrowsError(try execute(["diagnose-api-breaking-changes", "1.2.3", "-j", "2"], packagePath: packageRoot)) { error in
-                guard case SwiftPMProductError.executionFailure(error: _, output: let output, stderr: _) = error else {
-                    XCTFail("Unexpected error")
-                    return
-                }
-                XCTAssertMatch(output, .contains("2 breaking changes detected in Qux"))
-                XCTAssertMatch(output, .contains("💔 API breakage: class Qux has generic signature change from <T> to <T, U>"))
-                XCTAssertMatch(output, .contains("💔 API breakage: var Qux.x has been removed"))
-                XCTAssertMatch(output, .contains("1 breaking change detected in Baz"))
-                XCTAssertMatch(output, .contains("💔 API breakage: func bar() has been removed"))
+            XCTAssertThrowsCommandExecutionError(try execute(["diagnose-api-breaking-changes", "1.2.3", "-j", "2"], packagePath: packageRoot)) { error in
+                XCTAssertMatch(error.stdout, .contains("2 breaking changes detected in Qux"))
+                XCTAssertMatch(error.stdout, .contains("💔 API breakage: class Qux has generic signature change from <T> to <T, U>"))
+                XCTAssertMatch(error.stdout, .contains("💔 API breakage: var Qux.x has been removed"))
+                XCTAssertMatch(error.stdout, .contains("1 breaking change detected in Baz"))
+                XCTAssertMatch(error.stdout, .contains("💔 API breakage: func bar() has been removed"))
             }
         }
     }
@@ -129,18 +117,15 @@ final class APIDiffTests: CommandsTestCase {
             try localFileSystem.writeFileContents(customAllowlistPath) {
                 $0 <<< "API breakage: class Qux has generic signature change from <T> to <T, U>\n"
             }
-            XCTAssertThrowsError(try execute(["diagnose-api-breaking-changes", "1.2.3", "-j", "2",
-                                              "--breakage-allowlist-path", customAllowlistPath.pathString],
-                                             packagePath: packageRoot)) { error in
-                guard case SwiftPMProductError.executionFailure(error: _, output: let output, stderr: _) = error else {
-                    XCTFail("Unexpected error")
-                    return
-                }
-                XCTAssertMatch(output, .contains("1 breaking change detected in Qux"))
-                XCTAssertNoMatch(output, .contains("💔 API breakage: class Qux has generic signature change from <T> to <T, U>"))
-                XCTAssertMatch(output, .contains("💔 API breakage: var Qux.x has been removed"))
-                XCTAssertMatch(output, .contains("1 breaking change detected in Baz"))
-                XCTAssertMatch(output, .contains("💔 API breakage: func bar() has been removed"))
+            XCTAssertThrowsCommandExecutionError(
+                try execute(["diagnose-api-breaking-changes", "1.2.3", "-j", "2", "--breakage-allowlist-path", customAllowlistPath.pathString],
+                            packagePath: packageRoot)
+            ) { error in
+                XCTAssertMatch(error.stdout, .contains("1 breaking change detected in Qux"))
+                XCTAssertNoMatch(error.stdout, .contains("💔 API breakage: class Qux has generic signature change from <T> to <T, U>"))
+                XCTAssertMatch(error.stdout, .contains("💔 API breakage: var Qux.x has been removed"))
+                XCTAssertMatch(error.stdout, .contains("1 breaking change detected in Baz"))
+                XCTAssertMatch(error.stdout, .contains("💔 API breakage: func bar() has been removed"))
             }
 
         }
@@ -162,22 +147,18 @@ final class APIDiffTests: CommandsTestCase {
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Qux", "Qux.swift")) {
                 $0 <<< "public class Qux<T, U> { private let x = 1 }"
             }
-            XCTAssertThrowsError(try execute(["diagnose-api-breaking-changes", "1.2.3"], packagePath: packageRoot)) { error in
-                guard case SwiftPMProductError.executionFailure(error: _, output: let output, stderr: _) = error else {
-                    XCTFail("Unexpected error")
-                    return
-                }
-                XCTAssertMatch(output, .contains("1 breaking change detected in Foo"))
-                XCTAssertMatch(output, .contains("💔 API breakage: struct Foo has been removed"))
-                XCTAssertMatch(output, .contains("1 breaking change detected in Bar"))
-                XCTAssertMatch(output, .contains("💔 API breakage: func bar() has been removed"))
-                XCTAssertMatch(output, .contains("1 breaking change detected in Baz"))
-                XCTAssertMatch(output, .contains("💔 API breakage: enumelement Baz.b has been added as a new enum case"))
+            XCTAssertThrowsCommandExecutionError(try execute(["diagnose-api-breaking-changes", "1.2.3"], packagePath: packageRoot)) { error in
+                XCTAssertMatch(error.stdout, .contains("1 breaking change detected in Foo"))
+                XCTAssertMatch(error.stdout, .contains("💔 API breakage: struct Foo has been removed"))
+                XCTAssertMatch(error.stdout, .contains("1 breaking change detected in Bar"))
+                XCTAssertMatch(error.stdout, .contains("💔 API breakage: func bar() has been removed"))
+                XCTAssertMatch(error.stdout, .contains("1 breaking change detected in Baz"))
+                XCTAssertMatch(error.stdout, .contains("💔 API breakage: enumelement Baz.b has been added as a new enum case"))
 
                 // Qux is not part of a library product, so any API changes should be ignored
-                XCTAssertNoMatch(output, .contains("2 breaking changes detected in Qux"))
-                XCTAssertNoMatch(output, .contains("💔 API breakage: class Qux has generic signature change from <T> to <T, U>"))
-                XCTAssertNoMatch(output, .contains("💔 API breakage: var Qux.x has been removed"))
+                XCTAssertNoMatch(error.stdout, .contains("2 breaking changes detected in Qux"))
+                XCTAssertNoMatch(error.stdout, .contains("💔 API breakage: class Qux has generic signature change from <T> to <T, U>"))
+                XCTAssertNoMatch(error.stdout, .contains("💔 API breakage: var Qux.x has been removed"))
             }
         }
     }
@@ -198,58 +179,46 @@ final class APIDiffTests: CommandsTestCase {
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Qux", "Qux.swift")) {
                 $0 <<< "public class Qux<T, U> { private let x = 1 }"
             }
-            XCTAssertThrowsError(try execute(["diagnose-api-breaking-changes", "1.2.3", "--products", "One", "--targets", "Bar"],
-                                             packagePath: packageRoot)) { error in
-                guard case SwiftPMProductError.executionFailure(error: _, output: let output, stderr: _) = error else {
-                    XCTFail("Unexpected error")
-                    return
-                }
+            XCTAssertThrowsCommandExecutionError(
+                try execute(["diagnose-api-breaking-changes", "1.2.3", "--products", "One", "--targets", "Bar"], packagePath: packageRoot)
+            ) { error in
+                XCTAssertMatch(error.stdout, .contains("1 breaking change detected in Foo"))
+                XCTAssertMatch(error.stdout, .contains("💔 API breakage: struct Foo has been removed"))
+                XCTAssertMatch(error.stdout, .contains("1 breaking change detected in Bar"))
+                XCTAssertMatch(error.stdout, .contains("💔 API breakage: func bar() has been removed"))
 
-                XCTAssertMatch(output, .contains("1 breaking change detected in Foo"))
-                XCTAssertMatch(output, .contains("💔 API breakage: struct Foo has been removed"))
-                XCTAssertMatch(output, .contains("1 breaking change detected in Bar"))
-                XCTAssertMatch(output, .contains("💔 API breakage: func bar() has been removed"))
-
-                XCTAssertNoMatch(output, .contains("1 breaking change detected in Baz"))
-                XCTAssertNoMatch(output, .contains("💔 API breakage: enumelement Baz.b has been added as a new enum case"))
-                XCTAssertNoMatch(output, .contains("2 breaking changes detected in Qux"))
-                XCTAssertNoMatch(output, .contains("💔 API breakage: class Qux has generic signature change from <T> to <T, U>"))
-                XCTAssertNoMatch(output, .contains("💔 API breakage: var Qux.x has been removed"))
+                XCTAssertNoMatch(error.stdout, .contains("1 breaking change detected in Baz"))
+                XCTAssertNoMatch(error.stdout, .contains("💔 API breakage: enumelement Baz.b has been added as a new enum case"))
+                XCTAssertNoMatch(error.stdout, .contains("2 breaking changes detected in Qux"))
+                XCTAssertNoMatch(error.stdout, .contains("💔 API breakage: class Qux has generic signature change from <T> to <T, U>"))
+                XCTAssertNoMatch(error.stdout, .contains("💔 API breakage: var Qux.x has been removed"))
             }
 
             // Diff a target which didn't have a baseline generated as part of the first invocation
-            XCTAssertThrowsError(try execute(["diagnose-api-breaking-changes", "1.2.3", "--targets", "Baz"],
-                                             packagePath: packageRoot)) { error in
-                guard case SwiftPMProductError.executionFailure(error: _, output: let output, stderr: _) = error else {
-                    XCTFail("Unexpected error")
-                    return
-                }
+            XCTAssertThrowsCommandExecutionError(
+                try execute(["diagnose-api-breaking-changes", "1.2.3", "--targets", "Baz"], packagePath: packageRoot)
+            ) { error in
+                XCTAssertMatch(error.stdout, .contains("1 breaking change detected in Baz"))
+                XCTAssertMatch(error.stdout, .contains("💔 API breakage: enumelement Baz.b has been added as a new enum case"))
 
-                XCTAssertMatch(output, .contains("1 breaking change detected in Baz"))
-                XCTAssertMatch(output, .contains("💔 API breakage: enumelement Baz.b has been added as a new enum case"))
-
-                XCTAssertNoMatch(output, .contains("1 breaking change detected in Foo"))
-                XCTAssertNoMatch(output, .contains("💔 API breakage: struct Foo has been removed"))
-                XCTAssertNoMatch(output, .contains("1 breaking change detected in Bar"))
-                XCTAssertNoMatch(output, .contains("💔 API breakage: func bar() has been removed"))
-                XCTAssertNoMatch(output, .contains("2 breaking changes detected in Qux"))
-                XCTAssertNoMatch(output, .contains("💔 API breakage: class Qux has generic signature change from <T> to <T, U>"))
-                XCTAssertNoMatch(output, .contains("💔 API breakage: var Qux.x has been removed"))
+                XCTAssertNoMatch(error.stdout, .contains("1 breaking change detected in Foo"))
+                XCTAssertNoMatch(error.stdout, .contains("💔 API breakage: struct Foo has been removed"))
+                XCTAssertNoMatch(error.stdout, .contains("1 breaking change detected in Bar"))
+                XCTAssertNoMatch(error.stdout, .contains("💔 API breakage: func bar() has been removed"))
+                XCTAssertNoMatch(error.stdout, .contains("2 breaking changes detected in Qux"))
+                XCTAssertNoMatch(error.stdout, .contains("💔 API breakage: class Qux has generic signature change from <T> to <T, U>"))
+                XCTAssertNoMatch(error.stdout, .contains("💔 API breakage: var Qux.x has been removed"))
             }
 
             // Test diagnostics
-            XCTAssertThrowsError(try execute(["diagnose-api-breaking-changes", "1.2.3", "--targets", "NotATarget", "Exec",
-                                              "--products", "NotAProduct", "Exec"],
-                                             packagePath: packageRoot)) { error in
-                guard case SwiftPMProductError.executionFailure(error: _, output: _, stderr: let stderr) = error else {
-                    XCTFail("Unexpected error")
-                    return
-                }
-
-                XCTAssertMatch(stderr, .contains("error: no such product 'NotAProduct'"))
-                XCTAssertMatch(stderr, .contains("error: no such target 'NotATarget'"))
-                XCTAssertMatch(stderr, .contains("'Exec' is not a library product"))
-                XCTAssertMatch(stderr, .contains("'Exec' is not a library target"))
+            XCTAssertThrowsCommandExecutionError(
+                try execute(["diagnose-api-breaking-changes", "1.2.3", "--targets", "NotATarget", "Exec", "--products", "NotAProduct", "Exec"],
+                            packagePath: packageRoot)
+            ) { error in
+                XCTAssertMatch(error.stderr, .contains("error: no such product 'NotAProduct'"))
+                XCTAssertMatch(error.stderr, .contains("error: no such target 'NotATarget'"))
+                XCTAssertMatch(error.stderr, .contains("'Exec' is not a library product"))
+                XCTAssertMatch(error.stderr, .contains("'Exec' is not a library target"))
             }
         }
     }
@@ -269,23 +238,14 @@ final class APIDiffTests: CommandsTestCase {
                 }
                 """
             }
-            XCTAssertThrowsError(try execute(["diagnose-api-breaking-changes", "1.2.3"], packagePath: packageRoot)) { error in
-                guard case SwiftPMProductError.executionFailure(error: _, output: let output, stderr: _) = error else {
-                    XCTFail("Unexpected error")
-                    return
-                }
-                XCTAssertMatch(output, .contains("1 breaking change detected in Bar"))
-                XCTAssertMatch(output, .contains("💔 API breakage: func bar() has return type change from Swift.Int to Swift.String"))
+            XCTAssertThrowsCommandExecutionError(try execute(["diagnose-api-breaking-changes", "1.2.3"], packagePath: packageRoot)) { error in
+                XCTAssertMatch(error.stdout, .contains("1 breaking change detected in Bar"))
+                XCTAssertMatch(error.stdout, .contains("💔 API breakage: func bar() has return type change from Swift.Int to Swift.String"))
             }
 
             // Report an error if we explicitly ask to diff a C-family target
-            XCTAssertThrowsError(try execute(["diagnose-api-breaking-changes", "1.2.3", "--targets", "Foo"], packagePath: packageRoot)) { error in
-                guard case SwiftPMProductError.executionFailure(error: _, output: _, stderr: let stderr) = error else {
-                    XCTFail("Unexpected error")
-                    return
-                }
-
-                XCTAssertMatch(stderr, .contains("error: 'Foo' is not a Swift language target"))
+            XCTAssertThrowsCommandExecutionError(try execute(["diagnose-api-breaking-changes", "1.2.3", "--targets", "Foo"], packagePath: packageRoot)) { error in
+                XCTAssertMatch(error.stderr, .contains("error: 'Foo' is not a Swift language target"))
             }
         }
     }
@@ -342,12 +302,8 @@ final class APIDiffTests: CommandsTestCase {
         try skipIfApiDigesterUnsupportedOrUnset()
         try fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
             let packageRoot = fixturePath.appending(component: "Foo")
-            XCTAssertThrowsError(try execute(["diagnose-api-breaking-changes", "7.8.9"], packagePath: packageRoot)) { error in
-                guard case SwiftPMProductError.executionFailure(error: _, output: _, stderr: let stderr) = error else {
-                    XCTFail("Unexpected error")
-                    return
-                }
-                XCTAssertMatch(stderr, .contains("error: Couldn’t get revision"))
+            XCTAssertThrowsCommandExecutionError(try execute(["diagnose-api-breaking-changes", "7.8.9"], packagePath: packageRoot)) { error in
+                XCTAssertMatch(error.stderr, .contains("error: Couldn’t get revision"))
             }
         }
     }
@@ -365,14 +321,13 @@ final class APIDiffTests: CommandsTestCase {
                 }
                 try repo.stage(file: "Foo.swift")
                 try repo.commit(message: "Add foo")
-                XCTAssertThrowsError(try execute(["diagnose-api-breaking-changes", "main", "--baseline-dir", baselineDir.pathString],
-                                                 packagePath: packageRoot)) { error in
-                    guard case SwiftPMProductError.executionFailure(error: _, output: let output, stderr: _) = error else {
-                        XCTFail("Unexpected error")
-                        return
-                    }
-                    XCTAssertMatch(output, .contains("1 breaking change detected in Foo"))
-                    XCTAssertMatch(output, .contains("💔 API breakage: func foo() has been removed"))
+                XCTAssertThrowsCommandExecutionError(
+                    try execute(["diagnose-api-breaking-changes", "main", "--baseline-dir",
+                                 baselineDir.pathString],
+                                packagePath: packageRoot)
+                ) { error in
+                    XCTAssertMatch(error.stdout, .contains("1 breaking change detected in Foo"))
+                    XCTAssertMatch(error.stdout, .contains("💔 API breakage: func foo() has been removed"))
                 }
 
                 // Update `main` and ensure the baseline is regenerated.
@@ -403,15 +358,11 @@ final class APIDiffTests: CommandsTestCase {
             let repo = GitRepository(path: packageRoot)
             let revision = try repo.resolveRevision(identifier: "1.2.3")
 
-            XCTAssertThrowsError(try execute(["diagnose-api-breaking-changes", "1.2.3",
-                                              "--baseline-dir", baselineDir.pathString],
-                                             packagePath: packageRoot)) { error in
-                guard case SwiftPMProductError.executionFailure(error: _, output: let output, stderr: _) = error else {
-                    XCTFail("Unexpected error")
-                    return
-                }
-                XCTAssertMatch(output, .contains("1 breaking change detected in Foo"))
-                XCTAssertMatch(output, .contains("💔 API breakage: func foo() has been removed"))
+            XCTAssertThrowsCommandExecutionError(
+                try execute(["diagnose-api-breaking-changes", "1.2.3", "--baseline-dir", baselineDir.pathString], packagePath: packageRoot)
+            ) { error in
+                XCTAssertMatch(error.stdout, .contains("1 breaking change detected in Foo"))
+                XCTAssertMatch(error.stdout, .contains("💔 API breakage: func foo() has been removed"))
                 XCTAssertFileExists(baselineDir.appending(components: revision.identifier, "Foo.json"))
             }
         }
@@ -437,16 +388,14 @@ final class APIDiffTests: CommandsTestCase {
                 $0 <<< "Old Baseline"
             }
 
-            XCTAssertThrowsError(try execute(["diagnose-api-breaking-changes", "1.2.3",
-                                              "--baseline-dir", baselineDir.pathString,
-                                              "--regenerate-baseline"],
-                                             packagePath: packageRoot)) { error in
-                guard case SwiftPMProductError.executionFailure(error: _, output: let output, stderr: _) = error else {
-                    XCTFail("Unexpected error")
-                    return
-                }
-                XCTAssertMatch(output, .contains("1 breaking change detected in Foo"))
-                XCTAssertMatch(output, .contains("💔 API breakage: func foo() has been removed"))
+            XCTAssertThrowsCommandExecutionError(
+                try execute(["diagnose-api-breaking-changes", "1.2.3",
+                             "--baseline-dir", baselineDir.pathString,
+                             "--regenerate-baseline"],
+                            packagePath: packageRoot)
+            ) { error in
+                XCTAssertMatch(error.stdout, .contains("1 breaking change detected in Foo"))
+                XCTAssertMatch(error.stdout, .contains("💔 API breakage: func foo() has been removed"))
                 XCTAssertFileExists(fooBaselinePath)
                 let content: String = try! localFileSystem.readFileContents(fooBaselinePath)
                 XCTAssertNotEqual(content, "Old Baseline")
@@ -455,13 +404,8 @@ final class APIDiffTests: CommandsTestCase {
     }
 
     func testOldName() throws {
-        XCTAssertThrowsError(try execute(["experimental-api-diff", "1.2.3", "--regenerate-baseline"],
-                                         packagePath: nil)) { error in
-            guard case SwiftPMProductError.executionFailure(error: _, output: let output, stderr: _) = error else {
-                XCTFail("Unexpected error")
-                return
-            }
-            XCTAssertMatch(output, .contains("`swift package experimental-api-diff` has been renamed to `swift package diagnose-api-breaking-changes`"))
+        XCTAssertThrowsCommandExecutionError(try execute(["experimental-api-diff", "1.2.3", "--regenerate-baseline"], packagePath: nil)) { error in
+            XCTAssertMatch(error.stdout, .contains("`swift package experimental-api-diff` has been renamed to `swift package diagnose-api-breaking-changes`"))
         }
     }
 }

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -112,8 +112,6 @@ final class BuildToolTests: CommandsTestCase {
                 let result = try build(["--product", "exec1"], packagePath: fullPath)
                 XCTAssertMatch(result.binContents, ["exec1"])
                 XCTAssertNoMatch(result.binContents, ["exec2.build"])
-            } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-                XCTFail(stderr)
             }
 
             do {
@@ -126,50 +124,30 @@ final class BuildToolTests: CommandsTestCase {
                 let result = try build(["--target", "exec2"], packagePath: fullPath)
                 XCTAssertMatch(result.binContents, ["exec2.build"])
                 XCTAssertNoMatch(result.binContents, ["exec1"])
-            } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-                XCTFail(stderr)
             }
 
-            do {
-                _ = try execute(["--product", "exec1", "--target", "exec2"], packagePath: fixturePath)
-                XCTFail("Expected to fail")
-            } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-                XCTAssertMatch(stderr, .contains("error: '--product' and '--target' are mutually exclusive"))
+            XCTAssertThrowsCommandExecutionError(try execute(["--product", "exec1", "--target", "exec2"], packagePath: fixturePath)) { error in
+                XCTAssertMatch(error.stderr, .contains("error: '--product' and '--target' are mutually exclusive"))
             }
 
-            do {
-                _ = try execute(["--product", "exec1", "--build-tests"], packagePath: fixturePath)
-                XCTFail("Expected to fail")
-            } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-                XCTAssertMatch(stderr, .contains("error: '--product' and '--build-tests' are mutually exclusive"))
+            XCTAssertThrowsCommandExecutionError(try execute(["--product", "exec1", "--build-tests"], packagePath: fixturePath)) { error in
+                XCTAssertMatch(error.stderr, .contains("error: '--product' and '--build-tests' are mutually exclusive"))
             }
 
-            do {
-                _ = try execute(["--build-tests", "--target", "exec2"], packagePath: fixturePath)
-                XCTFail("Expected to fail")
-            } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-                XCTAssertMatch(stderr, .contains("error: '--target' and '--build-tests' are mutually exclusive"))
+            XCTAssertThrowsCommandExecutionError(try execute(["--build-tests", "--target", "exec2"], packagePath: fixturePath)) { error in
+                XCTAssertMatch(error.stderr, .contains("error: '--target' and '--build-tests' are mutually exclusive"))
             }
 
-            do {
-                _ = try execute(["--build-tests", "--target", "exec2", "--product", "exec1"], packagePath: fixturePath)
-                XCTFail("Expected to fail")
-            } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-                XCTAssertMatch(stderr, .contains("error: '--product', '--target', and '--build-tests' are mutually exclusive"))
+            XCTAssertThrowsCommandExecutionError(try execute(["--build-tests", "--target", "exec2", "--product", "exec1"], packagePath: fixturePath)) { error in
+                XCTAssertMatch(error.stderr, .contains("error: '--product', '--target', and '--build-tests' are mutually exclusive"))
             }
 
-            do {
-                _ = try execute(["--product", "UnkownProduct"], packagePath: fixturePath)
-                XCTFail("Expected to fail")
-            } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-                XCTAssertMatch(stderr, .contains("error: no product named 'UnkownProduct'"))
+            XCTAssertThrowsCommandExecutionError(try execute(["--product", "UnkownProduct"], packagePath: fixturePath)){ error in
+                XCTAssertMatch(error.stderr, .contains("error: no product named 'UnkownProduct'"))
             }
 
-            do {
-                _ = try execute(["--target", "UnkownTarget"], packagePath: fixturePath)
-                XCTFail("Expected to fail")
-            } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-                XCTAssertMatch(stderr, .contains("error: no target named 'UnkownTarget'"))
+            XCTAssertThrowsCommandExecutionError(try execute(["--target", "UnkownTarget"], packagePath: fixturePath)) { error in
+                XCTAssertMatch(error.stderr, .contains("error: no target named 'UnkownTarget'"))
             }
         }
     }
@@ -177,25 +155,20 @@ final class BuildToolTests: CommandsTestCase {
     func testAtMainSupport() throws {
         try fixture(name: "Miscellaneous/AtMainSupport") { fixturePath in
             let fullPath = resolveSymlinks(fixturePath)
+
             do {
                 let result = try build(["--product", "ClangExecSingleFile"], packagePath: fullPath)
                 XCTAssertMatch(result.binContents, ["ClangExecSingleFile"])
-            } catch SwiftPMProductError.executionFailure(_, let stdout, let stderr) {
-                XCTFail(stdout + "\n" + stderr)
             }
 
             do {
                 let result = try build(["--product", "SwiftExecSingleFile"], packagePath: fullPath)
                 XCTAssertMatch(result.binContents, ["SwiftExecSingleFile"])
-            } catch SwiftPMProductError.executionFailure(_, let stdout, let stderr) {
-                XCTFail(stdout + "\n" + stderr)
             }
 
             do {
                 let result = try build(["--product", "SwiftExecMultiFile"], packagePath: fullPath)
                 XCTAssertMatch(result.binContents, ["SwiftExecMultiFile"])
-            } catch SwiftPMProductError.executionFailure(_, let stdout, let stderr) {
-                XCTFail(stdout + "\n" + stderr)
             }
         }
     }
@@ -210,8 +183,6 @@ final class BuildToolTests: CommandsTestCase {
                 XCTAssertNoMatch(result.binContents, ["BTarget2.build"])
                 XCTAssertNoMatch(result.binContents, ["cexec"])
                 XCTAssertNoMatch(result.binContents, ["CTarget.build"])
-            } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-                XCTFail(stderr)
             }
 
             // Dependency contains a dependent product
@@ -237,8 +208,6 @@ final class BuildToolTests: CommandsTestCase {
                 XCTAssertNoMatch(result.binContents, ["ATarget.swiftinterface"])
                 XCTAssertNoMatch(result.binContents, ["BTarget.swiftinterface"])
                 XCTAssertNoMatch(result.binContents, ["CTarget.swiftinterface"])
-            } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-                XCTFail(stderr)
             }
         }
     }
@@ -261,8 +230,6 @@ final class BuildToolTests: CommandsTestCase {
                 let result = try build([], packagePath: fixturePath)
                 XCTAssertMatch(result.binContents, ["A.swiftinterface"])
                 XCTAssertMatch(result.binContents, ["B.swiftinterface"])
-            } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-                XCTFail(stderr)
             }
         }
     }
@@ -352,21 +319,14 @@ final class BuildToolTests: CommandsTestCase {
 
             // Now try building using XCBuild while specifying a faulty compiler override.  This should fail.  Note that we need to set the executable to use for the manifest itself to the default one, since it defaults to SWIFT_EXEC if not provided.
             var overriddenOutput = ""
-            do {
-                overriddenOutput = try execute(["-c", "debug", "--vv"], environment: ["SWIFT_EXEC": "/usr/bin/false", "SWIFT_EXEC_MANIFEST": ToolchainConfiguration.default.swiftCompilerPath.pathString], packagePath: fixturePath).stdout
-                XCTFail("unexpected success (was SWIFT_EXEC not overridden properly?)")
-            }
-            catch SwiftPMProductError.executionFailure(let error, _, let stderr) {
-                switch error {
-                case ProcessResult.Error.nonZeroExit(let result) where result.exitStatus != .terminated(code: 0):
-                    overriddenOutput = stderr
-                    break
-                default:
-                    XCTFail("`swift build' failed in an unexpected manner")
-                }
-            }
-            catch {
-                XCTFail("`swift build' failed in an unexpected manner")
+            XCTAssertThrowsCommandExecutionError(
+                try execute(
+                    ["-c", "debug", "--vv"],
+                    environment: ["SWIFT_EXEC": "/usr/bin/false", "SWIFT_EXEC_MANIFEST": ToolchainConfiguration.default.swiftCompilerPath.pathString],
+                    packagePath: fixturePath
+                )
+            ) { error in
+                overriddenOutput = error.stderr
             }
             XCTAssertMatch(overriddenOutput, .contains("/usr/bin/false"))
         }

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -55,30 +55,21 @@ final class PackageToolTests: CommandsTestCase {
     }
 
     func testPlugin() throws {
-        do {
-            try execute(["plugin"])
-            XCTFail("This should have been an error")
-        } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-            XCTAssertMatch(stderr, .contains("error: Missing expected plugin command"))
+        XCTAssertThrowsCommandExecutionError(try execute(["plugin"])) { error in
+            XCTAssertMatch(error.stderr, .contains("error: Missing expected plugin command"))
         }
     }
 
     func testUnknownOption() throws {
-        do {
-            try execute(["--foo"])
-            XCTFail("This should have been an error")
-        } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-            XCTAssertMatch(stderr, .contains("error: Unknown option '--foo'"))
+        XCTAssertThrowsCommandExecutionError(try execute(["--foo"])) { error in
+            XCTAssertMatch(error.stderr, .contains("error: Unknown option '--foo'"))
         }
     }
 
     func testUnknownSubommand() throws {
         try fixture(name: "Miscellaneous/ExeTest") { fixturePath in
-            do {
-                try execute(["foo"], packagePath: fixturePath)
-                XCTFail("This should have been an error")
-            } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-                XCTAssertMatch(stderr, .contains("error: Unknown subcommand or plugin name 'foo'"))
+            XCTAssertThrowsCommandExecutionError(try execute(["foo"], packagePath: fixturePath)) { error in
+                XCTAssertMatch(error.stderr, .contains("error: Unknown subcommand or plugin name 'foo'"))
             }
         }
     }
@@ -975,11 +966,8 @@ final class PackageToolTests: CommandsTestCase {
             // Try pinning a dependency which is in edit mode.
             do {
                 try execute("edit", "bar", "--branch", "bugfix")
-                do {
-                    try execute("resolve", "bar")
-                    XCTFail("This should have been an error")
-                } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-                    XCTAssertMatch(stderr, .contains("error: edited dependency 'bar' can't be resolved"))
+                XCTAssertThrowsCommandExecutionError(try execute("resolve", "bar")) { error in
+                    XCTAssertMatch(error.stderr, .contains("error: edited dependency 'bar' can't be resolved"))
                 }
                 try execute("unedit", "bar")
             }
@@ -1194,13 +1182,8 @@ final class PackageToolTests: CommandsTestCase {
             XCTAssertEqual(stdout.spm_chomp(), "git@mygithub.com:foo/swift-package-manager.git")
 
             func check(stderr: String, _ block: () throws -> ()) {
-                do {
-                    try block()
-                    XCTFail()
-                } catch SwiftPMProductError.executionFailure(_, _, let stderrOutput) {
-                    XCTAssertMatch(stderrOutput, .contains(stderr))
-                } catch {
-                    XCTFail("unexpected error: \(error)")
+                XCTAssertThrowsCommandExecutionError(try block()) { error in
+                    XCTAssertMatch(stderr, .contains(stderr))
                 }
             }
 

--- a/Tests/CommandsTests/RunToolTests.swift
+++ b/Tests/CommandsTests/RunToolTests.swift
@@ -53,22 +53,16 @@ final class RunToolTests: CommandsTestCase {
             XCTAssertMatch(try result.utf8stderrOutput(), .regex("Compiling"))
             XCTAssertMatch(try result.utf8stderrOutput(), .contains("Linking"))
 
-            do {
-                _ = try execute(["unknown"], packagePath: fixturePath)
-                XCTFail("Unexpected success")
-            } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-                XCTAssertMatch(stderr, .contains("error: no executable product named 'unknown'"))
+            XCTAssertThrowsCommandExecutionError(try execute(["unknown"], packagePath: fixturePath)) { error in
+                XCTAssertMatch(error.stderr, .contains("error: no executable product named 'unknown'"))
             }
         }
     }
 
     func testMultipleExecutableAndExplicitExecutable() throws {
         try fixture(name: "Miscellaneous/MultipleExecutables") { fixturePath in
-            do {
-                _ = try execute([], packagePath: fixturePath)
-                XCTFail("Unexpected success")
-            } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-                XCTAssertMatch(stderr, .contains("error: multiple executable products available: exec1, exec2"))
+            XCTAssertThrowsCommandExecutionError(try execute([], packagePath: fixturePath)) { error in
+                XCTAssertMatch(error.stderr, .contains("error: multiple executable products available: exec1, exec2"))
             }
             
             var (runOutput, _) = try execute(["exec1"], packagePath: fixturePath)
@@ -99,11 +93,8 @@ final class RunToolTests: CommandsTestCase {
 
     func testMutualExclusiveFlags() throws {
         try fixture(name: "Miscellaneous/EchoExecutable") { fixturePath in
-            do {
-                _ = try execute(["--build-tests", "--skip-build"], packagePath: fixturePath)
-                XCTFail("Expected to fail")
-            } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-                XCTAssertMatch(stderr, .contains("error: '--build-tests' and '--skip-build' are mutually exclusive"))
+            XCTAssertThrowsCommandExecutionError(try execute(["--build-tests", "--skip-build"], packagePath: fixturePath)) { error in
+                XCTAssertMatch(error.stderr, .contains("error: '--build-tests' and '--skip-build' are mutually exclusive"))
             }
         }
     }

--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -40,12 +40,8 @@ final class TestToolTests: CommandsTestCase {
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
         try fixture(name: "Miscellaneous/EchoExecutable") { fixturePath in
-            XCTAssertThrowsError(try execute(["--num-workers", "1"])) { error in
-                if case SwiftPMProductError.executionFailure(_, _, let stderr) = error {
-                    XCTAssertMatch(stderr, .contains("error: --num-workers must be used with --parallel"))
-                } else {
-                    XCTFail("invalid error")
-                }
+            XCTAssertThrowsCommandExecutionError(try execute(["--num-workers", "1"])) { error in
+                XCTAssertMatch(error.stderr, .contains("error: --num-workers must be used with --parallel"))
             }
         }
     }
@@ -56,12 +52,8 @@ final class TestToolTests: CommandsTestCase {
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
         try fixture(name: "Miscellaneous/EchoExecutable") { fixturePath in
-            XCTAssertThrowsError(try execute(["--parallel", "--num-workers", "0"])) { error in
-                if case SwiftPMProductError.executionFailure(_, _, let stderr) = error {
-                    XCTAssertMatch(stderr, .contains("error: '--num-workers' must be greater than zero"))
-                } else {
-                    XCTFail("invalid error")
-                }
+            XCTAssertThrowsCommandExecutionError(try execute(["--parallel", "--num-workers", "0"])) { error in
+                XCTAssertMatch(error.stderr, .contains("error: '--num-workers' must be greater than zero"))
             }
         }
     }
@@ -77,12 +69,8 @@ final class TestToolTests: CommandsTestCase {
 
         // disabled
         try fixture(name: "Miscellaneous/TestableExe") { fixturePath in
-            XCTAssertThrowsError(try execute(["--disable-testable-imports", "--vv"], packagePath: fixturePath)) { error in
-                if case SwiftPMProductError.executionFailure(_, _, let stderr) = error {
-                    XCTAssertMatch(stderr, .contains("was not compiled for testing"))
-                } else {
-                    XCTFail("invalid error")
-                }
+            XCTAssertThrowsCommandExecutionError( try execute(["--disable-testable-imports", "--vv"], packagePath: fixturePath)) { error in
+                XCTAssertMatch(error.stderr, .contains("was not compiled for testing"))
             }
         }
 

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -97,16 +97,9 @@ class PluginTests: XCTestCase {
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
 
         try fixture(name: "Miscellaneous/Plugins") { fixturePath in
-            do {
-                let (stdout, _) = try executeSwiftBuild(fixturePath.appending(component: "InvalidUseOfInternalPluginExecutable"))
-                XCTFail("Illegally used internal executable.\nstdout:\n\(stdout)")
-            }
-            catch SwiftPMProductError.executionFailure(_, _, let stderr) {
+            XCTAssertThrowsCommandExecutionError(try executeSwiftBuild(fixturePath.appending(component: "InvalidUseOfInternalPluginExecutable")), "Illegally used internal executable") { error in
                 XCTAssert(
-                    stderr.contains(
-                        "product 'PluginExecutable' required by package 'invaliduseofinternalpluginexecutable' target 'RootTarget' not found in package 'PluginWithInternalExecutable'."
-                    ),
-                    "stderr:\n\(stderr)"
+                    error.stderr.contains("product 'PluginExecutable' required by package 'invaliduseofinternalpluginexecutable' target 'RootTarget' not found in package 'PluginWithInternalExecutable'."), "stderr:\n\(error.stderr)"
                 )
             }
         }

--- a/Tests/FunctionalTests/ToolsVersionTests.swift
+++ b/Tests/FunctionalTests/ToolsVersionTests.swift
@@ -98,11 +98,8 @@ class ToolsVersionTests: XCTestCase {
             _ = try SwiftPMProduct.SwiftPackage.execute(
                 ["tools-version", "--set", "10000.1"], packagePath: primaryPath)
 
-            do {
-                _ = try SwiftPMProduct.SwiftBuild.execute([], packagePath: primaryPath)
-                XCTFail()
-            } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-                XCTAssert(stderr.contains("is using Swift tools version 10000.1.0 but the installed version is \(ToolsVersion.currentToolsVersion)"), stderr)
+            XCTAssertThrowsCommandExecutionError(try SwiftPMProduct.SwiftBuild.execute([], packagePath: primaryPath)) { error in
+                XCTAssert(error.stderr.contains("is using Swift tools version 10000.1.0 but the installed version is \(ToolsVersion.currentToolsVersion)"), error.stderr)
             }
 
             // Write the manifest with incompatible sources.
@@ -119,11 +116,8 @@ class ToolsVersionTests: XCTestCase {
             _ = try SwiftPMProduct.SwiftPackage.execute(
                 ["tools-version", "--set", "4.2"], packagePath: primaryPath).stdout.spm_chomp()
 
-            do {
-                _ = try SwiftPMProduct.SwiftBuild.execute([], packagePath: primaryPath)
-                XCTFail()
-            } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-                XCTAssertTrue(stderr.contains("package 'primary' requires minimum Swift language version 1000 which is not supported by the current tools version (\(ToolsVersion.currentToolsVersion))"), stderr)
+            XCTAssertThrowsCommandExecutionError(try SwiftPMProduct.SwiftBuild.execute([], packagePath: primaryPath)) { error in
+                XCTAssertTrue(error.stderr.contains("package 'primary' requires minimum Swift language version 1000 which is not supported by the current tools version (\(ToolsVersion.currentToolsVersion))"), error.stderr)
             }
 
              try fs.writeFileContents(primaryPath.appending(component: "Package.swift")) {


### PR DESCRIPTION
motivation: easier to maintain tests

changes:
* define new XCTAssertThrowsCommandExecutionError testing helper for test that invoke SwiftPM commands and check the output
* use the new helper in all potential call sites to reduce call site complexity and chance of missing errors
