### PR TITLE
reduce load created by manifest loading test

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -581,7 +581,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         let closeAfterWrite = closeAfterRead.delay()
 
         // shells out and compiles the manifest, finally output a JSON
-        observabilityScope.emit(debug: "evaluating manifest for '\(packageIdentity)' v. \(packageVersion?.description ?? "unknown") ")
+        observabilityScope.emit(debug: "evaluating manifest for '\(packageIdentity)' v. \(packageVersion?.description ?? "unknown")")
         self.evaluateManifest(
             packageIdentity: key.packageIdentity,
             manifestPath: key.manifestPath,


### PR DESCRIPTION
motivation: flaky test

changes: reduce the amount of concurrent manifest loaded since its causing CI flakiness (runs for 1m+) and not material for what the test is checking - any number significantly larger than number of cores is sufficient

rdar://91272154
