### PR TITLE
build: clean up some unnecessary conditions

### DIFF
--- a/Sources/Commands/CMakeLists.txt
+++ b/Sources/Commands/CMakeLists.txt
@@ -43,12 +43,8 @@ target_link_libraries(Commands PUBLIC
   Workspace
   XCBuildSupport
   Xcodeproj)
-if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  if(Foundation_FOUND)
-    target_link_libraries(Commands PUBLIC
-      FoundationXML)
-  endif()
-endif()
+target_link_libraries(Commands PRIVATE
+  $<$<NOT:$<PLATFORM_ID:Darwin>>:FoundationXML>)
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(Commands PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})

--- a/Sources/PackageDescription/CMakeLists.txt
+++ b/Sources/PackageDescription/CMakeLists.txt
@@ -47,10 +47,8 @@ set_target_properties(PackageDescription PROPERTIES
 )
 
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  if(Foundation_FOUND)
-    target_link_libraries(PackageDescription PRIVATE
-      Foundation)
-  endif()
+  target_link_libraries(PackageDescription PRIVATE
+    Foundation)
   target_link_options(PackageDescription PRIVATE
     "SHELL:-no-toolchain-stdlib-rpath")
   set_target_properties(PackageDescription PROPERTIES

--- a/Sources/PackageLoading/CMakeLists.txt
+++ b/Sources/PackageLoading/CMakeLists.txt
@@ -26,10 +26,8 @@ target_link_libraries(PackageLoading PUBLIC
   PackageModel
   SourceControl
   TSCUtility)
-if(Foundation_FOUND)
-  target_link_libraries(PackageLoading PUBLIC
-    $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)
-endif()
+target_link_libraries(PackageLoading PUBLIC
+  $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(PackageLoading PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})

--- a/Sources/PackagePlugin/CMakeLists.txt
+++ b/Sources/PackagePlugin/CMakeLists.txt
@@ -46,10 +46,8 @@ set_target_properties(PackagePlugin PROPERTIES
 )
 
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  if(Foundation_FOUND)
-    target_link_libraries(PackagePlugin PRIVATE
-      Foundation)
-  endif()
+  target_link_libraries(PackagePlugin PRIVATE
+    Foundation)
   target_link_options(PackagePlugin PRIVATE
     "SHELL:-no-toolchain-stdlib-rpath")
   set_target_properties(PackagePlugin PROPERTIES

--- a/Sources/Workspace/CMakeLists.txt
+++ b/Sources/Workspace/CMakeLists.txt
@@ -36,10 +36,8 @@ target_link_libraries(Workspace PUBLIC
   PackageModel
   SourceControl
   Xcodeproj)
-if(Foundation_FOUND)
-  target_link_libraries(PackageLoading PUBLIC
-    $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)
-endif()
+target_link_libraries(PackageLoading PUBLIC
+  $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(Workspace PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})


### PR DESCRIPTION
The dependencies on Foundation are effectively required on all
non-Darwin platforms.  Unconditionalize them and force the link against
the libraries irrespective of whether they are wired up to the build or
rely on the default linker search path.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
