### PR TITLE
[5.7] Fix ArgumentExtractor implementation bug (#4287)

### DIFF
--- a/Sources/PackagePlugin/ArgumentExtractor.swift
+++ b/Sources/PackagePlugin/ArgumentExtractor.swift
@@ -40,6 +40,7 @@ public struct ArgumentExtractor {
             else if arg.starts(with: "--\(name)=") {
                 arg.removeFirst(2 + name.count + 1)
                 values.append(arg)
+                args.remove(at: idx)
             }
             else {
                 idx += 1

--- a/Tests/PackagePluginAPITests/ArgumentExtractorTests.swift
+++ b/Tests/PackagePluginAPITests/ArgumentExtractorTests.swift
@@ -25,6 +25,15 @@ class ArgumentExtractorAPITests: XCTestCase {
         XCTAssertEqual(extractor.remainingArguments, ["Positional1", "Positional2"])
     }
 
+    func testExtractOption() throws {
+        var extractor = ArgumentExtractor(["--output", "Dir1", "--target=Target1", "Positional1", "--flag", "--target", "Target2", "Positional2", "--output=Dir2"])
+        XCTAssertEqual(extractor.extractOption(named: "target"), ["Target1", "Target2"])
+        XCTAssertEqual(extractor.extractOption(named: "output"), ["Dir1", "Dir2"])
+        XCTAssertEqual(extractor.extractFlag(named: "flag"), 1)
+        XCTAssertEqual(extractor.unextractedOptionsOrFlags, [])
+        XCTAssertEqual(extractor.remainingArguments, ["Positional1", "Positional2"])
+    }
+
     func testDashDashTerminal() throws {
         var extractor = ArgumentExtractor(["--verbose", "--", "--target", "Target1", "Positional", "--verbose"])
         XCTAssertEqual(extractor.extractOption(named: "target"), [])


### PR DESCRIPTION
Fix ArgumentExtractor implementation bug

### Motivation:
`swift-docc-plugin` uses the PackagePlugin API and support `generate-documentation` action.

If we run
```
swift package --allow-writing-to-directory ./docs \
    generate-documentation --target SymbolKit --output-path ./docs
```
It will be fine.
However if we run
```
swift package --allow-writing-to-directory ./docs \
    generate-documentation --target=SymbolKit --output-path ./docs
```
It will loop infinitely.

And the core reason seems to be the ArgumentExtractor implementation in PackagePlugin Package.

### Modifications:

- Fix the ArgumentExtractor implementation bug
- Add testExtractOption for ArgumentExtractor

### Result:

When using `--<name>=<value>` form to specify the argument, the Plugin will no long loop infinitely.
