### PR TITLE
improve manfiest loader concurrency control

### DIFF
--- a/Sources/SPMTestSupport/MockManifestLoader.swift
+++ b/Sources/SPMTestSupport/MockManifestLoader.swift
@@ -57,10 +57,11 @@ public final class MockManifestLoader: ManifestLoaderProtocol {
         identityResolver: IdentityResolver,
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope,
-        on queue: DispatchQueue,
+        delegateQueue: DispatchQueue,
+        callbackQueue: DispatchQueue,
         completion: @escaping (Result<Manifest, Error>) -> Void
     ) {
-        queue.async {
+        callbackQueue.async {
             let key = Key(url: packageLocation, version: version)
             if let result = self.manifests[key] {
                 return completion(.success(result))
@@ -115,7 +116,8 @@ extension ManifestLoader {
                 identityResolver: identityResolver,
                 fileSystem: fileSystem,
                 observabilityScope: observabilityScope,
-                on: .sharedConcurrent,
+                delegateQueue: .sharedConcurrent,
+                callbackQueue: .sharedConcurrent,
                 completion: $0
             )
         }

--- a/Sources/Workspace/FileSystemPackageContainer.swift
+++ b/Sources/Workspace/FileSystemPackageContainer.swift
@@ -91,7 +91,8 @@ public struct FileSystemPackageContainer: PackageContainer {
                     identityResolver: self.identityResolver,
                     fileSystem: self.fileSystem,
                     observabilityScope: self.observabilityScope,
-                    on: .sharedConcurrent,
+                    delegateQueue: .sharedConcurrent,
+                    callbackQueue: .sharedConcurrent,
                     completion: $0
                 )
             }

--- a/Sources/Workspace/RegistryPackageContainer.swift
+++ b/Sources/Workspace/RegistryPackageContainer.swift
@@ -120,87 +120,89 @@ public class RegistryPackageContainer: PackageContainer {
             }
         }
     }
-
+    
     private func loadManifest(version: Version,  completion: @escaping (Result<Manifest, Error>) -> Void) {
         self.getAvailableManifestsFilesystem(version: version) { result in
-                switch result {
-                case .failure(let error):
-                    return completion(.failure(error))
-                case .success(let result):
-                    do {
-                        let manifests = result.manifests
-                        let fileSystem = result.fileSystem
-
-                        // first, decide the tools-version we should use
-                        let preferredToolsVersion = try self.toolsVersionLoader.load(at: .root, fileSystem: fileSystem)
-                        // validate preferred the tools version is compatible with the current toolchain
-                        try preferredToolsVersion.validateToolsVersion(
-                            self.currentToolsVersion,
-                            packageIdentity: self.package.identity
+            switch result {
+            case .failure(let error):
+                return completion(.failure(error))
+            case .success(let result):
+                do {
+                    let manifests = result.manifests
+                    let fileSystem = result.fileSystem
+                    
+                    // first, decide the tools-version we should use
+                    let preferredToolsVersion = try self.toolsVersionLoader.load(at: .root, fileSystem: fileSystem)
+                    // validate preferred the tools version is compatible with the current toolchain
+                    try preferredToolsVersion.validateToolsVersion(
+                        self.currentToolsVersion,
+                        packageIdentity: self.package.identity
+                    )
+                    // load the manifest content
+                    guard let defaultManifestToolsVersion = manifests.first(where: { $0.key == Manifest.filename })?.value.toolsVersion else {
+                        throw StringError("Could not find the '\(Manifest.filename)' file for '\(self.package.identity)' '\(version)'")
+                    }
+                    if preferredToolsVersion == defaultManifestToolsVersion {
+                        // default tools version - we already have the content on disk from getAvailableManifestsFileSystem()
+                        self.manifestLoader.load(
+                            at: .root,
+                            packageIdentity: self.package.identity,
+                            packageKind: self.package.kind,
+                            packageLocation: self.package.locationString,
+                            version: version,
+                            revision: nil,
+                            toolsVersion: preferredToolsVersion,
+                            identityResolver: self.identityResolver,
+                            fileSystem: result.fileSystem,
+                            observabilityScope: self.observabilityScope,
+                            delegateQueue: .sharedConcurrent,
+                            callbackQueue: .sharedConcurrent,
+                            completion: completion
                         )
-                        // load the manifest content
-                        guard let defaultManifestToolsVersion = manifests.first(where: { $0.key == Manifest.filename })?.value.toolsVersion else {
-                            throw StringError("Could not find the '\(Manifest.filename)' file for '\(self.package.identity)' '\(version)'")
-                        }
-                        if preferredToolsVersion == defaultManifestToolsVersion {
-                            // default tools version - we already have the content on disk from getAvailableManifestsFileSystem()
-                            self.manifestLoader.load(
-                                at: .root,
-                                packageIdentity: self.package.identity,
-                                packageKind: self.package.kind,
-                                packageLocation: self.package.locationString,
-                                version: version,
-                                revision: nil,
-                                toolsVersion: preferredToolsVersion,
-                                identityResolver: self.identityResolver,
-                                fileSystem: result.fileSystem,
-                                observabilityScope: self.observabilityScope,
-                                on: .sharedConcurrent,
-                                completion: completion
-                            )
-                        } else {
-                            // custom tools-version, we need to fetch the content from the server
-                            self.registryClient.getManifestContent(
-                                package: self.package.identity,
-                                version: version,
-                                customToolsVersion: preferredToolsVersion,
-                                observabilityScope: self.observabilityScope,
-                                callbackQueue: .sharedConcurrent
-                            ) { result in
-                                    switch result {
-                                    case .failure(let error):
-                                        return completion(.failure(error))
-                                    case .success(let manifestContent):
-                                        do {
-                                            // replace the fake manifest with the real manifest content
-                                            let manifestPath = AbsolutePath.root.appending(component: Manifest.basename + "@swift-\(preferredToolsVersion).swift")
-                                            try fileSystem.removeFileTree(manifestPath)
-                                            try fileSystem.writeFileContents(manifestPath, string: manifestContent)
-                                            // finally, load the manifest
-                                            self.manifestLoader.load(
-                                                at: .root,
-                                                packageIdentity: self.package.identity,
-                                                packageKind: self.package.kind,
-                                                packageLocation: self.package.locationString,
-                                                version: version,
-                                                revision: nil,
-                                                toolsVersion: preferredToolsVersion,
-                                                identityResolver: self.identityResolver,
-                                                fileSystem: fileSystem,
-                                                observabilityScope: self.observabilityScope,
-                                                on: .sharedConcurrent,
-                                                completion: completion
-                                            )
-                                        } catch {
-                                            return completion(.failure(error))
-                                        }
-                                    }
+                    } else {
+                        // custom tools-version, we need to fetch the content from the server
+                        self.registryClient.getManifestContent(
+                            package: self.package.identity,
+                            version: version,
+                            customToolsVersion: preferredToolsVersion,
+                            observabilityScope: self.observabilityScope,
+                            callbackQueue: .sharedConcurrent
+                        ) { result in
+                            switch result {
+                            case .failure(let error):
+                                return completion(.failure(error))
+                            case .success(let manifestContent):
+                                do {
+                                    // replace the fake manifest with the real manifest content
+                                    let manifestPath = AbsolutePath.root.appending(component: Manifest.basename + "@swift-\(preferredToolsVersion).swift")
+                                    try fileSystem.removeFileTree(manifestPath)
+                                    try fileSystem.writeFileContents(manifestPath, string: manifestContent)
+                                    // finally, load the manifest
+                                    self.manifestLoader.load(
+                                        at: .root,
+                                        packageIdentity: self.package.identity,
+                                        packageKind: self.package.kind,
+                                        packageLocation: self.package.locationString,
+                                        version: version,
+                                        revision: nil,
+                                        toolsVersion: preferredToolsVersion,
+                                        identityResolver: self.identityResolver,
+                                        fileSystem: fileSystem,
+                                        observabilityScope: self.observabilityScope,
+                                        delegateQueue: .sharedConcurrent,
+                                        callbackQueue: .sharedConcurrent,
+                                        completion: completion
+                                    )
+                                } catch {
+                                    return completion(.failure(error))
+                                }
                             }
                         }
-                    } catch {
-                        return completion(.failure(error))
                     }
+                } catch {
+                    return completion(.failure(error))
                 }
+            }
         }
     }
 

--- a/Sources/Workspace/SourceControlPackageContainer.swift
+++ b/Sources/Workspace/SourceControlPackageContainer.swift
@@ -397,18 +397,21 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
         // Load the manifest.
         // FIXME: this should not block
         return try temp_await {
-            self.manifestLoader.load(at: AbsolutePath.root,
-                                     packageIdentity: self.package.identity,
-                                     packageKind: self.package.kind,
-                                     packageLocation: self.package.locationString,
-                                     version: version,
-                                     revision: nil,
-                                     toolsVersion: toolsVersion,
-                                     identityResolver: self.identityResolver,
-                                     fileSystem: fileSystem,
-                                     observabilityScope: self.observabilityScope,
-                                     on: .sharedConcurrent,
-                                     completion: $0)
+            self.manifestLoader.load(
+                at: AbsolutePath.root,
+                packageIdentity: self.package.identity,
+                packageKind: self.package.kind,
+                packageLocation: self.package.locationString,
+                version: version,
+                revision: nil,
+                toolsVersion: toolsVersion,
+                identityResolver: self.identityResolver,
+                fileSystem: fileSystem,
+                observabilityScope: self.observabilityScope,
+                delegateQueue: .sharedConcurrent,
+                callbackQueue: .sharedConcurrent,
+                completion: $0
+            )
         }
     }
 

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -2137,58 +2137,52 @@ extension Workspace {
             .packageMetadata(identity: packageIdentity, kind: packageKind)
         }
 
-        //diagnostics.with(location: PackageLocation.Local(packagePath: packagePath)) { diagnostics in
-            do {
-                // Load the tools version for the package.
-                let toolsVersion = try toolsVersionLoader.load(at: packagePath, fileSystem: fileSystem)
+        do {
+            // Load the tools version for the package.
+            let toolsVersion = try toolsVersionLoader.load(at: packagePath, fileSystem: fileSystem)
 
-                // Validate the tools version.
-                try toolsVersion.validateToolsVersion(currentToolsVersion, packageIdentity: packageIdentity)
+            // Validate the tools version.
+            try toolsVersion.validateToolsVersion(currentToolsVersion, packageIdentity: packageIdentity)
 
-                // Load the manifest.
-                // The delegate callback is only passed any diagnostics emitted during the parsing of the manifest, but they are also forwarded up to the caller.
-                //let manifestLoadingDiagnostics = DiagnosticsEngine(handlers: [{ diagnostics.emit($0) }], defaultLocation: diagnostics.defaultLocation)
-                //let manifestLoadingObservabilityScope = observabilityScope.makeChildScope(description: "Loading manifest")
-
-                let manifestLoadingDiagnostics = ThreadSafeArrayStore<Basics.Diagnostic>()
-                let manifestLoadingScope = ObservabilitySystem( { _, diagnostic in
-                    observabilityScope.emit(diagnostic)
-                    manifestLoadingDiagnostics.append(diagnostic)
-                }).topScope.makeChildScope(description: "Loading manifest") {
-                    .packageMetadata(identity: packageIdentity, kind: packageKind)
-                }
-
-                self.manifestLoader.load(
-                    at: packagePath,
-                    packageIdentity: packageIdentity,
-                    packageKind: packageKind,
-                    packageLocation: packageLocation,
-                    version: version,
-                    revision: nil,
-                    toolsVersion: toolsVersion,
-                    identityResolver: self.identityResolver,
-                    fileSystem: fileSystem,
-                    observabilityScope: manifestLoadingScope,
-                    on: .sharedConcurrent
-                ) { result in
-                    switch result {
-                    // Diagnostics.fatalError indicates that a more specific diagnostic has already been added.
-                    case .failure(Diagnostics.fatalError):
-                        self.delegate?.didLoadManifest(packagePath: packagePath, url: packageLocation, version: version, packageKind: packageKind, manifest: nil, diagnostics: manifestLoadingDiagnostics.get())
-                    case .failure(let error):
-                        manifestLoadingScope.emit(error)
-                        self.delegate?.didLoadManifest(packagePath: packagePath, url: packageLocation, version: version, packageKind: packageKind, manifest: nil, diagnostics: manifestLoadingDiagnostics.get())
-                    case .success(let manifest):
-                        manifestLoadingScope.trap { try self.validateManifest(manifest) }
-                        self.delegate?.didLoadManifest(packagePath: packagePath, url: packageLocation, version: version, packageKind: packageKind, manifest: manifest, diagnostics: manifestLoadingDiagnostics.get())
-                    }
-                    completion(result)
-                }
-            } catch {
-                observabilityScope.emit(error)
-                completion(.failure(error))
+            let manifestLoadingDiagnostics = ThreadSafeArrayStore<Basics.Diagnostic>()
+            let manifestLoadingScope = ObservabilitySystem( { _, diagnostic in
+                observabilityScope.emit(diagnostic)
+                manifestLoadingDiagnostics.append(diagnostic)
+            }).topScope.makeChildScope(description: "Loading manifest") {
+                .packageMetadata(identity: packageIdentity, kind: packageKind)
             }
-        //}
+
+            self.manifestLoader.load(
+                at: packagePath,
+                packageIdentity: packageIdentity,
+                packageKind: packageKind,
+                packageLocation: packageLocation,
+                version: version,
+                revision: nil,
+                toolsVersion: toolsVersion,
+                identityResolver: self.identityResolver,
+                fileSystem: fileSystem,
+                observabilityScope: manifestLoadingScope,
+                delegateQueue: .sharedConcurrent,
+                callbackQueue: .sharedConcurrent
+            ) { result in
+                switch result {
+                // Diagnostics.fatalError indicates that a more specific diagnostic has already been added.
+                case .failure(Diagnostics.fatalError):
+                    self.delegate?.didLoadManifest(packagePath: packagePath, url: packageLocation, version: version, packageKind: packageKind, manifest: nil, diagnostics: manifestLoadingDiagnostics.get())
+                case .failure(let error):
+                    manifestLoadingScope.emit(error)
+                    self.delegate?.didLoadManifest(packagePath: packagePath, url: packageLocation, version: version, packageKind: packageKind, manifest: nil, diagnostics: manifestLoadingDiagnostics.get())
+                case .success(let manifest):
+                    manifestLoadingScope.trap { try self.validateManifest(manifest) }
+                    self.delegate?.didLoadManifest(packagePath: packagePath, url: packageLocation, version: version, packageKind: packageKind, manifest: manifest, diagnostics: manifestLoadingDiagnostics.get())
+                }
+                completion(result)
+            }
+        } catch {
+            observabilityScope.emit(error)
+            completion(.failure(error))
+        }
     }
 
     // TODO: move more manifest validation in here from other parts of the code, e.g. from ManifestLoader
@@ -4237,7 +4231,8 @@ extension Workspace {
             identityResolver: IdentityResolver,
             fileSystem: FileSystem,
             observabilityScope: ObservabilityScope,
-            on queue: DispatchQueue,
+            delegateQueue: DispatchQueue,
+            callbackQueue: DispatchQueue,
             completion: @escaping (Result<Manifest, Error>) -> Void
         ) {
             self.underlying.load(
@@ -4251,7 +4246,8 @@ extension Workspace {
                 identityResolver: identityResolver,
                 fileSystem: fileSystem,
                 observabilityScope: observabilityScope,
-                on: queue
+                delegateQueue: delegateQueue,
+                callbackQueue: callbackQueue
             ) { result in
                 switch result {
                 case .failure(let error):
@@ -4261,7 +4257,7 @@ extension Workspace {
                         manifest: manifest,
                         transformationMode: transformationMode,
                         observabilityScope: observabilityScope,
-                        callbackQueue: queue,
+                        callbackQueue: callbackQueue,
                         completion: completion
                     )
                 }

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -36,18 +36,21 @@ class ManifestSourceGenerationTests: XCTestCase {
             let manifestLoader = ManifestLoader(toolchain: ToolchainConfiguration.default)
             let identityResolver = DefaultIdentityResolver()
             let manifest = try tsc_await {
-                manifestLoader.load(at: packageDir,
-                                    packageIdentity: .plain("Root"),
-                                    packageKind: .root(packageDir),
-                                    packageLocation: packageDir.pathString,
-                                    version: nil,
-                                    revision: nil,
-                                    toolsVersion: toolsVersion,
-                                    identityResolver: identityResolver,
-                                    fileSystem: fs,
-                                    observabilityScope: observability.topScope,
-                                    on: .global(),
-                                    completion: $0)
+                manifestLoader.load(
+                    at: packageDir,
+                    packageIdentity: .plain("Root"),
+                    packageKind: .root(packageDir),
+                    packageLocation: packageDir.pathString,
+                    version: nil,
+                    revision: nil,
+                    toolsVersion: toolsVersion,
+                    identityResolver: identityResolver,
+                    fileSystem: fs,
+                    observabilityScope: observability.topScope,
+                    delegateQueue: .sharedConcurrent,
+                    callbackQueue: .sharedConcurrent,
+                    completion: $0
+                )
             }
 
             XCTAssertNoDiagnostics(observability.diagnostics)
@@ -64,18 +67,21 @@ class ManifestSourceGenerationTests: XCTestCase {
             // Write out the generated manifest to replace the old manifest file contents, and load it again.
             try fs.writeFileContents(packageDir.appending(component: Manifest.filename), bytes: ByteString(encodingAsUTF8: newContents))
             let newManifest = try tsc_await {
-                manifestLoader.load(at: packageDir,
-                                    packageIdentity: .plain("Root"),
-                                    packageKind: .root(packageDir),
-                                    packageLocation: packageDir.pathString,
-                                    version: nil,
-                                    revision: nil,
-                                    toolsVersion: toolsVersion,
-                                    identityResolver: identityResolver,
-                                    fileSystem: fs,
-                                    observabilityScope: observability.topScope,
-                                    on: .global(),
-                                    completion: $0)
+                manifestLoader.load(
+                    at: packageDir,
+                    packageIdentity: .plain("Root"),
+                    packageKind: .root(packageDir),
+                    packageLocation: packageDir.pathString,
+                    version: nil,
+                    revision: nil,
+                    toolsVersion: toolsVersion,
+                    identityResolver: identityResolver,
+                    fileSystem: fs,
+                    observabilityScope: observability.topScope,
+                    delegateQueue: .sharedConcurrent,
+                    callbackQueue: .sharedConcurrent,
+                    completion: $0
+                )
             }
 
             XCTAssertNoDiagnostics(observability.diagnostics)

--- a/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
@@ -251,7 +251,8 @@ class RegistryPackageContainerTests: XCTestCase {
                           identityResolver: IdentityResolver,
                           fileSystem: FileSystem,
                           observabilityScope: ObservabilityScope,
-                          on queue: DispatchQueue,
+                          delegateQueue: DispatchQueue,
+                          callbackQueue: DispatchQueue,
                           completion: @escaping (Result<Manifest, Error>) -> Void) {
                     completion(.success(
                         Manifest(

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -9184,22 +9184,26 @@ final class WorkspaceTests: XCTestCase {
                 identityResolver: IdentityResolver,
                 fileSystem: FileSystem,
                 observabilityScope: ObservabilityScope,
-                on queue: DispatchQueue,
+                delegateQueue: DispatchQueue,
+                callbackQueue: DispatchQueue,
                 completion: @escaping (Result<Manifest, Error>) -> Void
             ) {
                 if let error = self.error {
-                    completion(.failure(error))
+                    callbackQueue.async {
+                        completion(.failure(error))
+                    }
                 } else {
-                    completion(.success(
-                        .init(
-                            displayName: packageIdentity.description,
-                            path: path,
-                            packageKind: packageKind,
-                            packageLocation: packageLocation,
-                            platforms: [],
-                            toolsVersion: toolsVersion)
-                        )
-                    )
+                    callbackQueue.async {
+                        completion(.success(
+                            .init(
+                                displayName: packageIdentity.description,
+                                path: path,
+                                packageKind: packageKind,
+                                packageLocation: packageLocation,
+                                platforms: [],
+                                toolsVersion: toolsVersion)
+                        ))
+                    }
                 }
             }
 


### PR DESCRIPTION
motivation: more correct and robust concurrency control for manifest loading

changes:
* use a seperate queue to schedule the evaluation tasks to ensure concurrency control is done correctly
* move concurrency control to the methods that forks the child processes so that its more targeted
* clarify what is the delegate queue and what is the callback queue
* move a handful of data structure defintions around to make code easier to read
* make concurrency tests more challanging