### PR TITLE
resolve deprecation warnings

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -329,7 +329,7 @@ public final class ClangTargetBuildDescription {
 
         return sources.flatMap { (root, relativePaths) in
             relativePaths.map { source in
-                let path = root.appending(source)
+                let path = AbsolutePath(source, relativeTo: root)
                 let object = AbsolutePath("\(source.pathString).o", relativeTo: tempsPath)
                 let deps = AbsolutePath("\(source.pathString).d", relativeTo: tempsPath)
                 return (source, path, object, deps)
@@ -487,7 +487,7 @@ public final class ClangTargetBuildDescription {
         // Write this file out.
         // FIXME: We should generate this file during the actual build.
         try fileSystem.writeIfChanged(
-            path: derivedSources.root.appending(implFileSubpath),
+            path: AbsolutePath(implFileSubpath, relativeTo: derivedSources.root),
             bytes: implFileStream.bytes
         )
 
@@ -738,7 +738,7 @@ public final class SwiftTargetBuildDescription {
 
         // Write this file out.
         // FIXME: We should generate this file during the actual build.
-        let path = derivedSources.root.appending(subpath)
+        let path = AbsolutePath(subpath, relativeTo: derivedSources.root)
         try self.fileSystem.writeIfChanged(path: path, bytes: stream.bytes)
     }
 

--- a/Sources/Build/LLBuildManifestBuilder.swift
+++ b/Sources/Build/LLBuildManifestBuilder.swift
@@ -172,14 +172,14 @@ extension LLBuildManifestBuilder {
 
         // Create a copy command for each resource file.
         for resource in target.target.underlyingTarget.resources {
-            let destination = bundlePath.appending(resource.destination)
+            let destination = AbsolutePath(resource.destination, relativeTo: bundlePath)
             let (_, output) = addCopyCommand(from: resource.path, to: destination)
             outputs.append(output)
         }
 
         // Create a copy command for the Info.plist if a resource with the same name doesn't exist yet.
         if let infoPlistPath = target.resourceBundleInfoPlistPath {
-            let destination = bundlePath.appending(infoPlistDestination)
+            let destination = AbsolutePath(infoPlistDestination, relativeTo: bundlePath)
             let (_, output) = addCopyCommand(from: infoPlistPath, to: destination)
             outputs.append(output)
         }
@@ -960,7 +960,7 @@ extension TypedVirtualPath {
             guard let workingDirectory = fileSystem.currentWorkingDirectory else {
                 throw InternalError("unknown working directory")
             }
-            return Node.file(workingDirectory.appending(relativePath))
+            return Node.file(AbsolutePath(relativePath, relativeTo: workingDirectory))
         } else if let temporaryFileName = file.temporaryFileName {
             return Node.virtual(temporaryFileName.pathString)
         } else {

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -485,7 +485,7 @@ public final class PackageBuilder {
                     throw ModuleError.unsupportedTargetPath(subpath)
                 }
 
-                let path = packagePath.appending(relativeSubPath)
+                let path = AbsolutePath(relativeSubPath, relativeTo: packagePath)
                 // Make sure the target is inside the package root.
                 guard path.isDescendantOfOrEqual(to: packagePath) else {
                     throw ModuleError.targetOutsidePackage(package: self.identity.description, target: target.name)
@@ -740,7 +740,7 @@ public final class PackageBuilder {
 
         // Compute the path to public headers directory.
         let publicHeaderComponent = manifestTarget.publicHeadersPath ?? ClangTarget.defaultPublicHeadersComponent
-        let publicHeadersPath = potentialModule.path.appending(try RelativePath(validating: publicHeaderComponent))
+        let publicHeadersPath = try AbsolutePath(RelativePath(validating: publicHeaderComponent), relativeTo: potentialModule.path)
         guard publicHeadersPath.isDescendantOfOrEqual(to: potentialModule.path) else {
             throw ModuleError.invalidPublicHeadersDirectory(potentialModule.name)
         }
@@ -876,7 +876,7 @@ public final class PackageBuilder {
 
                 // Ensure that the search path is contained within the package.
                 let subpath = try RelativePath(validating: value)
-                guard targetRoot.appending(subpath).isDescendantOfOrEqual(to: packagePath) else {
+                guard AbsolutePath(subpath, relativeTo: targetRoot).isDescendantOfOrEqual(to: packagePath) else {
                     throw ModuleError.invalidHeaderSearchPath(subpath.pathString)
                 }
 

--- a/Sources/PackageModel/Sources.swift
+++ b/Sources/PackageModel/Sources.swift
@@ -22,7 +22,7 @@ public struct Sources: Codable {
 
     /// The list of absolute paths of all files.
     public var paths: [AbsolutePath] {
-        return relativePaths.map({ root.appending($0) })
+        return relativePaths.map { AbsolutePath($0, relativeTo: root) }
     }
 
     public init(paths: [AbsolutePath], root: AbsolutePath) {

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -69,8 +69,7 @@ public final class UserToolchain: Toolchain {
         // bootstrap script.
         let swiftCompiler = resolveSymlinks(self.swiftCompilerPath)
 
-        let runtime = swiftCompiler.appending(
-            RelativePath("../../lib/swift/clang/lib/darwin/libclang_rt.\(sanitizer.shortName)_osx_dynamic.dylib"))
+        let runtime = AbsolutePath("../../lib/swift/clang/lib/darwin/libclang_rt.\(sanitizer.shortName)_osx_dynamic.dylib", relativeTo: swiftCompiler)
 
         // Ensure that the runtime is present.
         guard localFileSystem.exists(runtime) else {

--- a/Sources/PackageRegistry/RegistryDownloadsManager.swift
+++ b/Sources/PackageRegistry/RegistryDownloadsManager.swift
@@ -62,7 +62,7 @@ public class RegistryDownloadsManager: Cancellable {
 
         do {
             packageRelativePath = try package.downloadPath(version: version)
-            packagePath = self.path.appending(packageRelativePath)
+            packagePath = AbsolutePath(packageRelativePath, relativeTo: self.path)
 
             // TODO: we can do some finger-print checking to improve the validation
             // already exists and valid, we can exit early
@@ -99,7 +99,7 @@ public class RegistryDownloadsManager: Cancellable {
 
             // inform delegate that we are starting to fetch
             // calculate if cached (for delegate call) outside queue as it may change while queue is processing
-            let isCached = self.cachePath.map{ self.fileSystem.exists($0.appending(packageRelativePath)) } ?? false
+            let isCached = self.cachePath.map{ self.fileSystem.exists(AbsolutePath(packageRelativePath, relativeTo: $0)) } ?? false
             delegateQueue.async {
                 let details = FetchDetails(fromCache: isCached, updatedCache: false)
                 self.delegate?.willFetch(package: package, version: version, fetchDetails: details)
@@ -150,7 +150,7 @@ public class RegistryDownloadsManager: Cancellable {
         if let cachePath = self.cachePath {
             do {
                 let relativePath = try package.downloadPath(version: version)
-                let cachedPackagePath = cachePath.appending(relativePath)
+                let cachedPackagePath = AbsolutePath(relativePath, relativeTo: cachePath)
 
                 try self.initializeCacheIfNeeded(cachePath: cachePath)
                 try self.fileSystem.withLock(on: cachedPackagePath, type: .exclusive) {
@@ -243,7 +243,7 @@ public class RegistryDownloadsManager: Cancellable {
 
     public func remove(package: PackageIdentity) throws {
         let relativePath = try package.downloadPath()
-        let packagesPath = self.path.appending(relativePath)
+        let packagesPath = AbsolutePath(relativePath, relativeTo: self.path)
         try self.fileSystem.removeFileTree(packagesPath)
     }
 

--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -297,7 +297,7 @@ public struct BuildParameters: Encodable {
 
     /// Returns the path to the binary of a product for the current build parameters.
     public func binaryPath(for product: ResolvedProduct) -> AbsolutePath {
-        return buildPath.appending(binaryRelativePath(for: product))
+        return AbsolutePath(binaryRelativePath(for: product), relativeTo: buildPath)
     }
 
     /// Returns the path to the binary of a product for the current build parameters, relative to the build directory.

--- a/Sources/SPMBuildCore/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/PluginInvocation.swift
@@ -347,7 +347,7 @@ extension PackageGraph {
                 let toolNamesToPaths = accessibleTools.reduce(into: [String: AbsolutePath](), { dict, tool in
                     switch tool {
                     case .builtTool(let name, let path):
-                        dict[name] = builtToolsDir.appending(path)
+                        dict[name] = AbsolutePath(path, relativeTo: builtToolsDir)
                     case .vendedTool(let name, let path):
                         dict[name] = path
                     }

--- a/Sources/SPMTestSupport/MockDependency.swift
+++ b/Sources/SPMTestSupport/MockDependency.swift
@@ -33,7 +33,7 @@ public struct MockDependency {
     public func convert(baseURL: AbsolutePath, identityResolver: IdentityResolver) throws -> PackageDependency {
         switch self.location {
         case .fileSystem(let path):
-            let path = baseURL.appending(path)
+            let path = AbsolutePath(path, relativeTo: baseURL)
             let remappedPath = try AbsolutePath(validating: identityResolver.mappedLocation(for: path.pathString))
             let identity = try identityResolver.resolveIdentity(for: remappedPath)
             return .fileSystem(
@@ -43,7 +43,7 @@ public struct MockDependency {
                 productFilter: self.products
             )
         case .localSourceControl(let path, let requirement):
-            let absolutePath = baseURL.appending(path)
+            let absolutePath = AbsolutePath(path, relativeTo: baseURL)
             let remappedPath = try AbsolutePath(validating: identityResolver.mappedLocation(for: absolutePath.pathString))
             let identity = try identityResolver.resolveIdentity(for: remappedPath)
             return .localSourceControl(

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -120,7 +120,7 @@ public final class MockWorkspace {
             let packagePath: AbsolutePath
             switch package.location {
             case .fileSystem(let path):
-                packagePath = basePath.appending(path)
+                packagePath = AbsolutePath(path, relativeTo: basePath)
             case .sourceControl(let url):
                 if let containerProvider = customPackageContainerProvider {
                     let observability = ObservabilitySystem.makeForTesting()
@@ -151,9 +151,9 @@ public final class MockWorkspace {
                 packageKind = .root(packagePath)
                 sourceControlSpecifier = RepositorySpecifier(path: packagePath)
             case (_, .fileSystem(let path)):
-                packageLocation = self.packagesDir.appending(path).pathString
+                packageLocation = AbsolutePath(path, relativeTo: self.packagesDir).pathString
                 packageKind = .fileSystem(packagePath)
-                sourceControlSpecifier = RepositorySpecifier(path: self.packagesDir.appending(path))
+                sourceControlSpecifier = RepositorySpecifier(path: AbsolutePath(path, relativeTo: self.packagesDir))
             case (_, .sourceControl(let url)):
                 packageLocation = url.absoluteString
                 packageKind = .remoteSourceControl(url)

--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -57,7 +57,7 @@ public func fixture(
 
             // Construct the expected path of the fixture.
             // FIXME: This seems quite hacky; we should provide some control over where fixtures are found.
-            let fixtureDir = AbsolutePath("../../../Fixtures", relativeTo: AbsolutePath(#file)).appending(fixtureSubpath)
+            let fixtureDir = AbsolutePath(fixtureSubpath, relativeTo: AbsolutePath("../../../Fixtures", relativeTo: AbsolutePath(#file)))
 
             // Check that the fixture is really there.
             guard localFileSystem.isDirectory(fixtureDir) else {

--- a/Sources/Workspace/Workspace+BinaryArtifacts.swift
+++ b/Sources/Workspace/Workspace+BinaryArtifacts.swift
@@ -73,7 +73,7 @@ extension Workspace {
                 for target in manifest.targets where target.type == .binary {
                     if let path = target.path {
                         // TODO: find a better way to get the base path (not via the manifest)
-                        let absolutePath = try manifest.path.parentDirectory.appending(RelativePath(validating: path))
+                        let absolutePath = try AbsolutePath(RelativePath(validating: path), relativeTo: manifest.path.parentDirectory)
                         localArtifacts.append(
                             .local(
                                 packageRef: packageReference,

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1250,10 +1250,10 @@ extension Workspace {
                 // note this does not actually download remote artifacts and as such does not have the artifact's type or path
                 let binaryArtifacts = try manifest.targets.filter{ $0.type == .binary }.reduce(into: [String: BinaryArtifact]()) { partial, target in
                     if let path = target.path {
-                        let absolutePath = try manifest.path.parentDirectory.appending(RelativePath(validating: path))
+                        let absolutePath = try AbsolutePath(RelativePath(validating: path), relativeTo: manifest.path.parentDirectory)
                         partial[target.name] = try BinaryArtifact(kind: .forFileExtension(absolutePath.extension ?? "unknown") , originURL: .none, path: absolutePath)
                     } else if let url = target.url.flatMap(URL.init(string:)) {
-                        let fakePath = try manifest.path.parentDirectory.appending(components: "remote", "archive").appending(RelativePath(validating: url.lastPathComponent))
+                        let fakePath = try AbsolutePath(RelativePath(validating: url.lastPathComponent), relativeTo: manifest.path.parentDirectory.appending(components: "remote", "archive"))
                         partial[target.name] = BinaryArtifact(kind: .unknown, originURL: url.absoluteString, path: fakePath)
                     } else {
                         throw InternalError("a binary target should have either a path or a URL and a checksum")
@@ -3619,17 +3619,17 @@ extension Workspace {
 extension Workspace.Location {
     /// Returns the path to the dependency's repository checkout directory.
     fileprivate func repositoriesCheckoutSubdirectory(for dependency: Workspace.ManagedDependency) -> AbsolutePath {
-        self.repositoriesCheckoutsDirectory.appending(dependency.subpath)
+        AbsolutePath(dependency.subpath, relativeTo: self.repositoriesCheckoutsDirectory)
     }
 
     /// Returns the path to the  dependency's download directory.
     fileprivate func registryDownloadSubdirectory(for dependency: Workspace.ManagedDependency) -> AbsolutePath {
-        self.registryDownloadDirectory.appending(dependency.subpath)
+        AbsolutePath(dependency.subpath, relativeTo: self.registryDownloadDirectory)
     }
 
     /// Returns the path to the dependency's edit directory.
     fileprivate func editSubdirectory(for dependency: Workspace.ManagedDependency) -> AbsolutePath {
-        self.editsDirectory.appending(dependency.subpath)
+        AbsolutePath(dependency.subpath, relativeTo: self.editsDirectory)
     }
 }
 

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -156,8 +156,8 @@ class RepositoryManagerTests: XCTestCase {
             delegate.prepare(fetchExpected: true, updateExpected: false)
             _ = try manager.lookup(repository: repo, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
-            XCTAssertDirectoryExists(cachePath.appending(repo.storagePath()))
-            XCTAssertDirectoryExists(repositoriesPath.appending(repo.storagePath()))
+            XCTAssertDirectoryExists(AbsolutePath(repo.storagePath(), relativeTo: cachePath))
+            XCTAssertDirectoryExists(AbsolutePath(repo.storagePath(), relativeTo: repositoriesPath))
             try delegate.wait(timeout: .now() + 2)
             XCTAssertEqual(delegate.willFetch[0].details,
                            RepositoryManager.FetchDetails(fromCache: false, updatedCache: false))
@@ -171,7 +171,7 @@ class RepositoryManagerTests: XCTestCase {
             delegate.prepare(fetchExpected: true, updateExpected: false)
             _ = try manager.lookup(repository: repo, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
-            XCTAssertDirectoryExists(repositoriesPath.appending(repo.storagePath()))
+            XCTAssertDirectoryExists(AbsolutePath(repo.storagePath(), relativeTo: repositoriesPath))
             try delegate.wait(timeout: .now() + 2)
             XCTAssertEqual(delegate.willFetch[1].details,
                            RepositoryManager.FetchDetails(fromCache: true, updatedCache: false))
@@ -186,8 +186,8 @@ class RepositoryManagerTests: XCTestCase {
             delegate.prepare(fetchExpected: true, updateExpected: false)
             _ = try manager.lookup(repository: repo, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
-            XCTAssertDirectoryExists(cachePath.appending(repo.storagePath()))
-            XCTAssertDirectoryExists(repositoriesPath.appending(repo.storagePath()))
+            XCTAssertDirectoryExists(AbsolutePath(repo.storagePath(), relativeTo: cachePath))
+            XCTAssertDirectoryExists(AbsolutePath(repo.storagePath(), relativeTo: repositoriesPath))
             try delegate.wait(timeout: .now() + 2)
             XCTAssertEqual(delegate.willFetch[2].details,
                            RepositoryManager.FetchDetails(fromCache: false, updatedCache: false))
@@ -305,7 +305,7 @@ class RepositoryManagerTests: XCTestCase {
                     provider: provider,
                     delegate: delegate
                 )
-                try! fs.removeFileTree(path.appending(dummyRepo.storagePath()))
+                try! fs.removeFileTree(AbsolutePath(dummyRepo.storagePath(), relativeTo: path))
                 manager = RepositoryManager(
                     fileSystem: fs,
                     path: path,


### PR DESCRIPTION
motivation: address recent deprecation of TSC APIs

changes: migrate deprecated AbsolutePath::appending concatenation APIs to use replacement Windows friendly AbsolutePath(:relativeTo) API
