### PR TITLE
Pass `SWIFT_EXEC` to swift-test via bootstrap

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -363,7 +363,11 @@ def test(args):
 
     note("Testing")
     parse_test_args(args)
-    cmd = [os.path.join(args.bin_dir, "swift-test")]
+    cmd = [
+        "SWIFT_EXEC=" + args.swiftc_path,
+        "SWIFT_DRIVER_SWIFT_EXEC=" + args.swiftc_path,
+        os.path.join(args.bin_dir, "swift-test")
+    ]
     if args.parallel:
         cmd.append("--parallel")
     for arg in args.filter:


### PR DESCRIPTION
It looks like so far we have only been passing `SWIFT_EXEC` to `swift-build` but not `swift-test`.