### PR TITLE
refactor CLI options

### DIFF
--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -18,7 +18,223 @@ import Build
 import struct TSCUtility.BuildFlags
 import struct TSCUtility.Triple
 
-struct BuildFlagsGroup: ParsableArguments {
+struct GlobalOptions: ParsableArguments {
+    init() {}
+
+    @OptionGroup()
+    var locations: LocationOptions
+
+    @OptionGroup()
+    var caching: CachingOptions
+
+    @OptionGroup()
+    var logging: LoggingOptions
+
+    @OptionGroup()
+    var security: SecurityOptions
+
+    @OptionGroup()
+    var resolver: ResolverOptions
+
+    @OptionGroup()
+    var build: BuildOptions
+
+    @OptionGroup()
+    var linker: LinkerOptions
+}
+
+struct LocationOptions: ParsableArguments {
+    init() {}
+
+    /// The custom build directory, if provided.
+    @Option(help: "Specify build/cache directory")
+    var buildPath: AbsolutePath?
+
+    @Option(help: "Specify the shared cache directory")
+    var cachePath: AbsolutePath?
+
+    @Option(help: "Specify the shared configuration directory")
+    var configPath: AbsolutePath?
+
+    @Option(help: "Specify the shared security directory")
+    var securityPath: AbsolutePath?
+
+    /// The custom working directory that the tool should operate in (deprecated).
+    @Option(name: [.long, .customShort("C")])
+    var chdir: AbsolutePath?
+
+    /// The custom working directory that the tool should operate in.
+    @Option(help: "Change working directory before any other operation")
+    var packagePath: AbsolutePath?
+
+    /// The path to the file containing multiroot package data. This is currently Xcode's workspace file.
+    @Option(name: .customLong("multiroot-data-file"), completion: .file())
+    var multirootPackageDataFile: AbsolutePath?
+
+    /// Path to the compilation destination describing JSON file.
+    @Option(name: .customLong("destination"), completion: .file())
+    var customCompileDestination: AbsolutePath?
+}
+
+struct CachingOptions: ParsableArguments {
+    /// Disables package caching.
+    @Flag(name: .customLong("dependency-cache"), inversion: .prefixedEnableDisable, help: "Use a shared cache when fetching dependencies")
+    var _useDependenciesCache: Bool?
+
+    // TODO: simplify when deprecating the older flag
+    var useDependenciesCache: Bool {
+        if let value = self._useDependenciesCache {
+            return value
+        } else if let value = self._deprecated_useRepositoriesCache {
+            return value
+        } else {
+            return true
+        }
+    }
+
+    /// Disables manifest caching.
+    @Flag(name: .customLong("disable-package-manifest-caching"), help: .hidden)
+    var shouldDisableManifestCaching: Bool = false
+
+    /// Whether to enable llbuild manifest caching.
+    @Flag(name: .customLong("build-manifest-caching"), inversion: .prefixedEnableDisable)
+    var cacheBuildManifest: Bool = true
+
+    /// Disables manifest caching.
+    @Option(name: .customLong("manifest-cache"), help: "Caching mode of Package.swift manifests (shared: shared cache, local: package's build directory, none: disabled")
+    var manifestCachingMode: ManifestCachingMode = .shared
+
+    enum ManifestCachingMode: String, ExpressibleByArgument {
+        case none
+        case local
+        case shared
+
+        init?(argument: String) {
+            self.init(rawValue: argument)
+        }
+    }
+
+    /// Disables repository caching.
+    @Flag(name: .customLong("repository-cache"), inversion: .prefixedEnableDisable, help: .hidden)
+    var _deprecated_useRepositoriesCache: Bool?
+}
+
+struct LoggingOptions: ParsableArguments {
+    init() {}
+
+    /// The verbosity of informational output.
+    @Flag(name: .shortAndLong, help: "Increase verbosity to include informational output")
+    var verbose: Bool = false
+
+    /// The verbosity of informational output.
+    @Flag(name: [.long, .customLong("vv")], help: "Increase verbosity to include debug output")
+    var veryVerbose: Bool = false
+}
+
+struct SecurityOptions: ParsableArguments {
+    init() {}
+
+    /// Disables sandboxing when executing subprocesses.
+    @Flag(name: .customLong("disable-sandbox"), help: "Disable using the sandbox when executing subprocesses")
+    var shouldDisableSandbox: Bool = false
+
+    /// Whether to load .netrc files for authenticating with remote servers
+    /// when downloading binary artifacts or communicating with a registry.
+    @Flag(inversion: .prefixedEnableDisable,
+          exclusivity: .exclusive,
+          help: "Load credentials from a .netrc file")
+    var netrc: Bool = true
+
+    /// The path to the .netrc file used when `netrc` is `true`.
+    @Option(
+        name: .customLong("netrc-file"),
+        help: "Specify the .netrc file path.",
+        completion: .file())
+    var netrcFilePath: AbsolutePath?
+
+    /// Whether to use keychain for authenticating with remote servers
+    /// when downloading binary artifacts or communicating with a registry.
+    #if canImport(Security)
+    @Flag(inversion: .prefixedEnableDisable,
+          exclusivity: .exclusive,
+          help: "Search credentials in macOS keychain")
+    var keychain: Bool = true
+    #else
+    @Flag(inversion: .prefixedEnableDisable,
+          exclusivity: .exclusive,
+          help: .hidden)
+    var keychain: Bool = false
+    #endif
+
+    @Option(name: .customLong("resolver-fingerprint-checking"))
+    var fingerprintCheckingMode: FingerprintCheckingMode = .warn
+
+    @Flag(name: .customLong("netrc"), help: .hidden)
+    var _deprecated_netrc: Bool = false
+
+    @Flag(name: .customLong("netrc-optional"), help: .hidden)
+    var _deprecated_netrcOptional: Bool = false
+}
+
+struct ResolverOptions: ParsableArguments {
+    init() {}
+
+    /// Enable prefetching in resolver which will kick off parallel git cloning.
+    @Flag(name: .customLong("prefetching"), inversion: .prefixedEnableDisable)
+    var shouldEnableResolverPrefetching: Bool = true
+
+    /// Use Package.resolved file for resolving dependencies.
+    @Flag(name: [.long, .customLong("disable-automatic-resolution"), .customLong("only-use-versions-from-resolved-file")], help: "Only use versions from the Package.resolved file and fail resolution if it is out-of-date")
+    var forceResolvedVersions: Bool = false
+
+    /// Skip updating dependencies from their remote during a resolution.
+    @Flag(name: .customLong("skip-update"), help: "Skip updating dependencies from their remote during a resolution")
+    var skipDependencyUpdate: Bool = false
+
+
+    @Flag(help: "Define automatic transformation of source control based dependencies to registry based ones")
+    var sourceControlToRegistryDependencyTransformation: SourceControlToRegistryDependencyTransformation = .disabled
+
+    /// Write dependency resolver trace to a file.
+    @Flag(name: .customLong("trace-resolver"), help: .hidden)
+    var _deprecated_enableResolverTrace: Bool = false
+
+    enum SourceControlToRegistryDependencyTransformation: EnumerableFlag {
+        case disabled
+        case identity
+        case swizzle
+
+        static func name(for value: Self) -> NameSpecification {
+            switch value {
+            case .disabled:
+                return .customLong("disable-scm-to-registry-transformation")
+            case .identity:
+                return .customLong("use-registry-identity-for-scm")
+            case .swizzle:
+                return .customLong("replace-scm-with-registry")
+            }
+        }
+
+        static func help(for value: SourceControlToRegistryDependencyTransformation) -> ArgumentHelp? {
+            switch value {
+            case .disabled:
+                return "disable source control to registry transformation"
+            case .identity:
+                return "look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins"
+            case .swizzle:
+                return "look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible"
+            }
+        }
+    }
+}
+
+struct BuildOptions: ParsableArguments {
+    init() {}
+
+    /// Build configuration.
+    @Option(name: .shortAndLong, help: "Build with configuration")
+    var configuration: BuildConfiguration = .debug
+
     @Option(name: .customLong("Xcc", withSingleDash: true),
             parsing: .unconditionalSingleValue,
             help: "Pass flag through to all C compiler invocations")
@@ -60,165 +276,6 @@ struct BuildFlagsGroup: ParsableArguments {
             xlinker: linkerFlags)
     }
 
-    init() {}
-}
-
-extension BuildConfiguration: ExpressibleByArgument {
-    public init?(argument: String) {
-        self.init(rawValue: argument)
-    }
-}
-
-extension AbsolutePath: ExpressibleByArgument {
-    public init?(argument: String) {
-        if let cwd = localFileSystem.currentWorkingDirectory {
-            self.init(argument, relativeTo: cwd)
-        } else {
-            guard let path = try? AbsolutePath(validating: argument) else {
-                return nil
-            }
-            self = path
-        }
-    }
-
-    public static var defaultCompletionKind: CompletionKind {
-        // This type is most commonly used to select a directory, not a file.
-        // Specify '.file()' in an argument declaration when necessary.
-        .directory
-    }
-}
-
-enum BuildSystemKind: String, ExpressibleByArgument, CaseIterable {
-    case native
-    case xcode
-}
-
-extension FingerprintCheckingMode: ExpressibleByArgument {
-    public init?(argument: String) {
-        self.init(rawValue: argument)
-    }
-}
-
-public extension Sanitizer {
-    init(argument: String) throws {
-        if let sanitizer = Sanitizer(rawValue: argument) {
-            self = sanitizer
-            return
-        }
-
-        for sanitizer in Sanitizer.allCases where sanitizer.shortName == argument {
-            self = sanitizer
-            return
-        }
-
-        throw StringError("valid sanitizers: \(Sanitizer.formattedValues)")
-    }
-
-    /// All sanitizer options in a comma separated string
-    fileprivate static var formattedValues: String {
-        return Sanitizer.allCases.map(\.rawValue).joined(separator: ", ")
-    }
-}
-
-public struct SwiftToolOptions: ParsableArguments {
-    @OptionGroup()
-    var buildFlagsGroup: BuildFlagsGroup
-
-    /// Custom arguments to pass to C compiler, swift compiler and the linker.
-    var buildFlags: BuildFlags {
-        buildFlagsGroup.buildFlags
-    }
-
-    var xcbuildFlags: [String] {
-        buildFlagsGroup.xcbuildFlags
-    }
-
-    var manifestFlags: [String] {
-        buildFlagsGroup.manifestFlags
-    }
-
-    /// Build configuration.
-    @Option(name: .shortAndLong, help: "Build with configuration")
-    var configuration: BuildConfiguration = .debug
-
-    /// The custom build directory, if provided.
-    @Option(help: "Specify build/cache directory")
-    var buildPath: AbsolutePath?
-
-    @Option(help: "Specify the shared cache directory")
-    var cachePath: AbsolutePath?
-
-    @Option(help: "Specify the shared configuration directory")
-    var configPath: AbsolutePath?
-
-    @Option(help: "Specify the shared security directory")
-    var securityPath: AbsolutePath?
-
-    /// Disables package caching.
-    @Flag(name: .customLong("dependency-cache"), inversion: .prefixedEnableDisable, help: "Use a shared cache when fetching dependencies")
-    var _useDependenciesCache: Bool?
-
-    // TODO: simplify when deprecating the older flag
-    var useDependenciesCache: Bool {
-        if let value = self._useDependenciesCache {
-            return value
-        } else if let value = self._deprecated_useRepositoriesCache {
-            return value
-        } else {
-            return true
-        }
-    }
-
-    /// The custom working directory that the tool should operate in (deprecated).
-    @Option(name: [.long, .customShort("C")])
-    var chdir: AbsolutePath?
-
-    /// The custom working directory that the tool should operate in.
-    @Option(help: "Change working directory before any other operation")
-    var packagePath: AbsolutePath?
-
-    /// The path to the file containing multiroot package data. This is currently Xcode's workspace file.
-    @Option(name: .customLong("multiroot-data-file"), completion: .file())
-    var multirootPackageDataFile: AbsolutePath?
-
-    /// Enable prefetching in resolver which will kick off parallel git cloning.
-    @Flag(name: .customLong("prefetching"), inversion: .prefixedEnableDisable)
-    var shouldEnableResolverPrefetching: Bool = true
-
-    /// The verbosity of informational output.
-    @Flag(name: .shortAndLong, help: "Increase verbosity to include informational output")
-    var verbose: Bool = false
-
-    /// The verbosity of informational output.
-    @Flag(name: [.long, .customLong("vv")], help: "Increase verbosity to include debug output")
-    var veryVerbose: Bool = false
-
-    /// Disables sandboxing when executing subprocesses.
-    @Flag(name: .customLong("disable-sandbox"), help: "Disable using the sandbox when executing subprocesses")
-    var shouldDisableSandbox: Bool = false
-
-    /// Disables manifest caching.
-    @Flag(name: .customLong("disable-package-manifest-caching"), help: .hidden)
-    var shouldDisableManifestCaching: Bool = false
-
-    /// Disables manifest caching.
-    @Option(name: .customLong("manifest-cache"), help: "Caching mode of Package.swift manifests (shared: shared cache, local: package's build directory, none: disabled")
-    var manifestCachingMode: ManifestCachingMode = .shared
-
-    enum ManifestCachingMode: String, ExpressibleByArgument {
-        case none
-        case local
-        case shared
-
-        init?(argument: String) {
-            self.init(rawValue: argument)
-        }
-    }
-
-    /// Path to the compilation destination describing JSON file.
-    @Option(name: .customLong("destination"), completion: .file())
-    var customCompileDestination: AbsolutePath?
-
     /// The compilation destination’s target triple.
     @Option(name: .customLong("triple"), transform: Triple.init)
     var customCompileTriple: Triple?
@@ -239,14 +296,6 @@ public struct SwiftToolOptions: ParsableArguments {
         shouldDisplay: false))
     public var archs: [String] = []
 
-    /// If should link the Swift stdlib statically.
-    @Flag(name: .customLong("static-swift-stdlib"), inversion: .prefixedNo, help: "Link Swift stdlib statically")
-    var shouldLinkStaticSwiftStdlib: Bool = false
-
-    /// Skip updating dependencies from their remote during a resolution.
-    @Flag(name: .customLong("skip-update"), help: "Skip updating dependencies from their remote during a resolution")
-    var skipDependencyUpdate: Bool = false
-
     /// Which compile-time sanitizers should be enabled.
     @Option(name: .customLong("sanitize"),
             help: "Turn on runtime checks for erroneous behavior, possible values: \(Sanitizer.formattedValues)",
@@ -257,27 +306,8 @@ public struct SwiftToolOptions: ParsableArguments {
         EnabledSanitizers(Set(sanitizers))
     }
 
-    /// Whether to enable code coverage.
-    @Flag(name: .customLong("code-coverage"),
-          inversion: .prefixedEnableDisable,
-          help: "Enable code coverage")
-    var shouldEnableCodeCoverage: Bool = false
-
-    /// Use Package.resolved file for resolving dependencies.
-    @Flag(name: [.long, .customLong("disable-automatic-resolution"), .customLong("only-use-versions-from-resolved-file")], help: "Only use versions from the Package.resolved file and fail resolution if it is out-of-date")
-    var forceResolvedVersions: Bool = false
-
     @Flag(help: "Enable or disable indexing-while-building feature")
     var indexStoreMode: StoreMode = .autoIndexStore
-
-    // @Flag works best when there is a default value present
-    // if true, false aren't enough and a third state is needed
-    // nil should not be the goto. Instead create an enum
-    enum StoreMode: EnumerableFlag {
-        case autoIndexStore
-        case enableIndexStore
-        case disableIndexStore
-    }
 
     /// Whether to enable generation of `.swiftinterface`s alongside `.swiftmodule`s.
     @Flag(name: .customLong("enable-parseable-module-interfaces"))
@@ -286,14 +316,6 @@ public struct SwiftToolOptions: ParsableArguments {
     /// The number of jobs for llbuild to start (aka the number of schedulerLanes)
     @Option(name: .shortAndLong, help: "The number of jobs to spawn in parallel during the build process")
     var jobs: UInt32?
-
-    /// Whether to enable test discovery on platforms without Objective-C runtime.
-    @Flag(help: .hidden)
-    var enableTestDiscovery: Bool = false
-
-    /// Whether to enable llbuild manifest caching.
-    @Flag(name: .customLong("build-manifest-caching"), inversion: .prefixedEnableDisable)
-    var cacheBuildManifest: Bool = true
 
     /// Emit the Swift module separately from the object files.
     @Flag()
@@ -328,36 +350,27 @@ public struct SwiftToolOptions: ParsableArguments {
         #endif
     }
 
-    /// Whether to load .netrc files for authenticating with remote servers
-    /// when downloading binary artifacts or communicating with a registry.
-    @Flag(inversion: .prefixedEnableDisable,
-          exclusivity: .exclusive,
-          help: "Load credentials from a .netrc file")
-    var netrc: Bool = true
+    /// Whether to enable test discovery on platforms without Objective-C runtime.
+    @Flag(help: .hidden)
+    var enableTestDiscovery: Bool = false
 
-    /// The path to the .netrc file used when `netrc` is `true`.
-    @Option(
-        name: .customLong("netrc-file"),
-        help: "Specify the .netrc file path.",
-        completion: .file())
-    var netrcFilePath: AbsolutePath?
+    // @Flag works best when there is a default value present
+    // if true, false aren't enough and a third state is needed
+    // nil should not be the goto. Instead create an enum
+    enum StoreMode: EnumerableFlag {
+        case autoIndexStore
+        case enableIndexStore
+        case disableIndexStore
+    }
 
-    /// Whether to use keychain for authenticating with remote servers
-    /// when downloading binary artifacts or communicating with a registry.
-    #if canImport(Security)
-    @Flag(inversion: .prefixedEnableDisable,
-          exclusivity: .exclusive,
-          help: "Search credentials in macOS keychain")
-    var keychain: Bool = true
-    #else
-    @Flag(inversion: .prefixedEnableDisable,
-          exclusivity: .exclusive,
-          help: .hidden)
-    var keychain: Bool = false
-    #endif
-    
-    @Option(name: .customLong("resolver-fingerprint-checking"))
-    var resolverFingerprintCheckingMode: FingerprintCheckingMode = .warn
+    enum BuildSystemKind: String, ExpressibleByArgument, CaseIterable {
+        case native
+        case xcode
+    }
+}
+
+struct LinkerOptions: ParsableArguments {
+    init() {}
 
     @Flag(
         name: .customLong("dead-strip"),
@@ -365,50 +378,64 @@ public struct SwiftToolOptions: ParsableArguments {
         help: "Disable/enable dead code stripping by the linker")
     var linkerDeadStrip: Bool = true
 
-    @Flag(help: "Define automatic transformation of source control based dependencies to registry based ones")
-    var sourceControlToRegistryDependencyTransformation: SourceControlToRegistryDependencyTransformation = .disabled
+    /// If should link the Swift stdlib statically.
+    @Flag(name: .customLong("static-swift-stdlib"), inversion: .prefixedNo, help: "Link Swift stdlib statically")
+    var shouldLinkStaticSwiftStdlib: Bool = false
+}
 
-    enum SourceControlToRegistryDependencyTransformation: EnumerableFlag {
-        case disabled
-        case identity
-        case swizzle
 
-        static func name(for value: Self) -> NameSpecification {
-            switch value {
-            case .disabled:
-                return .customLong("disable-scm-to-registry-transformation")
-            case .identity:
-                return .customLong("use-registry-identity-for-scm")
-            case .swizzle:
-                return .customLong("replace-scm-with-registry")
+// MARK: - Extensions
+
+
+extension BuildConfiguration: ExpressibleByArgument {
+    public init?(argument: String) {
+        self.init(rawValue: argument)
+    }
+}
+
+extension AbsolutePath: ExpressibleByArgument {
+    public init?(argument: String) {
+        if let cwd = localFileSystem.currentWorkingDirectory {
+            self.init(argument, relativeTo: cwd)
+        } else {
+            guard let path = try? AbsolutePath(validating: argument) else {
+                return nil
             }
-        }
-
-        static func help(for value: SwiftToolOptions.SourceControlToRegistryDependencyTransformation) -> ArgumentHelp? {
-            switch value {
-            case .disabled:
-                return "disable source control to registry transformation"
-            case .identity:
-                return "look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins"
-            case .swizzle:
-                return "look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible"
-            }
+            self = path
         }
     }
 
-    @Flag(name: .customLong("netrc"), help: .hidden)
-    var _deprecated_netrc: Bool = false
+    public static var defaultCompletionKind: CompletionKind {
+        // This type is most commonly used to select a directory, not a file.
+        // Specify '.file()' in an argument declaration when necessary.
+        .directory
+    }
+}
 
-    @Flag(name: .customLong("netrc-optional"), help: .hidden)
-    var _deprecated_netrcOptional: Bool = false
 
-    /// Disables repository caching.
-    @Flag(name: .customLong("repository-cache"), inversion: .prefixedEnableDisable, help: .hidden)
-    var _deprecated_useRepositoriesCache: Bool?
+extension FingerprintCheckingMode: ExpressibleByArgument {
+    public init?(argument: String) {
+        self.init(rawValue: argument)
+    }
+}
 
-    /// Write dependency resolver trace to a file.
-    @Flag(name: .customLong("trace-resolver"), help: .hidden)
-    var _deprecated_enableResolverTrace: Bool = false
+extension Sanitizer {
+    init(argument: String) throws {
+        if let sanitizer = Sanitizer(rawValue: argument) {
+            self = sanitizer
+            return
+        }
 
-    public init() {}
+        for sanitizer in Sanitizer.allCases where sanitizer.shortName == argument {
+            self = sanitizer
+            return
+        }
+
+        throw StringError("valid sanitizers: \(Sanitizer.formattedValues)")
+    }
+
+    /// All sanitizer options in a comma separated string
+    fileprivate static var formattedValues: String {
+        return Sanitizer.allCases.map(\.rawValue).joined(separator: ", ")
+    }
 }

--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -86,8 +86,8 @@ public struct SwiftBuildTool: SwiftCommand {
         version: SwiftVersion.currentVersion.completeDisplayString,
         helpNames: [.short, .long, .customLong("help", withSingleDash: true)])
 
-    @OptionGroup(_hiddenFromHelp: true)
-    var swiftOptions: SwiftToolOptions
+    @OptionGroup()
+    var globalOptions: GlobalOptions
 
     @OptionGroup()
     var options: BuildToolOptions

--- a/Sources/Commands/SwiftPackageCollectionsTool.swift
+++ b/Sources/Commands/SwiftPackageCollectionsTool.swift
@@ -78,7 +78,7 @@ public struct SwiftPackageCollectionsTool: ParsableCommand {
         var jsonOptions: JSONOptions
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         func run(_ swiftTool: SwiftTool) throws {
             let collections = try with(swiftTool) { collections in
@@ -99,7 +99,7 @@ public struct SwiftPackageCollectionsTool: ParsableCommand {
         static let configuration = CommandConfiguration(abstract: "Refresh configured collections")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         func run(_ swiftTool: SwiftTool) throws {
             let collections = try with(swiftTool) { collections in
@@ -125,7 +125,7 @@ public struct SwiftPackageCollectionsTool: ParsableCommand {
         var skipSignatureCheck: Bool = false
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         func run(_ swiftTool: SwiftTool) throws {
             let collectionURL = try url(self.collectionURL)
@@ -164,7 +164,7 @@ public struct SwiftPackageCollectionsTool: ParsableCommand {
         var collectionURL: String
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         func run(_ swiftTool: SwiftTool) throws {
             let collectionURL = try url(self.collectionURL)
@@ -198,7 +198,7 @@ public struct SwiftPackageCollectionsTool: ParsableCommand {
         var searchQuery: String
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         func run(_ swiftTool: SwiftTool) throws {
             try with(swiftTool) { collections in
@@ -245,7 +245,7 @@ public struct SwiftPackageCollectionsTool: ParsableCommand {
         var version: String?
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         private func printVersion(_ version: PackageCollectionsModel.Package.Version?) -> String? {
             guard let version = version else {

--- a/Sources/Commands/SwiftPackageRegistryTool.swift
+++ b/Sources/Commands/SwiftPackageRegistryTool.swift
@@ -54,7 +54,7 @@ public struct SwiftPackageRegistryTool: ParsableCommand {
         helpNames: [.short, .long, .customLong("help", withSingleDash: true)])
 
     @OptionGroup()
-    var swiftOptions: SwiftToolOptions
+    var globalOptions: GlobalOptions
 
     public init() {}
 
@@ -63,7 +63,7 @@ public struct SwiftPackageRegistryTool: ParsableCommand {
             abstract: "Set a custom registry")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Flag(help: "Apply settings to all projects for this user")
         var global: Bool = false
@@ -115,7 +115,7 @@ public struct SwiftPackageRegistryTool: ParsableCommand {
             abstract: "Remove a configured registry")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Flag(help: "Apply settings to all projects for this user")
         var global: Bool = false

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -70,7 +70,7 @@ public struct SwiftPackageTool: ParsableCommand {
         helpNames: [.short, .long, .customLong("help", withSingleDash: true)])
 
     @OptionGroup()
-    var swiftOptions: SwiftToolOptions
+    var globalOptions: GlobalOptions
 
     public init() {}
 
@@ -85,7 +85,7 @@ extension SwiftPackageTool {
             abstract: "Delete build artifacts")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         func run(_ swiftTool: SwiftTool) throws {
             try swiftTool.getActiveWorkspace().clean(observabilityScope: swiftTool.observabilityScope)
@@ -97,7 +97,7 @@ extension SwiftPackageTool {
             abstract: "Purge the global repository cache.")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         func run(_ swiftTool: SwiftTool) throws {
             try swiftTool.getActiveWorkspace().purgeCache(observabilityScope: swiftTool.observabilityScope)
@@ -109,7 +109,7 @@ extension SwiftPackageTool {
             abstract: "Reset the complete cache/build directory")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         func run(_ swiftTool: SwiftTool) throws {
             try swiftTool.getActiveWorkspace().reset(observabilityScope: swiftTool.observabilityScope)
@@ -121,7 +121,7 @@ extension SwiftPackageTool {
             abstract: "Update package dependencies")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Flag(name: [.long, .customShort("n")],
               help: "Display the list of dependencies that can be updated")
@@ -191,7 +191,7 @@ extension SwiftPackageTool {
             abstract: "Describe the current package")
         
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
         
         @Option(help: "json | text")
         var type: DescribeMode = .text
@@ -244,7 +244,7 @@ extension SwiftPackageTool {
             abstract: "Initialize a new package")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Option(name: .customLong("type"), help: "Package type: empty | library | executable | system-module | manifest")
         var initMode: InitPackage.PackageType = .library
@@ -276,7 +276,7 @@ extension SwiftPackageTool {
             commandName: "_format")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Argument(parsing: .unconditionalRemaining,
                   help: "Pass flag through to the swift-format tool")
@@ -362,7 +362,7 @@ extension SwiftPackageTool {
             """)
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Option(help: """
         The path to a text file containing breaking changes which should be ignored by the API comparison. \
@@ -393,7 +393,7 @@ extension SwiftPackageTool {
             let apiDigesterPath = try swiftTool.getToolchain().getSwiftAPIDigester()
             let apiDigesterTool = SwiftAPIDigester(fileSystem: swiftTool.fileSystem, tool: apiDigesterPath)
 
-            let packageRoot = try swiftOptions.packagePath ?? swiftTool.getPackageRoot()
+            let packageRoot = try globalOptions.locations.packagePath ?? swiftTool.getPackageRoot()
             let repository = GitRepository(path: packageRoot)
             let baselineRevision = try repository.resolveRevision(identifier: treeish)
 
@@ -561,7 +561,7 @@ extension SwiftPackageTool {
         static let defaultMinimumAccessLevel = SymbolGraphExtract.AccessLevel.public
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Flag(help: "Pretty-print the output JSON.")
         var prettyPrint = false
@@ -617,7 +617,7 @@ extension SwiftPackageTool {
             abstract: "Print parsed Package.swift as JSON")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         func run(_ swiftTool: SwiftTool) throws {
             let workspace = try swiftTool.getActiveWorkspace()
@@ -645,7 +645,7 @@ extension SwiftPackageTool {
 
     struct DumpPIF: SwiftCommand {
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Flag(help: "Preserve the internal structure of PIF")
         var preserveStructure: Bool = false
@@ -669,7 +669,7 @@ extension SwiftPackageTool {
             abstract: "Put a package in editable mode")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Option(help: "The revision to edit", transform: { Revision(identifier: $0) })
         var revision: Revision?
@@ -703,7 +703,7 @@ extension SwiftPackageTool {
             abstract: "Remove a package from editable mode")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Flag(name: .customLong("force"),
               help: "Unedit the package even if it has uncommited and unpushed changes")
@@ -730,7 +730,7 @@ extension SwiftPackageTool {
             abstract: "Print the resolved dependency graph")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Option(help: "text | dot | json | flatlist")
         var format: ShowDependenciesMode = .text
@@ -798,7 +798,7 @@ extension SwiftPackageTool {
             abstract: "Manipulate tools version of the current package")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Flag(help: "Set tools version of package to the current tools version in use")
         var setCurrent: Bool = false
@@ -854,7 +854,7 @@ extension SwiftPackageTool {
             abstract: "Compute the checksum for a binary artifact.")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Argument(help: "The absolute or relative path to the binary artifact")
         var path: AbsolutePath
@@ -873,7 +873,7 @@ extension SwiftPackageTool {
         )
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Option(
             name: [.short, .long],
@@ -882,7 +882,7 @@ extension SwiftPackageTool {
         var output: AbsolutePath?
 
         func run(_ swiftTool: SwiftTool) throws {
-            let packageRoot = try swiftOptions.packagePath ?? swiftTool.getPackageRoot()
+            let packageRoot = try globalOptions.locations.packagePath ?? swiftTool.getPackageRoot()
             let repository = GitRepository(path: packageRoot)
 
             let destination: AbsolutePath
@@ -912,7 +912,7 @@ extension SwiftPackageTool {
         )
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Flag(name: .customLong("list"),
               help: "List the available command plugins")
@@ -999,7 +999,7 @@ extension SwiftPackageTool {
                 fileSystem: swiftTool.fileSystem,
                 cacheDir: pluginsDir.appending(component: "cache"),
                 toolchain: try swiftTool.getToolchain().configuration,
-                enableSandbox: !swiftTool.options.shouldDisableSandbox)
+                enableSandbox: !swiftTool.options.security.shouldDisableSandbox)
 
             // The `outputs` directory contains subdirectories for each combination of package and command plugin. Each usage of a plugin has an output directory that is writable by the plugin, where it can write additional files, and to which it can configure tools to write their outputs, etc.
             let outputDir = pluginsDir.appending(component: "outputs")
@@ -1237,19 +1237,23 @@ final class PluginDelegate: PluginInvocationDelegate {
         }
 
         // Construct the environment we'll pass down to the tests.
-        var environmentOptions = swiftTool.options
-        environmentOptions.shouldEnableCodeCoverage = parameters.enableCodeCoverage
         let testEnvironment = try TestingSupport.constructTestEnvironment(
             toolchain: toolchain,
-            options: environmentOptions,
-            buildParameters: buildParameters)
+            buildParameters: buildParameters,
+            sanitizers: swiftTool.options.build.sanitizers
+        )
 
         // Iterate over the tests and run those that match the filter.
         var testTargetResults: [PluginInvocationTestResult.TestTarget] = []
         var numFailedTests = 0
         for testProduct in buildSystem.builtTestProducts {
             // Get the test suites in the bundle. Each is just a container for test cases.
-            let testSuites = try TestingSupport.getTestSuites(fromTestAt: testProduct.bundlePath, swiftTool: swiftTool, swiftOptions: swiftTool.options)
+            let testSuites = try TestingSupport.getTestSuites(
+                fromTestAt: testProduct.bundlePath,
+                swiftTool: swiftTool,
+                enableCodeCoverage: parameters.enableCodeCoverage,
+                sanitizers: swiftTool.options.build.sanitizers
+            )
             for testSuite in testSuites {
                 // Each test suite is just a container for test cases (confusingly called "tests", though they are test cases).
                 for testCase in testSuite.tests {
@@ -1429,7 +1433,7 @@ extension SwiftPackageTool {
             shouldDisplay: false)
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @OptionGroup()
         var pluginOptions: PluginCommand.PluginOptions
@@ -1505,19 +1509,25 @@ extension SwiftPackageTool {
 
             @Flag(help: "Do not add file references for extra files to the generated Xcode project")
             var skipExtraFiles: Bool = false
+
+            /// Whether to enable code coverage.
+            @Flag(name: .customLong("code-coverage"),
+                  inversion: .prefixedEnableDisable,
+                  help: "Enable code coverage")
+            var enableCodeCoverage: Bool = false
         }
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @OptionGroup()
         var options: Options
 
         func xcodeprojOptions() -> XcodeprojOptions {
             XcodeprojOptions(
-                flags: swiftOptions.buildFlags,
+                flags: globalOptions.build.buildFlags,
                 xcconfigOverrides: options.xcconfigOverrides,
-                isCodeCoverageEnabled: swiftOptions.shouldEnableCodeCoverage,
+                isCodeCoverageEnabled: options.enableCodeCoverage,
                 useLegacySchemeGenerator: options.useLegacySchemeGenerator,
                 enableAutogeneration: options.enableAutogeneration,
                 addExtraFiles: !options.skipExtraFiles)
@@ -1586,7 +1596,7 @@ extension SwiftPackageTool.Config {
             abstract: "Set a mirror for a dependency")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Option(help: "The package dependency url")
         var packageURL: String?
@@ -1621,7 +1631,7 @@ extension SwiftPackageTool.Config {
             abstract: "Remove an existing mirror")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Option(help: "The package dependency url")
         var packageURL: String?
@@ -1656,7 +1666,7 @@ extension SwiftPackageTool.Config {
             abstract: "Print mirror configuration for the given package dependency")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Option(help: "The package dependency url")
         var packageURL: String?
@@ -1717,7 +1727,7 @@ extension SwiftPackageTool {
             abstract: "Resolve package dependencies")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @OptionGroup()
         var resolveOptions: ResolveOptions
@@ -1748,7 +1758,7 @@ extension SwiftPackageTool {
         static let configuration = CommandConfiguration(shouldDisplay: false)
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @OptionGroup()
         var resolveOptions: ResolveOptions
@@ -1756,7 +1766,7 @@ extension SwiftPackageTool {
         func run(_ swiftTool: SwiftTool) throws {
             swiftTool.observabilityScope.emit(warning: "'fetch' command is deprecated; use 'resolve' instead")
 
-            let resolveCommand = Resolve(swiftOptions: _swiftOptions, resolveOptions: _resolveOptions)
+            let resolveCommand = Resolve(globalOptions: _globalOptions, resolveOptions: _resolveOptions)
             try resolveCommand.run(swiftTool)
         }
     }
@@ -1793,7 +1803,7 @@ extension SwiftPackageTool {
         }
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Argument(help: "generate-bash-script | generate-zsh-script |\ngenerate-fish-script | list-dependencies | list-executables")
         var mode: Mode
@@ -1837,7 +1847,7 @@ extension SwiftPackageTool {
     struct Learn: SwiftCommand {
 
         @OptionGroup()
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         static let configuration = CommandConfiguration(abstract: "Learn about Swift and this package")
 

--- a/Sources/Commands/SwiftRunTool.swift
+++ b/Sources/Commands/SwiftRunTool.swift
@@ -94,8 +94,8 @@ public struct SwiftRunTool: SwiftCommand {
         version: SwiftVersion.currentVersion.completeDisplayString,
         helpNames: [.short, .long, .customLong("help", withSingleDash: true)])
 
-    @OptionGroup(_hiddenFromHelp: true)
-    public var swiftOptions: SwiftToolOptions
+    @OptionGroup()
+    var globalOptions: GlobalOptions
 
     @OptionGroup()
     var options: RunToolOptions

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -269,14 +269,14 @@ private class ToolWorkspaceDelegate: WorkspaceDelegate {
 }
 
 protocol SwiftCommand: ParsableCommand {
-    var swiftOptions: SwiftToolOptions { get }
+    var globalOptions: GlobalOptions { get }
 
     func run(_ swiftTool: SwiftTool) throws
 }
 
 extension SwiftCommand {
     public func run() throws {
-        let swiftTool = try SwiftTool(options: swiftOptions)
+        let swiftTool = try SwiftTool(options: globalOptions)
         try self.run(swiftTool)
         if swiftTool.observabilityScope.errorsReported || swiftTool.executionStatus == .failure {
             throw ExitCode.failure
@@ -296,7 +296,7 @@ public class SwiftTool {
     let originalWorkingDirectory: AbsolutePath
 
     /// The options of this tool.
-    let options: SwiftToolOptions
+    let options: GlobalOptions
 
     /// Path to the root package directory, nil if manifest is not found.
     let packageRoot: AbsolutePath?
@@ -313,7 +313,7 @@ public class SwiftTool {
     func getWorkspaceRoot() throws -> PackageGraphRootInput {
         let packages: [AbsolutePath]
 
-        if let workspace = options.multirootPackageDataFile {
+        if let workspace = options.locations.multirootPackageDataFile {
             packages = try XcodeWorkspaceLoader(fileSystem: self.fileSystem, observabilityScope: self.observabilityScope).load(workspace: workspace)
         } else {
             packages = [try getPackageRoot()]
@@ -366,7 +366,7 @@ public class SwiftTool {
     /// Create an instance of this tool.
     ///
     /// - parameter options: The command line options to be passed to this tool.
-    public convenience init(options: SwiftToolOptions) throws {
+    convenience init(options: GlobalOptions) throws {
         // output from background activities goes to stderr, this includes diagnostics and output from build operations,
         // package resolution that take place as part of another action
         // CLI commands that have user facing output, use stdout directly to emit the final result
@@ -376,10 +376,10 @@ public class SwiftTool {
     }
 
     // marked internal for testing
-    internal init(outputStream: OutputByteStream, options: SwiftToolOptions) throws {
+    internal init(outputStream: OutputByteStream, options: GlobalOptions) throws {
         self.fileSystem = localFileSystem
         // first, bootstrap the observability system
-        self.logLevel = options.logLevel
+        self.logLevel = options.logging.logLevel
         self.observabilityHandler = SwiftToolObservabilityHandler(outputStream: outputStream, logLevel: self.logLevel)
         let observabilitySystem = ObservabilitySystem(self.observabilityHandler)
         self.observabilityScope = observabilitySystem.topScope
@@ -396,7 +396,7 @@ public class SwiftTool {
             self.options = options
 
             // Honor package-path option is provided.
-            if let packagePath = options.packagePath ?? options.chdir {
+            if let packagePath = options.locations.packagePath ?? options.locations.chdir {
                 try ProcessEnv.chdir(packagePath)
             }
 
@@ -466,7 +466,7 @@ public class SwiftTool {
         }
 
         // Create local variables to use while finding build path to avoid capture self before init error.
-        let customBuildPath = options.buildPath
+        let customBuildPath = options.locations.buildPath
         let packageRoot = findPackageRoot(fileSystem: fileSystem)
 
         self.packageRoot = packageRoot
@@ -483,54 +483,53 @@ public class SwiftTool {
         Process.loggingHandler = { self.observabilityScope.emit(debug: $0) }
     }
 
-    static func postprocessArgParserResult(options: SwiftToolOptions, observabilityScope: ObservabilityScope) throws {
-        if options.chdir != nil {
+    static func postprocessArgParserResult(options: GlobalOptions, observabilityScope: ObservabilityScope) throws {
+        if options.locations.chdir != nil {
             observabilityScope.emit(warning: "'--chdir/-C' option is deprecated; use '--package-path' instead")
         }
 
-        if options.multirootPackageDataFile != nil {
+        if options.locations.multirootPackageDataFile != nil {
             observabilityScope.emit(.unsupportedFlag("--multiroot-data-file"))
         }
 
-        if options.useExplicitModuleBuild && !options.useIntegratedSwiftDriver {
+        if options.build.useExplicitModuleBuild && !options.build.useIntegratedSwiftDriver {
             observabilityScope.emit(error: "'--experimental-explicit-module-build' option requires '--use-integrated-swift-driver'")
         }
 
-        if !options.archs.isEmpty && options.customCompileTriple != nil {
+        if !options.build.archs.isEmpty && options.build.customCompileTriple != nil {
             observabilityScope.emit(.mutuallyExclusiveArgumentsError(arguments: ["--arch", "--triple"]))
         }
 
         // --enable-test-discovery should never be called on darwin based platforms
-#if canImport(Darwin)
-        if options.enableTestDiscovery {
+        #if canImport(Darwin)
+        if options.build.enableTestDiscovery {
             observabilityScope.emit(warning: "'--enable-test-discovery' option is deprecated; tests are automatically discovered on all platforms")
         }
-#endif
+        #endif
 
-        if options.shouldDisableManifestCaching {
+        if options.caching.shouldDisableManifestCaching {
             observabilityScope.emit(warning: "'--disable-package-manifest-caching' option is deprecated; use '--manifest-caching' instead")
         }
 
-        if let _ = options.netrcFilePath, options.netrc == false {
+        if let _ = options.security.netrcFilePath, options.security.netrc == false {
             observabilityScope.emit(.mutuallyExclusiveArgumentsError(arguments: ["--disable-netrc", "--netrc-file"]))
         }
 
-        if options._deprecated_netrc {
+        if options.security._deprecated_netrc {
             observabilityScope.emit(warning: "'--netrc' option is deprecated; .netrc files are located by default")
         }
 
-        if options._deprecated_netrcOptional {
+        if options.security._deprecated_netrcOptional {
             observabilityScope.emit(warning: "'--netrc-optional' option is deprecated; .netrc files are located by default")
         }
 
-        if options._deprecated_enableResolverTrace {
+        if options.resolver._deprecated_enableResolverTrace {
             observabilityScope.emit(warning: "'--enableResolverTrace' flag is deprecated; use '--verbose' option to log resolver output")
         }
 
-        if options._deprecated_useRepositoriesCache != nil {
+        if options.caching._deprecated_useRepositoriesCache != nil {
             observabilityScope.emit(warning: "'--disable-repository-cache'/'--enable-repository-cache' flags are deprecated; use '--disable-dependency-cache'/'--enable-dependency-cache' instead")
         }
-
     }
 
     /// Returns the currently active workspace.
@@ -541,7 +540,7 @@ public class SwiftTool {
 
         let delegate = ToolWorkspaceDelegate(self.outputStream, logLevel: self.logLevel, observabilityScope: self.observabilityScope)
         let repositoryProvider = GitRepositoryProvider(processSet: self.processSet)
-        let isXcodeBuildSystemEnabled = self.options.buildSystem == .xcode
+        let isXcodeBuildSystemEnabled = self.options.build.buildSystem == .xcode
         let workspace = try Workspace(
             fileSystem: self.fileSystem,
             location: .init(
@@ -555,12 +554,12 @@ public class SwiftTool {
             ),
             authorizationProvider: self.getAuthorizationProvider(),
             configuration: .init(
-                skipDependenciesUpdates: options.skipDependencyUpdate,
-                prefetchBasedOnResolvedFile: options.shouldEnableResolverPrefetching,
+                skipDependenciesUpdates: options.resolver.skipDependencyUpdate,
+                prefetchBasedOnResolvedFile: options.resolver.shouldEnableResolverPrefetching,
                 additionalFileRules: isXcodeBuildSystemEnabled ? FileRuleDescription.xcbuildFileTypes : FileRuleDescription.swiftpmFileTypes,
-                sharedDependenciesCacheEnabled: self.options.useDependenciesCache,
-                fingerprintCheckingMode: self.options.resolverFingerprintCheckingMode,
-                sourceControlToRegistryDependencyTransformation: self.options.sourceControlToRegistryDependencyTransformation.workspaceConfiguration
+                sharedDependenciesCacheEnabled: self.options.caching.useDependenciesCache,
+                fingerprintCheckingMode: self.options.security.fingerprintCheckingMode,
+                sourceControlToRegistryDependencyTransformation: self.options.resolver.sourceControlToRegistryDependencyTransformation.workspaceConfiguration
             ),
             initializationWarningHandler: { self.observabilityScope.emit(warning: $0) },
             customHostToolchain: self.getHostToolchain(),
@@ -575,7 +574,7 @@ public class SwiftTool {
 
     private func getEditsDirectory() throws -> AbsolutePath {
         // TODO: replace multiroot-data-file with explicit overrides
-        if let multiRootPackageDataFile = options.multirootPackageDataFile {
+        if let multiRootPackageDataFile = options.locations.multirootPackageDataFile {
             return multiRootPackageDataFile.appending(component: "Packages")
         }
         return try Workspace.DefaultLocations.editsDirectory(forRootPackage: self.getPackageRoot())
@@ -583,7 +582,7 @@ public class SwiftTool {
 
     private func getResolvedVersionsFile() throws -> AbsolutePath {
         // TODO: replace multiroot-data-file with explicit overrides
-        if let multiRootPackageDataFile = options.multirootPackageDataFile {
+        if let multiRootPackageDataFile = options.locations.multirootPackageDataFile {
             return multiRootPackageDataFile.appending(components: "xcshareddata", "swiftpm", "Package.resolved")
         }
         return try Workspace.DefaultLocations.resolvedVersionsFile(forRootPackage: self.getPackageRoot())
@@ -592,7 +591,7 @@ public class SwiftTool {
     internal func getLocalConfigurationDirectory() throws -> AbsolutePath {
         // Otherwise, use the default path.
         // TODO: replace multiroot-data-file with explicit overrides
-        if let multiRootPackageDataFile = options.multirootPackageDataFile {
+        if let multiRootPackageDataFile = options.locations.multirootPackageDataFile {
             // migrate from legacy location
             let legacyPath = multiRootPackageDataFile.appending(components: "xcshareddata", "swiftpm", "config")
             let newPath = Workspace.DefaultLocations.mirrorsConfigurationFile(at: multiRootPackageDataFile.appending(components: "xcshareddata", "swiftpm", "configuration"))
@@ -607,17 +606,17 @@ public class SwiftTool {
 
     func getAuthorizationProvider() throws -> AuthorizationProvider? {
         var authorization = Workspace.Configuration.Authorization.default
-        if !options.netrc {
+        if !options.security.netrc {
             authorization.netrc = .disabled
-        } else if let configuredPath = options.netrcFilePath {
+        } else if let configuredPath = options.security.netrcFilePath {
             authorization.netrc = .custom(configuredPath)
         } else {
-            let rootPath = try options.multirootPackageDataFile ?? self.getPackageRoot()
+            let rootPath = try options.locations.multirootPackageDataFile ?? self.getPackageRoot()
             authorization.netrc = .workspaceAndUser(rootPath: rootPath)
         }
 
         #if canImport(Security)
-        authorization.keychain = self.options.keychain ? .enabled : .disabled
+        authorization.keychain = self.options.security.keychain ? .enabled : .disabled
         #endif
 
         return try authorization.makeAuthorizationProvider(fileSystem: self.fileSystem, observabilityScope: self.observabilityScope)
@@ -628,7 +627,7 @@ public class SwiftTool {
         let workspace = try getActiveWorkspace()
         let root = try getWorkspaceRoot()
 
-        if options.forceResolvedVersions {
+        if options.resolver.forceResolvedVersions {
             try workspace.resolveBasedOnResolvedVersionsFile(root: root, observabilityScope: self.observabilityScope)
         } else {
             try workspace.resolve(root: root, observabilityScope: self.observabilityScope)
@@ -660,7 +659,7 @@ public class SwiftTool {
                 explicitProduct: explicitProduct,
                 createMultipleTestProducts: createMultipleTestProducts,
                 createREPLProduct: createREPLProduct,
-                forceResolvedVersions: options.forceResolvedVersions,
+                forceResolvedVersions: options.resolver.forceResolvedVersions,
                 observabilityScope: self.observabilityScope
             )
 
@@ -682,7 +681,7 @@ public class SwiftTool {
             fileSystem: self.fileSystem,
             cacheDir: cacheDir,
             toolchain: self.getHostToolchain().configuration,
-            enableSandbox: !self.options.shouldDisableSandbox
+            enableSandbox: !self.options.security.shouldDisableSandbox
         )
         return pluginScriptRunner
     }
@@ -701,7 +700,7 @@ public class SwiftTool {
     }
 
     private func canUseCachedBuildManifest() throws -> Bool {
-        if !self.options.cacheBuildManifest {
+        if !self.options.caching.cacheBuildManifest {
             return false
         }
 
@@ -771,7 +770,7 @@ public class SwiftTool {
         customObservabilityScope: ObservabilityScope? = .none
     ) throws -> BuildSystem {
         let buildSystem: BuildSystem
-        switch options.buildSystem {
+        switch options.build.buildSystem {
         case .native:
             let graphLoader = { try self.loadPackageGraph(explicitProduct: explicitProduct) }
 
@@ -781,7 +780,7 @@ public class SwiftTool {
                 packageGraphLoader: customPackageGraphLoader ?? graphLoader,
                 pluginScriptRunner: self.getPluginScriptRunner(),
                 pluginWorkDirectory: try self.getActiveWorkspace().location.pluginWorkingDirectory,
-                disableSandboxForPluginCommands: self.options.shouldDisableSandbox,
+                disableSandboxForPluginCommands: self.options.security.shouldDisableSandbox,
                 outputStream: customOutputStream ?? self.outputStream,
                 logLevel: self.logLevel,
                 fileSystem: self.fileSystem,
@@ -819,31 +818,31 @@ public class SwiftTool {
             // can be used to build for any Apple platform and it has it's own
             // conventions for build subpaths based on platforms.
             let dataPath = buildPath.appending(
-                component: options.buildSystem == .xcode ? "apple" : triple.platformBuildPathComponent())
+                component: options.build.buildSystem == .xcode ? "apple" : triple.platformBuildPathComponent())
             return BuildParameters(
                 dataPath: dataPath,
-                configuration: options.configuration,
+                configuration: options.build.configuration,
                 toolchain: toolchain,
                 destinationTriple: triple,
-                archs: options.archs,
-                flags: options.buildFlags,
-                xcbuildFlags: options.xcbuildFlags,
-                jobs: options.jobs ?? UInt32(ProcessInfo.processInfo.activeProcessorCount),
-                shouldLinkStaticSwiftStdlib: options.shouldLinkStaticSwiftStdlib,
+                archs: options.build.archs,
+                flags: options.build.buildFlags,
+                xcbuildFlags: options.build.xcbuildFlags,
+                jobs: options.build.jobs ?? UInt32(ProcessInfo.processInfo.activeProcessorCount),
+                shouldLinkStaticSwiftStdlib: options.linker.shouldLinkStaticSwiftStdlib,
                 canRenameEntrypointFunctionName: SwiftTargetBuildDescription.checkSupportedFrontendFlags(
                     flags: ["entry-point-function-name"], fileSystem: self.fileSystem
                 ),
-                sanitizers: options.enabledSanitizers,
-                enableCodeCoverage: options.shouldEnableCodeCoverage,
-                indexStoreMode: options.indexStoreMode.buildParameter,
-                enableParseableModuleInterfaces: options.shouldEnableParseableModuleInterfaces,
-                emitSwiftModuleSeparately: options.emitSwiftModuleSeparately,
-                useIntegratedSwiftDriver: options.useIntegratedSwiftDriver,
-                useExplicitModuleBuild: options.useExplicitModuleBuild,
-                isXcodeBuildSystemEnabled: options.buildSystem == .xcode,
-                printManifestGraphviz: options.printManifestGraphviz,
-                forceTestDiscovery: options.enableTestDiscovery, // backwards compatibility, remove with --enable-test-discovery
-                linkerDeadStrip: options.linkerDeadStrip,
+                sanitizers: options.build.enabledSanitizers,
+                enableCodeCoverage: false, // set by test commands when appropriate
+                indexStoreMode: options.build.indexStoreMode.buildParameter,
+                enableParseableModuleInterfaces: options.build.shouldEnableParseableModuleInterfaces,
+                emitSwiftModuleSeparately: options.build.emitSwiftModuleSeparately,
+                useIntegratedSwiftDriver: options.build.useIntegratedSwiftDriver,
+                useExplicitModuleBuild: options.build.useExplicitModuleBuild,
+                isXcodeBuildSystemEnabled: options.build.buildSystem == .xcode,
+                printManifestGraphviz: options.build.printManifestGraphviz,
+                forceTestDiscovery: options.build.enableTestDiscovery, // backwards compatibility, remove with --enable-test-discovery
+                linkerDeadStrip: options.linker.linkerDeadStrip,
                 verboseOutput: self.logLevel <= .info
             )
         })
@@ -856,9 +855,9 @@ public class SwiftTool {
         do {
             hostDestination = try self._hostToolchain.get().destination
             // Create custom toolchain if present.
-            if let customDestination = self.options.customCompileDestination {
+            if let customDestination = self.options.locations.customCompileDestination {
                 destination = try Destination(fromFile: customDestination, fileSystem: self.fileSystem)
-            } else if let target = self.options.customCompileTriple,
+            } else if let target = self.options.build.customCompileTriple,
                       let targetDestination = Destination.defaultDestination(for: target, host: hostDestination) {
                 destination = targetDestination
             } else {
@@ -869,16 +868,16 @@ public class SwiftTool {
             return .failure(error)
         }
         // Apply any manual overrides.
-        if let triple = self.options.customCompileTriple {
+        if let triple = self.options.build.customCompileTriple {
             destination.target = triple
         }
-        if let binDir = self.options.customCompileToolchain {
+        if let binDir = self.options.build.customCompileToolchain {
             destination.binDir = binDir.appending(components: "usr", "bin")
         }
-        if let sdk = self.options.customCompileSDK {
+        if let sdk = self.options.build.customCompileSDK {
             destination.sdk = sdk
         }
-        destination.archs = options.archs
+        destination.archs = options.build.archs
 
         // Check if we ended up with the host toolchain.
         if hostDestination == destination {
@@ -899,7 +898,7 @@ public class SwiftTool {
     private lazy var _manifestLoader: Result<ManifestLoader, Swift.Error> = {
         return Result(catching: {
             let cachePath: AbsolutePath?
-            switch (self.options.shouldDisableManifestCaching, self.options.manifestCachingMode) {
+            switch (self.options.caching.shouldDisableManifestCaching, self.options.caching.manifestCachingMode) {
             case (true, _):
                 // backwards compatibility
                 cachePath = .none
@@ -911,7 +910,7 @@ public class SwiftTool {
                 cachePath = self.sharedCacheDirectory.map{ Workspace.DefaultLocations.manifestsDirectory(at: $0) }
             }
 
-            var extraManifestFlags = self.options.manifestFlags
+            var extraManifestFlags = self.options.build.manifestFlags
             // Disable the implicit concurrency import if the compiler in use supports it to avoid warnings if we are building against an older SDK that does not contain a Concurrency module.
             if SwiftTargetBuildDescription.checkSupportedFrontendFlags(flags: ["disable-implicit-concurrency-module-import"], fileSystem: self.fileSystem) {
                 extraManifestFlags += ["-Xfrontend", "-disable-implicit-concurrency-module-import"]
@@ -924,7 +923,7 @@ public class SwiftTool {
             return try ManifestLoader(
                 // Always use the host toolchain's resources for parsing manifest.
                 toolchain: self.getHostToolchain().configuration,
-                isManifestSandboxEnabled: !self.options.shouldDisableSandbox,
+                isManifestSandboxEnabled: !self.options.security.shouldDisableSandbox,
                 cacheDir: cachePath,
                 extraManifestFlags: extraManifestFlags
             )
@@ -964,8 +963,8 @@ private func getEnvBuildPath(workingDir: AbsolutePath) -> AbsolutePath? {
 }
 
 
-private func getSharedSecurityDirectory(options: SwiftToolOptions, fileSystem: FileSystem, observabilityScope: ObservabilityScope) throws -> AbsolutePath? {
-    if let explicitSecurityPath = options.securityPath {
+private func getSharedSecurityDirectory(options: GlobalOptions, fileSystem: FileSystem, observabilityScope: ObservabilityScope) throws -> AbsolutePath? {
+    if let explicitSecurityPath = options.locations.securityPath {
         // Create the explicit security path if necessary
         if !fileSystem.exists(explicitSecurityPath) {
             try fileSystem.createDirectory(explicitSecurityPath, recursive: true)
@@ -977,8 +976,8 @@ private func getSharedSecurityDirectory(options: SwiftToolOptions, fileSystem: F
     }
 }
 
-private func getSharedConfigurationDirectory(options: SwiftToolOptions, fileSystem: FileSystem, observabilityScope: ObservabilityScope) throws -> AbsolutePath? {
-    if let explicitConfigPath = options.configPath {
+private func getSharedConfigurationDirectory(options: GlobalOptions, fileSystem: FileSystem, observabilityScope: ObservabilityScope) throws -> AbsolutePath? {
+    if let explicitConfigPath = options.locations.configPath {
         // Create the explicit config path if necessary
         if !fileSystem.exists(explicitConfigPath) {
             try fileSystem.createDirectory(explicitConfigPath, recursive: true)
@@ -990,8 +989,8 @@ private func getSharedConfigurationDirectory(options: SwiftToolOptions, fileSyst
     }
 }
 
-private func getSharedCacheDirectory(options: SwiftToolOptions, fileSystem: FileSystem, observabilityScope: ObservabilityScope) throws -> AbsolutePath? {
-    if let explicitCachePath = options.cachePath {
+private func getSharedCacheDirectory(options: GlobalOptions, fileSystem: FileSystem, observabilityScope: ObservabilityScope) throws -> AbsolutePath? {
+    if let explicitCachePath = options.locations.cachePath {
         // Create the explicit cache path if necessary
         if !fileSystem.exists(explicitCachePath) {
             try fileSystem.createDirectory(explicitCachePath, recursive: true)
@@ -1145,7 +1144,7 @@ extension Workspace.ManagedDependency {
     }
 }
 
-extension SwiftToolOptions {
+extension LoggingOptions {
     var logLevel: Diagnostic.Severity {
         if self.verbose {
             return .info
@@ -1157,7 +1156,7 @@ extension SwiftToolOptions {
     }
 }
 
-extension SwiftToolOptions.SourceControlToRegistryDependencyTransformation {
+extension ResolverOptions.SourceControlToRegistryDependencyTransformation {
     var workspaceConfiguration: WorkspaceConfiguration.SourceControlToRegistryDependencyTransformation {
         switch self {
         case .disabled:
@@ -1170,7 +1169,7 @@ extension SwiftToolOptions.SourceControlToRegistryDependencyTransformation {
     }
 }
 
-extension SwiftToolOptions.StoreMode {
+extension BuildOptions.StoreMode {
     var buildParameter: BuildParameters.IndexStoreMode {
         switch self {
         case .autoIndexStore:

--- a/Sources/Commands/TestingSupport.swift
+++ b/Sources/Commands/TestingSupport.swift
@@ -42,9 +42,19 @@ enum TestingSupport {
         throw InternalError("XCTestHelper binary not found.")
     }
 
-    static func getTestSuites(in testProducts: [BuiltTestProduct], swiftTool: SwiftTool, swiftOptions: SwiftToolOptions) throws -> [AbsolutePath: [TestSuite]] {
+    static func getTestSuites(in testProducts: [BuiltTestProduct], swiftTool: SwiftTool, enableCodeCoverage: Bool, sanitizers: [Sanitizer]) throws -> [AbsolutePath: [TestSuite]] {
         let testSuitesByProduct = try testProducts
-            .map { try ($0.bundlePath, TestingSupport.getTestSuites(fromTestAt: $0.bundlePath, swiftTool: swiftTool, swiftOptions: swiftOptions)) }
+            .map {
+                (
+                    $0.bundlePath,
+                    try TestingSupport.getTestSuites(
+                        fromTestAt: $0.bundlePath,
+                        swiftTool: swiftTool,
+                        enableCodeCoverage: enableCodeCoverage,
+                        sanitizers: sanitizers
+                    )
+                )
+            }
         return try Dictionary(throwingUniqueKeysWithValues: testSuitesByProduct)
     }
 
@@ -58,12 +68,18 @@ enum TestingSupport {
     /// - Throws: TestError, SystemError, TSCUtility.Error
     ///
     /// - Returns: Array of TestSuite
-    static func getTestSuites(fromTestAt path: AbsolutePath, swiftTool: SwiftTool, swiftOptions: SwiftToolOptions) throws -> [TestSuite] {
+    static func getTestSuites(fromTestAt path: AbsolutePath, swiftTool: SwiftTool, enableCodeCoverage: Bool, sanitizers: [Sanitizer]) throws -> [TestSuite] {
         // Run the correct tool.
         #if os(macOS)
         let data: String = try withTemporaryFile { tempFile in
             let args = [try TestingSupport.xctestHelperPath(swiftTool: swiftTool).pathString, path.pathString, tempFile.path.pathString]
-            var env = try TestingSupport.constructTestEnvironment(toolchain: try swiftTool.getToolchain(), options: swiftOptions, buildParameters: swiftTool.buildParametersForTest())
+            var env = try TestingSupport.constructTestEnvironment(
+                toolchain: try swiftTool.getToolchain(),
+                buildParameters: swiftTool.buildParametersForTest(
+                    enableCodeCoverage: enableCodeCoverage
+                ),
+                sanitizers: sanitizers
+            )
             // Add the sdk platform path if we have it. If this is not present, we
             // might always end up failing.
             if let sdkPlatformFrameworksPath = Destination.sdkPlatformFrameworkPaths() {
@@ -76,7 +92,7 @@ enum TestingSupport {
             return try swiftTool.fileSystem.readFileContents(tempFile.path)
         }
         #else
-        let env = try constructTestEnvironment(toolchain: try swiftTool.getToolchain(), options: swiftOptions, buildParameters: swiftTool.buildParametersForTest())
+        let env = try constructTestEnvironment(toolchain: try swiftTool.getToolchain(), buildParameters: swiftTool.buildParametersForTest(), options: options)
         let args = [path.description, "--dump-tests-json"]
         let data = try Process.checkNonZeroExit(arguments: args, environment: env)
         #endif
@@ -87,13 +103,13 @@ enum TestingSupport {
     /// Creates the environment needed to test related tools.
     static func constructTestEnvironment(
         toolchain: UserToolchain,
-        options: SwiftToolOptions,
-        buildParameters: BuildParameters
+        buildParameters: BuildParameters,
+        sanitizers: [Sanitizer]
     ) throws -> EnvironmentVariables {
         var env = EnvironmentVariables.process()
 
         // Add the code coverage related variables.
-        if options.shouldEnableCodeCoverage {
+        if buildParameters.enableCodeCoverage {
             // Defines the path at which the profraw files will be written on test execution.
             //
             // `%m` will create a pool of profraw files and append the data from
@@ -113,12 +129,12 @@ enum TestingSupport {
         return env
         #else
         // Fast path when no sanitizers are enabled.
-        if options.sanitizers.isEmpty {
+        if sanitizers.isEmpty {
             return env
         }
 
         // Get the runtime libraries.
-        var runtimes = try options.sanitizers.map({ sanitizer in
+        var runtimes = try sanitizers.map({ sanitizer in
             return try toolchain.runtimeLibrary(for: sanitizer).pathString
         })
 
@@ -135,9 +151,11 @@ enum TestingSupport {
 
 extension SwiftTool {
     func buildParametersForTest(
+        enableCodeCoverage: Bool,
         enableTestability: Bool? = nil
     ) throws -> BuildParameters {
         var parameters = try self.buildParameters()
+        parameters.enableCodeCoverage = enableCodeCoverage
         // for test commands, we normally enable building with testability
         // but we let users override this with a flag
         parameters.enableTestability = enableTestability ?? true

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -8,7 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Commands
+@testable import Commands
 import PackageGraph
 import PackageLoading
 import PackageModel

--- a/Tests/CommandsTests/SwiftToolTests.swift
+++ b/Tests/CommandsTests/SwiftToolTests.swift
@@ -20,7 +20,7 @@ final class SwiftToolTests: CommandsTestCase {
         try fixture(name: "Miscellaneous/Simple") { fixturePath in
             do {
                 let outputStream = BufferedOutputByteStream()
-                let options = try SwiftToolOptions.parse(["--package-path", fixturePath.pathString])
+                let options = try GlobalOptions.parse(["--package-path", fixturePath.pathString])
                 let tool = try SwiftTool(outputStream: outputStream, options: options)
                 XCTAssertEqual(tool.logLevel, .warning)
 
@@ -37,7 +37,7 @@ final class SwiftToolTests: CommandsTestCase {
 
             do {
                 let outputStream = BufferedOutputByteStream()
-                let options = try SwiftToolOptions.parse(["--package-path", fixturePath.pathString, "--verbose"])
+                let options = try GlobalOptions.parse(["--package-path", fixturePath.pathString, "--verbose"])
                 let tool = try SwiftTool(outputStream: outputStream, options: options)
                 XCTAssertEqual(tool.logLevel, .info)
 
@@ -54,7 +54,7 @@ final class SwiftToolTests: CommandsTestCase {
 
             do {
                 let outputStream = BufferedOutputByteStream()
-                let options = try SwiftToolOptions.parse(["--package-path", fixturePath.pathString, "-v"])
+                let options = try GlobalOptions.parse(["--package-path", fixturePath.pathString, "-v"])
                 let tool = try SwiftTool(outputStream: outputStream, options: options)
                 XCTAssertEqual(tool.logLevel, .info)
 
@@ -71,7 +71,7 @@ final class SwiftToolTests: CommandsTestCase {
 
             do {
                 let outputStream = BufferedOutputByteStream()
-                let options = try SwiftToolOptions.parse(["--package-path", fixturePath.pathString, "--very-verbose"])
+                let options = try GlobalOptions.parse(["--package-path", fixturePath.pathString, "--very-verbose"])
                 let tool = try SwiftTool(outputStream: outputStream, options: options)
                 XCTAssertEqual(tool.logLevel, .debug)
 
@@ -88,7 +88,7 @@ final class SwiftToolTests: CommandsTestCase {
 
             do {
                 let outputStream = BufferedOutputByteStream()
-                let options = try SwiftToolOptions.parse(["--package-path", fixturePath.pathString, "--vv"])
+                let options = try GlobalOptions.parse(["--package-path", fixturePath.pathString, "--vv"])
                 let tool = try SwiftTool(outputStream: outputStream, options: options)
                 XCTAssertEqual(tool.logLevel, .debug)
 
@@ -117,7 +117,7 @@ final class SwiftToolTests: CommandsTestCase {
                     "machine mymachine.labkey.org login custom@labkey.org password custom"
                 }
 
-                let options = try SwiftToolOptions.parse(["--package-path", fixturePath.pathString, "--netrc-file", customPath.pathString])
+                let options = try GlobalOptions.parse(["--package-path", fixturePath.pathString, "--netrc-file", customPath.pathString])
                 let tool = try SwiftTool(options: options)
 
                 let authorizationProvider = try tool.getAuthorizationProvider() as? CompositeAuthorizationProvider
@@ -142,7 +142,7 @@ final class SwiftToolTests: CommandsTestCase {
                     return "machine mymachine.labkey.org login local@labkey.org password local"
                 }
 
-                let options = try SwiftToolOptions.parse(["--package-path", fixturePath.pathString])
+                let options = try GlobalOptions.parse(["--package-path", fixturePath.pathString])
                 let tool = try SwiftTool(options: options)
 
                 let authorizationProvider = try tool.getAuthorizationProvider() as? CompositeAuthorizationProvider


### PR DESCRIPTION
motivation: fix an issue when not all options are presented as expected, and make the code clearer to reason about

changes:
* rename SwiftToolOptions to GlobalOptions
* refactor SwiftToolOptions (GlobalOptions) to multiple groups per domains: locations, caching, logging, build, linker, etc
* set GlobalOptions "hiddenFromHelp" flag to false for swift-build, swift-test and swift-package
* move enableCodeCoverage from GlobalOptions to TestToolOptions, since they apply there
* refactor code that construct test build to pass in more fine grained options rather than take the entire global options model
* adjust call sites and test

rdar://82658867
