### PR TITLE
fix a couple of data races in plugin tests

### DIFF
--- a/Sources/Basics/ConcurrencyHelpers.swift
+++ b/Sources/Basics/ConcurrencyHelpers.swift
@@ -182,6 +182,20 @@ public final class ThreadSafeBox<Value> {
         return value
     }
 
+    @discardableResult
+    public func memoize(body: () throws -> Value?) rethrows -> Value? {
+        if let value = self.get() {
+            return value
+        }
+        if let value = try body() {
+            self.lock.withLock {
+                self.underlying = value
+            }
+            return value
+        }
+        return nil
+    }
+
     public func clear() {
         self.lock.withLock {
             self.underlying = nil


### PR DESCRIPTION
motivation: address issues reported by tsan

changes: use thread safe data stores in plugin test delegates
