### PR TITLE
improve repository manager lookup concurrency control

### DIFF
--- a/Tests/PackageRegistryTests/RegistryDownloadsManagerTests.swift
+++ b/Tests/PackageRegistryTests/RegistryDownloadsManagerTests.swift
@@ -298,7 +298,7 @@ class RegistryDownloadsManagerTests: XCTestCase {
                 }
             }
 
-            if case .timedOut = group.wait(timeout: .now() + 10) {
+            if case .timedOut = group.wait(timeout: .now() + 60) {
                 return XCTFail("timeout")
             }
 
@@ -342,7 +342,7 @@ class RegistryDownloadsManagerTests: XCTestCase {
                 }
             }
 
-            if case .timedOut = group.wait(timeout: .now() + 10) {
+            if case .timedOut = group.wait(timeout: .now() + 60) {
                 return XCTFail("timeout")
             }
 

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -353,13 +353,13 @@ class RepositoryManagerTests: XCTestCase {
                     observabilityScope: observability.topScope,
                     delegateQueue: .sharedConcurrent,
                     callbackQueue: .sharedConcurrent
-                ) { result in
+                ) { result in                    
                     results[index] = result
                     group.leave()
                 }
             }
 
-            if case .timedOut = group.wait(timeout: .now() + 10) {
+            if case .timedOut = group.wait(timeout: .now() + 60) {
                 return XCTFail("timeout")
             }
 


### PR DESCRIPTION
motivation: improved concurrency control and cleaner code

changes:
* use a separate queue to schedule the lookup tasks to ensure concurrency control is done correctly
* create a sync version of lookup to help make maintaining the code easier, at least while the git client is sync
* reduce double queue overhead when Workspace::geContainer calls into RepositoryManager::lookup