### PR TITLE
cancellation handler

### DIFF
--- a/Sources/Basics/Archiver+Zip.swift
+++ b/Sources/Basics/Archiver+Zip.swift
@@ -12,11 +12,14 @@ import TSCBasic
 import Dispatch
 
 /// An `Archiver` that handles ZIP archives using the command-line `zip` and `unzip` tools.
-public struct ZipArchiver: Archiver {
+public struct ZipArchiver: Archiver, Cancellable {
     public var supportedExtensions: Set<String> { ["zip"] }
 
     /// The file-system implementation used for various file-system operations and checks.
     private let fileSystem: FileSystem
+
+    /// Helper for cancelling in-fligh requests
+    private let cancellator: Cancellator
 
     /// Creates a `ZipArchiver`.
     ///
@@ -24,6 +27,7 @@ public struct ZipArchiver: Archiver {
     ///   - fileSystem: The file-system to used by the `ZipArchiver`.
     public init(fileSystem: FileSystem) {
         self.fileSystem = fileSystem
+        self.cancellator = Cancellator(observabilityScope: .none)
     }
 
     public func extract(
@@ -31,35 +35,76 @@ public struct ZipArchiver: Archiver {
         to destinationPath: AbsolutePath,
         completion: @escaping (Result<Void, Error>) -> Void
     ) {
-        guard fileSystem.exists(archivePath) else {
-            completion(.failure(FileSystemError(.noEntry, archivePath)))
-            return
+        do {
+            guard self.fileSystem.exists(archivePath) else {
+                throw FileSystemError(.noEntry, archivePath)
+            }
+
+            guard self.fileSystem.isDirectory(destinationPath) else {
+                throw FileSystemError(.notDirectory, destinationPath)
+            }
+
+            let process = Process(arguments: ["unzip", archivePath.pathString, "-d", destinationPath.pathString])
+            guard let registrationKey = self.cancellator.register(process) else {
+                throw StringError("cancellation")
+            }
+
+            DispatchQueue.sharedConcurrent.async {
+                defer { self.cancellator.deregister(registrationKey) }
+                completion(.init(catching: {
+                    try process.launch()
+                    let processResult = try process.waitUntilExit()
+                    guard processResult.exitStatus == .terminated(code: 0) else {
+                        throw try StringError(processResult.utf8stderrOutput())
+                    }
+                }))
+            }
+        } catch {
+            return completion(.failure(error))
         }
 
-        guard fileSystem.isDirectory(destinationPath) else {
-            completion(.failure(FileSystemError(.notDirectory, destinationPath)))
-            return
-        }
-
+        /*
         Process.popen(arguments: ["unzip", archivePath.pathString, "-d", destinationPath.pathString], queue: .sharedConcurrent) { result in
             completion(result.tryMap { processResult in
                 guard processResult.exitStatus == .terminated(code: 0) else {
                     throw try StringError(processResult.utf8stderrOutput())
                 }
             })
-        }
+        }*/
     }
 
     public func validate(path: AbsolutePath, completion: @escaping (Result<Bool, Error>) -> Void) {
-        guard fileSystem.exists(path) else {
-            completion(.failure(FileSystemError(.noEntry, path)))
-            return
+        do {
+            guard self.fileSystem.exists(path) else {
+                throw FileSystemError(.noEntry, path)
+            }
+
+            let process = Process(arguments: ["unzip", "-t", path.pathString])
+            guard let registrationKey = self.cancellator.register(process) else {
+                throw StringError("cancellation")
+            }
+
+            DispatchQueue.sharedConcurrent.async {
+                defer { self.cancellator.deregister(registrationKey) }
+                completion(.init(catching: {
+                    try process.launch()
+                    let processResult = try process.waitUntilExit()
+                    return processResult.exitStatus == .terminated(code: 0)
+                }))
+            }
+        } catch {
+            return completion(.failure(error))
         }
 
+        /*
         Process.popen(arguments: ["unzip", "-t", path.pathString], queue: .sharedConcurrent) { result in
             completion(result.tryMap { processResult in
                 return processResult.exitStatus == .terminated(code: 0)
             })
-        }
+        }*/
+    }
+
+    public func cancel(deadline: DispatchTime) throws {
+        try self.cancellator.cancel(deadline: deadline)
     }
 }

--- a/Sources/Basics/Archiver+Zip.swift
+++ b/Sources/Basics/Archiver+Zip.swift
@@ -62,15 +62,6 @@ public struct ZipArchiver: Archiver, Cancellable {
         } catch {
             return completion(.failure(error))
         }
-
-        /*
-        Process.popen(arguments: ["unzip", archivePath.pathString, "-d", destinationPath.pathString], queue: .sharedConcurrent) { result in
-            completion(result.tryMap { processResult in
-                guard processResult.exitStatus == .terminated(code: 0) else {
-                    throw try StringError(processResult.utf8stderrOutput())
-                }
-            })
-        }*/
     }
 
     public func validate(path: AbsolutePath, completion: @escaping (Result<Bool, Error>) -> Void) {
@@ -95,13 +86,6 @@ public struct ZipArchiver: Archiver, Cancellable {
         } catch {
             return completion(.failure(error))
         }
-
-        /*
-        Process.popen(arguments: ["unzip", "-t", path.pathString], queue: .sharedConcurrent) { result in
-            completion(result.tryMap { processResult in
-                return processResult.exitStatus == .terminated(code: 0)
-            })
-        }*/
     }
 
     public func cancel(deadline: DispatchTime) throws {

--- a/Sources/Basics/CMakeLists.txt
+++ b/Sources/Basics/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(Basics
   Archiver+Zip.swift
   AuthorizationProvider.swift
   ByteString+Extensions.swift
+  Cancellator.swift
   ConcurrencyHelpers.swift
   Dictionary+Extensions.swift
   DispatchTimeInterval+Extensions.swift

--- a/Sources/Basics/Cancellator.swift
+++ b/Sources/Basics/Cancellator.swift
@@ -1,0 +1,135 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import Dispatch
+import Foundation
+import TSCBasic
+
+public typealias CancellationHandler = (DispatchTime) throws -> Void
+
+public class Cancellator: Cancellable {
+    public typealias RegistrationKey = String
+
+    private let observabilityScope: ObservabilityScope?
+    private let registry = ThreadSafeKeyValueStore<String, (name: String, handler: CancellationHandler)>()
+    private let cancelationQueue = DispatchQueue(label: "org.swift.swiftpm.cancellator", qos: .userInteractive, attributes: .concurrent)
+    private let cancelling = ThreadSafeBox<Bool>(false)
+
+    public init(observabilityScope: ObservabilityScope?) {
+        self.observabilityScope = observabilityScope
+    }
+
+    @discardableResult
+    public func register(name: String, handler: @escaping CancellationHandler) -> RegistrationKey? {
+        if self.cancelling.get(default: false) {
+            self.observabilityScope?.emit(debug: "not registering '\(name)' with terminator, termination in progress")
+            return .none
+        }
+        let key = UUID().uuidString
+        self.observabilityScope?.emit(debug: "registering '\(name)' with terminator")
+        self.registry[key] = (name: name, handler: handler)
+        return key
+    }
+
+    @discardableResult
+    public func register(name: String, handler: Cancellable) -> RegistrationKey? {
+        self.register(name: name, handler: handler.cancel(deadline:))
+    }
+
+    @discardableResult
+    public func register(name: String, handler: @escaping () throws -> Void) -> RegistrationKey? {
+        self.register(name: name, handler: { _ in try handler() })
+    }
+
+    public func register(_ process: TSCBasic.Process) -> RegistrationKey? {
+        self.register(name: "\(process.arguments.joined(separator: " "))", handler:  process.terminate)
+    }
+
+    public func deregister(_ key: RegistrationKey) {
+        self.registry[key] = nil
+    }
+
+    public func cancel(deadline: DispatchTime) throws -> Void {
+        self._cancel(deadline: deadline)
+    }
+
+    // marked internal for testing
+    @discardableResult
+    internal func _cancel(deadline: DispatchTime? = .none)-> Int {
+        self.cancelling.put(true)
+
+        self.observabilityScope?.emit(info: "starting cancellation cycle with \(self.registry.count) cancellation handlers registered")
+
+        let deadline = deadline ?? .now() + .seconds(30)
+        // deadline for individual handlers set slightly before overall deadline
+        let delta: DispatchTimeInterval = .nanoseconds(abs(deadline.distance(to: .now()).nanoseconds() ?? 0)  / 5)
+        let handlersDeadline = deadline - delta
+
+        let cancellationHandlers = self.registry.get()
+        let cancelled = ThreadSafeArrayStore<String>()
+        let group = DispatchGroup()
+        for (_, (name, handler)) in cancellationHandlers {
+            self.cancelationQueue.async(group: group) {
+                do {
+                    self.observabilityScope?.emit(debug: "cancelling '\(name)'")
+                    try handler(handlersDeadline)
+                    cancelled.append(name)
+                } catch {
+                    self.observabilityScope?.emit(warning: "failed cancelling '\(name)': \(error)")
+                }
+            }
+        }
+
+        if case .timedOut = group.wait(timeout: deadline) {
+            self.observabilityScope?.emit(warning: "timeout waiting for cancellation with \(cancellationHandlers.count - cancelled.count) cancellation handlers remaining")
+        } else {
+            self.observabilityScope?.emit(info: "cancellation cycle completed successfully")
+        }
+
+        self.cancelling.put(false)
+
+        return cancelled.count
+    }
+}
+
+public protocol Cancellable {
+    func cancel(deadline: DispatchTime) throws -> Void
+}
+
+public struct CancellationError: Error, CustomStringConvertible {
+    public let description = "Operation cancelled"
+
+    public init() {}
+}
+
+extension TSCBasic.Process {
+    fileprivate func terminate(timeout: DispatchTime) {
+        // send graceful shutdown signal
+        self.signal(SIGINT)
+
+        // start a thread to see if we need to terminate more forcibly
+        let forceKillSemaphore = DispatchSemaphore(value: 0)
+        let forceKillThread = TSCBasic.Thread {
+            if case .timedOut = forceKillSemaphore.wait(timeout: timeout) {
+                // send a force-kill signal
+                #if os(Windows)
+                self.signal(SIGTERM)
+                #else
+                self.signal(SIGKILL)
+                #endif
+            }
+        }
+        forceKillThread.start()
+        _ = try? self.waitUntilExit()
+        forceKillSemaphore.signal() // let the force-kill thread know we do not need it any more
+        // join the force-kill thread thread so we don't exit before everything terminates
+        forceKillThread.join()
+    }
+}

--- a/Sources/Basics/ConcurrencyHelpers.swift
+++ b/Sources/Basics/ConcurrencyHelpers.swift
@@ -55,9 +55,12 @@ public final class ThreadSafeKeyValueStore<Key, Value> where Key: Hashable {
         }
     }
 
-    public func clear() {
+    @discardableResult
+    public func clear() -> [Key: Value] {
         self.lock.withLock {
+            let underlying = self.underlying
             self.underlying.removeAll()
+            return underlying
         }
     }
 
@@ -113,9 +116,12 @@ public final class ThreadSafeArrayStore<Value> {
         }
     }
 
-    public func clear() {
+    @discardableResult
+    public func clear() -> [Value] {
         self.lock.withLock {
-            self.underlying = []
+            let underlying = self.underlying
+            self.underlying.removeAll()
+            return underlying
         }
     }
 

--- a/Sources/Basics/DispatchTimeInterval+Extensions.swift
+++ b/Sources/Basics/DispatchTimeInterval+Extensions.swift
@@ -27,6 +27,21 @@ extension DispatchTimeInterval {
         }
     }
 
+    public func nanoseconds() -> Int? {
+        switch self {
+        case .seconds(let value):
+            return value.multipliedReportingOverflow(by: 1_000_000_000).partialValue
+        case .milliseconds(let value):
+            return value.multipliedReportingOverflow(by: 1_000_000).partialValue
+        case .microseconds(let value):
+            return value.multipliedReportingOverflow(by: 1000).partialValue
+        case .nanoseconds(let value):
+            return value
+        default:
+            return nil
+        }
+    }
+
     public func milliseconds() -> Int? {
         switch self {
         case .seconds(let value):

--- a/Sources/Basics/DispatchTimeInterval+Extensions.swift
+++ b/Sources/Basics/DispatchTimeInterval+Extensions.swift
@@ -96,7 +96,7 @@ extension DispatchTimeInterval {
 #if os(Linux) || os(Windows) || os(Android) || os(OpenBSD)
 extension DispatchTime {
     public func distance(to: DispatchTime) -> DispatchTimeInterval {
-        let duration = to.uptimeNanoseconds - self.uptimeNanoseconds
+        let duration = to.uptimeNanoseconds.subtractingReportingOverflow(self.uptimeNanoseconds).partialValue
         return .nanoseconds(duration >= Int.max ? Int.max : Int(duration))
     }
 }

--- a/Sources/Basics/HTTPClient.swift
+++ b/Sources/Basics/HTTPClient.swift
@@ -15,6 +15,7 @@ import class Foundation.JSONDecoder
 import class Foundation.NSError
 import class Foundation.OperationQueue
 import struct Foundation.URL
+import struct Foundation.UUID
 import TSCBasic
 
 #if canImport(Glibc)
@@ -35,7 +36,7 @@ public enum HTTPClientError: Error, Equatable {
 
 // MARK: - HTTPClient
 
-public struct HTTPClient {
+public struct HTTPClient: Cancellable {
     public typealias Configuration = HTTPClientConfiguration
     public typealias Request = HTTPClientRequest
     public typealias Response = HTTPClientResponse
@@ -47,9 +48,12 @@ public struct HTTPClient {
     private let underlying: Handler
 
     /// DispatchSemaphore to restrict concurrent operations on manager.
-     private let concurrencySemaphore: DispatchSemaphore
-     /// OperationQueue to park pending requests
-     private let requestsQueue: OperationQueue
+    private let concurrencySemaphore: DispatchSemaphore
+    /// OperationQueue to park pending requests
+    private let requestsQueue: OperationQueue
+
+    // tracks outstanding requests for cancellation
+    private var outstandingRequests = ThreadSafeKeyValueStore<UUID, (url: URL, completion: CompletionHandler, progress: ProgressHandler?, queue: DispatchQueue)>()
 
     // static to share across instances of the http client
     private static var hostsErrorsLock = Lock()
@@ -76,7 +80,12 @@ public struct HTTPClient {
     ///   - observabilityScope: the observability scope to emit diagnostics on
     ///   - progress: A progress handler to handle progress for example for downloads
     ///   - completion: A completion handler to be notified of the completion of the request.
-    public func execute(_ request: Request, observabilityScope: ObservabilityScope? = nil, progress: ProgressHandler? = nil, completion: @escaping CompletionHandler) {
+    public func execute(
+        _ request: Request,
+        observabilityScope: ObservabilityScope? = nil,
+        progress: ProgressHandler? = nil,
+        completion: @escaping CompletionHandler
+    ) {
         // merge configuration
         var request = request
         if request.options.callbackQueue == nil {
@@ -107,7 +116,9 @@ public struct HTTPClient {
             request.headers.add(name: "Authorization", value: authorization)
         }
         // execute
-        let callbackQueue = request.options.callbackQueue ?? self.configuration.callbackQueue
+        guard let callbackQueue = request.options.callbackQueue else {
+            return completion(.failure(InternalError("unknown callback queue")))
+        }
         self._execute(
             request: request,
             requestNumber: 0,
@@ -129,13 +140,42 @@ public struct HTTPClient {
         )
     }
 
-    private func _execute(request: Request, requestNumber: Int, observabilityScope: ObservabilityScope?, progress: ProgressHandler?, completion: @escaping CompletionHandler) {
+    /// Cancel any outstanding requests
+    public func cancel(deadline: DispatchTime) throws {
+        let outstanding = self.outstandingRequests.clear()
+        for (_, callback, _, queue) in outstanding.values {
+            queue.async {
+                callback(.failure(CancellationError()))
+            }
+        }
+    }
+
+    private func _execute(
+        request: Request,
+        requestNumber: Int,
+        observabilityScope: ObservabilityScope?,
+        progress: ProgressHandler?,
+        completion: @escaping CompletionHandler
+    ) {
+        // records outstanding requests for cancellation purposes
+        guard let callbackQueue = request.options.callbackQueue else {
+            return completion(.failure(InternalError("unknown callback queue")))
+        }
+        let requestKey = UUID()
+        self.outstandingRequests[requestKey] = (url: request.url, completion: completion, progress: progress, queue: callbackQueue)
+
         // wrap completion handler with concurrency control cleanup
         let originalCompletion = completion
         let completion: CompletionHandler = { result in
             // free concurrency control semaphore
             self.concurrencySemaphore.signal()
-            originalCompletion(result)
+            // cancellation support
+            // if the callback is no longer on the pending lists it has been canceled already
+            // read + remove from outstanding requests atomically
+            if let (_, callback, _, queue) = self.outstandingRequests.removeValue(forKey: requestKey) {
+                // call back on the request queue
+                queue.async { callback(result) }
+            }
         }
 
         // we must not block the calling thread (for concurrency control) so nesting this in a queue
@@ -172,9 +212,11 @@ public struct HTTPClient {
                         // handle retry strategy
                         if let retryDelay = self.shouldRetry(response: response, request: request, requestNumber: requestNumber) {
                             observabilityScope?.emit(warning: "\(request.url) failed, retrying in \(retryDelay)")
-                            // free concurrency control semaphore, since we re-submitting the request with the original completion handler
-                            // using the wrapped completion handler may lead to starving the mac concurrent requests
+                            // free concurrency control semaphore and outstanding request,
+                            // since we re-submitting the request with the original completion handler
+                            // using the wrapped completion handler may lead to starving the max concurrent requests
                             self.concurrencySemaphore.signal()
+                            self.outstandingRequests[requestKey] = nil
                             // TODO: dedicated retry queue?
                             return self.configuration.callbackQueue.asyncAfter(deadline: .now() + retryDelay) {
                                 self._execute(request: request, requestNumber: requestNumber + 1, observabilityScope: observabilityScope, progress: progress, completion: originalCompletion)

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -140,7 +140,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
     }
 
     /// Cancel the active build operation.
-    public func cancel() {
+    public func cancel(deadline: DispatchTime) throws {
         buildSystem?.cancel()
     }
 

--- a/Sources/Commands/APIDigester.swift
+++ b/Sources/Commands/APIDigester.swift
@@ -102,7 +102,10 @@ struct APIDigesterBaselineDumper {
         try workingCopy.checkout(revision: baselineRevision)
 
         // Create the workspace for this package.
-        let workspace = try Workspace(forRootPackage: baselinePackageRoot)
+        let workspace = try Workspace(
+            forRootPackage: baselinePackageRoot,
+            cancellator: swiftTool.cancellator
+        )
 
         let graph = try workspace.loadPackageGraph(
             rootPath: baselinePackageRoot,

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -1280,7 +1280,7 @@ final class PluginDelegate: PluginInvocationDelegate {
                         let testRunner = TestRunner(
                             bundlePaths: [testProduct.bundlePath],
                             xctestArg: testSpecifier,
-                            processSet: swiftTool.processSet,
+                            cancellator: swiftTool.cancellator,
                             toolchain: toolchain,
                             testEnv: testEnvironment,
                             observabilityScope: swiftTool.observabilityScope)
@@ -1570,6 +1570,7 @@ extension SwiftPackageTool {
                 projectName: projectName,
                 xcodeprojPath: xcodeprojPath,
                 graph: graph,
+                repositoryProvider: GitRepositoryProvider(),
                 options: genOptions,
                 fileSystem: swiftTool.fileSystem,
                 observabilityScope: swiftTool.observabilityScope

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -289,7 +289,7 @@ extension SwiftCommand {
 public class SwiftTool {
     #if os(Windows)
     // unfortunately this is needed for C callback handlers used by Windows shutdown handler
-    static var shutdownRegistry: (processSet: ProcessSet, buildSystemRef: BuildSystemRef)?
+    static var cancellator: Cancellator?
     #endif
 
     /// The original working directory.
@@ -334,12 +334,8 @@ public class SwiftTool {
     /// Path to the shared configuration directory
     let sharedConfigurationDirectory: AbsolutePath?
 
-    /// The process set to hold the launched processes. These will be terminated on any signal
-    /// received by the swift tools.
-    let processSet: ProcessSet
-
-    /// The current build system reference. The actual reference is present only during an active build.
-    let buildSystemRef: BuildSystemRef
+    /// Cancellator to handle cancellation of outstanding work when handling SIGINT
+    let cancellator: Cancellator
 
     /// The execution status of the tool.
     var executionStatus: ExecutionStatus = .success
@@ -384,6 +380,8 @@ public class SwiftTool {
         let observabilitySystem = ObservabilitySystem(self.observabilityHandler)
         self.observabilityScope = observabilitySystem.topScope
 
+        let cancellator = Cancellator(observabilityScope: self.observabilityScope)
+
         // Capture the original working directory ASAP.
         guard let cwd = self.fileSystem.currentWorkingDirectory else {
             self.observabilityScope.emit(error: "couldn't determine the current working directory")
@@ -400,17 +398,13 @@ public class SwiftTool {
                 try ProcessEnv.chdir(packagePath)
             }
 
-            let processSet = ProcessSet()
-            let buildSystemRef = BuildSystemRef()
-
             #if os(Windows)
             // set shutdown handler to terminate sub-processes, etc
-            SwiftTool.shutdownRegistry = (processSet: processSet, buildSystemRef: buildSystemRef)
+            SwiftTool.cancellator = cancellator
             _ = SetConsoleCtrlHandler({ _ in
                 // Terminate all processes on receiving an interrupt signal.
                 DefaultPluginScriptRunner.cancelAllRunningPlugins()
-                SwiftTool.shutdownRegistry?.processSet.terminate()
-                SwiftTool.shutdownRegistry?.buildSystemRef.buildSystem?.cancel()
+                SwiftTool.cancellator?.cancel()
 
                 // Reset the handler.
                 _ = SetConsoleCtrlHandler(nil, false)
@@ -430,8 +424,7 @@ public class SwiftTool {
 
                 // Terminate all processes on receiving an interrupt signal.
                 DefaultPluginScriptRunner.cancelAllRunningPlugins()
-                processSet.terminate()
-                buildSystemRef.buildSystem?.cancel()
+                try? cancellator.cancel(deadline: .now() + .seconds(30))
 
                 #if os(macOS) || os(OpenBSD)
                 // Install the default signal handler.
@@ -457,9 +450,7 @@ public class SwiftTool {
             interruptSignalSource.resume()
             #endif
 
-            self.processSet = processSet
-            self.buildSystemRef = buildSystemRef
-
+            self.cancellator = cancellator
         } catch {
             self.observabilityScope.emit(error)
             throw ExitCode.failure
@@ -539,7 +530,6 @@ public class SwiftTool {
         }
 
         let delegate = ToolWorkspaceDelegate(self.outputStream, logLevel: self.logLevel, observabilityScope: self.observabilityScope)
-        let repositoryProvider = GitRepositoryProvider(processSet: self.processSet)
         let isXcodeBuildSystemEnabled = self.options.build.buildSystem == .xcode
         let workspace = try Workspace(
             fileSystem: self.fileSystem,
@@ -561,10 +551,10 @@ public class SwiftTool {
                 fingerprintCheckingMode: self.options.security.fingerprintCheckingMode,
                 sourceControlToRegistryDependencyTransformation: self.options.resolver.sourceControlToRegistryDependencyTransformation.workspaceConfiguration
             ),
+            cancellator: self.cancellator,
             initializationWarningHandler: { self.observabilityScope.emit(warning: $0) },
             customHostToolchain: self.getHostToolchain(),
             customManifestLoader: self.getManifestLoader(),
-            customRepositoryProvider: repositoryProvider, // FIXME: ideally we would not customize the repository provider. its currently done for shutdown handling which can be better abstracted
             delegate: delegate
         )
         _workspace = workspace
@@ -753,8 +743,8 @@ public class SwiftTool {
             observabilityScope: customObservabilityScope ?? self.observabilityScope
         )
 
-        // Save the instance so it can be cancelled from the int handler.
-        buildSystemRef.buildSystem = buildOp
+        // register the build system with the cancellation handler
+        self.cancellator.register(name: "build system", handler: buildOp.cancel)
         return buildOp
     }
 
@@ -799,8 +789,8 @@ public class SwiftTool {
             )
         }
 
-        // Save the instance so it can be cancelled from the int handler.
-        buildSystemRef.buildSystem = buildSystem
+        // register the build system with the cancellation handler
+        self.cancellator.register(name: "build system", handler: buildSystem.cancel)
         return buildSystem
     }
 
@@ -1000,12 +990,6 @@ private func getSharedCacheDirectory(options: GlobalOptions, fileSystem: FileSys
         // further validation is done in workspace
         return fileSystem.swiftPMCacheDirectory
     }
-}
-
-/// A wrapper to hold the build system so we can use it inside
-/// the int. handler without requiring to initialize it.
-final class BuildSystemRef {
-    var buildSystem: BuildSystem?
 }
 
 extension Basics.Diagnostic {

--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -18,7 +18,7 @@ import TSCBasic
 
 /// Package registry client.
 /// API specification: https://github.com/apple/swift-package-manager/blob/main/Documentation/Registry.md
-public final class RegistryClient {
+public final class RegistryClient: Cancellable {
     private let apiVersion: APIVersion = .v1
 
     private let configuration: RegistryConfiguration
@@ -48,6 +48,11 @@ public final class RegistryClient {
 
     public var configured: Bool {
         return !self.configuration.isEmpty
+    }
+
+    /// Cancel any outstanding requests
+    public func cancel(deadline: DispatchTime) throws {
+        try self.httpClient.cancel(deadline: deadline)
     }
 
     public func getPackageMetadata(

--- a/Sources/PackageRegistry/RegistryDownloadsManager.swift
+++ b/Sources/PackageRegistry/RegistryDownloadsManager.swift
@@ -15,7 +15,7 @@ import PackageModel
 import TSCBasic
 import PackageLoading
 
-public class RegistryDownloadsManager {
+public class RegistryDownloadsManager: Cancellable {
     public typealias Delegate = RegistryDownloadsManagerDelegate
 
     private let fileSystem: FileSystem
@@ -55,7 +55,7 @@ public class RegistryDownloadsManager {
         // wrap the callback in the requested queue
         let completion = { result in callbackQueue.async { completion(result) } }
         
-        let packageRelativePath: RelativePath!
+        let packageRelativePath: RelativePath
         let packagePath: AbsolutePath
 
         do {
@@ -131,7 +131,12 @@ public class RegistryDownloadsManager {
         }
     }
 
-    func downloadAndPopulateCache(
+    /// Cancel any outstanding requests
+    public func cancel(deadline: DispatchTime) throws {
+        try self.registryClient.cancel(deadline: deadline)
+    }
+
+    private func downloadAndPopulateCache(
         package: PackageIdentity,
         version: Version,
         packagePath: AbsolutePath,

--- a/Sources/SPMBuildCore/BuildSystem.swift
+++ b/Sources/SPMBuildCore/BuildSystem.swift
@@ -8,6 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import Basics
 import PackageGraph
 
 /// An enum representing what subset of the package to build.
@@ -27,7 +28,7 @@ public enum BuildSubset {
 
 /// A protocol that represents a build system used by SwiftPM for all build operations. This allows factoring out the
 /// implementation details between SwiftPM's `BuildOperation` and the XCBuild backed `XCBuildSystem`.
-public protocol BuildSystem {
+public protocol BuildSystem: Cancellable {
 
     /// The delegate used by the build system.
     var delegate: BuildSystemDelegate? { get }
@@ -42,9 +43,6 @@ public protocol BuildSystem {
     /// - Parameters:
     ///   - subset: The subset of the package graph to build.
     func build(subset: BuildSubset) throws
-
-    /// Cancels the currently running operation, if possible.
-    func cancel()
 }
 
 extension BuildSystem {

--- a/Sources/SPMTestSupport/GitRepositoryExtensions.swift
+++ b/Sources/SPMTestSupport/GitRepositoryExtensions.swift
@@ -16,7 +16,6 @@ import enum TSCUtility.Git
 /// Extensions useful for unit testing purposes.
 /// Note: These are not thread safe.
 public extension GitRepository {
-
     /// Create the repository using git init.
     func create() throws {
         try systemQuietly([Git.tool, "-C", self.path.pathString, "init"])

--- a/Sources/SPMTestSupport/InMemoryGitRepository.swift
+++ b/Sources/SPMTestSupport/InMemoryGitRepository.swift
@@ -480,4 +480,8 @@ public final class InMemoryGitRepositoryProvider: RepositoryProvider {
     public func isValidRefFormat(_ ref: String) -> Bool {
         return true
     }
+
+    public func cancel(deadline: DispatchTime) throws {
+        // noop
+    }
 }

--- a/Sources/SourceControl/Repository.swift
+++ b/Sources/SourceControl/Repository.swift
@@ -10,6 +10,7 @@
 
 import Foundation
 import TSCBasic
+import Basics
 
 /// Specifies a repository address.
 public struct RepositorySpecifier: Hashable {
@@ -72,7 +73,7 @@ extension RepositorySpecifier: CustomStringConvertible {
 /// This protocol defines the lower level interface used to to access
 /// repositories. High-level clients should access repositories via a
 /// `RepositoryManager`.
-public protocol RepositoryProvider {
+public protocol RepositoryProvider: Cancellable {
     /// Fetch the complete repository at the given location to `path`.
     ///
     /// - Parameters:

--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -15,7 +15,7 @@ import TSCBasic
 import PackageModel
 
 /// Manages a collection of bare repositories.
-public class RepositoryManager {
+public class RepositoryManager: Cancellable {
     public typealias Delegate = RepositoryManagerDelegate
 
     /// The path under which repositories are stored.
@@ -41,8 +41,12 @@ public class RepositoryManager {
     /// The filesystem to operate on.
     private let fileSystem: FileSystem
 
+    // tracks outstanding lookups for de-duping requests
     private var pendingLookups = [RepositorySpecifier: DispatchGroup]()
     private var pendingLookupsLock = NSLock()
+
+    // tracks outstanding lookups for cancellation
+    private var outstandingLookups = ThreadSafeKeyValueStore<UUID, (repository: RepositorySpecifier, completion: (Result<RepositoryHandle, Error>) -> Void, queue: DispatchQueue)>()
 
     /// Create a new empty manager.
     ///
@@ -54,6 +58,7 @@ public class RepositoryManager {
     ///   - provider: The repository provider.
     ///   - cachePath: The repository cache location.
     ///   - cacheLocalPackages: Should cache local packages as well. For testing purposes.
+    ///   - maxConcurrentOperations: Max concurrent lookup operations
     ///   - initializationWarningHandler: Initialization warnings handler.
     ///   - delegate: The repository manager delegate.
     public init(
@@ -62,6 +67,7 @@ public class RepositoryManager {
         provider: RepositoryProvider,
         cachePath: AbsolutePath? =  .none,
         cacheLocalPackages: Bool = false,
+        maxConcurrentOperations: Int? = .none,
         initializationWarningHandler: (String) -> Void,
         delegate: Delegate? = .none
     ) {
@@ -74,11 +80,11 @@ public class RepositoryManager {
         self.delegate = delegate
 
         // this queue and semaphore is used to limit the amount of concurrent git operations taking place
-        let maxOperations = min(3, Concurrency.maxOperations)
+        let maxConcurrentOperations = min(maxConcurrentOperations ?? 3, Concurrency.maxOperations)
         self.lookupQueue = OperationQueue()
         self.lookupQueue.name = "org.swift.swiftpm.repository-manager"
-        self.lookupQueue.maxConcurrentOperationCount = maxOperations
-        self.concurrencySemaphore = DispatchSemaphore(value: maxOperations)
+        self.lookupQueue.maxConcurrentOperationCount = maxConcurrentOperations
+        self.concurrencySemaphore = DispatchSemaphore(value: maxConcurrentOperations)
     }
 
     /// Get a handle to a repository.
@@ -105,6 +111,10 @@ public class RepositoryManager {
         callbackQueue: DispatchQueue,
         completion: @escaping (Result<RepositoryHandle, Error>) -> Void
     ) {
+        // records outstanding lookups for cancellation purposes
+        let lookupKey = UUID()
+        self.outstandingLookups[lookupKey] = (repository: repository, completion: completion, queue: callbackQueue)
+
         // wrap the callback in the requested queue and cleanup operations
         let completion: (Result<RepositoryHandle, Error>) -> Void = { result in
             // free concurrency control semaphore
@@ -114,9 +124,12 @@ public class RepositoryManager {
             self.pendingLookups[repository]?.leave()
             self.pendingLookups[repository] = nil
             self.pendingLookupsLock.unlock()
-            // call back on the request queue
-            callbackQueue.async {
-                completion(result)
+            // cancellation support
+            // if the callback is no longer on the pending lists it has been canceled already
+            // read + remove from outstanding requests atomically
+            if let (_, callback, queue) = self.outstandingLookups.removeValue(forKey: lookupKey) {
+                // call back on the request queue
+                queue.async { callback(result) }
             }
         }
 
@@ -235,6 +248,18 @@ public class RepositoryManager {
         _ = try fetchResult.get()
 
         return handle
+    }
+
+    public func cancel(deadline: DispatchTime) throws {
+        // ask the provider to cancel
+        try self.provider.cancel(deadline: deadline)
+        // cancel any outstanding lookups
+        let outstanding = self.outstandingLookups.clear()
+        for (_, callback, queue) in outstanding.values {
+            queue.async {
+                callback(.failure(CancellationError()))
+            }
+        }
     }
 
     /// Fetches the repository into the cache. If no `cachePath` is set or an error occurred fall back to fetching the repository without populating the cache.

--- a/Sources/Workspace/Workspace+BinaryArtifacts.swift
+++ b/Sources/Workspace/Workspace+BinaryArtifacts.swift
@@ -30,7 +30,7 @@ extension Workspace {
     }
 
     // marked public since used in tools
-    public struct BinaryArtifactsManager {
+    public struct BinaryArtifactsManager: Cancellable {
         public typealias Delegate = BinaryArtifactsManagerDelegate
 
         private let fileSystem: FileSystem
@@ -396,6 +396,13 @@ extension Workspace {
 
             let contents = try self.fileSystem.readFileContents(path)
             return self.checksumAlgorithm.hash(contents).hexadecimalRepresentation
+        }
+
+        public func cancel(deadline: DispatchTime) throws {
+            try self.httpClient.cancel(deadline: deadline)
+            if let cancellableArchiver = self.archiver as? Cancellable {
+                try cancellableArchiver.cancel(deadline: deadline)
+            }
         }
     }
 }

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -9,6 +9,7 @@ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
 import Basics
+import Dispatch
 import class Foundation.JSONEncoder
 import PackageGraph
 import PackageModel
@@ -213,7 +214,7 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
         return file
     }
 
-    public func cancel() {
+    public func cancel(deadline: DispatchTime) throws {
     }
 
     /// Returns a new instance of `XCBuildDelegate` for a build operation.

--- a/Sources/Xcodeproj/generate.swift
+++ b/Sources/Xcodeproj/generate.swift
@@ -74,7 +74,7 @@ public enum XcodeProject {
         projectName: String,
         xcodeprojPath: AbsolutePath,
         graph: PackageGraph,
-        repositoryProvider: RepositoryProvider = GitRepositoryProvider(),
+        repositoryProvider: RepositoryProvider,
         options: XcodeprojOptions,
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope

--- a/Tests/BasicsTests/CancellatorTests.swift
+++ b/Tests/BasicsTests/CancellatorTests.swift
@@ -42,6 +42,9 @@ final class CancellatorTests: XCTestCase {
     }
 
     func testProcess() throws {
+        #if !os(macOS)
+        try XCTSkipIf(true, "skipping on non-macOS, signal traps do not work well on docker")
+        #endif
         try withTemporaryDirectory { temporaryDirectory in
             let scriptPath = temporaryDirectory.appending(component: "script")
             try localFileSystem.writeFileContents(scriptPath) {
@@ -59,10 +62,13 @@ final class CancellatorTests: XCTestCase {
 
             // outputRedirection used to signal that the process SIGINT traps have been set up
             let startSemaphore = ProcessStartedSemaphore(term: "process started")
-            let process = TSCBasic.Process(arguments: ["bash", scriptPath.pathString], outputRedirection: .stream(
-                stdout: startSemaphore.handleOutput,
-                stderr: startSemaphore.handleOutput
-            ))
+            let process = TSCBasic.Process(
+                arguments: ["bash", scriptPath.pathString],
+                outputRedirection: .stream(
+                    stdout: startSemaphore.handleOutput,
+                    stderr: startSemaphore.handleOutput
+                )
+            )
 
             let registrationKey = cancellator.register(process)
             XCTAssertNotNil(registrationKey)
@@ -93,6 +99,9 @@ final class CancellatorTests: XCTestCase {
     }
 
     func testProcessForceKill() throws {
+        #if !os(macOS)
+        try XCTSkipIf(true, "skipping on non-macOS, signal traps do not work well on docker")
+        #endif
         try withTemporaryDirectory { temporaryDirectory in
             let scriptPath = temporaryDirectory.appending(component: "script")
             try localFileSystem.writeFileContents(scriptPath) {
@@ -119,10 +128,13 @@ final class CancellatorTests: XCTestCase {
 
             // outputRedirection used to signal that the process SIGINT traps have been set up
             let startSemaphore = ProcessStartedSemaphore(term: "trap installed")
-            let process = TSCBasic.Process(arguments: ["bash", scriptPath.pathString], outputRedirection: .stream(
-                stdout: startSemaphore.handleOutput,
-                stderr: startSemaphore.handleOutput
-            ))
+            let process = TSCBasic.Process(
+                arguments: ["bash", scriptPath.pathString],
+                outputRedirection: .stream(
+                    stdout: startSemaphore.handleOutput,
+                    stderr: startSemaphore.handleOutput
+                )
+            )
             let registrationKey = cancellator.register(process)
             XCTAssertNotNil(registrationKey)
 

--- a/Tests/BasicsTests/CancellatorTests.swift
+++ b/Tests/BasicsTests/CancellatorTests.swift
@@ -1,0 +1,276 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+@testable import Basics
+import TSCBasic
+import XCTest
+import SPMTestSupport
+
+final class CancellatorTests: XCTestCase {
+    func testHappyCase() throws {
+        let observability = ObservabilitySystem.makeForTesting()
+        let cancellator = Cancellator(observabilityScope: observability.topScope)
+        let worker = Worker(name: "test")
+        cancellator.register(name: worker.name, handler: worker.cancel)
+
+        let startSemaphore = DispatchSemaphore(value: 0)
+        let finishSemaphore = DispatchSemaphore(value: 0)
+        let finishDeadline = DispatchTime.now() + .seconds(5)
+        DispatchQueue.sharedConcurrent.async() {
+            startSemaphore.signal()
+            defer { finishSemaphore.signal() }
+            if case .timedOut = worker.work(deadline: finishDeadline) {
+                XCTFail("worker \(worker.name) timed out")
+            }
+        }
+
+        XCTAssertEqual(.success, startSemaphore.wait(timeout: .now() + .seconds(1)), "timeout starting tasks")
+
+        let cancelled = cancellator._cancel(deadline: finishDeadline + .seconds(5))
+        XCTAssertEqual(cancelled, 1)
+
+        XCTAssertEqual(.success, finishSemaphore.wait(timeout: finishDeadline + .seconds(5)), "timeout finishing tasks")
+
+        XCTAssertNoDiagnostics(observability.diagnostics)
+    }
+
+    func testProcess() throws {
+        try withTemporaryDirectory { temporaryDirectory in
+            let scriptPath = temporaryDirectory.appending(component: "script")
+            try localFileSystem.writeFileContents(scriptPath) {
+                """
+                set -e
+
+                echo "process started"
+                sleep 10
+                echo "exit normally"
+                """
+            }
+
+            let observability = ObservabilitySystem.makeForTesting()
+            let cancellator = Cancellator(observabilityScope: observability.topScope)
+
+            // outputRedirection used to signal that the process SIGINT traps have been set up
+            let startSemaphore = ProcessStartedSemaphore(term: "process started")
+            let process = TSCBasic.Process(arguments: ["bash", scriptPath.pathString], outputRedirection: .stream(
+                stdout: startSemaphore.handleOutput,
+                stderr: startSemaphore.handleOutput
+            ))
+
+            let registrationKey = cancellator.register(process)
+            XCTAssertNotNil(registrationKey)
+
+            let finishSemaphore = DispatchSemaphore(value: 0)
+            DispatchQueue.sharedConcurrent.async {
+                defer { finishSemaphore.signal() }
+                do {
+                    try process.launch()
+                    let result = try process.waitUntilExit()
+                    print("process finished")
+                    XCTAssertEqual(result.exitStatus, .signalled(signal: SIGINT))
+                } catch {
+                    XCTFail("failed launching process: \(error)")
+                }
+            }
+
+            XCTAssertEqual(.success, startSemaphore.wait(timeout: .now() + .seconds(5)), "timeout starting tasks")
+            print("process started")
+
+            let canncelled = cancellator._cancel(deadline: .now() + .seconds(1))
+            XCTAssertEqual(canncelled, 1)
+
+            XCTAssertEqual(.success, finishSemaphore.wait(timeout: .now() + .seconds(5)), "timeout finishing tasks")
+
+            XCTAssertNoDiagnostics(observability.diagnostics)
+        }
+    }
+
+    func testProcessForceKill() throws {
+        try withTemporaryDirectory { temporaryDirectory in
+            let scriptPath = temporaryDirectory.appending(component: "script")
+            try localFileSystem.writeFileContents(scriptPath) {
+                """
+                set -e
+
+                trap_handler() {
+                    echo "SIGINT trap"
+                    sleep 10
+                    echo "exit SIGINT trap"
+                }
+
+                echo "process started"
+                trap trap_handler SIGINT
+                echo "trap installed"
+
+                sleep 10
+                echo "exit normally"
+                """
+            }
+
+            let observability = ObservabilitySystem.makeForTesting()
+            let cancellator = Cancellator(observabilityScope: observability.topScope)
+
+            // outputRedirection used to signal that the process SIGINT traps have been set up
+            let startSemaphore = ProcessStartedSemaphore(term: "trap installed")
+            let process = TSCBasic.Process(arguments: ["bash", scriptPath.pathString], outputRedirection: .stream(
+                stdout: startSemaphore.handleOutput,
+                stderr: startSemaphore.handleOutput
+            ))
+            let registrationKey = cancellator.register(process)
+            XCTAssertNotNil(registrationKey)
+
+            let finishSemaphore = DispatchSemaphore(value: 0)
+            DispatchQueue.sharedConcurrent.async {
+                defer { finishSemaphore.signal() }
+                do {
+                    try process.launch()
+                    let result = try process.waitUntilExit()
+                    print("process finished")
+                    XCTAssertEqual(result.exitStatus, .signalled(signal: SIGKILL))
+                } catch {
+                    XCTFail("failed launching process: \(error)")
+                }
+            }
+
+            XCTAssertEqual(.success, startSemaphore.wait(timeout: .now() + .seconds(5)), "timeout starting tasks")
+            print("process started")
+
+            let cancelled = cancellator._cancel(deadline: .now() + .seconds(1))
+            XCTAssertEqual(cancelled, 1)
+
+            XCTAssertEqual(.success, finishSemaphore.wait(timeout: .now() + .seconds(5)), "timeout finishing tasks")
+
+            XCTAssertNoDiagnostics(observability.diagnostics)
+        }
+    }
+
+    func testConcurrency() throws {
+        let observability = ObservabilitySystem.makeForTesting()
+        let cancellator = Cancellator(observabilityScope: observability.topScope)
+
+        let total = Concurrency.maxOperations
+        let workers: [Worker] = (0 ..< total).map { index in
+            let worker = Worker(name: "worker \(index)")
+            cancellator.register(name: worker.name, handler: worker.cancel)
+            return worker
+        }
+
+        let startGroup = DispatchGroup()
+        let finishGroup = DispatchGroup()
+        let finishDeadline = DispatchTime.now() + .seconds(5)
+        let results = ThreadSafeKeyValueStore<String, DispatchTimeoutResult>()
+        for worker in workers {
+            startGroup.enter()
+            DispatchQueue.sharedConcurrent.async(group: finishGroup) {
+                startGroup.leave()
+                results[worker.name] = worker.work(deadline: finishDeadline)
+            }
+        }
+
+        XCTAssertEqual(.success, startGroup.wait(timeout: .now() + .seconds(1)), "timeout starting tasks")
+
+        let cancelled = cancellator._cancel(deadline: finishDeadline + .seconds(5))
+        XCTAssertEqual(cancelled, total)
+
+        XCTAssertEqual(.success, finishGroup.wait(timeout: finishDeadline + .seconds(5)), "timeout finishing tasks")
+
+        XCTAssertEqual(results.count, total)
+        for (name, result) in results.get() {
+            if case .timedOut = result {
+                XCTFail("worker \(name) timed out")
+            }
+        }
+
+        XCTAssertNoDiagnostics(observability.diagnostics)
+    }
+
+    func testTimeout() throws {
+        struct Worker {
+            func work()  {}
+
+            func cancel() {
+                sleep(5)
+            }
+        }
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let cancellator = Cancellator(observabilityScope: observability.topScope)
+        let worker = Worker()
+        cancellator.register(name: "test", handler: worker.cancel)
+
+        let startSemaphore = DispatchSemaphore(value: 0)
+        DispatchQueue.sharedConcurrent.async {
+            startSemaphore.signal()
+            worker.work()
+        }
+
+        XCTAssertEqual(.success, startSemaphore.wait(timeout: .now() + .seconds(1)), "timeout starting tasks")
+
+        let cancelled = cancellator._cancel(deadline: .now() + .seconds(1))
+        XCTAssertEqual(cancelled, 0)
+
+        testDiagnostics(observability.diagnostics) { result in
+            result.check(
+                diagnostic: .contains("timeout waiting for cancellation"),
+                severity: .warning
+            )
+        }
+    }
+}
+
+fileprivate struct Worker {
+    let name: String
+    let semaphore = DispatchSemaphore(value: 0)
+
+    init(name: String) {
+        self.name = name
+    }
+
+    func work(deadline: DispatchTime) -> DispatchTimeoutResult {
+        print("\(self.name) work")
+        return self.semaphore.wait(timeout: deadline)
+    }
+
+    func cancel() {
+        print("\(self.name) cancel")
+        self.semaphore.signal()
+    }
+}
+
+class ProcessStartedSemaphore {
+    let term: String
+    let underlying = DispatchSemaphore(value: 0)
+    let lock = Lock()
+    var trapped = false
+    var output = ""
+
+    init(term: String) {
+        self.term = term
+    }
+
+    func handleOutput(_ bytes: [UInt8]) {
+        self.lock.withLock {
+            guard !self.trapped else {
+                return
+            }
+            if let output = String(bytes: bytes, encoding: .utf8) {
+                self.output += output
+            }
+            if self.output.contains(self.term) {
+                self.trapped = true
+                self.underlying.signal()
+            }
+        }
+    }
+
+    func wait(timeout: DispatchTime) -> DispatchTimeoutResult {
+        self.underlying.wait(timeout: timeout)
+    }
+}

--- a/Tests/BasicsTests/HTTPClientTests.swift
+++ b/Tests/BasicsTests/HTTPClientTests.swift
@@ -9,7 +9,7 @@
  */
 
 @testable import Basics
-import TSCTestSupport
+import SPMTestSupport
 import XCTest
 
 final class HTTPClientTest: XCTestCase {
@@ -577,6 +577,81 @@ final class HTTPClientTest: XCTestCase {
         for result in results.get() {
             XCTAssertEqual(try? result.get().statusCode, 200, "expected '200 okay' response")
         }
+    }
+
+    func testCancel() throws {
+        let observability = ObservabilitySystem.makeForTesting()
+        let cancellator = Cancellator(observabilityScope: observability.topScope)
+
+        let total = 10
+        // this DispatchGroup is used to wait for the requests to start before calling cancel
+        let startGroup = DispatchGroup()
+        // this DispatchGroup is used to park the delayed threads that would be cancelled
+        let terminatedGroup = DispatchGroup()
+        terminatedGroup.enter()
+        // this DispatchGroup is used to monitor the outstanding threads that would be cancelled and completion handlers thrown away
+        let outstandingGroup = DispatchGroup()
+
+        let httpClient = HTTPClient(handler: { request, _, completion in
+            print("handling \(request.url)")
+            if Int(request.url.lastPathComponent)! < total / 2 {
+                DispatchQueue.sharedConcurrent.async {
+                    defer { startGroup.leave() }
+                    print("\(request.url) okay")
+                    completion(.success(.okay()))
+                }
+            } else {
+                defer { startGroup.leave() }
+                outstandingGroup.enter()
+                print("\(request.url) waiting to be cancelled")
+                DispatchQueue.sharedConcurrent.async {
+                    defer { outstandingGroup.leave() }
+                    XCTAssertEqual(.success, terminatedGroup.wait(timeout: .now() + 5), "timeout waiting on terminated signal")
+                    completion(.failure(StringError("should be cancelled")))
+                }
+            }
+        })
+
+        cancellator.register(name: "http client", handler: httpClient)
+
+        let finishGroup = DispatchGroup()
+        let results = ThreadSafeKeyValueStore<URL, Result<HTTPClient.Response, Error>>()
+        for index in 0 ..< total {
+            startGroup.enter()
+            finishGroup.enter()
+            let url = URL(string: "http://test/\(index)")!
+            httpClient.head(url) { result in
+                defer { finishGroup.leave() }
+                results[url] = result
+            }
+        }
+
+        XCTAssertEqual(.success, startGroup.wait(timeout: .now() + 5), "timeout starting tasks")
+
+        let cancelled = cancellator._cancel(deadline: .now() + .seconds(1))
+        XCTAssertEqual(cancelled, 1, "expected to be terminated")
+        XCTAssertNoDiagnostics(observability.diagnostics)
+        // this releases the http handler threads that are waiting to test if the call was cancelled
+        terminatedGroup.leave()
+
+        XCTAssertEqual(.success, finishGroup.wait(timeout: .now() + 5), "timeout finishing tasks")
+
+        XCTAssertEqual(results.count, total, "expected \(total) results")
+        for (url, result) in results.get() {
+            switch (Int(url.lastPathComponent)! < total / 2, result) {
+            case (true, .success):
+                break // as expected!
+            case (true, .failure(let error)):
+                XCTFail("expected success, but failed with \(type(of: error)) '\(error)'")
+            case (false, .success):
+                XCTFail("expected operation to be cancelled")
+            case (false, .failure(let error)):
+                XCTAssert(error is CancellationError, "expected error to be CancellationError, but was \(type(of: error)) '\(error)'")
+            }
+        }
+
+        // wait for outstanding threads that would be cancelled and completion handlers thrown away
+        XCTAssertEqual(.success, outstandingGroup.wait(timeout: .now() + .seconds(5)), "timeout waiting for outstanding tasks")
     }
 
     private func assertRequestHeaders(_ headers: HTTPClientHeaders, expected: HTTPClientHeaders) {

--- a/Tests/BasicsTests/ZipArchiverTests.swift
+++ b/Tests/BasicsTests/ZipArchiverTests.swift
@@ -12,6 +12,7 @@ import Basics
 import TSCBasic
 import TSCTestSupport
 import XCTest
+import SPMTestSupport
 
 class ZipArchiverTests: XCTestCase {
     func testZipArchiverSuccess() throws {
@@ -86,6 +87,80 @@ class ZipArchiverTests: XCTestCase {
                 XCTAssertEqual(error as? FileSystemError, FileSystemError(.noEntry, path))
             }
         }
+    }
+}
+
+class ArchiverTests: XCTestCase {
+    func testCancel() throws {
+        struct MockArchiver: Archiver, Cancellable {
+            var supportedExtensions: Set<String> = []
+
+            let cancelSemaphores = ThreadSafeArrayStore<DispatchSemaphore>()
+            let startGroup = DispatchGroup()
+            let finishGroup = DispatchGroup()
+
+            func extract(from archivePath: AbsolutePath, to destinationPath: AbsolutePath, completion: @escaping (Result<Void, Error>) -> Void) {
+                let cancelSemaphore = DispatchSemaphore(value: 0)
+                self.cancelSemaphores.append(cancelSemaphore)
+
+                self.startGroup.enter()
+                DispatchQueue.sharedConcurrent.async {
+                    self.startGroup.leave()
+                    self.finishGroup.enter()
+                    defer { self.finishGroup.leave() }
+                    switch cancelSemaphore.wait(timeout: .now() + .seconds(5)) {
+                    case .success:
+                        completion(.success(()))
+                    case .timedOut:
+                        completion(.failure(StringError("should be cancelled")))
+                    }
+                }
+            }
+
+            func validate(path: AbsolutePath, completion: @escaping (Result<Bool, Error>) -> Void) {
+                let cancelSemaphore = DispatchSemaphore(value: 0)
+                self.cancelSemaphores.append(cancelSemaphore)
+
+                self.startGroup.enter()
+                DispatchQueue.sharedConcurrent.async {
+                    self.startGroup.leave()
+                    self.finishGroup.enter()
+                    defer { self.finishGroup.leave() }
+                    switch cancelSemaphore.wait(timeout: .now() + .seconds(5)) {
+                    case .success:
+                        completion(.success(true))
+                    case .timedOut:
+                        completion(.failure(StringError("should be cancelled")))
+                    }
+                }
+            }
+
+            func cancel(deadline: DispatchTime) throws {
+                for semaphore in self.cancelSemaphores.get() {
+                    semaphore.signal()
+                }
+            }
+        }
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let cancellator = Cancellator(observabilityScope: observability.topScope)
+
+        let archiver = MockArchiver()
+        cancellator.register(name: "archiver", handler: archiver)
+
+        archiver.extract(from: .root, to: .root) { result in
+            XCTAssertResultSuccess(result)
+        }
+
+        archiver.validate(path: .root) { result in
+            XCTAssertResultSuccess(result)
+        }
+
+        XCTAssertEqual(.success, archiver.startGroup.wait(timeout: .now() + .seconds(5)), "timeout waiting for tasks to start")
+
+        try cancellator.cancel(deadline: .now() + .seconds(5))
+
+        XCTAssertEqual(.success, archiver.finishGroup.wait(timeout: .now() + .seconds(5)), "timeout waiting for tasks to finish")
     }
 }
 

--- a/Tests/SourceControlTests/GitRepositoryProviderTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryProviderTests.swift
@@ -38,5 +38,4 @@ class GitRepositoryProviderTests: XCTestCase {
             XCTAssertFalse(provider.repositoryExists(at: notGitChildPath))
         }
     }
-
 }

--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -57,7 +57,7 @@ class GitRepositoryTests: XCTestCase {
             let provider = GitRepositoryProvider()
             XCTAssertTrue(try provider.workingCopyExists(at: testRepoPath))
             let repoSpec = RepositorySpecifier(path: testRepoPath)
-            try! provider.fetch(repository: repoSpec, to: testCheckoutPath)
+            try provider.fetch(repository: repoSpec, to: testCheckoutPath)
 
             // Verify the checkout was made.
             XCTAssertDirectoryExists(testCheckoutPath)

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -8,7 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
-import Basics
+@testable import Basics
 import PackageModel
 import SPMTestSupport
 @testable import SourceControl
@@ -428,6 +428,138 @@ class RepositoryManagerTests: XCTestCase {
             XCTAssertEqual(delegate.didUpdate.count, 2)
         }
     }
+
+    func testCancel() throws {
+        let observability = ObservabilitySystem.makeForTesting()
+        let cancellator = Cancellator(observabilityScope: observability.topScope)
+
+        let total = 10
+        let provider = MockRepositoryProvider(total: total)
+        let manager = RepositoryManager(
+            fileSystem: InMemoryFileSystem(),
+            path: .root,
+            provider: provider,
+            maxConcurrentOperations: total
+        )
+
+        cancellator.register(name: "repository manager", handler: manager)
+
+        //let startGroup = DispatchGroup()
+        let finishGroup = DispatchGroup()
+        let results = ThreadSafeKeyValueStore<RepositorySpecifier, Result<RepositoryManager.RepositoryHandle, Error>>()
+        for index in 0 ..< total {
+            let repository = RepositorySpecifier(path: .init("/repo/\(index)"))
+            provider.startGroup.enter()
+            finishGroup.enter()
+            manager.lookup(
+                package: .init(url: repository.url),
+                repository: repository,
+                skipUpdate: true,
+                observabilityScope: observability.topScope,
+                delegateQueue: .sharedConcurrent,
+                callbackQueue: .sharedConcurrent
+            ) { result in
+                defer { finishGroup.leave() }
+                results[repository] = result
+            }
+        }
+
+        XCTAssertEqual(.success, provider.startGroup.wait(timeout: .now() + 5), "timeout starting tasks")
+
+        let cancelled = cancellator._cancel(deadline: .now() + .seconds(1))
+        XCTAssertEqual(cancelled, 1, "expected to be terminated")
+        XCTAssertNoDiagnostics(observability.diagnostics)
+        // this releases the fetch threads that are waiting to test if the call was cancelled
+        provider.terminatedGroup.leave()
+
+        XCTAssertEqual(.success, finishGroup.wait(timeout: .now() + 5), "timeout finishing tasks")
+
+        XCTAssertEqual(results.count, total, "expected \(total) results")
+        for (repository, result) in results.get() {
+            switch (Int(repository.basename)! < total / 2, result) {
+            case (true, .success):
+                break // as expected!
+            case (true, .failure(let error)):
+                XCTFail("expected success, but failed with \(type(of: error)) '\(error)'")
+            case (false, .success):
+                XCTFail("expected operation to be cancelled")
+            case (false, .failure(let error)):
+                XCTAssert(error is CancellationError, "expected error to be CancellationError, but was \(type(of: error)) '\(error)'")
+            }
+        }
+
+        // wait for outstanding threads that would be cancelled and completion handlers thrown away
+        XCTAssertEqual(.success, provider.outstandingGroup.wait(timeout: .now() + .seconds(5)), "timeout waiting for outstanding tasks")
+
+        // the provider called in a thread managed by the RepositoryManager
+        // the use of blocking semaphore is intentional
+        class MockRepositoryProvider: RepositoryProvider {
+            let total: Int
+            // this DispatchGroup is used to wait for the requests to start before calling cancel
+            let startGroup = DispatchGroup()
+            // this DispatchGroup is used to park the delayed threads that would be cancelled
+            let terminatedGroup = DispatchGroup()
+            // this DispatchGroup is used to monitor the outstanding threads that would be cancelled and completion handlers thrown away
+            let outstandingGroup = DispatchGroup()
+
+            init(total: Int) {
+                self.total = total
+                self.terminatedGroup.enter()
+            }
+
+            func fetch(repository: RepositorySpecifier, to path: AbsolutePath, progressHandler: ((FetchProgress) -> Void)?) throws {
+                print("fetching \(repository)")
+                // startGroup may not be 100% accurate given the blocking nature of the provider so giving it a bit of a buffer
+                DispatchQueue.sharedConcurrent.asyncAfter(deadline: .now() + .milliseconds(100)) {
+                    self.startGroup.leave()
+                }
+                if Int(repository.basename)! >= total / 2 {
+                    self.outstandingGroup.enter()
+                    defer { self.outstandingGroup.leave() }
+                    print("\(repository) waiting to be cancelled")
+                    XCTAssertEqual(.success, self.terminatedGroup.wait(timeout: .now() + 5), "timeout waiting on terminated signal")
+                    throw StringError("\(repository) should be cancelled")
+                }
+                print("\(repository) okay")
+            }
+
+            func repositoryExists(at path: AbsolutePath) throws -> Bool {
+                return false
+            }
+
+            func open(repository: RepositorySpecifier, at path: AbsolutePath) throws -> Repository {
+                fatalError("should not be called")
+            }
+
+            func createWorkingCopy(repository: RepositorySpecifier, sourcePath: AbsolutePath, at destinationPath: AbsolutePath, editable: Bool) throws -> WorkingCheckout {
+                fatalError("should not be called")
+            }
+
+            func workingCopyExists(at path: AbsolutePath) throws -> Bool {
+                fatalError("should not be called")
+            }
+
+            func openWorkingCopy(at path: AbsolutePath) throws -> WorkingCheckout {
+                fatalError("should not be called")
+            }
+
+            func copy(from sourcePath: AbsolutePath, to destinationPath: AbsolutePath) throws {
+                fatalError("should not be called")
+            }
+
+            func isValidDirectory(_ directory: AbsolutePath) -> Bool {
+                fatalError("should not be called")
+            }
+
+            func isValidRefFormat(_ ref: String) -> Bool {
+                fatalError("should not be called")
+            }
+
+            func cancel(deadline: DispatchTime) throws {
+                print("cancel")
+            }
+        }
+    }
 }
 
 extension RepositoryManager {
@@ -437,6 +569,7 @@ extension RepositoryManager {
         provider: RepositoryProvider,
         cachePath: AbsolutePath? =  .none,
         cacheLocalPackages: Bool = false,
+        maxConcurrentOperations: Int? = .none,
         delegate: RepositoryManagerDelegate? = .none
     ) {
         self.init(
@@ -445,6 +578,7 @@ extension RepositoryManager {
             provider: provider,
             cachePath: cachePath,
             cacheLocalPackages: cacheLocalPackages,
+            maxConcurrentOperations: maxConcurrentOperations,
             initializationWarningHandler: { _ in },
             delegate: delegate
         )
@@ -582,6 +716,10 @@ private class DummyRepositoryProvider: RepositoryProvider {
 
     func isValidRefFormat(_ ref: String) -> Bool {
         return true
+    }
+
+    func cancel(deadline: DispatchTime) throws {
+        // noop
     }
 
     func increaseFetchCount() {

--- a/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
@@ -146,6 +146,10 @@ private class MockRepositories: RepositoryProvider {
     func isValidRefFormat(_ ref: String) -> Bool {
         return true
     }
+
+    func cancel(deadline: DispatchTime) throws {
+        // noop
+    }
 }
 
 private class MockResolverDelegate: RepositoryManager.Delegate {

--- a/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
+++ b/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
@@ -464,3 +464,25 @@ class GenerateXcodeprojTests: XCTestCase {
         }
     }
 }
+
+extension XcodeProject {
+    @discardableResult
+    static func generate(
+        projectName: String,
+        xcodeprojPath: AbsolutePath,
+        graph: PackageGraph,
+        options: XcodeprojOptions,
+        fileSystem: FileSystem,
+        observabilityScope: ObservabilityScope
+    ) throws -> Xcode.Project {
+        try Self.generate(
+            projectName: projectName,
+            xcodeprojPath: xcodeprojPath,
+            graph: graph,
+            repositoryProvider: GitRepositoryProvider(),
+            options: options,
+            fileSystem: fileSystem,
+            observabilityScope: observabilityScope
+        )
+    }
+}


### PR DESCRIPTION
motivation: allow clients of SwiftPM to cancel background activities

changes:
* introduce new "cancellator" utility that is a registry for cancellation handlers
* use the "cancellator" instead of ProcessSet to manage the cancellation of active processes (eg git, tests) and build system
* add cancel method to GitRepositoryProvider protocol so that it can be interuppted
* add cancel methods to RepositoryManager, RegistryDownloadManager and HTTPClient so that it can be interrupted
* change workspace initializer to take a terminator so that CLI and other consumer of libSwiftPM can interrupt
* register interruption points mentioned above in workspace
* adjust related call sites, ie CLI signal handler now uses the workspace terminator to interrupt
* add tests

rdar://64900054
rdar://63723896