### PR TITLE
Temporarily mark `testSwiftRunSIGINT` as skipped since it fails occasionally

### DIFF
--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -382,7 +382,10 @@ class MiscellaneousTestCase: XCTestCase {
       #endif
     }
 
-    func testSwiftRunSIGNINT() throws {
+    func testSwiftRunSIGINT() throws {
+        #if true
+        throw XCTSkip("skipping intermittently failing test (rdar://91024625)")
+        #else
         try fixture(name: "Miscellaneous/SwiftRun") { fixturePath in
             let mainFilePath = fixturePath.appending(component: "main.swift")
             try localFileSystem.removeFileTree(mainFilePath)
@@ -460,6 +463,7 @@ class MiscellaneousTestCase: XCTestCase {
                 case done
             }
         }
+        #endif
     }
 
     func testReportingErrorFromGitCommand() throws {


### PR DESCRIPTION
### Motivation:

This test has been failing intermittently in CI, causing problems producing a nightly toolchain, so we've been asked to mark it skipped for now.


I didn't see anything by code inspection, and I couldn't get it to reproduce locally.  The problem seems to be in the test itself and not in the SIGINT functionality itself.

The `#if true` notation is to avoid getting a warning about unreachable code.
