### PR TITLE
Fix a build failure on Windows (#4224)

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -288,8 +288,11 @@ extension SwiftCommand {
 
 /// A safe wrapper of TSCBasic.exec.
 func exec(path: String, args: [String]) throws -> Never {
-    // SwiftTool can't handle signals anymore, so reset the signal handler to SIG_DFL before call TSCBasic.exec()
+    #if !os(Windows)
+    // On platforms other than Windows, signal(SIGINT, SIG_IGN) is used for handling SIGINT by DispatchSourceSignal,
+    // but this process is about to be replaced by exec, so SIG_IGN must be returned to default.
     signal(SIGINT, SIG_DFL)
+    #endif
 
     try TSCBasic.exec(path: path, args: args)
 }


### PR DESCRIPTION
This is a hot fix for Windows build broken by #4224. #4231 also needs this change.

### Motivation:

#4224 broke Windows build as @compnerd pointed out at https://github.com/apple/swift-package-manager/pull/4224#issuecomment-1072474100. The global function `exec` added in #4224 is actually unnecessary for Windows because [`signal(SIGINT, SIG_IGN)`](https://github.com/apple/swift-package-manager/blob/0e804edf19e05ddd02d05c1534d4ceea01117e5f/Sources/Commands/SwiftTool.swift#L418) is not compiled for Windows target.

```swift
            #if os(Windows)
            // set shutdown handler to terminate sub-processes, etc
            SwiftTool.cancellator = cancellator
            _ = SetConsoleCtrlHandler({ _ in
                // Terminate all processes on receiving an interrupt signal.
                try? SwiftTool.cancellator?.cancel(deadline: .now() + .seconds(30))

                // Reset the handler.
                _ = SetConsoleCtrlHandler(nil, false)

                // Exit as if by signal()
                TerminateProcess(GetCurrentProcess(), 3)

                return true
            }, true)
            #else
            // trap SIGINT to terminate sub-processes, etc
            signal(SIGINT, SIG_IGN)
            ...
            #endif
```

### Modifications:

- Enclosed `exec` with `#if !(os(Windows))` and `#endif`
- Changed comments to be clearer

### Result:

Combined with this change, #4224 no longer affects Windows.