### PR TITLE
[5.6] Remove binary target downloads on failure

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -2400,6 +2400,7 @@ extension Workspace {
                             observabilityScope.trap { try self.fileSystem.removeFileTree(archivePath) }
                         })
                     case .failure(let error):
+                        observabilityScope.trap ({ try self.fileSystem.removeFileTree(archivePath) })
                         observabilityScope.emit(.artifactFailedDownload(artifactURL: artifact.url, targetName: artifact.targetName, reason: "\(error)"))
                     }
                 })


### PR DESCRIPTION
In the case of 404s from binary target URLs, the URLSession delegate to
write the file still gets called, since it's just a HTTP failure, and we
ended up copying an invalid file into the destination. This resulted in
subsequent builds failing since the file still existed. Now in this case
we remove the invalid archive regardless of failure reason.

Relevant log:

```
error: failed downloading 'https://github.com/keith/StaticInternalSwiftSyntaxParser/releases/download/5.6/lib_InternalSwiftSyntaxParser.xcframework.zip' which is required by binary target 'lib_InternalSwiftSyntaxParser': badResponseStatusCode(404)

% swift build
error: failed downloading 'https://github.com/keith/StaticInternalSwiftSyntaxParser/releases/download/5.6/lib_InternalSwiftSyntaxParser.xcframework.zip' which is required by binary target 'lib_InternalSwiftSyntaxParser': /.../.build/artifacts/deadcode/lib_InternalSwiftSyntaxParser.xcframework.zip already exists in file system
```

https://github.com/apple/swift-package-manager/pull/4232

rdar://90575490