### PR TITLE
consolidate and improve manifest validation

### DIFF
--- a/Sources/Basics/Observability.swift
+++ b/Sources/Basics/Observability.swift
@@ -160,6 +160,12 @@ public protocol DiagnosticsEmitterProtocol {
 }
 
 extension DiagnosticsEmitterProtocol {
+    public func emit(_ diagnostics: [Diagnostic]) {
+        for diagnostic in diagnostics {
+            self.emit(diagnostic)
+        }
+    }
+
     public func emit(severity: Diagnostic.Severity, message: String, metadata: ObservabilityMetadata? = .none) {
         self.emit(.init(severity: severity, message: message, metadata: metadata))
     }

--- a/Sources/PackageLoading/CMakeLists.txt
+++ b/Sources/PackageLoading/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(PackageLoading
   Diagnostics.swift
   IdentityResolver.swift
   ManifestLoader.swift
+  ManifestLoader+Validation.swift
   ModuleMapGenerator.swift
   PackageBuilder.swift
   ManifestJSONParser.swift

--- a/Sources/PackageLoading/ManifestLoader+Validation.swift
+++ b/Sources/PackageLoading/ManifestLoader+Validation.swift
@@ -1,0 +1,327 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import Foundation
+import PackageModel
+import TSCBasic
+
+public struct ManifestValidator {
+    static var supportedLocalBinaryDependencyExtensions: [String] {
+        ["zip"] + BinaryTarget.Kind.allCases.filter{ $0 != .unknown }.map { $0.fileExtension }
+    }
+    static var supportedRemoteBinaryDependencyExtensions: [String] {
+        ["zip", "artifactbundleindex"]
+    }
+
+    private let manifest: Manifest
+    private let sourceControlValidator: ManifestSourceControlValidator
+    private let fileSystem: FileSystem
+
+    public init(manifest: Manifest, sourceControlValidator: ManifestSourceControlValidator, fileSystem: FileSystem) {
+        self.manifest = manifest
+        self.sourceControlValidator = sourceControlValidator
+        self.fileSystem = fileSystem
+    }
+
+    /// Validate the provided manifest.
+    public func validate() -> [Basics.Diagnostic] {
+        var diagnostics = [Basics.Diagnostic]()
+
+        diagnostics += self.validateTargets()
+        diagnostics += self.validateProducts()
+        diagnostics += self.validateDependencies()
+
+        // Checks reserved for tools version 5.2 features
+        if self.manifest.toolsVersion >= .v5_2 {
+            diagnostics += self.validateTargetDependencyReferences()
+            diagnostics += self.validateBinaryTargets()
+        }
+
+        return diagnostics
+    }
+
+    private func validateTargets() -> [Basics.Diagnostic] {
+        var diagnostics = [Basics.Diagnostic]()
+
+        let duplicateTargetNames = self.manifest.targets.map({ $0.name }).spm_findDuplicates()
+        for name in duplicateTargetNames {
+            diagnostics.append(.duplicateTargetName(targetName: name))
+        }
+
+        return diagnostics
+    }
+
+    private func validateProducts()  -> [Basics.Diagnostic] {
+        var diagnostics = [Basics.Diagnostic]()
+        
+        for product in self.manifest.products {
+            // Check that the product contains targets.
+            guard !product.targets.isEmpty else {
+                diagnostics.append(.emptyProductTargets(productName: product.name))
+                continue
+            }
+
+            // Check that the product references existing targets.
+            for target in product.targets {
+                if !self.manifest.targetMap.keys.contains(target) {
+                    diagnostics.append(.productTargetNotFound(productName: product.name, targetName: target, validTargets: self.manifest.targetMap.keys.sorted()))
+                }
+            }
+
+            // Check that products that reference only binary targets don't define a type.
+            let areTargetsBinary = product.targets.allSatisfy { self.manifest.targetMap[$0]?.type == .binary }
+            if areTargetsBinary && product.type != .library(.automatic) {
+                diagnostics.append(.invalidBinaryProductType(productName: product.name))
+            }
+        }
+
+        return diagnostics
+    }
+
+    private func validateDependencies() -> [Basics.Diagnostic] {
+        var diagnostics = [Basics.Diagnostic]()
+
+        // validate dependency requirements
+        for dependency in self.manifest.dependencies {
+            switch dependency {
+            case .sourceControl(let sourceControl):
+                diagnostics += validateSourceControlDependency(sourceControl)
+            default:
+                break
+            }
+        }
+
+        return diagnostics
+    }
+
+    private func validateBinaryTargets() -> [Basics.Diagnostic] {
+        var diagnostics = [Basics.Diagnostic]()
+
+        // Check that binary targets point to the right file type.
+        for target in self.manifest.targets where target.type == .binary {
+            if target.isLocal {
+                guard let path = target.path else {
+                    diagnostics.append(.invalidBinaryLocation(targetName: target.name))
+                    continue
+                }
+
+                guard let path = path.spm_chuzzle(), !path.isEmpty else {
+                    diagnostics.append(.invalidLocalBinaryPath(path: path, targetName: target.name))
+                    continue
+                }
+
+                guard let relativePath = try? RelativePath(validating: path) else {
+                    diagnostics.append(.invalidLocalBinaryPath(path: path, targetName: target.name))
+                    continue
+                }
+
+                let validExtensions = Self.supportedLocalBinaryDependencyExtensions
+                guard let fileExtension = relativePath.extension, validExtensions.contains(fileExtension) else {
+                    diagnostics.append(.unsupportedBinaryLocationExtension(
+                        targetName: target.name,
+                        validExtensions: validExtensions
+                    ))
+                    continue
+                }
+            } else if target.isRemote {
+                guard let url = target.url else {
+                    diagnostics.append(.invalidBinaryLocation(targetName: target.name))
+                    continue
+                }
+
+                guard let url = url.spm_chuzzle(), !url.isEmpty else {
+                    diagnostics.append(.invalidBinaryURL(url: url, targetName: target.name))
+                    continue
+                }
+
+                guard let url = URL(string: url) else {
+                    diagnostics.append(.invalidBinaryURL(url: url, targetName: target.name))
+                    continue
+                }
+
+                let validSchemes = ["https"]
+                guard url.scheme.map({ validSchemes.contains($0) }) ?? false else {
+                    diagnostics.append(.invalidBinaryURLScheme(
+                        targetName: target.name,
+                        validSchemes: validSchemes
+                    ))
+                    continue
+                }
+
+                guard Self.supportedRemoteBinaryDependencyExtensions.contains(url.pathExtension) else {
+                    diagnostics.append(.unsupportedBinaryLocationExtension(
+                        targetName: target.name,
+                        validExtensions: Self.supportedRemoteBinaryDependencyExtensions
+                    ))
+                    continue
+                }
+
+            } else {
+                diagnostics.append(.invalidBinaryLocation(targetName: target.name))
+                continue
+            }
+        }
+
+        return diagnostics
+    }
+
+    /// Validates that product target dependencies reference an existing package.
+    private func validateTargetDependencyReferences() -> [Basics.Diagnostic] {
+        var diagnostics = [Basics.Diagnostic]()
+
+        for target in self.manifest.targets {
+            for targetDependency in target.dependencies {
+                switch targetDependency {
+                case .target:
+                    // If this is a target dependency, we don't need to check anything.
+                    break
+                case .product(_, let packageName, _, _):
+                    if self.manifest.packageDependency(referencedBy: targetDependency) == nil {
+                        diagnostics.append(.unknownTargetPackageDependency(
+                            packageName: packageName ?? "unknown package name",
+                            targetName: target.name,
+                            validPackages: self.manifest.dependencies.map { $0.nameForTargetDependencyResolutionOnly }
+                        ))
+                    }
+                case .byName(let name, _):
+                    // Don't diagnose root manifests so we can emit a better diagnostic during package loading.
+                    if !self.manifest.packageKind.isRoot &&
+                        !self.manifest.targetMap.keys.contains(name) &&
+                        self.manifest.packageDependency(referencedBy: targetDependency) == nil
+                    {
+                        diagnostics.append(.unknownTargetDependency(
+                            dependency: name,
+                            targetName: target.name,
+                            validDependencies: self.manifest.dependencies.map { $0.nameForTargetDependencyResolutionOnly }
+                        ))
+                    }
+                }
+            }
+        }
+
+        return diagnostics
+    }
+
+    func validateSourceControlDependency(_ dependency: PackageDependency.SourceControl) -> [Basics.Diagnostic] {
+        var diagnostics = [Basics.Diagnostic]()
+
+        // validate source control ref
+        switch dependency.requirement {
+        case .branch(let name):
+            if !self.sourceControlValidator.isValidRefFormat(name) {
+                diagnostics.append(.invalidSourceControlBranchName(name))
+            }
+        case .revision(let revision):
+            if !self.sourceControlValidator.isValidRefFormat(revision) {
+                diagnostics.append(.invalidSourceControlRevision(revision))
+            }
+        default:
+            break
+        }
+        // if a location is on file system, validate it is in fact a git repo
+        // there is a case to be made to throw early (here) if the path does not exists
+        // but many of our tests assume they can pass a non existent path
+        if case .local(let localPath) = dependency.location, self.fileSystem.exists(localPath) {
+            if !self.sourceControlValidator.isValidDirectory(localPath) {
+                // Provides better feedback when mistakingly using url: for a dependency that
+                // is a local package. Still allows for using url with a local package that has
+                // also been initialized by git
+                diagnostics.append(.invalidSourceControlDirectory(localPath))
+            }
+        }
+        return diagnostics
+    }
+}
+
+public protocol ManifestSourceControlValidator {
+    func isValidRefFormat(_ revision: String) -> Bool
+    func isValidDirectory(_ path: AbsolutePath) -> Bool
+}
+
+extension Basics.Diagnostic {
+    static func duplicateTargetName(targetName: String) -> Self {
+        .error("duplicate target named '\(targetName)'")
+    }
+
+    static func emptyProductTargets(productName: String) -> Self {
+        .error("product '\(productName)' doesn't reference any targets")
+    }
+
+    static func productTargetNotFound(productName: String, targetName: String, validTargets: [String]) -> Self {
+        .error("target '\(targetName)' referenced in product '\(productName)' could not be found; valid targets are: '\(validTargets.joined(separator: "', '"))'")
+    }
+
+    static func invalidBinaryProductType(productName: String) -> Self {
+        .error("invalid type for binary product '\(productName)'; products referencing only binary targets must have a type of 'library'")
+    }
+
+    /*static func duplicateDependency(dependencyIdentity: PackageIdentity) -> Self {
+        .error("duplicate dependency '\(dependencyIdentity)'")    
+    }
+
+    static func duplicateDependencyName(dependencyName: String) -> Self {
+        .error("duplicate dependency named '\(dependencyName)'; consider differentiating them using the 'name' argument")
+    }*/
+
+    static func unknownTargetDependency(dependency: String, targetName: String, validDependencies: [String]) -> Self {
+        .error("unknown dependency '\(dependency)' in target '\(targetName)'; valid dependencies are: '\(validDependencies.joined(separator: "', '"))'")
+    }
+
+    static func unknownTargetPackageDependency(packageName: String, targetName: String, validPackages: [String]) -> Self {
+        .error("unknown package '\(packageName)' in dependencies of target '\(targetName)'; valid packages are: '\(validPackages.joined(separator: "', '"))'")
+    }
+
+    static func invalidBinaryLocation(targetName: String) -> Self {
+        .error("invalid location for binary target '\(targetName)'")
+    }
+
+    static func invalidBinaryURL(url: String, targetName: String) -> Self {
+        .error("invalid URL '\(url)' for binary target '\(targetName)'")
+    }
+
+    static func invalidLocalBinaryPath(path: String, targetName: String) -> Self {
+        .error("invalid local path '\(path)' for binary target '\(targetName)', path expected to be relative to package root.")
+    }
+
+    static func invalidBinaryURLScheme(targetName: String, validSchemes: [String]) -> Self {
+        .error("invalid URL scheme for binary target '\(targetName)'; valid schemes are: '\(validSchemes.joined(separator: "', '"))'")
+    }
+
+    static func unsupportedBinaryLocationExtension(targetName: String, validExtensions: [String]) -> Self {
+        .error("unsupported extension for binary target '\(targetName)'; valid extensions are: '\(validExtensions.joined(separator: "', '"))'")
+    }
+
+    static func invalidLanguageTag(_ languageTag: String) -> Self {
+        .error("""
+            invalid language tag '\(languageTag)'; the pattern for language tags is groups of latin characters and \
+            digits separated by hyphens
+            """)
+    }
+
+    static func invalidSourceControlBranchName(_ name: String) -> Self {
+        .error("invalid branch name: '\(name)'")
+    }
+
+    static func invalidSourceControlRevision(_ revision: String) -> Self {
+        .error("invalid revision: '\(revision)'")
+    }
+
+    static func invalidSourceControlDirectory(_ path: AbsolutePath) -> Self {
+        .error("cannot clone from local directory \(path)\nPlease git init or use \"path:\" for \(path)")
+    }
+}
+
+extension TargetDescription {
+    fileprivate var isRemote: Bool { url != nil }
+    fileprivate var isLocal: Bool { path != nil }
+}

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -497,7 +497,7 @@ class MiscellaneousTestCase: XCTestCase {
             let result = try SwiftPMProduct.SwiftBuild.executeProcess([], packagePath: fixturePath.appending(component: "Bar"))
             XCTAssert(result.exitStatus != .terminated(code: 0))
             let output = try result.utf8stderrOutput()
-            XCTAssert(output.contains("Cannot clone from local directory"), "Didn't find expected output: \(output)")
+            XCTAssert(output.contains("cannot clone from local directory"), "Didn't find expected output: \(output)")
         }
     }
 
@@ -507,13 +507,13 @@ class MiscellaneousTestCase: XCTestCase {
                 let result = try SwiftPMProduct.SwiftBuild.executeProcess([], packagePath: fixturePath.appending(component: "InvalidBranch"))
                 XCTAssert(result.exitStatus != .terminated(code: 0))
                 let output = try result.utf8stderrOutput()
-                XCTAssert(output.contains("Invalid branch name: "), "Didn't find expected output: \(output)")
+                XCTAssert(output.contains("invalid branch name: "), "Didn't find expected output: \(output)")
             }
             do {
                 let result = try SwiftPMProduct.SwiftBuild.executeProcess([], packagePath: fixturePath.appending(component: "InvalidRevision"))
                 XCTAssert(result.exitStatus != .terminated(code: 0))
                 let output = try result.utf8stderrOutput()
-                XCTAssert(output.contains("Invalid revision: "), "Didn't find expected output: \(output)")
+                XCTAssert(output.contains("invalid revision: "), "Didn't find expected output: \(output)")
             }
         }
     }

--- a/Tests/PackageLoadingTests/PD_4_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_0_LoadingTests.swift
@@ -37,8 +37,9 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
+        XCTAssertNoDiagnostics(validationDiagnostics)
 
         XCTAssertEqual(manifest.displayName, "Trivial")
         XCTAssertEqual(manifest.toolsVersion, .v4)
@@ -66,8 +67,9 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
+        XCTAssertNoDiagnostics(validationDiagnostics)
 
         XCTAssertEqual(manifest.displayName, "Trivial")
         let foo = manifest.targetMap["foo"]!
@@ -99,8 +101,9 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
                 )
                 """
             let observability = ObservabilitySystem.makeForTesting()
-            let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+            let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
             XCTAssertEqual(manifest.swiftLanguageVersions?.map({$0.rawValue}), ["3", "4"])
         }
 
@@ -113,8 +116,9 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
                 )
                 """
             let observability = ObservabilitySystem.makeForTesting()
-            let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+            let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
             XCTAssertEqual(manifest.swiftLanguageVersions, [])
         }
 
@@ -125,8 +129,9 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
                    name: "Foo")
                 """
             let observability = ObservabilitySystem.makeForTesting()
-            let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+            let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
             XCTAssertEqual(manifest.swiftLanguageVersions, nil)
         }
     }
@@ -148,8 +153,9 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
+        XCTAssertNoDiagnostics(validationDiagnostics)
 
         let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
         XCTAssertEqual(deps["foo1"], .localSourceControl(path: .init("/foo1"), requirement: .upToNextMajor(from: "1.0.0")))
@@ -178,8 +184,9 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
+        XCTAssertNoDiagnostics(validationDiagnostics)
 
         let products = Dictionary(uniqueKeysWithValues: manifest.products.map{ ($0.name, $0) })
         // Check tool.
@@ -213,8 +220,9 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
+        XCTAssertNoDiagnostics(validationDiagnostics)
 
         XCTAssertEqual(manifest.displayName, "Copenssl")
         XCTAssertEqual(manifest.pkgConfig, "openssl")
@@ -240,8 +248,9 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
+        XCTAssertNoDiagnostics(validationDiagnostics)
 
         let foo = manifest.targetMap["Foo"]!
         XCTAssertEqual(foo.publicHeadersPath, "inc")
@@ -269,8 +278,9 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
+        XCTAssertNoDiagnostics(validationDiagnostics)
 
         let foo = manifest.targetMap["Foo"]!
         XCTAssertEqual(foo.publicHeadersPath, "inc")
@@ -300,7 +310,7 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error") { error in
+        XCTAssertThrowsError(try loadAndValidateManifest(content, observabilityScope: observability.topScope), "expected error") { error in
             if case ManifestParseError.invalidManifestFormat(let error, _) = error {
                 XCTAssert(error.contains("error: 'package(url:version:)' is unavailable: use package(url:exact:) instead"), "\(error)")
                 XCTAssert(error.contains("error: 'package(url:range:)' is unavailable: use package(url:_:) instead"), "\(error)")
@@ -324,8 +334,9 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
         """
 
         let observability = ObservabilitySystem.makeForTesting()
-        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
+        XCTAssertNoDiagnostics(validationDiagnostics)
 
         XCTAssertEqual(manifest.displayName, "testPackage")
         XCTAssertEqual(manifest.cLanguageStandard, "iso9899:199409")
@@ -383,8 +394,9 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error")
-        testDiagnostics(observability.diagnostics) { result in
+        let (_, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
+        XCTAssertNoDiagnostics(observability.diagnostics)
+        testDiagnostics(validationDiagnostics) { result in
             result.checkUnordered(diagnostic: "duplicate target named 'A'", severity: .error)
             result.checkUnordered(diagnostic: "duplicate target named 'B'", severity: .error)
         }
@@ -406,8 +418,9 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error")
-        testDiagnostics(observability.diagnostics) { result in
+        let (_, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
+        XCTAssertNoDiagnostics(observability.diagnostics)
+        testDiagnostics(validationDiagnostics) { result in
             result.check(diagnostic: "product 'Product' doesn't reference any targets", severity: .error)
         }
     }
@@ -428,8 +441,9 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error")
-        testDiagnostics(observability.diagnostics) { result in
+        let (_, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
+        XCTAssertNoDiagnostics(observability.diagnostics)
+        testDiagnostics(validationDiagnostics) { result in
             result.check(diagnostic: "target 'B' referenced in product 'Product' could not be found; valid targets are: 'A'", severity: .error)
         }
     }

--- a/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
@@ -55,8 +55,9 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
+        XCTAssertNoDiagnostics(validationDiagnostics)
 
         XCTAssertEqual(manifest.displayName, "Trivial")
 
@@ -101,7 +102,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             let observability = ObservabilitySystem.makeForTesting()
-            XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error") { error in
+            XCTAssertThrowsError(try loadAndValidateManifest(content, observabilityScope: observability.topScope), "expected error") { error in
                 if case ManifestParseError.invalidManifestFormat(let message, _) = error {
                     XCTAssertMatch(
                         message,
@@ -127,8 +128,9 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             let observability = ObservabilitySystem.makeForTesting()
-            let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+            let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
             XCTAssertEqual(manifest.swiftLanguageVersions, [])
         }
@@ -143,8 +145,9 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             let observability = ObservabilitySystem.makeForTesting()
-            let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+            let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
             XCTAssertEqual(
                 manifest.swiftLanguageVersions,
@@ -162,7 +165,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             let observability = ObservabilitySystem.makeForTesting()
-            XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error") { error in
+            XCTAssertThrowsError(try loadAndValidateManifest(content, observabilityScope: observability.topScope), "expected error") { error in
                 if case ManifestParseError.invalidManifestFormat(let message, _) = error {
                     XCTAssertMatch(message, .contains("is unavailable"))
                     XCTAssertMatch(message, .contains("was introduced in PackageDescription 5"))
@@ -184,7 +187,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             let observability = ObservabilitySystem.makeForTesting()
-            XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error") { error in
+            XCTAssertThrowsError(try loadAndValidateManifest(content, observabilityScope: observability.topScope), "expected error") { error in
                 if case ManifestParseError.invalidManifestFormat(let message, _) = error {
                     XCTAssertMatch(message, .contains("is unavailable"))
                     XCTAssertMatch(message, .contains("was introduced in PackageDescription 5"))
@@ -204,7 +207,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             let observability = ObservabilitySystem.makeForTesting()
-            XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error") { error in
+            XCTAssertThrowsError(try loadAndValidateManifest(content, observabilityScope: observability.topScope), "expected error") { error in
                 if case ManifestParseError.invalidManifestFormat(let message, _) = error {
                     XCTAssertMatch(message, .contains("is unavailable"))
                     XCTAssertMatch(message, .contains("was introduced in PackageDescription 5"))
@@ -235,7 +238,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error") { error in
+        XCTAssertThrowsError(try loadAndValidateManifest(content, observabilityScope: observability.topScope), "expected error") { error in
             if case ManifestParseError.invalidManifestFormat(let message, _) = error {
                 XCTAssertMatch(message, .contains("is unavailable"))
                 XCTAssertMatch(message, .contains("was introduced in PackageDescription 5"))
@@ -270,8 +273,9 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
+        XCTAssertNoDiagnostics(validationDiagnostics)
 
         let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
         XCTAssertEqual(deps["foo1"], .localSourceControl(path: .init("/foo1"), requirement: .upToNextMajor(from: "1.0.0")))
@@ -348,8 +352,9 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
+        XCTAssertNoDiagnostics(validationDiagnostics)
 
         let foo = manifest.targetMap["foo"]!
         XCTAssertEqual(foo.name, "foo")
@@ -467,41 +472,12 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error") { error in
+        XCTAssertThrowsError(try loadAndValidateManifest(content, observabilityScope: observability.topScope), "expected error") { error in
             if case ManifestParseError.runtimeManifestErrors(let errors) = error {
                 XCTAssertEqual(errors, ["Invalid semantic version string '1.0,0'"])
             } else {
                 XCTFail("unexpected error: \(error)")
             }
-        }
-    }
-
-    func testDuplicateDependencyDecl() throws {
-        let content = """
-            import PackageDescription
-            let package = Package(
-                name: "Trivial",
-                dependencies: [
-                    .package(path: "../foo1"),
-                    .package(url: "/foo1.git", from: "1.0.1"),
-                    .package(url: "path/to/foo1", from: "3.0.0"),
-                    .package(url: "/foo2.git", from: "1.0.1"),
-                    .package(url: "/foo2.git", from: "1.1.1"),
-                    .package(url: "/foo3.git", from: "1.0.1"),
-                ],
-                targets: [
-                    .target(
-                        name: "foo",
-                        dependencies: ["dep1", .target(name: "target")]),
-                ]
-            )
-            """
-
-        let observability = ObservabilitySystem.makeForTesting()
-        XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error")
-        testDiagnostics(observability.diagnostics) { result in
-            result.check(diagnostic: .regex("duplicate dependency 'foo(1|2)'"), severity: .error)
-            result.check(diagnostic: .regex("duplicate dependency 'foo(1|2)'"), severity: .error)
         }
     }
 
@@ -522,7 +498,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
         """
 
         let observability = ObservabilitySystem.makeForTesting()
-        XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error") { error in
+        XCTAssertThrowsError(try loadAndValidateManifest(content, observabilityScope: observability.topScope), "expected error") { error in
             if case ManifestParseError.invalidManifestFormat(let message, let diagnosticFile) = error {
                 XCTAssertNil(diagnosticFile)
                 XCTAssertEqual(message, "'https://someurl.com' is not a valid path for path-based dependencies; use relative or absolute path instead.")
@@ -569,7 +545,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             """
 
             let observability = ObservabilitySystem.makeForTesting()
-            XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error") { error in
+            XCTAssertThrowsError(try loadAndValidateManifest(content, observabilityScope: observability.topScope), "expected error") { error in
                 XCTAssertEqual(error as? ManifestParseError, expectedError.manifestError)
             }
         }
@@ -795,8 +771,9 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error")
-        testDiagnostics(observability.diagnostics) { result in
+        let (_, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
+        XCTAssertNoDiagnostics(observability.diagnostics)
+        testDiagnostics(validationDiagnostics) { result in
             result.check(diagnostic: .contains("target 'B' referenced in product 'Product' could not be found; valid targets are: 'A', 'C', 'b'"), severity: .error)
         }
     }

--- a/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
@@ -48,8 +48,9 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
+        XCTAssertNoDiagnostics(validationDiagnostics)
 
         XCTAssertEqual(manifest.displayName, "Trivial")
 
@@ -93,8 +94,9 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             let observability = ObservabilitySystem.makeForTesting()
-            let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+            let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
             XCTAssertEqual(manifest.swiftLanguageVersions, [.v4, .v4_2, .v5])
         }
@@ -109,7 +111,7 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             let observability = ObservabilitySystem.makeForTesting()
-            XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error") { error in
+            XCTAssertThrowsError(try loadAndValidateManifest(content, observabilityScope: observability.topScope), "expected error") { error in
                 if case ManifestParseError.invalidManifestFormat(let message, _) = error {
                     XCTAssertMatch(message, .contains("'v3' is unavailable"))
                     XCTAssertMatch(message, .contains("'v3' was obsoleted in PackageDescription 5"))
@@ -129,7 +131,7 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
             """
 
             let observability = ObservabilitySystem.makeForTesting()
-            XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error") { error in
+            XCTAssertThrowsError(try loadAndValidateManifest(content, observabilityScope: observability.topScope), "expected error") { error in
                 if case ManifestParseError.runtimeManifestErrors(let messages) = error {
                     XCTAssertEqual(messages, ["invalid Swift language version: "])
                 } else {
@@ -152,8 +154,9 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
+        XCTAssertNoDiagnostics(validationDiagnostics)
 
         XCTAssertEqual(manifest.platforms, [
             PlatformDescription(name: "macos", version: "10.13", options: ["option1", "option2"]),
@@ -176,8 +179,9 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             let observability = ObservabilitySystem.makeForTesting()
-            let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+            let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
             XCTAssertEqual(manifest.platforms, [
                 PlatformDescription(name: "macos", version: "10.13"),
@@ -200,7 +204,7 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             let observability = ObservabilitySystem.makeForTesting()
-            XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error") { error in
+            XCTAssertThrowsError(try loadAndValidateManifest(content, observabilityScope: observability.topScope), "expected error") { error in
                 if case ManifestParseError.runtimeManifestErrors(let errors) = error {
                     XCTAssertEqual(errors, [
                         "invalid macOS version -11.2; -11 should be a positive integer",
@@ -227,7 +231,7 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             let observability = ObservabilitySystem.makeForTesting()
-            XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error") { error in
+            XCTAssertThrowsError(try loadAndValidateManifest(content, observabilityScope: observability.topScope), "expected error") { error in
                 if case ManifestParseError.runtimeManifestErrors(let errors) = error {
                     XCTAssertEqual(errors, ["found multiple declaration for the platform: macos"])
                 } else {
@@ -247,7 +251,7 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             let observability = ObservabilitySystem.makeForTesting()
-            XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error") { error in
+            XCTAssertThrowsError(try loadAndValidateManifest(content, observabilityScope: observability.topScope), "expected error") { error in
                 if case ManifestParseError.runtimeManifestErrors(let errors) = error {
                     XCTAssertEqual(errors, ["supported platforms can't be empty"])
                 } else {
@@ -269,7 +273,7 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             let observability = ObservabilitySystem.makeForTesting()
-            XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error") { error in
+            XCTAssertThrowsError(try loadAndValidateManifest(content, observabilityScope: observability.topScope), "expected error") { error in
                 if case ManifestParseError.invalidManifestFormat(let message, _) = error {
                     XCTAssertMatch(message, .contains("error: 'v11' is unavailable"))
                     XCTAssertMatch(message, .contains("note: 'v11' was introduced in PackageDescription 5.3"))
@@ -293,7 +297,7 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             let observability = ObservabilitySystem.makeForTesting()
-            XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error") { error in
+            XCTAssertThrowsError(try loadAndValidateManifest(content, observabilityScope: observability.topScope), "expected error") { error in
                 if case ManifestParseError.invalidManifestFormat(let message, _) = error {
                     XCTAssertMatch(message, .contains("error: 'v10_16' has been renamed to 'v11'"))
                     XCTAssertMatch(message, .contains("note: 'v10_16' has been explicitly marked unavailable here"))
@@ -336,8 +340,9 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
+        XCTAssertNoDiagnostics(validationDiagnostics)
 
         let settings = manifest.targets[0].settings
 
@@ -453,7 +458,7 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             let observability = ObservabilitySystem.makeForTesting()
-            XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error") { error in
+            XCTAssertThrowsError(try loadAndValidateManifest(content, observabilityScope: observability.topScope), "expected error") { error in
                 if case ManifestParseError.runtimeManifestErrors(let errors) = error {
                     XCTAssertEqual(errors, ["the build setting 'headerSearchPath' contains invalid component(s): $(BYE) $(SRCROOT) $(HELLO)"])
                 } else {
@@ -477,7 +482,7 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             let observability = ObservabilitySystem.makeForTesting()
-            _ = try loadManifest(content, observabilityScope: observability.topScope)
+            _ = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
         }
     }
@@ -500,7 +505,7 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
 
         do {
             let observability = ObservabilitySystem.makeForTesting()
-            XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error") { error in
+            XCTAssertThrowsError(try loadAndValidateManifest(content, observabilityScope: observability.topScope), "expected error") { error in
                 if case ManifestParseError.invalidManifestFormat(let message, _) = error {
                     XCTAssertMatch(message, .contains("is unavailable"))
                     XCTAssertMatch(message, .contains("was introduced in PackageDescription 5.2"))
@@ -512,8 +517,9 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
 
         do {
             let observability = ObservabilitySystem.makeForTesting()
-            let manifest = try loadManifest(content, toolsVersion: .v5_2, observabilityScope: observability.topScope)
+            let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, toolsVersion: .v5_2, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
             XCTAssertEqual(manifest.displayName, "Foo")
 
@@ -546,7 +552,7 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error") { error in
+        XCTAssertThrowsError(try loadAndValidateManifest(content, observabilityScope: observability.topScope), "expected error") { error in
             if case ManifestParseError.invalidManifestFormat(let message, _) = error {
                 XCTAssertMatch(message, .contains("is unavailable"))
                 XCTAssertMatch(message, .contains("was introduced in PackageDescription 5.2"))
@@ -566,8 +572,9 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
-        XCTAssertFalse(observability.diagnostics.hasErrors)
+        let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
+        XCTAssertNoDiagnostics(validationDiagnostics)
+        XCTAssertNoDiagnostics(validationDiagnostics)
 
         XCTAssertEqual(manifest.displayName, "PackageWithChattyManifest")
         XCTAssertEqual(manifest.toolsVersion, .v5)

--- a/Tests/PackageLoadingTests/PD_5_3_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_3_LoadingTests.swift
@@ -48,8 +48,9 @@ class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
+        XCTAssertNoDiagnostics(validationDiagnostics)
 
         let resources = manifest.targets[0].resources
         XCTAssertEqual(resources[0], TargetDescription.Resource(rule: .copy, path: "foo.txt"))
@@ -86,8 +87,9 @@ class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
+        XCTAssertNoDiagnostics(validationDiagnostics)
 
         let targets = Dictionary(uniqueKeysWithValues: manifest.targets.map({ ($0.name, $0) }))
         let foo1 = targets["Foo1"]!
@@ -151,7 +153,7 @@ class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error") { error in
+        XCTAssertThrowsError(try loadAndValidateManifest(content, observabilityScope: observability.topScope), "expected error") { error in
             XCTAssertEqual(error.localizedDescription, "target 'Foo' contains a value for disallowed property 'settings'")
         }
     }
@@ -172,8 +174,9 @@ class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             let observability = ObservabilitySystem.makeForTesting()
-            XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error")
-            testDiagnostics(observability.diagnostics) { result in
+            let (_, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            testDiagnostics(validationDiagnostics) { result in
                 result.check(diagnostic: "invalid type for binary product 'FooLibrary'; products referencing only binary targets must have a type of 'library'", severity: .error)
             }
         }
@@ -193,8 +196,9 @@ class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             let observability = ObservabilitySystem.makeForTesting()
-            XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error")
-            testDiagnostics(observability.diagnostics) { result in
+            let (_, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            testDiagnostics(validationDiagnostics) { result in
                 result.check(diagnostic: "invalid type for binary product 'FooLibrary'; products referencing only binary targets must have a type of 'library'", severity: .error)
             }
         }
@@ -215,8 +219,9 @@ class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             let observability = ObservabilitySystem.makeForTesting()
-            _ = try loadManifest(content, observabilityScope: observability.topScope)
+            let (_, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
         }
 
         do {
@@ -234,8 +239,9 @@ class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             let observability = ObservabilitySystem.makeForTesting()
-            XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error")
-            testDiagnostics(observability.diagnostics) { result in
+            let (_, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            testDiagnostics(validationDiagnostics) { result in
                 result.check(diagnostic: "invalid local path ' ' for binary target 'Foo', path expected to be relative to package root.", severity: .error)
             }
         }
@@ -255,8 +261,9 @@ class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             let observability = ObservabilitySystem.makeForTesting()
-            XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error")
-            testDiagnostics(observability.diagnostics) { result in
+            let (_, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            testDiagnostics(validationDiagnostics) { result in
                 result.check(diagnostic: "invalid URL scheme for binary target 'Foo'; valid schemes are: 'https'", severity: .error)
             }
         }
@@ -276,8 +283,9 @@ class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             let observability = ObservabilitySystem.makeForTesting()
-            XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error")
-            testDiagnostics(observability.diagnostics) { result in
+            let (_, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            testDiagnostics(validationDiagnostics) { result in
                 result.check(diagnostic: "unsupported extension for binary target 'Foo'; valid extensions are: 'zip', 'xcframework', 'artifactbundle'", severity: .error)
             }
         }
@@ -300,9 +308,10 @@ class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             let observability = ObservabilitySystem.makeForTesting()
-            XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error")
-            testDiagnostics(observability.diagnostics) { result in
-                result.check(diagnostic: "unsupported extension for binary target 'Foo'; valid extensions are: 'zip'", severity: .error)
+            let (_, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            testDiagnostics(validationDiagnostics) { result in
+                result.check(diagnostic: "unsupported extension for binary target 'Foo'; valid extensions are: 'zip', 'artifactbundleindex'", severity: .error)
             }
         }
 
@@ -321,8 +330,9 @@ class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             let observability = ObservabilitySystem.makeForTesting()
-            XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error")
-            testDiagnostics(observability.diagnostics) { result in
+            let (_, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            testDiagnostics(validationDiagnostics) { result in
                 result.check(diagnostic: "unsupported extension for binary target 'Foo'; valid extensions are: 'zip', 'xcframework', 'artifactbundle'", severity: .error)
             }
         }
@@ -345,9 +355,10 @@ class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             let observability = ObservabilitySystem.makeForTesting()
-            XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error")
-            testDiagnostics(observability.diagnostics) { result in
-                result.check(diagnostic: "unsupported extension for binary target 'Foo'; valid extensions are: 'zip'", severity: .error)
+            let (_, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            testDiagnostics(validationDiagnostics) { result in
+                result.check(diagnostic: "unsupported extension for binary target 'Foo'; valid extensions are: 'zip', 'artifactbundleindex'", severity: .error)
             }
         }
 
@@ -369,8 +380,9 @@ class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             let observability = ObservabilitySystem.makeForTesting()
-            XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error")
-            testDiagnostics(observability.diagnostics) { result in
+            let (_, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            testDiagnostics(validationDiagnostics) { result in
                 result.check(diagnostic: "invalid URL scheme for binary target 'Foo'; valid schemes are: 'https'", severity: .error)
             }
         }
@@ -393,8 +405,9 @@ class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             let observability = ObservabilitySystem.makeForTesting()
-            XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error")
-            testDiagnostics(observability.diagnostics) { result in
+            let (_, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            testDiagnostics(validationDiagnostics) { result in
                 result.check(diagnostic: "invalid URL ' ' for binary target 'Foo'", severity: .error)
             }
         }
@@ -416,8 +429,9 @@ class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             let observability = ObservabilitySystem.makeForTesting()
-            XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error")
-            testDiagnostics(observability.diagnostics) { result in
+            let (_, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            testDiagnostics(validationDiagnostics) { result in
                 result.check(diagnostic: "invalid local path '/tmp/foo/bar' for binary target 'Foo', path expected to be relative to package root.", severity: .error)
             }
         }
@@ -445,8 +459,9 @@ class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
+        XCTAssertNoDiagnostics(validationDiagnostics)
 
         let dependencies = manifest.targets[0].dependencies
         XCTAssertEqual(dependencies[0], .target(name: "Biz"))
@@ -468,8 +483,9 @@ class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
+        XCTAssertNoDiagnostics(validationDiagnostics)
         XCTAssertEqual(manifest.defaultLocalization, "fr")
     }
 
@@ -495,7 +511,7 @@ class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             let observability = ObservabilitySystem.makeForTesting()
-            XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error") { error in
+            XCTAssertThrowsError(try loadAndValidateManifest(content, observabilityScope: observability.topScope), "expected error") { error in
                 if let error = error as? PathValidationError {
                     XCTAssertMatch(error.description, .contains(expectedDiag))
                 } else {
@@ -521,7 +537,7 @@ class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error") { error in
+        XCTAssertThrowsError(try loadAndValidateManifest(content, observabilityScope: observability.topScope), "expected error") { error in
             XCTAssertNotNil(error as? ManifestParseError)
         }
     }
@@ -546,7 +562,7 @@ class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error") { error in
+        XCTAssertThrowsError(try loadAndValidateManifest(content, observabilityScope: observability.topScope), "expected error") { error in
             if case ManifestParseError.invalidManifestFormat(let error, _) = error {
                 XCTAssertTrue(error.contains("Operation not permitted"), "unexpected error message: \(error)")
             } else {

--- a/Tests/PackageLoadingTests/PD_5_4_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_4_LoadingTests.swift
@@ -36,8 +36,9 @@ class PackageDescription5_4LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
+        XCTAssertNoDiagnostics(validationDiagnostics)
 
         XCTAssertEqual(manifest.targets[0].type, .executable)
     }
@@ -57,7 +58,7 @@ class PackageDescription5_4LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error") { error in
+        XCTAssertThrowsError(try loadAndValidateManifest(content, observabilityScope: observability.topScope), "expected error") { error in
             if case ManifestParseError.invalidManifestFormat(let message, _) = error {
                 XCTAssertMatch(message, .contains("is unavailable"))
                 XCTAssertMatch(message, .contains("was introduced in PackageDescription 5.5"))

--- a/Tests/PackageLoadingTests/PD_5_5_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_5_LoadingTests.swift
@@ -36,8 +36,9 @@ class PackageDescription5_5LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
+        XCTAssertNoDiagnostics(validationDiagnostics)
 
         let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
         XCTAssertEqual(deps["foo5"], .localSourceControl(path: .init("/foo5"), requirement: .branch("main")))
@@ -58,8 +59,9 @@ class PackageDescription5_5LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
+        XCTAssertNoDiagnostics(validationDiagnostics)
 
         XCTAssertEqual(manifest.platforms, [
             PlatformDescription(name: "macos", version: "12.0"),

--- a/Tests/PackageLoadingTests/PD_5_6_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_6_LoadingTests.swift
@@ -53,8 +53,9 @@ class PackageDescription5_6LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
         XCTAssertFalse(observability.diagnostics.hasErrors)
+        XCTAssertNoDiagnostics(validationDiagnostics)
 
         let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
         XCTAssertEqual(deps["foo1"], .remoteSourceControl(identity: .plain("foo1"), deprecatedName: "foo1", url: URL(string: "http://localhost/foo1")!, requirement: .range("1.1.1" ..< "2.0.0")))
@@ -89,8 +90,9 @@ class PackageDescription5_6LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
+        XCTAssertNoDiagnostics(validationDiagnostics)
 
         XCTAssertEqual(manifest.targets[0].type, .plugin)
         XCTAssertEqual(manifest.targets[0].pluginCapability, .buildTool)
@@ -114,8 +116,9 @@ class PackageDescription5_6LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
+        XCTAssertNoDiagnostics(validationDiagnostics)
 
         XCTAssertEqual(manifest.targets[0].type, .plugin)
         XCTAssertEqual(manifest.targets[0].pluginCapability, .buildTool)
@@ -138,8 +141,9 @@ class PackageDescription5_6LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             let observability = ObservabilitySystem.makeForTesting()
-            let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+            let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
             XCTAssertEqual(manifest.platforms, [
                 PlatformDescription(name: "customos", version: "1.0"),
@@ -160,8 +164,9 @@ class PackageDescription5_6LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             let observability = ObservabilitySystem.makeForTesting()
-            let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+            let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
             XCTAssertEqual(manifest.platforms, [
                 PlatformDescription(name: "customos", version: "1.0"),
@@ -178,7 +183,9 @@ class PackageDescription5_6LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
+        XCTAssertNoDiagnostics(observability.diagnostics)
+        XCTAssertNoDiagnostics(validationDiagnostics)
 
         let name = parsedManifest.parentDirectory?.pathString ?? ""
         XCTAssertEqual(manifest.displayName, name)
@@ -198,7 +205,9 @@ class PackageDescription5_6LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
+        XCTAssertNoDiagnostics(observability.diagnostics)
+        XCTAssertNoDiagnostics(validationDiagnostics)
 
         let name = parsedManifest.components?.last ?? ""
         let swiftFiles = manifest.displayName.split(separator: ",").map(String.init)
@@ -223,8 +232,9 @@ class PackageDescription5_6LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
+        XCTAssertNoDiagnostics(validationDiagnostics)
 
         XCTAssertEqual(manifest.targets[0].type, .plugin)
         XCTAssertEqual(manifest.targets[0].pluginCapability, .command(intent: .custom(verb: "mycmd", description: "helpful description of mycmd"), permissions: [.writeToPackageDirectory(reason: "YOLO")]))

--- a/Tests/PackageLoadingTests/PD_5_7_LoadingTests .swift
+++ b/Tests/PackageLoadingTests/PD_5_7_LoadingTests .swift
@@ -38,8 +38,9 @@ class PackageDescription5_7LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
+        XCTAssertNoDiagnostics(validationDiagnostics)
 
         let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
         XCTAssertEqual(deps["x.foo"], .registry(identity: "x.foo", requirement: .range("1.1.1" ..< "2.0.0")))
@@ -67,8 +68,9 @@ class PackageDescription5_7LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
+        XCTAssertNoDiagnostics(validationDiagnostics)
 
         let dependencies = manifest.targets[0].dependencies
         XCTAssertEqual(dependencies[0], .target(name: "Bar", condition: .none))
@@ -91,7 +93,7 @@ class PackageDescription5_7LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope), "expected error") { error in
+        XCTAssertThrowsError(try loadAndValidateManifest(content, observabilityScope: observability.topScope), "expected error") { error in
             if case ManifestParseError.invalidManifestFormat(let error, _) = error {
                 XCTAssertMatch(error, .contains("when(platforms:)' was obsoleted"))
             } else {
@@ -118,7 +120,7 @@ class PackageDescription5_7LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope)) { error in
+        XCTAssertThrowsError(try loadAndValidateManifest(content, observabilityScope: observability.topScope)) { error in
             if case ManifestParseError.invalidManifestFormat(let message, _) = error {
                 XCTAssertMatch(message, .contains("error: 'productItem(name:package:condition:)' is unavailable: use .product(name:package:condition) instead."))
             } else {
@@ -141,8 +143,9 @@ class PackageDescription5_7LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
         XCTAssertNoDiagnostics(observability.diagnostics)
+        XCTAssertNoDiagnostics(validationDiagnostics)
 
         XCTAssertEqual(manifest.platforms, [
             PlatformDescription(name: "macos", version: "13.0"),

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -8620,7 +8620,7 @@ final class WorkspaceTests: XCTestCase {
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
                             .product(name: "FooProduct", package: "foo"),
-                            .product(name: "BarProduct", package: "bar"),
+                            .product(name: "BarProduct", package: "foo"),
                         ]),
                     ],
                     products: [],
@@ -9720,22 +9720,6 @@ final class WorkspaceTests: XCTestCase {
         }
 
         do {
-            // Diagnostics.fatalError
-            let delegate = MockWorkspaceDelegate()
-            let workspace = try Workspace(
-                fileSystem: fs,
-                forRootPackage: .root,
-                customManifestLoader: TestLoader(error: Diagnostics.fatalError),
-                delegate: delegate
-            )
-            try workspace.loadPackageGraph(rootPath: .root, observabilityScope: observability.topScope)
-
-            XCTAssertNil(delegate.manifest)
-            XCTAssertNoDiagnostics(observability.diagnostics)
-            XCTAssertNoDiagnostics(delegate.manifestLoadingDiagnostics ?? [])
-        }
-
-        do {
             // actual error
             let delegate = MockWorkspaceDelegate()
             let workspace = try Workspace(
@@ -10159,7 +10143,7 @@ final class WorkspaceTests: XCTestCase {
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
                             .product(name: "FooProduct", package: "foo"),
-                            .product(name: "BarProduct", package: "bar")
+                            .product(name: "BarProduct", package: "org.bar")
                         ]),
                     ],
                     products: [],
@@ -10563,7 +10547,7 @@ final class WorkspaceTests: XCTestCase {
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
                             .product(name: "FooProduct", package: "foo"),
-                            .product(name: "BarProduct", package: "bar")
+                            .product(name: "BarProduct", package: "org.bar")
                         ]),
                     ],
                     products: [],
@@ -10837,8 +10821,8 @@ final class WorkspaceTests: XCTestCase {
                     path: "root",
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
-                            .product(name: "FooProduct", package: "foo"),
-                            .product(name: "BarProduct", package: "bar")
+                            .product(name: "FooProduct", package: "org.foo"),
+                            .product(name: "BarProduct", package: "org.bar")
                         ]),
                     ],
                     products: [],
@@ -10980,8 +10964,8 @@ final class WorkspaceTests: XCTestCase {
                     path: "root",
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
-                            .product(name: "FooProduct", package: "foo"),
-                            .product(name: "BarProduct", package: "bar")
+                            .product(name: "FooProduct", package: "org.foo"),
+                            .product(name: "BarProduct", package: "org.bar")
                         ]),
                     ],
                     products: [],
@@ -11112,8 +11096,8 @@ final class WorkspaceTests: XCTestCase {
                     path: "root",
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
-                            .product(name: "FooProduct", package: "foo"),
-                            .product(name: "BarProduct", package: "bar")
+                            .product(name: "FooProduct", package: "org.foo"),
+                            .product(name: "BarProduct", package: "org.bar")
                         ]),
                     ],
                     products: [],
@@ -11277,8 +11261,8 @@ final class WorkspaceTests: XCTestCase {
                     path: "root",
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
-                            .product(name: "FooProduct", package: "foo"),
-                            .product(name: "BarProduct", package: "bar")
+                            .product(name: "FooProduct", package: "org.foo"),
+                            .product(name: "BarProduct", package: "org.bar")
                         ]),
                     ],
                     products: [],
@@ -11426,7 +11410,7 @@ final class WorkspaceTests: XCTestCase {
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
                             .product(name: "FooProduct", package: "foo"),
-                            .product(name: "BarProduct", package: "bar")
+                            .product(name: "BarProduct", package: "org.bar")
                         ]),
                     ],
                     products: [],


### PR DESCRIPTION
motivation: make code easier to reason about and maintain

changes:
* create new ManfeistValidator utility
* move manifest validation code out of ManifestLoader and Workspace and into the new validation utility
* seperate out manifst validation diagnostics from manifest loading diagnostics such that a fake diagnostics scope is no longer required
* adjust call sites and test
