### PR TITLE
Expose ObservabilitySystem to Clients

### DIFF
--- a/Examples/package-info/Sources/package-info/main.swift
+++ b/Examples/package-info/Sources/package-info/main.swift
@@ -1,4 +1,3 @@
-import Basics
 import TSCBasic
 import Workspace
 

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -19,6 +19,10 @@ import PackageRegistry
 import SourceControl
 import TSCBasic
 
+// The Basics module is unavailable to package clients,
+// but ObservabilitySystem is necessary in order to use many of these APIs.
+@_exported import class Basics.ObservabilitySystem
+
 import enum TSCUtility.Diagnostics
 import enum TSCUtility.SignpostName
 import struct TSCUtility.Triple


### PR DESCRIPTION
This exposes ObservabilitySystem to clients by exporting it from the Workspace module.

### Motivation:

When diagnostics were refactored, ObservabilityScope became necessary in order to do almost anything, but it is located in the Basics module, which is not formally a part of any of the library products. For now it is certain to be present and importable, but that is only because SwiftPM currently allows transitive dependencies to leak through to higher levels.