### PR TITLE
Throw an error if Target.Dependency.productItem is used instead of .product. 

### DIFF
--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -922,7 +922,7 @@ public final class Target {
 }
 
 extension Target.Dependency {
-    @available(_PackageDescription, obsoleted: 5.6, message: "use .product(name:package:condition) instead.")
+    @available(_PackageDescription, obsoleted: 5.7, message: "use .product(name:package:condition) instead.")
     public static func productItem(name: String, package: String? = nil, condition: TargetDependencyCondition? = nil) -> Target.Dependency {
         return .productItem(name: name, package: package, moduleAliases: nil, condition: nil)
     }

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -922,6 +922,11 @@ public final class Target {
 }
 
 extension Target.Dependency {
+    @available(_PackageDescription, obsoleted: 5.6, message: "use .product(name:package:condition) instead.")
+    public static func productItem(name: String, package: String? = nil, condition: TargetDependencyCondition? = nil) -> Target.Dependency {
+        return .productItem(name: name, package: package, moduleAliases: nil, condition: nil)
+    }
+
     /// Creates a dependency on a target in the same package.
     ///
     /// - parameters:

--- a/Tests/PackageLoadingTests/PD_5_6_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_6_LoadingTests.swift
@@ -12,7 +12,6 @@
 
 import Basics
 import PackageModel
-import PackageLoading
 import SPMTestSupport
 import TSCBasic
 import XCTest

--- a/Tests/PackageLoadingTests/PD_5_6_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_6_LoadingTests.swift
@@ -230,31 +230,4 @@ class PackageDescription5_6LoadingTests: PackageDescriptionLoadingTests {
         XCTAssertEqual(manifest.targets[0].type, .plugin)
         XCTAssertEqual(manifest.targets[0].pluginCapability, .command(intent: .custom(verb: "mycmd", description: "helpful description of mycmd"), permissions: [.writeToPackageDirectory(reason: "YOLO")]))
     }
-    
-    func testTargetDeprecatedDependencyCase() throws {
-        let content = """
-            import PackageDescription
-            let package = Package(
-                name: "Foo",
-                dependencies: [
-                   .package(url: "http://localhost/BarPkg", from: "1.1.1"),
-                ],
-                targets: [
-                    .target(name: "Foo",
-                            dependencies: [
-                                .productItem(name: "Bar", package: "BarPkg", condition: nil),
-                            ]),
-                ]
-            )
-            """
-
-        let observability = ObservabilitySystem.makeForTesting()
-        XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope)) { error in
-            if case ManifestParseError.invalidManifestFormat(let message, _) = error {
-                XCTAssertMatch(message, .contains("error: 'productItem(name:package:condition:)' is unavailable: use .product(name:package:condition) instead."))
-            } else {
-                XCTFail("unexpected error: \(error)")
-            }
-        }
-    }
 }

--- a/Tests/PackageLoadingTests/PD_5_7_LoadingTests .swift
+++ b/Tests/PackageLoadingTests/PD_5_7_LoadingTests .swift
@@ -99,4 +99,31 @@ class PackageDescription5_7LoadingTests: PackageDescriptionLoadingTests {
             }
         }
     }
+
+    func testTargetDeprecatedDependencyCase() throws {
+        let content = """
+            import PackageDescription
+            let package = Package(
+                name: "Foo",
+                dependencies: [
+                   .package(url: "http://localhost/BarPkg", from: "1.1.1"),
+                ],
+                targets: [
+                    .target(name: "Foo",
+                            dependencies: [
+                                .productItem(name: "Bar", package: "BarPkg", condition: nil),
+                            ]),
+                ]
+            )
+            """
+
+        let observability = ObservabilitySystem.makeForTesting()
+        XCTAssertThrowsError(try loadManifest(content, observabilityScope: observability.topScope)) { error in
+            if case ManifestParseError.invalidManifestFormat(let message, _) = error {
+                XCTAssertMatch(message, .contains("error: 'productItem(name:package:condition:)' is unavailable: use .product(name:package:condition) instead."))
+            } else {
+                XCTFail("unexpected error: \(error)")
+            }
+        }
+    }
 }


### PR DESCRIPTION
Target.Dependency.productItem/targetItem/byNameItem should not be used in a package manifest (they are only visible/public since they are part of function sigs that became public). Changing them to internal requires a lot more changes so throw an error with a suggestion to use the right API for now. Creating a static func for targetItem and byNameItem throws an invalid redeclaration error so this PR currently only handles .productItem use case.
Resolves rdar://91013735