### PR TITLE
Support module aliasing for PIF gen with xcode build system in SwiftPM

### DIFF
--- a/Sources/XCBuildSupport/PIF.swift
+++ b/Sources/XCBuildSupport/PIF.swift
@@ -963,6 +963,7 @@ public enum PIF {
             case SPECIALIZATION_SDK_OPTIONS
             case SUPPORTED_PLATFORMS
             case SWIFT_ACTIVE_COMPILATION_CONDITIONS
+            case SWIFT_MODULE_ALIASES
         }
 
         public enum Platform: String, CaseIterable, Codable {

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -582,6 +582,9 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         // Disable code coverage linker flags since we're producing .o files. Otherwise, we will run into duplicated
         // symbols when there are more than one targets that produce .o as their product.
         settings[.CLANG_COVERAGE_MAPPING_LINKER_ARGS] = "NO"
+        if let aliases = target.moduleAliases {
+            settings[.SWIFT_MODULE_ALIASES] = aliases.map{ $0.key + "=" + $0.value }
+        }
 
         // Create a set of build settings that will be imparted to any target that depends on this one.
         var impartedSettings = PIF.BuildSettings()

--- a/Sources/Xcodeproj/XcodeProjectModel.swift
+++ b/Sources/Xcodeproj/XcodeProjectModel.swift
@@ -391,6 +391,7 @@ public struct Xcode {
             public var SWIFT_ACTIVE_COMPILATION_CONDITIONS: [String]?
             public var SWIFT_FORCE_STATIC_LINK_STDLIB: String?
             public var SWIFT_FORCE_DYNAMIC_LINK_STDLIB: String?
+            public var SWIFT_MODULE_ALIASES: [String: String]?
             public var SWIFT_OPTIMIZATION_LEVEL: String?
             public var SWIFT_VERSION: String?
             public var TARGET_NAME: String?
@@ -440,6 +441,7 @@ public struct Xcode {
                 SWIFT_ACTIVE_COMPILATION_CONDITIONS: [String]? = nil,
                 SWIFT_FORCE_STATIC_LINK_STDLIB: String? = nil,
                 SWIFT_FORCE_DYNAMIC_LINK_STDLIB: String? = nil,
+                SWIFT_MODULE_ALIASES: [String: String]? = nil,
                 SWIFT_OPTIMIZATION_LEVEL: String? = nil,
                 SWIFT_VERSION: String? = nil,
                 TARGET_NAME: String? = nil,
@@ -488,6 +490,7 @@ public struct Xcode {
                 self.SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_ACTIVE_COMPILATION_CONDITIONS
                 self.SWIFT_FORCE_STATIC_LINK_STDLIB = SWIFT_FORCE_STATIC_LINK_STDLIB
                 self.SWIFT_FORCE_DYNAMIC_LINK_STDLIB = SWIFT_FORCE_DYNAMIC_LINK_STDLIB
+                self.SWIFT_MODULE_ALIASES = SWIFT_MODULE_ALIASES
                 self.SWIFT_OPTIMIZATION_LEVEL = SWIFT_OPTIMIZATION_LEVEL
                 self.SWIFT_VERSION = SWIFT_VERSION
                 self.TARGET_NAME = TARGET_NAME


### PR DESCRIPTION
When `—arch` has more than 1 arg, `swift build` triggers Xcode build system, e.g. `swift build —arch x86_64 —arch arm64`. Module aliasing needs to be supported with PIF gen in such scenario.
Resolves rdar://87363580
