### PR TITLE
Fix a bug that caused a plugin dependency on a local executable to not work properly

### DIFF
--- a/Fixtures/Miscellaneous/Plugins/PluginUsingLocalAndRemoteTool/MyLibrary/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/PluginUsingLocalAndRemoteTool/MyLibrary/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version: 5.6
+import PackageDescription
+
+let package = Package(
+    name: "MyLibrary",
+    dependencies: [
+        .package(path: "../MyPlugin")
+    ],
+    targets: [
+        .target(
+            name: "MyLibrary"
+        ),
+        .testTarget(
+            name: "MyLibraryTests",
+            dependencies: ["MyLibrary"]
+        )
+    ]
+)

--- a/Fixtures/Miscellaneous/Plugins/PluginUsingLocalAndRemoteTool/MyLibrary/Sources/MyLibrary/library.swift
+++ b/Fixtures/Miscellaneous/Plugins/PluginUsingLocalAndRemoteTool/MyLibrary/Sources/MyLibrary/library.swift
@@ -1,0 +1,3 @@
+public func Foo() -> String {
+    return "Foo"
+}

--- a/Fixtures/Miscellaneous/Plugins/PluginUsingLocalAndRemoteTool/MyLibrary/Tests/MyLibraryTests/test.swift
+++ b/Fixtures/Miscellaneous/Plugins/PluginUsingLocalAndRemoteTool/MyLibrary/Tests/MyLibraryTests/test.swift
@@ -1,0 +1,9 @@
+import XCTest
+import MyLibrary
+
+final class MyLibraryTests: XCTestCase {
+    
+    func testLibrary() throws {
+        XCTAssertEqual(Foo(), "Foo")
+    }
+}

--- a/Fixtures/Miscellaneous/Plugins/PluginUsingLocalAndRemoteTool/MyPlugin/Libraries/LocalToolHelperLibrary/library.swift
+++ b/Fixtures/Miscellaneous/Plugins/PluginUsingLocalAndRemoteTool/MyPlugin/Libraries/LocalToolHelperLibrary/library.swift
@@ -1,0 +1,3 @@
+public func LocalToolHelperFunction() -> String {
+    return "local"
+}

--- a/Fixtures/Miscellaneous/Plugins/PluginUsingLocalAndRemoteTool/MyPlugin/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/PluginUsingLocalAndRemoteTool/MyPlugin/Package.swift
@@ -1,0 +1,45 @@
+// swift-tools-version: 5.6
+import PackageDescription
+
+let package = Package(
+    name: "MyPlugin",
+    products: [
+        .plugin(
+            name: "MyPlugin",
+            targets: ["MyPlugin"]
+        ),
+    ],
+    dependencies: [
+        .package(path: "../RemoteTool"),
+    ],
+    targets: [
+        .plugin(
+            name: "MyPlugin",
+            capability: .command(
+                intent: .custom(
+                    verb: "my-plugin",
+                    description: "Tester plugin"
+                )
+            ),
+            dependencies: [
+                .product(name: "RemoteTool", package: "RemoteTool"),
+                "LocalTool",
+                "ImpliedLocalTool",
+            ]
+        ),
+        .executableTarget(
+            name: "LocalTool",
+            dependencies: ["LocalToolHelperLibrary"],
+            path: "Tools/LocalTool"
+        ),
+        .executableTarget(
+            name: "ImpliedLocalTool",
+            dependencies: ["LocalToolHelperLibrary"],
+            path: "Tools/ImpliedLocalTool"
+        ),
+        .target(
+            name: "LocalToolHelperLibrary",
+            path: "Libraries/LocalToolHelperLibrary"
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/Plugins/PluginUsingLocalAndRemoteTool/MyPlugin/Plugins/MyPlugin/plugin.swift
+++ b/Fixtures/Miscellaneous/Plugins/PluginUsingLocalAndRemoteTool/MyPlugin/Plugins/MyPlugin/plugin.swift
@@ -1,0 +1,21 @@
+import PackagePlugin
+import Foundation
+
+@main
+struct MyPlugin: CommandPlugin {
+    func performCommand(context: PluginContext, arguments: [String]) async throws {
+        for name in ["RemoteTool", "LocalTool", "ImpliedLocalTool"] {
+            let tool = try context.tool(named: name)
+            print("tool path is \(tool.path)")
+            
+            do {
+                let process = Process()
+                process.executableURL = URL(fileURLWithPath: tool.path.string)
+                try process.run()
+            }
+            catch {
+                print("error: \(error)")
+            }
+        }
+    }
+}

--- a/Fixtures/Miscellaneous/Plugins/PluginUsingLocalAndRemoteTool/MyPlugin/Tools/ImpliedLocalTool/main.swift
+++ b/Fixtures/Miscellaneous/Plugins/PluginUsingLocalAndRemoteTool/MyPlugin/Tools/ImpliedLocalTool/main.swift
@@ -1,0 +1,3 @@
+import LocalToolHelperLibrary
+
+print("A message from the implied \(LocalToolHelperFunction()) tool.")

--- a/Fixtures/Miscellaneous/Plugins/PluginUsingLocalAndRemoteTool/MyPlugin/Tools/LocalTool/main.swift
+++ b/Fixtures/Miscellaneous/Plugins/PluginUsingLocalAndRemoteTool/MyPlugin/Tools/LocalTool/main.swift
@@ -1,0 +1,3 @@
+import LocalToolHelperLibrary
+
+print("A message from the \(LocalToolHelperFunction()) tool.")

--- a/Fixtures/Miscellaneous/Plugins/PluginUsingLocalAndRemoteTool/RemoteTool/Libraries/RemoteToolHelperLibrary/library.swift
+++ b/Fixtures/Miscellaneous/Plugins/PluginUsingLocalAndRemoteTool/RemoteTool/Libraries/RemoteToolHelperLibrary/library.swift
@@ -1,0 +1,3 @@
+public func RemoteToolHelperLibraryFunction() -> String {
+    return "remote"
+}

--- a/Fixtures/Miscellaneous/Plugins/PluginUsingLocalAndRemoteTool/RemoteTool/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/PluginUsingLocalAndRemoteTool/RemoteTool/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 5.6
+import PackageDescription
+
+let package = Package(
+    name: "RemoteTool",
+    products: [
+        .executable(
+            name: "RemoteTool",
+            targets: ["RemoteTool"]
+        ),
+    ],
+    targets: [
+        .executableTarget(
+            name: "RemoteTool",
+            dependencies: ["RemoteToolHelperLibrary"],
+            path: "Tools/RemoteTool"
+        ),
+        .target(
+            name: "RemoteToolHelperLibrary",
+            path: "Libraries/RemoteToolHelperLibrary"
+        )
+    ]
+)

--- a/Fixtures/Miscellaneous/Plugins/PluginUsingLocalAndRemoteTool/RemoteTool/Tools/RemoteTool/main.swift
+++ b/Fixtures/Miscellaneous/Plugins/PluginUsingLocalAndRemoteTool/RemoteTool/Tools/RemoteTool/main.swift
@@ -1,0 +1,3 @@
+import RemoteToolHelperLibrary
+
+print("A message from the \(RemoteToolHelperLibraryFunction()) tool.")

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -1044,9 +1044,9 @@ extension SwiftPackageTool {
                             toolNamesToPaths[exec.name] = exec.executablePath
                         }
                     }
-                    else {
-                        // Build the target referenced by the tool, and add the executable to the tool map.
-                        try buildOperation.build(subset: .target(target.name))
+                    else {                        
+                        // Build the product referenced by the tool, and add the executable to the tool map. Product dependencies are not supported within a package, so we instead find the executable that corresponds to the product. There is always one, because of autogeneration of implicit executables with the same name as the target if there isn't an explicit one.
+                        try buildOperation.build(subset: .product(target.name))
                         if let builtTool = buildOperation.buildPlan?.buildProducts.first(where: { $0.product.name == target.name}) {
                             toolNamesToPaths[target.name] = builtTool.binary
                         }

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -471,6 +471,22 @@ class PluginTests: XCTestCase {
         }
     }
 
+    func testLocalAndRemoteToolDependencies() throws {
+        // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
+        try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+
+        try fixture(name: "Miscellaneous/Plugins/PluginUsingLocalAndRemoteTool") { path in
+            let (stdout, stderr) = try executeSwiftPackage(path.appending(component: "MyLibrary"), configuration: .Debug, extraArgs: ["plugin", "my-plugin"])
+            XCTAssert(stderr.contains("Linking RemoteTool"), "stdout:\n\(stderr)\n\(stdout)")
+            XCTAssert(stderr.contains("Linking LocalTool"), "stdout:\n\(stderr)\n\(stdout)")
+            XCTAssert(stderr.contains("Linking ImpliedLocalTool"), "stdout:\n\(stderr)\n\(stdout)")
+            XCTAssert(stderr.contains("Build complete!"), "stdout:\n\(stderr)\n\(stdout)")
+            XCTAssert(stdout.contains("A message from the remote tool."), "stdout:\n\(stderr)\n\(stdout)")
+            XCTAssert(stdout.contains("A message from the local tool."), "stdout:\n\(stderr)\n\(stdout)")
+            XCTAssert(stdout.contains("A message from the implied local tool."), "stdout:\n\(stderr)\n\(stdout)")
+        }
+    }
+
     func testCommandPluginCancellation() throws {
         // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")


### PR DESCRIPTION
Motivation:  This bug affects how packages that vend plugins that rely on built tools can be structured (remote tool dependencies work but local dependencies do not, without this fix).

Changes:
- pass `.product` instead of `.target` to make sure that the executable is linked and not just compiled
- add a unit test that checks remote and local tools, with both implicitly and explicitly defined products for the local case

rdar://89267060