### PR TITLE
reduce use of preconditions and asserts

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -876,7 +876,7 @@ public final class SwiftTargetBuildDescription {
     /// Command-line for emitting just the Swift module.
     public func emitModuleCommandLine() throws -> [String] {
         guard buildParameters.emitSwiftModuleSeparately else {
-            throw InternalError("expecting emitSwiftModuleSeparately build")
+            throw InternalError("expecting emitSwiftModuleSeparately in build parameters")
         }
 
         var result: [String] = []

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -923,7 +923,7 @@ public final class SwiftTargetBuildDescription {
     /// Note: This doesn't emit the module.
     public func emitObjectsCommandLine() throws -> [String] {
         guard buildParameters.emitSwiftModuleSeparately else {
-            throw InternalError("expecting emitSwiftModuleSeparately build")
+            throw InternalError("expecting emitSwiftModuleSeparately in build parameters")
         }
 
         var result: [String] = []

--- a/Sources/Build/LLBuildManifestBuilder.swift
+++ b/Sources/Build/LLBuildManifestBuilder.swift
@@ -549,8 +549,8 @@ extension LLBuildManifestBuilder {
             // Depend on the binary for executable targets.
             if target.type == .executable {
                 // FIXME: Optimize.
-                let _product = plan.graph.allProducts.first {
-                    $0.type == .executable && $0.executableModule == target
+                let _product = try plan.graph.allProducts.first {
+                    try $0.type == .executable && $0.executableTarget() == target
                 }
                 if let product = _product {
                     guard let planProduct = plan.productMap[product] else {

--- a/Sources/PackageGraph/Pubgrub/Incompatibility.swift
+++ b/Sources/PackageGraph/Pubgrub/Incompatibility.swift
@@ -45,8 +45,9 @@ public struct Incompatibility: Equatable, Hashable {
         }
 
         let normalizedTerms = try normalize(terms: terms.elements)
-        assert(normalizedTerms.count > 0,
-               "An incompatibility must contain at least one term after normalization.")
+        guard normalizedTerms.count > 0 else {
+            throw InternalError("An incompatibility must contain at least one term after normalization.")
+        }
         self.init(terms: OrderedSet(normalizedTerms), cause: cause)
     }
 }

--- a/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
+++ b/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
@@ -227,7 +227,9 @@ public struct PubgrubDependencyResolver {
             let updatePackage = try container.underlying.loadPackageReference(at: boundVersion)
 
             if var existing = flattenedAssignments[updatePackage] {
-                assert(existing.binding == boundVersion, "Two products in one package resolved to different versions: \(existing.products)@\(existing.binding) vs \(products)@\(boundVersion)")
+                guard existing.binding == boundVersion else {
+                    throw InternalError("Two products in one package resolved to different versions: \(existing.products)@\(existing.binding) vs \(products)@\(boundVersion)")
+                }
                 existing.products.formUnion(products)
                 flattenedAssignments[updatePackage] = existing
             } else {
@@ -284,7 +286,9 @@ public struct PubgrubDependencyResolver {
 
             // Mark the package as overridden.
             if var existing = overriddenPackages[constraint.package] {
-                assert(existing.version == .unversioned, "Overridden package is not unversioned: \(constraint.package)@\(existing.version)")
+                guard existing.version == .unversioned else {
+                    throw InternalError("Overridden package is not unversioned: \(constraint.package)@\(existing.version)")
+                }
                 existing.products.formUnion(constraint.products)
                 overriddenPackages[constraint.package] = existing
             } else {

--- a/Sources/PackageGraph/ResolvedProduct.swift
+++ b/Sources/PackageGraph/ResolvedProduct.swift
@@ -8,6 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import Basics
 import TSCBasic
 import PackageModel
 
@@ -34,8 +35,10 @@ public final class ResolvedProduct {
     /// The main executable target of product.
     ///
     /// Note: This property is only valid for executable products.
-    public var executableModule: ResolvedTarget {
-        precondition(type == .executable || type == .snippet, "This property should only be called for executable targets")
+    public func executableTarget() throws -> ResolvedTarget {
+        guard type == .executable || type == .snippet else {
+            throw InternalError("firstExecutableModule should only be called for executable targets")
+        }
         return targets.first(where: { $0.type == .executable || $0.type == .snippet })!
     }
 

--- a/Sources/PackageModel/Manifest/ProductDescription.swift
+++ b/Sources/PackageModel/Manifest/ProductDescription.swift
@@ -8,6 +8,8 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import Basics
+
 /// The product description
 public struct ProductDescription: Equatable, Codable {
 
@@ -24,8 +26,10 @@ public struct ProductDescription: Equatable, Codable {
         name: String,
         type: ProductType,
         targets: [String]
-    ) {
-        precondition(type != .test, "Declaring test products isn't supported: \(name):\(targets)")
+    ) throws {
+        guard type != .test else {
+            throw InternalError("Declaring test products isn't supported: \(name):\(targets)")
+        }
         self.name = name
         self.type = type
         self.targets = targets

--- a/Sources/PackageModel/Product.swift
+++ b/Sources/PackageModel/Product.swift
@@ -8,6 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import Basics
 import TSCBasic
 
 import struct TSCUtility.PolymorphicCodableArray
@@ -32,14 +33,19 @@ public class Product: Codable {
     /// The suffix for REPL product name.
     public static let replProductSuffix: String = "__REPL"
 
-    public init(name: String, type: ProductType, targets: [Target], testManifest: AbsolutePath? = nil) {
-        precondition(!targets.isEmpty)
+    public init(name: String, type: ProductType, targets: [Target], testManifest: AbsolutePath? = nil) throws {
+        guard !targets.isEmpty else {
+            throw InternalError("Targets cannot be empty")
+        }
         if type == .executable {
-            assert(targets.filter({ $0.type == .executable }).count == 1,
-                   "Executable products should have exactly one executable target.")
+            guard targets.filter({ $0.type == .executable }).count == 1 else {
+                throw InternalError("Executable products should have exactly one executable target.")
+            }
         }
         if testManifest != nil {
-            assert(type == .test, "Test manifest should only be set on test products")
+            guard type == .test else {
+                throw InternalError("Test manifest should only be set on test products")
+            }
         }
         self.name = name
         self.type = type

--- a/Sources/PackageModel/Target.swift
+++ b/Sources/PackageModel/Target.swift
@@ -11,6 +11,7 @@
 import TSCBasic
 
 import protocol TSCUtility.PolymorphicCodableProtocol
+import Basics
 
 public class Target: PolymorphicCodableProtocol {
     public static var implementations: [PolymorphicCodableProtocol.Type] = [
@@ -484,8 +485,10 @@ public final class ClangTarget: Target {
         others: [AbsolutePath] = [],
         dependencies: [Target.Dependency] = [],
         buildSettings: BuildSettings.AssignmentTable = .init()
-    ) {
-        assert(includeDir.isDescendantOfOrEqual(to: sources.root), "\(includeDir) should be contained in the source root \(sources.root)")
+    ) throws {
+        guard includeDir.isDescendantOfOrEqual(to: sources.root) else {
+            throw StringError("\(includeDir) should be contained in the source root \(sources.root)")
+        }
         self.isCXX = sources.containsCXXFiles
         self.cLanguageStandard = cLanguageStandard
         self.cxxLanguageStandard = cxxLanguageStandard

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -206,7 +206,7 @@ public final class MockWorkspace {
                     version: v,
                     toolsVersion: toolsVersion,
                     dependencies: package.dependencies.map { try $0.convert(baseURL: packagesDir, identityResolver: self.identityResolver) },
-                    products: package.products.map { ProductDescription(name: $0.name, type: .library(.automatic), targets: $0.targets) },
+                    products: package.products.map { try ProductDescription(name: $0.name, type: .library(.automatic), targets: $0.targets) },
                     targets: try package.targets.map { try $0.convert() }
                 )
             }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -2755,7 +2755,7 @@ final class BuildPlanTests: XCTestCase {
             path: .init("/B"),
             toolsVersion: .v5,
             products: [
-                ProductDescription(name: "Dep", type: .library(.automatic), targets: ["t1", "t2"]),
+                try ProductDescription(name: "Dep", type: .library(.automatic), targets: ["t1", "t2"]),
             ],
             targets: [
                 try TargetDescription(

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -497,7 +497,7 @@ final class PackageToolTests: CommandsTestCase {
                 .fileSystem(path: .init("/PackageC")),
             ],
             products: [
-                .init(name: "exe", type: .executable, targets: ["TargetA"])
+                try .init(name: "exe", type: .executable, targets: ["TargetA"])
             ],
             targets: [
                 try .init(name: "TargetA", dependencies: ["PackageB", "PackageC"])
@@ -513,7 +513,7 @@ final class PackageToolTests: CommandsTestCase {
                 .fileSystem(path: .init("/PackageD")),
             ],
             products: [
-                .init(name: "PackageB", type: .library(.dynamic), targets: ["TargetB"])
+                try .init(name: "PackageB", type: .library(.dynamic), targets: ["TargetB"])
             ],
             targets: [
                 try .init(name: "TargetB", dependencies: ["PackageC", "PackageD"])
@@ -528,7 +528,7 @@ final class PackageToolTests: CommandsTestCase {
                 .fileSystem(path: .init("/PackageD")),
             ],
             products: [
-                .init(name: "PackageC", type: .library(.dynamic), targets: ["TargetC"])
+                try .init(name: "PackageC", type: .library(.dynamic), targets: ["TargetC"])
             ],
             targets: [
                 try .init(name: "TargetC", dependencies: ["PackageD"])
@@ -540,7 +540,7 @@ final class PackageToolTests: CommandsTestCase {
             path: .init("/PackageD"),
             toolsVersion: .v5_3,
             products: [
-                .init(name: "PackageD", type: .library(.dynamic), targets: ["TargetD"])
+                try .init(name: "PackageD", type: .library(.dynamic), targets: ["TargetD"])
             ],
             targets: [
                 try .init(name: "TargetD")

--- a/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
@@ -59,7 +59,7 @@ class PackageGraphPerfTests: XCTestCasePerf {
                 toolsVersion: .v4_2,
                 dependencies: dependencies,
                 products: [
-                    ProductDescription(name: name, type: .library(.automatic), targets: [name])
+                    try ProductDescription(name: name, type: .library(.automatic), targets: [name])
                 ],
                 targets: targets
             )

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -339,7 +339,7 @@ class PackageBuilderTests: XCTestCase {
         var manifest = Manifest.createRootManifest(
             name: "pkg",
             products: [
-                ProductDescription(name: "exec", type: .executable, targets: ["exec", "foo"]),
+                try ProductDescription(name: "exec", type: .executable, targets: ["exec", "foo"]),
             ],
             targets: [
                 try TargetDescription(name: "foo"),
@@ -375,7 +375,7 @@ class PackageBuilderTests: XCTestCase {
         manifest = Manifest.createRootManifest(
             name: "pkg",
             products: [
-                ProductDescription(name: "exec1", type: .executable, targets: ["exec"]),
+                try ProductDescription(name: "exec1", type: .executable, targets: ["exec"]),
             ],
             targets: [
                 try TargetDescription(name: "foo"),
@@ -403,7 +403,7 @@ class PackageBuilderTests: XCTestCase {
             name: "pkg",
             toolsVersion: .v5_5,
             products: [
-                ProductDescription(name: "exec1", type: .executable, targets: ["exec1", "lib"]),
+                try ProductDescription(name: "exec1", type: .executable, targets: ["exec1", "lib"]),
             ],
             targets: [
                 try TargetDescription(name: "exec1", type: .executable),
@@ -441,7 +441,7 @@ class PackageBuilderTests: XCTestCase {
             name: "pkg",
             toolsVersion: .v5_5,
             products: [
-                ProductDescription(name: "exec1", type: .executable, targets: ["exec1"]),
+                try ProductDescription(name: "exec1", type: .executable, targets: ["exec1"]),
             ],
             targets: [
                 try TargetDescription(name: "lib"),
@@ -461,7 +461,7 @@ class PackageBuilderTests: XCTestCase {
             name: "pkg",
             toolsVersion: .v5_5,
             products: [
-                ProductDescription(name: "exec1", type: .executable, targets: ["exec1"]),
+                try ProductDescription(name: "exec1", type: .executable, targets: ["exec1"]),
             ],
             targets: [
                 try TargetDescription(name: "lib"),
@@ -481,7 +481,7 @@ class PackageBuilderTests: XCTestCase {
             name: "pkg",
             toolsVersion: .v5_5,
             products: [
-                ProductDescription(name: "exec2", type: .executable, targets: ["exec2"]),
+                try ProductDescription(name: "exec2", type: .executable, targets: ["exec2"]),
             ],
             targets: [
                 try TargetDescription(name: "lib"),
@@ -1456,10 +1456,10 @@ class PackageBuilderTests: XCTestCase {
         let manifest = Manifest.createRootManifest(
             name: "pkg",
             products: [
-                ProductDescription(name: "foo", type: .library(.automatic), targets: ["foo"]),
-                ProductDescription(name: "foo", type: .library(.static), targets: ["foo"]),
-                ProductDescription(name: "foo", type: .library(.dynamic), targets: ["foo"]),
-                ProductDescription(name: "foo-dy", type: .library(.dynamic), targets: ["foo"]),
+                try ProductDescription(name: "foo", type: .library(.automatic), targets: ["foo"]),
+                try ProductDescription(name: "foo", type: .library(.static), targets: ["foo"]),
+                try ProductDescription(name: "foo", type: .library(.dynamic), targets: ["foo"]),
+                try ProductDescription(name: "foo-dy", type: .library(.dynamic), targets: ["foo"]),
             ],
             targets: [
                 try TargetDescription(name: "foo"),
@@ -1519,7 +1519,7 @@ class PackageBuilderTests: XCTestCase {
         let manifest = Manifest.createRootManifest(
             name: "pkg",
             products: [
-                ProductDescription(name: "foo", type: .library(.automatic), targets: ["foo"]),
+                try ProductDescription(name: "foo", type: .library(.automatic), targets: ["foo"]),
             ],
             targets: [
                 try TargetDescription(name: "foo", type: .system),
@@ -1551,7 +1551,7 @@ class PackageBuilderTests: XCTestCase {
         var manifest = Manifest.createRootManifest(
             name: "SystemModulePackage",
             products: [
-                ProductDescription(name: "foo", type: .library(.automatic), targets: ["foo", "bar"]),
+                try ProductDescription(name: "foo", type: .library(.automatic), targets: ["foo", "bar"]),
             ],
             targets: [
                 try TargetDescription(name: "foo", type: .system),
@@ -1570,7 +1570,7 @@ class PackageBuilderTests: XCTestCase {
         manifest = Manifest.createRootManifest(
             name: "SystemModulePackage",
             products: [
-                ProductDescription(name: "foo", type: .library(.static), targets: ["foo"]),
+                try ProductDescription(name: "foo", type: .library(.static), targets: ["foo"]),
             ],
             targets: [
                 try TargetDescription(name: "foo", type: .system),
@@ -1589,7 +1589,7 @@ class PackageBuilderTests: XCTestCase {
         manifest = Manifest.createRootManifest(
             name: "bar",
             products: [
-                ProductDescription(name: "bar", type: .library(.automatic), targets: ["bar"])
+                try ProductDescription(name: "bar", type: .library(.automatic), targets: ["bar"])
             ],
             targets: [
                 try TargetDescription(name: "bar", type: .system)
@@ -1614,9 +1614,9 @@ class PackageBuilderTests: XCTestCase {
         let manifest = Manifest.createRootManifest(
             name: "MyPackage",
             products: [
-                ProductDescription(name: "foo1", type: .executable, targets: ["FooLib1"]),
-                ProductDescription(name: "foo2", type: .executable, targets: ["FooLib1", "FooLib2"]),
-                ProductDescription(name: "foo3", type: .executable, targets: ["foo1", "foo2"]),
+                try ProductDescription(name: "foo1", type: .executable, targets: ["FooLib1"]),
+                try ProductDescription(name: "foo2", type: .executable, targets: ["FooLib1", "FooLib2"]),
+                try ProductDescription(name: "foo3", type: .executable, targets: ["foo1", "foo2"]),
             ],
             targets: [
                 try TargetDescription(name: "foo1"),

--- a/Tests/PackageLoadingTests/PkgConfigParserTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigParserTests.swift
@@ -205,7 +205,7 @@ final class PkgConfigParserTests: XCTestCase {
     }
 
     private func loadPCFile(_ inputName: String, body: ((PkgConfigParser) -> Void)? = nil) throws {
-        var parser = PkgConfigParser(pcFile: pcFilePath(inputName), fileSystem: localFileSystem)
+        var parser = try PkgConfigParser(pcFile: pcFilePath(inputName), fileSystem: localFileSystem)
         try parser.parse()
         body?(parser)
     }

--- a/Tests/PackageModelTests/ManifestTests.swift
+++ b/Tests/PackageModelTests/ManifestTests.swift
@@ -15,8 +15,8 @@ import SPMTestSupport
 class ManifestTests: XCTestCase {
     func testRequiredTargets() throws {
         let products = [
-            ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Foo"]),
-            ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
+            try ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Foo"]),
+            try ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
         ]
 
         let targets = [
@@ -71,7 +71,7 @@ class ManifestTests: XCTestCase {
         ]
 
         let products = [
-            ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Foo1"])
+            try ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Foo1"])
         ]
 
         let targets = [

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -398,7 +398,7 @@ class ManifestSourceGenerationTests: XCTestCase {
             platforms: [],
             toolsVersion: .v5_5,
             products: [
-                .init(name: "Foo", type: .library(.static), targets: ["Bar"])
+                try .init(name: "Foo", type: .library(.static), targets: ["Bar"])
             ]
         )
 

--- a/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
@@ -414,7 +414,7 @@ class SourceControlPackageContainerTests: XCTestCase {
         ]
 
         let products = [
-            ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Foo1"]),
+            try ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Foo1"]),
         ]
 
         let targets = [
@@ -642,7 +642,9 @@ class SourceControlPackageContainerTests: XCTestCase {
                         productFilter: .specific([])
                     )
                 ],
-                products: [ProductDescription(name: "Product", type: .library(.automatic), targets: ["Target"])],
+                products: [
+                    try ProductDescription(name: "Product", type: .library(.automatic), targets: ["Target"])
+                ],
                 targets: [
                     try TargetDescription(
                         name: "Target",


### PR DESCRIPTION
motivation: better robustness

changes:replace use of preconditions and asserts with throwing guards

