### PR TITLE
fix a bug in resolving registry dependencies with alternative manifest versions

### DIFF
--- a/Sources/Workspace/RegistryPackageContainer.swift
+++ b/Sources/Workspace/RegistryPackageContainer.swift
@@ -179,7 +179,7 @@ public class RegistryPackageContainer: PackageContainer {
                                             return true
                                         } else if preferredToolsVersion.patch == 0, file == Manifest.basename + "@swift-\(preferredToolsVersion.major).\(preferredToolsVersion.minor).swift" {
                                             return true
-                                        } else  {
+                                        } else {
                                             return false
                                         }
                                     }) else {

--- a/Sources/Workspace/RegistryPackageContainer.swift
+++ b/Sources/Workspace/RegistryPackageContainer.swift
@@ -173,8 +173,20 @@ public class RegistryPackageContainer: PackageContainer {
                                 return completion(.failure(error))
                             case .success(let manifestContent):
                                 do {
+                                    // find the fake manifest so we can replace it with the real manifest content
+                                    guard let placeholderManifestFileName = try fileSystem.getDirectoryContents(.root).first(where: { file in
+                                        if file == Manifest.basename + "@swift-\(preferredToolsVersion).swift" {
+                                            return true
+                                        } else if preferredToolsVersion.patch == 0, file == Manifest.basename + "@swift-\(preferredToolsVersion.major).\(preferredToolsVersion.minor).swift" {
+                                            return true
+                                        } else  {
+                                            return false
+                                        }
+                                    }) else {
+                                        throw StringError("failed locating placeholder manifest for \(preferredToolsVersion)")
+                                    }
                                     // replace the fake manifest with the real manifest content
-                                    let manifestPath = AbsolutePath.root.appending(component: Manifest.basename + "@swift-\(preferredToolsVersion).swift")
+                                    let manifestPath = AbsolutePath.root.appending(component: placeholderManifestFileName)
                                     try fileSystem.removeFileTree(manifestPath)
                                     try fileSystem.writeFileContents(manifestPath, string: manifestContent)
                                     // finally, load the manifest


### PR DESCRIPTION
motivation: fix an existing issue with registry dependencies that can lead to resolution failure

changes:
* improve the placeholder manifest lookup of registry based dependencies that have alternative manifests
* add test
