### PR TITLE
[5.7] The `shouldDisableSandbox` setting wasn't being passed along to build tool plugin commands (#4283)

### DIFF
--- a/Fixtures/Miscellaneous/Plugins/SandboxViolatingBuildToolPluginCommands/MyLibrary/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/SandboxViolatingBuildToolPluginCommands/MyLibrary/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version: 5.6
+import PackageDescription
+
+let package = Package(
+    name: "MyLibrary",
+    dependencies: [
+        .package(path: "../MyPlugin")
+    ],
+    targets: [
+        .target(
+            name: "MyLibrary",
+            plugins: [
+                .plugin(name: "PackageScribblerPlugin", package: "MyPlugin")
+            ])
+    ]
+)

--- a/Fixtures/Miscellaneous/Plugins/SandboxViolatingBuildToolPluginCommands/MyLibrary/Sources/MyLibrary/library.swift
+++ b/Fixtures/Miscellaneous/Plugins/SandboxViolatingBuildToolPluginCommands/MyLibrary/Sources/MyLibrary/library.swift
@@ -1,0 +1,3 @@
+public func MyLibraryStruct() -> String {
+    return "This is \(foo)"
+}

--- a/Fixtures/Miscellaneous/Plugins/SandboxViolatingBuildToolPluginCommands/MyPlugin/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/SandboxViolatingBuildToolPluginCommands/MyPlugin/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version: 5.6
+import PackageDescription
+
+let package = Package(
+    name: "MyPlugin",
+    products: [
+        .plugin(
+            name: "PackageScribblerPlugin",
+            targets: ["PackageScribblerPlugin"]
+        ),
+    ],
+    targets: [
+        .plugin(
+            name: "PackageScribblerPlugin",
+            capability: .buildTool()
+        )
+    ]
+)

--- a/Fixtures/Miscellaneous/Plugins/SandboxViolatingBuildToolPluginCommands/MyPlugin/Plugins/PackageScribblerPlugin/plugin.swift
+++ b/Fixtures/Miscellaneous/Plugins/SandboxViolatingBuildToolPluginCommands/MyPlugin/Plugins/PackageScribblerPlugin/plugin.swift
@@ -1,0 +1,18 @@
+import PackagePlugin
+import Foundation
+
+@main
+struct MyPlugin: BuildToolPlugin {
+
+    func createBuildCommands(context: PluginContext, target: Target) async throws -> [Command] {
+        let outputDir = target.directory.appending("generated")
+        try FileManager.default.createDirectory(atPath: outputDir.string, withIntermediateDirectories: true)
+        return [
+            .prebuildCommand(
+                displayName: "Creating Foo.swift in the target directory…",
+                executable: Path("/bin/bash"),
+                arguments: [ "-c", "echo 'let foo = \"\(target.name)\"' > '\(outputDir)/foo.swift'" ],
+                outputFilesDirectory: outputDir)
+        ]
+    }
+}

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -754,6 +754,7 @@ public class SwiftTool {
             packageGraphLoader: customPackageGraphLoader ?? graphLoader,
             pluginScriptRunner: self.getPluginScriptRunner(),
             pluginWorkDirectory: try self.getActiveWorkspace().location.pluginWorkingDirectory,
+            disableSandboxForPluginCommands: self.options.security.shouldDisableSandbox,
             outputStream: customOutputStream ?? self.outputStream,
             logLevel: customLogLevel ?? self.logLevel,
             fileSystem: self.fileSystem,

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -855,4 +855,27 @@ class PluginTests: XCTestCase {
             XCTAssert(stdout.contains("type of snippet target: snippet"), "output:\n\(stderr)\n\(stdout)")
         }
     }
+
+    func testSandboxViolatingBuildToolPluginCommands() throws {
+        #if !os(macOS)
+        try XCTSkipIf(true, "sandboxing tests are only supported on macOS")
+        #endif
+        
+        // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
+        try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+
+        // Check that the build fails with a sandbox violation by default.
+        try fixture(name: "Miscellaneous/Plugins/SandboxViolatingBuildToolPluginCommands") { path in
+            XCTAssertThrowsError(try executeSwiftBuild(path.appending(component: "MyLibrary"), configuration: .Debug)) { error in
+                XCTAssertMatch("\(error)", .contains("You don’t have permission to save the file “generated” in the folder “MyLibrary”."))
+            }
+        }
+
+        // Check that the build succeeds if we disable the sandbox.
+        try fixture(name: "Miscellaneous/Plugins/SandboxViolatingBuildToolPluginCommands") { path in
+            let (stdout, stderr) = try executeSwiftBuild(path.appending(component: "MyLibrary"), configuration: .Debug, extraArgs: ["--disable-sandbox"])
+            XCTAssert(stdout.contains("Compiling MyLibrary foo.swift"), "[STDOUT]\n\(stdout)\n[STDERR]\n\(stderr)\n")
+        }
+
+    }
 }


### PR DESCRIPTION
This is the 5.7 nomination of #4283.  See that PR for details.