### PR TITLE
Fix broken link

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -85,7 +85,7 @@ Dependencies are specified in your `Package.swift` manifest file.
 1. The conflict may be in unfamiliar dependencies (of dependencies) that the user did not explicitly request.
 2. Due to the nature of development it would be rare for two dependency graphs to be the same. Thus the amount of help other users (often even the package authors) can offer is limited. Internet searches will likely prove fruitless.
 
-A good package manager should be designed from the start to minimize the risk of dependency hell, and where this is not possible, to mitigate it and provide tooling so that the user can solve the scenario with a minimum of trouble. The [Package Manager Community Proposal](Internals/PackageManagerCommunityProposal.md) contains our thoughts on how we intend to iterate with these hells in mind.
+A good package manager should be designed from the start to minimize the risk of dependency hell, and where this is not possible, to mitigate it and provide tooling so that the user can solve the scenario with a minimum of trouble. The [Package Manager Community Proposal](Design/PackageManagerCommunityProposal.md) contains our thoughts on how we intend to iterate with these hells in mind.
 
 The following are some of the most common “dependency hell” scenarios:
 


### PR DESCRIPTION
Replace the Package Manager Community Proposal broken link with a new working one.

replace the broken link with a new working one.

### Motivation:
Avoiding error 404 page.

### Modifications:

change the path from Internals/PackageManagerCommunityProposal.md  to ->  Design/PackageManagerCommunityProposal.md 


### Result:

The link will work properly.