### PR TITLE
http client to support configurable max concurrent requests

### DIFF
--- a/Sources/Basics/ConcurrencyHelpers.swift
+++ b/Sources/Basics/ConcurrencyHelpers.swift
@@ -12,6 +12,8 @@ import Dispatch
 import class Foundation.ProcessInfo
 import TSCBasic
 
+public typealias Lock = TSCBasic.Lock
+
 /// Thread-safe dictionary like structure
 public final class ThreadSafeKeyValueStore<Key, Value> where Key: Hashable {
     private var underlying: [Key: Value]
@@ -194,6 +196,12 @@ public final class ThreadSafeBox<Value> {
         }
     }
 
+    public func get(`default`: Value) -> Value {
+        self.lock.withLock {
+            self.underlying ?? `default`
+        }
+    }
+
     public func put(_ newValue: Value) {
         self.lock.withLock {
             self.underlying = newValue
@@ -217,6 +225,23 @@ public final class ThreadSafeBox<Value> {
                 if var value = self.underlying {
                     value[keyPath: keyPath] = newValue
                 }
+            }
+        }
+    }
+}
+
+extension ThreadSafeBox where Value == Int {
+    public func increment() {
+        self.lock.withLock {
+            if let value = self.underlying {
+                self.underlying = value + 1
+            }
+        }
+    }
+    public func decrement() {
+        self.lock.withLock {
+            if let value = self.underlying {
+                self.underlying = value - 1
             }
         }
     }

--- a/Sources/Basics/Errors.swift
+++ b/Sources/Basics/Errors.swift
@@ -8,6 +8,10 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
+import struct TSCBasic.StringError
+
+public typealias StringError = TSCBasic.StringError
+
 public struct InternalError: Error {
     private let description: String
     public init(_ description: String) {

--- a/Sources/Basics/HTTPClient.swift
+++ b/Sources/Basics/HTTPClient.swift
@@ -13,6 +13,7 @@ import struct Foundation.Data
 import struct Foundation.Date
 import class Foundation.JSONDecoder
 import class Foundation.NSError
+import class Foundation.OperationQueue
 import struct Foundation.URL
 import TSCBasic
 
@@ -45,6 +46,11 @@ public struct HTTPClient {
     public var configuration: HTTPClientConfiguration
     private let underlying: Handler
 
+    /// DispatchSemaphore to restrict concurrent operations on manager.
+     private let concurrencySemaphore: DispatchSemaphore
+     /// OperationQueue to park pending requests
+     private let requestsQueue: OperationQueue
+
     // static to share across instances of the http client
     private static var hostsErrorsLock = Lock()
     private static var hostsErrors = [String: [Date]]()
@@ -53,6 +59,14 @@ public struct HTTPClient {
         self.configuration = configuration
         // FIXME: inject platform specific implementation here
         self.underlying = handler ?? URLSessionHTTPClient().execute
+
+        // this queue and semaphore is used to limit the amount of concurrent http requests taking place
+        // the default max number of request chosen to match Concurrency.maxOperations which is the number of active CPUs
+        let maxConcurrentRequests = configuration.maxConcurrentRequests ?? Concurrency.maxOperations
+        self.requestsQueue = OperationQueue()
+        self.requestsQueue.name = "org.swift.swiftpm.http-client"
+        self.requestsQueue.maxConcurrentOperationCount = maxConcurrentRequests
+        self.concurrencySemaphore = DispatchSemaphore(value: maxConcurrentRequests)
     }
 
     /// Execute an HTTP request asynchronously
@@ -100,12 +114,14 @@ public struct HTTPClient {
             observabilityScope: observabilityScope,
             progress: progress.map { handler in
                 { received, expected in
+                    // call back on the requested queue
                     callbackQueue.async {
                         handler(received, expected)
                     }
                 }
             },
             completion: { result in
+                // call back on the requested queue
                 callbackQueue.async {
                     completion(result)
                 }
@@ -114,45 +130,65 @@ public struct HTTPClient {
     }
 
     private func _execute(request: Request, requestNumber: Int, observabilityScope: ObservabilityScope?, progress: ProgressHandler?, completion: @escaping CompletionHandler) {
-        if self.shouldCircuitBreak(request: request) {
-            observabilityScope?.emit(warning: "Circuit breaker triggered for \(request.url)")
-            return completion(.failure(HTTPClientError.circuitBreakerTriggered))
+        // wrap completion handler with concurrency control cleanup
+        let originalCompletion = completion
+        let completion: CompletionHandler = { result in
+            // free concurrency control semaphore
+            self.concurrencySemaphore.signal()
+            originalCompletion(result)
         }
 
-        self.underlying(
-            request,
-            { received, expected in
-                if let max = request.options.maximumResponseSizeInBytes {
-                    guard received < max else {
-                        // FIXME: cancel the request?
-                        return completion(.failure(HTTPClientError.responseTooLarge(received)))
-                    }
-                }
-                progress?(received, expected)
-            },
-            { result in
-                switch result {
-                case .failure(let error):
-                    completion(.failure(error))
-                case .success(let response):
-                    // record host errors for circuit breaker
-                    self.recordErrorIfNecessary(response: response, request: request)
-                    // handle retry strategy
-                    if let retryDelay = self.shouldRetry(response: response, request: request, requestNumber: requestNumber) {
-                        observabilityScope?.emit(warning: "\(request.url) failed, retrying in \(retryDelay)")
-                        // TODO: dedicated retry queue?
-                        return self.configuration.callbackQueue.asyncAfter(deadline: .now() + retryDelay) {
-                            self._execute(request: request, requestNumber: requestNumber + 1, observabilityScope: observabilityScope, progress: progress, completion: completion)
+        // we must not block the calling thread (for concurrency control) so nesting this in a queue
+        self.requestsQueue.addOperation {
+            // park the request thread based on the max concurrency allowed
+            self.concurrencySemaphore.wait()
+
+            // apply circuit breaker if necessary
+            if self.shouldCircuitBreak(request: request) {
+                observabilityScope?.emit(warning: "Circuit breaker triggered for \(request.url)")
+                return completion(.failure(HTTPClientError.circuitBreakerTriggered))
+            }
+
+            // call underlying handler
+            self.underlying(
+                request,
+                { received, expected in
+                    if let max = request.options.maximumResponseSizeInBytes {
+                        guard received < max else {
+                            // FIXME: cancel the request?
+                            return completion(.failure(HTTPClientError.responseTooLarge(received)))
                         }
                     }
-                    // check for valid response codes
-                    if let validResponseCodes = request.options.validResponseCodes, !validResponseCodes.contains(response.statusCode) {
-                        return completion(.failure(HTTPClientError.badResponseStatusCode(response.statusCode)))
+                    progress?(received, expected)
+                },
+                { result in
+                    // handle result
+                    switch result {
+                    case .failure(let error):
+                        completion(.failure(error))
+                    case .success(let response):
+                        // record host errors for circuit breaker
+                        self.recordErrorIfNecessary(response: response, request: request)
+                        // handle retry strategy
+                        if let retryDelay = self.shouldRetry(response: response, request: request, requestNumber: requestNumber) {
+                            observabilityScope?.emit(warning: "\(request.url) failed, retrying in \(retryDelay)")
+                            // free concurrency control semaphore, since we re-submitting the request with the original completion handler
+                            // using the wrapped completion handler may lead to starving the mac concurrent requests
+                            self.concurrencySemaphore.signal()
+                            // TODO: dedicated retry queue?
+                            return self.configuration.callbackQueue.asyncAfter(deadline: .now() + retryDelay) {
+                                self._execute(request: request, requestNumber: requestNumber + 1, observabilityScope: observabilityScope, progress: progress, completion: originalCompletion)
+                            }
+                        }
+                        // check for valid response codes
+                        if let validResponseCodes = request.options.validResponseCodes, !validResponseCodes.contains(response.statusCode) {
+                            return completion(.failure(HTTPClientError.badResponseStatusCode(response.statusCode)))
+                        }
+                        completion(.success(response))
                     }
-                    completion(.success(response))
                 }
-            }
-        )
+            )
+        }
     }
 
     private func shouldRetry(response: Response, request: Request, requestNumber: Int) -> DispatchTimeInterval? {
@@ -245,6 +281,7 @@ public struct HTTPClientConfiguration {
     public var authorizationProvider: HTTPClientAuthorizationProvider?
     public var retryStrategy: HTTPClientRetryStrategy?
     public var circuitBreakerStrategy: HTTPClientCircuitBreakerStrategy?
+    public var maxConcurrentRequests: Int?
     public var callbackQueue: DispatchQueue
 
     public init() {
@@ -253,6 +290,7 @@ public struct HTTPClientConfiguration {
         self.authorizationProvider = .none
         self.retryStrategy = .none
         self.circuitBreakerStrategy = .none
+        self.maxConcurrentRequests = .none
         self.callbackQueue = .sharedConcurrent
     }
 }

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -2521,9 +2521,6 @@ extension Workspace {
             }
         }
 
-        // download max n files concurrently
-        let semaphore = DispatchSemaphore(value: Concurrency.maxOperations)
-
         // finally download zip files, if any
         for artifact in zipArtifacts.get() {
             let parentDirectory =  self.location.artifactsDirectory.appending(component: artifact.packageRef.identity.description)
@@ -2538,7 +2535,6 @@ extension Workspace {
                 }
             }
 
-            semaphore.wait()
             group.enter()
             var headers = HTTPClientHeaders()
             headers.add(name: "Accept", value: "application/octet-stream")
@@ -2559,10 +2555,7 @@ extension Workspace {
                         totalBytesToDownload: totalBytesToDownload)
                 },
                 completion: { downloadResult in
-                    defer {
-                        group.leave()
-                        semaphore.signal()
-                    }
+                    defer { group.leave() }
 
                     // TODO: Use the same extraction logic for both remote and local archived artifacts.
                     switch downloadResult {

--- a/Tests/BasicsTests/HTTPClientTests.swift
+++ b/Tests/BasicsTests/HTTPClientTests.swift
@@ -321,19 +321,19 @@ final class HTTPClientTest: XCTestCase {
     }
 
     func testExponentialBackoff() {
-        var count = 0
-        var lastCall: Date?
+        let count = ThreadSafeBox<Int>(0)
+        let lastCall = ThreadSafeBox<Date>()
         let maxAttempts = 5
         let errorCode = Int.random(in: 500 ..< 600)
         let delay = DispatchTimeInterval.milliseconds(100)
 
         let brokenHandler: HTTPClient.Handler = { _, _, completion in
-            let expectedDelta = pow(2.0, Double(count - 1)) * delay.timeInterval()!
-            let delta = lastCall.flatMap { Date().timeIntervalSince($0) } ?? 0
+            let expectedDelta = pow(2.0, Double(count.get(default: 0) - 1)) * delay.timeInterval()!
+            let delta = lastCall.get().flatMap { Date().timeIntervalSince($0) } ?? 0
             XCTAssertEqual(delta, expectedDelta, accuracy: 0.1)
 
-            count += 1
-            lastCall = Date()
+            count.increment()
+            lastCall.put(Date())
             completion(.success(HTTPClient.Response(statusCode: errorCode)))
         }
 
@@ -348,97 +348,133 @@ final class HTTPClientTest: XCTestCase {
                 XCTFail("unexpected error \(error)")
             case .success(let response):
                 XCTAssertEqual(response.statusCode, errorCode)
-                XCTAssertEqual(count, maxAttempts, "retries should match")
+                XCTAssertEqual(count.get(), maxAttempts, "retries should match")
             }
             promise.fulfill()
         }
 
         let timeout = Double(Int(pow(2.0, Double(maxAttempts))) * delay.milliseconds()!) / 1000
-        wait(for: [promise], timeout: timeout)
+        wait(for: [promise], timeout: 1.0 + timeout)
     }
 
     func testHostCircuitBreaker() {
-        var count = 0
-        let errorCode = Int.random(in: 500 ..< 600)
         let maxErrors = 5
-        let age = DispatchTimeInterval.milliseconds(100)
-
-        let brokenHandler: HTTPClient.Handler = { _, _, completion in
-            count += 1
-            completion(.success(HTTPClient.Response(statusCode: errorCode)))
-        }
+        let errorCode = Int.random(in: 500 ..< 600)
+        let age = DispatchTimeInterval.seconds(5)
 
         let host = "http://tes-\(UUID().uuidString).com"
-        let httpClient = HTTPClient(handler: brokenHandler)
+        var httpClient = HTTPClient(handler: { _, _, completion in
+            completion(.success(HTTPClient.Response(statusCode: errorCode)))
+        })
+        httpClient.configuration.circuitBreakerStrategy = .hostErrors(maxErrors: maxErrors, age: age)
 
+        // make the initial errors
+        do {
+            let sync = DispatchGroup()
+            let count = ThreadSafeBox<Int>(0)
+            (0 ..< maxErrors).forEach { index in
+                sync.enter()
+                httpClient.get(URL(string: "\(host)/\(index)/foo")!) { result in
+                    defer { sync.leave() }
+                    count.increment()
+                    switch result {
+                    case .failure(let error):
+                        XCTFail("unexpected failure \(error)")
+                    case .success(let response):
+                        XCTAssertEqual(response.statusCode, errorCode)
+                    }
+                }
+            }
+            XCTAssertEqual(sync.wait(timeout: .now() + .seconds(1)), .success, "should not timeout")
+            XCTAssertEqual(count.get(), maxErrors, "expected results count to match")
+        }
+
+        // these should all circuit break
         let sync = DispatchGroup()
-        (0 ... maxErrors * 2).forEach { index in
+        let count = ThreadSafeBox<Int>(0)
+        let total = Int.random(in: 10 ..< 20)
+        (0 ..< total).forEach { index in
             sync.enter()
-            var request = HTTPClient.Request(method: .get, url: URL(string: "\(host)/\(index)/foo")!)
-            request.options.circuitBreakerStrategy = .hostErrors(maxErrors: maxErrors, age: age)
-            httpClient.execute(request) { result in
+            httpClient.get(URL(string: "\(host)/\(index)/foo")!) { result in
                 defer { sync.leave() }
+                count.increment()
                 switch result {
                 case .failure(let error):
-                    if index < maxErrors {
-                        XCTFail("unexpected error \(error)")
-                    } else {
-                        XCTAssertEqual(error as? HTTPClientError, .circuitBreakerTriggered, "expected error to match")
-                    }
+                    XCTAssertEqual(error as? HTTPClientError, .circuitBreakerTriggered, "expected error to match")
                 case .success(let response):
-                    if index < maxErrors {
-                        XCTAssertEqual(response.statusCode, errorCode, "expected status code to match")
-                    } else {
-                        XCTFail("unexpected success \(response)")
-                    }
+                    XCTFail("unexpected success \(response)")
                 }
             }
         }
 
-        let timeout = DispatchTime.now() + .milliseconds(age.milliseconds()! * maxErrors)
-        XCTAssertEqual(sync.wait(timeout: timeout), .success, "should not timeout")
+        XCTAssertEqual(sync.wait(timeout: .now() + .seconds(1)), .success, "should not timeout")
+        XCTAssertEqual(count.get(), total, "expected results count to match")
     }
 
     func testHostCircuitBreakerAging() {
-        var count = 0
-        let errorCode = Int.random(in: 500 ..< 600)
         let maxErrors = 5
+        let errorCode = Int.random(in: 500 ..< 600)
         let age = DispatchTimeInterval.milliseconds(100)
 
-        let brokenHandler: HTTPClient.Handler = { _, _, completion in
-            if count < maxErrors / 2 {
-                // immediate
-                completion(.success(HTTPClient.Response(statusCode: errorCode)))
-            } else {
-                // age it
-                DispatchQueue.global().asyncAfter(deadline: .now() + age) {
-                    completion(.success(HTTPClient.Response(statusCode: errorCode)))
-                }
-            }
-            count += 1
-        }
-
         let host = "http://tes-\(UUID().uuidString).com"
-        let httpClient = HTTPClient(handler: brokenHandler)
+        var httpClient = HTTPClient(handler: { request, _, completion in
+            if request.url.lastPathComponent == "error" {
+                completion(.success(HTTPClient.Response(statusCode: errorCode)))
+            } else if request.url.lastPathComponent == "okay" {
+                completion(.success(.okay()))
+            } else {
+                completion(.failure(StringError("unknown request \(request.url)")))
+            }
+        })
+        httpClient.configuration.circuitBreakerStrategy = .hostErrors(maxErrors: maxErrors, age: age)
 
+
+        // make the initial errors
+        do {
+            let sync = DispatchGroup()
+            let count = ThreadSafeBox<Int>(0)
+            (0 ..< maxErrors).forEach { index in
+                sync.enter()
+                httpClient.get(URL(string: "\(host)/\(index)/error")!) { result in
+                    defer { sync.leave() }
+                    count.increment()
+                    switch result {
+                    case .failure(let error):
+                        XCTFail("unexpected failure \(error)")
+                    case .success(let response):
+                        XCTAssertEqual(response.statusCode, errorCode)
+                    }
+                }
+            }
+            XCTAssertEqual(sync.wait(timeout: .now() + .seconds(1)), .success, "should not timeout")
+            XCTAssertEqual(count.get(), maxErrors, "expected results count to match")
+        }
+
+        // these should not circuit break since they are deliberately aged
         let sync = DispatchGroup()
-        (0 ... maxErrors * 2).forEach { index in
+        let total = Int.random(in: 10 ..< 20)
+        let count = ThreadSafeBox<Int>(0)
+
+        (0 ..< total).forEach { index in
             sync.enter()
-            var request = HTTPClient.Request(method: .get, url: URL(string: "\(host)/\(index)/foo")!)
-            request.options.circuitBreakerStrategy = .hostErrors(maxErrors: maxErrors, age: age)
-            httpClient.execute(request) { result in
-                defer { sync.leave() }
-                switch result {
-                case .failure(let error):
-                    XCTFail("unexpected error \(error)")
-                case .success(let response):
-                    XCTAssertEqual(response.statusCode, errorCode, "expected status code to match")
+            // age it
+            DispatchQueue.sharedConcurrent.asyncAfter(deadline: .now() + age) {
+                httpClient.get(URL(string: "\(host)/\(index)/okay")!) { result in
+                    defer { sync.leave() }
+                    count.increment()
+                    switch result {
+                    case .failure(let error):
+                        XCTFail("unexpected error \(error)")
+                    case .success(let response):
+                        XCTAssertEqual(response.statusCode, 200, "expected status code to match")
+                    }
                 }
             }
         }
 
-        let timeout = DispatchTime.now() + .milliseconds(age.milliseconds()! * maxErrors)
+        let timeout = DispatchTime.now() + .seconds(1) + .milliseconds(age.milliseconds()! * maxErrors)
         XCTAssertEqual(sync.wait(timeout: timeout), .success, "should not timeout")
+        XCTAssertEqual(count.get(), total, "expected results count to match")
     }
 
     func testHTTPClientHeaders() {
@@ -462,6 +498,85 @@ final class HTTPClientTest: XCTestCase {
         }
         XCTAssertEqual(headers.count, items.count + 1, "headers count should match (no duplicates)")
         XCTAssertEqual(values, headers.get(name), "multiple headers value should match")
+    }
+
+    func testExceedsDownloadSizeLimitProgress() throws {
+        let maxSize: Int64 = 50
+
+        let httpClient = HTTPClient(handler: { request, progress, completion in
+            switch request.method {
+            case .head:
+                completion(.success(.init(
+                    statusCode: 200,
+                    headers: .init([.init(name: "Content-Length", value: "0")])
+                )))
+            case .get:
+                progress?(Int64(maxSize * 2), 0)
+            default:
+                XCTFail("method should match")
+            }
+        })
+
+        var request = HTTPClient.Request(url: URL(string: "http://test")!)
+        request.options.maximumResponseSizeInBytes = 10
+
+        let promise = XCTestExpectation(description: "completed")
+        httpClient.execute(request) { result in
+            switch result {
+            case .failure(let error):
+                XCTAssertEqual(error as? HTTPClientError, .responseTooLarge(maxSize * 2), "expected error to match")
+            case .success(let response):
+                XCTFail("unexpected success \(response)")
+            }
+            promise.fulfill()
+        }
+
+        wait(for: [promise], timeout: 1)
+    }
+
+    func testMaxConcurrency() throws {
+        let maxConcurrentRequests = 2
+        var concurrentRequests = 0
+        let concurrentRequestsLock = Lock()
+
+        var configuration = HTTPClient.Configuration()
+        configuration.maxConcurrentRequests = maxConcurrentRequests
+        let httpClient = HTTPClient(configuration: configuration, handler: { request, _, completion in
+            defer {
+                concurrentRequestsLock.withLock {
+                    concurrentRequests -= 1
+                }
+            }
+
+            concurrentRequestsLock.withLock {
+                concurrentRequests += 1
+                if concurrentRequests > maxConcurrentRequests {
+                    XCTFail("too many concurrent requests \(concurrentRequests), expected \(maxConcurrentRequests)")
+                }
+            }
+
+            completion(.success(.okay()))
+        })
+
+        let total = 1000
+        let sync = DispatchGroup()
+        let results = ThreadSafeArrayStore<Result<HTTPClient.Response, Error>>()
+        for _ in 0 ..< total {
+            sync.enter()
+            httpClient.get(URL(string: "http://localhost/test")!) { result in
+                defer { sync.leave() }
+                results.append(result)
+            }
+        }
+
+        if case .timedOut = sync.wait(timeout: .now() + .seconds(5)) {
+            throw StringError("requests timed out")
+        }
+
+        XCTAssertEqual(results.count, total, "expected number of results to match")
+        for result in results.get() {
+            XCTAssertEqual(try? result.get().statusCode, 200, "expected '200 okay' response")
+        }
     }
 
     private func assertRequestHeaders(_ headers: HTTPClientHeaders, expected: HTTPClientHeaders) {

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -6737,14 +6737,13 @@ final class WorkspaceTests: XCTestCase {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
-        // this has knowledge of the expected behavior, we can also make this configurable
-        let maxConcurrentRequests = Concurrency.maxOperations
-
+        let maxConcurrentRequests = 2
         var concurrentRequests = 0
         let concurrentRequestsLock = Lock()
 
-        // returns a dummy zipfile for the requested artifact
-        let httpClient = HTTPClient(handler: { request, _, completion in
+        var configuration = HTTPClient.Configuration()
+        configuration.maxConcurrentRequests = maxConcurrentRequests
+        let httpClient = HTTPClient(configuration: configuration, handler: { request, _, completion in
             defer {
                 concurrentRequestsLock.withLock {
                     concurrentRequests -= 1
@@ -6763,6 +6762,7 @@ final class WorkspaceTests: XCTestCase {
                     }
                 }
 
+                // returns a dummy zipfile for the requested artifact
                 try fileSystem.writeFileContents(
                     destination,
                     bytes: [0x01],


### PR DESCRIPTION
motivation: controlling how many concurrent requests are taking place is important for controlling bandwidth requirements, especially as we are transitioning to registry based dependencies

changes:
* add max concurrency controls to http client using a dedicated queue
* remove workspace binary dependencies concurrency control since its not longer necessary (applied at http client level)
* fix a bug in URLSeesion based HTTP client where download can be removed between delegate calls
* add and adjust tests
