### PR TITLE
expose both raw and derived platform support information

### DIFF
--- a/Sources/PackageGraph/ResolvedPackage.swift
+++ b/Sources/PackageGraph/ResolvedPackage.swift
@@ -40,13 +40,23 @@ public final class ResolvedPackage {
     /// The dependencies of the package.
     public let dependencies: [ResolvedPackage]
 
+    /// The default localization for resources.
+    public let defaultLocalization: String?
+
+    /// The list of platforms that are supported by this target.
+    public let platforms: SupportedPlatforms
+
     public init(
         package: Package,
+        defaultLocalization: String?,
+        platforms: SupportedPlatforms,
         dependencies: [ResolvedPackage],
         targets: [ResolvedTarget],
         products: [ResolvedProduct]
     ) {
         self.underlyingPackage = package
+        self.defaultLocalization = defaultLocalization
+        self.platforms = platforms
         self.dependencies = dependencies
         self.targets = targets
         self.products = products

--- a/Sources/PackageGraph/ResolvedProduct.swift
+++ b/Sources/PackageGraph/ResolvedProduct.swift
@@ -32,6 +32,12 @@ public final class ResolvedProduct {
     /// Executable target for test manifest file.
     public let testManifestTarget: ResolvedTarget?
 
+    /// The default localization for resources.
+    public let defaultLocalization: String?
+
+    /// The list of platforms that are supported by this product.
+    public let platforms: SupportedPlatforms
+
     /// The main executable target of product.
     ///
     /// Note: This property is only valid for executable products.
@@ -50,9 +56,20 @@ public final class ResolvedProduct {
         self.testManifestTarget = underlyingProduct.testManifest.map{ testManifest in
             // Create an executable resolved target with the linux main, adding product's targets as dependencies.
             let dependencies: [Target.Dependency] = product.targets.map { .target($0, conditions: []) }
-            let swiftTarget = SwiftTarget(testManifest: testManifest, name: product.name, dependencies: dependencies)
-            return ResolvedTarget(target: swiftTarget, dependencies: targets.map { .target($0, conditions: []) })
+            let swiftTarget = SwiftTarget(name: product.name, dependencies: dependencies, testManifest: testManifest)
+            return ResolvedTarget(
+                target: swiftTarget,
+                dependencies: targets.map { .target($0, conditions: []) },
+                defaultLocalization: .none, // safe since this is a derived product
+                platforms: .init(declared: [], derived: []) // safe since this is a derived product
+            )
         }
+
+        // defaultLocalization is currently shared across the entire package
+        // this may need to be enhanced if / when we support localization per target or product
+        self.defaultLocalization = self.targets.first?.defaultLocalization
+
+        self.platforms = Self.computePlatforms(targets: targets)
     }
 
     /// True if this product contains Swift targets.
@@ -71,6 +88,40 @@ public final class ResolvedProduct {
     public func recursiveTargetDependencies() throws -> [ResolvedTarget] {
         let recursiveDependencies = try targets.lazy.flatMap { try $0.recursiveTargetDependencies() }
         return Array(Set(targets).union(recursiveDependencies))
+    }
+
+    private static func computePlatforms(targets: [ResolvedTarget]) -> SupportedPlatforms {
+        // merge from targets, preferring the max constraint
+        let declared = targets.reduce(into: [SupportedPlatform]()) { partial, item in
+            for declared in item.platforms.declared {
+                if let existing = partial.firstIndex(where: { $0.platform == declared.platform }) {
+                    if partial[existing].version < declared.version {
+                        partial.remove(at: existing)
+                        partial.append(declared)
+                    }
+                } else {
+                    partial.append(declared)
+                }
+            }
+        }
+
+        let derived = targets.reduce(into: [SupportedPlatform]()) { partial, item in
+            for derived in item.platforms.derived {
+                if let existing = partial.firstIndex(where: { $0.platform == derived.platform }) {
+                    if partial[existing].version < derived.version {
+                        partial.remove(at: existing)
+                        partial.append(derived)
+                    }
+                } else {
+                    partial.append(derived)
+                }
+            }
+        }
+
+        return SupportedPlatforms(
+            declared: declared.sorted(by: { $0.platform.name < $1.platform.name }),
+            derived: derived.sorted(by: { $0.platform.name < $1.platform.name })
+        )
     }
 }
 

--- a/Sources/PackageGraph/ResolvedTarget.swift
+++ b/Sources/PackageGraph/ResolvedTarget.swift
@@ -127,10 +127,23 @@ public final class ResolvedTarget {
         return underlyingTarget.sources
     }
 
+    /// The default localization for resources.
+    public let defaultLocalization: String?
+
+    /// The list of platforms that are supported by this target.
+    public let platforms: SupportedPlatforms
+
     /// Create a target instance.
-    public init(target: Target, dependencies: [Dependency]) {
+    public init(
+        target: Target,
+        dependencies: [Dependency],
+        defaultLocalization: String?,
+        platforms: SupportedPlatforms
+    ) {
         self.underlyingTarget = target
         self.dependencies = dependencies
+        self.defaultLocalization = defaultLocalization
+        self.platforms = platforms
     }
 }
 

--- a/Sources/PackageLoading/PkgConfig.swift
+++ b/Sources/PackageLoading/PkgConfig.swift
@@ -381,7 +381,6 @@ internal struct PCFileFinder {
     /// This is needed because on Linux machines, the search paths can be different
     /// from the standard locations that we are currently searching.
     public init(brewPrefix: AbsolutePath? = .none) {
-        //self.diagnostics = diagnostics
         if PCFileFinder.pkgConfigPaths == nil {
             do {
                 let pkgConfigPath: String

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -69,7 +69,6 @@ public struct TargetSourcesBuilder {
     ) {
         self.packageIdentity = packageIdentity
         self.packageKind = packageKind
-        //self.packageLocation = packageLocation
         self.packagePath = packagePath
         self.target = target
         self.defaultLocalization = defaultLocalization

--- a/Sources/PackageModel/Platform.swift
+++ b/Sources/PackageModel/Platform.swift
@@ -43,6 +43,21 @@ public struct Platform: Equatable, Hashable, Codable {
 
 }
 
+public struct SupportedPlatforms {
+    public let declared: [SupportedPlatform]
+    public let derived: [SupportedPlatform]
+
+    public init(declared: [SupportedPlatform], derived: [SupportedPlatform]) {
+        self.declared = declared
+        self.derived = derived
+    }
+
+    /// Returns the supported platform instance for the given platform.
+    public func getDerived(for platform: Platform) -> SupportedPlatform? {
+        return self.derived.first(where: { $0.platform == platform })
+    }
+}
+
 /// Represents a platform supported by a target.
 public struct SupportedPlatform: Equatable, Codable {
     /// The platform.

--- a/Sources/PackageModel/Target.swift
+++ b/Sources/PackageModel/Target.swift
@@ -143,8 +143,6 @@ public class Target: PolymorphicCodableProtocol {
             self.c99name = alias.spm_mangledToC99ExtendedIdentifier()
         }
     }
-    /// The default localization for resources.
-    public let defaultLocalization: String?
 
     /// The dependencies of this target.
     public let dependencies: [Dependency]
@@ -173,14 +171,6 @@ public class Target: PolymorphicCodableProtocol {
     /// Other kinds of files in the target.
     public let others: [AbsolutePath]
 
-    /// The list of platforms that are supported by this target.
-    public let platforms: [SupportedPlatform]
-
-    /// Returns the supported platform instance for the given platform.
-    public func getSupportedPlatform(for platform: Platform) -> SupportedPlatform? {
-        return self.platforms.first(where: { $0.platform == platform })
-    }
-
     /// The build settings assignments of this target.
     public let buildSettings: BuildSettings.AssignmentTable
 
@@ -190,8 +180,6 @@ public class Target: PolymorphicCodableProtocol {
     fileprivate init(
         name: String,
         bundleName: String? = nil,
-        defaultLocalization: String?,
-        platforms: [SupportedPlatform],
         type: Kind,
         sources: Sources,
         resources: [Resource] = [],
@@ -203,8 +191,6 @@ public class Target: PolymorphicCodableProtocol {
     ) {
         self.name = name
         self.bundleName = bundleName
-        self.defaultLocalization = defaultLocalization
-        self.platforms = platforms
         self.type = type
         self.sources = sources
         self.resources = resources
@@ -227,8 +213,8 @@ public class Target: PolymorphicCodableProtocol {
         // the actual target dependency object.
         try container.encode(name, forKey: .name)
         try container.encode(bundleName, forKey: .bundleName)
-        try container.encode(defaultLocalization, forKey: .defaultLocalization)
-        try container.encode(platforms, forKey: .platforms)
+        //try container.encode(defaultLocalization, forKey: .defaultLocalization)
+        //try container.encode(platforms, forKey: .platforms)
         try container.encode(type, forKey: .type)
         try container.encode(sources, forKey: .sources)
         try container.encode(resources, forKey: .resources)
@@ -243,8 +229,6 @@ public class Target: PolymorphicCodableProtocol {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.name = try container.decode(String.self, forKey: .name)
         self.bundleName = try container.decodeIfPresent(String.self, forKey: .bundleName)
-        self.defaultLocalization = try container.decodeIfPresent(String.self, forKey: .defaultLocalization)
-        self.platforms = try container.decode([SupportedPlatform].self, forKey: .platforms)
         self.type = try container.decode(Kind.self, forKey: .type)
         self.sources = try container.decode(Sources.self, forKey: .sources)
         self.resources = try container.decode([Resource].self, forKey: .resources)
@@ -282,13 +266,11 @@ public final class SwiftTarget: Target {
     /// The file name of test manifest.
     public static let testManifestNames = ["XCTMain.swift", "LinuxMain.swift"]
 
-    public init(testDiscoverySrc: Sources, name: String, dependencies: [Target.Dependency]) {
+    public init(name: String, dependencies: [Target.Dependency], testDiscoverySrc: Sources) {
         self.swiftVersion = .v5
 
         super.init(
             name: name,
-            defaultLocalization: nil,
-            platforms: [],
             type: .executable,
             sources: testDiscoverySrc,
             dependencies: dependencies,
@@ -303,8 +285,6 @@ public final class SwiftTarget: Target {
     public init(
         name: String,
         bundleName: String? = nil,
-        defaultLocalization: String? = nil,
-        platforms: [SupportedPlatform] = [],
         type: Kind,
         sources: Sources,
         resources: [Resource] = [],
@@ -319,8 +299,6 @@ public final class SwiftTarget: Target {
         super.init(
             name: name,
             bundleName: bundleName,
-            defaultLocalization: defaultLocalization,
-            platforms: platforms,
             type: type,
             sources: sources,
             resources: resources,
@@ -333,7 +311,7 @@ public final class SwiftTarget: Target {
     }
 
     /// Create an executable Swift target from test manifest file.
-    public init(testManifest: AbsolutePath, name: String, dependencies: [Target.Dependency]) {
+    public init(name: String, dependencies: [Target.Dependency], testManifest: AbsolutePath) {
         // Look for the first swift test target and use the same swift version
         // for linux main target. This will need to change if we move to a model
         // where we allow per target swift language version build settings.
@@ -349,12 +327,8 @@ public final class SwiftTarget: Target {
         self.swiftVersion = swiftTestTarget?.swiftVersion ?? SwiftLanguageVersion(string: String(ToolsVersion.currentToolsVersion.major)) ?? .v4
         let sources = Sources(paths: [testManifest], root: testManifest.parentDirectory)
 
-        let platforms: [SupportedPlatform] = swiftTestTarget?.platforms ?? []
-
         super.init(
             name: name,
-            defaultLocalization: nil,
-            platforms: platforms,
             type: .executable,
             sources: sources,
             dependencies: dependencies,
@@ -399,7 +373,6 @@ public final class SystemLibraryTarget: Target {
 
     public init(
         name: String,
-        platforms: [SupportedPlatform] = [],
         path: AbsolutePath,
         isImplicit: Bool = true,
         pkgConfig: String? = nil,
@@ -411,8 +384,6 @@ public final class SystemLibraryTarget: Target {
         self.isImplicit = isImplicit
         super.init(
             name: name,
-            defaultLocalization: nil,
-            platforms: platforms,
             type: .systemModule,
             sources: sources,
             dependencies: [],
@@ -470,8 +441,6 @@ public final class ClangTarget: Target {
     public init(
         name: String,
         bundleName: String? = nil,
-        defaultLocalization: String? = nil,
-        platforms: [SupportedPlatform] = [],
         cLanguageStandard: String?,
         cxxLanguageStandard: String?,
         includeDir: AbsolutePath,
@@ -497,8 +466,6 @@ public final class ClangTarget: Target {
         super.init(
             name: name,
             bundleName: bundleName,
-            defaultLocalization: defaultLocalization,
-            platforms: platforms,
             type: type,
             sources: sources,
             resources: resources,
@@ -552,7 +519,6 @@ public final class BinaryTarget: Target {
     public init(
         name: String,
         kind: Kind,
-        platforms: [SupportedPlatform] = [],
         path: AbsolutePath,
         origin: Origin
     ) {
@@ -561,8 +527,6 @@ public final class BinaryTarget: Target {
         let sources = Sources(paths: [], root: path)
         super.init(
             name: name,
-            defaultLocalization: nil,
-            platforms: platforms,
             type: .binary,
             sources: sources,
             dependencies: [],
@@ -674,7 +638,6 @@ public final class PluginTarget: Target {
 
     public init(
         name: String,
-        platforms: [SupportedPlatform] = [],
         sources: Sources,
         apiVersion: ToolsVersion,
         pluginCapability: PluginCapability,
@@ -684,8 +647,6 @@ public final class PluginTarget: Target {
         self.apiVersion = apiVersion
         super.init(
             name: name,
-            defaultLocalization: nil,
-            platforms: platforms,
             type: .plugin,
             sources: sources,
             dependencies: dependencies,

--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -219,18 +219,19 @@ private func swiftArgs(
 
 public func loadPackageGraph(
     identityResolver: IdentityResolver = DefaultIdentityResolver(),
-    fs: FileSystem,
+    fileSystem: FileSystem,
     manifests: [Manifest],
     binaryArtifacts: [PackageIdentity: [String: BinaryArtifact]] = [:],
-    explicitProduct: String? = nil,
+    explicitProduct: String? = .none,
     shouldCreateMultipleTestProducts: Bool = false,
     createREPLProduct: Bool = false,
     useXCBuildFileRules: Bool = false,
+    customXCTestMinimumDeploymentTargets: [PackageModel.Platform: PlatformVersion]? = .none,
     observabilityScope: ObservabilityScope
 ) throws -> PackageGraph {
     let rootManifests = manifests.filter { $0.packageKind.isRoot }.spm_createDictionary{ ($0.path, $0) }
     let externalManifests = try manifests.filter { !$0.packageKind.isRoot }.reduce(into: OrderedCollections.OrderedDictionary<PackageIdentity, (manifest: Manifest, fs: FileSystem)>()) { partial, item in
-        partial[try identityResolver.resolveIdentity(for: item.packageKind)] = (item, fs)
+        partial[try identityResolver.resolveIdentity(for: item.packageKind)] = (item, fileSystem)
     }
 
     let packages = Array(rootManifests.keys)
@@ -245,7 +246,8 @@ public func loadPackageGraph(
         binaryArtifacts: binaryArtifacts,
         shouldCreateMultipleTestProducts: shouldCreateMultipleTestProducts,
         createREPLProduct: createREPLProduct,
-        fileSystem: fs,
+        customXCTestMinimumDeploymentTargets: customXCTestMinimumDeploymentTargets,
+        fileSystem: fileSystem,
         observabilityScope: observabilityScope
     )
 }

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1165,7 +1165,6 @@ extension Workspace {
             createMultipleTestProducts: createMultipleTestProducts,
             createREPLProduct: createREPLProduct,
             forceResolvedVersions: forceResolvedVersions,
-            xcTestMinimumDeploymentTargets: xcTestMinimumDeploymentTargets,
             observabilityScope: ObservabilitySystem(diagnosticEngine: diagnostics).topScope
         )
     }
@@ -1177,7 +1176,6 @@ extension Workspace {
         createMultipleTestProducts: Bool = false,
         createREPLProduct: Bool = false,
         forceResolvedVersions: Bool = false,
-        xcTestMinimumDeploymentTargets: [PackageModel.Platform:PlatformVersion]? = nil,
         observabilityScope: ObservabilityScope
     ) throws -> PackageGraph {
 
@@ -1212,7 +1210,6 @@ extension Workspace {
             requiredDependencies: manifests.computePackages().required,
             unsafeAllowedPackages: manifests.unsafeAllowedPackages(),
             binaryArtifacts: binaryArtifacts,
-            xcTestMinimumDeploymentTargets: xcTestMinimumDeploymentTargets ?? MinimumDeploymentTarget.default.xcTestMinimumDeploymentTargets,
             shouldCreateMultipleTestProducts: createMultipleTestProducts,
             createREPLProduct: createREPLProduct,
             fileSystem: fileSystem,
@@ -1376,8 +1373,8 @@ extension Workspace {
                     manifest: manifest,
                     productFilter: .everything,
                     path: path,
+                    additionalFileRules: [],
                     binaryArtifacts: binaryArtifacts,
-                    xcTestMinimumDeploymentTargets: MinimumDeploymentTarget.default.xcTestMinimumDeploymentTargets,
                     fileSystem: self.fileSystem,
                     observabilityScope: observabilityScope
                 )

--- a/Sources/Xcodeproj/pbxproj.swift
+++ b/Sources/Xcodeproj/pbxproj.swift
@@ -425,7 +425,7 @@ public func xcodeProject(
 
         // Assign the deployment target if the package is using the newer manifest version.
         if package.manifest.toolsVersion >= .v5 {
-            for supportedPlatform in target.underlyingTarget.platforms {
+            for supportedPlatform in target.platforms.derived {
                 let version = supportedPlatform.version.versionString
                 switch supportedPlatform.platform {
                 case .macOS:

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -114,7 +114,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -222,7 +222,7 @@ final class BuildPlanTests: XCTestCase {
             // Plan package build with explicit module build
             let observability = ObservabilitySystem.makeForTesting()
             let graph = try loadPackageGraph(
-                fs: fs,
+                fileSystem: fs,
                 manifests: [
                     Manifest.createRootManifest(
                         name: "ExplicitTest",
@@ -282,7 +282,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -383,7 +383,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fileSystem,
+            fileSystem: fileSystem,
             manifests: [
                 Manifest.createRootManifest(
                     name: "A",
@@ -437,7 +437,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -491,7 +491,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -550,7 +550,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -662,7 +662,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -747,7 +747,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -813,7 +813,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -887,7 +887,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -932,7 +932,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -985,7 +985,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -1051,7 +1051,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -1105,7 +1105,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -1154,7 +1154,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -1216,7 +1216,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -1255,7 +1255,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let g = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "Bar",
@@ -1354,7 +1354,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -1422,7 +1422,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -1499,7 +1499,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fileSystem,
+            fileSystem: fileSystem,
             manifests: [
                 Manifest.createRootManifest(
                     name: "A",
@@ -1585,7 +1585,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fileSystem,
+            fileSystem: fileSystem,
             manifests: [
                 Manifest.createRootManifest(
                     name: "A",
@@ -1705,7 +1705,7 @@ final class BuildPlanTests: XCTestCase {
         
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "fooPkg",
@@ -1792,7 +1792,7 @@ final class BuildPlanTests: XCTestCase {
         
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "otherPkg",
@@ -1864,7 +1864,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let _ = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "otherPkg",
@@ -1913,7 +1913,7 @@ final class BuildPlanTests: XCTestCase {
         
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "barPkg",
@@ -1984,7 +1984,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "barPkg",
@@ -2071,7 +2071,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "drawPkg",
@@ -2177,7 +2177,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "drawPkg",
@@ -2283,7 +2283,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "drawPkg",
@@ -2394,7 +2394,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "drawPkg",
@@ -2502,7 +2502,7 @@ final class BuildPlanTests: XCTestCase {
         
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "barPkg",
@@ -2578,7 +2578,7 @@ final class BuildPlanTests: XCTestCase {
         
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "carPkg",
@@ -2664,7 +2664,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -2693,7 +2693,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fileSystem,
+            fileSystem: fileSystem,
             manifests: [
                 Manifest.createRootManifest(
                     name: "A",
@@ -2736,7 +2736,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fileSystem,
+            fileSystem: fileSystem,
             manifests: [
                 Manifest.createRootManifest(
                     name: "A",
@@ -2777,7 +2777,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -2834,7 +2834,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -2921,7 +2921,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -2968,7 +2968,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -3016,7 +3016,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fileSystem,
+            fileSystem: fileSystem,
             manifests: [
                 Manifest.createRootManifest(
                     name: "A",
@@ -3079,7 +3079,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fileSystem,
+            fileSystem: fileSystem,
             manifests: [
                 Manifest.createRootManifest(
                     name: "A",
@@ -3212,7 +3212,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [aManifest, bManifest],
             observabilityScope: observability.topScope
         )
@@ -3281,7 +3281,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [aManifest],
             observabilityScope: observability.topScope
         )
@@ -3309,7 +3309,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -3362,7 +3362,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "PkgA",
@@ -3417,7 +3417,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "PkgA",
@@ -3476,7 +3476,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "PkgA",
@@ -3546,7 +3546,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "PkgA",
@@ -3616,7 +3616,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -3677,7 +3677,7 @@ final class BuildPlanTests: XCTestCase {
         let observability = ObservabilitySystem.makeForTesting()
 
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "PkgA",
@@ -3741,7 +3741,7 @@ final class BuildPlanTests: XCTestCase {
         let observability = ObservabilitySystem.makeForTesting()
 
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "PkgA",
@@ -3802,7 +3802,7 @@ final class BuildPlanTests: XCTestCase {
         let observability = ObservabilitySystem.makeForTesting()
 
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -3908,7 +3908,7 @@ final class BuildPlanTests: XCTestCase {
         let observability = ObservabilitySystem.makeForTesting()
 
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -4019,7 +4019,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -4097,7 +4097,7 @@ final class BuildPlanTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -549,7 +549,7 @@ final class PackageToolTests: CommandsTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fileSystem,
+            fileSystem: fileSystem,
             manifests: [manifestA, manifestB, manifestC, manifestD],
             observabilityScope: observability.topScope
         )

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -29,7 +29,7 @@ class PackageGraphTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let g = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "Foo",
@@ -96,7 +96,7 @@ class PackageGraphTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let g = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -140,7 +140,7 @@ class PackageGraphTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         _ = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -193,7 +193,7 @@ class PackageGraphTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         _ = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -225,7 +225,7 @@ class PackageGraphTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let g = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Bar",
@@ -267,7 +267,7 @@ class PackageGraphTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         _ = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -303,7 +303,7 @@ class PackageGraphTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         _ = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "Fourth",
@@ -362,7 +362,7 @@ class PackageGraphTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         _ = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "Fourth",
@@ -422,7 +422,7 @@ class PackageGraphTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         _ = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "Fourth",
@@ -486,7 +486,7 @@ class PackageGraphTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         _ = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -529,7 +529,7 @@ class PackageGraphTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         _ = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -557,7 +557,7 @@ class PackageGraphTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         _ = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -588,7 +588,7 @@ class PackageGraphTests: XCTestCase {
         )
         let observability = ObservabilitySystem.makeForTesting()
         _ = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "XYZ",
@@ -612,7 +612,7 @@ class PackageGraphTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         _ = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -637,7 +637,7 @@ class PackageGraphTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         _ = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -666,7 +666,7 @@ class PackageGraphTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         _ = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -698,7 +698,7 @@ class PackageGraphTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         _ = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -775,7 +775,7 @@ class PackageGraphTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         _ = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -814,7 +814,7 @@ class PackageGraphTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         _ = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -874,7 +874,7 @@ class PackageGraphTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         _ = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Bar",
@@ -908,7 +908,7 @@ class PackageGraphTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         _ = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Start",
@@ -961,7 +961,7 @@ class PackageGraphTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         _ = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -1013,7 +1013,7 @@ class PackageGraphTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         _ = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -1082,7 +1082,7 @@ class PackageGraphTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -1164,7 +1164,7 @@ class PackageGraphTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         _ = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Root",
@@ -1283,7 +1283,7 @@ class PackageGraphTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         _ = try loadPackageGraph(
-            fs: fileSystem,
+            fileSystem: fileSystem,
             manifests: [
                 Manifest.createRootManifest(
                     name: "A",
@@ -1369,7 +1369,7 @@ class PackageGraphTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         _ = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -1406,7 +1406,7 @@ class PackageGraphTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         _ = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -1450,7 +1450,7 @@ class PackageGraphTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         _ = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -1487,7 +1487,7 @@ class PackageGraphTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         _ = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -1554,7 +1554,7 @@ class PackageGraphTests: XCTestCase {
 
         do {
             let observability = ObservabilitySystem.makeForTesting()
-            _ = try loadPackageGraph(fs: fs, manifests: manifests, observabilityScope: observability.topScope)
+            _ = try loadPackageGraph(fileSystem: fs, manifests: manifests, observabilityScope: observability.topScope)
             testDiagnostics(observability.diagnostics) { result in
                 result.check(
                     diagnostic: """
@@ -1576,7 +1576,7 @@ class PackageGraphTests: XCTestCase {
             ]
 
             let observability = ObservabilitySystem.makeForTesting()
-            _ = try loadPackageGraph(fs: fs, manifests: fixedManifests, observabilityScope: observability.topScope)
+            _ = try loadPackageGraph(fileSystem: fs, manifests: fixedManifests, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
         }
     }
@@ -1614,7 +1614,7 @@ class PackageGraphTests: XCTestCase {
 
         do {
             let observability = ObservabilitySystem.makeForTesting()
-            _ = try loadPackageGraph(fs: fs, manifests: manifests, observabilityScope: observability.topScope)
+            _ = try loadPackageGraph(fileSystem: fs, manifests: manifests, observabilityScope: observability.topScope)
             testDiagnostics(observability.diagnostics) { result in
                 result.check(
                     diagnostic: """
@@ -1637,7 +1637,7 @@ class PackageGraphTests: XCTestCase {
             ]
 
             let observability = ObservabilitySystem.makeForTesting()
-            _ = try loadPackageGraph(fs: fs, manifests: fixedManifests, observabilityScope: observability.topScope)
+            _ = try loadPackageGraph(fileSystem: fs, manifests: fixedManifests, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
         }
     }
@@ -1673,7 +1673,7 @@ class PackageGraphTests: XCTestCase {
 
         do {
             let observability = ObservabilitySystem.makeForTesting()
-            _ = try loadPackageGraph(fs: fs, manifests: manifests, observabilityScope: observability.topScope)
+            _ = try loadPackageGraph(fileSystem: fs, manifests: manifests, observabilityScope: observability.topScope)
             testDiagnostics(observability.diagnostics) { result in
                 result.check(
                     diagnostic: """
@@ -1695,7 +1695,7 @@ class PackageGraphTests: XCTestCase {
             ]
 
             let observability = ObservabilitySystem.makeForTesting()
-            _ = try loadPackageGraph(fs: fs, manifests: fixedManifests, observabilityScope: observability.topScope)
+            _ = try loadPackageGraph(fileSystem: fs, manifests: fixedManifests, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
         }
     }
@@ -1731,7 +1731,7 @@ class PackageGraphTests: XCTestCase {
 
         do {
             let observability = ObservabilitySystem.makeForTesting()
-            _ = try loadPackageGraph(fs: fs, manifests: manifests, observabilityScope: observability.topScope)
+            _ = try loadPackageGraph(fileSystem: fs, manifests: manifests, observabilityScope: observability.topScope)
             testDiagnostics(observability.diagnostics) { result in
                 let diagnostic = result.check(
                     diagnostic: """
@@ -1754,7 +1754,7 @@ class PackageGraphTests: XCTestCase {
             ]
 
             let observability = ObservabilitySystem.makeForTesting()
-            _ = try loadPackageGraph(fs: fs, manifests: fixedManifests, observabilityScope: observability.topScope)
+            _ = try loadPackageGraph(fileSystem: fs, manifests: fixedManifests, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
         }
     }
@@ -1791,7 +1791,7 @@ class PackageGraphTests: XCTestCase {
         ]
 
         let observability = ObservabilitySystem.makeForTesting()
-        _ = try loadPackageGraph(fs: fs, manifests: manifests, observabilityScope: observability.topScope)
+        _ = try loadPackageGraph(fileSystem: fs, manifests: manifests, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
     }
 
@@ -1828,7 +1828,7 @@ class PackageGraphTests: XCTestCase {
 
         do {
             let observability = ObservabilitySystem.makeForTesting()
-            _ = try loadPackageGraph(fs: fs, manifests: manifests, observabilityScope: observability.topScope)
+            _ = try loadPackageGraph(fileSystem: fs, manifests: manifests, observabilityScope: observability.topScope)
             testDiagnostics(observability.diagnostics) { result in
                 let diagnostic = result.check(
                     diagnostic: """
@@ -1851,7 +1851,7 @@ class PackageGraphTests: XCTestCase {
             ]
 
             let observability = ObservabilitySystem.makeForTesting()
-            _ = try loadPackageGraph(fs: fs, manifests: fixedManifests, observabilityScope: observability.topScope)
+            _ = try loadPackageGraph(fileSystem: fs, manifests: fixedManifests, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
         }
     }
@@ -1891,6 +1891,304 @@ class PackageGraphTests: XCTestCase {
         // Unrelated should not have been asked for Product, because it should know Product comes from Identity.
         XCTAssertFalse(requestedProducts.contains("Product"), "Product requests are leaking.")
         #endif
+    }
+
+    func testPlatforms() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/Sources/foo/module.modulemap",
+            "/Sources/bar/bar.swift",
+            "/Sources/cbar/bar.c",
+            "/Sources/cbar/include/bar.h",
+            "/Tests/test/test.swift"
+        )
+
+        let defaultDerivedPlatforms = [
+            "linux": "0.0",
+            "macos": "10.10",
+            "maccatalyst": "13.0",
+            "ios": "9.0",
+            "tvos": "9.0",
+            "driverkit": "19.0",
+            "watchos": "2.0",
+            "android": "0.0",
+            "windows": "0.0",
+            "wasi": "0.0",
+            "openbsd": "0.0"
+        ]
+
+        do {
+            // One platform with an override.
+            let manifest = Manifest.createRootManifest(
+                name: "pkg",
+                platforms: [
+                    PlatformDescription(name: "macos", version: "10.12", options: ["option1"]),
+                ],
+                products: [
+                    try ProductDescription(name: "foo", type: .library(.automatic), targets: ["foo"]),
+                    try ProductDescription(name: "cbar", type: .library(.automatic), targets: ["cbar"]),
+                    try ProductDescription(name: "bar", type: .library(.automatic), targets: ["bar"]),
+                    try ProductDescription(name: "multi-target", type: .library(.automatic), targets: ["bar", "cbar", "bar", "test"]),
+                ],
+                targets: [
+                    try TargetDescription(name: "foo", type: .system),
+                    try TargetDescription(name: "cbar"),
+                    try TargetDescription(name: "bar", dependencies: ["foo"]),
+                    try TargetDescription(name: "test", type: .test)
+                ]
+            )
+
+            let customXCTestMinimumDeploymentTargets = [
+                PackageModel.Platform.macOS: PlatformVersion("10.15"),
+                PackageModel.Platform.iOS: PlatformVersion("9.0"),
+                PackageModel.Platform.tvOS: PlatformVersion("9.0"),
+                PackageModel.Platform.watchOS: PlatformVersion("2.0"),
+            ]
+
+            let observability = ObservabilitySystem.makeForTesting()
+            let graph = try loadPackageGraph(
+                fileSystem: fs,
+                manifests: [manifest],
+                customXCTestMinimumDeploymentTargets: customXCTestMinimumDeploymentTargets,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+
+            PackageGraphTester(graph) { result in
+                let expectedDeclaredPlatforms = [
+                    "macos": "10.12"
+                ]
+
+                // default platforms will be auto-added during package build
+                let expectedDerivedPlatforms = defaultDerivedPlatforms.merging(expectedDeclaredPlatforms, uniquingKeysWith: { lhs, rhs in rhs })
+
+                result.checkTarget("foo") { target in
+                    target.checkDeclaredPlatforms(expectedDeclaredPlatforms)
+                    target.checkDerivedPlatforms(expectedDerivedPlatforms)
+                    target.checkDerivedPlatformOptions(.macOS, options: ["option1"])
+                    target.checkDerivedPlatformOptions(.iOS, options: [])
+                }
+                result.checkTarget("bar") { target in
+                    target.checkDeclaredPlatforms(expectedDeclaredPlatforms)
+                    target.checkDerivedPlatforms(expectedDerivedPlatforms)
+                    target.checkDerivedPlatformOptions(.macOS, options: ["option1"])
+                    target.checkDerivedPlatformOptions(.iOS, options: [])
+
+                }
+                result.checkTarget("cbar") { target in
+                    target.checkDeclaredPlatforms(expectedDeclaredPlatforms)
+                    target.checkDerivedPlatforms(expectedDerivedPlatforms)
+                    target.checkDerivedPlatformOptions(.macOS, options: ["option1"])
+                    target.checkDerivedPlatformOptions(.iOS, options: [])
+                }
+                result.checkTarget("test") { target in
+                    var expected = expectedDerivedPlatforms
+                    [PackageModel.Platform.macOS, .iOS, .tvOS, .watchOS].forEach {
+                        expected[$0.name] = customXCTestMinimumDeploymentTargets[$0]?.versionString
+                    }
+                    target.checkDerivedPlatforms(expected)
+                    target.checkDerivedPlatformOptions(.macOS, options: ["option1"])
+                    target.checkDerivedPlatformOptions(.iOS, options: [])
+                }
+                result.checkProduct("foo") { product in
+                    product.checkDeclaredPlatforms(expectedDeclaredPlatforms)
+                    product.checkDerivedPlatforms(expectedDerivedPlatforms)
+                    product.checkDerivedPlatformOptions(.macOS, options: ["option1"])
+                    product.checkDerivedPlatformOptions(.iOS, options: [])
+                }
+                result.checkProduct("bar") { product in
+                    product.checkDeclaredPlatforms(expectedDeclaredPlatforms)
+                    product.checkDerivedPlatforms(expectedDerivedPlatforms)
+                    product.checkDerivedPlatformOptions(.macOS, options: ["option1"])
+                    product.checkDerivedPlatformOptions(.iOS, options: [])
+
+                }
+                result.checkProduct("cbar") { product in
+                    product.checkDeclaredPlatforms(expectedDeclaredPlatforms)
+                    product.checkDerivedPlatforms(expectedDerivedPlatforms)
+                    product.checkDerivedPlatformOptions(.macOS, options: ["option1"])
+                    product.checkDerivedPlatformOptions(.iOS, options: [])
+                }
+                result.checkProduct("multi-target") { product in
+                    var expected = expectedDerivedPlatforms
+                    [PackageModel.Platform.macOS, .iOS, .tvOS, .watchOS].forEach {
+                        expected[$0.name] = customXCTestMinimumDeploymentTargets[$0]?.versionString
+                    }
+                    product.checkDerivedPlatforms(expected)
+                    product.checkDerivedPlatformOptions(.macOS, options: ["option1"])
+                    product.checkDerivedPlatformOptions(.iOS, options: [])
+                }
+            }
+        }
+
+        do {
+            // Two platforms with overrides.
+            let manifest = Manifest.createRootManifest(
+                name: "pkg",
+                platforms: [
+                    PlatformDescription(name: "macos", version: "10.12"),
+                    PlatformDescription(name: "tvos", version: "10.0"),
+                ],
+                products: [
+                    try ProductDescription(name: "foo", type: .library(.automatic), targets: ["foo"]),
+                    try ProductDescription(name: "cbar", type: .library(.automatic), targets: ["cbar"]),
+                    try ProductDescription(name: "bar", type: .library(.automatic), targets: ["bar"]),
+                ],
+                targets: [
+                    try TargetDescription(name: "foo", type: .system),
+                    try TargetDescription(name: "cbar"),
+                    try TargetDescription(name: "bar", dependencies: ["foo"]),
+                ]
+            )
+
+            let observability = ObservabilitySystem.makeForTesting()
+            let graph = try loadPackageGraph(
+                fileSystem: fs,
+                manifests: [manifest],
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+
+            PackageGraphTester(graph) { result in
+                let expectedDeclaredPlatforms = [
+                    "macos": "10.12",
+                    "tvos": "10.0",
+                ]
+
+                // default platforms will be auto-added during package build
+                let expectedDerivedPlatforms = defaultDerivedPlatforms.merging(expectedDeclaredPlatforms, uniquingKeysWith: { lhs, rhs in rhs })
+
+                result.checkTarget("foo") { target in
+                    target.checkDeclaredPlatforms(expectedDeclaredPlatforms)
+                    target.checkDerivedPlatforms(expectedDerivedPlatforms)
+                }
+                result.checkTarget("bar") { target in
+                    target.checkDeclaredPlatforms(expectedDeclaredPlatforms)
+                    target.checkDerivedPlatforms(expectedDerivedPlatforms)
+                }
+                result.checkTarget("cbar") { target in
+                    target.checkDeclaredPlatforms(expectedDeclaredPlatforms)
+                    target.checkDerivedPlatforms(expectedDerivedPlatforms)
+                }
+                result.checkProduct("foo") { product in
+                    product.checkDeclaredPlatforms(expectedDeclaredPlatforms)
+                    product.checkDerivedPlatforms(expectedDerivedPlatforms)
+                }
+                result.checkProduct("bar") { product in
+                    product.checkDeclaredPlatforms(expectedDeclaredPlatforms)
+                    product.checkDerivedPlatforms(expectedDerivedPlatforms)
+                }
+                result.checkProduct("cbar") { product in
+                    product.checkDeclaredPlatforms(expectedDeclaredPlatforms)
+                    product.checkDerivedPlatforms(expectedDerivedPlatforms)
+                }
+            }
+        }
+    }
+
+    func testCustomPlatforms() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/Sources/foo/module.modulemap"
+        )
+
+        let defaultDerivedPlatforms = [
+            "linux": "0.0",
+            "macos": "10.10",
+            "maccatalyst": "13.0",
+            "ios": "9.0",
+            "tvos": "9.0",
+            "driverkit": "19.0",
+            "watchos": "2.0",
+            "android": "0.0",
+            "windows": "0.0",
+            "wasi": "0.0",
+            "openbsd": "0.0"
+        ]
+
+        do {
+            // One custom platform.
+            let manifest = Manifest.createRootManifest(
+                name: "pkg",
+                platforms: [
+                    PlatformDescription(name: "customos", version: "1.0"),
+                ],
+                products: [
+                    try ProductDescription(name: "foo", type: .library(.automatic), targets: ["foo"]),
+                ],
+                targets: [
+                    try TargetDescription(name: "foo", type: .system),
+                ]
+            )
+
+            let observability = ObservabilitySystem.makeForTesting()
+            let graph = try loadPackageGraph(
+                fileSystem: fs,
+                manifests: [manifest],
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+
+            PackageGraphTester(graph) { result in
+                let expectedDeclaredPlatforms = [
+                    "customos": "1.0"
+                ]
+
+                // default platforms will be auto-added during package build
+                let expectedDerivedPlatforms = defaultDerivedPlatforms.merging(expectedDeclaredPlatforms, uniquingKeysWith: { lhs, rhs in rhs })
+
+                result.checkTarget("foo") { target in
+                    target.checkDeclaredPlatforms(expectedDeclaredPlatforms)
+                    target.checkDerivedPlatforms(expectedDerivedPlatforms)
+                }
+                result.checkProduct("foo") { product in
+                    product.checkDeclaredPlatforms(expectedDeclaredPlatforms)
+                    product.checkDerivedPlatforms(expectedDerivedPlatforms)
+                }
+            }
+        }
+
+        do {
+            // Two platforms with overrides.
+            let manifest = Manifest.createRootManifest(
+                name: "pkg",
+                platforms: [
+                    PlatformDescription(name: "customos", version: "1.0"),
+                    PlatformDescription(name: "anothercustomos", version: "2.3"),
+                ],
+                products: [
+                    try ProductDescription(name: "foo", type: .library(.automatic), targets: ["foo"]),
+                ],
+                targets: [
+                    try TargetDescription(name: "foo", type: .system),
+                ]
+            )
+
+            let observability = ObservabilitySystem.makeForTesting()
+            let graph = try loadPackageGraph(
+                fileSystem: fs,
+                manifests: [manifest],
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+
+            PackageGraphTester(graph) { result in
+                let expectedDeclaredPlatforms = [
+                    "customos": "1.0",
+                    "anothercustomos": "2.3"
+                ]
+
+                // default platforms will be auto-added during package build
+                let expectedDerivedPlatforms = defaultDerivedPlatforms.merging(expectedDeclaredPlatforms, uniquingKeysWith: { lhs, rhs in rhs })
+
+                result.checkTarget("foo") { target in
+                    target.checkDeclaredPlatforms(expectedDeclaredPlatforms)
+                    target.checkDerivedPlatforms(expectedDerivedPlatforms)
+                }
+                result.checkProduct("foo") { product in
+                    product.checkDeclaredPlatforms(expectedDeclaredPlatforms)
+                    product.checkDerivedPlatforms(expectedDerivedPlatforms)
+                }
+            }
+        }
     }
 }
 

--- a/Tests/PackageGraphTests/TargetTests.swift
+++ b/Tests/PackageGraphTests/TargetTests.swift
@@ -19,8 +19,14 @@ private extension ResolvedTarget {
         self.init(
             target: SwiftTarget(
                 name: name, type: .library, 
-                sources: Sources(paths: [], root: AbsolutePath("/")), dependencies: [], swiftVersion: .v4),
-            dependencies: deps.map { .target($0, conditions: []) })
+                sources: Sources(paths: [], root: AbsolutePath("/")),
+                dependencies: [],
+                swiftVersion: .v4
+            ),
+            dependencies: deps.map { .target($0, conditions: []) },
+            defaultLocalization: nil,
+            platforms: .init(declared: [], derived: [])
+        )
     }
 }
 

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -33,7 +33,7 @@ class PluginInvocationTests: XCTestCase {
         )
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fileSystem,
+            fileSystem: fileSystem,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -38,7 +38,7 @@ class PIFBuilderTests: XCTestCase {
 
             let observability = ObservabilitySystem.makeForTesting()
             let graph = try loadPackageGraph(
-                fs: fs,
+                fileSystem: fs,
                 manifests: [
                     Manifest.createLocalSourceControlManifest(
                         name: "B",
@@ -109,7 +109,7 @@ class PIFBuilderTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createManifest(
                     name: "Foo",
@@ -392,7 +392,7 @@ class PIFBuilderTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -726,7 +726,7 @@ class PIFBuilderTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -974,7 +974,7 @@ class PIFBuilderTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -1176,7 +1176,7 @@ class PIFBuilderTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -1474,7 +1474,7 @@ class PIFBuilderTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "App",
@@ -1697,7 +1697,7 @@ class PIFBuilderTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Bar",
@@ -1750,7 +1750,7 @@ class PIFBuilderTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createManifest(
                     name: "Bar",
@@ -1808,7 +1808,7 @@ class PIFBuilderTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -1927,7 +1927,7 @@ class PIFBuilderTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -2001,7 +2001,7 @@ class PIFBuilderTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -2217,7 +2217,7 @@ class PIFBuilderTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -2431,7 +2431,7 @@ class PIFBuilderTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createManifest(
                     name: "Foo",
@@ -2500,7 +2500,7 @@ class PIFBuilderTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -2550,7 +2550,7 @@ class PIFBuilderTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "MyLib",

--- a/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
+++ b/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
@@ -38,7 +38,7 @@ class GenerateXcodeprojTests: XCTestCase {
 
             let observability = ObservabilitySystem.makeForTesting()
             let graph = try loadPackageGraph(
-                fs: localFileSystem,
+                fileSystem: localFileSystem,
                 manifests: [
                     Manifest.createRootManifest(
                         name: "Foo",
@@ -96,7 +96,7 @@ class GenerateXcodeprojTests: XCTestCase {
 
             let observability = ObservabilitySystem.makeForTesting()
             let graph = try loadPackageGraph(
-                fs: localFileSystem,
+                fileSystem: localFileSystem,
                 manifests: [
                     Manifest.createRootManifest(
                         name: "Bar",
@@ -138,7 +138,7 @@ class GenerateXcodeprojTests: XCTestCase {
 
             let observability = ObservabilitySystem.makeForTesting()
             let graph = try loadPackageGraph(
-                fs: localFileSystem,
+                fileSystem: localFileSystem,
                 manifests: [
                     Manifest.createRootManifest(
                         name: "Modules",
@@ -177,7 +177,7 @@ class GenerateXcodeprojTests: XCTestCase {
 
             let observability = ObservabilitySystem.makeForTesting()
             let graph = try loadPackageGraph(
-                fs: localFileSystem,
+                fileSystem: localFileSystem,
                 manifests: [
                     Manifest.createRootManifest(
                         name: "Foo",
@@ -218,7 +218,7 @@ class GenerateXcodeprojTests: XCTestCase {
 
             let observability = ObservabilitySystem.makeForTesting()
             let graph = try loadPackageGraph(
-                fs: localFileSystem,
+                fileSystem: localFileSystem,
                 manifests: [
                     Manifest.createRootManifest(
                         name: "Foo",
@@ -258,7 +258,7 @@ class GenerateXcodeprojTests: XCTestCase {
 
             let observability = ObservabilitySystem.makeForTesting()
             let graph = try loadPackageGraph(
-                fs: localFileSystem,
+                fileSystem: localFileSystem,
                 manifests: [
                     Manifest.createRootManifest(
                         name: "Foo",
@@ -309,7 +309,7 @@ class GenerateXcodeprojTests: XCTestCase {
 
             let observability = ObservabilitySystem.makeForTesting()
             let graph = try loadPackageGraph(
-                fs: localFileSystem,
+                fileSystem: localFileSystem,
                 manifests: [
                     Manifest.createRootManifest(
                         name: "Foo",
@@ -358,7 +358,7 @@ class GenerateXcodeprojTests: XCTestCase {
 
             let observability = ObservabilitySystem.makeForTesting()
             let graph = try loadPackageGraph(
-                fs: localFileSystem,
+                fileSystem: localFileSystem,
                 manifests: [
                     Manifest.createRootManifest(
                         name: "Foo",
@@ -407,7 +407,7 @@ class GenerateXcodeprojTests: XCTestCase {
 
             let observability = ObservabilitySystem.makeForTesting()
             let graph = try loadPackageGraph(
-                fs: localFileSystem,
+                fileSystem: localFileSystem,
                 manifests: [
                     Manifest.createRootManifest(
                         name: "Foo",

--- a/Tests/XcodeprojTests/PackageGraphTests.swift
+++ b/Tests/XcodeprojTests/PackageGraphTests.swift
@@ -35,7 +35,7 @@ class PackageGraphTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let g = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createLocalSourceControlManifest(
                     name: "Foo",
@@ -206,7 +206,7 @@ class PackageGraphTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let g = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -255,7 +255,7 @@ class PackageGraphTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let g = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Bar",
@@ -306,7 +306,7 @@ class PackageGraphTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let g = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
@@ -377,7 +377,7 @@ class PackageGraphTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
-            fs: fs,
+            fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
@@ -430,7 +430,7 @@ class PackageGraphTests: XCTestCase {
 
             let observability = ObservabilitySystem.makeForTesting()
             let graph = try loadPackageGraph(
-                fs: fs,
+                fileSystem: fs,
                 manifests: [
                     Manifest.createRootManifest(
                         name: "Foo",


### PR DESCRIPTION
motivation: clients of libSwiftPM need access to both the raw (as entered in manifest) and derived (computed) platform support information

changes:
* move defaultLocalization and platforms information from target to ResolvedTarget, as this is derviced from the package level
* add defaultLocalization and platforms information to ResolvedPackage
* add defaultLocalization and platforms information to ResolvedProduct,derived from the product targets
* move the computation of derived platforms to package graph loading phase
* udpate call sites
* add and update test

rdar://86748009