### PR TITLE
make registry dependencies available in 5.7

### DIFF
--- a/Sources/PackageDescription/PackageDependency.swift
+++ b/Sources/PackageDescription/PackageDependency.swift
@@ -495,7 +495,7 @@ extension Package.Dependency {
     /// - Parameters:
     ///     - id: The identity of the package.
     ///     - version: The minimum version requirement.
-    @available(_PackageDescription, introduced: 999)
+    @available(_PackageDescription, introduced: 5.7)
     public static func package(
         id: String,
         from version: Version
@@ -519,7 +519,7 @@ extension Package.Dependency {
     /// - Parameters:
     ///     - id: The identity of the package.
     ///     - version: The minimum version requirement.
-    @available(_PackageDescription, introduced: 999)
+    @available(_PackageDescription, introduced: 5.7)
     public static func package(
         id: String,
         exact version: Version
@@ -548,7 +548,7 @@ extension Package.Dependency {
     /// - Parameters:
     ///     - id: The identity of the package.
     ///     - range: The custom version range requirement.
-    @available(_PackageDescription, introduced: 999)
+    @available(_PackageDescription, introduced: 5.7)
     public static func package(
         id: String,
         _ range: Range<Version>
@@ -567,7 +567,7 @@ extension Package.Dependency {
     /// - Parameters:
     ///     - id: The identity of the package.
     ///     - range: The closed version range requirement.
-    @available(_PackageDescription, introduced: 999)
+    @available(_PackageDescription, introduced: 5.7)
     public static func package(
         id: String,
         _ range: ClosedRange<Version>
@@ -582,7 +582,7 @@ extension Package.Dependency {
     }
 
     // intentionally private to hide enum detail
-    @available(_PackageDescription, introduced: 999)
+    @available(_PackageDescription, introduced: 5.7)
     private static func package(
         id: String,
         requirement: Package.Dependency.RegistryRequirement

--- a/Tests/PackageLoadingTests/PD_5_7_LoadingTests .swift
+++ b/Tests/PackageLoadingTests/PD_5_7_LoadingTests .swift
@@ -22,6 +22,33 @@ class PackageDescription5_7LoadingTests: PackageDescriptionLoadingTests {
         .v5_7
     }
 
+    func testRegistryDependencies() throws {
+        let content = """
+            import PackageDescription
+            let package = Package(
+               name: "MyPackage",
+               dependencies: [
+                   .package(id: "x.foo", from: "1.1.1"),
+                   .package(id: "x.bar", exact: "1.1.1"),
+                   .package(id: "x.baz", .upToNextMajor(from: "1.1.1")),
+                   .package(id: "x.qux", .upToNextMinor(from: "1.1.1")),
+                   .package(id: "x.quux", "1.1.1" ..< "3.0.0"),
+               ]
+            )
+            """
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
+        let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
+        XCTAssertEqual(deps["x.foo"], .registry(identity: "x.foo", requirement: .range("1.1.1" ..< "2.0.0")))
+        XCTAssertEqual(deps["x.bar"], .registry(identity: "x.bar", requirement: .exact("1.1.1")))
+        XCTAssertEqual(deps["x.baz"], .registry(identity: "x.baz", requirement: .range("1.1.1" ..< "2.0.0")))
+        XCTAssertEqual(deps["x.qux"], .registry(identity: "x.qux", requirement: .range("1.1.1" ..< "1.2.0")))
+        XCTAssertEqual(deps["x.quux"], .registry(identity: "x.quux", requirement: .range("1.1.1" ..< "3.0.0")))
+    }
+
     func testConditionalTargetDependencies() throws {
         let content = """
             import PackageDescription

--- a/Tests/PackageLoadingTests/PD_Next_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_Next_LoadingTests.swift
@@ -19,31 +19,4 @@ class PackageDescriptionNextLoadingTests: PackageDescriptionLoadingTests {
     override var toolsVersion: ToolsVersion {
         .vNext
     }
-
-    func testRegistryDependencies() throws {
-        let content = """
-            import PackageDescription
-            let package = Package(
-               name: "MyPackage",
-               dependencies: [
-                   .package(id: "x.foo", from: "1.1.1"),
-                   .package(id: "x.bar", exact: "1.1.1"),
-                   .package(id: "x.baz", .upToNextMajor(from: "1.1.1")),
-                   .package(id: "x.qux", .upToNextMinor(from: "1.1.1")),
-                   .package(id: "x.quux", "1.1.1" ..< "3.0.0"),
-               ]
-            )
-            """
-
-        let observability = ObservabilitySystem.makeForTesting()
-        let manifest = try loadManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
-
-        let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
-        XCTAssertEqual(deps["x.foo"], .registry(identity: "x.foo", requirement: .range("1.1.1" ..< "2.0.0")))
-        XCTAssertEqual(deps["x.bar"], .registry(identity: "x.bar", requirement: .exact("1.1.1")))
-        XCTAssertEqual(deps["x.baz"], .registry(identity: "x.baz", requirement: .range("1.1.1" ..< "2.0.0")))
-        XCTAssertEqual(deps["x.qux"], .registry(identity: "x.qux", requirement: .range("1.1.1" ..< "1.2.0")))
-        XCTAssertEqual(deps["x.quux"], .registry(identity: "x.quux", requirement: .range("1.1.1" ..< "3.0.0")))
-    }
 }


### PR DESCRIPTION
motivation: make experimental use of registry easier

changes:
* make registry based dependencies syntax available in 5.7
* move the relevant tests to the 5.7 suite
