### PR TITLE
Restore the ability to pass in `customXCTestMinimumDeploymentTargets` when loading a package graph

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1189,6 +1189,7 @@ extension Workspace {
         createMultipleTestProducts: Bool = false,
         createREPLProduct: Bool = false,
         forceResolvedVersions: Bool = false,
+        customXCTestMinimumDeploymentTargets: [PackageModel.Platform: PlatformVersion]? = .none,
         observabilityScope: ObservabilityScope
     ) throws -> PackageGraph {
 
@@ -1225,6 +1226,7 @@ extension Workspace {
             binaryArtifacts: binaryArtifacts,
             shouldCreateMultipleTestProducts: createMultipleTestProducts,
             createREPLProduct: createREPLProduct,
+            customXCTestMinimumDeploymentTargets: customXCTestMinimumDeploymentTargets,
             fileSystem: fileSystem,
             observabilityScope: observabilityScope
         )


### PR DESCRIPTION
### Motivation:

This had been removed in one of the previous refactorings, but clients of libSwiftPM still need it.  This is because the actual minimum deployment version of the installed XCTest framework (part of the toolchain) establishes a hard floor on the minimum deployment version that can be used for tests, no matter what the package says.

### Modifications:

- put back `customXCTestMinimumDeploymentTargets` with default value and pass it through

### Result:

Clients of libSwiftPM can pass in a minimum deployment version for each platform, which will be used for the unit tests built for the package.