### PR TITLE
Update to manifest API to make it impossible to create an invalid target dependency condition.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,15 @@ Swift 5.7
 
 * [#4131]
 
-  Update to manifest API to make it impossible to create an invalid build setttings condition.
+  Update to manifest API to make it impossible to create an invalid build settings condition.
 
 * [#4135]
 
   Enable linker dead stripping for all platforms. This can be disabled with `--disable-dead-strip`
+
+* [#4168]
+
+  Update to manifest API to make it impossible to create an invalid target dependency condition.
 
 Swift 5.6
 -----------
@@ -232,4 +236,4 @@ Swift 3.0
 [#4119]: https://github.com/apple/swift-package-manager/pull/4119
 [#4131]: https://github.com/apple/swift-package-manager/pull/4131
 [#4135]: https://github.com/apple/swift-package-manager/pull/4135
-
+[#4168]: https://github.com/apple/swift-package-manager/pull/4168

--- a/Sources/PackageDescription/BuildSettings.swift
+++ b/Sources/PackageDescription/BuildSettings.swift
@@ -58,7 +58,7 @@ public struct BuildSettingCondition: Encodable {
         self.config = config
     }
     
-    @available(_PackageDescription, deprecated: 999.0)
+    @available(_PackageDescription, deprecated: 5.7)
     public static func when(
         platforms: [Platform]? = nil,
         configuration: BuildConfiguration? = nil
@@ -72,7 +72,7 @@ public struct BuildSettingCondition: Encodable {
     /// - Parameters:
     ///   - platforms: The applicable platforms for this build setting condition.
     ///   - configuration: The applicable build configuration for this build setting condition.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 5.7)
     public static func when(platforms: [Platform], configuration: BuildConfiguration) -> BuildSettingCondition {
         BuildSettingCondition(platforms: platforms, config: configuration)
     }
@@ -81,7 +81,7 @@ public struct BuildSettingCondition: Encodable {
     ///
     /// - Parameters:
     ///   - platforms: The applicable platforms for this build setting condition.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 5.7)
     public static func when(platforms: [Platform]) -> BuildSettingCondition {
         BuildSettingCondition(platforms: platforms, config: .none)
     }
@@ -90,7 +90,7 @@ public struct BuildSettingCondition: Encodable {
     ///
     /// - Parameters:
     ///   - configuration: The applicable build configuration for this build setting condition.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 5.7)
     public static func when(configuration: BuildConfiguration) -> BuildSettingCondition {
         BuildSettingCondition(platforms: .none, config: configuration)
     }

--- a/Sources/PackageDescription/PackageDescriptionSerialization.swift
+++ b/Sources/PackageDescription/PackageDescriptionSerialization.swift
@@ -384,28 +384,6 @@ extension Target: Encodable {
     }
 }
 
-/// A condition that limits the application of a target's dependency.
-public struct TargetDependencyCondition: Encodable {
-
-    private let platforms: [Platform]?
-
-    private init(platforms: [Platform]?) {
-        self.platforms = platforms
-    }
-
-    /// Creates a target dependency condition.
-    ///
-    /// - Parameters:
-    ///   - platforms: The applicable platforms for this target dependency condition.
-    public static func when(
-        platforms: [Platform]? = nil
-    ) -> TargetDependencyCondition {
-        // FIXME: This should be an error, not a precondition.
-        precondition(!(platforms == nil))
-        return TargetDependencyCondition(platforms: platforms)
-    }
-}
-
 extension Target.PluginUsage: Encodable {
     private enum CodingKeys: CodingKey {
         case type, name, package

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -992,7 +992,8 @@ extension Target.Dependency {
     ///   - package: The name of the package.
     ///   - condition: A condition that limits the application of the target dependency. For example, only apply a
     ///       dependency for a specific platform.
-    @available(_PackageDescription, introduced: 5.3, obsoleted: 999.0)
+    @_disfavoredOverload
+    @available(_PackageDescription, introduced: 5.3, obsoleted: 5.7)
     public static func product(
         name: String,
         package: String,
@@ -1009,7 +1010,7 @@ extension Target.Dependency {
     ///   - moduleAliases: The module aliases for targets in the product.
     ///   - condition: A condition that limits the application of the target dependency. For example, only apply a
     ///       dependency for a specific platform.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 5.7)
     public static func product(
       name: String,
       package: String,
@@ -1029,6 +1030,40 @@ extension Target.Dependency {
     @available(_PackageDescription, introduced: 5.3)
     public static func byName(name: String, condition: TargetDependencyCondition? = nil) -> Target.Dependency {
         return .byNameItem(name: name, condition: condition)
+    }
+}
+
+/// A condition that limits the application of a target's dependency.
+public struct TargetDependencyCondition: Encodable {
+    private let platforms: [Platform]?
+
+    private init(platforms: [Platform]?) {
+        self.platforms = platforms
+    }
+
+    /// Creates a target dependency condition.
+    ///
+    /// - Parameters:
+    ///   - platforms: The applicable platforms for this target dependency condition.
+    @_disfavoredOverload
+    @available(_PackageDescription, obsoleted: 5.7, message: "using .when with nil platforms is obsolete")
+    public static func when(
+        platforms: [Platform]? = nil
+    ) -> TargetDependencyCondition {
+        // FIXME: This should be an error, not a precondition.
+        precondition(!(platforms == nil))
+        return TargetDependencyCondition(platforms: platforms)
+    }
+
+    /// Creates a target dependency condition.
+    ///
+    /// - Parameters:
+    ///   - platforms: The applicable platforms for this target dependency condition.
+    @available(_PackageDescription, introduced: 5.7)
+    public static func when(
+        platforms: [Platform]
+    ) -> TargetDependencyCondition? {
+        return !platforms.isEmpty ? TargetDependencyCondition(platforms: platforms) : .none
     }
 }
 
@@ -1132,7 +1167,7 @@ extension Target.PluginUsage {
 // MARK: ExpressibleByStringLiteral
 
 extension Target.Dependency: ExpressibleByStringLiteral {
-    
+
     /// Creates a target dependency instance with the given value.
     ///
     /// - parameters:
@@ -1143,7 +1178,7 @@ extension Target.Dependency: ExpressibleByStringLiteral {
 }
 
 extension Target.PluginUsage: ExpressibleByStringLiteral {
-    
+
     /// Specifies use of a plugin target in the same package.
     ///
     /// - parameters:

--- a/Tests/PackageLoadingTests/PD_5_3_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_3_LoadingTests.swift
@@ -451,7 +451,6 @@ class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
         XCTAssertEqual(dependencies[1], .target(name: "Bar", condition: .init(platformNames: ["linux"], config: nil)))
         XCTAssertEqual(dependencies[2], .product(name: "Baz", package: "Baz", condition: .init(platformNames: ["macos"])))
         XCTAssertEqual(dependencies[3], .byName(name: "Bar", condition: .init(platformNames: ["watchos", "ios"])))
-
     }
 
     func testDefaultLocalization() throws {

--- a/Tests/PackageLoadingTests/PD_5_7_LoadingTests .swift
+++ b/Tests/PackageLoadingTests/PD_5_7_LoadingTests .swift
@@ -9,12 +9,65 @@
 */
 
 import Basics
+import PackageLoading
 import PackageModel
 import SPMTestSupport
+import TSCBasic
 import XCTest
 
 class PackageDescription5_7LoadingTests: PackageDescriptionLoadingTests {
     override var toolsVersion: ToolsVersion {
         .v5_7
+    }
+
+    func testConditionalTargetDependencies() throws {
+        let content = """
+            import PackageDescription
+            let package = Package(
+                name: "Foo",
+                dependencies: [],
+                targets: [
+                    .target(name: "Foo", dependencies: [
+                        .target(name: "Bar", condition: .when(platforms: [])),
+                        .target(name: "Baz", condition: .when(platforms: [.linux])),
+                    ]),
+                    .target(name: "Bar"),
+                    .target(name: "Baz"),
+                ]
+            )
+            """
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
+        let dependencies = manifest.targets[0].dependencies
+        XCTAssertEqual(dependencies[0], .target(name: "Bar", condition: .none))
+        XCTAssertEqual(dependencies[1], .target(name: "Baz", condition: .init(platformNames: ["linux"], config: .none)))
+    }
+
+    func testConditionalTargetDependenciesDeprecation() throws {
+        let content = """
+            import PackageDescription
+            let package = Package(
+                name: "Foo",
+                dependencies: [],
+                targets: [
+                    .target(name: "Foo", dependencies: [
+                        .target(name: "Bar", condition: .when(platforms: nil))
+                    ]),
+                    .target(name: "Bar")
+                ]
+            )
+            """
+
+        let observability = ObservabilitySystem.makeForTesting()
+        XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error") { error in
+            if case ManifestParseError.invalidManifestFormat(let error, _) = error {
+                XCTAssertMatch(error, .contains("when(platforms:)' was obsoleted"))
+            } else {
+                XCTFail("unexpected error: \(error)")
+            }
+        }
     }
 }


### PR DESCRIPTION
motivation: reduce use of preconditions, make editing manifest safer

changes:
* deprecate TargetDependencyCondition "when" initializor that uses a precondition
* move TargetDependencyCondition code to a more appropriate place
* add tests
* update change log
