### PR TITLE
refactor resource localization model

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -1434,6 +1434,18 @@ extension Sources {
     }
 }
 
+extension Target.Dependency {
+    fileprivate var nameAndType: String {
+        switch self {
+            case .target:
+                return "target-\(name)"
+            case .product:
+                return "product-\(name)"
+        }
+    }
+}
+
+
 // MARK: - Snippets
 
 extension PackageBuilder {
@@ -1467,17 +1479,5 @@ extension PackageBuilder {
                                    swiftVersion: try swiftVersion(),
                                    buildSettings: buildSettings)
             }
-    }
-}
-
-private extension Target.Dependency {
-    
-    var nameAndType: String {
-        switch self {
-            case .target:
-                return "target-\(name)"
-            case .product:
-                return "product-\(name)"
-        }
     }
 }

--- a/Sources/PackageModel/Manifest/TargetDescription.swift
+++ b/Sources/PackageModel/Manifest/TargetDescription.swift
@@ -9,10 +9,10 @@
 */
 
 /// The description of an individual target.
-public struct TargetDescription: Equatable, Codable {
+public struct TargetDescription: Equatable, Encodable {
 
     /// The target type.
-    public enum TargetType: String, Equatable, Codable {
+    public enum TargetType: String, Equatable, Encodable {
         case regular
         case executable
         case test
@@ -36,13 +36,13 @@ public struct TargetDescription: Equatable, Codable {
         }
     }
 
-    public struct Resource: Codable, Equatable {
-        public enum Rule: String, Codable, Equatable {
-            case process
+    public struct Resource: Encodable, Equatable {
+        public enum Rule: Encodable, Equatable {
+            case process(localization: Localization?)
             case copy
         }
 
-        public enum Localization: String, Codable, Equatable {
+        public enum Localization: String, Encodable {
             case `default`
             case base
         }
@@ -53,14 +53,9 @@ public struct TargetDescription: Equatable, Codable {
         /// The path of the resource.
         public let path: String
 
-        /// The explicit localization of the resource.
-        public let localization: Localization?
-
-        public init(rule: Rule, path: String, localization: Localization? = nil) {
-            precondition(rule == .process || localization == nil)
+        public init(rule: Rule, path: String) {
             self.rule = rule
             self.path = path
-            self.localization = localization
         }
     }
 

--- a/Sources/PackageModel/ManifestSourceGeneration.swift
+++ b/Sources/PackageModel/ManifestSourceGeneration.swift
@@ -403,11 +403,11 @@ fileprivate extension SourceCodeFragment {
     init(from resource: TargetDescription.Resource) {
         var params: [SourceCodeFragment] = []
         params.append(SourceCodeFragment(string: resource.path))
-        if let localization = resource.localization {
-            params.append(SourceCodeFragment(key: "localization", enum: localization.rawValue))
-        }
         switch resource.rule {
-        case .process:
+        case .process(let localization):
+            if let localization = localization {
+                params.append(SourceCodeFragment(key: "localization", enum: localization.rawValue))
+            }
             self.init(enum: "process", subnodes: params)
         case .copy:
             self.init(enum: "copy", subnodes: params)

--- a/Tests/BasicsTests/URLSessionHTTPClientTests.swift
+++ b/Tests/BasicsTests/URLSessionHTTPClientTests.swift
@@ -17,7 +17,6 @@ import FoundationNetworking
 #endif
 import TSCBasic
 import TSCTestSupport
-import struct TSCUtility.Netrc
 import XCTest
 
 final class URLSessionHTTPClientTest: XCTestCase {
@@ -281,9 +280,7 @@ final class URLSessionHTTPClientTest: XCTestCase {
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
         let netrcContent = "machine protected.downloader-tests.com login anonymous password qwerty"
-        guard case .success(let netrc) = Netrc.from(netrcContent) else {
-            return XCTFail("Cannot load netrc content")
-        }
+        let netrc = try NetrcWrapper(underlying: NetrcParser.parse(netrcContent))
         let authData = "anonymous:qwerty".data(using: .utf8)!
         let testAuthHeader = "Basic \(authData.base64EncodedString())"
 
@@ -301,7 +298,7 @@ final class URLSessionHTTPClientTest: XCTestCase {
             let url = URL(string: "https://protected.downloader-tests.com/testBasics.zip")!
             let destination = tmpdir.appending(component: "download")
             var request = HTTPClient.Request.download(url: url, fileSystem: localFileSystem, destination: destination)
-            request.options.authorizationProvider = netrc.authorization(for:)
+            request.options.authorizationProvider = netrc.httpAuthorizationHeader(for:)
             httpClient.execute(
                 request,
                 progress: { bytesDownloaded, totalBytesToDownload in
@@ -352,9 +349,7 @@ final class URLSessionHTTPClientTest: XCTestCase {
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
         let netrcContent = "default login default password default"
-        guard case .success(let netrc) = Netrc.from(netrcContent) else {
-            return XCTFail("Cannot load netrc content")
-        }
+        let netrc = try NetrcWrapper(underlying: NetrcParser.parse(netrcContent))
         let authData = "default:default".data(using: .utf8)!
         let testAuthHeader = "Basic \(authData.base64EncodedString())"
 
@@ -372,7 +367,7 @@ final class URLSessionHTTPClientTest: XCTestCase {
             let url = URL(string: "https://restricted.downloader-tests.com/testBasics.zip")!
             let destination = tmpdir.appending(component: "download")
             var request = HTTPClient.Request.download(url: url, fileSystem: localFileSystem, destination: destination)
-            request.options.authorizationProvider = netrc.authorization(for:)
+            request.options.authorizationProvider = netrc.httpAuthorizationHeader(for:)
             httpClient.execute(
                 request,
                 progress: { bytesDownloaded, totalBytesToDownload in
@@ -811,5 +806,14 @@ class FailingFileSystem: FileSystem {
 
     func move(from sourcePath: AbsolutePath, to destinationPath: AbsolutePath) throws {
         throw FileSystemError(.unsupported)
+    }
+}
+
+
+struct NetrcWrapper: AuthorizationProvider {
+    let underlying : Netrc
+
+    func authentication(for url: URL) -> (user: String, password: String)? {
+        self.underlying.authorization(for: url).map { (user: $0.login, password: $0.password) }
     }
 }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -3251,7 +3251,7 @@ final class BuildPlanTests: XCTestCase {
                             name: "Foo",
                             resources: [
                                 .init(rule: .copy, path: "foo.txt"),
-                                .init(rule: .process, path: "bar.txt"),
+                                .init(rule: .process(localization: .none), path: "bar.txt"),
                             ]
                         ),
                         TargetDescription(
@@ -3315,7 +3315,7 @@ final class BuildPlanTests: XCTestCase {
                             name: "Foo",
                             resources: [
                                 .init(rule: .copy, path: "foo.txt"),
-                                .init(rule: .process, path: "bar.txt"),
+                                .init(rule: .process(localization: .none), path: "bar.txt"),
                             ]
                         ),
                         TargetDescription(

--- a/Tests/PackageLoadingTests/PD_5_3_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_3_LoadingTests.swift
@@ -51,12 +51,12 @@ class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
 
         let resources = manifest.targets[0].resources
         XCTAssertEqual(resources[0], TargetDescription.Resource(rule: .copy, path: "foo.txt"))
-        XCTAssertEqual(resources[1], TargetDescription.Resource(rule: .process, path: "bar.txt"))
-        XCTAssertEqual(resources[2], TargetDescription.Resource(rule: .process, path: "biz.txt", localization: .default))
-        XCTAssertEqual(resources[3], TargetDescription.Resource(rule: .process, path: "baz.txt", localization: .base))
+        XCTAssertEqual(resources[1], TargetDescription.Resource(rule: .process(localization: .none), path: "bar.txt"))
+        XCTAssertEqual(resources[2], TargetDescription.Resource(rule: .process(localization: .default), path: "biz.txt"))
+        XCTAssertEqual(resources[3], TargetDescription.Resource(rule: .process(localization: .base), path: "baz.txt"))
 
         let testResources = manifest.targets[1].resources
-        XCTAssertEqual(testResources[0], TargetDescription.Resource(rule: .process, path: "testfixture.txt"))
+        XCTAssertEqual(testResources[0], TargetDescription.Resource(rule: .process(localization: .none), path: "testfixture.txt"))
     }
 
     func testBinaryTargetsTrivial() throws {

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -2320,7 +2320,7 @@ class PackageBuilderTests: XCTestCase {
             toolsVersion: .v5_3,
             targets: [
                 try TargetDescription(name: "Foo", resources: [
-                    .init(rule: .process, path: "Resources")
+                    .init(rule: .process(localization: .none), path: "Resources")
                 ]),
             ]
         )

--- a/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
+++ b/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
@@ -200,7 +200,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             exclude: ["some2"],
             sources: nil,
             resources: [
-                .init(rule: .process, path: "path"),
+                .init(rule: .process(localization: .none), path: "path"),
                 .init(rule: .copy, path: "some/path/toBeCopied"),
             ],
             publicHeadersPath: nil,
@@ -223,7 +223,7 @@ class TargetSourcesBuilderTests: XCTestCase {
         ])
 
         let somethingRule = FileRuleDescription(
-            rule: .processResource,
+            rule: .processResource(localization: .none),
             toolsVersion: .minimumRequired,
             fileTypes: ["something"])
 
@@ -271,7 +271,7 @@ class TargetSourcesBuilderTests: XCTestCase {
 
         do {
             let target = try TargetDescription(name: "Foo", resources: [
-                .init(rule: .process, path: "Resources")
+                .init(rule: .process(localization: .none), path: "Resources")
             ])
 
             let fs = InMemoryFileSystem(emptyFiles:
@@ -297,7 +297,7 @@ class TargetSourcesBuilderTests: XCTestCase {
 
         do {
             let target = try TargetDescription(name: "Foo", resources: [
-                .init(rule: .process, path: "Processed"),
+                .init(rule: .process(localization: .none), path: "Processed"),
                 .init(rule: .copy, path: "Copied/foo.txt"),
             ])
 
@@ -324,7 +324,7 @@ class TargetSourcesBuilderTests: XCTestCase {
 
         do {
             let target = try TargetDescription(name: "Foo", resources: [
-                .init(rule: .process, path: "Processed"),
+                .init(rule: .process(localization: .none), path: "Processed"),
                 .init(rule: .copy, path: "Copied"),
             ])
 
@@ -369,8 +369,8 @@ class TargetSourcesBuilderTests: XCTestCase {
 
         do {
             let target = try TargetDescription(name: "Foo", resources: [
-                .init(rule: .process, path: "A"),
-                .init(rule: .process, path: "B"),
+                .init(rule: .process(localization: .none), path: "A"),
+                .init(rule: .process(localization: .none), path: "B"),
             ])
 
             let fs = InMemoryFileSystem(emptyFiles:
@@ -396,7 +396,7 @@ class TargetSourcesBuilderTests: XCTestCase {
 
         do {
             let target = try TargetDescription(name: "Foo", resources: [
-                .init(rule: .process, path: "A"),
+                .init(rule: .process(localization: .none), path: "A"),
                 .init(rule: .copy, path: "B/en.lproj"),
             ])
 
@@ -432,7 +432,7 @@ class TargetSourcesBuilderTests: XCTestCase {
 
     func testLocalizationDirectorySubDirectory() throws {
         let target = try TargetDescription(name: "Foo", resources: [
-            .init(rule: .process, path: "Processed"),
+            .init(rule: .process(localization: .none), path: "Processed"),
             .init(rule: .copy, path: "Copied")
         ])
 
@@ -454,7 +454,7 @@ class TargetSourcesBuilderTests: XCTestCase {
 
     func testExplicitLocalizationInLocalizationDirectory() throws {
         let target = try TargetDescription(name: "Foo", resources: [
-            .init(rule: .process, path: "Resources", localization: .base),
+            .init(rule: .process(localization: .base), path: "Resources"),
         ])
 
         let fs = InMemoryFileSystem(emptyFiles:
@@ -477,9 +477,9 @@ class TargetSourcesBuilderTests: XCTestCase {
 
     func testMissingDefaultLocalization() throws {
         let target = try TargetDescription(name: "Foo", resources: [
-            .init(rule: .process, path: "Resources"),
-            .init(rule: .process, path: "Image.png", localization: .default),
-            .init(rule: .process, path: "Icon.png", localization: .base),
+            .init(rule: .process(localization: .none), path: "Resources"),
+            .init(rule: .process(localization: .default), path: "Image.png"),
+            .init(rule: .process(localization: .base), path: "Icon.png"),
         ])
 
         let fs = InMemoryFileSystem(emptyFiles:
@@ -505,9 +505,9 @@ class TargetSourcesBuilderTests: XCTestCase {
 
     func testLocalizedAndUnlocalizedResources() throws {
         let target = try TargetDescription(name: "Foo", resources: [
-            .init(rule: .process, path: "Resources"),
-            .init(rule: .process, path: "Image.png", localization: .default),
-            .init(rule: .process, path: "Icon.png", localization: .base),
+            .init(rule: .process(localization: .none), path: "Resources"),
+            .init(rule: .process(localization: .default), path: "Image.png"),
+            .init(rule: .process(localization: .base), path: "Icon.png"),
         ])
 
         let fs = InMemoryFileSystem(emptyFiles:
@@ -550,10 +550,10 @@ class TargetSourcesBuilderTests: XCTestCase {
 
     func testLocalizedResources() throws {
         let target = try TargetDescription(name: "Foo", resources: [
-            .init(rule: .process, path: "Processed"),
+            .init(rule: .process(localization: .none), path: "Processed"),
             .init(rule: .copy, path: "Copied"),
-            .init(rule: .process, path: "Other/Launch.storyboard", localization: .base),
-            .init(rule: .process, path: "Other/Image.png", localization: .default),
+            .init(rule: .process(localization: .base), path: "Other/Launch.storyboard"),
+            .init(rule: .process(localization: .default), path: "Other/Image.png"),
         ])
 
         let fs = InMemoryFileSystem(emptyFiles:
@@ -569,17 +569,17 @@ class TargetSourcesBuilderTests: XCTestCase {
         )
 
         build(target: target, defaultLocalization: "fr", toolsVersion: .v5_3, fs: fs) { _, resources, _,  _, _, _, _, diagnostics in
-            XCTAssertEqual(Set(resources), [
-                Resource(rule: .process, path: AbsolutePath("/Processed/foo.txt"), localization: nil),
-                Resource(rule: .process, path: AbsolutePath("/Processed/En-uS.lproj/Localizable.stringsdict"), localization: "en-us"),
-                Resource(rule: .process, path: AbsolutePath("/Processed/en-US.lproj/Localizable.strings"), localization: "en-us"),
-                Resource(rule: .process, path: AbsolutePath("/Processed/fr.lproj/Localizable.strings"), localization: "fr"),
-                Resource(rule: .process, path: AbsolutePath("/Processed/fr.lproj/Localizable.stringsdict"), localization: "fr"),
-                Resource(rule: .process, path: AbsolutePath("/Processed/Base.lproj/Storyboard.storyboard"), localization: "Base"),
-                Resource(rule: .copy, path: AbsolutePath("/Copied"), localization: nil),
-                Resource(rule: .process, path: AbsolutePath("/Other/Launch.storyboard"), localization: "Base"),
-                Resource(rule: .process, path: AbsolutePath("/Other/Image.png"), localization: "fr"),
-            ])
+            XCTAssertEqual(resources.sorted(by: { $0.path < $1.path }), [
+                Resource(rule: .process(localization: .none), path: AbsolutePath("/Processed/foo.txt")),
+                Resource(rule: .process(localization: "en-us"), path: AbsolutePath("/Processed/En-uS.lproj/Localizable.stringsdict")),
+                Resource(rule: .process(localization: "en-us"), path: AbsolutePath("/Processed/en-US.lproj/Localizable.strings")),
+                Resource(rule: .process(localization: "fr"), path: AbsolutePath("/Processed/fr.lproj/Localizable.strings")),
+                Resource(rule: .process(localization: "fr"), path: AbsolutePath("/Processed/fr.lproj/Localizable.stringsdict")),
+                Resource(rule: .process(localization: "Base"), path: AbsolutePath("/Processed/Base.lproj/Storyboard.storyboard")),
+                Resource(rule: .copy, path: AbsolutePath("/Copied")),
+                Resource(rule: .process(localization: "Base"), path: AbsolutePath("/Other/Launch.storyboard")),
+                Resource(rule: .process(localization: "fr"), path: AbsolutePath("/Other/Image.png")),
+            ].sorted(by: { $0.path < $1.path }))
         }
     }
 
@@ -590,17 +590,17 @@ class TargetSourcesBuilderTests: XCTestCase {
         )
 
         build(target: try TargetDescription(name: "Foo"), defaultLocalization: "fr", toolsVersion: .v5_3, fs: fs) { _, resources, _, _, _, _, _, diagnostics in
-            XCTAssertEqual(Set(resources), [
-                Resource(rule: .process, path: AbsolutePath("/Foo/fr.lproj/Image.png"), localization: "fr"),
-                Resource(rule: .process, path: AbsolutePath("/Foo/es.lproj/Image.png"), localization: "es"),
-            ])
+            XCTAssertEqual(resources.sorted(by: { $0.path < $1.path }), [
+                Resource(rule: .process(localization: "fr"), path: AbsolutePath("/Foo/fr.lproj/Image.png")),
+                Resource(rule: .process(localization: "es"), path: AbsolutePath("/Foo/es.lproj/Image.png")),
+            ].sorted(by: { $0.path < $1.path }))
         }
     }
 
     func testInfoPlistResource() throws {
         do {
             let target = try TargetDescription(name: "Foo", resources: [
-                .init(rule: .process, path: "Resources"),
+                .init(rule: .process(localization: .none), path: "Resources"),
             ])
 
             let fs = InMemoryFileSystem(emptyFiles:
@@ -715,7 +715,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             exclude: [],
             sources: nil,
             resources: [.init(rule: .copy, path: "../../../Fake.txt"),
-                        .init(rule: .process, path: "NotReal")],
+                        .init(rule: .process(localization: .none), path: "NotReal")],
             publicHeadersPath: nil,
             type: .regular
         )

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -1784,13 +1784,13 @@ class PIFBuilderTests: XCTestCase {
                     targets: [
                         .init(name: "foo", resources: [
                             // This is intentionally specific to test that we pick up `.xcdatamodel` implicitly.
-                            .init(rule: .process, path: "Resources/Data.plist")
+                            .init(rule: .process(localization: .none), path: "Resources/Data.plist")
                         ]),
                         .init(name: "FooLib", resources: [
-                            .init(rule: .process, path: "Resources")
+                            .init(rule: .process(localization: .none), path: "Resources")
                         ]),
                         .init(name: "FooTests", resources: [
-                            .init(rule: .process, path: "Resources")
+                            .init(rule: .process(localization: .none), path: "Resources")
                         ], type: .test),
                     ]),
             ],


### PR DESCRIPTION
motivation: while looking to eliminate preconditions from the code, noticed the resource localization model could be improved to better use the type system

changes:
* move localization from a floating optional attribute to the process rule enum case
* adjust call sites and tests
