### PR TITLE
Tests: replace use of `AbsolutePath.appending(RelativePath(_:))`

### DIFF
--- a/IntegrationTests/Tests/IntegrationTests/BasicTests.swift
+++ b/IntegrationTests/Tests/IntegrationTests/BasicTests.swift
@@ -28,7 +28,7 @@ final class BasicTests: XCTestCase {
             XCTAssertMatch(build1Output, .contains("Build complete"))
 
             // Verify that the app works.
-            let dealerOutput = try sh(packagePath.appending(RelativePath(".build/debug/dealer")), "10").stdout
+            let dealerOutput = try sh(AbsolutePath(".build/debug/dealer", relativeTo: packagePath), "10").stdout
             XCTAssertEqual(dealerOutput.filter(\.isPlayingCardSuit).count, 10)
 
             // Verify that the 'git status' is clean after a build.

--- a/IntegrationTests/Tests/IntegrationTests/Helpers.swift
+++ b/IntegrationTests/Tests/IntegrationTests/Helpers.swift
@@ -209,7 +209,7 @@ func fixture(
 
             // Construct the expected path of the fixture.
             // FIXME: This seems quite hacky; we should provide some control over where fixtures are found.
-            let fixtureDir = AbsolutePath(#file).appending(RelativePath("../../../Fixtures")).appending(fixtureSubpath)
+            let fixtureDir = AbsolutePath("../../../Fixtures/\(name)", relativeTo: AbsolutePath(#file))
 
             // Check that the fixture is really there.
             guard localFileSystem.isDirectory(fixtureDir) else {
@@ -317,7 +317,7 @@ func binaryTargetsFixture(_ closure: (AbsolutePath) throws -> Void) throws {
             let subpath = inputsPath.appending(component: "SwiftFramework")
             let projectPath = subpath.appending(component: "SwiftFramework.xcodeproj")
             try sh(xcodebuild, "-project", projectPath, "-scheme", "SwiftFramework", "-derivedDataPath", tmpDir, "COMPILER_INDEX_STORE_ENABLE=NO")
-            let frameworkPath = tmpDir.appending(RelativePath("Build/Products/Debug/SwiftFramework.framework"))
+            let frameworkPath = AbsolutePath("Build/Products/Debug/SwiftFramework.framework", relativeTo: tmpDir)
             let xcframeworkPath = packagePath.appending(component: "SwiftFramework.xcframework")
             try sh(xcodebuild, "-create-xcframework", "-framework", frameworkPath, "-output", xcframeworkPath)
         }

--- a/IntegrationTests/Tests/IntegrationTests/SwiftPMTests.swift
+++ b/IntegrationTests/Tests/IntegrationTests/SwiftPMTests.swift
@@ -62,24 +62,24 @@ final class SwiftPMTests: XCTestCase {
             for entry in try localFileSystem.getDirectoryContents(packagePath.appending(components: "Sources", "foo")) {
                 try localFileSystem.removeFileTree(packagePath.appending(components: "Sources", "foo", entry))
             }
-            try localFileSystem.writeFileContents(packagePath.appending(RelativePath("Sources/foo/main.m"))) {
+            try localFileSystem.writeFileContents(AbsolutePath("Sources/foo/main.m", relativeTo: packagePath)) {
                 $0 <<< "int main() {}"
             }
             let archs = ["x86_64", "arm64"]
 
             for arch in archs {
                 try sh(swiftBuild, "--package-path", packagePath, "--arch", arch)
-                let fooPath = packagePath.appending(RelativePath(".build/\(arch)-apple-macosx/debug/foo"))
+                let fooPath = AbsolutePath(".build/\(arch)-apple-macosx/debug/foo", relativeTo: packagePath)
                 XCTAssertFileExists(fooPath)
             }
 
             let args = [swiftBuild.pathString, "--package-path", packagePath.pathString] + archs.flatMap{ ["--arch", $0] }
             try _sh(args)
 
-            let fooPath = packagePath.appending(RelativePath(".build/apple/Products/Debug/foo"))
+            let fooPath = AbsolutePath(".build/apple/Products/Debug/foo", relativeTo: packagePath)
             XCTAssertFileExists(fooPath)
 
-            let objectsDir = packagePath.appending(RelativePath(".build/apple/Intermediates.noindex/foo.build/Debug/foo.build/Objects-normal"))
+            let objectsDir = AbsolutePath(".build/apple/Intermediates.noindex/foo.build/Debug/foo.build/Objects-normal", relativeTo: packagePath)
             for arch in archs {
                 XCTAssertDirectoryExists(objectsDir.appending(component: arch))
             }

--- a/Tests/CommandsTests/PackageRegistryToolTests.swift
+++ b/Tests/CommandsTests/PackageRegistryToolTests.swift
@@ -52,7 +52,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
     func testLocalConfiguration() throws {
         try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
             let packageRoot = fixturePath.appending(component: "Bar")
-            let configurationFilePath = packageRoot.appending(RelativePath(".swiftpm/configuration/registries.json"))
+            let configurationFilePath = AbsolutePath(".swiftpm/configuration/registries.json", relativeTo: packageRoot)
 
             XCTAssertFalse(localFileSystem.exists(configurationFilePath))
 
@@ -131,7 +131,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
     func testSetMissingURL() throws {
         try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
             let packageRoot = fixturePath.appending(component: "Bar")
-            let configurationFilePath = packageRoot.appending(RelativePath(".swiftpm/configuration/registries.json"))
+            let configurationFilePath = AbsolutePath(".swiftpm/configuration/registries.json", relativeTo: packageRoot)
 
             XCTAssertFalse(localFileSystem.exists(configurationFilePath))
 
@@ -148,7 +148,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
     func testSetInvalidURL() throws {
         try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
             let packageRoot = fixturePath.appending(component: "Bar")
-            let configurationFilePath = packageRoot.appending(RelativePath(".swiftpm/configuration/registries.json"))
+            let configurationFilePath = AbsolutePath(".swiftpm/configuration/registries.json", relativeTo: packageRoot)
 
             XCTAssertFalse(localFileSystem.exists(configurationFilePath))
 
@@ -165,7 +165,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
     func testSetInvalidScope() throws {
         try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
             let packageRoot = fixturePath.appending(component: "Bar")
-            let configurationFilePath = packageRoot.appending(RelativePath(".swiftpm/configuration/registries.json"))
+            let configurationFilePath = AbsolutePath(".swiftpm/configuration/registries.json", relativeTo: packageRoot)
 
             XCTAssertFalse(localFileSystem.exists(configurationFilePath))
 
@@ -182,7 +182,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
     func testUnsetMissingEntry() throws {
         try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
             let packageRoot = fixturePath.appending(component: "Bar")
-            let configurationFilePath = packageRoot.appending(RelativePath(".swiftpm/configuration/registries.json"))
+            let configurationFilePath = AbsolutePath(".swiftpm/configuration/registries.json", relativeTo: packageRoot)
 
             XCTAssertFalse(localFileSystem.exists(configurationFilePath))
 

--- a/Tests/FunctionalTests/ResourcesTests.swift
+++ b/Tests/FunctionalTests/ResourcesTests.swift
@@ -37,7 +37,7 @@ class ResourcesTests: XCTestCase {
         try fixture(name: "Resources/Localized") { fixturePath in
             try executeSwiftBuild(fixturePath)
 
-            let exec = fixturePath.appending(RelativePath(".build/debug/exe"))
+            let exec = AbsolutePath(".build/debug/exe", relativeTo: fixturePath)
             // Note: <rdar://problem/59738569> Source from LANG and -AppleLanguages on command line for Linux resources
             let output = try Process.checkNonZeroExit(args: exec.pathString, "-AppleLanguages", "(en_US)")
             XCTAssertEqual(output, """

--- a/Tests/XcodeprojTests/FunctionalTests.swift
+++ b/Tests/XcodeprojTests/FunctionalTests.swift
@@ -27,7 +27,7 @@ class FunctionalTests: XCTestCase {
             let pbx = fixturePath.appending(component: "Library.xcodeproj")
             XCTAssertDirectoryExists(pbx)
             XCTAssertXcodeBuild(project: pbx)
-            let build = fixturePath.appending(RelativePath("build/Build/Products/Debug"))
+            let build = AbsolutePath("build/Build/Products/Debug", relativeTo: fixturePath)
             XCTAssertDirectoryExists(build.appending(component: "Library.framework"))
         }
     }
@@ -45,7 +45,7 @@ class FunctionalTests: XCTestCase {
             XCTAssertFileExists(pbx.appending(component: "SeaLib_Info.plist"))
 
             XCTAssertXcodeBuild(project: pbx)
-            let build = fixturePath.appending(RelativePath("build/Build/Products/Debug"))
+            let build = AbsolutePath("build/Build/Products/Debug", relativeTo: fixturePath)
             XCTAssertDirectoryExists(build.appending(component: "SeaLib.framework"))
             XCTAssertFileExists(build.appending(component: "SeaExec"))
             XCTAssertFileExists(build.appending(component: "CExec"))
@@ -84,7 +84,7 @@ class FunctionalTests: XCTestCase {
             let pbx = moduleUser.appending(component: "SystemModuleUser.xcodeproj")
             XCTAssertDirectoryExists(pbx)
             XCTAssertXcodeBuild(project: pbx)
-            let build = moduleUser.appending(RelativePath("build/Build/Products/Debug"))
+            let build = AbsolutePath("build/Build/Products/Debug", relativeTo: moduleUser)
             XCTAssertFileExists(build.appending(components: "SystemModuleUser"))
         }
     }
@@ -98,7 +98,7 @@ class FunctionalTests: XCTestCase {
             let pbx = fixturePath.appending(component: "PackageWithNonc99NameModules.xcodeproj")
             XCTAssertDirectoryExists(pbx)
             XCTAssertXcodeBuild(project: pbx)
-            let build = fixturePath.appending(RelativePath("build/Build/Products/Debug"))
+            let build = AbsolutePath("build/Build/Products/Debug", relativeTo: fixturePath)
             XCTAssertDirectoryExists(build.appending(component: "A_B.framework"))
             XCTAssertDirectoryExists(build.appending(component: "B_C.framework"))
             XCTAssertDirectoryExists(build.appending(component: "C_D.framework"))


### PR DESCRIPTION
This cleans up the last of the instances of
`AbsolutePath.appending(RelativePath(_:))` in favour of
`AbsolutePath(_:relativeTo:)`.  The three remaining instances are of
`AbsolutePath.appending(RelativePath(validating:))`.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
