### PR TITLE
integrate plugins with new cancellation sub-system

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -1010,11 +1010,9 @@ extension SwiftPackageTool {
             let pluginsDir = try swiftTool.getActiveWorkspace().location.pluginWorkingDirectory.appending(component: plugin.name)
 
             // The `cache` directory is in the plugin’s directory and is where the plugin script runner caches compiled plugin binaries and any other derived information for this plugin.
-            let pluginScriptRunner = DefaultPluginScriptRunner(
-                fileSystem: swiftTool.fileSystem,
-                cacheDir: pluginsDir.appending(component: "cache"),
-                toolchain: try swiftTool.getToolchain().configuration,
-                enableSandbox: !swiftTool.options.security.shouldDisableSandbox)
+            let pluginScriptRunner = try swiftTool.getPluginScriptRunner(
+                customPluginsDir: pluginsDir
+            )
 
             // The `outputs` directory contains subdirectories for each combination of package and command plugin. Each usage of a plugin has an output directory that is writable by the plugin, where it can write additional files, and to which it can configure tools to write their outputs, etc.
             let outputDir = pluginsDir.appending(component: "outputs")

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -665,11 +665,10 @@ class PluginTests: XCTestCase {
             #endif
             
             // Ask the plugin running to cancel all plugins.
-            DefaultPluginScriptRunner.cancelAllRunningPlugins()
+            try scriptRunner.cancel(deadline: .now() + .seconds(5))
             
             // Check that it's no longer running (we do this by asking for its priority — this only works on some platforms).
             #if os(macOS)
-            usleep(500)
             errno = 0
             getpriority(Int32(PRIO_PROCESS), UInt32(pid))
             XCTAssertEqual(errno, ESRCH, "unexpectedly got errno \(errno) when trying to check process \(pid)")


### PR DESCRIPTION
motivation: consistent cancellation system to include plugins

changes:
* DefaultPluginScriptRunner is now Cancellable, with an internal copy of canncelator to maange its internal state
* dedup call sites that create DefaultPluginScriptRunner so that we can register it more easily with the SwiftTool::Cancellator instance
* Cancellator now supports Foundation::Process
* add and adjust tests

