### PR TITLE
Fix a tsan issue in `PluginTests.testCommandPluginCancellation()`

### DIFF
--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -636,7 +636,11 @@ class PluginTests: XCTestCase {
             XCTAssertEqual(result, .timedOut, "expected the plugin to time out")
             
             // At this point we should have parsed out the process identifier. But it's possible we don't always — this is being investigated in rdar://88792829.
-            guard let pid = delegate.parsedProcessIdentifier else {
+            var pid: Int? = .none
+            delegateQueue.sync {
+                pid = delegate.parsedProcessIdentifier
+            }
+            guard let pid = pid else {
                 throw XCTSkip("skipping test because no pid was received from the plugin; being investigated as rdar://88792829\n\(delegate.diagnostics.description)")
             }
             


### PR DESCRIPTION
This fixes a reported thread sanitizer issue in the `PluginTests.testCommandPluginCancellation()` test.

**Description:** The delegate is called in sequence because the caller passes in a serial queue, but there is a race condition between the timeout of waiting for the subprocess to finish and accessing the delegate’s parsed-out process identifier.  Accessing it on the delegate queue will preserve the thread access integrity.

This is an alternate (and in my view better) fix of https://github.com/apple/swift-package-manager/pull/4159 because making the data structures thread-safe would mask further tsan issues.

**Motivation:** Fixes a reported tsan violation in unit tests.

**Changes:**
- access the parsed process identifier from the serial delegate callback queue
