### PR TITLE
Build: adjust the BuildSystemDelegate hander

### DIFF
--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -568,7 +568,9 @@ final class BuildOperationBuildSystemDelegateHandler: LLBuildBuildSystemDelegate
         if let swiftParser = swiftParsers[command.name] {
             swiftParser.parse(bytes: data)
         } else {
-            self.nonSwiftMessageBuffers[command.name, default: []] += data
+            queue.async {
+                self.nonSwiftMessageBuffers[command.name, default: []] += data
+            }
         }
     }
 

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -410,7 +410,8 @@ final class BuildOperationBuildSystemDelegateHandler: LLBuildBuildSystemDelegate
     /// Swift parsers keyed by llbuild command name.
     private var swiftParsers: [String: SwiftCompilerOutputParser] = [:]
 
-    private var nonSwiftMessageBuffers: [String:[UInt8]] = [:]
+    /// Buffer to accumulate non-swift output until command is finished
+    private var nonSwiftMessageBuffers: [String: [UInt8]] = [:]
 
     /// The build execution context.
     private let buildExecutionContext: BuildExecutionContext

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -410,6 +410,8 @@ final class BuildOperationBuildSystemDelegateHandler: LLBuildBuildSystemDelegate
     /// Swift parsers keyed by llbuild command name.
     private var swiftParsers: [String: SwiftCompilerOutputParser] = [:]
 
+    private var nonSwiftMessageBuffers: [String:[UInt8]] = [:]
+
     /// The build execution context.
     private let buildExecutionContext: BuildExecutionContext
 
@@ -565,11 +567,7 @@ final class BuildOperationBuildSystemDelegateHandler: LLBuildBuildSystemDelegate
         if let swiftParser = swiftParsers[command.name] {
             swiftParser.parse(bytes: data)
         } else {
-            queue.async {
-                self.progressAnimation.clear()
-                self.outputStream <<< data
-                self.outputStream.flush()
-            }
+            self.nonSwiftMessageBuffers[command.name, default: []] += data
         }
     }
 
@@ -578,6 +576,14 @@ final class BuildOperationBuildSystemDelegateHandler: LLBuildBuildSystemDelegate
         process: ProcessHandle,
         result: CommandExtendedResult
     ) {
+        if let buffer = self.nonSwiftMessageBuffers[command.name] {
+            queue.async {
+                self.progressAnimation.clear()
+                self.outputStream <<< buffer
+                self.outputStream.flush()
+                self.nonSwiftMessageBuffers[command.name] = nil
+            }
+        }
         if result.result == .failed {
             // The command failed, so we queue up an asynchronous task to see if we have any error messages from the target to provide advice about.
             queue.async {


### PR DESCRIPTION
llbuild does not make guarantees that the output from subcommands are
emitted in complete buffers.  This shows up particularly well on
Windows.  clang will emit diagnostics which get read in different
chunks.  By emitting these eagerly we would print partial messages which
would leave the terminal in the improper state due to the message not
being complete.  With multiple parallel threads writing the messages
partially, we would get splits in the message that would yield
unreadable messages.

Switch to a buffering approach, buffering the entire content until the
command exits.  At that time we can emit the complete message in a
"single" write (which is locked).  This ensures that the output is no
longer partially emitted and corrects the rendering with the animated
emission on Windows.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
