### PR TITLE
Package plugins throw an exception if snippets are present

### DIFF
--- a/Fixtures/Miscellaneous/Plugins/PluginsAndSnippets/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/PluginsAndSnippets/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version: 999.0
+import PackageDescription
+
+let package = Package(
+    name: "PluginsAndSnippets",
+    products: [
+        .plugin(
+            name: "PluginScriptProduct",
+            targets: [
+                "PluginScriptTarget"
+            ]
+        ),
+    ],
+    targets: [
+        .plugin(
+            name: "PluginScriptTarget",
+            capability: .command(
+                intent: .custom(
+                    verb: "do-something",
+                    description: "Do something"
+                )
+            )
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/Plugins/PluginsAndSnippets/Plugins/PluginScriptTarget/Script.swift
+++ b/Fixtures/Miscellaneous/Plugins/PluginsAndSnippets/Plugins/PluginScriptTarget/Script.swift
@@ -1,0 +1,12 @@
+import PackagePlugin
+
+@main
+struct PluginScript: CommandPlugin {
+    
+    func performCommand(context: PluginContext, arguments: [String]) async throws {
+        dump(context)
+        if let target = try context.package.targets(named: ["MySnippet"]).first as? SourceModuleTarget {
+            print("type of snippet target: \(target.kind)")
+        }
+    }
+}

--- a/Sources/PackagePlugin/PackageModel.swift
+++ b/Sources/PackagePlugin/PackageModel.swift
@@ -216,6 +216,9 @@ public enum ModuleKind {
     case generic
     /// A module that contains code for an executable's main module.
     case executable
+    /// A module that contains code for a snippet.
+    @available(_PackageDescription, deprecated: 999.0)
+    case snippet
     /// A module that contains unit tests.
     case test
 }

--- a/Sources/PackagePlugin/PluginContextDeserializer.swift
+++ b/Sources/PackagePlugin/PluginContextDeserializer.swift
@@ -255,6 +255,8 @@ fileprivate extension ModuleKind {
             self = .generic
         case .executable:
             self = .executable
+        case .snippet:
+            self = .snippet
         case .test:
             self = .test
         }

--- a/Sources/PackagePlugin/PluginMessages.swift
+++ b/Sources/PackagePlugin/PluginMessages.swift
@@ -163,6 +163,7 @@ enum HostToPluginMessage: Codable {
                     enum SourceModuleKind: String, Codable {
                         case generic
                         case executable
+                        case snippet
                         case test
                     }
 

--- a/Sources/SPMBuildCore/PluginContextSerializer.swift
+++ b/Sources/SPMBuildCore/PluginContextSerializer.swift
@@ -268,9 +268,11 @@ fileprivate extension WireInput.Target.TargetInfo.SourceModuleKind {
             self = .generic
         case .executable:
             self = .executable
+        case .snippet:
+            self = .snippet
         case .test:
             self = .test
-        case .binary, .plugin, .snippet, .systemModule:
+        case .binary, .plugin, .systemModule:
             throw StringError("unexpected target kind \(kind) for source module")
         }
     }

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -843,4 +843,14 @@ class PluginTests: XCTestCase {
             }
         }
     }
+
+    func testSnippetSupport() throws {
+        // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
+        try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+
+        try fixture(name: "Miscellaneous/Plugins") { path in
+            let (stdout, stderr) = try executeSwiftPackage(path.appending(component: "PluginsAndSnippets"), configuration: .Debug, extraArgs: ["do-something"])
+            XCTAssert(stdout.contains("type of snippet target: snippet"), "output:\n\(stderr)\n\(stdout)")
+        }
+    }
 }


### PR DESCRIPTION
Snippets seem to be a kind of executable, and weren't handled properly by package plugins.  This adds a module type for snippets so that they are included in the list of targets passed to a plugin.

### Motivation:

Snippets are a new experimental feature and should work with plugins.

### Modifications:

- handle the case of a .snippet module
- add an enum type to represent snippet modules
- add a unit test

### Result:

Plugin is invoked without error and plugin can see the snippet.

rdar://89773759&89787888
