### PR TITLE
work around argument parser usage synopsis issue

### DIFF
--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -79,16 +79,14 @@ struct LocationOptions: ParsableArguments {
 struct CachingOptions: ParsableArguments {
     /// Disables package caching.
     @Flag(name: .customLong("dependency-cache"), inversion: .prefixedEnableDisable, help: "Use a shared cache when fetching dependencies")
-    var _useDependenciesCache: Bool?
+    var _useDependenciesCache: Bool = true
 
     // TODO: simplify when deprecating the older flag
     var useDependenciesCache: Bool {
-        if let value = self._useDependenciesCache {
+        if let value = self._deprecated_useRepositoriesCache {
             return value
-        } else if let value = self._deprecated_useRepositoriesCache {
-            return value
-        } else {
-            return true
+        }  else {
+            return self._useDependenciesCache
         }
     }
 


### PR DESCRIPTION
motivation: When invoking any unknown or help-triggering `swift package` command in terminal, the suggested invocation always includes the `--enable-dependency-cache` flag.

changes: useDependenciesCache flag to be non-optional, since this triggres a bug in argument parser which adds the option to the usage synopsis

note: underlying issue fixed in https://github.com/apple/swift-argument-parser/pull/416

rdar://89488586
