### PR TITLE
build: explicitly select the librarian on Darwin

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -546,6 +546,7 @@ def build_dependency(args, target_name, common_cmake_flags = [], non_darwin_cmak
     if platform.system() == 'Darwin':
         cmake_flags.append("-DCMAKE_C_FLAGS=-target %s%s" % (get_build_target(args), g_macos_deployment_target))
         cmake_flags.append("-DCMAKE_OSX_DEPLOYMENT_TARGET=%s" % g_macos_deployment_target)
+        cmake_flags.append("-DCMAKE_AR=ar")
     else:
         cmake_flags += non_darwin_cmake_flags
 


### PR DESCRIPTION
Newer CMake will attempt to use the LLVM toolchain if clang is detected.
This generates an archive that ld64 may not be able to properly process.
Explicitly specify the librarian to be `ar` so that the cctools archiver
is used.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
