### PR TITLE
deprecate validation that a resource localization exists when English is the default language

### DIFF
--- a/Sources/PackageLoading/Diagnostics.swift
+++ b/Sources/PackageLoading/Diagnostics.swift
@@ -127,17 +127,6 @@ extension Basics.Diagnostic {
             localized variants will never be chosen
             """)
     }
-
-    static func missingDefaultLocalizationResource(
-        resource: String,
-        targetName: String,
-        defaultLocalization: String
-    ) -> Self {
-        .warning("""
-            resource '\(resource)' in target '\(targetName)' is missing the default localization \
-            '\(defaultLocalization)'; the default localization is used as a fallback when no other localization matches
-            """)
-    }
 }
 
 extension ObservabilityMetadata {

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -172,7 +172,6 @@ public struct TargetSourcesBuilder {
         diagnoseConflictingResources(in: resources)
         diagnoseCopyConflictsWithLocalizationDirectories(in: resources)
         diagnoseLocalizedAndUnlocalizedVariants(in: resources)
-        diagnoseMissingDevelopmentRegionResource(in: resources)
         diagnoseInfoPlistConflicts(in: resources)
         diagnoseInvalidResource(in: target.resources)
 
@@ -318,30 +317,6 @@ public struct TargetSourcesBuilder {
             let hasUnlocalized = resources.contains(where: { $0.localization == nil })
             if hasLocalizations && hasUnlocalized {
                 self.observabilityScope.emit(.localizedAndUnlocalizedVariants(resource: basename, targetName: target.name))
-            }
-        }
-    }
-
-    private func diagnoseMissingDevelopmentRegionResource(in resources: [Resource]) {
-        // We can't diagnose anything here without a default localization set.
-        guard let defaultLocalization = self.defaultLocalization else {
-            return
-        }
-
-        // rdar://86297221
-        // There is no need to validate for english, because the string key is already in english
-        if self.defaultLocalization == "en" {
-            return
-        }
-
-        let localizedResources = resources.lazy.filter({ $0.localization != nil && $0.localization != "Base" })
-        let resourcesByBasename = Dictionary(grouping: localizedResources, by: { $0.path.basename })
-        for (basename, resources) in resourcesByBasename {
-            if !resources.contains(where: { $0.localization == defaultLocalization }) {
-                self.observabilityScope.emit(.missingDefaultLocalizationResource(
-                    resource: basename,
-                    targetName: target.name,
-                    defaultLocalization: defaultLocalization))
             }
         }
     }

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -328,6 +328,12 @@ public struct TargetSourcesBuilder {
             return
         }
 
+        // rdar://86297221
+        // There is no need to validate for english, because the string key is already in english
+        if self.defaultLocalization == "en" {
+            return
+        }
+
         let localizedResources = resources.lazy.filter({ $0.localization != nil && $0.localization != "Base" })
         let resourcesByBasename = Dictionary(grouping: localizedResources, by: { $0.path.basename })
         for (basename, resources) in resourcesByBasename {

--- a/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
+++ b/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
@@ -227,8 +227,8 @@ class TargetSourcesBuilderTests: XCTestCase {
             toolsVersion: .minimumRequired,
             fileTypes: ["something"])
 
-        build(target: target, additionalFileRules: [somethingRule], toolsVersion: .v5, fs: fs) { _, _, _, _, _, _, _, _  in
-            // No diagnostics
+        build(target: target, additionalFileRules: [somethingRule], toolsVersion: .v5, fs: fs) { _, _, _, _, _, _, _, diagnostics in
+            XCTAssertNoDiagnostics(diagnostics)
         }
     }
 
@@ -258,7 +258,8 @@ class TargetSourcesBuilderTests: XCTestCase {
             fileTypes: ["something"]
         )
 
-        build(target: target, additionalFileRules: [somethingRule], toolsVersion: .v5_5, fs: fs) { sources, _, _, _, _, _, _, _  in
+        build(target: target, additionalFileRules: [somethingRule], toolsVersion: .v5_5, fs: fs) { sources, _, _, _, _, _, _, diagnostics in
+            XCTAssertNoDiagnostics(diagnostics)
             XCTAssertEqual(
                 sources.paths.map(\.pathString).sorted(),
                 files.sorted()
@@ -279,16 +280,18 @@ class TargetSourcesBuilderTests: XCTestCase {
                 "/Resources/Sub/foo.txt"
             )
 
-            build(target: target, toolsVersion: .v5_3, checkProblemsOnly: false, fs: fs) { _, _, _, _, identity, kind, path, diagnostics in
-                var diagnosticsFound = [Basics.Diagnostic?]()
-                diagnosticsFound.append(diagnostics.check(diagnostic: "multiple resources named 'foo.txt' in target 'Foo'", severity: .error))
-                diagnosticsFound.append(diagnostics.checkUnordered(diagnostic: "found 'Resources/foo.txt'", severity: .info))
-                diagnosticsFound.append(diagnostics.checkUnordered(diagnostic: "found 'Resources/Sub/foo.txt'", severity: .info))
+            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, kind, path, diagnostics in
+                testDiagnostics(diagnostics, problemsOnly: false) { result in
+                    var diagnosticsFound = [Basics.Diagnostic?]()
+                    diagnosticsFound.append(result.check(diagnostic: "multiple resources named 'foo.txt' in target 'Foo'", severity: .error))
+                    diagnosticsFound.append(result.checkUnordered(diagnostic: "found 'Resources/foo.txt'", severity: .info))
+                    diagnosticsFound.append(result.checkUnordered(diagnostic: "found 'Resources/Sub/foo.txt'", severity: .info))
 
-                for diagnostic in diagnosticsFound {
-                    XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
-                    XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
-                    XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+                    for diagnostic in diagnosticsFound {
+                        XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
+                        XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
+                        XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+                    }
                 }
             }
         }
@@ -306,16 +309,18 @@ class TargetSourcesBuilderTests: XCTestCase {
                 "/Copied/foo.txt"
             )
 
-            build(target: target, toolsVersion: .v5_3, checkProblemsOnly: false, fs: fs) { _, _, _, _, identity, kind, path, diagnostics in
-                var diagnosticsFound = [Basics.Diagnostic?]()
-                diagnosticsFound.append(diagnostics.check(diagnostic: "multiple resources named 'foo.txt' in target 'Foo'", severity: .error))
-                diagnosticsFound.append(diagnostics.checkUnordered(diagnostic: "found 'Processed/foo.txt'", severity: .info))
-                diagnosticsFound.append(diagnostics.checkUnordered(diagnostic: "found 'Copied/foo.txt'", severity: .info))
+            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, kind, path, diagnostics in
+                testDiagnostics(diagnostics, problemsOnly: false) { result in
+                    var diagnosticsFound = [Basics.Diagnostic?]()
+                    diagnosticsFound.append(result.check(diagnostic: "multiple resources named 'foo.txt' in target 'Foo'", severity: .error))
+                    diagnosticsFound.append(result.checkUnordered(diagnostic: "found 'Processed/foo.txt'", severity: .info))
+                    diagnosticsFound.append(result.checkUnordered(diagnostic: "found 'Copied/foo.txt'", severity: .info))
 
-                for diagnostic in diagnosticsFound {
-                    XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
-                    XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
-                    XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+                    for diagnostic in diagnosticsFound {
+                        XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
+                        XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
+                        XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+                    }
                 }
             }
         }
@@ -334,7 +339,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             )
 
             build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, _, _, _, diagnostics in
-                // No diagnostics
+                XCTAssertNoDiagnostics(diagnostics)
             }
         }
 
@@ -351,16 +356,18 @@ class TargetSourcesBuilderTests: XCTestCase {
                 "/B/Copy/foo.txt"
             )
 
-            build(target: target, toolsVersion: .v5_3, checkProblemsOnly: false, fs: fs) { _, _, _, _, identity, kind, path, diagnostics in
-                var diagnosticsFound = [Basics.Diagnostic?]()
-                diagnosticsFound.append(diagnostics.check(diagnostic: "multiple resources named 'Copy' in target 'Foo'", severity: .error))
-                diagnosticsFound.append(diagnostics.checkUnordered(diagnostic: "found 'A/Copy'", severity: .info))
-                diagnosticsFound.append(diagnostics.checkUnordered(diagnostic: "found 'B/Copy'", severity: .info))
+            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, kind, path, diagnostics in
+                testDiagnostics(diagnostics, problemsOnly: false) { result in
+                    var diagnosticsFound = [Basics.Diagnostic?]()
+                    diagnosticsFound.append(result.check(diagnostic: "multiple resources named 'Copy' in target 'Foo'", severity: .error))
+                    diagnosticsFound.append(result.checkUnordered(diagnostic: "found 'A/Copy'", severity: .info))
+                    diagnosticsFound.append(result.checkUnordered(diagnostic: "found 'B/Copy'", severity: .info))
 
-                for diagnostic in diagnosticsFound {
-                    XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
-                    XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
-                    XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+                    for diagnostic in diagnosticsFound {
+                        XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
+                        XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
+                        XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+                    }
                 }
             }
         }
@@ -378,16 +385,18 @@ class TargetSourcesBuilderTests: XCTestCase {
                 "/B/EN.lproj/foo.txt"
             )
 
-            build(target: target, toolsVersion: .v5_3, checkProblemsOnly: false, fs: fs) { _, _, _, _, identity, kind, path, diagnostics in
-                var diagnosticsFound = [Basics.Diagnostic?]()
-                diagnosticsFound.append(diagnostics.check(diagnostic: "multiple resources named 'en.lproj/foo.txt' in target 'Foo'", severity: .error))
-                diagnosticsFound.append(diagnostics.checkUnordered(diagnostic: "found 'A/en.lproj/foo.txt'", severity: .info))
-                diagnosticsFound.append(diagnostics.checkUnordered(diagnostic: "found 'B/EN.lproj/foo.txt'", severity: .info))
+            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, kind, path, diagnostics in
+                testDiagnostics(diagnostics, problemsOnly: false) { result in
+                    var diagnosticsFound = [Basics.Diagnostic?]()
+                    diagnosticsFound.append(result.check(diagnostic: "multiple resources named 'en.lproj/foo.txt' in target 'Foo'", severity: .error))
+                    diagnosticsFound.append(result.checkUnordered(diagnostic: "found 'A/en.lproj/foo.txt'", severity: .info))
+                    diagnosticsFound.append(result.checkUnordered(diagnostic: "found 'B/EN.lproj/foo.txt'", severity: .info))
 
-                for diagnostic in diagnosticsFound {
-                    XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
-                    XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
-                    XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+                    for diagnostic in diagnosticsFound {
+                        XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
+                        XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
+                        XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+                    }
                 }
             }
         }
@@ -406,13 +415,15 @@ class TargetSourcesBuilderTests: XCTestCase {
             )
 
             build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, kind, path, diagnostics in
-                let diagnostic = diagnostics.check(
-                    diagnostic: "resource 'B/en.lproj' in target 'Foo' conflicts with other localization directories",
-                    severity: .error
-                )
-                XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
-                XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
-                XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+                testDiagnostics(diagnostics) { result in
+                    let diagnostic = result.check(
+                        diagnostic: "resource 'B/en.lproj' in target 'Foo' conflicts with other localization directories",
+                        severity: .error
+                    )
+                    XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
+                    XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
+                    XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+                }
             }
         }
     }
@@ -424,9 +435,9 @@ class TargetSourcesBuilderTests: XCTestCase {
             "/en.lproj/Localizable.strings"
         )
 
-        build(target: target, toolsVersion: .v5_2, fs: fs) { _, resources, _, _, _, _, _, _ in
+        build(target: target, toolsVersion: .v5_2, fs: fs) { _, resources, _, _, _, _, _, diagnostics in
             XCTAssert(resources.isEmpty)
-            // No diagnostics
+            XCTAssertNoDiagnostics(diagnostics)
         }
     }
 
@@ -442,13 +453,15 @@ class TargetSourcesBuilderTests: XCTestCase {
         )
 
         build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, kind, path, diagnostics in
-            let diagnostic = diagnostics.check(
-                diagnostic: "localization directory 'Processed/en.lproj' in target 'Foo' contains sub-directories, which is forbidden",
-                severity: .error
-            )
-            XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
-            XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
-            XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+            testDiagnostics(diagnostics) { result in
+                let diagnostic = result.check(
+                    diagnostic: "localization directory 'Processed/en.lproj' in target 'Foo' contains sub-directories, which is forbidden",
+                    severity: .error
+                )
+                XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
+                XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
+                XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+            }
         }
     }
 
@@ -462,16 +475,18 @@ class TargetSourcesBuilderTests: XCTestCase {
         )
 
         build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, kind, path, diagnostics in
-            let diagnostic = diagnostics.check(
-                diagnostic: .contains("""
-                    resource 'Resources/en.lproj/Localizable.strings' in target 'Foo' is in a localization directory \
-                    and has an explicit localization declaration
-                    """),
-                severity: .error
-            )
-            XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
-            XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
-            XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+            testDiagnostics(diagnostics) { result in
+                let diagnostic = result.check(
+                    diagnostic: .contains("""
+                        resource 'Resources/en.lproj/Localizable.strings' in target 'Foo' is in a localization directory \
+                        and has an explicit localization declaration
+                        """),
+                    severity: .error
+                )
+                XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
+                XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
+                XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+            }
         }
     }
 
@@ -492,14 +507,24 @@ class TargetSourcesBuilderTests: XCTestCase {
             "/Icon.png"
         )
 
-        build(target: target, defaultLocalization: "fr", toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, kind, path, diagnostics in
-            let diagnostic = diagnostics.check(
-                diagnostic: .contains("resource 'Icon.png' in target 'Foo' is missing the default localization 'fr'"),
-                severity: .warning
-            )
-            XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
-            XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
-            XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+        do {
+            build(target: target, defaultLocalization: "fr", toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, kind, path, diagnostics in
+                testDiagnostics(diagnostics) { result in
+                    let diagnostic = result.check(
+                        diagnostic: .contains("resource 'Icon.png' in target 'Foo' is missing the default localization 'fr'"),
+                        severity: .warning
+                    )
+                    XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
+                    XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
+                    XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+                }
+            }
+        }
+
+        do {
+            build(target: target, defaultLocalization: "en", toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, kind, path, diagnostics in
+                XCTAssertNoDiagnostics(diagnostics)
+            }
         }
     }
 
@@ -522,28 +547,30 @@ class TargetSourcesBuilderTests: XCTestCase {
         )
 
         build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, kind, path, diagnostics in
-            var diagnosticsFound = [Basics.Diagnostic?]()
-            diagnosticsFound.append(diagnostics.checkUnordered(
-                diagnostic: .contains("resource 'Localizable.strings' in target 'Foo' has both localized and un-localized variants"),
-                severity: .warning
-            ))
-            diagnosticsFound.append(diagnostics.checkUnordered(
-                diagnostic: .contains("resource 'Storyboard.storyboard' in target 'Foo' has both localized and un-localized variants"),
-                severity: .warning
-            ))
-            diagnosticsFound.append(diagnostics.checkUnordered(
-                diagnostic: .contains("resource 'Image.png' in target 'Foo' has both localized and un-localized variants"),
-                severity: .warning
-            ))
-            diagnosticsFound.append(diagnostics.checkUnordered(
-                diagnostic: .contains("resource 'Icon.png' in target 'Foo' has both localized and un-localized variants"),
-                severity: .warning
-            ))
+            testDiagnostics(diagnostics) { result in
+                var diagnosticsFound = [Basics.Diagnostic?]()
+                diagnosticsFound.append(result.checkUnordered(
+                    diagnostic: .contains("resource 'Localizable.strings' in target 'Foo' has both localized and un-localized variants"),
+                    severity: .warning
+                ))
+                diagnosticsFound.append(result.checkUnordered(
+                    diagnostic: .contains("resource 'Storyboard.storyboard' in target 'Foo' has both localized and un-localized variants"),
+                    severity: .warning
+                ))
+                diagnosticsFound.append(result.checkUnordered(
+                    diagnostic: .contains("resource 'Image.png' in target 'Foo' has both localized and un-localized variants"),
+                    severity: .warning
+                ))
+                diagnosticsFound.append(result.checkUnordered(
+                    diagnostic: .contains("resource 'Icon.png' in target 'Foo' has both localized and un-localized variants"),
+                    severity: .warning
+                ))
 
-            for diagnostic in diagnosticsFound {
-                XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
-                XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
-                XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+                for diagnostic in diagnosticsFound {
+                    XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
+                    XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
+                    XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+                }
             }
         }
     }
@@ -608,13 +635,15 @@ class TargetSourcesBuilderTests: XCTestCase {
             )
 
             build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, kind, path, diagnostics in
-                let diagnostic = diagnostics.check(
-                    diagnostic: .contains("resource 'Resources/Processed/Info.plist' in target 'Foo' is forbidden"),
-                    severity: .error
-                )
-                XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
-                XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
-                XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+                testDiagnostics(diagnostics) { result in
+                    let diagnostic = result.check(
+                        diagnostic: .contains("resource 'Resources/Processed/Info.plist' in target 'Foo' is forbidden"),
+                        severity: .error
+                    )
+                    XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
+                    XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
+                    XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+                }
             }
         }
 
@@ -628,13 +657,15 @@ class TargetSourcesBuilderTests: XCTestCase {
             )
 
             build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, kind, path, diagnostics in
-                let diagnostic = diagnostics.check(
-                    diagnostic: .contains("resource 'Resources/Copied/Info.plist' in target 'Foo' is forbidden"),
-                    severity: .error
-                )
-                XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
-                XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
-                XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+                testDiagnostics(diagnostics) { result in
+                    let diagnostic = result.check(
+                        diagnostic: .contains("resource 'Resources/Copied/Info.plist' in target 'Foo' is forbidden"),
+                        severity: .error
+                    )
+                    XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
+                    XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
+                    XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+                }
             }
         }
     }
@@ -975,11 +1006,10 @@ class TargetSourcesBuilderTests: XCTestCase {
         defaultLocalization: String? = nil,
         additionalFileRules: [FileRuleDescription] = [],
         toolsVersion: ToolsVersion,
-        checkProblemsOnly: Bool = true,
         fs: FileSystem,
         file: StaticString = #file,
         line: UInt = #line,
-        checker: (Sources, [Resource], [AbsolutePath], [AbsolutePath], PackageIdentity, PackageReference.Kind, AbsolutePath, DiagnosticsTestResult) throws -> Void
+        checker: (Sources, [Resource], [AbsolutePath], [AbsolutePath], PackageIdentity, PackageReference.Kind, AbsolutePath, [Basics.Diagnostic]) throws -> Void
     ) {
         let observability = ObservabilitySystem.makeForTesting()
         let builder = TargetSourcesBuilder(
@@ -997,13 +1027,9 @@ class TargetSourcesBuilderTests: XCTestCase {
 
         do {
             let (sources, resources, headers, _, others) = try builder.run()
-
-            testDiagnostics(observability.diagnostics, problemsOnly: checkProblemsOnly, file: file, line: line) { diagnostics in
-                try checker(sources, resources, headers, others, builder.packageIdentity, builder.packageKind, builder.packagePath, diagnostics)
-            }
+            try checker(sources, resources, headers, others, builder.packageIdentity, builder.packageKind, builder.packagePath, observability.diagnostics)
         } catch {
             XCTFail(error.localizedDescription, file: file, line: line)
         }
     }
-
 }

--- a/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
+++ b/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
@@ -490,6 +490,8 @@ class TargetSourcesBuilderTests: XCTestCase {
         }
     }
 
+    // rdar://86297221
+    // There is no need to validate localization exists for default localization
     func testMissingDefaultLocalization() throws {
         let target = try TargetDescription(name: "Foo", resources: [
             .init(rule: .process(localization: .none), path: "Resources"),
@@ -509,15 +511,7 @@ class TargetSourcesBuilderTests: XCTestCase {
 
         do {
             build(target: target, defaultLocalization: "fr", toolsVersion: .v5_3, fs: fs) { _, _, _, _, identity, kind, path, diagnostics in
-                testDiagnostics(diagnostics) { result in
-                    let diagnostic = result.check(
-                        diagnostic: .contains("resource 'Icon.png' in target 'Foo' is missing the default localization 'fr'"),
-                        severity: .warning
-                    )
-                    XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
-                    XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
-                    XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
-                }
+                XCTAssertNoDiagnostics(diagnostics)
             }
         }
 


### PR DESCRIPTION
motivation: the warning is redundant

changes:
* remove the validation when english is the default langauge
* adjust test
* refactor TargetSourcesBuilderTests so we can test for no diagnostics

rdar://86297221
