### PR TITLE
add test fixture for handling SIGINT on "swift run"

### DIFF
--- a/Fixtures/Miscellaneous/SwiftRun/Package.swift
+++ b/Fixtures/Miscellaneous/SwiftRun/Package.swift
@@ -1,0 +1,12 @@
+// swift-tools-version: 5.6
+import PackageDescription
+
+let package = Package(
+    name: "TestableExe",
+    targets: [
+        .executableTarget(
+            name: "Test",
+            path: "."
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/SwiftRun/main.swift
+++ b/Fixtures/Miscellaneous/SwiftRun/main.swift
@@ -1,0 +1,1 @@
+print("done")


### PR DESCRIPTION
motivation: test coverage for newly discovered regression

changes: add fixture based test case for this use case

