### PR TITLE
Fix a warning by correcting a `deprecated:` that should have been `introduced:`

### DIFF
--- a/Sources/PackagePlugin/PackageModel.swift
+++ b/Sources/PackagePlugin/PackageModel.swift
@@ -219,7 +219,7 @@ public enum ModuleKind {
     /// A module that contains code for an executable's main module.
     case executable
     /// A module that contains code for a snippet.
-    @available(_PackageDescription, deprecated: 999.0)
+    @available(_PackageDescription, introduced: 999.0)
     case snippet
     /// A module that contains unit tests.
     case test


### PR DESCRIPTION
### Motivation:

An incorrect annotation from a recent change causes a warning.

### Modifications:

Change `deprecated:` to `introduced:` for a new enum value.

### Result:

Fix a warning (and correctly mark the symbol as not available in 5.7 and earlier).