### PR TITLE
Pass `-enable-bare-slash-regex` to Swift compiler for packages with tools version ≥ 5.7

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -752,9 +752,9 @@ public final class SwiftTargetBuildDescription {
         }
     }
 
-    // True if the active Swift compiler supports the `-enable-regex-literals` flag.
+    // True if the active Swift compiler supports the `-enable-bare-slash-regex` flag.
     public static var compilerSupportsRegexLiterals: Bool {
-        return self.checkSupportedFrontendFlags(flags: ["enable-regex-literals"], fileSystem: localFileSystem)
+        return self.checkSupportedFrontendFlags(flags: ["enable-bare-slash-regex"], fileSystem: localFileSystem)
     }
 
     /// The arguments needed to compile this target.
@@ -1070,7 +1070,7 @@ public final class SwiftTargetBuildDescription {
         
         // Add arguments to enable regular expression literals if the package is new enough and the compiler supports them.
         if toolsVersion >= .v5_7 && SwiftTargetBuildDescription.compilerSupportsRegexLiterals {
-            flags += ["-enable-regex-literals"]
+            flags += ["-enable-bare-slash-regex"]
          }
 
         // Other Swift flags.

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -752,6 +752,11 @@ public final class SwiftTargetBuildDescription {
         }
     }
 
+    // True if the active Swift compiler supports the `-enable-regex-literals` flag.
+    public static var compilerSupportsRegexLiterals: Bool {
+        return self.checkSupportedFrontendFlags(flags: ["enable-regex-literals"], fileSystem: localFileSystem)
+    }
+
     /// The arguments needed to compile this target.
     public func compileArguments() throws -> [String] {
         var args = [String]()
@@ -1062,6 +1067,11 @@ public final class SwiftTargetBuildDescription {
         // Swift defines.
         let swiftDefines = scope.evaluate(.SWIFT_ACTIVE_COMPILATION_CONDITIONS)
         flags += swiftDefines.map({ "-D" + $0 })
+        
+        // Add arguments to enable regular expression literals if the package is new enough and the compiler supports them.
+        if toolsVersion >= .v5_7 && SwiftTargetBuildDescription.compilerSupportsRegexLiterals {
+            flags += ["-enable-regex-literals"]
+         }
 
         // Other Swift flags.
         flags += scope.evaluate(.OTHER_SWIFT_FLAGS)

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -3042,9 +3042,9 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testEnablingRegexLiterals() throws {
-        // Skip the test if the compiler doens't support `-enable-regex-literals`.
+        // Skip the test if the compiler doens't support `-enable-bare-slash-regex`.
         try XCTSkipUnless(SwiftTargetBuildDescription.checkSupportedFrontendFlags(
-            flags: ["enable-regex-literals"], fileSystem: localFileSystem
+            flags: ["enable-bare-slash-regex"], fileSystem: localFileSystem
         ))
 
         // Construct a test fixture that has a target that sets `SWIFT_ENABLE_REGEX_LITERALS` and another that doesn't.
@@ -3099,11 +3099,11 @@ final class BuildPlanTests: XCTestCase {
             
             // Check that the target that specifies tools version 5.7 does get regex literals.
             let exe = try result.target(for: "exe").swiftTarget().compileArguments()
-            XCTAssertMatch(exe, ["-enable-regex-literals"])
+            XCTAssertMatch(exe, ["-enable-bare-slash-regex"])
 
             // Check that the target that specifies tools version 5.6 doesn't get regex literals.
             let lib = try result.target(for: "lib").swiftTarget().compileArguments()
-            XCTAssertNoMatch(lib, ["-enable-regex-literals"])
+            XCTAssertNoMatch(lib, ["-enable-bare-slash-regex"])
         }
     }
 


### PR DESCRIPTION
Pass the `-enable-bare-slash-regex` flag when the tools version of the package is at least 5.7 (to make sure that existing packages do not break, since the spelling of regular expressions that this flag enables could cause existing source code to be misinterpreted).  This change will also avoid passing the flag if the compiler doesn't support it.

### Motivation:

This is in support of https://github.com/apple/swift/pull/42140, and then changed by https://github.com/apple/swift/pull/42217.

Rather than introduce new API into the package manifest, which would need to be gated on tools version 5.7, we pass `-enable-bare-slash-regex` when compiling any Swift target that is in a package with tools version ≥ 5.7.  Packages opting into 5.7 behaviour will get this flag.

### Modifications:

- add `-enable-bare-slash-regex` to the Swift compiler for any target in a package that has tools version 5.7 or greater
- but only when the driver says that the compiler supports that flag
- add a unit test

We need to consider whether we should also update the xcbuild PIF generation.  We would need to use `OTHER_SWIFTFLAGS` to convey this flag to the compiler since the PIF doesn't define a special flag for it.

rdar://91118955