### PR TITLE
ignore empty configuration files in legacy check

### DIFF
--- a/Sources/Basics/FileSystem+Extensions.swift
+++ b/Sources/Basics/FileSystem+Extensions.swift
@@ -107,7 +107,7 @@ extension FileSystem {
             if self.exists(oldConfigDirectory, followSymlink: false) && self.isDirectory(oldConfigDirectory) {
                 let configurationFiles = try self.getDirectoryContents(oldConfigDirectory)
                     .map{ oldConfigDirectory.appending(component: $0) }
-                    .filter{ self.isFile($0) && !self.isSymlink($0) && $0.extension != "lock"}
+                    .filter{ self.isFile($0) && !self.isSymlink($0) && $0.extension != "lock" && ((try? self.readFileContents($0)) ?? []).count > 0 }
                 for file in configurationFiles {
                     let destination = idiomaticConfigurationDirectory.appending(component: file.basename)
                     if !self.exists(destination) {
@@ -124,7 +124,7 @@ extension FileSystem {
             if self.exists(oldConfigDirectory, followSymlink: false) && self.isDirectory(oldConfigDirectory) {
                 let configurationFiles = try self.getDirectoryContents(oldConfigDirectory)
                     .map{ oldConfigDirectory.appending(component: $0) }
-                    .filter{ self.isFile($0) && !self.isSymlink($0) && $0.extension != "lock"}
+                    .filter{ self.isFile($0) && !self.isSymlink($0) && $0.extension != "lock" && ((try? self.readFileContents($0)) ?? []).count > 0 }
                 for file in configurationFiles {
                     let destination = idiomaticConfigurationDirectory.appending(component: file.basename)
                     if !self.exists(destination) {

--- a/Sources/Workspace/Workspace+Configuration.swift
+++ b/Sources/Workspace/Workspace+Configuration.swift
@@ -256,7 +256,7 @@ extension Workspace {
                 return try migrateMirrorsConfiguration(from: resolvedLegacyPath, to: newPath, observabilityScope: observabilityScope)
             } else if localFileSystem.isFile(newPath.parentDirectory) {
                 observabilityScope.emit(warning: "Unable to migrate legacy mirrors configuration, because \(newPath.parentDirectory) already exists.")
-            } else {
+            } else if let content = try? localFileSystem.readFileContents(legacyPath), content.count > 0 {
                 observabilityScope.emit(warning: "Usage of \(legacyPath) has been deprecated. Please delete it and use the new \(newPath) instead.")
                 if !localFileSystem.exists(newPath, followSymlink: false) {
                     try localFileSystem.createDirectory(newPath.parentDirectory, recursive: true)


### PR DESCRIPTION
motivation: make legacy file warning less noisy if the file is empty

changes: check to see if the configuration file in the legacy location is empty before migrating it and emitting the warning

