### PR TITLE
PackageModel: pass along `-sdk` property on Windows

### DIFF
--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -277,7 +277,7 @@ public final class UserToolchain: Toolchain {
             return destination.extraSwiftCFlags
         }
 
-        return (triple.isDarwin() || triple.isAndroid() || triple.isWASI()
+        return (triple.isDarwin() || triple.isAndroid() || triple.isWASI() || triple.isWindows()
                 ? ["-sdk", sdk.pathString]
                 : [])
         + destination.extraSwiftCFlags


### PR DESCRIPTION
If the user specifies `-sdk` always prefer that over the `SDKROOT`
environment variable.  We would previously honor that but then fail to
pass along the argument.  We never noticed this as `SDKROOT` has always
been set up until this point.  With newer SDKs, this will become less a
guarantee.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
