### PR TITLE
Improve handling of PD/PluginAPI libraries

### DIFF
--- a/Sources/PackageLoading/CMakeLists.txt
+++ b/Sources/PackageLoading/CMakeLists.txt
@@ -11,11 +11,9 @@ add_library(PackageLoading
   Diagnostics.swift
   IdentityResolver.swift
   ManifestLoader.swift
-  MinimumDeploymentTarget.swift
   ModuleMapGenerator.swift
   PackageBuilder.swift
   ManifestJSONParser.swift
-  PlatformRegistry.swift
   PkgConfig.swift
   Target+PkgConfig.swift
   TargetSourcesBuilder.swift

--- a/Sources/PackageModel/CMakeLists.txt
+++ b/Sources/PackageModel/CMakeLists.txt
@@ -20,11 +20,13 @@ add_library(PackageModel
   Manifest/TargetBuildSettingDescription.swift
   Manifest/TargetDescription.swift
   ManifestSourceGeneration.swift
+  MinimumDeploymentTarget.swift
   ModuleMapType.swift
   Package.swift
   PackageIdentity.swift
   PackageReference.swift
   Platform.swift
+  PlatformRegistry.swift
   Product.swift
   Resource.swift
   Snippets/Model/Snippet.swift

--- a/Sources/PackageModel/MinimumDeploymentTarget.swift
+++ b/Sources/PackageModel/MinimumDeploymentTarget.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import PackageModel
 import TSCBasic
 
 public struct MinimumDeploymentTarget {

--- a/Sources/PackageModel/PlatformRegistry.swift
+++ b/Sources/PackageModel/PlatformRegistry.swift
@@ -10,8 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import PackageModel
-
 /// A registry for available platforms.
 public final class PlatformRegistry {
 

--- a/Sources/PackageModel/ToolchainConfiguration.swift
+++ b/Sources/PackageModel/ToolchainConfiguration.swift
@@ -93,24 +93,83 @@ public struct ToolchainConfiguration {
 
 extension ToolchainConfiguration {
     public struct SwiftPMLibrariesLocation {
-        public var manifestAPI: AbsolutePath
-        public var pluginAPI: AbsolutePath
+        public var manifestLibraryPath: AbsolutePath
+        public var pluginLibraryPath: AbsolutePath
 
-        public init(manifestAPI: AbsolutePath, pluginAPI: AbsolutePath) {
-            self.manifestAPI = manifestAPI
-            self.pluginAPI = pluginAPI
+        public init(manifestLibraryPath: AbsolutePath, manifestLibraryMinimumDeploymentTarget: PlatformVersion? = nil, pluginLibraryPath: AbsolutePath, pluginLibraryMinimumDeploymentTarget: PlatformVersion? = nil) {
+            #if os(macOS)
+            if let manifestLibraryMinimumDeploymentTarget = manifestLibraryMinimumDeploymentTarget {
+                self.manifestLibraryMinimumDeploymentTarget = manifestLibraryMinimumDeploymentTarget
+            } else if let manifestLibraryMinimumDeploymentTarget = try? MinimumDeploymentTarget.computeMinimumDeploymentTarget(of: Self.macOSManifestLibraryPath(for: manifestLibraryPath), platform: .macOS) {
+                self.manifestLibraryMinimumDeploymentTarget = manifestLibraryMinimumDeploymentTarget
+            } else {
+                self.manifestLibraryMinimumDeploymentTarget = Self.defaultMinimumDeploymentTarget
+            }
+
+            if let pluginLibraryMinimumDeploymentTarget = pluginLibraryMinimumDeploymentTarget {
+                self.pluginLibraryMinimumDeploymentTarget = pluginLibraryMinimumDeploymentTarget
+            } else if let pluginLibraryMinimumDeploymentTarget = try? MinimumDeploymentTarget.computeMinimumDeploymentTarget(of: Self.macOSPluginLibraryPath(for: pluginLibraryPath), platform: .macOS) {
+                self.pluginLibraryMinimumDeploymentTarget = pluginLibraryMinimumDeploymentTarget
+            } else {
+                self.pluginLibraryMinimumDeploymentTarget = Self.defaultMinimumDeploymentTarget
+            }
+            #else
+            precondition(manifestLibraryMinimumDeploymentTarget == nil && pluginLibraryMinimumDeploymentTarget == nil, "deployment targets can only be specified on macOS")
+            #endif
+
+            self.manifestLibraryPath = manifestLibraryPath
+            self.pluginLibraryPath = pluginLibraryPath
         }
 
-        public init(root: AbsolutePath) {
+        public init(root: AbsolutePath, manifestLibraryMinimumDeploymentTarget: PlatformVersion? = nil, pluginLibraryMinimumDeploymentTarget: PlatformVersion? = nil) {
             self.init(
-                manifestAPI: root.appending(component: "ManifestAPI"),
-                pluginAPI: root.appending(component: "PluginAPI")
+                manifestLibraryPath: root.appending(component: "ManifestAPI"),
+                manifestLibraryMinimumDeploymentTarget: manifestLibraryMinimumDeploymentTarget,
+                pluginLibraryPath: root.appending(component: "PluginAPI"),
+                pluginLibraryMinimumDeploymentTarget: pluginLibraryMinimumDeploymentTarget
             )
         }
 
-        public init(swiftCompilerPath: AbsolutePath) {
+        public init(swiftCompilerPath: AbsolutePath, manifestLibraryMinimumDeploymentTarget: PlatformVersion? = nil, pluginLibraryMinimumDeploymentTarget: PlatformVersion? = nil) {
             let rootPath = swiftCompilerPath.parentDirectory.parentDirectory.appending(components: "lib", "swift", "pm")
-            self.init(root: rootPath)
+            self.init(root: rootPath,
+                      manifestLibraryMinimumDeploymentTarget: manifestLibraryMinimumDeploymentTarget,
+                      pluginLibraryMinimumDeploymentTarget: pluginLibraryMinimumDeploymentTarget)
         }
+
+#if os(macOS)
+        private static let defaultMinimumDeploymentTarget = PlatformVersion("10.15")
+
+        public var manifestLibraryMinimumDeploymentTarget: PlatformVersion
+        public var pluginLibraryMinimumDeploymentTarget: PlatformVersion
+
+        private static func macOSManifestLibraryPath(for manifestAPI: AbsolutePath) -> AbsolutePath {
+            if manifestAPI.extension == "framework" {
+                return manifestAPI.appending(component: "PackageDescription")
+            } else {
+                // note: this is not correct for all platforms, but we only actually use it on macOS.
+                return manifestAPI.appending(component: "libPackageDescription.dylib")
+            }
+        }
+
+        public var macOSManifestLibraryPath: AbsolutePath {
+            return Self.macOSManifestLibraryPath(for: manifestLibraryPath)
+        }
+
+        private static func macOSPluginLibraryPath(for pluginAPI: AbsolutePath) -> AbsolutePath {
+            // if runtimePath is set to "PackageFrameworks" that means we could be developing SwiftPM in Xcode
+            // which produces a framework for dynamic package products.
+            if pluginAPI.extension == "framework" {
+                return pluginAPI.appending(component: "PackagePlugin")
+            } else {
+                // note: this is not correct for all platforms, but we only actually use it on macOS.
+                return pluginAPI.appending(component: "libPackagePlugin.dylib")
+            }
+        }
+
+        public var macOSPluginLibraryPath: AbsolutePath {
+            return Self.macOSPluginLibraryPath(for: pluginLibraryPath)
+        }
+#endif
     }
 }

--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -430,16 +430,16 @@ public final class UserToolchain: Toolchain {
         let pluginFrameworksPath = applicationPath.appending(components: "PackageFrameworks", "PackagePlugin.framework")
         if localFileSystem.exists(manifestFrameworksPath) && localFileSystem.exists(pluginFrameworksPath) {
             return .init(
-                manifestAPI: manifestFrameworksPath,
-                pluginAPI: pluginFrameworksPath
+                manifestLibraryPath: manifestFrameworksPath,
+                pluginLibraryPath: pluginFrameworksPath
             )
         }
 
         // this tests if we are debugging / testing SwiftPM with SwiftPM
         if localFileSystem.exists(applicationPath.appending(component: "swift-package")) {
             return .init(
-                manifestAPI: applicationPath,
-                pluginAPI: applicationPath
+                manifestLibraryPath: applicationPath,
+                pluginLibraryPath: applicationPath
             )
         }
 

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -12,8 +12,8 @@
 
 import Basics
 @testable import Build
-@testable import PackageLoading
-import PackageModel
+import PackageLoading
+@testable import PackageModel
 import SPMBuildCore
 import SPMTestSupport
 import SwiftDriver

--- a/Tests/PackageModelTests/MinimumDeploymentTargetTests.swift
+++ b/Tests/PackageModelTests/MinimumDeploymentTargetTests.swift
@@ -13,7 +13,7 @@
 import TSCBasic
 import XCTest
 
-@testable import PackageLoading
+@testable import PackageModel
 
 class MinimumDeploymentTargetTests: XCTestCase {
     func testDoesNotAssertWithNoOutput() throws {

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -13,8 +13,8 @@
 import Basics
 import Foundation
 import PackageGraph
-import PackageModel
-@testable import PackageLoading
+@testable import PackageModel
+import PackageLoading
 import SPMBuildCore
 import SPMTestSupport
 import TSCBasic


### PR DESCRIPTION
- Remove old fallback for PD libs in `ManifestLoader`
- Move computation for PD/PluginAPI library paths to `SwiftPMLibrariesLocation`
- Extend `SwiftPMLibrariesLocation` with the ability to pass in a minimum deployment target for PD/PluginAPI libraries. If a minimum deployment target is passed in by the client, `ManifestLoader`/`DefaultPluginScriptRunner` will not try to determine it on their own using `vtool`
- Remove copy of `computeMinimumDeploymentTarget` from `DefaultPluginScriptRunner`