### PR TITLE
Allow binary targets to change checksums and URLs at the same time

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -2358,14 +2358,15 @@ extension Workspace {
             ]
 
             if let existingArtifact = existingArtifact {
-                if case .remote(_, let existingChecksum) = existingArtifact.source {
+                if case .remote(let existingURL, let existingChecksum) = existingArtifact.source {
                     // If we already have an artifact with the same checksum, we don't need to download it again.
                     if artifact.checksum == existingChecksum {
                         continue
                     }
 
+                    let urlChanged = artifact.url != URL(string: existingURL)
                     // If the checksum is different but the package wasn't updated, this is a security risk.
-                    if !addedOrUpdatedPackages.contains(artifact.packageRef) {
+                    if !urlChanged && !addedOrUpdatedPackages.contains(artifact.packageRef) {
                         observabilityScope.emit(.artifactChecksumChanged(targetName: artifact.targetName))
                         continue
                     }


### PR DESCRIPTION
Previously if you had a binary target, that you replaced the checksum
and URL for at the same time, SwiftPM would reject it because the
checksum had changed. In my experience this is the common case when you
are copy pasting the inclusion instructions from documentation for an
update and then you run `swift build`.

In the case of package resolution the addedOrUpdatedPackages list is
always empty.