### PR TITLE
[PackageLoading] Filter out library creation note from `LINK`

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -290,7 +290,9 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         // We might have some non-fatal output (warnings/notes) from the compiler even when
         // we were able to parse the manifest successfully.
         if let compilerOutput = result.compilerOutput {
-            // FIXME: Isn't the strategy too naive?
+            // FIXME: We shouldn't assume the compiler output to be a single piece. There could be combined
+            // output from different stages of compiling the manifest, but it's hard to distinguish them.
+            // A better approach might be teaching the driver to emit a structured log with context and severity.
             var outputSeverity: Basics.Diagnostic.Severity = .warning
 #if os(Windows)
             // Filter out `LINK` note for creating manifest executable.


### PR DESCRIPTION
Filter out library creation note from `LINK` in `ManifestLoader`.

### Motivation:

We're using `LINK` for linking on Windows by default, and it will always emit a note like this:
```
   Creating library TMP_DIR\package-manifest.lib and object TMP_DIR\package-manifest.exp
```

Since there's no way to opt out, and this isn't a real warning, we should filter it out in `ManifestLoader`.

### Modifications:

- Downgrade library creation note from `LINK` in `ManifestLoader` to `debug` level.
- Remove `rdar://73710910` workaround.

### Result:

Users no longer see the false warning of `Creating library ... and object ...` when building the manifest.