### PR TITLE
PackageModel: support the unified swift modules for XCTest

### DIFF
--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -261,6 +261,16 @@ public final class UserToolchain: Toolchain {
                                         .appending(component: "XCTest-\(info.defaults.xctestVersion)")
 
                         xctest = [
+                            "-I", AbsolutePath("usr/lib/swift/windows", relativeTo: installation).pathString,
+                            // Migration Path
+                            //
+                            // Older Swift (<=5.7) installations placed the
+                            // XCTest Swift module into the architecture
+                            // specified directory.  This was in order to match
+                            // the SDK setup.  However, the toolchain finally
+                            // gained the ability to consult the architecture
+                            // indepndent directory for Swift modules, allowing
+                            // the merged swiftmodules.  XCTest followed suit.
                             "-I", AbsolutePath("usr/lib/swift/windows/\(triple.arch)", relativeTo: installation).pathString,
                             "-L", AbsolutePath("usr/lib/swift/windows/\(triple.arch)", relativeTo: installation).pathString,
                         ]


### PR DESCRIPTION
`XCTest` accidentally did not use the directory form of the swiftmodule,
which did not matter with a single architecture being available.
Migrate to the directory form to match the SDK setup.  With the SDK
migrating to the architecture independent directory for the modules,
follow suit and provide a compatibility path that will allow use of
either.

Co-dependents:
apple/swift#42419
apple/swift-installer-scripts#119
apple/swift-driver#1063