### PR TITLE
Re-add class name to '__allTests' for test discovery

### DIFF
--- a/Fixtures/Miscellaneous/TestDiscovery/Subclass/Package.swift
+++ b/Fixtures/Miscellaneous/TestDiscovery/Subclass/Package.swift
@@ -1,0 +1,10 @@
+// swift-tools-version:5.6
+import PackageDescription
+
+let package = Package(
+    name: "Subclass",
+    targets: [
+        .target(name: "Subclass"),
+        .testTarget(name: "SubclassTests", dependencies: ["Subclass"]),
+    ]
+)

--- a/Fixtures/Miscellaneous/TestDiscovery/Subclass/Sources/Subclass/Subclass.swift
+++ b/Fixtures/Miscellaneous/TestDiscovery/Subclass/Sources/Subclass/Subclass.swift
@@ -1,0 +1,2 @@
+struct Subclass {
+}

--- a/Fixtures/Miscellaneous/TestDiscovery/Subclass/Tests/SubclassTests/SubclassTestsBase.swift
+++ b/Fixtures/Miscellaneous/TestDiscovery/Subclass/Tests/SubclassTests/SubclassTestsBase.swift
@@ -1,0 +1,7 @@
+import XCTest
+@testable import Subclass
+
+class SubclassTestsBase: XCTestCase {
+    func test1() {
+    }
+}

--- a/Fixtures/Miscellaneous/TestDiscovery/Subclass/Tests/SubclassTests/SubclassTestsDerived.swift
+++ b/Fixtures/Miscellaneous/TestDiscovery/Subclass/Tests/SubclassTests/SubclassTestsDerived.swift
@@ -1,0 +1,7 @@
+import XCTest
+@testable import Subclass
+
+class SubclassTestsDerived: SubclassTestsBase {
+    override func test1() {
+    }
+}

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -77,7 +77,8 @@ final class TestDiscoveryCommand: CustomLLBuildCommand {
             stream <<< "\n"
             stream <<< "fileprivate extension " <<< className <<< " {" <<< "\n"
             stream <<< indent(4) <<< "@available(*, deprecated, message: \"Not actually deprecated. Marked as deprecated to allow inclusion of deprecated tests (which test deprecated functionality) without warnings\")" <<< "\n"
-            stream <<< indent(4) <<< "static let __allTests = [" <<< "\n"
+            // 'className' provides uniqueness for derived class.
+            stream <<< indent(4) <<< "static let __allTests__\(className) = [" <<< "\n"
             for method in testMethods {
                 stream <<< indent(8) <<< method.allTestsEntry <<< ",\n"
             }
@@ -93,7 +94,7 @@ final class TestDiscoveryCommand: CustomLLBuildCommand {
 
         for iterator in testsByClassNames {
             let className = iterator.key
-            stream <<< indent(8) <<< "testCase(\(className).__allTests),\n"
+            stream <<< indent(8) <<< "testCase(\(className).__allTests__\(className)),\n"
         }
 
         stream <<< """

--- a/Tests/FunctionalTests/TestDiscoveryTests.swift
+++ b/Tests/FunctionalTests/TestDiscoveryTests.swift
@@ -118,4 +118,19 @@ class TestDiscoveryTests: XCTestCase {
             XCTAssertNoMatch(stderr, .contains("is deprecated"))
         }
     }
+
+    func testSubclassedTestClassTests() throws {
+        #if os(macOS)
+        try XCTSkipIf(true)
+        #endif
+        try fixture(name: "Miscellaneous/TestDiscovery/Subclass") { fixturePath in
+            let (stdout, stderr) = try executeSwiftTest(fixturePath)
+            // in "swift test" build output goes to stderr
+            XCTAssertMatch(stderr, .contains("Build complete!"))
+            // in "swift test" test output goes to stdout
+            XCTAssertMatch(stdout, .contains("SubclassTestsBase.test1"))
+            XCTAssertMatch(stdout, .contains("SubclassTestsDerived.test1"))
+            XCTAssertMatch(stdout, .contains("Executed 2 tests"))
+        }
+    }
 }


### PR DESCRIPTION
Motivation:

In https://github.com/apple/swift-package-manager/pull/3992 the class name was stripped from the static array of tests (i.e. `__allTests_CLASSNAME` became `__allTests`). The class name ensured the variable was uniquely named. Without it, in a test class which is derived from another, it is not unique and results in compile-time errors. 

This is a regression introduced into Swift 5.6. See also: https://bugs.swift.org/browse/SR-15955

Modifications:

- Reintroduce the class name
- Add tests

Result:

Derived test classes do not result in compilation errors on Linux.
