### PR TITLE
refactor how plugins call the build system when using the CLI

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -735,6 +735,7 @@ public class SwiftTool {
         customBuildParameters: BuildParameters? = .none,
         customPackageGraphLoader: (() throws -> PackageGraph)? = .none,
         customOutputStream: OutputByteStream? = .none,
+        customLogLevel: Diagnostic.Severity? = .none,
         customObservabilityScope: ObservabilityScope? = .none
     ) throws -> BuildOperation {
         let graphLoader = { try self.loadPackageGraph(explicitProduct: explicitProduct) }
@@ -748,7 +749,7 @@ public class SwiftTool {
             pluginScriptRunner: self.getPluginScriptRunner(),
             pluginWorkDirectory: try self.getActiveWorkspace().location.pluginWorkingDirectory,
             outputStream: customOutputStream ?? self.outputStream,
-            logLevel: self.logLevel,
+            logLevel: customLogLevel ?? self.logLevel,
             fileSystem: self.fileSystem,
             observabilityScope: customObservabilityScope ?? self.observabilityScope
         )


### PR DESCRIPTION
motivation: consolidate use of build operation construction which is important for cancellation support

changes:
* use the general purpose function to create a build operation
* small refactoring of how build plan is extracted after the build is complete

