### PR TITLE
Time tests for display in xunit report

### DIFF
--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -233,6 +233,8 @@ class MiscellaneousTestCase: XCTestCase {
                 XCTAssertFileExists(xUnitOutput)
                 let contents: String = try localFileSystem.readFileContents(xUnitOutput)
                 XCTAssertMatch(contents, .contains("tests=\"3\" failures=\"1\""))
+                XCTAssertMatch(contents, .regex("time=\"[0-9]+\\.[0-9]+\""))
+                XCTAssertNoMatch(contents, .contains("time=\"0.0\""))
             }
         }
     }


### PR DESCRIPTION
Time tests for display in xunit report

### Motivation:

It is useful to see simple reports on how long tests take to complete so a proper time duration has been added to the xunit report.

### Modifications:

Replaced hardcoded time of `0.0` in xunit reports with proper time duration for each test run.

### Result:

Xunit reports now report an accurate time duration for each testcase and an aggregate duration for each testsuite.
