### PR TITLE
[5.6] refactor CLI options

### DIFF
--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -16,7 +16,223 @@ import PackageModel
 import SPMBuildCore
 import Build
 
-struct BuildFlagsGroup: ParsableArguments {
+struct GlobalOptions: ParsableArguments {
+    init() {}
+
+    @OptionGroup()
+    var locations: LocationOptions
+
+    @OptionGroup()
+    var caching: CachingOptions
+
+    @OptionGroup()
+    var logging: LoggingOptions
+
+    @OptionGroup()
+    var security: SecurityOptions
+
+    @OptionGroup()
+    var resolver: ResolverOptions
+
+    @OptionGroup()
+    var build: BuildOptions
+
+    @OptionGroup()
+    var linker: LinkerOptions
+}
+
+struct LocationOptions: ParsableArguments {
+    init() {}
+
+    /// The custom build directory, if provided.
+    @Option(help: "Specify build/cache directory")
+    var buildPath: AbsolutePath?
+
+    @Option(help: "Specify the shared cache directory")
+    var cachePath: AbsolutePath?
+
+    @Option(help: "Specify the shared configuration directory")
+    var configPath: AbsolutePath?
+
+    @Option(help: "Specify the shared security directory")
+    var securityPath: AbsolutePath?
+
+    /// The custom working directory that the tool should operate in (deprecated).
+    @Option(name: [.long, .customShort("C")])
+    var chdir: AbsolutePath?
+
+    /// The custom working directory that the tool should operate in.
+    @Option(help: "Change working directory before any other operation")
+    var packagePath: AbsolutePath?
+
+    /// The path to the file containing multiroot package data. This is currently Xcode's workspace file.
+    @Option(name: .customLong("multiroot-data-file"), completion: .file())
+    var multirootPackageDataFile: AbsolutePath?
+
+    /// Path to the compilation destination describing JSON file.
+    @Option(name: .customLong("destination"), completion: .file())
+    var customCompileDestination: AbsolutePath?
+}
+
+struct CachingOptions: ParsableArguments {
+    /// Disables package caching.
+    @Flag(name: .customLong("dependency-cache"), inversion: .prefixedEnableDisable, help: "Use a shared cache when fetching dependencies")
+    var _useDependenciesCache: Bool?
+
+    // TODO: simplify when deprecating the older flag
+    var useDependenciesCache: Bool {
+        if let value = self._useDependenciesCache {
+            return value
+        } else if let value = self._deprecated_useRepositoriesCache {
+            return value
+        } else {
+            return true
+        }
+    }
+
+    /// Disables manifest caching.
+    @Flag(name: .customLong("disable-package-manifest-caching"), help: .hidden)
+    var shouldDisableManifestCaching: Bool = false
+
+    /// Whether to enable llbuild manifest caching.
+    @Flag(name: .customLong("build-manifest-caching"), inversion: .prefixedEnableDisable)
+    var cacheBuildManifest: Bool = true
+
+    /// Disables manifest caching.
+    @Option(name: .customLong("manifest-cache"), help: "Caching mode of Package.swift manifests (shared: shared cache, local: package's build directory, none: disabled")
+    var manifestCachingMode: ManifestCachingMode = .shared
+
+    enum ManifestCachingMode: String, ExpressibleByArgument {
+        case none
+        case local
+        case shared
+
+        init?(argument: String) {
+            self.init(rawValue: argument)
+        }
+    }
+
+    /// Disables repository caching.
+    @Flag(name: .customLong("repository-cache"), inversion: .prefixedEnableDisable, help: .hidden)
+    var _deprecated_useRepositoriesCache: Bool?
+}
+
+struct LoggingOptions: ParsableArguments {
+    init() {}
+
+    /// The verbosity of informational output.
+    @Flag(name: .shortAndLong, help: "Increase verbosity to include informational output")
+    var verbose: Bool = false
+
+    /// The verbosity of informational output.
+    @Flag(name: [.long, .customLong("vv")], help: "Increase verbosity to include debug output")
+    var veryVerbose: Bool = false
+}
+
+struct SecurityOptions: ParsableArguments {
+    init() {}
+
+    /// Disables sandboxing when executing subprocesses.
+    @Flag(name: .customLong("disable-sandbox"), help: "Disable using the sandbox when executing subprocesses")
+    var shouldDisableSandbox: Bool = false
+
+    /// Whether to load .netrc files for authenticating with remote servers
+    /// when downloading binary artifacts or communicating with a registry.
+    @Flag(inversion: .prefixedEnableDisable,
+          exclusivity: .exclusive,
+          help: "Load credentials from a .netrc file")
+    var netrc: Bool = true
+
+    /// The path to the .netrc file used when `netrc` is `true`.
+    @Option(
+        name: .customLong("netrc-file"),
+        help: "Specify the .netrc file path.",
+        completion: .file())
+    var netrcFilePath: AbsolutePath?
+
+    /// Whether to use keychain for authenticating with remote servers
+    /// when downloading binary artifacts or communicating with a registry.
+    #if canImport(Security)
+    @Flag(inversion: .prefixedEnableDisable,
+          exclusivity: .exclusive,
+          help: "Search credentials in macOS keychain")
+    var keychain: Bool = true
+    #else
+    @Flag(inversion: .prefixedEnableDisable,
+          exclusivity: .exclusive,
+          help: .hidden)
+    var keychain: Bool = false
+    #endif
+
+    @Option(name: .customLong("resolver-fingerprint-checking"))
+    var fingerprintCheckingMode: FingerprintCheckingMode = .warn
+
+    @Flag(name: .customLong("netrc"), help: .hidden)
+    var _deprecated_netrc: Bool = false
+
+    @Flag(name: .customLong("netrc-optional"), help: .hidden)
+    var _deprecated_netrcOptional: Bool = false
+}
+
+struct ResolverOptions: ParsableArguments {
+    init() {}
+
+    /// Enable prefetching in resolver which will kick off parallel git cloning.
+    @Flag(name: .customLong("prefetching"), inversion: .prefixedEnableDisable)
+    var shouldEnableResolverPrefetching: Bool = true
+
+    /// Use Package.resolved file for resolving dependencies.
+    @Flag(name: [.long, .customLong("disable-automatic-resolution"), .customLong("only-use-versions-from-resolved-file")], help: "Only use versions from the Package.resolved file and fail resolution if it is out-of-date")
+    var forceResolvedVersions: Bool = false
+
+    /// Skip updating dependencies from their remote during a resolution.
+    @Flag(name: .customLong("skip-update"), help: "Skip updating dependencies from their remote during a resolution")
+    var skipDependencyUpdate: Bool = false
+
+
+    @Flag(help: "Define automatic transformation of source control based dependencies to registry based ones")
+    var sourceControlToRegistryDependencyTransformation: SourceControlToRegistryDependencyTransformation = .disabled
+
+    /// Write dependency resolver trace to a file.
+    @Flag(name: .customLong("trace-resolver"), help: .hidden)
+    var _deprecated_enableResolverTrace: Bool = false
+
+    enum SourceControlToRegistryDependencyTransformation: EnumerableFlag {
+        case disabled
+        case identity
+        case swizzle
+
+        static func name(for value: Self) -> NameSpecification {
+            switch value {
+            case .disabled:
+                return .customLong("disable-scm-to-registry-transformation")
+            case .identity:
+                return .customLong("use-registry-identity-for-scm")
+            case .swizzle:
+                return .customLong("replace-scm-with-registry")
+            }
+        }
+
+        static func help(for value: SourceControlToRegistryDependencyTransformation) -> ArgumentHelp? {
+            switch value {
+            case .disabled:
+                return "disable source control to registry transformation"
+            case .identity:
+                return "look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins"
+            case .swizzle:
+                return "look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible"
+            }
+        }
+    }
+}
+
+struct BuildOptions: ParsableArguments {
+    init() {}
+
+    /// Build configuration.
+    @Option(name: .shortAndLong, help: "Build with configuration")
+    var configuration: BuildConfiguration = .debug
+
     @Option(name: .customLong("Xcc", withSingleDash: true),
             parsing: .unconditionalSingleValue,
             help: "Pass flag through to all C compiler invocations")
@@ -58,154 +274,6 @@ struct BuildFlagsGroup: ParsableArguments {
             xlinker: linkerFlags)
     }
 
-    init() {}
-}
-
-extension BuildConfiguration: ExpressibleByArgument {
-    public init?(argument: String) {
-        self.init(rawValue: argument)
-    }
-}
-
-extension AbsolutePath: ExpressibleByArgument {
-    public init?(argument: String) {
-        if let cwd = localFileSystem.currentWorkingDirectory {
-            self.init(argument, relativeTo: cwd)
-        } else {
-            guard let path = try? AbsolutePath(validating: argument) else {
-                return nil
-            }
-            self = path
-        }
-    }
-
-    public static var defaultCompletionKind: CompletionKind {
-        // This type is most commonly used to select a directory, not a file.
-        // Specify '.file()' in an argument declaration when necessary.
-        .directory
-    }
-}
-
-enum BuildSystemKind: String, ExpressibleByArgument, CaseIterable {
-    case native
-    case xcode
-}
-
-extension FingerprintCheckingMode: ExpressibleByArgument {
-    public init?(argument: String) {
-        self.init(rawValue: argument)
-    }
-}
-
-public extension Sanitizer {
-    init(argument: String) throws {
-        if let sanitizer = Sanitizer(rawValue: argument) {
-            self = sanitizer
-            return
-        }
-
-        for sanitizer in Sanitizer.allCases where sanitizer.shortName == argument {
-            self = sanitizer
-            return
-        }
-
-        throw StringError("valid sanitizers: \(Sanitizer.formattedValues)")
-    }
-
-    /// All sanitizer options in a comma separated string
-    fileprivate static var formattedValues: String {
-        return Sanitizer.allCases.map(\.rawValue).joined(separator: ", ")
-    }
-}
-
-public struct SwiftToolOptions: ParsableArguments {
-    @OptionGroup()
-    var buildFlagsGroup: BuildFlagsGroup
-
-    /// Custom arguments to pass to C compiler, swift compiler and the linker.
-    var buildFlags: BuildFlags {
-        buildFlagsGroup.buildFlags
-    }
-
-    var xcbuildFlags: [String] {
-        buildFlagsGroup.xcbuildFlags
-    }
-
-    var manifestFlags: [String] {
-        buildFlagsGroup.manifestFlags
-    }
-
-    /// Build configuration.
-    @Option(name: .shortAndLong, help: "Build with configuration")
-    var configuration: BuildConfiguration = .debug
-
-    /// The custom build directory, if provided.
-    @Option(help: "Specify build/cache directory")
-    var buildPath: AbsolutePath?
-
-    @Option(help: "Specify the shared cache directory")
-    var cachePath: AbsolutePath?
-
-    @Option(help: "Specify the shared configuration directory")
-    var configPath: AbsolutePath?
-
-    @Option(help: "Specify the shared security directory")
-    var securityPath: AbsolutePath?
-
-    /// Disables repository caching.
-    @Flag(name: .customLong("repository-cache"), inversion: .prefixedEnableDisable, help: "Use a shared cache when fetching repositories")
-    var useRepositoriesCache: Bool = true
-
-    /// The custom working directory that the tool should operate in (deprecated).
-    @Option(name: [.long, .customShort("C")])
-    var chdir: AbsolutePath?
-
-    /// The custom working directory that the tool should operate in.
-    @Option(help: "Change working directory before any other operation")
-    var packagePath: AbsolutePath?
-
-    /// The path to the file containing multiroot package data. This is currently Xcode's workspace file.
-    @Option(name: .customLong("multiroot-data-file"), completion: .file())
-    var multirootPackageDataFile: AbsolutePath?
-
-    /// Enable prefetching in resolver which will kick off parallel git cloning.
-    @Flag(name: .customLong("prefetching"), inversion: .prefixedEnableDisable)
-    var shouldEnableResolverPrefetching: Bool = true
-
-    /// The verbosity of informational output.
-    @Flag(name: .shortAndLong, help: "Increase verbosity to include informational output")
-    var verbose: Bool = false
-
-    /// The verbosity of informational output.
-    @Flag(name: [.long, .customLong("vv")], help: "Increase verbosity to include debug output")
-    var veryVerbose: Bool = false
-
-    /// Disables sandboxing when executing subprocesses.
-    @Flag(name: .customLong("disable-sandbox"), help: "Disable using the sandbox when executing subprocesses")
-    var shouldDisableSandbox: Bool = false
-
-    /// Disables manifest caching.
-    @Flag(name: .customLong("disable-package-manifest-caching"), help: .hidden)
-    var shouldDisableManifestCaching: Bool = false
-
-    /// Disables manifest caching.
-    @Option(name: .customLong("manifest-cache"), help: "Caching mode of Package.swift manifests (shared: shared cache, local: package's build directory, none: disabled")
-    var manifestCachingMode: ManifestCachingMode = .shared
-
-    enum ManifestCachingMode: String, ExpressibleByArgument {
-        case none
-        case local
-        case shared
-
-        init?(argument: String) {
-            self.init(rawValue: argument)
-        }
-    }
-
-    /// Path to the compilation destination describing JSON file.
-    @Option(name: .customLong("destination"), completion: .file())
-    var customCompileDestination: AbsolutePath?
-
     /// The compilation destination’s target triple.
     @Option(name: .customLong("triple"), transform: Triple.init)
     var customCompileTriple: Triple?
@@ -226,14 +294,6 @@ public struct SwiftToolOptions: ParsableArguments {
         shouldDisplay: false))
     public var archs: [String] = []
 
-    /// If should link the Swift stdlib statically.
-    @Flag(name: .customLong("static-swift-stdlib"), inversion: .prefixedNo, help: "Link Swift stdlib statically")
-    var shouldLinkStaticSwiftStdlib: Bool = false
-
-    /// Skip updating dependencies from their remote during a resolution.
-    @Flag(name: .customLong("skip-update"), help: "Skip updating dependencies from their remote during a resolution")
-    var skipDependencyUpdate: Bool = false
-
     /// Which compile-time sanitizers should be enabled.
     @Option(name: .customLong("sanitize"),
             help: "Turn on runtime checks for erroneous behavior, possible values: \(Sanitizer.formattedValues)",
@@ -244,37 +304,6 @@ public struct SwiftToolOptions: ParsableArguments {
         EnabledSanitizers(Set(sanitizers))
     }
 
-    /// Whether to enable code coverage.
-    @Flag(name: .customLong("code-coverage"),
-          inversion: .prefixedEnableDisable,
-          help: "Enable code coverage")
-    var shouldEnableCodeCoverage: Bool = false
-
-    /// Use Package.resolved file for resolving dependencies.
-    @Flag(name: [.long, .customLong("disable-automatic-resolution"), .customLong("only-use-versions-from-resolved-file")], help: "Only use versions from the Package.resolved file and fail resolution if it is out-of-date")
-    var forceResolvedVersions: Bool = false
-
-    // @Flag works best when there is a default value present
-    // if true, false aren't enough and a third state is needed
-    // nil should not be the goto. Instead create an enum
-    enum StoreMode: EnumerableFlag {
-        case autoIndexStore
-        case enableIndexStore
-        case disableIndexStore
-
-        /// The mode to use for indexing-while-building feature.
-        var indexStoreMode: BuildParameters.IndexStoreMode {
-            switch self {
-            case .autoIndexStore:
-                return .auto
-            case .enableIndexStore:
-                return .on
-            case .disableIndexStore:
-                return .off
-            }
-        }
-    }
-
     @Flag(help: "Enable or disable indexing-while-building feature")
     var indexStoreMode: StoreMode = .autoIndexStore
 
@@ -282,21 +311,9 @@ public struct SwiftToolOptions: ParsableArguments {
     @Flag(name: .customLong("enable-parseable-module-interfaces"))
     var shouldEnableParseableModuleInterfaces: Bool = false
 
-    /// Write dependency resolver trace to a file.
-    @Flag(name: .customLong("trace-resolver"), help: .hidden)
-    var _deprecated_enableResolverTrace: Bool = false
-
     /// The number of jobs for llbuild to start (aka the number of schedulerLanes)
     @Option(name: .shortAndLong, help: "The number of jobs to spawn in parallel during the build process")
     var jobs: UInt32?
-
-    /// Whether to enable test discovery on platforms without Objective-C runtime.
-    @Flag(help: .hidden)
-    var enableTestDiscovery: Bool = false
-
-    /// Whether to enable llbuild manifest caching.
-    @Flag(name: .customLong("build-manifest-caching"), inversion: .prefixedEnableDisable)
-    var cacheBuildManifest: Bool = true
 
     /// Emit the Swift module separately from the object files.
     @Flag()
@@ -331,42 +348,91 @@ public struct SwiftToolOptions: ParsableArguments {
         #endif
     }
 
-    /// Whether to load .netrc files for authenticating with remote servers
-    /// when downloading binary artifacts or communicating with a registry.
-    @Flag(inversion: .prefixedEnableDisable,
-          exclusivity: .exclusive,
-          help: "Load credentials from a .netrc file")
-    var netrc: Bool = true
+    /// Whether to enable test discovery on platforms without Objective-C runtime.
+    @Flag(help: .hidden)
+    var enableTestDiscovery: Bool = false
 
-    /// The path to the .netrc file used when `netrc` is `true`.
-    @Option(
-        name: .customLong("netrc-file"),
-        help: "Specify the .netrc file path.",
-        completion: .file())
-    var netrcFilePath: AbsolutePath?
+    // @Flag works best when there is a default value present
+    // if true, false aren't enough and a third state is needed
+    // nil should not be the goto. Instead create an enum
+    enum StoreMode: EnumerableFlag {
+        case autoIndexStore
+        case enableIndexStore
+        case disableIndexStore
+    }
 
-    /// Whether to use keychain for authenticating with remote servers
-    /// when downloading binary artifacts or communicating with a registry.
-#if canImport(Security)
-    @Flag(inversion: .prefixedEnableDisable,
-          exclusivity: .exclusive,
-          help: "Search credentials in macOS keychain")
-    var keychain: Bool = true
-#else
-    @Flag(inversion: .prefixedEnableDisable,
-          exclusivity: .exclusive,
-          help: .hidden)
-    var keychain: Bool = false
-#endif
-    
-    @Option(name: .customLong("resolver-fingerprint-checking"))
-    var resolverFingerprintCheckingMode: FingerprintCheckingMode = .warn
+    enum BuildSystemKind: String, ExpressibleByArgument, CaseIterable {
+        case native
+        case xcode
+    }
+}
 
-    @Flag(name: .customLong("netrc"), help: .hidden)
-    var _deprecated_netrc: Bool = false
+struct LinkerOptions: ParsableArguments {
+    init() {}
 
-    @Flag(name: .customLong("netrc-optional"), help: .hidden)
-    var _deprecated_netrcOptional: Bool = false
+    @Flag(
+        name: .customLong("dead-strip"),
+        inversion: .prefixedEnableDisable,
+        help: "Disable/enable dead code stripping by the linker")
+    var linkerDeadStrip: Bool = true
 
-    public init() {}
+    /// If should link the Swift stdlib statically.
+    @Flag(name: .customLong("static-swift-stdlib"), inversion: .prefixedNo, help: "Link Swift stdlib statically")
+    var shouldLinkStaticSwiftStdlib: Bool = false
+}
+
+
+// MARK: - Extensions
+
+
+extension BuildConfiguration: ExpressibleByArgument {
+    public init?(argument: String) {
+        self.init(rawValue: argument)
+    }
+}
+
+extension AbsolutePath: ExpressibleByArgument {
+    public init?(argument: String) {
+        if let cwd = localFileSystem.currentWorkingDirectory {
+            self.init(argument, relativeTo: cwd)
+        } else {
+            guard let path = try? AbsolutePath(validating: argument) else {
+                return nil
+            }
+            self = path
+        }
+    }
+
+    public static var defaultCompletionKind: CompletionKind {
+        // This type is most commonly used to select a directory, not a file.
+        // Specify '.file()' in an argument declaration when necessary.
+        .directory
+    }
+}
+
+extension FingerprintCheckingMode: ExpressibleByArgument {
+    public init?(argument: String) {
+        self.init(rawValue: argument)
+    }
+}
+
+extension Sanitizer {
+    init(argument: String) throws {
+        if let sanitizer = Sanitizer(rawValue: argument) {
+            self = sanitizer
+            return
+        }
+
+        for sanitizer in Sanitizer.allCases where sanitizer.shortName == argument {
+            self = sanitizer
+            return
+        }
+
+        throw StringError("valid sanitizers: \(Sanitizer.formattedValues)")
+    }
+
+    /// All sanitizer options in a comma separated string
+    fileprivate static var formattedValues: String {
+        return Sanitizer.allCases.map(\.rawValue).joined(separator: ", ")
+    }
 }

--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -83,8 +83,8 @@ public struct SwiftBuildTool: SwiftCommand {
         version: SwiftVersion.currentVersion.completeDisplayString,
         helpNames: [.short, .long, .customLong("help", withSingleDash: true)])
 
-    @OptionGroup(_hiddenFromHelp: true)
-    var swiftOptions: SwiftToolOptions
+    @OptionGroup()
+    var globalOptions: GlobalOptions
 
     @OptionGroup()
     var options: BuildToolOptions

--- a/Sources/Commands/SwiftPackageCollectionsTool.swift
+++ b/Sources/Commands/SwiftPackageCollectionsTool.swift
@@ -79,7 +79,7 @@ public struct SwiftPackageCollectionsTool: ParsableCommand {
         var jsonOptions: JSONOptions
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         func run(_ swiftTool: SwiftTool) throws {
             let collections = try with(swiftTool) { collections in
@@ -100,7 +100,7 @@ public struct SwiftPackageCollectionsTool: ParsableCommand {
         static let configuration = CommandConfiguration(abstract: "Refresh configured collections")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         func run(_ swiftTool: SwiftTool) throws {
             let collections = try with(swiftTool) { collections in
@@ -126,7 +126,7 @@ public struct SwiftPackageCollectionsTool: ParsableCommand {
         var skipSignatureCheck: Bool = false
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         func run(_ swiftTool: SwiftTool) throws {
             let collectionURL = try url(self.collectionURL)
@@ -165,7 +165,7 @@ public struct SwiftPackageCollectionsTool: ParsableCommand {
         var collectionURL: String
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         func run(_ swiftTool: SwiftTool) throws {
             let collectionURL = try url(self.collectionURL)
@@ -199,7 +199,7 @@ public struct SwiftPackageCollectionsTool: ParsableCommand {
         var searchQuery: String
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         func run(_ swiftTool: SwiftTool) throws {
             try with(swiftTool) { collections in
@@ -246,7 +246,7 @@ public struct SwiftPackageCollectionsTool: ParsableCommand {
         var version: String?
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         private func printVersion(_ version: PackageCollectionsModel.Package.Version?) -> String? {
             guard let version = version else {

--- a/Sources/Commands/SwiftPackageRegistryTool.swift
+++ b/Sources/Commands/SwiftPackageRegistryTool.swift
@@ -55,7 +55,7 @@ public struct SwiftPackageRegistryTool: ParsableCommand {
         helpNames: [.short, .long, .customLong("help", withSingleDash: true)])
 
     @OptionGroup()
-    var swiftOptions: SwiftToolOptions
+    var globalOptions: GlobalOptions
 
     public init() {}
 
@@ -64,7 +64,7 @@ public struct SwiftPackageRegistryTool: ParsableCommand {
             abstract: "Set a custom registry")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Flag(help: "Apply settings to all projects for this user")
         var global: Bool = false
@@ -116,7 +116,7 @@ public struct SwiftPackageRegistryTool: ParsableCommand {
             abstract: "Remove a configured registry")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Flag(help: "Apply settings to all projects for this user")
         var global: Bool = false

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -69,7 +69,7 @@ public struct SwiftPackageTool: ParsableCommand {
         helpNames: [.short, .long, .customLong("help", withSingleDash: true)])
 
     @OptionGroup()
-    var swiftOptions: SwiftToolOptions
+    var globalOptions: GlobalOptions
 
     public init() {}
 
@@ -84,7 +84,7 @@ extension SwiftPackageTool {
             abstract: "Delete build artifacts")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         func run(_ swiftTool: SwiftTool) throws {
             try swiftTool.getActiveWorkspace().clean(observabilityScope: swiftTool.observabilityScope)
@@ -96,7 +96,7 @@ extension SwiftPackageTool {
             abstract: "Purge the global repository cache.")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         func run(_ swiftTool: SwiftTool) throws {
             try swiftTool.getActiveWorkspace().purgeCache(observabilityScope: swiftTool.observabilityScope)
@@ -108,7 +108,7 @@ extension SwiftPackageTool {
             abstract: "Reset the complete cache/build directory")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         func run(_ swiftTool: SwiftTool) throws {
             try swiftTool.getActiveWorkspace().reset(observabilityScope: swiftTool.observabilityScope)
@@ -120,7 +120,7 @@ extension SwiftPackageTool {
             abstract: "Update package dependencies")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Flag(name: [.long, .customShort("n")],
               help: "Display the list of dependencies that can be updated")
@@ -166,7 +166,7 @@ extension SwiftPackageTool {
             abstract: "Describe the current package")
         
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
         
         @Option(help: "json | text")
         var type: DescribeMode = .text
@@ -220,7 +220,7 @@ extension SwiftPackageTool {
             abstract: "Initialize a new package")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Option(name: .customLong("type"), help: "Package type: empty | library | executable | system-module | manifest")
         var initMode: InitPackage.PackageType = .library
@@ -251,7 +251,7 @@ extension SwiftPackageTool {
             commandName: "_format")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Argument(parsing: .unconditionalRemaining,
                   help: "Pass flag through to the swift-format tool")
@@ -337,7 +337,7 @@ extension SwiftPackageTool {
             """)
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Option(help: """
         The path to a text file containing breaking changes which should be ignored by the API comparison. \
@@ -368,7 +368,7 @@ extension SwiftPackageTool {
             let apiDigesterPath = try swiftTool.getToolchain().getSwiftAPIDigester()
             let apiDigesterTool = SwiftAPIDigester(tool: apiDigesterPath)
 
-            let packageRoot = try swiftOptions.packagePath ?? swiftTool.getPackageRoot()
+            let packageRoot = try globalOptions.locations.packagePath ?? swiftTool.getPackageRoot()
             let repository = GitRepository(path: packageRoot)
             let baselineRevision = try repository.resolveRevision(identifier: treeish)
 
@@ -537,7 +537,7 @@ extension SwiftPackageTool {
         static let defaultMinimumAccessLevel = SymbolGraphExtract.AccessLevel.public
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Flag(help: "Pretty-print the output JSON.")
         var prettyPrint = false
@@ -591,7 +591,7 @@ extension SwiftPackageTool {
             abstract: "Print parsed Package.swift as JSON")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         func run(_ swiftTool: SwiftTool) throws {
             let workspace = try swiftTool.getActiveWorkspace()
@@ -619,7 +619,7 @@ extension SwiftPackageTool {
 
     struct DumpPIF: SwiftCommand {
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Flag(help: "Preserve the internal structure of PIF")
         var preserveStructure: Bool = false
@@ -643,7 +643,7 @@ extension SwiftPackageTool {
             abstract: "Put a package in editable mode")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Option(help: "The revision to edit", transform: { Revision(identifier: $0) })
         var revision: Revision?
@@ -677,7 +677,7 @@ extension SwiftPackageTool {
             abstract: "Remove a package from editable mode")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Flag(name: .customLong("force"),
               help: "Unedit the package even if it has uncommited and unpushed changes")
@@ -704,7 +704,7 @@ extension SwiftPackageTool {
             abstract: "Print the resolved dependency graph")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Option(help: "text | dot | json | flatlist")
         var format: ShowDependenciesMode = .text
@@ -770,7 +770,7 @@ extension SwiftPackageTool {
             abstract: "Manipulate tools version of the current package")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Flag(help: "Set tools version of package to the current tools version in use")
         var setCurrent: Bool = false
@@ -826,7 +826,7 @@ extension SwiftPackageTool {
             abstract: "Compute the checksum for a binary artifact.")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Argument(help: "The absolute or relative path to the binary artifact")
         var path: AbsolutePath
@@ -847,7 +847,7 @@ extension SwiftPackageTool {
         )
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Option(
             name: [.short, .long],
@@ -856,7 +856,7 @@ extension SwiftPackageTool {
         var output: AbsolutePath?
 
         func run(_ swiftTool: SwiftTool) throws {
-            let packageRoot = try swiftOptions.packagePath ?? swiftTool.getPackageRoot()
+            let packageRoot = try globalOptions.locations.packagePath ?? swiftTool.getPackageRoot()
             let repository = GitRepository(path: packageRoot)
 
             let destination: AbsolutePath
@@ -888,7 +888,7 @@ extension SwiftPackageTool {
         )
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Flag(name: .customLong("list"),
               help: "List the available command plugins")
@@ -974,7 +974,7 @@ extension SwiftPackageTool {
             let pluginScriptRunner = DefaultPluginScriptRunner(
                 cacheDir: pluginsDir.appending(component: "cache"),
                 toolchain: try swiftTool.getToolchain().configuration,
-                enableSandbox: !swiftTool.options.shouldDisableSandbox)
+                enableSandbox: !swiftTool.options.security.shouldDisableSandbox)
 
             // The `outputs` directory contains subdirectories for each combination of package and command plugin. Each usage of a plugin has an output directory that is writable by the plugin, where it can write additional files, and to which it can configure tools to write their outputs, etc.
             let outputDir = pluginsDir.appending(component: "outputs")
@@ -1232,19 +1232,23 @@ final class PluginDelegate: PluginInvocationDelegate {
         }
 
         // Construct the environment we'll pass down to the tests.
-        var environmentOptions = swiftTool.options
-        environmentOptions.shouldEnableCodeCoverage = parameters.enableCodeCoverage
         let testEnvironment = try TestingSupport.constructTestEnvironment(
             toolchain: toolchain,
-            options: environmentOptions,
-            buildParameters: buildParameters)
+            buildParameters: buildParameters,
+            sanitizers: swiftTool.options.build.sanitizers
+        )
 
         // Iterate over the tests and run those that match the filter.
         var testTargetResults: [PluginInvocationTestResult.TestTarget] = []
         var numFailedTests = 0
         for testProduct in buildSystem.builtTestProducts {
             // Get the test suites in the bundle. Each is just a container for test cases.
-            let testSuites = try TestingSupport.getTestSuites(fromTestAt: testProduct.bundlePath, swiftTool: swiftTool, swiftOptions: swiftTool.options)
+            let testSuites = try TestingSupport.getTestSuites(
+                fromTestAt: testProduct.bundlePath,
+                swiftTool: swiftTool,
+                enableCodeCoverage: parameters.enableCodeCoverage,
+                sanitizers: swiftTool.options.build.sanitizers
+            )
             for testSuite in testSuites {
                 // Each test suite is just a container for test cases (confusingly called "tests", though they are test cases).
                 for testCase in testSuite.tests {
@@ -1421,7 +1425,7 @@ extension SwiftPackageTool {
             shouldDisplay: false)
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @OptionGroup()
         var pluginOptions: PluginCommand.PluginOptions
@@ -1497,19 +1501,25 @@ extension SwiftPackageTool {
 
             @Flag(help: "Do not add file references for extra files to the generated Xcode project")
             var skipExtraFiles: Bool = false
+
+            /// Whether to enable code coverage.
+            @Flag(name: .customLong("code-coverage"),
+                  inversion: .prefixedEnableDisable,
+                  help: "Enable code coverage")
+            var enableCodeCoverage: Bool = false
         }
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @OptionGroup()
         var options: Options
 
         func xcodeprojOptions() -> XcodeprojOptions {
             XcodeprojOptions(
-                flags: swiftOptions.buildFlags,
+                flags: globalOptions.build.buildFlags,
                 xcconfigOverrides: options.xcconfigOverrides,
-                isCodeCoverageEnabled: swiftOptions.shouldEnableCodeCoverage,
+                isCodeCoverageEnabled: options.enableCodeCoverage,
                 useLegacySchemeGenerator: options.useLegacySchemeGenerator,
                 enableAutogeneration: options.enableAutogeneration,
                 addExtraFiles: !options.skipExtraFiles)
@@ -1578,7 +1588,7 @@ extension SwiftPackageTool.Config {
             abstract: "Set a mirror for a dependency")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Option(help: "The package dependency url")
         var packageURL: String?
@@ -1613,7 +1623,7 @@ extension SwiftPackageTool.Config {
             abstract: "Remove an existing mirror")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Option(help: "The package dependency url")
         var packageURL: String?
@@ -1648,7 +1658,7 @@ extension SwiftPackageTool.Config {
             abstract: "Print mirror configuration for the given package dependency")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Option(help: "The package dependency url")
         var packageURL: String?
@@ -1700,7 +1710,7 @@ extension SwiftPackageTool {
             abstract: "Resolve package dependencies")
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @OptionGroup()
         var resolveOptions: ResolveOptions
@@ -1731,7 +1741,7 @@ extension SwiftPackageTool {
         static let configuration = CommandConfiguration(shouldDisplay: false)
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @OptionGroup()
         var resolveOptions: ResolveOptions
@@ -1739,7 +1749,7 @@ extension SwiftPackageTool {
         func run(_ swiftTool: SwiftTool) throws {
             swiftTool.observabilityScope.emit(warning: "'fetch' command is deprecated; use 'resolve' instead")
 
-            let resolveCommand = Resolve(swiftOptions: _swiftOptions, resolveOptions: _resolveOptions)
+            let resolveCommand = Resolve(globalOptions: _globalOptions, resolveOptions: _resolveOptions)
             try resolveCommand.run(swiftTool)
         }
     }
@@ -1776,7 +1786,7 @@ extension SwiftPackageTool {
         }
 
         @OptionGroup(_hiddenFromHelp: true)
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         @Argument(help: "generate-bash-script | generate-zsh-script |\ngenerate-fish-script | list-dependencies | list-executables")
         var mode: Mode
@@ -1820,7 +1830,7 @@ extension SwiftPackageTool {
     struct Learn: SwiftCommand {
 
         @OptionGroup()
-        var swiftOptions: SwiftToolOptions
+        var globalOptions: GlobalOptions
 
         static let configuration = CommandConfiguration(abstract: "Learn about Swift and this package")
 

--- a/Sources/Commands/SwiftRunTool.swift
+++ b/Sources/Commands/SwiftRunTool.swift
@@ -93,8 +93,8 @@ public struct SwiftRunTool: SwiftCommand {
         version: SwiftVersion.currentVersion.completeDisplayString,
         helpNames: [.short, .long, .customLong("help", withSingleDash: true)])
 
-    @OptionGroup(_hiddenFromHelp: true)
-    public var swiftOptions: SwiftToolOptions
+    @OptionGroup()
+    var globalOptions: GlobalOptions
 
     @OptionGroup()
     var options: RunToolOptions

--- a/Sources/Commands/TestingSupport.swift
+++ b/Sources/Commands/TestingSupport.swift
@@ -42,9 +42,17 @@ enum TestingSupport {
         throw InternalError("XCTestHelper binary not found.")
     }
 
-    static func getTestSuites(in testProducts: [BuiltTestProduct], swiftTool: SwiftTool, swiftOptions: SwiftToolOptions) throws -> [AbsolutePath: [TestSuite]] {
+    static func getTestSuites(in testProducts: [BuiltTestProduct], swiftTool: SwiftTool, enableCodeCoverage: Bool, sanitizers: [Sanitizer]) throws -> [AbsolutePath: [TestSuite]] {
         let testSuitesByProduct = try testProducts
-            .map { try ($0.bundlePath, TestingSupport.getTestSuites(fromTestAt: $0.bundlePath, swiftTool: swiftTool, swiftOptions: swiftOptions)) }
+            .map {(
+                $0.bundlePath,
+                try Self.getTestSuites(
+                    fromTestAt: $0.bundlePath,
+                    swiftTool: swiftTool,
+                    enableCodeCoverage: enableCodeCoverage,
+                    sanitizers: sanitizers
+                )
+            )}
         return Dictionary(uniqueKeysWithValues: testSuitesByProduct)
     }
 
@@ -58,12 +66,18 @@ enum TestingSupport {
     /// - Throws: TestError, SystemError, TSCUtility.Error
     ///
     /// - Returns: Array of TestSuite
-    static func getTestSuites(fromTestAt path: AbsolutePath, swiftTool: SwiftTool, swiftOptions: SwiftToolOptions) throws -> [TestSuite] {
+    static func getTestSuites(fromTestAt path: AbsolutePath, swiftTool: SwiftTool, enableCodeCoverage: Bool, sanitizers: [Sanitizer]) throws -> [TestSuite] {
         // Run the correct tool.
         #if os(macOS)
         let data: String = try withTemporaryFile { tempFile in
-            let args = [try TestingSupport.xctestHelperPath(swiftTool: swiftTool).pathString, path.pathString, tempFile.path.pathString]
-            var env = try TestingSupport.constructTestEnvironment(toolchain: try swiftTool.getToolchain(), options: swiftOptions, buildParameters: swiftTool.buildParametersForTest())
+            let args = [try Self.xctestHelperPath(swiftTool: swiftTool).pathString, path.pathString, tempFile.path.pathString]
+            var env = try Self.constructTestEnvironment(
+                toolchain: try swiftTool.getToolchain(),
+                buildParameters: swiftTool.buildParametersForTest(
+                    enableCodeCoverage: enableCodeCoverage
+                ),
+                sanitizers: sanitizers
+            )
             // Add the sdk platform path if we have it. If this is not present, we
             // might always end up failing.
             if let sdkPlatformFrameworksPath = Destination.sdkPlatformFrameworkPaths() {
@@ -76,7 +90,13 @@ enum TestingSupport {
             return try localFileSystem.readFileContents(tempFile.path).validDescription ?? ""
         }
         #else
-        let env = try constructTestEnvironment(toolchain: try swiftTool.getToolchain(), options: swiftOptions, buildParameters: swiftTool.buildParametersForTest())
+        let env = try Self.constructTestEnvironment(
+            toolchain: try swiftTool.getToolchain(),
+            buildParameters: swiftTool.buildParametersForTest(
+                enableCodeCoverage: enableCodeCoverage
+            ),
+            sanitizers: sanitizers
+        )
         let args = [path.description, "--dump-tests-json"]
         let data = try Process.checkNonZeroExit(arguments: args, environment: env)
         #endif
@@ -87,13 +107,13 @@ enum TestingSupport {
     /// Creates the environment needed to test related tools.
     static func constructTestEnvironment(
         toolchain: UserToolchain,
-        options: SwiftToolOptions,
-        buildParameters: BuildParameters
+        buildParameters: BuildParameters,
+        sanitizers: [Sanitizer]
     ) throws -> EnvironmentVariables {
         var env = EnvironmentVariables.process()
 
         // Add the code coverage related variables.
-        if options.shouldEnableCodeCoverage {
+        if buildParameters.enableCodeCoverage {
             // Defines the path at which the profraw files will be written on test execution.
             //
             // `%m` will create a pool of profraw files and append the data from
@@ -113,12 +133,12 @@ enum TestingSupport {
         return env
         #else
         // Fast path when no sanitizers are enabled.
-        if options.sanitizers.isEmpty {
+        if sanitizers.isEmpty {
             return env
         }
 
         // Get the runtime libraries.
-        var runtimes = try options.sanitizers.map({ sanitizer in
+        var runtimes = try sanitizers.map({ sanitizer in
             return try toolchain.runtimeLibrary(for: sanitizer).pathString
         })
 
@@ -134,8 +154,11 @@ enum TestingSupport {
 }
 
 extension SwiftTool {
-    func buildParametersForTest() throws -> BuildParameters {
+    func buildParametersForTest(
+        enableCodeCoverage: Bool
+    ) throws -> BuildParameters {
         var parameters = try self.buildParameters()
+        parameters.enableCodeCoverage = enableCodeCoverage
         // for test commands, alway enable building with testability enabled
         parameters.enableTestability = true
         return parameters

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -8,7 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Commands
+@testable import Commands
 import PackageGraph
 import PackageLoading
 import PackageModel

--- a/Tests/CommandsTests/SwiftToolTests.swift
+++ b/Tests/CommandsTests/SwiftToolTests.swift
@@ -19,7 +19,7 @@ final class SwiftToolTests: CommandsTestCase {
     func testVerbosityLogLevel() throws {
         fixture(name: "Miscellaneous/Simple") { packageRoot in
             do {
-                let options = try SwiftToolOptions.parse(["--package-path", packageRoot.pathString])
+                let options = try GlobalOptions.parse(["--package-path", packageRoot.pathString])
                 let tool = try SwiftTool(options: options)
                 XCTAssertEqual(tool.logLevel, .warning)
 
@@ -30,7 +30,7 @@ final class SwiftToolTests: CommandsTestCase {
             }
 
             do {
-                let options = try SwiftToolOptions.parse(["--package-path", packageRoot.pathString, "--verbose"])
+                let options = try GlobalOptions.parse(["--package-path", packageRoot.pathString, "--verbose"])
                 let tool = try SwiftTool(options: options)
                 XCTAssertEqual(tool.logLevel, .info)
 
@@ -41,13 +41,13 @@ final class SwiftToolTests: CommandsTestCase {
             }
 
             do {
-                let options = try SwiftToolOptions.parse(["--package-path", packageRoot.pathString, "-v"])
+                let options = try GlobalOptions.parse(["--package-path", packageRoot.pathString, "-v"])
                 let tool = try SwiftTool(options: options)
                 XCTAssertEqual(tool.logLevel, .info)
             }
 
             do {
-                let options = try SwiftToolOptions.parse(["--package-path", packageRoot.pathString, "--very-verbose"])
+                let options = try GlobalOptions.parse(["--package-path", packageRoot.pathString, "--very-verbose"])
                 let tool = try SwiftTool(options: options)
                 XCTAssertEqual(tool.logLevel, .debug)
 
@@ -58,7 +58,7 @@ final class SwiftToolTests: CommandsTestCase {
             }
 
             do {
-                let options = try SwiftToolOptions.parse(["--package-path", packageRoot.pathString, "--vv"])
+                let options = try GlobalOptions.parse(["--package-path", packageRoot.pathString, "--vv"])
                 let tool = try SwiftTool(options: options)
                 XCTAssertEqual(tool.logLevel, .debug)
             }
@@ -77,7 +77,7 @@ final class SwiftToolTests: CommandsTestCase {
                     "machine mymachine.labkey.org login custom@labkey.org password custom"
                 }
 
-                let options = try SwiftToolOptions.parse(["--package-path", packageRoot.pathString, "--netrc-file", customPath.pathString])
+                let options = try GlobalOptions.parse(["--package-path", packageRoot.pathString, "--netrc-file", customPath.pathString])
                 let tool = try SwiftTool(options: options)
 
                 let netrcProviders = try tool.getNetrcAuthorizationProviders()
@@ -101,7 +101,7 @@ final class SwiftToolTests: CommandsTestCase {
                     return "machine mymachine.labkey.org login local@labkey.org password local"
                 }
 
-                let options = try SwiftToolOptions.parse(["--package-path", packageRoot.pathString])
+                let options = try GlobalOptions.parse(["--package-path", packageRoot.pathString])
                 let tool = try SwiftTool(options: options)
 
                 let netrcProviders = try tool.getNetrcAuthorizationProviders()

--- a/Tests/FunctionalTests/CFamilyTargetTests.swift
+++ b/Tests/FunctionalTests/CFamilyTargetTests.swift
@@ -100,7 +100,7 @@ class CFamilyTargetTestCase: XCTestCase {
     }
     
     func testCanBuildRelativeHeaderSearchPaths() throws {
-        try fixture(name: "CFamilyTargets/CLibraryParentSearchPath") { fixturePath in
+        fixture(name: "CFamilyTargets/CLibraryParentSearchPath") { fixturePath in
             XCTAssertBuilds(fixturePath)
             XCTAssertDirectoryContainsFile(dir: fixturePath.appending(components: ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug"), filename: "HeaderInclude.swiftmodule")
         }

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -400,7 +400,7 @@ class MiscellaneousTestCase: XCTestCase {
     }
 
     func testSwiftRunSIGNINT() throws {
-        try fixture(name: "Miscellaneous/SwiftRun") { fixturePath in
+        fixture(name: "Miscellaneous/SwiftRun") { fixturePath in
             let mainFilePath = fixturePath.appending(component: "main.swift")
             try localFileSystem.removeFileTree(mainFilePath)
             try localFileSystem.writeFileContents(mainFilePath) {

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -117,7 +117,7 @@ class PluginTests: XCTestCase {
         // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
         
-        try fixture(name: "Miscellaneous/Plugins") { fixturePath in
+        fixture(name: "Miscellaneous/Plugins") { fixturePath in
             let (stdout, _) = try executeSwiftBuild(fixturePath.appending(component: "LibraryWithLocalBuildToolPluginUsingRemoteTool"))
             XCTAssert(stdout.contains("Compiling MySourceGenBuildTool main.swift"), "stdout:\n\(stdout)")
             XCTAssert(stdout.contains("Linking MySourceGenBuildTool"), "stdout:\n\(stdout)")

--- a/Tests/FunctionalTests/TestDiscoveryTests.swift
+++ b/Tests/FunctionalTests/TestDiscoveryTests.swift
@@ -132,7 +132,7 @@ class TestDiscoveryTests: XCTestCase {
         #if os(macOS)
         try XCTSkipIf(true)
         #endif
-        try fixture(name: "Miscellaneous/TestDiscovery/Subclass") { fixturePath in
+        fixture(name: "Miscellaneous/TestDiscovery/Subclass") { fixturePath in
             let (stdout, _) = try executeSwiftTest(fixturePath)
             // in "swift test" test output goes to stdout
             XCTAssertMatch(stdout, .contains("SubclassTestsBase.test1"))


### PR DESCRIPTION
motivation: fix an issue when not all options are presented as expected, and make the code clearer to reason about

changes:
* rename SwiftToolOptions to GlobalOptions
* refactor SwiftToolOptions (GlobalOptions) to multiple groups per domains: locations, caching, logging, build, linker, etc
* set GlobalOptions "hiddenFromHelp" flag to false for swift-build, swift-test and swift-package
* move enableCodeCoverage from GlobalOptions to TestToolOptions, since they apply there
* refactor code that construct test build to pass in more fine grained options rather than take the entire global options model
* adjust call sites and test

rdar://82658867
