### PR TITLE
Repair #4258

### DIFF
--- a/Sources/Commands/TestingSupport.swift
+++ b/Sources/Commands/TestingSupport.swift
@@ -129,7 +129,7 @@ enum TestingSupport {
         }
         #if !os(macOS)
         #if os(Windows)
-        if let location = toolchain.configuration.xctestPath {
+        if let location = toolchain.xctestPath {
             env.prependPath("Path", value: location.pathString)
         }
         #endif

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -27,7 +27,7 @@ public final class UserToolchain: Toolchain {
     public typealias SwiftCompilers = (compile: AbsolutePath, manifest: AbsolutePath)
 
     /// The toolchain configuration.
-    public let configuration: ToolchainConfiguration
+    private let configuration: ToolchainConfiguration
 
     /// Path of the `swiftc` compiler.
     public let swiftCompilerPath: AbsolutePath


### PR DESCRIPTION
The original change was the most expedient change to get the CI
coverage restored.  After further investigation, it seems that we are
able to reconstruct the XCTest path through a public variable that has
appeared after the original Windows support was added.  This now allows
us to restore the configuration to its previous state of `private`.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
