### PR TITLE
improve platform conditional imports

### DIFF
--- a/Sources/Basics/HTTPClient.swift
+++ b/Sources/Basics/HTTPClient.swift
@@ -20,9 +20,7 @@ import TSCBasic
 
 #if canImport(Glibc)
 import Glibc
-#endif
-
-#if os(Windows)
+#elseif canImport(CRT)
 import CRT
 #endif
 

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -23,11 +23,11 @@ import TSCBasic
 import Workspace
 import XCBuildSupport
 
-#if os(Windows)
+#if canImport(WinSDK)
 import WinSDK
-#elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#elseif canImport(Darwin)
 import Darwin
-#else
+#elseif canImport(Glibc)
 import Glibc
 #endif
 

--- a/Sources/PackageDescription/PackageDescription.swift
+++ b/Sources/PackageDescription/PackageDescription.swift
@@ -10,9 +10,9 @@
 
 #if canImport(Glibc)
 @_implementationOnly import Glibc
-#elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#elseif canImport(Darwin)
 @_implementationOnly import Darwin.C
-#elseif os(Windows)
+#elseif canImport(ucrt) && canImport(WinSDK)
 @_implementationOnly import ucrt
 @_implementationOnly import struct WinSDK.HANDLE
 #endif

--- a/Sources/PackageDescription/PackageDescriptionSerialization.swift
+++ b/Sources/PackageDescription/PackageDescriptionSerialization.swift
@@ -11,9 +11,9 @@
 import Foundation
 #if canImport(Glibc)
 @_implementationOnly import Glibc
-#elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#elseif canImport(Darwin)
 @_implementationOnly import Darwin.C
-#elseif os(Windows)
+#elseif canImport(ucrt) && canImport(WinSDK)
 @_implementationOnly import ucrt
 @_implementationOnly import struct WinSDK.HANDLE
 #endif


### PR DESCRIPTION
motivation: more reliable conditional imports

changes: use canImport(module) instead of os(OS) to drive conditional imports

