### PR TITLE
Fix name of the renamed `--scratch-path` flag in deprecation warning

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -474,7 +474,7 @@ public class SwiftTool {
 
     static func postprocessArgParserResult(options: GlobalOptions, observabilityScope: ObservabilityScope) throws {
         if options.locations._deprecated_buildPath != nil {
-            observabilityScope.emit(warning: "'--build-path' option is deprecated; use '--scratch-space-path' instead")
+            observabilityScope.emit(warning: "'--build-path' option is deprecated; use '--scratch-path' instead")
         }
 
         if options.locations._deprecated_chdir != nil {


### PR DESCRIPTION
When using `--build-path` there is now a deprecation warning that it's called `--scratch-space-path` now. But the actual name of the new flag is `--scratch-path`.

### Motivation:

Fix a mistake in an error message.

### Modifications:

- just changing the string to match the option