### PR TITLE
build: statically link a subset of libraries

### DIFF
--- a/Sources/LLBuildManifest/CMakeLists.txt
+++ b/Sources/LLBuildManifest/CMakeLists.txt
@@ -6,7 +6,7 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
-add_library(LLBuildManifest
+add_library(LLBuildManifest STATIC
   BuildManifest.swift
   Command.swift
   ManifestWriter.swift
@@ -22,10 +22,4 @@ target_link_libraries(LLBuildManifest PUBLIC
 set_target_properties(LLBuildManifest PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 
-if(USE_CMAKE_INSTALL)
-    install(TARGETS LLBuildManifest
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin)
-endif()
 set_property(GLOBAL APPEND PROPERTY SwiftPM_EXPORTS LLBuildManifest)

--- a/Sources/PackageCollections/CMakeLists.txt
+++ b/Sources/PackageCollections/CMakeLists.txt
@@ -6,7 +6,7 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
-add_library(PackageCollections
+add_library(PackageCollections STATIC
   Model/Collection.swift
   Model/CVE.swift
   Model/License.swift
@@ -46,10 +46,4 @@ target_link_libraries(PackageCollections PUBLIC
 set_target_properties(PackageCollections PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 
-if(USE_CMAKE_INSTALL)
-install(TARGETS PackageCollections
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin)
-endif()
 set_property(GLOBAL APPEND PROPERTY SwiftPM_EXPORTS PackageCollections)

--- a/Sources/PackageCollectionsModel/CMakeLists.txt
+++ b/Sources/PackageCollectionsModel/CMakeLists.txt
@@ -6,7 +6,7 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
-add_library(PackageCollectionsModel
+add_library(PackageCollectionsModel STATIC
   PackageCollectionModel.swift
   PackageCollectionModel+v1.swift)
 target_link_libraries(PackageCollectionsModel PUBLIC
@@ -15,10 +15,4 @@ target_link_libraries(PackageCollectionsModel PUBLIC
 set_target_properties(PackageCollectionsModel PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 
-if(USE_CMAKE_INSTALL)
-install(TARGETS PackageCollectionsModel
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin)
-endif()
 set_property(GLOBAL APPEND PROPERTY SwiftPM_EXPORTS PackageCollectionsModel)

--- a/Sources/PackageCollectionsSigning/CMakeLists.txt
+++ b/Sources/PackageCollectionsSigning/CMakeLists.txt
@@ -6,7 +6,7 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
-add_library(PackageCollectionsSigning
+add_library(PackageCollectionsSigning STATIC
   Certificate/Certificate.swift
   Certificate/CertificatePolicy.swift
   Key/ASN1/ASN1.swift
@@ -50,10 +50,4 @@ set_target_properties(PackageCollectionsSigning PROPERTIES
 target_link_options(PackageCollectionsSigning PRIVATE
     "$<$<PLATFORM_ID:Darwin>:SHELL:-Xlinker -framework -Xlinker Security>")
 
-if(USE_CMAKE_INSTALL)
-install(TARGETS PackageCollectionsSigning
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin)
-endif()
 set_property(GLOBAL APPEND PROPERTY SwiftPM_EXPORTS PackageCollectionsSigning)

--- a/Sources/PackageFingerprint/CMakeLists.txt
+++ b/Sources/PackageFingerprint/CMakeLists.txt
@@ -6,7 +6,7 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
-add_library(PackageFingerprint
+add_library(PackageFingerprint STATIC
   FilePackageFingerprintStorage.swift
   Model.swift
   PackageFingerprintStorage.swift)
@@ -19,10 +19,4 @@ target_link_libraries(PackageFingerprint PUBLIC
 set_target_properties(PackageFingerprint PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 
-if(USE_CMAKE_INSTALL)
-install(TARGETS PackageFingerprint
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin)
-endif()
 set_property(GLOBAL APPEND PROPERTY SwiftPM_EXPORTS PackageFingerprint)

--- a/Sources/PackageRegistry/CMakeLists.txt
+++ b/Sources/PackageRegistry/CMakeLists.txt
@@ -6,7 +6,7 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
-add_library(PackageRegistry
+add_library(PackageRegistry STATIC
   Registry.swift
   RegistryConfiguration.swift
   RegistryClient.swift
@@ -22,10 +22,4 @@ target_link_libraries(PackageRegistry PUBLIC
 set_target_properties(PackageRegistry PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 
-if(USE_CMAKE_INSTALL)
-install(TARGETS PackageRegistry
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin)
-endif()
 set_property(GLOBAL APPEND PROPERTY SwiftPM_EXPORTS PackageRegistry)

--- a/Sources/SPMLLBuild/CMakeLists.txt
+++ b/Sources/SPMLLBuild/CMakeLists.txt
@@ -6,7 +6,7 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
-add_library(SPMLLBuild
+add_library(SPMLLBuild STATIC
   llbuild.swift)
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(SPMLLBuild PROPERTIES
@@ -18,10 +18,4 @@ target_link_libraries(SPMLLBuild PUBLIC
   Basics
   llbuildSwift)
 
-if(USE_CMAKE_INSTALL)
-install(TARGETS SPMLLBuild
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin)
-endif()
 set_property(GLOBAL APPEND PROPERTY SwiftPM_EXPORTS SPMLLBuild)

--- a/Sources/SourceControl/CMakeLists.txt
+++ b/Sources/SourceControl/CMakeLists.txt
@@ -6,11 +6,10 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
-add_library(SourceControl  
+add_library(SourceControl STATIC
   GitRepository.swift
   Repository.swift
   RepositoryManager.swift)
-
 target_link_libraries(SourceControl PUBLIC
   Basics
   PackageModel
@@ -22,10 +21,4 @@ target_link_libraries(SourceControl PUBLIC
 set_target_properties(SourceControl PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 
-if(USE_CMAKE_INSTALL)
-install(TARGETS SourceControl
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin)
-endif()
 set_property(GLOBAL APPEND PROPERTY SwiftPM_EXPORTS SourceControl)

--- a/Sources/XCBuildSupport/CMakeLists.txt
+++ b/Sources/XCBuildSupport/CMakeLists.txt
@@ -6,14 +6,13 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
-add_library(XCBuildSupport
+add_library(XCBuildSupport STATIC
   PIF.swift
   PIFBuilder.swift
   XCBuildDelegate.swift
   XCBuildMessage.swift
   XCBuildOutputParser.swift
-  XcodeBuildSystem.swift
-)
+  XcodeBuildSystem.swift)
 target_link_libraries(XCBuildSupport PUBLIC
   Build
   TSCBasic
@@ -23,10 +22,3 @@ target_link_libraries(XCBuildSupport PUBLIC
 
 set_target_properties(XCBuildSupport PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
-
-if(USE_CMAKE_INSTALL)
-install(TARGETS XCBuildSupport
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin)
-endif()

--- a/Sources/Xcodeproj/CMakeLists.txt
+++ b/Sources/Xcodeproj/CMakeLists.txt
@@ -6,7 +6,7 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
-add_library(Xcodeproj
+add_library(Xcodeproj STATIC
   generate.swift
   pbxproj.swift
   PropertyList.swift
@@ -22,9 +22,3 @@ target_link_libraries(Xcodeproj PUBLIC
 set_target_properties(Xcodeproj PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 
-if(USE_CMAKE_INSTALL)
-install(TARGETS Xcodeproj
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin)
-endif()


### PR DESCRIPTION
Now that Windows supports static link (to a certain extent), this
strategically statically links some of the internal libraries of Swift
Package manager.  This set was determined empirically, and was shown to
have a size benefit (beyond just reducing the distributed file count).

Before:
  273,408 Basics.dll
  543,232 Build.dll
3,083,776 Commands.dll
  187,904 LLBuildManifest.dll
  994,304 PackageCollections.dll
  168,960 PackageCollectionsModel.dll
  892,928 PackageCollectionsSigning.dll
   74,240 PackageFingerprint.dll
  818,176 PackageGraph.dll
  591,872 PackageLoading.dll
  776,704 PackageModel.dll
  220,672 PackageRegistry.dll
  181,248 SourceControl.dll
  560,640 SPMBuildCore.dll
   44,544 SPMLLBuild.dll
1,037,312 Workspace.dll
  587,776 XCBuildSupport.dll
  310,272 Xcodeproj.dll

   22,016 swift-build.exe
   24,576 swift-package.exe
   22,016 swift-run.exe
   22,016 swift-test.exe
11,438,592 bytes

After:
  273,408 Basics.dll
  662,528 Build.dll
5,531,136 Commands.dll
  817,664 PackageGraph.dll
  591,872 PackageLoading.dll
  776,704 PackageModel.dll
  560,640 SPMBuildCore.dll
1,355,264 Workspace.dll

   20,992 swift-build.exe
   23,552 swift-package.exe
   20,992 swift-run.exe
   20,992 swift-test.exe
10,655,744 bytes

This saves ~768KiB.

This additionally helps save ~1KiB from sourcekit-lsp after
SourceKit-LSP transitions to static linking.

Statically linking all the content in the repository causes the SPM
distribution to balloon 250% to ~25MiB and causes SourceKit-LSP to
balloon 300% to ~7MiB.

While it would be nice to statically link in Build into the Commands
(which saves ~100 KiB), it results in an overall bloat due to SK-LSP
increasing by ~300 KiB.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
