### PR TITLE
refactor target build settings model

### DIFF
--- a/Sources/PackageModel/BuildSettings.swift
+++ b/Sources/PackageModel/BuildSettings.swift
@@ -46,7 +46,7 @@ public enum BuildSettings {
     /// An individual build setting assignment.
     public struct Assignment: Codable {
         /// The assignment value.
-        public var value: [String]
+        public var values: [String]
 
         // FIXME: This should be a set but we need Equatable existential (or AnyEquatable) for that.
         /// The condition associated with this assignment.
@@ -63,7 +63,7 @@ public enum BuildSettings {
 
         public init() { 
             self._conditions = []
-            self.value = []
+            self.values = []
         }
     }
 
@@ -108,7 +108,7 @@ public enum BuildSettings {
             let values = assignments
                 .lazy
                 .filter { $0.conditions.allSatisfy { $0.satisfies(self.environment) } }
-                .flatMap { $0.value }
+                .flatMap { $0.values }
 
             return Array(values)
         }

--- a/Sources/PackageModel/Manifest/TargetBuildSettingDescription.swift
+++ b/Sources/PackageModel/Manifest/TargetBuildSettingDescription.swift
@@ -19,14 +19,14 @@ public enum TargetBuildSettingDescription {
         case linker
     }
 
-    /// The name of the build setting.
-    public enum SettingName: String, Codable, Equatable {
-        case headerSearchPath
-        case define
-        case linkedLibrary
-        case linkedFramework
+    /// The kind of the build setting, with associate configuration
+    public enum Kind: Codable, Equatable {
+        case headerSearchPath(String)
+        case define(String)
+        case linkedLibrary(String)
+        case linkedFramework(String)
 
-        case unsafeFlags
+        case unsafeFlags([String])
     }
 
     /// An individual build setting.
@@ -35,38 +35,19 @@ public enum TargetBuildSettingDescription {
         /// The tool associated with this setting.
         public let tool: Tool
 
-        /// The name of the setting.
-        public let name: SettingName
+        /// The kind of the setting.
+        public let kind: Kind
 
         /// The condition at which the setting should be applied.
         public let condition: PackageConditionDescription?
 
-        /// The value of the setting.
-        ///
-        /// This is kind of like an "untyped" value since the length
-        /// of the array will depend on the setting type.
-        public let value: [String]
-
         public init(
             tool: Tool,
-            name: SettingName,
-            value: [String],
-            condition: PackageConditionDescription? = nil
+            kind: Kind,
+            condition: PackageConditionDescription? = .none
         ) {
-            switch name {
-            case .headerSearchPath: fallthrough
-            case .define: fallthrough
-            case .linkedLibrary: fallthrough
-            case .linkedFramework:
-                assert(value.count == 1, "\(tool) \(name) \(value)")
-                break
-            case .unsafeFlags:
-                break
-            }
-
             self.tool = tool
-            self.name = name
-            self.value = value
+            self.kind = kind
             self.condition = condition
         }
     }

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -1440,16 +1440,16 @@ private extension BuildSettings.AssignmentTable {
                 switch declaration {
                 case .LINK_LIBRARIES:
                     setting = .OTHER_LDFLAGS
-                    value = assignment.value.map { "-l\($0)" }
+                    value = assignment.values.map { "-l\($0)" }
                 case .LINK_FRAMEWORKS:
                     setting = .OTHER_LDFLAGS
-                    value = assignment.value.flatMap { ["-framework", $0] }
+                    value = assignment.values.flatMap { ["-framework", $0] }
                 default:
                     guard let parsedSetting = PIF.BuildSettings.MultipleValueSetting(rawValue: declaration.name) else {
                         continue
                     }
                     setting = parsedSetting
-                    value = assignment.value
+                    value = assignment.values
                 }
 
                 let pifAssignment = PIFBuildSettingAssignment(

--- a/Sources/Xcodeproj/pbxproj.swift
+++ b/Sources/Xcodeproj/pbxproj.swift
@@ -632,7 +632,7 @@ public func xcodeProject(
                     }
                 }
                 let config = assignment.conditions.compactMap { $0 as? ConfigurationCondition }.first?.configuration
-                try appendSetting(assignment.value, forDecl: decl, to: xcodeTarget.buildSettings, config: config)
+                try appendSetting(assignment.values, forDecl: decl, to: xcodeTarget.buildSettings, config: config)
             }
         }
     }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -2716,38 +2716,34 @@ final class BuildPlanTests: XCTestCase {
                 try TargetDescription(
                     name: "cbar",
                     settings: [
-                    .init(tool: .c, name: .headerSearchPath, value: ["Sources/headers"]),
-                    .init(tool: .cxx, name: .headerSearchPath, value: ["Sources/cppheaders"]),
-
-                    .init(tool: .c, name: .define, value: ["CCC=2"]),
-                    .init(tool: .cxx, name: .define, value: ["RCXX"], condition: .init(config: "release")),
-
-                    .init(tool: .linker, name: .linkedFramework, value: ["best"]),
-
-                    .init(tool: .c, name: .unsafeFlags, value: ["-Icfoo", "-L", "cbar"]),
-                    .init(tool: .cxx, name: .unsafeFlags, value: ["-Icxxfoo", "-L", "cxxbar"]),
+                        .init(tool: .c, kind: .headerSearchPath("Sources/headers")),
+                        .init(tool: .cxx, kind: .headerSearchPath("Sources/cppheaders")),
+                        .init(tool: .c, kind: .define("CCC=2")),
+                        .init(tool: .cxx, kind: .define("RCXX"), condition: .init(config: "release")),
+                        .init(tool: .linker, kind: .linkedFramework("best")),
+                        .init(tool: .c, kind: .unsafeFlags(["-Icfoo", "-L", "cbar"])),
+                        .init(tool: .cxx, kind: .unsafeFlags(["-Icxxfoo", "-L", "cxxbar"])),
                     ]
                 ),
                 try TargetDescription(
                     name: "bar", dependencies: ["cbar", "Dep"],
                     settings: [
-                    .init(tool: .swift, name: .define, value: ["LINUX"], condition: .init(platformNames: ["linux"])),
-                    .init(tool: .swift, name: .define, value: ["RLINUX"], condition: .init(platformNames: ["linux"], config: "release")),
-                    .init(tool: .swift, name: .define, value: ["DMACOS"], condition: .init(platformNames: ["macos"], config: "debug")),
-                    .init(tool: .swift, name: .unsafeFlags, value: ["-Isfoo", "-L", "sbar"]),
+                        .init(tool: .swift, kind: .define("LINUX"), condition: .init(platformNames: ["linux"])),
+                        .init(tool: .swift, kind: .define("RLINUX"), condition: .init(platformNames: ["linux"], config: "release")),
+                        .init(tool: .swift, kind: .define("DMACOS"), condition: .init(platformNames: ["macos"], config: "debug")),
+                        .init(tool: .swift, kind: .unsafeFlags(["-Isfoo", "-L", "sbar"])),
                     ]
                 ),
                 try TargetDescription(
                     name: "exe", dependencies: ["bar"],
                     settings: [
-                    .init(tool: .swift, name: .define, value: ["FOO"]),
-                    .init(tool: .linker, name: .linkedLibrary, value: ["sqlite3"]),
-                    .init(tool: .linker, name: .linkedFramework, value: ["CoreData"], condition: .init(platformNames: ["macos"])),
-                    .init(tool: .linker, name: .unsafeFlags, value: ["-Ilfoo", "-L", "lbar"]),
+                        .init(tool: .swift, kind: .define("FOO")),
+                        .init(tool: .linker, kind: .linkedLibrary("sqlite3")),
+                        .init(tool: .linker, kind: .linkedFramework("CoreData"), condition: .init(platformNames: ["macos"])),
+                        .init(tool: .linker, kind: .unsafeFlags(["-Ilfoo", "-L", "lbar"])),
                     ]
                 ),
             ]
-
         )
 
         let bManifest = Manifest.createFileSystemManifest(
@@ -2761,14 +2757,14 @@ final class BuildPlanTests: XCTestCase {
                 try TargetDescription(
                     name: "t1",
                     settings: [
-                        .init(tool: .swift, name: .define, value: ["DEP"]),
-                        .init(tool: .linker, name: .linkedLibrary, value: ["libz"]),
+                        .init(tool: .swift, kind: .define("DEP")),
+                        .init(tool: .linker, kind: .linkedLibrary("libz")),
                     ]
                 ),
                 try TargetDescription(
                     name: "t2",
                     settings: [
-                        .init(tool: .linker, name: .linkedLibrary, value: ["libz"]),
+                        .init(tool: .linker, kind: .linkedLibrary("libz")),
                     ]
                 ),
             ])

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -1036,15 +1036,15 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(
                             name: "Bar",
                             settings: [
-                                .init(tool: .swift, name: .unsafeFlags, value: ["-Icfoo", "-L", "cbar"]),
-                                .init(tool: .c, name: .unsafeFlags, value: ["-Icfoo", "-L", "cbar"]),
+                                .init(tool: .swift, kind: .unsafeFlags(["-Icfoo", "-L", "cbar"])),
+                                .init(tool: .c, kind: .unsafeFlags(["-Icfoo", "-L", "cbar"])),
                             ]
                         ),
                         TargetDescription(
                             name: "Bar2",
                             settings: [
-                                .init(tool: .swift, name: .unsafeFlags, value: ["-Icfoo", "-L", "cbar"]),
-                                .init(tool: .c, name: .unsafeFlags, value: ["-Icfoo", "-L", "cbar"]),
+                                .init(tool: .swift, kind: .unsafeFlags(["-Icfoo", "-L", "cbar"])),
+                                .init(tool: .c, kind: .unsafeFlags(["-Icfoo", "-L", "cbar"])),
                             ]
                         ),
                         TargetDescription(

--- a/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
@@ -340,18 +340,18 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
 
         let settings = manifest.targets[0].settings
 
-        XCTAssertEqual(settings[0], .init(tool: .c, name: .headerSearchPath, value: ["path/to/foo"]))
-        XCTAssertEqual(settings[1], .init(tool: .c, name: .define, value: ["C"], condition: .init(platformNames: ["linux"])))
-        XCTAssertEqual(settings[2], .init(tool: .c, name: .define, value: ["CC=4"], condition: .init(platformNames: ["linux"], config: "release")))
+        XCTAssertEqual(settings[0], .init(tool: .c, kind: .headerSearchPath("path/to/foo")))
+        XCTAssertEqual(settings[1], .init(tool: .c, kind: .define("C"), condition: .init(platformNames: ["linux"])))
+        XCTAssertEqual(settings[2], .init(tool: .c, kind: .define("CC=4"), condition: .init(platformNames: ["linux"], config: "release")))
 
-        XCTAssertEqual(settings[3], .init(tool: .cxx, name: .headerSearchPath, value: ["path/to/bar"]))
-        XCTAssertEqual(settings[4], .init(tool: .cxx, name: .define, value: ["CXX"]))
+        XCTAssertEqual(settings[3], .init(tool: .cxx, kind: .headerSearchPath("path/to/bar")))
+        XCTAssertEqual(settings[4], .init(tool: .cxx, kind: .define("CXX")))
 
-        XCTAssertEqual(settings[5], .init(tool: .swift, name: .define, value: ["SWIFT"], condition: .init(config: "release")))
-        XCTAssertEqual(settings[6], .init(tool: .swift, name: .define, value: ["SWIFT_DEBUG"], condition: .init(platformNames: ["watchos"], config: "debug")))
+        XCTAssertEqual(settings[5], .init(tool: .swift, kind: .define("SWIFT"), condition: .init(config: "release")))
+        XCTAssertEqual(settings[6], .init(tool: .swift, kind: .define("SWIFT_DEBUG"), condition: .init(platformNames: ["watchos"], config: "debug")))
 
-        XCTAssertEqual(settings[7], .init(tool: .linker, name: .linkedLibrary, value: ["libz"]))
-        XCTAssertEqual(settings[8], .init(tool: .linker, name: .linkedFramework, value: ["CoreData"], condition: .init(platformNames: ["macos", "tvos"])))
+        XCTAssertEqual(settings[7], .init(tool: .linker, kind: .linkedLibrary("libz")))
+        XCTAssertEqual(settings[8], .init(tool: .linker, kind: .linkedFramework("CoreData"), condition: .init(platformNames: ["macos", "tvos"])))
     }
 
     func testSerializedDiagnostics() throws {
@@ -523,7 +523,7 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
             XCTAssertEqual(foo.dependencies, [])
 
             let settings = foo.settings
-            XCTAssertEqual(settings[0], .init(tool: .c, name: .define, value: ["LLVM_ON_WIN32"], condition: .init(platformNames: ["windows"])))
+            XCTAssertEqual(settings[0], .init(tool: .c, kind: .define("LLVM_ON_WIN32"), condition: .init(platformNames: ["windows"])))
         }
     }
 

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -1961,33 +1961,33 @@ class PackageBuilderTests: XCTestCase {
                 try TargetDescription(
                     name: "cbar",
                     settings: [
-                        .init(tool: .c, name: .headerSearchPath, value: ["Sources/headers"]),
-                        .init(tool: .cxx, name: .headerSearchPath, value: ["Sources/cppheaders"]),
+                        .init(tool: .c, kind: .headerSearchPath("Sources/headers")),
+                        .init(tool: .cxx, kind: .headerSearchPath("Sources/cppheaders")),
 
-                        .init(tool: .c, name: .define, value: ["CCC=2"]),
-                        .init(tool: .cxx, name: .define, value: ["CXX"]),
-                        .init(tool: .cxx, name: .define, value: ["RCXX"], condition: .init(config: "release")),
+                        .init(tool: .c, kind: .define("CCC=2")),
+                        .init(tool: .cxx, kind: .define("CXX")),
+                        .init(tool: .cxx, kind: .define("RCXX"), condition: .init(config: "release")),
 
-                        .init(tool: .c, name: .unsafeFlags, value: ["-Icfoo", "-L", "cbar"]),
-                        .init(tool: .cxx, name: .unsafeFlags, value: ["-Icxxfoo", "-L", "cxxbar"]),
+                        .init(tool: .c, kind: .unsafeFlags(["-Icfoo", "-L", "cbar"])),
+                        .init(tool: .cxx, kind: .unsafeFlags(["-Icxxfoo", "-L", "cxxbar"])),
                     ]
                 ),
                 try TargetDescription(
                     name: "bar", dependencies: ["foo"],
                     settings: [
-                        .init(tool: .swift, name: .define, value: ["SOMETHING"]),
-                        .init(tool: .swift, name: .define, value: ["LINUX"], condition: .init(platformNames: ["linux"])),
-                        .init(tool: .swift, name: .define, value: ["RLINUX"], condition: .init(platformNames: ["linux"], config: "release")),
-                        .init(tool: .swift, name: .define, value: ["DMACOS"], condition: .init(platformNames: ["macos"], config: "debug")),
-                        .init(tool: .swift, name: .unsafeFlags, value: ["-Isfoo", "-L", "sbar"]),
+                        .init(tool: .swift, kind: .define("SOMETHING")),
+                        .init(tool: .swift, kind: .define("LINUX"), condition: .init(platformNames: ["linux"])),
+                        .init(tool: .swift, kind: .define("RLINUX"), condition: .init(platformNames: ["linux"], config: "release")),
+                        .init(tool: .swift, kind: .define("DMACOS"), condition: .init(platformNames: ["macos"], config: "debug")),
+                        .init(tool: .swift, kind: .unsafeFlags(["-Isfoo", "-L", "sbar"])),
                     ]
                 ),
                 try TargetDescription(
                     name: "exe", dependencies: ["bar"],
                     settings: [
-                        .init(tool: .linker, name: .linkedLibrary, value: ["sqlite3"]),
-                        .init(tool: .linker, name: .linkedFramework, value: ["CoreData"], condition: .init(platformNames: ["ios"])),
-                        .init(tool: .linker, name: .unsafeFlags, value: ["-Ilfoo", "-L", "lbar"]),
+                        .init(tool: .linker, kind: .linkedLibrary("sqlite3")),
+                        .init(tool: .linker, kind: .linkedFramework("CoreData"), condition: .init(platformNames: ["ios"])),
+                        .init(tool: .linker, kind: .unsafeFlags(["-Ilfoo", "-L", "lbar"])),
                     ]
                 ),
             ]
@@ -2072,18 +2072,18 @@ class PackageBuilderTests: XCTestCase {
                 try TargetDescription(
                     name: "foo",
                     settings: [
-                        .init(tool: .c, name: .unsafeFlags, value: []),
-                        .init(tool: .cxx, name: .unsafeFlags, value: []),
-                        .init(tool: .cxx, name: .unsafeFlags, value: [], condition: .init(config: "release")),
-                        .init(tool: .linker, name: .unsafeFlags, value: []),
+                        .init(tool: .c, kind: .unsafeFlags([])),
+                        .init(tool: .cxx, kind: .unsafeFlags([])),
+                        .init(tool: .cxx, kind: .unsafeFlags([]), condition: .init(config: "release")),
+                        .init(tool: .linker, kind: .unsafeFlags([])),
                     ]
                 ),
                 try TargetDescription(
                     name: "bar",
                     settings: [
-                        .init(tool: .swift, name: .unsafeFlags, value: [], condition: .init(platformNames: ["macos"], config: "debug")),
-                        .init(tool: .linker, name: .unsafeFlags, value: []),
-                        .init(tool: .linker, name: .unsafeFlags, value: [], condition: .init(platformNames: ["linux"])),
+                        .init(tool: .swift, kind: .unsafeFlags([]), condition: .init(platformNames: ["macos"], config: "debug")),
+                        .init(tool: .linker, kind: .unsafeFlags([])),
+                        .init(tool: .linker, kind: .unsafeFlags([]), condition: .init(platformNames: ["linux"])),
                     ]
                 ),
             ]
@@ -2145,7 +2145,7 @@ class PackageBuilderTests: XCTestCase {
                 try TargetDescription(
                     name: "exe",
                     settings: [
-                        .init(tool: .c, name: .headerSearchPath, value: ["/Sources/headers"]),
+                        .init(tool: .c, kind: .headerSearchPath("/Sources/headers")),
                     ]
                 ),
             ]
@@ -2162,7 +2162,7 @@ class PackageBuilderTests: XCTestCase {
                 try TargetDescription(
                     name: "exe",
                     settings: [
-                        .init(tool: .c, name: .headerSearchPath, value: ["../../.."]),
+                        .init(tool: .c, kind: .headerSearchPath("../../..")),
                     ]
                 ),
             ]

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -4390,7 +4390,7 @@ final class WorkspaceTests: XCTestCase {
                 MockPackage(
                     name: "Bar",
                     targets: [
-                        MockTarget(name: "Bar", settings: [.init(tool: .swift, name: .unsafeFlags, value: ["-F", "/tmp"])]),
+                        MockTarget(name: "Bar", settings: [.init(tool: .swift, kind: .unsafeFlags(["-F", "/tmp"]))]),
                     ],
                     products: [
                         MockProduct(name: "Bar", targets: ["Bar"]),
@@ -4413,7 +4413,7 @@ final class WorkspaceTests: XCTestCase {
                 MockPackage(
                     name: "Bar",
                     targets: [
-                        MockTarget(name: "Bar", settings: [.init(tool: .swift, name: .unsafeFlags, value: ["-F", "/tmp"])]),
+                        MockTarget(name: "Bar", settings: [.init(tool: .swift, kind: .unsafeFlags(["-F", "/tmp"]))]),
                     ],
                     products: [
                         MockProduct(name: "Bar", targets: ["Bar"]),
@@ -4423,7 +4423,7 @@ final class WorkspaceTests: XCTestCase {
                 MockPackage(
                     name: "Baz",
                     targets: [
-                        MockTarget(name: "Baz", dependencies: ["Bar"], settings: [.init(tool: .swift, name: .unsafeFlags, value: ["-F", "/tmp"])]),
+                        MockTarget(name: "Baz", dependencies: ["Bar"], settings: [.init(tool: .swift, kind: .unsafeFlags(["-F", "/tmp"]))]),
                     ],
                     products: [
                         MockProduct(name: "Baz", targets: ["Baz"]),

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -2001,64 +2001,52 @@ class PIFBuilderTests: XCTestCase {
                         .init(name: "foo", settings: [
                             .init(
                                 tool: .c,
-                                name: .define,
-                                value: ["ENABLE_BEST_MODE"]),
+                                kind: .define("ENABLE_BEST_MODE")),
                             .init(
                                 tool: .cxx,
-                                name: .headerSearchPath,
-                                value: ["some/path"],
+                                kind: .headerSearchPath("some/path"),
                                 condition: .init(platformNames: ["macos"])),
                             .init(
                                 tool: .linker,
-                                name: .linkedLibrary,
-                                value: ["z"],
+                                kind: .linkedLibrary("z"),
                                 condition: .init(config: "debug")),
                             .init(
                                 tool: .swift,
-                                name: .unsafeFlags,
-                                value: ["-secret", "value"],
+                                kind: .unsafeFlags(["-secret", "value"]),
                                 condition: .init(platformNames: ["macos", "linux"], config: "release")),
                         ]),
                         .init(name: "FooLib", settings: [
                             .init(
                                 tool: .c,
-                                name: .define,
-                                value: ["ENABLE_BEST_MODE"]),
+                                kind: .define("ENABLE_BEST_MODE")),
                             .init(
                                 tool: .cxx,
-                                name: .headerSearchPath,
-                                value: ["some/path"],
+                                kind: .headerSearchPath("some/path"),
                                 condition: .init(platformNames: ["macos"])),
                             .init(
                                 tool: .linker,
-                                name: .linkedLibrary,
-                                value: ["z"],
+                                kind: .linkedLibrary("z"),
                                 condition: .init(config: "debug")),
                             .init(
                                 tool: .swift,
-                                name: .unsafeFlags,
-                                value: ["-secret", "value"],
+                                kind: .unsafeFlags(["-secret", "value"]),
                                 condition: .init(platformNames: ["macos", "linux"], config: "release")),
                         ]),
                         .init(name: "FooTests", type: .test, settings: [
                             .init(
                                 tool: .c,
-                                name: .define,
-                                value: ["ENABLE_BEST_MODE"]),
+                                kind: .define("ENABLE_BEST_MODE")),
                             .init(
                                 tool: .cxx,
-                                name: .headerSearchPath,
-                                value: ["some/path"],
+                                kind: .headerSearchPath("some/path"),
                                 condition: .init(platformNames: ["macos"])),
                             .init(
                                 tool: .linker,
-                                name: .linkedLibrary,
-                                value: ["z"],
+                                kind: .linkedLibrary("z"),
                                 condition: .init(config: "debug")),
                             .init(
                                 tool: .swift,
-                                name: .unsafeFlags,
-                                value: ["-secret", "value"],
+                                kind: .unsafeFlags(["-secret", "value"]),
                                 condition: .init(platformNames: ["macos", "linux"], config: "release")),
                         ]),
                     ]),
@@ -2346,8 +2334,7 @@ class PIFBuilderTests: XCTestCase {
                         .init(name: "MyLib", settings: [
                             .init(
                                 tool: .swift,
-                                name: .unsafeFlags,
-                                value: ["-enable-library-evolution"],
+                                kind: .unsafeFlags(["-enable-library-evolution"]),
                                 condition: .init(config: "release")),
                         ]),
                     ]),

--- a/Tests/XcodeprojTests/PackageGraphTests.swift
+++ b/Tests/XcodeprojTests/PackageGraphTests.swift
@@ -47,9 +47,9 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(
                             name: "Foo",
                             settings: [
-                                .init(tool: .swift, name: .define, value: ["CUSTOM"]),
-                                .init(tool: .swift, name: .define, value: ["LINUX"], condition: .init(platformNames: ["linux"])),
-                                .init(tool: .swift, name: .define, value: ["DMACOS"], condition: .init(platformNames: ["linux", "macos"], config: "debug")),
+                                .init(tool: .swift, kind: .define("CUSTOM")),
+                                .init(tool: .swift, kind: .define("LINUX"), condition: .init(platformNames: ["linux"])),
+                                .init(tool: .swift, kind: .define("DMACOS"), condition: .init(platformNames: ["linux", "macos"], config: "debug")),
                             ]
                         ),
                         TargetDescription(name: "FooTests", dependencies: ["Foo"], type: .test),


### PR DESCRIPTION
motivation: as part of auditing the code for preconditions and assets it came to light that the target build setting model can be improved to handle preconditions via the type system

changes:
* move the build settings values into the build setting kind enum as associated values (istead of floating attribute)
* adjust call sites and test

