### PR TITLE
audit and use abstract FileSystem instead of localFileSystem where possible

### DIFF
--- a/Sources/Basics/Archiver+Zip.swift
+++ b/Sources/Basics/Archiver+Zip.swift
@@ -22,7 +22,7 @@ public struct ZipArchiver: Archiver {
     ///
     /// - Parameters:
     ///   - fileSystem: The file-system to used by the `ZipArchiver`.
-    public init(fileSystem: FileSystem = localFileSystem) {
+    public init(fileSystem: FileSystem) {
         self.fileSystem = fileSystem
     }
 

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -307,7 +307,7 @@ public final class ClangTargetBuildDescription {
             try self.generateResourceAccessor()
 
             let infoPlistPath = tempsPath.appending(component: "Info.plist")
-            if try generateResourceInfoPlist(for: target, to: infoPlistPath) {
+            if try generateResourceInfoPlist(fileSystem: fileSystem, target: target, path: infoPlistPath) {
                 resourceBundleInfoPlistPath = infoPlistPath
             }
         }
@@ -678,7 +678,7 @@ public final class SwiftTargetBuildDescription {
             try self.generateResourceAccessor()
 
             let infoPlistPath = tempsPath.appending(component: "Info.plist")
-            if try generateResourceInfoPlist(for: target, to: infoPlistPath) {
+            if try generateResourceInfoPlist(fileSystem: self.fileSystem, target: target, path: infoPlistPath) {
                 resourceBundleInfoPlistPath = infoPlistPath
             }
         }
@@ -2232,9 +2232,9 @@ extension FileSystem {
 
 /// Generate the resource bundle Info.plist.
 private func generateResourceInfoPlist(
-    for target: ResolvedTarget,
-    to path: AbsolutePath,
-    fileSystem: FileSystem = localFileSystem
+    fileSystem: FileSystem,
+    target: ResolvedTarget,
+    path: AbsolutePath
 ) throws -> Bool {
     guard let defaultLocalization = target.underlyingTarget.defaultLocalization else {
         return false

--- a/Sources/Commands/SwiftPackageCollectionsTool.swift
+++ b/Sources/Commands/SwiftPackageCollectionsTool.swift
@@ -380,6 +380,7 @@ private extension ParsableCommand {
                 configurationDirectory: swiftTool.sharedConfigurationDirectory,
                 cacheDirectory: swiftTool.sharedCacheDirectory
             ),
+            fileSystem: swiftTool.fileSystem,
             observabilityScope: swiftTool.observabilityScope
         )
         defer {

--- a/Sources/Commands/SwiftPackageRegistryTool.swift
+++ b/Sources/Commands/SwiftPackageRegistryTool.swift
@@ -152,7 +152,7 @@ public struct SwiftPackageRegistryTool: ParsableCommand {
     static func getRegistriesConfig(_ swiftTool: SwiftTool) throws -> Workspace.Configuration.Registries {
         let workspace = try swiftTool.getActiveWorkspace()
         return try .init(
-            fileSystem: localFileSystem,
+            fileSystem: swiftTool.fileSystem,
             localRegistriesFile: workspace.location.localRegistriesConfigurationFile,
             sharedRegistriesFile: workspace.location.sharedRegistriesConfigurationFile
         )

--- a/Sources/Commands/SymbolGraphExtract.swift
+++ b/Sources/Commands/SymbolGraphExtract.swift
@@ -18,6 +18,7 @@ import TSCBasic
 
 /// A wrapper for swift-symbolgraph-extract tool.
 public struct SymbolGraphExtract {
+    let fileSystem: FileSystem
     let tool: AbsolutePath
     
     var skipSynthesizedMembers = false
@@ -47,7 +48,7 @@ public struct SymbolGraphExtract {
         verboseOutput: Bool
     ) throws {
         let buildParameters = buildPlan.buildParameters
-        try localFileSystem.createDirectory(outputDirectory, recursive: true)
+        try self.fileSystem.createDirectory(outputDirectory, recursive: true)
 
         // Construct arguments for extracting symbols for a single target.
         var commandLine = [self.tool.pathString]

--- a/Sources/Commands/TestingSupport.swift
+++ b/Sources/Commands/TestingSupport.swift
@@ -30,13 +30,13 @@ enum TestingSupport {
             relativeTo: swiftTool.originalWorkingDirectory).parentDirectory
         // XCTestHelper tool is installed in libexec.
         let maybePath = binDirectory.parentDirectory.appending(components: "libexec", "swift", "pm", xctestHelperBin)
-        if localFileSystem.isFile(maybePath) {
+        if swiftTool.fileSystem.isFile(maybePath) {
             return maybePath
         }
         // This will be true during swiftpm development.
         // FIXME: Factor all of the development-time resource location stuff into a common place.
         let path = binDirectory.appending(component: xctestHelperBin)
-        if localFileSystem.isFile(path) {
+        if swiftTool.fileSystem.isFile(path) {
             return path
         }
         throw InternalError("XCTestHelper binary not found.")
@@ -73,7 +73,7 @@ enum TestingSupport {
             }
             try Process.checkNonZeroExit(arguments: args, environment: env)
             // Read the temporary file's content.
-            return try localFileSystem.readFileContents(tempFile.path)
+            return try swiftTool.fileSystem.readFileContents(tempFile.path)
         }
         #else
         let env = try constructTestEnvironment(toolchain: try swiftTool.getToolchain(), options: swiftOptions, buildParameters: swiftTool.buildParametersForTest())

--- a/Sources/LLBuildManifest/ManifestWriter.swift
+++ b/Sources/LLBuildManifest/ManifestWriter.swift
@@ -11,11 +11,10 @@
 import TSCBasic
 
 public struct ManifestWriter {
+    let fileSystem: FileSystem
 
-    let fs: FileSystem
-
-    public init(_ fs: FileSystem = localFileSystem) {
-        self.fs = fs
+    public init(fileSystem: FileSystem) {
+        self.fileSystem = fileSystem
     }
 
     public func write(
@@ -68,7 +67,7 @@ public struct ManifestWriter {
             stream <<< "\n"
         }
 
-        try fs.writeFileContents(path, bytes: stream.bytes)
+        try self.fileSystem.writeFileContents(path, bytes: stream.bytes)
     }
 }
 

--- a/Sources/PackageCollections/PackageCollections+Validation.swift
+++ b/Sources/PackageCollections/PackageCollections+Validation.swift
@@ -17,7 +17,7 @@ import PackageModel
 // MARK: - Model validations
 
 extension Model.CollectionSource {
-    func validate() -> [ValidationMessage]? {
+    func validate(fileSystem: FileSystem) -> [ValidationMessage]? {
         var messages: [ValidationMessage]?
         let appendMessage = { (message: ValidationMessage) in
             if messages == nil {
@@ -38,7 +38,7 @@ extension Model.CollectionSource {
 
                 if absolutePath == nil {
                     appendMessage(.error("Invalid file path: \(self.url.path). It must be an absolute file system path."))
-                } else if let absolutePath = absolutePath, !localFileSystem.exists(absolutePath) {
+                } else if let absolutePath = absolutePath, !fileSystem.exists(absolutePath) {
                     appendMessage(.error("\(self.url.path) is either a non-local path or the file does not exist."))
                 }
             }

--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -22,6 +22,7 @@ public struct PackageCollections: PackageCollectionsProtocol, Closable {
     #endif
 
     let configuration: Configuration
+    private let fileSystem: FileSystem
     private let observabilityScope: ObservabilityScope
     private let storageContainer: (storage: Storage, owned: Bool)
     private let collectionProviders: [Model.CollectionSourceType: PackageCollectionProvider]
@@ -32,17 +33,28 @@ public struct PackageCollections: PackageCollectionsProtocol, Closable {
     }
 
     // initialize with defaults
-    public init(configuration: Configuration = .init(), observabilityScope: ObservabilityScope) {
-        self.init(configuration: configuration, customMetadataProvider: nil, observabilityScope: observabilityScope)
+    public init(
+        configuration: Configuration = .init(),
+        fileSystem: FileSystem,
+        observabilityScope: ObservabilityScope
+    ) {
+        self.init(
+            configuration: configuration,
+            customMetadataProvider: nil,
+            fileSystem: fileSystem,
+            observabilityScope: observabilityScope
+        )
     }
     
     init(
         configuration: Configuration = .init(),
         customMetadataProvider: PackageMetadataProvider?,
+        fileSystem: FileSystem,
         observabilityScope: ObservabilityScope
     ) {
         let storage = Storage(
             sources: FilePackageCollectionsSourcesStorage(
+                fileSystem: fileSystem,
                 path: configuration.configurationDirectory?.appending(component: "collections.json")
             ),
             collections: SQLitePackageCollectionsStorage(
@@ -52,7 +64,10 @@ public struct PackageCollections: PackageCollectionsProtocol, Closable {
         )
 
         let collectionProviders = [
-            Model.CollectionSourceType.json: JSONPackageCollectionProvider(observabilityScope: observabilityScope)
+            Model.CollectionSourceType.json: JSONPackageCollectionProvider(
+                fileSystem: fileSystem,
+                observabilityScope: observabilityScope
+            )
         ]
 
         let metadataProvider = customMetadataProvider ?? GitHubPackageMetadataProvider(
@@ -64,6 +79,7 @@ public struct PackageCollections: PackageCollectionsProtocol, Closable {
         )
 
         self.configuration = configuration
+        self.fileSystem = fileSystem
         self.observabilityScope = observabilityScope
         self.storageContainer = (storage, true)
         self.collectionProviders = collectionProviders
@@ -72,12 +88,14 @@ public struct PackageCollections: PackageCollectionsProtocol, Closable {
 
     // internal initializer for testing
     init(configuration: Configuration = .init(),
+         fileSystem: FileSystem,
          observabilityScope: ObservabilityScope,
          storage: Storage,
          collectionProviders: [Model.CollectionSourceType: PackageCollectionProvider],
          metadataProvider: PackageMetadataProvider
     ) {
         self.configuration = configuration
+        self.fileSystem = fileSystem
         self.observabilityScope = observabilityScope
         self.storageContainer = (storage, false)
         self.collectionProviders = collectionProviders
@@ -214,7 +232,7 @@ public struct PackageCollections: PackageCollectionsProtocol, Closable {
             return callback(.failure(PackageCollectionError.unsupportedPlatform))
         }
 
-        if let errors = source.validate()?.errors() {
+        if let errors = source.validate(fileSystem: self.fileSystem)?.errors() {
             return callback(.failure(MultipleErrors(errors)))
         }
 
@@ -301,7 +319,7 @@ public struct PackageCollections: PackageCollectionsProtocol, Closable {
             switch result {
             case .failure:
                 // The collection is not in storage. Validate the source before fetching it.
-                if let errors = source.validate()?.errors() {
+                if let errors = source.validate(fileSystem: self.fileSystem)?.errors() {
                     return callback(.failure(MultipleErrors(errors)))
                 }
                 guard let provider = self.collectionProviders[source.type] else {

--- a/Sources/PackageCollections/PackageIndexAndCollections.swift
+++ b/Sources/PackageCollections/PackageIndexAndCollections.swift
@@ -22,6 +22,7 @@ public struct PackageIndexAndCollections: Closable {
     public init(
         indexConfiguration: PackageIndexConfiguration = .init(),
         collectionsConfiguration: PackageCollections.Configuration = .init(),
+        fileSystem: FileSystem,
         observabilityScope: ObservabilityScope
     ) {
         let index = PackageIndex(
@@ -44,6 +45,7 @@ public struct PackageIndexAndCollections: Closable {
         self.collections = PackageCollections(
             configuration: collectionsConfiguration,
             customMetadataProvider: metadataProvider,
+            fileSystem: fileSystem,
             observabilityScope: observabilityScope
         )
         self.observabilityScope = observabilityScope

--- a/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
@@ -287,12 +287,14 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider, Closable {
         public var cacheTTLInSeconds: Int
         public var cacheSizeInMegabytes: Int
 
-        public init(authTokens: @escaping () -> [AuthTokenType: String]? = { nil },
-                    apiLimitWarningThreshold: Int? = nil,
-                    disableCache: Bool = false,
-                    cacheDir: AbsolutePath? = nil,
-                    cacheTTLInSeconds: Int? = nil,
-                    cacheSizeInMegabytes: Int? = nil) {
+        public init(
+            authTokens: @escaping () -> [AuthTokenType: String]? = { nil },
+            apiLimitWarningThreshold: Int? = nil,
+            disableCache: Bool = false,
+            cacheDir: AbsolutePath? = nil,
+            cacheTTLInSeconds: Int? = nil,
+            cacheSizeInMegabytes: Int? = nil            
+        ) {
             self.authTokens = authTokens
             self.apiLimitWarningThreshold = apiLimitWarningThreshold ?? 5
             self.cacheDir = cacheDir.map(resolveSymlinks) ?? localFileSystem.swiftPMCacheDirectory.appending(components: "package-metadata")

--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -36,6 +36,7 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
     static let defaultCertPolicyKeys: [CertificatePolicyKey] = [.default]
 
     private let configuration: Configuration
+    private let fileSystem: FileSystem
     private let observabilityScope: ObservabilityScope
     private let httpClient: HTTPClient
     private let decoder: JSONDecoder
@@ -43,24 +44,27 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
     private let signatureValidator: PackageCollectionSignatureValidator
     private let sourceCertPolicy: PackageCollectionSourceCertificatePolicy
 
-    init(configuration: Configuration = .init(),
-         observabilityScope: ObservabilityScope,
-         httpClient: HTTPClient? = nil,
-         signatureValidator: PackageCollectionSignatureValidator? = nil,
-         sourceCertPolicy: PackageCollectionSourceCertificatePolicy = PackageCollectionSourceCertificatePolicy(),
-         fileSystem: FileSystem = localFileSystem) {
+    init(
+        configuration: Configuration = .init(),
+        fileSystem: FileSystem,
+        observabilityScope: ObservabilityScope,
+        sourceCertPolicy: PackageCollectionSourceCertificatePolicy = PackageCollectionSourceCertificatePolicy(),
+        customHTTPClient: HTTPClient? = nil,
+        customSignatureValidator: PackageCollectionSignatureValidator? = nil
+    ) {
         self.configuration = configuration
-        self.observabilityScope = observabilityScope
-        self.httpClient = httpClient ?? Self.makeDefaultHTTPClient()
-        self.decoder = JSONDecoder.makeWithDefaults()
         self.validator = JSONModel.Validator(configuration: configuration.validator)
-        self.signatureValidator = signatureValidator ?? PackageCollectionSigning(
+        self.fileSystem = fileSystem
+        self.observabilityScope = observabilityScope
+        self.httpClient = customHTTPClient ?? Self.makeDefaultHTTPClient()
+        self.signatureValidator = customSignatureValidator ?? PackageCollectionSigning(
             trustedRootCertsDir: configuration.trustedRootCertsDir ?? fileSystem.swiftPMConfigurationDirectory.appending(component: "trust-root-certs").asURL,
             additionalTrustedRootCerts: sourceCertPolicy.allRootCerts.map { Array($0) },
             observabilityScope: observabilityScope,
             callbackQueue: .sharedConcurrent
         )
         self.sourceCertPolicy = sourceCertPolicy
+        self.decoder = JSONDecoder.makeWithDefaults()
     }
 
     func get(_ source: Model.CollectionSource, callback: @escaping (Result<Model.Collection, Error>) -> Void) {
@@ -68,14 +72,14 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
             return callback(.failure(InternalError("JSONPackageCollectionProvider can only be used for fetching 'json' package collections")))
         }
 
-        if let errors = source.validate()?.errors() {
+        if let errors = source.validate(fileSystem: fileSystem)?.errors() {
             return callback(.failure(JSONPackageCollectionProviderError.invalidSource("\(errors)")))
         }
 
         // Source is a local file
         if let absolutePath = source.absolutePath {
             do {
-                let data: Data = try localFileSystem.readFileContents(absolutePath)
+                let data: Data = try self.fileSystem.readFileContents(absolutePath)
                 return self.decodeAndRunSignatureCheck(source: source, data: data, certPolicyKeys: Self.defaultCertPolicyKeys, callback: callback)
             } catch {
                 return callback(.failure(error))

--- a/Sources/PackageCollections/Storage/FilePackageCollectionsSourcesStorage.swift
+++ b/Sources/PackageCollections/Storage/FilePackageCollectionsSourcesStorage.swift
@@ -23,7 +23,7 @@ struct FilePackageCollectionsSourcesStorage: PackageCollectionsSourcesStorage {
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
 
-    init(fileSystem: FileSystem = localFileSystem, path: AbsolutePath? = nil) {
+    init(fileSystem: FileSystem, path: AbsolutePath? = nil) {
         self.fileSystem = fileSystem
 
         self.path = path ?? fileSystem.swiftPMConfigurationDirectory.appending(component: "collections.json")

--- a/Sources/SPMPackageEditor/PackageEditor.swift
+++ b/Sources/SPMPackageEditor/PackageEditor.swift
@@ -131,7 +131,7 @@ public final class PackageEditor {
 
         // Write template files.
         let targetPath = manifest.parentDirectory.appending(components: "Sources", targetName)
-        if !localFileSystem.exists(targetPath) {
+        if !fs.exists(targetPath) {
             let file = targetPath.appending(components: targetName + ".swift")
             try fs.createDirectory(targetPath)
             try fs.writeFileContents(file, bytes: "")
@@ -259,11 +259,11 @@ public final class PackageEditorContext {
     let repositoryManager: RepositoryManager
 
     /// The file system in use.
-    let fs: FileSystem
+    let fileSystem: FileSystem
 
-    public init(buildDir: AbsolutePath, fs: FileSystem = localFileSystem) throws {
+    public init(buildDir: AbsolutePath, fileSystem: FileSystem) throws {
         self.buildDir = buildDir
-        self.fs = fs
+        self.fileSystem = fileSystem
 
         // Create toolchain.
         let hostToolchain = try UserToolchain(destination: .hostDestination())

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -725,7 +725,7 @@ public class Workspace {
         }
 
         let httpClient = customHTTPClient ?? HTTPClient()
-        let archiver = customArchiver ?? ZipArchiver()
+        let archiver = customArchiver ?? ZipArchiver(fileSystem: fileSystem)
 
         // initialize
         self.fileSystem = fileSystem

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -80,7 +80,7 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
             xcbuildPath = xcodeDirectory.appending(RelativePath("../SharedFrameworks/XCBuild.framework/Versions/A/Support/xcbuild"))
         }
 
-        guard localFileSystem.exists(xcbuildPath) else {
+        guard fileSystem.exists(xcbuildPath) else {
             throw StringError("xcbuild executable at '\(xcbuildPath)' does not exist or is not executable")
         }
     }
@@ -88,7 +88,7 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
     public func build(subset: BuildSubset) throws {
         let pifBuilder = try getPIFBuilder()
         let pif = try pifBuilder.generatePIF()
-        try localFileSystem.writeIfChanged(path: buildParameters.pifManifest, bytes: ByteString(encodingAsUTF8: pif))
+        try self.fileSystem.writeIfChanged(path: buildParameters.pifManifest, bytes: ByteString(encodingAsUTF8: pif))
 
         var arguments = [
             xcbuildPath.pathString,
@@ -135,7 +135,7 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
         let result = try process.waitUntilExit()
 
         if let buildParamsFile = buildParamsFile {
-            try? localFileSystem.removeFileTree(buildParamsFile)
+            try? self.fileSystem.removeFileTree(buildParamsFile)
         }
 
         guard result.exitStatus == .terminated(code: 0) else {
@@ -209,7 +209,7 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
         let encoder = JSONEncoder.makeWithDefaults()
         let data = try encoder.encode(params)
         let file = try withTemporaryFile(deleteOnClose: false) { $0.path }
-        try localFileSystem.writeFileContents(file, bytes: ByteString(data))
+        try self.fileSystem.writeFileContents(file, bytes: ByteString(data))
         return file
     }
 

--- a/Tests/BasicsTests/ZipArchiverTests.swift
+++ b/Tests/BasicsTests/ZipArchiverTests.swift
@@ -16,7 +16,7 @@ import XCTest
 class ZipArchiverTests: XCTestCase {
     func testZipArchiverSuccess() throws {
         try testWithTemporaryDirectory { tmpdir in
-            let archiver = ZipArchiver()
+            let archiver = ZipArchiver(fileSystem: localFileSystem)
             let inputArchivePath = AbsolutePath(#file).parentDirectory.appending(components: "Inputs", "archive.zip")
             try archiver.extract(from: inputArchivePath, to: tmpdir)
             let content = tmpdir.appending(component: "file")
@@ -54,7 +54,7 @@ class ZipArchiverTests: XCTestCase {
 
     func testZipArchiverInvalidArchive() throws {
         try testWithTemporaryDirectory { tmpdir in
-            let archiver = ZipArchiver()
+            let archiver = ZipArchiver(fileSystem: localFileSystem)
             let inputArchivePath = AbsolutePath(#file).parentDirectory
                 .appending(components: "Inputs", "invalid_archive.zip")
             XCTAssertThrowsError(try archiver.extract(from: inputArchivePath, to: tmpdir)) { error in
@@ -66,21 +66,21 @@ class ZipArchiverTests: XCTestCase {
     func testValidation() throws {
         // valid
         try testWithTemporaryDirectory { tmpdir in
-            let archiver = ZipArchiver()
+            let archiver = ZipArchiver(fileSystem: localFileSystem)
             let path = AbsolutePath(#file).parentDirectory
                 .appending(components: "Inputs", "archive.zip")
             XCTAssertTrue(try archiver.validate(path: path))
         }
         // invalid
         try testWithTemporaryDirectory { tmpdir in
-            let archiver = ZipArchiver()
+            let archiver = ZipArchiver(fileSystem: localFileSystem)
             let path = AbsolutePath(#file).parentDirectory
                 .appending(components: "Inputs", "invalid_archive.zip")
             XCTAssertFalse(try archiver.validate(path: path))
         }
         // error
         try testWithTemporaryDirectory { tmpdir in
-            let archiver = ZipArchiver()
+            let archiver = ZipArchiver(fileSystem: localFileSystem)
             let path = AbsolutePath.root.appending(component: "does_not_exist.zip")
             XCTAssertThrowsError(try archiver.validate(path: path)) { error in
                 XCTAssertEqual(error as? FileSystemError, FileSystemError(.noEntry, path))

--- a/Tests/BuildTests/LLBuildManifestTests.swift
+++ b/Tests/BuildTests/LLBuildManifestTests.swift
@@ -32,7 +32,7 @@ final class LLBuildManifestTests: XCTestCase {
         manifest.addNode(.virtual("Foo"), toTarget: "main")
 
         let fs = InMemoryFileSystem()
-        try ManifestWriter(fs).write(manifest, at: AbsolutePath("/manifest.yaml"))
+        try ManifestWriter(fileSystem: fs).write(manifest, at: AbsolutePath("/manifest.yaml"))
 
         let contents: String = try fs.readFileContents(AbsolutePath("/manifest.yaml"))
 
@@ -83,7 +83,7 @@ final class LLBuildManifestTests: XCTestCase {
         manifest.addNode(.file(AbsolutePath("/file.out")), toTarget: "main")
 
         let fs = InMemoryFileSystem()
-        try ManifestWriter(fs).write(manifest, at: AbsolutePath("/manifest.yaml"))
+        try ManifestWriter(fileSystem: fs).write(manifest, at: AbsolutePath("/manifest.yaml"))
 
         let contents: String = try fs.readFileContents(AbsolutePath("/manifest.yaml"))
 

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -419,7 +419,11 @@ class PluginTests: XCTestCase {
                 }
 
                 let pluginDir = tmpPath.appending(components: package.identity.description, plugin.name)
-                let scriptRunner = DefaultPluginScriptRunner(cacheDir: pluginDir.appending(component: "cache"), toolchain: ToolchainConfiguration.default)
+                let scriptRunner = DefaultPluginScriptRunner(
+                    fileSystem: localFileSystem,
+                    cacheDir: pluginDir.appending(component: "cache"),
+                    toolchain: ToolchainConfiguration.default
+                )
                 let delegate = PluginDelegate(delegateQueue: delegateQueue)
                 do {
                     let success = try tsc_await { plugin.invoke(
@@ -608,7 +612,11 @@ class PluginTests: XCTestCase {
 
             // Run the plugin.
             let pluginDir = tmpPath.appending(components: package.identity.description, plugin.name)
-            let scriptRunner = DefaultPluginScriptRunner(cacheDir: pluginDir.appending(component: "cache"), toolchain: ToolchainConfiguration.default)
+            let scriptRunner = DefaultPluginScriptRunner(
+                fileSystem: localFileSystem,
+                cacheDir: pluginDir.appending(component: "cache"),
+                toolchain: ToolchainConfiguration.default
+            )
             let delegate = PluginDelegate(delegateQueue: delegateQueue)
             let sync = DispatchSemaphore(value: 0)
             plugin.invoke(

--- a/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
+++ b/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
@@ -837,11 +837,11 @@ internal extension JSONPackageCollectionProvider {
     ) {
         self.init(
             configuration: configuration,
+            fileSystem: fileSystem,
             observabilityScope: ObservabilitySystem.NOOP,
-            httpClient: httpClient,
-            signatureValidator: signatureValidator,
             sourceCertPolicy: sourceCertPolicy,
-            fileSystem: fileSystem
+            customHTTPClient: httpClient ,
+            customSignatureValidator: signatureValidator
         )
     }
 }

--- a/Tests/PackageCollectionsTests/PackageCollectionsModelTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsModelTests.swift
@@ -9,6 +9,7 @@
  */
 
 import SPMTestSupport
+import TSCBasic
 import XCTest
 
 @testable import PackageCollections
@@ -69,22 +70,22 @@ final class PackageCollectionsModelTests: XCTestCase {
 
     func testSourceValidation() throws {
         let httpsSource = PackageCollectionsModel.CollectionSource(type: .json, url: URL(string: "https://feed.mock.io")!)
-        XCTAssertNil(httpsSource.validate(), "not expecting errors")
+        XCTAssertNil(httpsSource.validate(fileSystem: localFileSystem), "not expecting errors")
 
         let httpsSource2 = PackageCollectionsModel.CollectionSource(type: .json, url: URL(string: "HTTPS://feed.mock.io")!)
-        XCTAssertNil(httpsSource2.validate(), "not expecting errors")
+        XCTAssertNil(httpsSource2.validate(fileSystem: localFileSystem), "not expecting errors")
 
         let httpsSource3 = PackageCollectionsModel.CollectionSource(type: .json, url: URL(string: "HttpS://feed.mock.io")!)
-        XCTAssertNil(httpsSource3.validate(), "not expecting errors")
+        XCTAssertNil(httpsSource3.validate(fileSystem: localFileSystem), "not expecting errors")
 
         let httpSource = PackageCollectionsModel.CollectionSource(type: .json, url: URL(string: "http://feed.mock.io")!)
-        XCTAssertEqual(httpSource.validate()?.count, 1, "expecting errors")
+        XCTAssertEqual(httpSource.validate(fileSystem: localFileSystem)?.count, 1, "expecting errors")
 
         let otherProtocolSource = PackageCollectionsModel.CollectionSource(type: .json, url: URL(string: "ftp://feed.mock.io")!)
-        XCTAssertEqual(otherProtocolSource.validate()?.count, 1, "expecting errors")
+        XCTAssertEqual(otherProtocolSource.validate(fileSystem: localFileSystem)?.count, 1, "expecting errors")
 
         let brokenUrlSource = PackageCollectionsModel.CollectionSource(type: .json, url: URL(string: "blah")!)
-        XCTAssertEqual(brokenUrlSource.validate()?.count, 1, "expecting errors")
+        XCTAssertEqual(brokenUrlSource.validate(fileSystem: localFileSystem)?.count, 1, "expecting errors")
     }
 
     func testSourceValidation_localFile() throws {
@@ -93,14 +94,14 @@ final class PackageCollectionsModelTests: XCTestCase {
             let path = fixturePath.appending(components: "JSON", "good.json")
 
             let source = PackageCollectionsModel.CollectionSource(type: .json, url: path.asURL)
-            XCTAssertNil(source.validate())
+            XCTAssertNil(source.validate(fileSystem: localFileSystem))
         }
     }
 
     func testSourceValidation_localFileDoesNotExist() throws {
         let source = PackageCollectionsModel.CollectionSource(type: .json, url: URL(fileURLWithPath: "/foo/bar"))
 
-        let messages = source.validate()!
+        let messages = source.validate(fileSystem: localFileSystem)!
         XCTAssertEqual(1, messages.count)
 
         guard case .error = messages[0].level else {

--- a/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
@@ -1605,6 +1605,7 @@ private extension PackageCollections {
     ) {
         self.init(
             configuration: configuration,
+            fileSystem: localFileSystem,
             observabilityScope: ObservabilitySystem.NOOP,
             storage: storage,
             collectionProviders: collectionProviders,

--- a/Tests/PackageCollectionsTests/PackageIndexAndCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageIndexAndCollectionsTests.swift
@@ -668,6 +668,7 @@ private func makePackageCollections(
     
     return PackageCollections(
         configuration: configuration,
+        fileSystem: localFileSystem,
         observabilityScope: ObservabilitySystem.NOOP,
         storage: storage,
         collectionProviders: collectionProviders,

--- a/Tests/PackageCollectionsTests/Utility.swift
+++ b/Tests/PackageCollectionsTests/Utility.swift
@@ -126,8 +126,14 @@ func makeMockPackageBasicMetadata() -> PackageCollectionsModel.PackageBasicMetad
 
 func makeMockStorage(_ collectionsStorageConfig: SQLitePackageCollectionsStorage.Configuration = .init()) -> PackageCollections.Storage {
     let mockFileSystem = InMemoryFileSystem()
-    return .init(sources: FilePackageCollectionsSourcesStorage(fileSystem: mockFileSystem),
-                 collections: SQLitePackageCollectionsStorage(location: .memory, configuration: collectionsStorageConfig, observabilityScope: ObservabilitySystem.NOOP))
+    return .init(
+        sources: FilePackageCollectionsSourcesStorage(fileSystem: mockFileSystem),
+        collections: SQLitePackageCollectionsStorage(
+            location: .memory,
+            configuration: collectionsStorageConfig,
+            observabilityScope: ObservabilitySystem.NOOP
+        )
+    )
 }
 
 struct MockCollectionsProvider: PackageCollectionProvider {

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -276,7 +276,11 @@ class PluginInvocationTests: XCTestCase {
 
             // Create a plugin script runner for the duration of the test.
             let pluginCacheDir = tmpPath.appending(component: "plugin-cache")
-            let pluginScriptRunner = DefaultPluginScriptRunner(cacheDir: pluginCacheDir, toolchain: ToolchainConfiguration.default)
+            let pluginScriptRunner = DefaultPluginScriptRunner(
+                fileSystem: localFileSystem,
+                cacheDir: pluginCacheDir,
+                toolchain: ToolchainConfiguration.default
+            )
 
             // Try to compile the broken plugin script.
             do {

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -26,7 +26,12 @@ class InitTests: XCTestCase {
             try fs.createDirectory(path)
             
             // Create the package
-            let initPackage = try InitPackage(name: name, destinationPath: path, packageType: InitPackage.PackageType.empty)
+            let initPackage = try InitPackage(
+                name: name,
+                packageType: .empty,
+                destinationPath: path,
+                fileSystem: localFileSystem
+            )
             var progressMessages = [String]()
             initPackage.progressReporter = { message in
                 progressMessages.append(message)
@@ -58,7 +63,12 @@ class InitTests: XCTestCase {
             try fs.createDirectory(path)
 
             // Create the package
-            let initPackage = try InitPackage(name: name, destinationPath: path, packageType: InitPackage.PackageType.executable)
+            let initPackage = try InitPackage(
+                name: name,
+                packageType: .executable,
+                destinationPath: path,
+                fileSystem: localFileSystem
+            )
             var progressMessages = [String]()
             initPackage.progressReporter = { message in
                 progressMessages.append(message)
@@ -103,7 +113,12 @@ class InitTests: XCTestCase {
             try fs.createDirectory(path)
 
             // Create the package
-            let initPackage = try InitPackage(name: name, destinationPath: path, packageType: InitPackage.PackageType.library)
+            let initPackage = try InitPackage(
+                name: name,
+                packageType: .library,
+                destinationPath: path,
+                fileSystem: localFileSystem
+            )
             var progressMessages = [String]()
             initPackage.progressReporter = { message in
                 progressMessages.append(message)
@@ -154,7 +169,12 @@ class InitTests: XCTestCase {
             try fs.createDirectory(path)
             
             // Create the package
-            let initPackage = try InitPackage(name: name, destinationPath: path, packageType: InitPackage.PackageType.systemModule)
+            let initPackage = try InitPackage(
+                name: name,
+                packageType: .systemModule,
+                destinationPath: path,
+                fileSystem: localFileSystem
+            )
             var progressMessages = [String]()
             initPackage.progressReporter = { message in
                 progressMessages.append(message)
@@ -185,7 +205,12 @@ class InitTests: XCTestCase {
             try fs.createDirectory(path)
 
             // Create the package
-            let initPackage = try InitPackage(name: name, destinationPath: path, packageType: InitPackage.PackageType.manifest)
+            let initPackage = try InitPackage(
+                name: name,
+                packageType: InitPackage.PackageType.manifest,
+                destinationPath: path,
+                fileSystem: localFileSystem
+            )
             var progressMessages = [String]()
             initPackage.progressReporter = { message in
                 progressMessages.append(message)
@@ -218,7 +243,12 @@ class InitTests: XCTestCase {
             XCTAssertDirectoryExists(packageRoot)
             
             // Create the package
-            let initPackage = try InitPackage(name: packageName, destinationPath: packageRoot, packageType: InitPackage.PackageType.library)
+            let initPackage = try InitPackage(
+                name: packageName,
+                packageType: .library,
+                destinationPath: packageRoot,
+                fileSystem: localFileSystem
+            )
             initPackage.progressReporter = { message in }
             try initPackage.writePackageStructure()
 
@@ -238,7 +268,12 @@ class InitTests: XCTestCase {
             XCTAssertDirectoryExists(packageRoot)
             
             // Create package with non c99name.
-            let initPackage = try InitPackage(name: "package-name", destinationPath: packageRoot, packageType: InitPackage.PackageType.executable)
+            let initPackage = try InitPackage(
+                name: "package-name",
+                packageType: .executable,
+                destinationPath: packageRoot,
+                fileSystem: localFileSystem
+            )
             try initPackage.writePackageStructure()
             
             #if os(macOS)
@@ -265,8 +300,9 @@ class InitTests: XCTestCase {
 
             let initPackage = try InitPackage(
                 name: "Foo",
+                options: options,
                 destinationPath: packageRoot,
-                options: options
+                fileSystem: localFileSystem
             )
             try initPackage.writePackageStructure()
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -4147,7 +4147,12 @@ final class WorkspaceTests: XCTestCase {
         try testWithTemporaryDirectory { path in
             // Create a temporary package as a test case.
             let packagePath = path.appending(component: "MyPkg")
-            let initPackage = try InitPackage(name: packagePath.basename, destinationPath: packagePath, packageType: .executable)
+            let initPackage = try InitPackage(
+                name: packagePath.basename,
+                packageType: .executable,
+                destinationPath: packagePath,
+                fileSystem: localFileSystem
+            )
             try initPackage.writePackageStructure()
 
             // Load the workspace.


### PR DESCRIPTION
motivation: using the FileSystem helps testing and robustness

changes: review all use sites of localFileSystem and replace them with abstract FileSystem where possible
