### PR TITLE
improve location CLI options

### DIFF
--- a/Sources/Commands/APIDigester.swift
+++ b/Sources/Commands/APIDigester.swift
@@ -119,7 +119,7 @@ struct APIDigesterBaselineDumper {
 
         // Update the data path input build parameters so it's built in the sandbox.
         var buildParameters = inputBuildParameters
-        buildParameters.dataPath = workspace.location.workingDirectory
+        buildParameters.dataPath = workspace.location.scratchDirectory
 
         // Build the baseline module.
         // FIXME: We need to implement the build tool invocation closure here so that build tool plugins work with the APIDigester. rdar://86112934

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -66,14 +66,14 @@ struct LocationOptions: ParsableArguments {
     }
 
     /// The custom .build directory, if provided.
-    @Option(name: .customLong("working-directory-path"), help: "Specify a custom working directory path (default .build)", completion: .directory)
-    var _workingDirectory: AbsolutePath?
+    @Option(name: .customLong("scratch-path"), help: "Specify a custom scratch directory path (default .build)", completion: .directory)
+    var _scratchDirectory: AbsolutePath?
 
     @Option(name: .customLong("build-path"), help: .hidden)
     var _deprecated_buildPath: AbsolutePath?
 
-    var workingDirectory: AbsolutePath? {
-        self._workingDirectory ?? self._deprecated_buildPath
+    var scratchDirectory: AbsolutePath? {
+        self._scratchDirectory ?? self._deprecated_buildPath
     }
 
     /// The path to the file containing multiroot package data. This is currently Xcode's workspace file.

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -46,33 +46,42 @@ struct GlobalOptions: ParsableArguments {
 struct LocationOptions: ParsableArguments {
     init() {}
 
-    /// The custom build directory, if provided.
-    @Option(help: "Specify build/cache directory")
-    var buildPath: AbsolutePath?
+    @Option(name: .customLong("package-path"), help: "Specify the package path to operate on (default current directory). This changes the working directory before any other operation", completion: .directory)
+    var _packageDirectory: AbsolutePath?
 
-    @Option(help: "Specify the shared cache directory")
-    var cachePath: AbsolutePath?
+    @Option(name: .customLong("cache-path"), help: "Specify the shared cache directory path", completion: .directory)
+    var cacheDirectory: AbsolutePath?
 
-    @Option(help: "Specify the shared configuration directory")
-    var configPath: AbsolutePath?
+    @Option(name: .customLong("config-path"), help: "Specify the shared configuration directory path", completion: .directory)
+    var configurationDirectory: AbsolutePath?
 
-    @Option(help: "Specify the shared security directory")
-    var securityPath: AbsolutePath?
+    @Option(name: .customLong("security-path"), help: "Specify the shared security directory path", completion: .directory)
+    var securityDirectory: AbsolutePath?
 
-    /// The custom working directory that the tool should operate in (deprecated).
-    @Option(name: [.long, .customShort("C")])
-    var chdir: AbsolutePath?
+    @Option(name: [.long, .customShort("C")], help: .hidden)
+    var _deprecated_chdir: AbsolutePath?
 
-    /// The custom working directory that the tool should operate in.
-    @Option(help: "Change working directory before any other operation")
-    var packagePath: AbsolutePath?
+    var packageDirectory: AbsolutePath? {
+        self._packageDirectory ?? self._deprecated_chdir
+    }
+
+    /// The custom .build directory, if provided.
+    @Option(name: .customLong("working-directory-path"), help: "Specify a custom working directory path (default .build)", completion: .directory)
+    var _workingDirectory: AbsolutePath?
+
+    @Option(name: .customLong("build-path"), help: .hidden)
+    var _deprecated_buildPath: AbsolutePath?
+
+    var workingDirectory: AbsolutePath? {
+        self._workingDirectory ?? self._deprecated_buildPath
+    }
 
     /// The path to the file containing multiroot package data. This is currently Xcode's workspace file.
-    @Option(name: .customLong("multiroot-data-file"), completion: .file())
+    @Option(name: .customLong("multiroot-data-file"), help: .hidden, completion: .directory)
     var multirootPackageDataFile: AbsolutePath?
 
     /// Path to the compilation destination describing JSON file.
-    @Option(name: .customLong("destination"), completion: .file())
+    @Option(name: .customLong("destination"), help: .hidden, completion: .directory)
     var customCompileDestination: AbsolutePath?
 }
 

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -393,7 +393,7 @@ extension SwiftPackageTool {
             let apiDigesterPath = try swiftTool.getToolchain().getSwiftAPIDigester()
             let apiDigesterTool = SwiftAPIDigester(fileSystem: swiftTool.fileSystem, tool: apiDigesterPath)
 
-            let packageRoot = try globalOptions.locations.packagePath ?? swiftTool.getPackageRoot()
+            let packageRoot = try globalOptions.locations.packageDirectory ?? swiftTool.getPackageRoot()
             let repository = GitRepository(path: packageRoot)
             let baselineRevision = try repository.resolveRevision(identifier: treeish)
 
@@ -890,7 +890,7 @@ extension SwiftPackageTool {
         var output: AbsolutePath?
 
         func run(_ swiftTool: SwiftTool) throws {
-            let packageRoot = try globalOptions.locations.packagePath ?? swiftTool.getPackageRoot()
+            let packageRoot = try globalOptions.locations.packageDirectory ?? swiftTool.getPackageRoot()
             let repository = GitRepository(path: packageRoot)
 
             let destination: AbsolutePath
@@ -1580,7 +1580,7 @@ extension SwiftPackageTool {
             // Run the file watcher if requested.
             if options.enableAutogeneration {
                 try WatchmanHelper(
-                    watchmanScriptsDir: swiftTool.buildPath.appending(component: "watchman"),
+                    watchmanScriptsDir: swiftTool.workingDirectory.appending(component: "watchman"),
                     packageRoot: swiftTool.packageRoot!,
                     fileSystem: swiftTool.fileSystem,
                     observabilityScope: swiftTool.observabilityScope

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -1580,7 +1580,7 @@ extension SwiftPackageTool {
             // Run the file watcher if requested.
             if options.enableAutogeneration {
                 try WatchmanHelper(
-                    watchmanScriptsDir: swiftTool.workingDirectory.appending(component: "watchman"),
+                    watchmanScriptsDir: swiftTool.scratchDirectory.appending(component: "watchman"),
                     packageRoot: swiftTool.packageRoot!,
                     fileSystem: swiftTool.fileSystem,
                     observabilityScope: swiftTool.observabilityScope

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -323,7 +323,7 @@ public class SwiftTool {
     }
 
     /// Scratch space (.build) directory.
-    let workingDirectory: AbsolutePath
+    let scratchDirectory: AbsolutePath
 
     /// Path to the shared security directory
     let sharedSecurityDirectory: AbsolutePath?
@@ -469,9 +469,9 @@ public class SwiftTool {
         let packageRoot = findPackageRoot(fileSystem: fileSystem)
 
         self.packageRoot = packageRoot
-        self.workingDirectory =
+        self.scratchDirectory =
             getEnvBuildPath(workingDir: cwd) ??
-            options.locations.workingDirectory ??
+            options.locations.scratchDirectory ??
             (packageRoot ?? cwd).appending(component: ".build")
 
         // make sure common directories are created
@@ -548,7 +548,7 @@ public class SwiftTool {
         let workspace = try Workspace(
             fileSystem: self.fileSystem,
             location: .init(
-                workingDirectory: self.workingDirectory,
+                scratchDirectory: self.scratchDirectory,
                 editsDirectory: self.getEditsDirectory(),
                 resolvedVersionsFile: self.getResolvedVersionsFile(),
                 localConfigurationDirectory: try self.getLocalConfigurationDirectory(),
@@ -821,7 +821,7 @@ public class SwiftTool {
             // Use "apple" as the subdirectory because in theory Xcode build system
             // can be used to build for any Apple platform and it has it's own
             // conventions for build subpaths based on platforms.
-            let dataPath = self.workingDirectory.appending(
+            let dataPath = self.scratchDirectory.appending(
                 component: options.build.buildSystem == .xcode ? "apple" : triple.platformBuildPathComponent())
             return BuildParameters(
                 dataPath: dataPath,
@@ -909,7 +909,7 @@ public class SwiftTool {
             case (false, .none):
                 cachePath = .none
             case (false, .local):
-                cachePath = self.workingDirectory
+                cachePath = self.scratchDirectory
             case (false, .shared):
                 cachePath = self.sharedCacheDirectory.map{ Workspace.DefaultLocations.manifestsDirectory(at: $0) }
             }

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -322,8 +322,8 @@ public class SwiftTool {
         return PackageGraphRootInput(packages: packages)
     }
 
-    /// Path to the build directory.
-    let buildPath: AbsolutePath
+    /// Scratch space (.build) directory.
+    let workingDirectory: AbsolutePath
 
     /// Path to the shared security directory
     let sharedSecurityDirectory: AbsolutePath?
@@ -396,7 +396,7 @@ public class SwiftTool {
             self.options = options
 
             // Honor package-path option is provided.
-            if let packagePath = options.locations.packagePath ?? options.locations.chdir {
+            if let packagePath = options.locations.packageDirectory {
                 try ProcessEnv.chdir(packagePath)
             }
 
@@ -466,13 +466,13 @@ public class SwiftTool {
         }
 
         // Create local variables to use while finding build path to avoid capture self before init error.
-        let customBuildPath = options.locations.buildPath
         let packageRoot = findPackageRoot(fileSystem: fileSystem)
 
         self.packageRoot = packageRoot
-        self.buildPath = getEnvBuildPath(workingDir: cwd) ??
-        customBuildPath ??
-        (packageRoot ?? cwd).appending(component: ".build")
+        self.workingDirectory =
+            getEnvBuildPath(workingDir: cwd) ??
+            options.locations.workingDirectory ??
+            (packageRoot ?? cwd).appending(component: ".build")
 
         // make sure common directories are created
         self.sharedSecurityDirectory = try getSharedSecurityDirectory(options: self.options, fileSystem: fileSystem, observabilityScope: self.observabilityScope)
@@ -484,7 +484,11 @@ public class SwiftTool {
     }
 
     static func postprocessArgParserResult(options: GlobalOptions, observabilityScope: ObservabilityScope) throws {
-        if options.locations.chdir != nil {
+        if options.locations._deprecated_buildPath != nil {
+            observabilityScope.emit(warning: "'--build-path' option is deprecated; use '--scratch-space-path' instead")
+        }
+
+        if options.locations._deprecated_chdir != nil {
             observabilityScope.emit(warning: "'--chdir/-C' option is deprecated; use '--package-path' instead")
         }
 
@@ -544,7 +548,7 @@ public class SwiftTool {
         let workspace = try Workspace(
             fileSystem: self.fileSystem,
             location: .init(
-                workingDirectory: self.buildPath,
+                workingDirectory: self.workingDirectory,
                 editsDirectory: self.getEditsDirectory(),
                 resolvedVersionsFile: self.getResolvedVersionsFile(),
                 localConfigurationDirectory: try self.getLocalConfigurationDirectory(),
@@ -817,7 +821,7 @@ public class SwiftTool {
             // Use "apple" as the subdirectory because in theory Xcode build system
             // can be used to build for any Apple platform and it has it's own
             // conventions for build subpaths based on platforms.
-            let dataPath = buildPath.appending(
+            let dataPath = self.workingDirectory.appending(
                 component: options.build.buildSystem == .xcode ? "apple" : triple.platformBuildPathComponent())
             return BuildParameters(
                 dataPath: dataPath,
@@ -905,7 +909,7 @@ public class SwiftTool {
             case (false, .none):
                 cachePath = .none
             case (false, .local):
-                cachePath = self.buildPath
+                cachePath = self.workingDirectory
             case (false, .shared):
                 cachePath = self.sharedCacheDirectory.map{ Workspace.DefaultLocations.manifestsDirectory(at: $0) }
             }
@@ -964,12 +968,12 @@ private func getEnvBuildPath(workingDir: AbsolutePath) -> AbsolutePath? {
 
 
 private func getSharedSecurityDirectory(options: GlobalOptions, fileSystem: FileSystem, observabilityScope: ObservabilityScope) throws -> AbsolutePath? {
-    if let explicitSecurityPath = options.locations.securityPath {
+    if let explicitSecurityDirectory = options.locations.securityDirectory {
         // Create the explicit security path if necessary
-        if !fileSystem.exists(explicitSecurityPath) {
-            try fileSystem.createDirectory(explicitSecurityPath, recursive: true)
+        if !fileSystem.exists(explicitSecurityDirectory) {
+            try fileSystem.createDirectory(explicitSecurityDirectory, recursive: true)
         }
-        return explicitSecurityPath
+        return explicitSecurityDirectory
     } else {
         // further validation is done in workspace
         return fileSystem.swiftPMSecurityDirectory
@@ -977,12 +981,12 @@ private func getSharedSecurityDirectory(options: GlobalOptions, fileSystem: File
 }
 
 private func getSharedConfigurationDirectory(options: GlobalOptions, fileSystem: FileSystem, observabilityScope: ObservabilityScope) throws -> AbsolutePath? {
-    if let explicitConfigPath = options.locations.configPath {
+    if let explicitConfigurationDirectory = options.locations.configurationDirectory {
         // Create the explicit config path if necessary
-        if !fileSystem.exists(explicitConfigPath) {
-            try fileSystem.createDirectory(explicitConfigPath, recursive: true)
+        if !fileSystem.exists(explicitConfigurationDirectory) {
+            try fileSystem.createDirectory(explicitConfigurationDirectory, recursive: true)
         }
-        return explicitConfigPath
+        return explicitConfigurationDirectory
     } else {
         // further validation is done in workspace
         return fileSystem.swiftPMConfigurationDirectory
@@ -990,12 +994,12 @@ private func getSharedConfigurationDirectory(options: GlobalOptions, fileSystem:
 }
 
 private func getSharedCacheDirectory(options: GlobalOptions, fileSystem: FileSystem, observabilityScope: ObservabilityScope) throws -> AbsolutePath? {
-    if let explicitCachePath = options.locations.cachePath {
+    if let explicitCacheDirectory = options.locations.cacheDirectory {
         // Create the explicit cache path if necessary
-        if !fileSystem.exists(explicitCachePath) {
-            try fileSystem.createDirectory(explicitCachePath, recursive: true)
+        if !fileSystem.exists(explicitCacheDirectory) {
+            try fileSystem.createDirectory(explicitCacheDirectory, recursive: true)
         }
-        return explicitCachePath
+        return explicitCacheDirectory
     } else {
         // further validation is done in workspace
         return fileSystem.swiftPMCacheDirectory

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -245,7 +245,7 @@ public final class MockWorkspace {
         let workspace = try Workspace._init(
             fileSystem: self.fileSystem,
             location: .init(
-                workingDirectory: self.sandbox.appending(component: ".build"),
+                scratchDirectory: self.sandbox.appending(component: ".build"),
                 editsDirectory: self.sandbox.appending(component: "edits"),
                 resolvedVersionsFile: self.sandbox.appending(component: "Package.resolved"),
                 localConfigurationDirectory: Workspace.DefaultLocations.configurationDirectory(forRootPackage: self.sandbox),

--- a/Sources/Workspace/Workspace+Configuration.swift
+++ b/Sources/Workspace/Workspace+Configuration.swift
@@ -25,8 +25,8 @@ import protocol TSCUtility.SimplePersistanceProtocol
 extension Workspace {
     /// Workspace location configuration
     public struct Location {
-        /// Path to scratch space / working directory for this workspace.
-        public var workingDirectory: AbsolutePath
+        /// Path to scratch space (working) directory for this workspace.
+        public var scratchDirectory: AbsolutePath
 
         /// Path to store the editable versions of dependencies.
         public var editsDirectory: AbsolutePath
@@ -50,27 +50,27 @@ extension Workspace {
 
         /// Path to the repositories clones.
         public var repositoriesDirectory: AbsolutePath {
-            self.workingDirectory.appending(component: "repositories")
+            self.scratchDirectory.appending(component: "repositories")
         }
 
         /// Path to the repository checkouts.
         public var repositoriesCheckoutsDirectory: AbsolutePath {
-            self.workingDirectory.appending(component: "checkouts")
+            self.scratchDirectory.appending(component: "checkouts")
         }
 
         /// Path to the registry downloads.
         public var registryDownloadDirectory: AbsolutePath {
-            self.workingDirectory.appending(components: "registry", "downloads")
+            self.scratchDirectory.appending(components: "registry", "downloads")
         }
 
         /// Path to the downloaded binary artifacts.
         public var artifactsDirectory: AbsolutePath {
-            self.workingDirectory.appending(component: "artifacts")
+            self.scratchDirectory.appending(component: "artifacts")
         }
 
         // Path to temporary files related to running plugins in the workspace
         public var pluginWorkingDirectory: AbsolutePath {
-            self.workingDirectory.appending(component: "plugins")
+            self.scratchDirectory.appending(component: "plugins")
         }
 
         // config locations
@@ -123,15 +123,7 @@ extension Workspace {
             self.sharedCacheDirectory.map { $0.appending(components: "registry", "downloads") }
         }
 
-        /// Create a new workspace location.
-        ///
-        /// - Parameters:
-        ///   - workingDirectory: Path to working directory for this workspace.
-        ///   - editsDirectory: Path to store the editable versions of dependencies.
-        ///   - resolvedVersionsFile: Path to the Package.resolved file.
-        ///   - sharedSecurityDirectory: Path to the shared security directory.
-        ///   - sharedCacheDirectory: Path to the shared cache directory.
-        ///   - sharedConfigurationDirectory: Path to the shared configuration directory.
+        @available(*, deprecated, message: "use (scratchDirectory:) variant instead")
         public init(
             workingDirectory: AbsolutePath,
             editsDirectory: AbsolutePath,
@@ -141,7 +133,34 @@ extension Workspace {
             sharedSecurityDirectory: AbsolutePath?,
             sharedCacheDirectory: AbsolutePath?
         ) {
-            self.workingDirectory = workingDirectory
+            self.scratchDirectory = workingDirectory
+            self.editsDirectory = editsDirectory
+            self.resolvedVersionsFile = resolvedVersionsFile
+            self.localConfigurationDirectory = localConfigurationDirectory
+            self.sharedConfigurationDirectory = sharedConfigurationDirectory
+            self.sharedSecurityDirectory = sharedSecurityDirectory
+            self.sharedCacheDirectory = sharedCacheDirectory
+        }
+
+        /// Create a new workspace location.
+        ///
+        /// - Parameters:
+        ///   - scratchDirectory: Path to scratch space (working) directory for this workspace.
+        ///   - editsDirectory: Path to store the editable versions of dependencies.
+        ///   - resolvedVersionsFile: Path to the Package.resolved file.
+        ///   - sharedSecurityDirectory: Path to the shared security directory.
+        ///   - sharedCacheDirectory: Path to the shared cache directory.
+        ///   - sharedConfigurationDirectory: Path to the shared configuration directory.
+        public init(
+            scratchDirectory: AbsolutePath,
+            editsDirectory: AbsolutePath,
+            resolvedVersionsFile: AbsolutePath,
+            localConfigurationDirectory: AbsolutePath,
+            sharedConfigurationDirectory: AbsolutePath?,
+            sharedSecurityDirectory: AbsolutePath?,
+            sharedCacheDirectory: AbsolutePath?
+        ) {
+            self.scratchDirectory = scratchDirectory
             self.editsDirectory = editsDirectory
             self.resolvedVersionsFile = resolvedVersionsFile
             self.localConfigurationDirectory = localConfigurationDirectory
@@ -156,7 +175,7 @@ extension Workspace {
         ///   - rootPath: Path to the root of the package, from which other locations can be derived.
         public init(forRootPackage rootPath: AbsolutePath, fileSystem: FileSystem) {
             self.init(
-                workingDirectory: DefaultLocations.workingDirectory(forRootPackage: rootPath),
+                scratchDirectory: DefaultLocations.scratchDirectory(forRootPackage: rootPath),
                 editsDirectory: DefaultLocations.editsDirectory(forRootPackage: rootPath),
                 resolvedVersionsFile: DefaultLocations.resolvedVersionsFile(forRootPackage: rootPath),
                 localConfigurationDirectory: DefaultLocations.configurationDirectory(forRootPackage: rootPath),
@@ -173,7 +192,12 @@ extension Workspace {
 extension Workspace {
     /// Workspace default locations utilities
     public struct DefaultLocations {
+        @available(*, deprecated, message: "use scratchDirectory instead")
         public static func workingDirectory(forRootPackage rootPath: AbsolutePath) -> AbsolutePath {
+            Self.scratchDirectory(forRootPackage: rootPath)
+        }
+
+        public static func scratchDirectory(forRootPackage rootPath: AbsolutePath) -> AbsolutePath {
             rootPath.appending(component: ".build")
         }
 

--- a/Sources/Workspace/Workspace+Configuration.swift
+++ b/Sources/Workspace/Workspace+Configuration.swift
@@ -25,8 +25,19 @@ import protocol TSCUtility.SimplePersistanceProtocol
 extension Workspace {
     /// Workspace location configuration
     public struct Location {
-        /// Path to scratch space (working) directory for this workspace.
+        /// Path to scratch space (working) directory for this workspace (aka .build).
         public var scratchDirectory: AbsolutePath
+
+        // deprecated 3/22, remove once client move over
+        @available(*, deprecated, message: "use scratchDirectory instead")
+        public var workingDirectory: AbsolutePath {
+            get {
+                self.scratchDirectory
+            }
+            set {
+                self.scratchDirectory = newValue
+            }
+        }
 
         /// Path to store the editable versions of dependencies.
         public var editsDirectory: AbsolutePath
@@ -123,6 +134,7 @@ extension Workspace {
             self.sharedCacheDirectory.map { $0.appending(components: "registry", "downloads") }
         }
 
+        // deprecated 3/22, remove once client move over
         @available(*, deprecated, message: "use (scratchDirectory:) variant instead")
         public init(
             workingDirectory: AbsolutePath,
@@ -192,6 +204,7 @@ extension Workspace {
 extension Workspace {
     /// Workspace default locations utilities
     public struct DefaultLocations {
+        // deprecated 3/22, remove once client move over
         @available(*, deprecated, message: "use scratchDirectory instead")
         public static func workingDirectory(forRootPackage rootPath: AbsolutePath) -> AbsolutePath {
             Self.scratchDirectory(forRootPackage: rootPath)

--- a/Sources/Workspace/Workspace+Configuration.swift
+++ b/Sources/Workspace/Workspace+Configuration.swift
@@ -25,7 +25,7 @@ import protocol TSCUtility.SimplePersistanceProtocol
 extension Workspace {
     /// Workspace location configuration
     public struct Location {
-        /// Path to working directory for this workspace.
+        /// Path to scratch space / working directory for this workspace.
         public var workingDirectory: AbsolutePath
 
         /// Path to store the editable versions of dependencies.

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -775,7 +775,7 @@ public class Workspace {
         self.pinsStore = LoadableResult {
             try PinsStore(
                 pinsFile: location.resolvedVersionsFile,
-                workingDirectory: location.workingDirectory,
+                workingDirectory: location.scratchDirectory,
                 fileSystem: fileSystem,
                 mirrors: mirrors
             )
@@ -783,7 +783,7 @@ public class Workspace {
 
         self.state = WorkspaceState(
             fileSystem: fileSystem,
-            storageDirectory: self.location.workingDirectory,
+            storageDirectory: self.location.scratchDirectory,
             initializationWarningHandler: initializationWarningHandler
         )
     }
@@ -948,23 +948,23 @@ extension Workspace {
             self.state.storagePath,
         ].map({ path -> String in
             // Assert that these are present inside data directory.
-            assert(path.parentDirectory == self.location.workingDirectory)
+            assert(path.parentDirectory == self.location.scratchDirectory)
             return path.basename
         })
 
         // If we have no data yet, we're done.
-        guard fileSystem.exists(self.location.workingDirectory) else {
+        guard fileSystem.exists(self.location.scratchDirectory) else {
             return
         }
 
-        guard let contents = observabilityScope.trap({ try fileSystem.getDirectoryContents(self.location.workingDirectory) }) else {
+        guard let contents = observabilityScope.trap({ try fileSystem.getDirectoryContents(self.location.scratchDirectory) }) else {
             return
         }
 
         // Remove all but protected paths.
         let contentsToRemove = Set(contents).subtracting(protectedAssets)
         for name in contentsToRemove {
-            try? fileSystem.removeFileTree(self.location.workingDirectory.appending(RelativePath(name)))
+            try? fileSystem.removeFileTree(self.location.scratchDirectory.appending(RelativePath(name)))
         }
     }
 
@@ -1010,7 +1010,7 @@ extension Workspace {
         try? self.repositoryManager.reset()
         try? self.registryDownloadsManager.reset()
         try? self.manifestLoader.resetCache()
-        try? self.fileSystem.removeFileTree(self.location.workingDirectory)
+        try? self.fileSystem.removeFileTree(self.location.scratchDirectory)
     }
 
     // FIXME: @testable internal

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -1668,7 +1668,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Drop a build artifact in data directory.
         let ws = try workspace.getOrCreateWorkspace()
-        let buildArtifact = ws.location.workingDirectory.appending(component: "test.o")
+        let buildArtifact = ws.location.scratchDirectory.appending(component: "test.o")
         try fs.writeFileContents(buildArtifact, bytes: "Hi")
 
         // Sanity checks.
@@ -1680,7 +1680,7 @@ final class WorkspaceTests: XCTestCase {
             // Only the build artifact should be removed.
             XCTAssertFalse(fs.exists(buildArtifact))
             XCTAssert(fs.exists(ws.location.repositoriesCheckoutsDirectory))
-            XCTAssert(fs.exists(ws.location.workingDirectory))
+            XCTAssert(fs.exists(ws.location.scratchDirectory))
 
             XCTAssertNoDiagnostics(diagnostics)
         }
@@ -1696,7 +1696,7 @@ final class WorkspaceTests: XCTestCase {
             // Only the build artifact should be removed.
             XCTAssertFalse(fs.exists(buildArtifact))
             XCTAssertFalse(fs.exists(ws.location.repositoriesCheckoutsDirectory))
-            XCTAssertFalse(fs.exists(ws.location.workingDirectory))
+            XCTAssertFalse(fs.exists(ws.location.scratchDirectory))
 
             XCTAssertNoDiagnostics(diagnostics)
         }


### PR DESCRIPTION
motivation: nicer CLI experience

changes:
* rename --build-path to --scratch-space-path which better aligns with the meaning, and improve help messae
* use the "direcotry" completion option for locations since they mostly point to directories
* hide deprecate options like -C
* rename flag variables to better align with meaning
* adjust call sites

