### PR TITLE
Fixes data access race in command output handling detected by ThreadSanitizer

### DIFF
--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -579,8 +579,8 @@ final class BuildOperationBuildSystemDelegateHandler: LLBuildBuildSystemDelegate
         process: ProcessHandle,
         result: CommandExtendedResult
     ) {
-        if let buffer = self.nonSwiftMessageBuffers[command.name] {
-            queue.async {
+        queue.async {
+            if let buffer = self.nonSwiftMessageBuffers[command.name] {
                 self.progressAnimation.clear()
                 self.outputStream <<< buffer
                 self.outputStream.flush()


### PR DESCRIPTION
Specifically between the `BuildOperationBuildSystemDelegateHandler.commandProcessFinished()` and `BuildOperationBuildSystemDelegateHandler.commandProcessHadOutput()` methods.

The issue is that in one case there is access to `nonSwiftMessageBuffers` from outside the `org.swift.swiftpm.build-delegate` serial queue.

### Motivation:

Fix ThreadSanitizer violation.

### Modifications:

Move access to `nonSwiftMessageBuffers` inside the `queue.async`.

### Result:

These tests were failing with thread sanitizer enabled, and now they're passing:

BuildToolTests.testXcodeBuildSystemDefaultSettings
BuildToolTests.testXcodeBuildSystemOverrides
TestToolTests.testEnableDisableTestability
MiscellaneousTestCase.testExternalDependencyEdges1
MiscellaneousTestCase.testExternalDependencyEdges2
MiscellaneousTestCase.testPkgConfigCFamilyTargets
ModuleMapsTestCase.testDirectDependency
ModuleMapsTestCase.testTransitiveDependency
PluginTests.testUseOfVendedBinaryTool
