### PR TITLE
Fix issues with recent `UserToolchain` refactor

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -702,7 +702,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         let moduleCachePath = (ProcessEnv.vars["SWIFTPM_MODULECACHE_OVERRIDE"] ?? ProcessEnv.vars["SWIFTPM_TESTS_MODULECACHE"]).flatMap{ AbsolutePath.init($0) }
 
         var cmd: [String] = []
-        cmd += [self.toolchain.swiftCompilerPath.pathString]
+        cmd += [self.toolchain.swiftCompilerPathForManifests.pathString]
 
         // if runtimePath is set to "PackageFrameworks" that means we could be developing SwiftPM in Xcode
         // which produces a framework for dynamic package products.

--- a/Sources/Workspace/DefaultPluginScriptRunner.swift
+++ b/Sources/Workspace/DefaultPluginScriptRunner.swift
@@ -145,7 +145,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
             let runtimePath = self.toolchain.swiftPMLibrariesLocation.pluginLibraryPath
 
             // We use the toolchain's Swift compiler for compiling the plugin.
-            var command = [self.toolchain.swiftCompilerPath.pathString]
+            var command = [self.toolchain.swiftCompilerPathForManifests.pathString]
 
             // if runtimePath is set to "PackageFrameworks" that means we could be developing SwiftPM in Xcode
             // which produces a framework for dynamic package products.
@@ -174,7 +174,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
             }
             else {
                 // Add an `-rpath` so the Swift 5.5 fallback libraries can be found.
-                let swiftSupportLibPath = self.toolchain.swiftCompilerPath.parentDirectory.parentDirectory.appending(components: "lib", "swift-5.5", "macosx")
+                let swiftSupportLibPath = self.toolchain.swiftCompilerPathForManifests.parentDirectory.parentDirectory.appending(components: "lib", "swift-5.5", "macosx")
                 command += ["-Xlinker", "-rpath", "-Xlinker", swiftSupportLibPath.pathString]
             }
             #endif


### PR DESCRIPTION
This fixes two issues with the recent toolchain refactor:
- The custom search paths weren't being used for finding `swiftc`
- We lost the differentiation between the general and the manifest-specific Swift compiler. This restores it.
