### PR TITLE
Validate module alias input values

### DIFF
--- a/Sources/Basics/String+Extensions.swift
+++ b/Sources/Basics/String+Extensions.swift
@@ -25,4 +25,9 @@ extension String {
         }
         return self
     }
+
+    public var isValidIdentifier: Bool {
+        guard let first = first else { return false }
+        return first.isLetter && allSatisfy { $0.isLetter || $0.isNumber }
+    }
 }

--- a/Sources/Basics/String+Extensions.swift
+++ b/Sources/Basics/String+Extensions.swift
@@ -27,7 +27,7 @@ extension String {
     }
 
     public var isValidIdentifier: Bool {
-        guard let first = first else { return false }
-        return first.isLetter && allSatisfy { $0.isLetter || $0.isNumber }
+        guard !isEmpty else { return false }
+        return allSatisfy { $0.isLetter || $0.isNumber || $0 == "_" }
     }
 }

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -33,6 +33,9 @@ public enum ModuleError: Swift.Error {
     /// The artifact for the binary target could not be found.
     case artifactNotFound(targetName: String, expectedArtifactName: String)
 
+    /// Invalid module alias.
+    case invalidModuleAlias(originalName: String, newName: String)
+
     /// Invalid custom path.
     case invalidCustomPath(target: String, path: String)
 
@@ -84,6 +87,8 @@ extension ModuleError: CustomStringConvertible {
             return "Source files for target \(target) should be located under '\(folderName)/\(target)', or a custom sources path can be set with the 'path' property in Package.swift"
         case .artifactNotFound(let targetName, let expectedArtifactName):
             return "binary target '\(targetName)' could not be mapped to an artifact with expected name '\(expectedArtifactName)'"
+        case .invalidModuleAlias(let originalName, let newName):
+            return "empty or invalid module alias; ['\(originalName)': '\(newName)']"
         case .invalidLayout(let type):
             return "package has unsupported layout; \(type)"
         case .invalidManifestConfig(let package, let message):
@@ -645,8 +650,8 @@ public final class PackageBuilder {
             let manifestTarget = manifest.targetMap[potentialModule.name]
 
             // Get the dependencies of this target.
-            let dependencies: [Target.Dependency] = manifestTarget.map {
-                $0.dependencies.compactMap { dependency in
+            let dependencies: [Target.Dependency] = try manifestTarget.map {
+                try $0.dependencies.compactMap { dependency in
                     switch dependency {
                     case .target(let name, let condition):
                         // We don't create an object for targets which have no sources.
@@ -655,6 +660,7 @@ public final class PackageBuilder {
                         return .target(target, conditions: buildConditions(from: condition))
 
                     case .product(let name, let package, let moduleAliases, let condition):
+                        try validateModuleAliases(moduleAliases)
                         return .product(
                             .init(name: name, package: package, moduleAliases: moduleAliases),
                             conditions: buildConditions(from: condition)
@@ -717,6 +723,16 @@ public final class PackageBuilder {
             throw Target.Error.invalidName(
                 path: path.relative(to: packagePath),
                 problem: .emptyName)
+        }
+    }
+
+    /// Validates module alias key and value pairs and throws an error if empty or contains invalid characters.
+    private func validateModuleAliases(_ aliases: [String: String]?) throws {
+        guard let aliases = aliases else { return }
+        for (aliasKey, aliasValue) in aliases {
+            if !aliasKey.isValidIdentifier || !aliasValue.isValidIdentifier {
+                throw ModuleError.invalidModuleAlias(originalName: aliasKey, newName: aliasValue)
+            }
         }
     }
 

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -730,7 +730,9 @@ public final class PackageBuilder {
     private func validateModuleAliases(_ aliases: [String: String]?) throws {
         guard let aliases = aliases else { return }
         for (aliasKey, aliasValue) in aliases {
-            if !aliasKey.isValidIdentifier || !aliasValue.isValidIdentifier {
+            if !aliasKey.isValidIdentifier ||
+                !aliasValue.isValidIdentifier ||
+                aliasKey == aliasValue {
                 throw ModuleError.invalidModuleAlias(originalName: aliasKey, newName: aliasValue)
             }
         }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -1725,9 +1725,9 @@ final class BuildPlanTests: XCTestCase {
             observabilityScope: observability.topScope
         )
 
-        XCTAssertTrue(observability.diagnostics.contains(where: {
-            $0.message.contains("empty or invalid module alias; ['Logging': '']")
-        }), "expected invalid aliases diagnostics")
+        testDiagnostics(observability.diagnostics) { result in
+            result.check(diagnostic: .contains("empty or invalid module alias; ['Logging': '']"), severity: .error)
+        }
     }
 
     func testModuleAliasingInvalidIdentifierAlias() throws {
@@ -1770,9 +1770,9 @@ final class BuildPlanTests: XCTestCase {
             observabilityScope: observability.topScope
         )
 
-        XCTAssertTrue(observability.diagnostics.contains(where: {
-            $0.message.contains("empty or invalid module alias; ['Logging': 'P$0%^#@']")
-        }), "expected invalid aliases diagnostics")
+        testDiagnostics(observability.diagnostics) { result in
+            result.check(diagnostic: .contains("empty or invalid module alias; ['Logging': 'P$0%^#@']"), severity: .error)
+        }
     }
 
     func testModuleAliasingDirectDeps() throws {

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -1685,6 +1685,96 @@ final class BuildPlanTests: XCTestCase {
         }
     }
 
+    func testModuleAliasingEmptyAlias() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+                                        "/thisPkg/Sources/exe/main.swift",
+                                        "/thisPkg/Sources/Logging/file.swift",
+                                        "/fooPkg/Sources/Logging/fileLogging.swift"
+        )
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let _ = try loadPackageGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    name: "fooPkg",
+                    path: .init("/fooPkg"),
+                    products: [
+                        ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Logging"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "Logging", dependencies: []),
+                    ]),
+                Manifest.createRootManifest(
+                    name: "thisPkg",
+                    path: .init("/thisPkg"),
+                    dependencies: [
+                        .localSourceControl(path: .init("/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    targets: [
+                        TargetDescription(name: "exe",
+                                          dependencies: ["Logging",
+                                                         .product(name: "Foo",
+                                                                  package: "fooPkg",
+                                                                  moduleAliases: ["Logging": ""]
+                                                                 ),
+                                                        ]),
+                        TargetDescription(name: "Logging", dependencies: []),
+                    ]),
+            ],
+            observabilityScope: observability.topScope
+        )
+
+        XCTAssertTrue(observability.diagnostics.contains(where: {
+            $0.message.contains("empty or invalid module alias; ['Logging': '']")
+        }), "expected invalid aliases diagnostics")
+    }
+
+    func testModuleAliasingInvalidIdentifierAlias() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+                                        "/thisPkg/Sources/exe/main.swift",
+                                        "/thisPkg/Sources/Logging/file.swift",
+                                        "/fooPkg/Sources/Logging/fileLogging.swift"
+        )
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let _ = try loadPackageGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    name: "fooPkg",
+                    path: .init("/fooPkg"),
+                    products: [
+                        ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Logging"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "Logging", dependencies: []),
+                    ]),
+                Manifest.createRootManifest(
+                    name: "thisPkg",
+                    path: .init("/thisPkg"),
+                    dependencies: [
+                        .localSourceControl(path: .init("/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    targets: [
+                        TargetDescription(name: "exe",
+                                          dependencies: ["Logging",
+                                                         .product(name: "Foo",
+                                                                  package: "fooPkg",
+                                                                  moduleAliases: ["Logging": "P$0%^#@"]
+                                                                 ),
+                                                        ]),
+                        TargetDescription(name: "Logging", dependencies: []),
+                    ]),
+            ],
+            observabilityScope: observability.topScope
+        )
+
+        XCTAssertTrue(observability.diagnostics.contains(where: {
+            $0.message.contains("empty or invalid module alias; ['Logging': 'P$0%^#@']")
+        }), "expected invalid aliases diagnostics")
+    }
+
     func testModuleAliasingDirectDeps() throws {
         let fs = InMemoryFileSystem(emptyFiles:
                                         "/thisPkg/Sources/exe/main.swift",


### PR DESCRIPTION
Throw an error if the module aliases parameter key/value pairs contain empty or invalid identifiers 
rdar://89836778
