### PR TITLE
Allow empty unsafeFlags from dependencies

### DIFF
--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -881,9 +881,9 @@ private final class ResolvedTargetBuilder: ResolvedBuilder<ResolvedTarget> {
     func diagnoseInvalidUseOfUnsafeFlags(_ product: ResolvedProduct) throws {
         // Diagnose if any target in this product uses an unsafe flag.
         for target in try product.recursiveTargetDependencies() {
-            let declarations = target.underlyingTarget.buildSettings.assignments.keys
-            for decl in declarations {
-                if BuildSettings.Declaration.unsafeSettings.contains(decl) {
+            for (decl, assignments) in target.underlyingTarget.buildSettings.assignments {
+                let flags = assignments.flatMap(\.values)
+                if BuildSettings.Declaration.unsafeSettings.contains(decl) && !flags.isEmpty {
                     self.diagnosticsEmitter.emit(.productUsesUnsafeFlags(product: product.name, target: target.name))
                     break
                 }

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -1048,7 +1048,10 @@ class PackageGraphTests: XCTestCase {
                             ]
                         ),
                         TargetDescription(
-                            name: "Bar3"
+                            name: "Bar3",
+                            settings: [
+                                .init(tool: .swift, kind: .unsafeFlags([])),
+                            ]
                         ),
                         TargetDescription(
                             name: "TransitiveBar",


### PR DESCRIPTION
Some projects like SwiftSyntax conditionally add some unsafe flags based
on environment variables. In the case they don't need them they add an
empty unsafe flags target. Previously this caused a failure, with this
change there is only a failure in the case the unsafe declaration
provides flags.

SwiftSyntax has also updated its Package.swift to not add the
empty `.unsafeFlags([])`, but this seems reasonable to be less strict
about as well.

Fixes https://bugs.swift.org/browse/SR-15989