### PR TITLE
Make the `WorkspaceTests.testSimpleAPI` test more robust w.r.t. XCTest minimum deployment version

### DIFF
--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -4147,9 +4147,13 @@ final class WorkspaceTests: XCTestCase {
         try testWithTemporaryDirectory { path in
             // Create a temporary package as a test case.
             let packagePath = path.appending(component: "MyPkg")
+            let xctestMinVersions = MinimumDeploymentTarget.default.xcTestMinimumDeploymentTargets
             let initPackage = try InitPackage(
                 name: packagePath.basename,
-                packageType: .executable,
+                options: .init(
+                    packageType: .executable,
+                    platforms: xctestMinVersions[.macOS].map{ .init(platform: .macOS, version: $0) }.map{ [$0] } ?? []
+                ),
                 destinationPath: packagePath,
                 fileSystem: localFileSystem
             )


### PR DESCRIPTION
### Motivation:

This test is dependent on the minimum deployment version of the installed XCTest.  This can result in warnings causing the test to fail.

### Modifications:

- when creating the test fixture, pass options to honor the min deployment target

### Discussion

It's possible that package creation should always set a minimum deployment target of at least what XCTest supports as minimum.  For my toolchain this is macOS 11.  But it's a more general problem, since this can vary.

It's also not clear that the minimum version if there is no declaration should remain at 10.15.4.  Perhaps tools version 5.7 should increase that to 11?

This test only sets the macOS deployment version since that's the only place I've seen this come up.  Iterating over all the platforms doesn't easily work since some of them aren't supported in the manifest with the same names.

However we do this, we should find a way to make the test not fail.  Perhaps we could also strip out the version warnings.

Putting this up partly for discussion, but we do want to avoid the warnings.