### PR TITLE
[5.7] Cherry-pick DocC documentation updates.

### DIFF
--- a/Sources/PackageDescription/BuildSettings.swift
+++ b/Sources/PackageDescription/BuildSettings.swift
@@ -28,28 +28,31 @@ public struct BuildConfiguration: Encodable {
 /// A condition that limits the application of a build setting.
 ///
 /// By default, build settings are applicable for all platforms and build
-/// configurations. Use the ``when(platforms:configuration:)`` modifier to define  a build
-/// setting for a specific condition. Invalid usage of `.when` emits an error during
-/// manifest parsing. For example, it's invalid to specify a `.when` condition with
-/// both parameters as `nil`.
+/// configurations. Use the `.when` modifier to define a build setting for a
+/// specific condition. Invalid usage of `.when` emits an error during manifest
+/// parsing. For example, it's invalid to specify a `.when` condition with both
+/// parameters as `nil`.
 ///
-/// The following example shows how to use build setting conditions with various APIs:
+/// The following example shows how to use build setting conditions with various
+/// APIs:
 ///
-///     ...
-///     .target(
-///         name: "MyTool",
-///         dependencies: ["Utility"],
-///         cSettings: [
-///             .headerSearchPath("path/relative/to/my/target"),
-///             .define("DISABLE_SOMETHING", .when(platforms: [.iOS], configuration: .release)),
-///         ],
-///         swiftSettings: [
-///             .define("ENABLE_SOMETHING", .when(configuration: .release)),
-///         ],
-///         linkerSettings: [
-///             .linkedLibrary("openssl", .when(platforms: [.linux])),
-///         ]
-///     ),
+/// ```swift
+/// ...
+/// .target(
+///     name: "MyTool",
+///     dependencies: ["Utility"],
+///     cSettings: [
+///         .headerSearchPath("path/relative/to/my/target"),
+///         .define("DISABLE_SOMETHING", .when(platforms: [.iOS], configuration: .release)),
+///     ],
+///     swiftSettings: [
+///         .define("ENABLE_SOMETHING", .when(configuration: .release)),
+///     ],
+///     linkerSettings: [
+///         .linkLibrary("openssl", .when(platforms: [.linux])),
+///     ]
+/// ),
+/// ```
 public struct BuildSettingCondition: Encodable {
 
     private let platforms: [Platform]?
@@ -125,10 +128,10 @@ public struct CSetting: Encodable {
     ///
     /// The path must be a directory inside the package.
     ///
-    /// - Since: First available in PackageDescription 5.0
+    /// - Since: First available in PackageDescription 5.0.
     ///
     /// - Parameters:
-    ///   - path: The path of the directory that contains the  headers. The path is relative to the target's directory.
+    ///   - path: The path of the directory that contains the headers. The path is relative to the target's directory.
     ///   - condition: A condition that restricts the application of the build setting.
     public static func headerSearchPath(_ path: String, _ condition: BuildSettingCondition? = nil) -> CSetting {
         return CSetting(name: "headerSearchPath", value: [path], condition: condition)
@@ -138,12 +141,13 @@ public struct CSetting: Encodable {
     ///
     /// If you don't specify a value, the macro's default value is 1.
     ///
-    /// - Since: First available in PackageDescription 5.0
+    /// - Since: First available in PackageDescription 5.0.
     ///
     /// - Parameters:
     ///   - name: The name of the macro.
     ///   - value: The value of the macro.
-    ///   - condition: A condition that restricts the application of the build setting.
+    ///   - condition: A condition that restricts the application of the build
+    /// setting.
     public static func define(_ name: String, to value: String? = nil, _ condition: BuildSettingCondition? = nil) -> CSetting {
         var settingValue = name
         if let value = value {
@@ -152,22 +156,23 @@ public struct CSetting: Encodable {
         return CSetting(name: "define", value: [settingValue], condition: condition)
     }
 
-    /// Sets unsafe flags to pass arbitrary command-line flags to the corresponding build tool.
+    /// Sets unsafe flags to pass arbitrary command-line flags to the
+    /// corresponding build tool.
     ///
-    /// As the usage of the word "unsafe" implies, the Swift Package Manager
-    /// can't safely determine if the build flags have any negative
-    /// side effect on the build since certain flags can change the behavior of
-    /// how it performs a build.
+    /// As the usage of the word “unsafe” implies, Swift Package Manager can't safely determine
+    /// if the build flags have any negative side effect on the build since
+    /// certain flags can change the behavior of how it performs a build.
     ///
     /// As some build flags can be exploited for unsupported or malicious
-    /// behavior, the use of unsafe flags make the products containing this
+    /// behavior, the use of unsafe flags makes the products containing this
     /// target ineligible for use by other packages.
     ///
-    /// - Since: First available in PackageDescription 5.0
+    /// - Since: First available in PackageDescription 5.0.
     ///
     /// - Parameters:
     ///   - flags: The unsafe flags to set.
-    ///   - condition: A condition that restricts the application of the build setting.
+    ///   - condition: A condition that restricts the application of the build
+    /// setting.
     public static func unsafeFlags(_ flags: [String], _ condition: BuildSettingCondition? = nil) -> CSetting {
         return CSetting(name: "unsafeFlags", value: flags, condition: condition)
     }
@@ -189,10 +194,10 @@ public struct CXXSetting: Encodable {
     ///
     /// The path must be a directory inside the package.
     ///
-    /// - Since: First available in PackageDescription 5.0
+    /// - Since: First available in PackageDescription 5.0.
     ///
     /// - Parameters:
-    ///   - path: The path of the directory that contains the  headers. The path is relative to the target's directory.
+    ///   - path: The path of the directory that contains the headers. The path is
     ///   - condition: A condition that restricts the application of the build setting.
     public static func headerSearchPath(_ path: String, _ condition: BuildSettingCondition? = nil) -> CXXSetting {
         return CXXSetting(name: "headerSearchPath", value: [path], condition: condition)
@@ -202,12 +207,13 @@ public struct CXXSetting: Encodable {
     ///
     /// If you don't specify a value, the macro's default value is 1.
     ///
-    /// - Since: First available in PackageDescription 5.0
+    /// - Since: First available in PackageDescription 5.0.
     ///
     /// - Parameters:
     ///   - name: The name of the macro.
     ///   - value: The value of the macro.
-    ///   - condition: A condition that restricts the application of the build setting.
+    ///   - condition: A condition that restricts the application of the build
+    /// setting.
     public static func define(_ name: String, to value: String? = nil, _ condition: BuildSettingCondition? = nil) -> CXXSetting {
         var settingValue = name
         if let value = value {
@@ -216,21 +222,22 @@ public struct CXXSetting: Encodable {
         return CXXSetting(name: "define", value: [settingValue], condition: condition)
     }
 
-    /// Sets unsafe flags to pass arbitrary command-line flags to the corresponding build tool.
+    /// Sets unsafe flags to pass arbitrary command-line flags to the
+    /// corresponding build tool.
     ///
-    /// As the usage of the word "unsafe" implies, the Swift Package Manager
-    /// can't safely determine if the build flags have any negative
-    /// side effect on the build since certain flags can change the behavior of
-    /// how a build is performed.
+    /// As the usage of the word “unsafe” implies, Swift Package Manager can't safely determine
+    /// if the build flags have any negative side effect on the build since
+    /// certain flags can change the behavior of how it performs a build.
     ///
     /// As some build flags can be exploited for unsupported or malicious
-    /// behavior, a product can't be used as a dependency in another package if one of its targets uses unsafe flags.
+    /// behavior, you can't use products with unsafe build flags as dependencies in another package.
     ///
-    /// - Since: First available in PackageDescription 5.0
+    /// - Since: First available in PackageDescription 5.0.
     ///
     /// - Parameters:
     ///   - flags: The unsafe flags to set.
-    ///   - condition: A condition that restricts the application of the build setting.
+    ///   - condition: A condition that restricts the application of the build
+    /// setting.
     public static func unsafeFlags(_ flags: [String], _ condition: BuildSettingCondition? = nil) -> CXXSetting {
         return CXXSetting(name: "unsafeFlags", value: flags, condition: condition)
     }
@@ -246,41 +253,46 @@ public struct SwiftSetting: Encodable {
 
     /// Defines a compilation condition.
     ///
-    /// Use compilation conditions to only compile statements if a certain condition is true.
-    /// For example, the Swift compiler will only compile the
+    /// Use compilation conditions to only compile statements if a certain
+    /// condition is true. For example, the Swift compiler will only compile the
     /// statements inside the `#if` block when `ENABLE_SOMETHING` is defined:
     ///
-    ///     #if ENABLE_SOMETHING
-    ///        ...
-    ///     #endif
+    /// ```swift
+    /// #if ENABLE_SOMETHING
+    ///    ...
+    /// #endif
+    /// ```
     ///
-    /// Unlike macros in C/C++, compilation conditions don't have an
-    /// associated value.
+    /// Unlike macros in C/C++, compilation conditions don't have an associated
+    /// value.
     ///
-    /// - Since: First available in PackageDescription 5.0
+    /// - Since: First available in PackageDescription 5.0.
     ///
     /// - Parameters:
     ///   - name: The name of the macro.
-    ///   - condition: A condition that restricts the application of the build setting.
+    ///   - condition: A condition that restricts the application of the build
+    /// setting.
     public static func define(_ name: String, _ condition: BuildSettingCondition? = nil) -> SwiftSetting {
         return SwiftSetting(name: "define", value: [name], condition: condition)
     }
 
-    /// Sets unsafe flags to pass arbitrary command-line flags to the corresponding build tool.
+    /// Set unsafe flags to pass arbitrary command-line flags to the
+    /// corresponding build tool.
     ///
-    /// As the usage of the word "unsafe" implies, the Swift Package Manager
-    /// can't safely determine if the build flags have any negative
-    /// side effect on the build since certain flags can change the behavior of
-    /// how a build is performed.
+    /// As the usage of the word “unsafe” implies, Swift Package Manager can't safely determine
+    /// if the build flags have any negative side effect on the build since
+    /// certain flags can change the behavior of how it performs a build.
     ///
     /// As some build flags can be exploited for unsupported or malicious
-    /// behavior, a product can't be used as a dependency in another package if one of its targets uses unsafe flags.
+    /// behavior, the use of unsafe flags makes the products containing this
+    /// target ineligible for use by other packages.
     ///
-    /// - Since: First available in PackageDescription 5.0
+    /// - Since: First available in PackageDescription 5.0.
     ///
     /// - Parameters:
     ///   - flags: The unsafe flags to set.
-    ///   - condition: A condition that restricts the application of the build setting..
+    ///   - condition: A condition that restricts the application of the build
+    /// setting.
     public static func unsafeFlags(_ flags: [String], _ condition: BuildSettingCondition? = nil) -> SwiftSetting {
         return SwiftSetting(name: "unsafeFlags", value: flags, condition: condition)
     }
@@ -297,14 +309,14 @@ public struct LinkerSetting: Encodable {
     /// Declares linkage to a system library.
     ///
     /// This setting is most useful when the library can't be linked
-    /// automatically, such as C++ based libraries and non-modular
-    /// libraries.
+    /// automatically, such as C++ based libraries and non-modular libraries.
     ///
-    /// - Since: First available in PackageDescription 5.0
+    /// - Since: First available in PackageDescription 5.0.
     ///
     /// - Parameters:
     ///   - library: The library name.
-    ///   - condition: A condition that restricts the application of the build setting.
+    ///   - condition: A condition that restricts the application of the build
+    /// setting.
     public static func linkedLibrary(_ library: String, _ condition: BuildSettingCondition? = nil) -> LinkerSetting {
         return LinkerSetting(name: "linkedLibrary", value: [library], condition: condition)
     }
@@ -312,33 +324,35 @@ public struct LinkerSetting: Encodable {
     /// Declares linkage to a system framework.
     ///
     /// This setting is most useful when the framework can't be linked
-    /// automatically, such as C++ based frameworks and non-modular
-    /// frameworks.
+    /// automatically, such as C++ based frameworks and non-modular frameworks.
     ///
-    /// - Since: First available in PackageDescription 5.0
+    /// - Since: First available in PackageDescription 5.0.
     ///
     /// - Parameters:
     ///   - framework: The framework name.
-    ///   - condition: A condition that restricts the application of the build setting.
+    ///   - condition: A condition that restricts the application of the build
+    /// setting.
     public static func linkedFramework(_ framework: String, _ condition: BuildSettingCondition? = nil) -> LinkerSetting {
         return LinkerSetting(name: "linkedFramework", value: [framework], condition: condition)
     }
-
-    /// Sets unsafe flags to pass arbitrary command-line flags to the corresponding build tool.
+   
+    /// Sets unsafe flags to pass arbitrary command-line flags to the
+    /// corresponding build tool.
     ///
-    /// As the usage of the word "unsafe" implies, the Swift Package Manager
-    /// can't safely determine if the build flags have any negative
-    /// side effect on the build since certain flags can change the behavior of
-    /// how a build is performed.
+    /// As the usage of the word “unsafe” implies, Swift Package Manager can't safely determine
+    /// if the build flags have any negative side effect on the build since
+    /// certain flags can change the behavior of how it performs a build.
     ///
     /// As some build flags can be exploited for unsupported or malicious
-    /// behavior, a product can't be used as a dependency in another package if one of its targets uses unsafe flags.
+    /// behavior, the use of unsafe flags makes the products containing this
+    /// target ineligible for use by other packages.
     ///
-    /// - Since: First available in PackageDescription 5.0
+    /// - Since: First available in PackageDescription 5.0.
     ///
     /// - Parameters:
     ///   - flags: The unsafe flags to set.
-    ///   - condition: A condition that restricts the application of the build setting.
+    ///   - condition: A condition that restricts the application of the build
+    /// setting.
     public static func unsafeFlags(_ flags: [String], _ condition: BuildSettingCondition? = nil) -> LinkerSetting {
         return LinkerSetting(name: "unsafeFlags", value: flags, condition: condition)
     }

--- a/Sources/PackageDescription/BuildSettings.swift
+++ b/Sources/PackageDescription/BuildSettings.swift
@@ -81,8 +81,7 @@ public struct BuildSettingCondition: Encodable {
 
     /// Creates a build setting condition.
     ///
-    /// - Parameters:
-    ///   - platforms: The applicable platforms for this build setting condition.
+    /// - Parameter platforms: The applicable platforms for this build setting condition.
     @available(_PackageDescription, introduced: 5.7)
     public static func when(platforms: [Platform]) -> BuildSettingCondition {
         BuildSettingCondition(platforms: platforms, config: .none)
@@ -90,8 +89,7 @@ public struct BuildSettingCondition: Encodable {
 
     /// Creates a build setting condition.
     ///
-    /// - Parameters:
-    ///   - configuration: The applicable build configuration for this build setting condition.
+    /// - Parameter configuration: The applicable build configuration for this build setting condition.
     @available(_PackageDescription, introduced: 5.7)
     public static func when(configuration: BuildConfiguration) -> BuildSettingCondition {
         BuildSettingCondition(platforms: .none, config: configuration)

--- a/Sources/PackageDescription/Context.swift
+++ b/Sources/PackageDescription/Context.swift
@@ -10,13 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// The context a Swift package is running in. This encapsulates states that are known at build-time.
-/// For example where in the file system the current package resides.
+/// The context information for a Swift package.
+///
+/// The context encapsulates states that are known when Swift Package Manager interprets the package manifest,
+/// for example the location in the file system where the current package resides.
 @available(_PackageDescription, introduced: 5.6)
 public struct Context {
     private static let model = try! ContextModel.decode()
 
-    /// The directory containing Package.swift.
+    /// The directory that contains `Package.swift`.
     public static var packageDirectory : String {
         model.packageDirectory
     }

--- a/Sources/PackageDescription/LanguageStandardSettings.swift
+++ b/Sources/PackageDescription/LanguageStandardSettings.swift
@@ -10,161 +10,160 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// The supported C language standard to use for compiling C sources in the package.
-///
-/// Aliases are available for some C language standards. For example,
-/// use `c89`, `c90`, or `iso9899_1990` for the "ISO C 1990" standard.
-/// To learn more, read the [Clang Compiler User's Manual][1].
-///
-/// [1]: <https://clang.llvm.org/docs/UsersManual.html#differences-between-various-standard-modes>
+/// The supported C language standard you use to compile C sources in the
+/// package.
 public enum CLanguageStandard: String, Encodable {
 
-    /// ISO C 1990.
+    /// The identifier for the ISO C 1990 language standard.
     case c89
 
-    /// ISO C 1990.
+    /// The identifier for the ISO C 1990 language standard.
     case c90
 
-    /// ISO C 1999.
+    /// The identifier for the ISO C 1999 language standard.
     case c99
 
-    /// ISO C 2011.
+    /// The identifier for the ISO C 2011 language standard.
     case c11
 
-    /// ISO C 2017.
+    /// The identifier for the ISO C 2017 language stadard.
     @available(_PackageDescription, introduced: 5.4)
     case c17
 
-    /// ISO C 2017.
+    /// The identifier for the ISO C 2017 language standard.
     @available(_PackageDescription, introduced: 5.4)
     case c18
 
-    /// Working Draft for ISO C2x.
+    /// The identifier for the ISO C2x draft language standard.
     @available(_PackageDescription, introduced: 5.4)
     case c2x
 
-    /// ISO C 1990 with GNU extensions.
+    /// The identifier for the ISO C 1990 language standard with GNU extensions.
     case gnu89
 
-    /// ISO C 1990 with GNU extensions.
+    /// The identifier for the ISO C 1990 language standard with GNU extensions.
     case gnu90
 
-    /// ISO C 1999 with GNU extensions.
+    /// The identifier for the ISO C 1999 language standard with GNU extensions.
     case gnu99
 
-    /// ISO C 2011 with GNU extensions.
+    /// The identifier for the ISO C 2011 language standard with GNU extensions.
     case gnu11
 
-    /// ISO C 2017 with GNU extensions.
+    /// The identifier for the ISO C 2017 language standard with GNU extensions.
     @available(_PackageDescription, introduced: 5.4)
     case gnu17
 
-    /// ISO C 2017 with GNU extensions.
+    /// The identifier for the ISO C 2017 language standard with GNU extensions.
     @available(_PackageDescription, introduced: 5.4)
     case gnu18
 
-    /// Working Draft for ISO C2x with GNU extensions.
+    /// The identifier for the ISO C2x draft language standard with GNU extensions.
     @available(_PackageDescription, introduced: 5.4)
     case gnu2x
 
-    /// ISO C 1990.
+    /// The identifier for the ISO C 1990 language standard.
     case iso9899_1990 = "iso9899:1990"
 
-    /// ISO C 1990 with amendment 1.
+    /// The identifier for the ISO C 1990 language standard with amendment 1.
     case iso9899_199409 = "iso9899:199409"
 
-    /// ISO C 1999.
+    /// The identifier for the ISO C 1999 language standard.
     case iso9899_1999 = "iso9899:1999"
 
-    /// ISO C 2011.
+    /// The identifier for the ISO C 2011 language standard.
     case iso9899_2011 = "iso9899:2011"
 
-    /// ISO C 2017.
+    /// The identifier for the ISO C 2017 language standard.
     @available(_PackageDescription, introduced: 5.4)
     case iso9899_2017 = "iso9899:2017"
 
-    /// ISO C 2017.
+    /// The identifier for the ISO C 2017 language standard.
     @available(_PackageDescription, introduced: 5.4)
     case iso9899_2018 = "iso9899:2018"
 }
 
-/// The supported C++ language standard to use for compiling C++ sources in the package.
+/// The supported C++ language standard you use to compile C++ sources in the
+/// package.
 ///
 /// Aliases are available for some C++ language standards. For example,
 /// use `cxx98` or `cxx03` for the "ISO C++ 1998 with amendments" standard.
-/// To learn more, read the [C++ Support in Clang][1] status page.
-///
-/// [1]: <https://clang.llvm.org/cxx_status.html>
+/// To learn more, see [C++ Support in Clang](https://clang.llvm.org/cxx_status.html).
 public enum CXXLanguageStandard: String, Encodable {
 
-    /// ISO C++ 1998 with amendments.
+    /// The identifier for the ISO C++ 1998 language standard with amendments.
     case cxx98 = "c++98"
 
-    /// ISO C++ 1998 with amendments.
+    /// The identifier for the ISO C++ 1998 language standard with amendments.
     case cxx03 = "c++03"
 
-    /// ISO C++ 2011 with amendments.
+    /// The identifier for the ISO C++ 2011 language standard with amendments.
     case cxx11 = "c++11"
 
-    /// ISO C++ 2014 with amendments.
+    /// The identifier for the ISO C++ 2014 language standard with amendments.
     case cxx14 = "c++14"
 
-    /// ISO C++ 2017 with amendments.
+    /// The identifier for the ISO C++ 2017 language standard with amendments.
     @available(_PackageDescription, introduced: 5.4)
     case cxx17 = "c++17"
 
-    /// ISO C++ 2017 with amendments.
+    /// The identifier for the ISO C++ 2017 language standard with amendments.
     @available(_PackageDescription, introduced: 4, deprecated: 5.4, renamed: "cxx17")
     case cxx1z = "c++1z"
 
-    /// ISO C++ 2020 DIS.
+    /// The identifier for the ISO C++ 2020 language standard.
     @available(_PackageDescription, introduced: 5.4)
     case cxx20 = "c++20"
 
-    /// Working draft for ISO C++ 2023 DIS.
+    /// The identifier for the ISO C++ 2023 draft language standard.
     @available(_PackageDescription, introduced: 5.6)
     case cxx2b = "c++2b"
 
-    /// ISO C++ 1998 with amendments and GNU extensions.
+    /// The identifier for the ISO C++ 1998 language standard with amendments and GNU extensions.
     case gnucxx98 = "gnu++98"
 
-    /// ISO C++ 1998 with amendments and GNU extensions.
+    /// The identifier for the ISO C++ 1998 language standard with amendments and GNU extensions.
     case gnucxx03 = "gnu++03"
 
-    /// ISO C++ 2011 with amendments and GNU extensions.
+    /// The identifier for the ISO C++ 2011 language standard with amendments and GNU extensions.
     case gnucxx11 = "gnu++11"
 
-    /// ISO C++ 2014 with amendments and GNU extensions.
+    /// The identifier for the ISO C++ 2014 language standard with amendments and GNU extensions.
     case gnucxx14 = "gnu++14"
 
-    /// ISO C++ 2017 with amendments and GNU extensions.
+    /// The identifier for the ISO C++ 2017 language standard with amendments and GNU extensions.
     @available(_PackageDescription, introduced: 5.4)
     case gnucxx17 = "gnu++17"
 
-    /// ISO C++ 2017 with amendments and GNU extensions.
+    /// The identifier for the ISO C++ 2017 language standard with amendments and GNU extensions.
     @available(_PackageDescription, introduced: 4, deprecated: 5.4, renamed: "gnucxx17")
     case gnucxx1z = "gnu++1z"
 
-    /// ISO C++ 2020 DIS with GNU extensions.
+    /// The identifier for the ISO C++ 2020 language standard with GNU extensions.
     @available(_PackageDescription, introduced: 5.4)
     case gnucxx20 = "gnu++20"
 
-    /// Working draft for ISO C++ 2023 DIS with GNU extensions.
+    /// The identifier for the ISO C++ 2023 draft language standard with GNU extensions.
     @available(_PackageDescription, introduced: 5.6)
     case gnucxx2b = "gnu++2b"
 }
 
-/// The version of the Swift language to use for compiling Swift sources in the package.
+/// The version of the Swift language you use to compile Swift sources in the
+/// package.
 public enum SwiftVersion {
+    /// The identifier for the Swift 3 language version.
     @available(_PackageDescription, introduced: 4, obsoleted: 5)
     case v3
 
+    /// The identifier for the Swift 4 language version.
     @available(_PackageDescription, introduced: 4)
     case v4
 
+    /// The identifier for the Swift 4.2 language version.
     @available(_PackageDescription, introduced: 4)
     case v4_2
 
+    /// The identifier for the Swift 5 language version.
     @available(_PackageDescription, introduced: 5)
     case v5
 

--- a/Sources/PackageDescription/PackageDependency.swift
+++ b/Sources/PackageDescription/PackageDependency.swift
@@ -20,24 +20,43 @@ extension Package {
     /// A package dependency consists of a Git URL to the source of the package,
     /// and a requirement for the version of the package.
     ///
-    /// The Swift Package Manager performs a process called *dependency resolution* to
-    /// figure out the exact version of the package dependencies that an app or other
-    /// Swift package can use. The `Package.resolved` file records the results of the
-    /// dependency resolution and lives in the top-level directory of a Swift package.
-    /// If you add the Swift package as a package dependency to an app for an Apple platform,
-    /// you can find the `Package.resolved` file inside your `.xcodeproj` or `.xcworkspace`.
+    /// Swift Package Manager performs a process called _dependency resolution_ to figure out
+    /// the exact version of the package dependencies that an app or other Swift
+    /// package can use. The `Package.resolved` file records the results of the
+    /// dependency resolution and lives in the top-level directory of a Swift
+    /// package. If you add the Swift package as a package dependency to an app
+    /// for an Apple platform, you can find the `Package.resolved` file inside
+    /// your `.xcodeproj` or `.xcworkspace`.
     public class Dependency: Encodable {
+        /// The kind of dependency.
         @available(_PackageDescription, introduced: 5.6)
         public enum Kind {
+            /// A dependency located at the given path.
+            /// - Parameters:
+            ///    - name: The name of the dependency.
+            ///    - path: The path to the dependency.
             case fileSystem(name: String?, path: String)
+            /// A dependency based on a source control requirement.
+            ///  - Parameters:
+            ///    - name: The name of the dependency.
+            ///    - location: The Git URL of the dependency.
+            ///    - requirement: The version-based requirement for a package.
             case sourceControl(name: String?, location: String, requirement: SourceControlRequirement)
+            /// A dependency based on a registry requirement.
+            /// - Parameters:
+            ///   - id: The package identifier of the dependency.
+            ///   - requirement: The version based requirement for a package.
             case registry(id: String, requirement: RegistryRequirement)
         }
 
+        /// A description of the package dependency.
         @available(_PackageDescription, introduced: 5.6)
         public let kind: Kind
 
-        /// The name of the dependency, or `nil` to deduce the name using the package's Git URL.
+        /// The name of the dependency.
+        ///
+        /// If the `name` is `nil`, Swift Package Manager deduces the dependency's name from its
+        /// package identity or Git URL.
         @available(_PackageDescription, deprecated: 5.6, message: "use kind instead")
         public var name: String? {
             get {
@@ -52,7 +71,7 @@ extension Package {
             }
         }
 
-        /// The location of the dependency.
+        /// The Git URL of the package dependency.
         @available(_PackageDescription, deprecated: 5.6, message: "use kind instead")
         public var url: String? {
             get {
@@ -72,7 +91,7 @@ extension Package {
         @available(_PackageDescription, introduced: 5.7)
         public var moduleAliases: [String: String]?
 
-        /// The requirement of the dependency.
+        /// The dependency requirement of the package dependency.
         @available(_PackageDescription, deprecated: 5.6, message: "use kind instead")
         public var requirement: Requirement {
             get {
@@ -139,31 +158,34 @@ extension Package {
 // MARK: - file system
 
 extension Package.Dependency {
-    /// Adds a package dependency to a local package on the filesystem.
+    /// Adds a dependency to a package located at the given path.
     ///
     /// The Swift Package Manager uses the package dependency as-is
     /// and does not perform any source control access. Local package dependencies
     /// are especially useful during development of a new package or when working
     /// on multiple tightly coupled packages.
     ///
-    /// - Parameters
-    ///   - path: The file system path to the package.
+    /// - Parameter path: The file system path to the package.
+    ///
+    /// - Returns: A package dependency.
     public static func package(
         path: String
     ) -> Package.Dependency {
         return .init(name: nil, path: path)
     }
 
-    /// Adds a package dependency to a local package on the filesystem.
+    /// Adds a dependency to a package located at the given path on the filesystem.
     ///
-    /// The Swift Package Manager uses the package dependency as-is
-    /// and doesn't perform any source control access. Local package dependencies
-    /// are especially useful during development of a new package or when working
-    /// on multiple tightly coupled packages.
+    /// Swift Package Manager uses the package dependency as-is and doesn't perform any source
+    /// control access. Local package dependencies are especially useful during
+    /// development of a new package or when working on multiple tightly coupled
+    /// packages.
     ///
-    /// - Parameters
-    ///   - name: The name of the Swift package, used only for target dependencies lookup.
-    ///   - path: The file system path to the package.
+    /// - Parameters:
+    ///   - name: The name of the Swift package or `nil` to deduce the name from path.
+    ///   - path: The local path to the package.
+    ///
+    /// - Returns: A package dependency.
     @available(_PackageDescription, introduced: 5.2)
     public static func package(
         name: String,
@@ -189,12 +211,15 @@ extension Package.Dependency {
     /// The following example allows the Swift Package Manager to select a version
     /// like a  `1.2.3`, `1.2.4`, or `1.3.0`, but not `2.0.0`.
     ///
-    ///    .package(url: "https://example.com/example-package.git", from: "1.2.3"),
+    ///```swift
+    ///.package(url: "https://example.com/example-package.git", from: "1.2.3"),
+    ///```
     ///
     /// - Parameters:
-    ///     - name: The name of the package, or nil to deduce it from the URL.
-    ///     - url: The valid Git URL of the package.
-    ///     - version: The minimum version requirement.
+    ///    - url: The valid Git URL of the package.
+    ///    - version: The minimum version requirement.
+    ///
+    /// - Returns: A `Package.Dependency` instance.
     public static func package(
         url: String,
         from version: Version
@@ -202,25 +227,32 @@ extension Package.Dependency {
         return .package(url: url, .upToNextMajor(from: version))
     }
 
-    /// Adds a package dependency that uses the version requirement, starting with the given minimum version,
-    /// going up to the next major version.
+    /// Adds a package dependency that uses the version requirement, starting
+    /// with the given minimum version, going up to the next major version.
     ///
-    /// This is the recommended way to specify a remote package dependency.
-    /// It allows you to specify the minimum version you require, allows updates that include bug fixes
-    /// and backward-compatible feature updates, but requires you to explicitly update to a new major version of the dependency.
-    /// This approach provides the maximum flexibility on which version to use,
-    /// while making sure you don't update to a version with breaking changes,
-    /// and helps to prevent conflicts in your dependency graph.
+    /// This is the recommended way to specify a remote package dependency. It
+    /// allows you to specify the minimum version you require, allows updates
+    /// that include bug fixes and backward-compatible feature updates, but
+    /// requires you to explicitly update to a new major version of the
+    /// dependency. This approach provides the maximum flexibility on which
+    /// version to use, while making sure you don't update to a version with
+    /// breaking changes, and helps to prevent conflicts in your dependency
+    /// graph.
     ///
-    /// The following example allows the Swift Package Manager to select a version
-    /// like a  `1.2.3`, `1.2.4`, or `1.3.0`, but not `2.0.0`.
+    /// The following example allows the Swift package manager to select a
+    /// version like a `1.2.3`, `1.2.4`, or `1.3.0`, but not `2.0.0`.
     ///
-    ///    .package(url: "https://example.com/example-package.git", from: "1.2.3"),
+    /// ```swift
+    /// .package(url: "https://example.com/example-package.git", from:
+    /// "1.2.3"),
+    /// ```
     ///
     /// - Parameters:
-    ///     - name: The name of the package, or nil to deduce it from the URL.
-    ///     - url: The valid Git URL of the package.
-    ///     - version: The minimum version requirement.
+    ///   - name: The name of the Swift package or `nil` to deduce the name from  the package's Git URL.
+    ///   - url: The valid Git URL of the package.
+    ///   - version: The minimum version requirement.
+    ///
+    /// - Returns: A `Package.Dependency` instance.
     @available(_PackageDescription, introduced: 5.2, deprecated: 5.6, message: "use package(url:from:) instead")
     public static func package(
         name: String,
@@ -232,11 +264,15 @@ extension Package.Dependency {
 
     /// Adds a remote package dependency given a branch requirement.
     ///
-    ///    .package(url: "https://example.com/example-package.git", branch: "main"),
+    ///```swift
+    /// .package(url: "https://example.com/example-package.git", branch: "main"),
+    /// ```
     ///
     /// - Parameters:
-    ///     - url: The valid Git URL of the package.
-    ///     - branch: A dependency requirement. See static methods on `Package.Dependency.Requirement` for available options.
+    ///   - url: The valid Git URL of the package.
+    ///   - branch: A dependency requirement. See static methods on ``Requirement-swift.enum`` for available options.
+    ///
+    /// - Returns: A `Package.Dependency` instance.
     @available(_PackageDescription, introduced: 5.5)
     public static func package(
         url: String,
@@ -247,12 +283,16 @@ extension Package.Dependency {
 
     /// Adds a remote package dependency given a branch requirement.
     ///
-    ///    .package(url: "https://example.com/example-package.git", branch: "main"),
+    /// ```swift
+    /// .package(url: "https://example.com/example-package.git", branch: "main"),
+    /// ```
     ///
     /// - Parameters:
-    ///     - name: The name of the package, or nil to deduce it from the URL.
-    ///     - url: The valid Git URL of the package.
-    ///     - branch: A dependency requirement. See static methods on `Package.Dependency.Requirement` for available options.
+    ///   - name: The name of the package, or nil to deduce it from the URL.
+    ///   - url: The valid Git URL of the package.
+    ///   - branch: A dependency requirement. See static methods on ``Requirement-swift.enum`` for available options.
+    ///
+    /// - Returns: A `Package.Dependency` instance.
     @available(_PackageDescription, introduced: 5.5, deprecated: 5.6, message: "use package(url:branch:) instead")
     public static func package(
         name: String,
@@ -264,11 +304,15 @@ extension Package.Dependency {
 
     /// Adds a remote package dependency given a revision requirement.
     ///
-    ///    .package(url: "https://example.com/example-package.git", revision: "aa681bd6c61e22df0fd808044a886fc4a7ed3a65"),
+    /// ```swift
+    /// .package(url: "https://example.com/example-package.git", revision: "aa681bd6c61e22df0fd808044a886fc4a7ed3a65"),
+    /// ```
     ///
     /// - Parameters:
-    ///     - url: The valid Git URL of the package.
-    ///     - revision: A dependency requirement. See static methods on `Package.Dependency.Requirement` for available options.
+    ///   - url: The valid Git URL of the package.
+    ///   - revision: A dependency requirement. See static methods on ``Requirement-swift.enum`` for available options.
+    ///
+    /// - Returns: A `Package.Dependency` instance.
     @available(_PackageDescription, introduced: 5.5)
     public static func package(
         url: String,
@@ -279,12 +323,16 @@ extension Package.Dependency {
 
     /// Adds a remote package dependency given a revision requirement.
     ///
-    ///    .package(url: "https://example.com/example-package.git", revision: "aa681bd6c61e22df0fd808044a886fc4a7ed3a65"),
+    /// ```swift
+    /// .package(url: "https://example.com/example-package.git", revision: "aa681bd6c61e22df0fd808044a886fc4a7ed3a65"),
+    /// ```
     ///
     /// - Parameters:
-    ///     - name: The name of the package, or nil to deduce it from the URL.
-    ///     - url: The valid Git URL of the package.
-    ///     - revision: A dependency requirement. See static methods on `Package.Dependency.Requirement` for available options.
+    ///   - name: The name of the package, or nil to deduce it from the URL.
+    ///   - url: The valid Git URL of the package.
+    ///   - revision: A dependency requirement. See static methods on ``Requirement-swift.enum`` for available options.
+    ///
+    /// - Returns: A `Package.Dependency` instance.
     @available(_PackageDescription, introduced: 5.5, deprecated: 5.6, message: "use package(url:revision:) instead")
     public static func package(
         name: String,
@@ -300,12 +348,16 @@ extension Package.Dependency {
     /// The following example allows the Swift Package Manager to pick
     /// versions `1.2.3`, `1.2.4`, `1.2.5`, but not `1.2.6`.
     ///
-    ///     .package(url: "https://example.com/example-package.git", "1.2.3"..<"1.2.6"),
+    /// ```swift
+    /// .package(url: "https://example.com/example-package.git", "1.2.3"..<"1.2.6"),
+    /// ```
     ///
     /// - Parameters:
-    ///     - name: The name of the package, or nil to deduce it from the URL.
-    ///     - url: The valid Git URL of the package.
-    ///     - range: The custom version range requirement.
+    ///   - name: The name of the package, or nil to deduce it from the URL.
+    ///   - url: The valid Git URL of the package.
+    ///   - range: The custom version range requirement.
+    ///
+    /// - Returns: A `Package.Dependency` instance.
     public static func package(
         url: String,
         _ range: Range<Version>
@@ -319,12 +371,16 @@ extension Package.Dependency {
     /// The following example allows the Swift Package Manager to pick
     /// versions `1.2.3`, `1.2.4`, `1.2.5`, but not `1.2.6`.
     ///
-    ///     .package(url: "https://example.com/example-package.git", "1.2.3"..<"1.2.6"),
+    /// ```swift
+    /// .package(url: "https://example.com/example-package.git", "1.2.3"..<"1.2.6"),
+    /// ```
     ///
     /// - Parameters:
-    ///     - name: The name of the package, or `nil` to deduce it from the URL.
-    ///     - url: The valid Git URL of the package.
-    ///     - range: The custom version range requirement.
+    ///   - name: The name of the package, or `nil` to deduce it from the URL.
+    ///   - url: The valid Git URL of the package.
+    ///   - range: The custom version range requirement.
+    ///
+    /// - Returns: A `Package.Dependency` instance.
     @available(_PackageDescription, introduced: 5.2, deprecated: 5.6, message: "use package(url:_:) instead")
     public static func package(
         name: String,
@@ -340,12 +396,16 @@ extension Package.Dependency {
     /// The following example allows the Swift Package Manager to pick
     /// versions 1.2.3, 1.2.4, 1.2.5, as well as 1.2.6.
     ///
-    ///     .package(url: "https://example.com/example-package.git", "1.2.3"..."1.2.6"),
+    /// ```swift
+    /// .package(url: "https://example.com/example-package.git", "1.2.3"..."1.2.6"),
+    /// ```
     ///
     /// - Parameters:
-    ///     - name: The name of the package, or `nil` to deduce it from the URL.
-    ///     - url: The valid Git URL of the package.
-    ///     - range: The closed version range requirement.
+    ///   - name: The name of the package, or `nil` to deduce it from the URL.
+    ///   - url: The valid Git URL of the package.
+    ///   - range: The closed version range requirement.
+    ///
+    /// - Returns: A `Package.Dependency` instance.
     public static func package(
         url: String,
         _ range: ClosedRange<Version>
@@ -359,22 +419,30 @@ extension Package.Dependency {
     /// The following example allows the Swift Package Manager to pick
     /// versions 1.2.3, 1.2.4, 1.2.5, as well as 1.2.6.
     ///
-    ///    .package(url: "https://example.com/example-package.git", "1.2.3"..."1.2.6"),
+    /// ```swift
+    /// .package(url: "https://example.com/example-package.git", "1.2.3"..."1.2.6"),
+    /// ```
     ///
     /// The following example allows the Swift Package Manager to pick
     /// versions between 1.0.0 and 2.0.0
     ///
-    ///    .package(url: "https://example.com/example-package.git", .upToNextMajor("1.0.0"),
+    /// ```swift
+    /// .package(url: "https://example.com/example-package.git", .upToNextMajor("1.0.0"),
+    /// ```
     ///
     /// The following example allows the Swift Package Manager to pick
     /// versions between 1.0.0 and 1.1.0
     ///
-    ///    .package(url: "https://example.com/example-package.git", .upToNextMinor("1.0.0"),
+    /// ```swift
+    /// .package(url: "https://example.com/example-package.git", .upToNextMinor("1.0.0"),
+    /// ```
     ///
     /// - Parameters:
-    ///     - name: The name of the package, or `nil` to deduce it from the URL.
-    ///     - url: The valid Git URL of the package.
-    ///     - range: The closed version range requirement.
+    ///   - name: The name of the package, or `nil` to deduce it from the URL.
+    ///   - url: The valid Git URL of the package.
+    ///   - range: The closed version range requirement.
+    ///
+    /// - Returns: A `Package.Dependency` instance.
     @available(_PackageDescription, introduced: 5.2, deprecated: 5.6, message: "use package(url:_:) instead")
     public static func package(
         name: String,
@@ -390,12 +458,16 @@ extension Package.Dependency {
     /// The following example allows the Swift Package Manager to pick
     /// versions 1.2.3, 1.2.4, 1.2.5, as well as 1.2.6.
     ///
-    ///    .package(url: "https://example.com/example-package.git", "1.2.3"..."1.2.6"),
+    /// ```swift
+    /// .package(url: "https://example.com/example-package.git", "1.2.3"..."1.2.6"),
+    /// ```
     ///
     /// - Parameters:
-    ///     - name: The name of the package, or `nil` to deduce it from the URL.
-    ///     - url: The valid Git URL of the package.
-    ///     - range: The closed version range requirement.
+    ///   - name: The name of the package, or `nil` to deduce it from the URL.
+    ///   - url: The valid Git URL of the package.
+    ///   - range: The closed version range requirement.
+    ///
+    /// - Returns: A `Package.Dependency` instance.
     private static func package(
         name: String?,
         url: String,
@@ -421,11 +493,15 @@ extension Package.Dependency {
     ///
     /// The following example instruct the Swift Package Manager to use version `1.2.3`.
     ///
-    ///    .package(url: "https://example.com/example-package.git", exact: "1.2.3"),
+    /// ```swift
+    /// .package(url: "https://example.com/example-package.git", exact: "1.2.3"),
+    /// ```
     ///
     /// - Parameters:
-    ///     - url: The valid Git URL of the package.
-    ///     - version: The minimum version requirement.
+    ///   - url: The valid Git URL of the package.
+    ///   - version: The exact version of the dependency for this requirement.
+    ///
+    /// - Returns: A `Package.Dependency` instance.
     @available(_PackageDescription, introduced: 5.6)
     public static func package(
         url: String,
@@ -437,9 +513,11 @@ extension Package.Dependency {
     /// Adds a remote package dependency given a version requirement.
     ///
     /// - Parameters:
-    ///     - name: The name of the package, or nil to deduce it from the URL.
-    ///     - url: The valid Git URL of the package.
-    ///     - requirement: A dependency requirement. See static methods on `Package.Dependency.Requirement` for available options.
+    ///   - name: The name of the package, or nil to deduce it from the URL.
+    ///   - url: The valid Git URL of the package.
+    ///   - requirement: A dependency requirement. See static methods on `Package.Dependency.Requirement` for available options.
+    ///
+    /// - Returns: A `Package.Dependency` instance.
     @available(_PackageDescription, deprecated: 5.6, message: "use specific requirement APIs instead (e.g. use 'branch:' instead of '.branch')")
     public static func package(
         url: String,
@@ -451,9 +529,12 @@ extension Package.Dependency {
     /// Adds a remote package dependency with a given version requirement.
     ///
     /// - Parameters:
-    ///     - name: The name of the package, or `nil` to deduce it from the URL.
-    ///     - url: The valid Git URL of the package.
-    ///     - requirement: A dependency requirement. See static methods on `Package.Dependency.Requirement` for available options.
+    ///   - name: The name of the Swift package or `nil` to deduce the name from the package's Git URL.
+    ///   - url: The valid Git URL of the package.
+    ///   - requirement: A dependency requirement. See static methods on
+    ///     ``Package/Dependency/Requirement-swift.enum`` for available options.
+    ///
+    /// - Returns: A `Package.Dependency` instance.
     @available(_PackageDescription, introduced: 5.2, deprecated: 5.6, message: "use specific requirement APIs instead (e.g. use 'branch:' instead of '.branch')")
     public static func package(
         name: String?,
@@ -490,11 +571,15 @@ extension Package.Dependency {
     /// The following example allows the Swift Package Manager to select a version
     /// like a  `1.2.3`, `1.2.4`, or `1.3.0`, but not `2.0.0`.
     ///
-    ///    .package(id: "scope.name", from: "1.2.3"),
+    /// ```swift
+    /// .package(id: "scope.name", from: "1.2.3"),
+    /// ```
     ///
     /// - Parameters:
-    ///     - id: The identity of the package.
-    ///     - version: The minimum version requirement.
+    ///   - id: The identity of the package.
+    ///   - version: The minimum version requirement.
+    ///
+    /// - Returns: A `Package.Dependency` instance.
     @available(_PackageDescription, introduced: 5.7)
     public static func package(
         id: String,
@@ -514,11 +599,15 @@ extension Package.Dependency {
     ///
     /// The following example instruct the Swift Package Manager to use version `1.2.3`.
     ///
-    ///    .package(id: "scope.name", exact: "1.2.3"),
+    /// ```swift
+    /// .package(id: "scope.name", exact: "1.2.3"),
+    /// ```
     ///
     /// - Parameters:
-    ///     - id: The identity of the package.
-    ///     - version: The minimum version requirement.
+    ///   - id: The identity of the package.
+    ///   - version: The exact version of the dependency for this requirement.
+    ///
+    /// - Returns: A `Package.Dependency` instance.
     @available(_PackageDescription, introduced: 5.7)
     public static func package(
         id: String,
@@ -533,21 +622,29 @@ extension Package.Dependency {
     /// The following example allows the Swift Package Manager to pick
     /// versions `1.2.3`, `1.2.4`, `1.2.5`, but not `1.2.6`.
     ///
-    ///    .package(id: "scope.name", "1.2.3"..<"1.2.6"),
+    /// ```swift
+    /// .package(id: "scope.name", "1.2.3"..<"1.2.6"),
+    /// ```
     ///
     /// The following example allows the Swift Package Manager to pick
     /// versions between 1.0.0 and 2.0.0
     ///
-    ///    .package(id: "scope.name", .upToNextMajor("1.0.0"),
+    /// ```swift
+    /// .package(id: "scope.name", .upToNextMajor("1.0.0"),
+    /// ```
     ///
     /// The following example allows the Swift Package Manager to pick
     /// versions between 1.0.0 and 1.1.0
     ///
-    ///    .package(id: "scope.name", .upToNextMinor("1.0.0"),
+    /// ```swift
+    /// .package(id: "scope.name", .upToNextMinor("1.0.0"),
+    /// ```
     ///
     /// - Parameters:
-    ///     - id: The identity of the package.
-    ///     - range: The custom version range requirement.
+    ///   - id: The identity of the package.
+    ///   - range: The custom version range requirement.
+    ///
+    /// - Returns: A `Package.Dependency` instance.
     @available(_PackageDescription, introduced: 5.7)
     public static func package(
         id: String,
@@ -562,11 +659,15 @@ extension Package.Dependency {
     /// The following example allows the Swift Package Manager to pick
     /// versions 1.2.3, 1.2.4, 1.2.5, as well as 1.2.6.
     ///
-    ///    .package(id: "scope.name", "1.2.3"..."1.2.6"),
+    /// ```swift
+    /// .package(id: "scope.name", "1.2.3"..."1.2.6"),
+    /// ```
     ///
     /// - Parameters:
-    ///     - id: The identity of the package.
-    ///     - range: The closed version range requirement.
+    ///   - id: The identity of the package.
+    ///   - range: The closed version range requirement.
+    ///
+    /// - Returns: A `Package.Dependency` instance.
     @available(_PackageDescription, introduced: 5.7)
     public static func package(
         id: String,

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/BuildConfiguration.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/BuildConfiguration.md
@@ -1,0 +1,12 @@
+# ``PackageDescription/BuildConfiguration``
+
+## Topics
+
+### Describing Build Configurations
+
+- ``debug``
+- ``release``
+
+### Encoding and Decoding
+
+- ``encode(to:)``

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/BuildSettingCondition.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/BuildSettingCondition.md
@@ -1,0 +1,14 @@
+# ``PackageDescription/BuildSettingCondition``
+
+## Topics
+
+### Checking for a Build Condition
+
+- ``when(platforms:)``
+- ``when(configuration:)``
+- ``when(platforms:configuration:)-2991l``
+- ``when(platforms:configuration:)-475co``
+
+### Encoding and Decoding
+
+- ``encode(to:)``

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/CLanguageStandard.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/CLanguageStandard.md
@@ -1,0 +1,48 @@
+# ``PackageDescription/CLanguageStandard``
+
+## Topics
+
+### Enumeration Cases
+
+- ``c11``
+- ``c17``
+- ``c18``
+- ``c2x``
+- ``c89``
+- ``c90``
+- ``c99``
+- ``gnu11``
+- ``gnu17``
+- ``gnu18``
+- ``gnu2x``
+- ``gnu89``
+- ``gnu90``
+- ``gnu99``
+- ``iso9899_1990``
+- ``iso9899_199409``
+- ``iso9899_1999``
+- ``iso9899_2011``
+- ``iso9899_2017``
+- ``iso9899_2018``
+
+### Encoding and Decoding
+
+- ``encode(to:)``
+
+### Hashing
+
+- ``hash(into:)``
+- ``hashValue``
+
+### Operator Functions
+
+- ``!=(_:_:)``
+
+### Creating a Value
+
+- ``init(rawValue:)``
+
+### Accessing the Raw Value
+
+- ``rawValue-swift.property``
+- ``RawValue-swift.typealias``

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/CSetting.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/CSetting.md
@@ -1,0 +1,13 @@
+# ``PackageDescription/CSetting``
+
+## Topics
+
+### Configuring C Settings
+
+- ``define(_:to:_:)``
+- ``headerSearchPath(_:_:)``
+- ``unsafeFlags(_:_:)``
+
+### Encoding and Decoding
+
+- ``encode(to:)``

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/CXXLanguageStandard.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/CXXLanguageStandard.md
@@ -1,0 +1,44 @@
+# ``PackageDescription/CXXLanguageStandard``
+
+## Topics
+
+### Enumeration Cases
+
+- ``cxx03``
+- ``cxx11``
+- ``cxx14``
+- ``cxx1z``
+- ``cxx98``
+- ``gnucxx03``
+- ``gnucxx11``
+- ``gnucxx14``
+- ``gnucxx1z``
+- ``gnucxx98``
+- ``cxx17``
+- ``cxx20``
+- ``cxx2b``
+- ``gnucxx17``
+- ``gnucxx20``
+- ``gnucxx2b``
+
+### Encoding and Decoding
+
+- ``encode(to:)``
+
+### Hashing
+
+- ``hash(into:)``
+- ``hashValue``
+
+### Operator Functions
+
+- ``!=(_:_:)``
+
+### Creating a Value
+
+- ``init(rawValue:)``
+
+### Accessing the Raw Value
+
+- ``rawValue-swift.property``
+- ``RawValue-swift.typealias``

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/CXXSetting.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/CXXSetting.md
@@ -1,0 +1,13 @@
+# ``PackageDescription/CXXSetting``
+
+## Topics
+
+### Configuring CXX Settings
+
+- ``define(_:to:_:)``
+- ``headerSearchPath(_:_:)``
+- ``unsafeFlags(_:_:)``
+
+### Encoding and Decoding
+
+- ``encode(to:)``

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Dependency.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Dependency.md
@@ -1,0 +1,28 @@
+# ``PackageDescription/Package/Dependency``
+
+## Topics
+
+### Creating a Package Dependency
+
+- ``package(name:path:)``
+- ``package(url:from:)``
+- ``package(url:_:)-2ys47``
+- ``package(url:_:)-1r6rc``
+- ``package(url:branch:)``
+- ``package(url:revision:)``
+- ``package(url:exact:)``
+- ``package(path:)``
+
+### Declaring Requirements
+
+- ``requirement-swift.property``
+- ``Requirement-swift.enum``
+
+### Describing a Package Dependency
+
+- ``kind-swift.property``
+- ``Version``
+
+### Encoding and Decoding
+
+- ``encode(to:)``

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/CLanguageStandard-hash.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/CLanguageStandard-hash.md
@@ -1,0 +1,9 @@
+# ``PackageDescription/CLanguageStandard/hash(into:)``
+
+@Metadata {
+   @DocumentationExtension(mergeBehavior: override)
+}
+
+Hashes the C language standard by feeding the item into the given hasher.
+
+- Parameter into: The hasher.

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/CLanguageStandard-hashValue.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/CLanguageStandard-hashValue.md
@@ -1,0 +1,7 @@
+# ``PackageDescription/CLanguageStandard/hashValue``
+
+@Metadata {
+   @DocumentationExtension(mergeBehavior: override)
+}
+
+The hash value for the C language standard.

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/CLanguageStandard-notEqual.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/CLanguageStandard-notEqual.md
@@ -1,0 +1,15 @@
+# ``PackageDescription/CLanguageStandard/!=(_:_:)``
+
+@Metadata {
+   @DocumentationExtension(mergeBehavior: override)
+}
+
+Returns a Boolean value indicating whether two values are not equal.
+
+- Parameters:
+  - lhs: A value to compare.
+  - rhs: Another value to compare.
+
+Inequality is the inverse of equality. For any values a and b, a != b implies that a == b is false.
+
+This is the default implementation of the not-equal-to operator (!=) for any type that conforms to Equatable.

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/CXXLanguageStandard-hash.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/CXXLanguageStandard-hash.md
@@ -1,0 +1,9 @@
+# ``PackageDescription/CXXLanguageStandard/hash(into:)``
+
+@Metadata {
+   @DocumentationExtension(mergeBehavior: override)
+}
+
+Hashes the C++ language standard by feeding the item into the given hasher.
+
+- Parameter into: The hasher.

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/CXXLanguageStandard-hashValue.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/CXXLanguageStandard-hashValue.md
@@ -1,0 +1,8 @@
+# ``PackageDescription/CXXLanguageStandard/hashValue``
+
+@Metadata {
+   @DocumentationExtension(mergeBehavior: override)
+}
+
+The hash value for the C++ language standard.
+

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/CXXLanguageStandard-notEqual.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/CXXLanguageStandard-notEqual.md
@@ -1,0 +1,15 @@
+# ``PackageDescription/CXXLanguageStandard/!=(_:_:)``
+
+@Metadata {
+   @DocumentationExtension(mergeBehavior: override)
+}
+
+Returns a Boolean value indicating whether two values are not equal.
+
+- Parameters:
+  - lhs: A value to compare.
+  - rhs: Another value to compare.
+
+Inequality is the inverse of equality. For any values a and b, a != b implies that a == b is false.
+
+This is the default implementation of the not-equal-to operator (!=) for any type that conforms to Equatable.

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/LanguageTag-hash.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/LanguageTag-hash.md
@@ -1,0 +1,9 @@
+# ``PackageDescription/LanguageTag/hash(into:)``
+
+@Metadata {
+   @DocumentationExtension(mergeBehavior: override)
+}
+
+Hashes the language tag by feeding the item into the given hasher.
+
+- Parameter into: The hasher.

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/LanguageTag-hashValue.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/LanguageTag-hashValue.md
@@ -1,0 +1,7 @@
+# ``PackageDescription/LanguageTag/hashValue``
+
+@Metadata {
+   @DocumentationExtension(mergeBehavior: override)
+}
+
+The hash value for language tag.

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/LanguageTag-initRawValue.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/LanguageTag-initRawValue.md
@@ -1,0 +1,12 @@
+# ``PackageDescription/LanguageTag/init(rawValue:)``
+
+@Metadata {
+   @DocumentationExtension(mergeBehavior: override)
+}
+
+Creates a new instance with the specified raw value.
+
+- Parameter rawValue: The raw value to use for the new instance.
+
+If there is no value of the type that corresponds with the specified raw value, this initializer returns `nil`.
+

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/LanguageTag-notEqual.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/LanguageTag-notEqual.md
@@ -1,0 +1,15 @@
+# ``PackageDescription/LanguageTag/!=(_:_:)``
+
+@Metadata {
+   @DocumentationExtension(mergeBehavior: override)
+}
+
+Returns a Boolean value indicating whether two values are not equal.
+
+- Parameters:
+  - lhs: A value to compare.
+  - rhs: Another value to compare.
+
+Inequality is the inverse of equality. For any values a and b, a != b implies that a == b is false.
+
+This is the default implementation of the not-equal-to operator (!=) for any type that conforms to Equatable.

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/LanguageTag-rawValue.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/LanguageTag-rawValue.md
@@ -1,0 +1,9 @@
+# ``PackageDescription/LanguageTag/rawValue``
+
+@Metadata {
+   @DocumentationExtension(mergeBehavior: override)
+}
+
+The corresponding value of the raw type.
+
+A new instance initialized with `rawValue` will be equivalent to this instance.

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/LanguageTg-ExtendedGraphemeClusterLiteralType.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/LanguageTg-ExtendedGraphemeClusterLiteralType.md
@@ -1,0 +1,10 @@
+# ``PackageDescription/LanguageTag/ExtendedGraphemeClusterLiteralType``
+
+
+@Metadata {
+   @DocumentationExtension(mergeBehavior: override)
+}
+
+A type that represents an extended grapheme cluster literal.
+
+Valid types for ExtendedGraphemeClusterLiteralType are Character, String, and StaticString.

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/Library-LibraryType-hash.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/Library-LibraryType-hash.md
@@ -1,0 +1,14 @@
+# ``PackageDescription/Product/Library/LibraryType/hash(into:)``
+
+@Metadata {
+   @DocumentationExtension(mergeBehavior: override)
+}
+
+Hashes the essential components of this value by feeding them into the given hasher.
+
+Implement this method to conform to the Hashable protocol. The components used for hashing must be the same as the components compared in your type’s == operator implementation. Call hasher.combine(_:) with each of these components.
+
+> Important:
+> Never call finalize() on hasher. Doing so may become a compile-time error in the future.
+
+- Parameter into: The hasher to use when combining the components of this instance.

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/Library-LibraryType-hashValue.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/Library-LibraryType-hashValue.md
@@ -1,0 +1,7 @@
+# ``PackageDescription/Product/Library/LibraryType/hashValue``
+
+@Metadata {
+   @DocumentationExtension(mergeBehavior: override)
+}
+
+The library type’s hash value.

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/Library-LibraryType-initRawValue.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/Library-LibraryType-initRawValue.md
@@ -1,0 +1,11 @@
+# ``PackageDescription/Product/Library/LibraryType/init(rawValue:)``
+
+@Metadata {
+   @DocumentationExtension(mergeBehavior: override)
+}
+
+Creates a new instance with the specified raw value.
+
+- Parameter rawValue: The raw value to use for the new instance.
+
+If there is no value of the type that corresponds with the specified raw value, this initializer returns `nil`.

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/Library-LibraryType-notEqual.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/Library-LibraryType-notEqual.md
@@ -1,0 +1,15 @@
+# ``PackageDescription/Product/Library/LibraryType/!=(_:_:)``
+
+@Metadata {
+   @DocumentationExtension(mergeBehavior: override)
+}
+
+Returns a Boolean value indicating whether two values are not equal.
+
+- Parameters:
+  - lhs: A value to compare.
+  - rhs: Another value to compare.
+
+Inequality is the inverse of equality. For any values a and b, `a != b` implies that `a == b` is `false`.
+
+This is the default implementation of the not-equal-to operator (`!=`) for any type that conforms to `Equatable`.

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/Library-LibraryType-rawValue.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/Library-LibraryType-rawValue.md
@@ -1,0 +1,5 @@
+# ``PackageDescription/Product/Library/LibraryType/rawValue``
+
+The corresponding value of the raw type.
+
+A new instance initialized with `rawValue` will be equivalent to this instance.

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/Library-LibraryType.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/Library-LibraryType.md
@@ -1,0 +1,30 @@
+# ``PackageDescription/Product/Library/LibraryType``
+
+## Topics
+
+### Enumeration Cases
+
+- ``dynamic``
+- ``static``
+
+### Encoding and Decoding
+
+- ``encode(to:)``
+
+### Hashing
+
+- <doc:/documentation/PackageDescription/Product/Library/LibraryType/hash(into:)>
+- <doc:/documentation/PackageDescription/Product/Library/LibraryType/hashValue>
+
+### Operator Functions
+
+- <doc:/documentation/PackageDescription/Product/Library/LibraryType/!=(_:_:)>
+
+### Creating a Value
+
+- <doc:/documentation/PackageDescription/Product/Library/LibraryType/init(rawValue:)>
+
+### Accessing the Raw Value
+
+- ``rawValue-swift.property``
+- ``RawValue-swift.typealias``

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/Product-Executable.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/Product-Executable.md
@@ -1,0 +1,11 @@
+# ``PackageDescription/Product/Executable``
+
+## Topics
+
+### Describing an Executable Product
+
+- ``targets``
+
+### Encoding and Decoding
+
+- ``encode(to:)``

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/Resource-Localization-hash.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/Resource-Localization-hash.md
@@ -1,0 +1,9 @@
+# ``PackageDescription/Resource/Localization/hash(into:)``
+
+@Metadata {
+   @DocumentationExtension(mergeBehavior: override)
+}
+
+Hashes the localization by feeding the item into the given hasher.
+
+- Parameter into: The hasher.

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/Resource-Localization-hashValue.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/Resource-Localization-hashValue.md
@@ -1,0 +1,7 @@
+# ``PackageDescription/Resource/Localization/hashValue``
+
+@Metadata {
+   @DocumentationExtension(mergeBehavior: override)
+}
+
+The localization's hash value.

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/Resource-Localization-notEqual.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/Resource-Localization-notEqual.md
@@ -1,0 +1,15 @@
+# ``PackageDescription/Resource/Localization/!=(_:_:)``
+
+@Metadata {
+   @DocumentationExtension(mergeBehavior: override)
+}
+
+Returns a Boolean value indicating whether two values are not equal.
+
+- Parameters:
+  - lhs: A value to compare.
+  - rhs: Another value to compare.
+
+Inequality is the inverse of equality. For any values a and b, `a != b` implies that `a == b` is `false`.
+
+This is the default implementation of the not-equal-to operator (`!=`) for any type that conforms to `Equatable`.

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/Target-TargetType-hash.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/Target-TargetType-hash.md
@@ -1,0 +1,11 @@
+# ``PackageDescription/Target/TargetType/hash(into:)``
+
+@Metadata {
+   @DocumentationExtension(mergeBehavior: override)
+}
+
+Hashes the target type by feeding the item into the given hasher.
+
+- Parameter into: The hasher.
+
+

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/Target-TargetType-hashValue.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/Target-TargetType-hashValue.md
@@ -1,0 +1,7 @@
+# ``PackageDescription/Target/TargetType/hashValue``
+
+@Metadata {
+   @DocumentationExtension(mergeBehavior: override)
+}
+
+The target type's hash value.

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/Target-TargetType-notEqual.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/Target-TargetType-notEqual.md
@@ -1,0 +1,16 @@
+# ``PackageDescription/Target/TargetType/!=(_:_:)``
+
+@Metadata {
+   @DocumentationExtension(mergeBehavior: override)
+}
+
+Returns a Boolean value indicating whether two values are not equal.
+
+- Parameters:
+  - lhs: A value to compare.
+  - rhs: Another value to compare.
+
+Inequality is the inverse of equality. For any values a and b, `a != b` implies that `a == b` is `false`.
+
+This is the default implementation of the not-equal-to operator (`!=`) for any type that conforms to `Equatable`.
+

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/LanguageTag.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/LanguageTag.md
@@ -1,0 +1,33 @@
+#  ``PackageDescription/LanguageTag``
+
+## Topics
+
+### Creating a Language Tag
+
+- ``init(_:)``
+- <doc:/documentation/PackageDescription/LanguageTag/init(extendedGraphemeClusterLiteral:)-36buv>
+- ``init(stringLiteral:)``
+- <doc:/documentation/PackageDescription/LanguageTag/init(unicodeScalarLiteral:)-1j41k>
+- ``init(rawValue:)``
+- ``rawValue-swift.property``
+
+### Describing a Language Tag
+
+- ``tag``
+- ``description``
+
+### Hashing
+
+- <doc:/documentation/PackageDescription/LanguageTag/hash(into:)>
+- <doc:/documentation/PackageDescription/LanguageTag/hashValue>
+
+### Operator Functions
+
+- <doc:/documentation/PackageDescription/LanguageTag/!=(_:_:)>
+
+### Identifying Related Types
+
+- ``LanguageTag/ExtendedGraphemeClusterLiteralType``
+- ``LanguageTag/RawValue-swift.typealias``
+- ``LanguageTag/StringLiteralType``
+- ``LanguageTag/UnicodeScalarLiteralType``

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Library.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Library.md
@@ -1,0 +1,13 @@
+# ``PackageDescription/Product/Library``
+
+## Topics
+
+### Describing a Library Product
+
+- ``targets``
+- ``type``
+- ``LibraryType``
+
+### Encoding and Decoding
+
+- ``encode(to:)``

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/LinkerSetting.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/LinkerSetting.md
@@ -1,0 +1,13 @@
+# ``PackageDescription/LinkerSetting``
+
+## Topics
+
+### Configuring Linker Settings
+
+- ``linkedFramework(_:_:)``
+- ``linkedLibrary(_:_:)``
+- ``unsafeFlags(_:_:)``
+
+### Encoding and Decoding
+
+- ``encode(to:)``

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Package.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Package.md
@@ -1,0 +1,57 @@
+#  ``PackageDescription/Package``
+
+## Topics
+
+### Creating a Package
+
+- ``Package/init(name:defaultLocalization:platforms:pkgConfig:providers:products:dependencies:targets:swiftLanguageVersions:cLanguageStandard:cxxLanguageStandard:)``
+
+### Naming the Package
+
+- ``Package/name``
+
+### Localizing Package Resources
+
+- ``Package/defaultLocalization``
+- ``LanguageTag``
+
+### Configuring Products
+
+- ``Package/products``
+- ``Product``
+
+### Configuring Targets
+
+- ``Package/targets``
+- ``Target``
+
+### Declaring Supported Platforms
+
+- ``Package/platforms``
+- ``SupportedPlatform``
+- ``Platform``
+
+### Configuring System Packages
+
+- ``SystemPackageProvider``
+- ``Package/pkgConfig``
+- ``Package/providers``
+
+### Declaring Package Dependencies
+
+- ``Package/dependencies``
+- ``Package/Dependency``
+
+### Declaring Supported Languages
+
+- ``SwiftVersion``
+- ``CLanguageStandard``
+- ``CXXLanguageStandard``
+- ``Package/swiftLanguageVersions``
+- ``Package/cLanguageStandard``
+- ``Package/cxxLanguageStandard``
+
+### Encoding and Decoding
+
+- ``Package/encode(to:)``
+

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Platform-notEqual.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Platform-notEqual.md
@@ -1,0 +1,15 @@
+# ``PackageDescription/Platform/!=(_:_:)``
+
+@Metadata {
+   @DocumentationExtension(mergeBehavior: override)
+}
+
+Returns a Boolean value indicating whether two values are not equal.
+
+- Parameters:
+  - lhs: A value to compare.
+  - rhs: Another value to compare.
+
+Inequality is the inverse of equality. For any values a and b, `a != b` implies that `a == b` is `false`.
+
+This is the default implementation of the not-equal-to operator (`!=`) for any type that conforms to `Equatable`.

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Platform.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Platform.md
@@ -1,0 +1,30 @@
+# ``PackageDescription/Platform``
+
+
+## Topics
+
+### Platforms
+
+- ``iOS``
+- ``macOS``
+- ``tvOS``
+- ``watchOS``
+- ``macCatalyst``
+- ``driverKit``
+- ``android``
+- ``linux``
+- ``openbsd``
+- ``wasi``
+- ``windows``
+
+### Encoding and Decoding
+
+- ``encode(to:)``
+
+### Type Methods
+
+- ``custom(_:)``
+
+### Operator Functions
+
+- ``!=(_:_:)``

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Plugin.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Plugin.md
@@ -1,0 +1,11 @@
+# ``PackageDescription/Product/Plugin``
+
+## Topics
+
+### Describing a Plugin Product
+
+- ``targets``
+
+### Encoding and Decoding
+
+- ``encode(to:)``

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/PluginCapability.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/PluginCapability.md
@@ -1,0 +1,12 @@
+# ``PackageDescription/Target/PluginCapability-swift.enum``
+
+## Topics
+
+### Creating a Plugin Capability
+
+- ``buildTool()``
+- ``command(intent:permissions:)``
+
+### Encoding and Decoding
+
+- ``encode(to:)``

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/PluginCommandIntent.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/PluginCommandIntent.md
@@ -1,0 +1,13 @@
+# ``PackageDescription/PluginCommandIntent``
+
+## Topics
+
+### Creating a Command Intent
+
+- ``documentationGeneration()``
+- ``sourceCodeFormatting()``
+- ``custom(verb:description:)``
+
+### Encoding and Decoding
+
+- ``encode(to:)``

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/PluginPermission.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/PluginPermission.md
@@ -1,0 +1,11 @@
+# ``PackageDescription/PluginPermission``
+
+## Topics
+
+### Create a Permission
+
+- ``writeToPackageDirectory(reason:)``
+
+### Encoding and Decoding
+
+- ``encode(to:)``

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/PluginUsage.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/PluginUsage.md
@@ -1,0 +1,12 @@
+# ``PackageDescription/Target/PluginUsage``
+
+## Topics
+
+### Creating a Plugin Usage
+
+- ``plugin(name:)``
+- ``plugin(name:package:)``
+
+### Encoding and Decoding
+
+-  ``encode(to:)``

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Product.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Product.md
@@ -1,0 +1,26 @@
+#  ``PackageDescription/Product``
+
+## Topics
+
+### Creating a Library Product
+
+- ``library(name:type:targets:)``
+- ``Library``
+
+### Creating an Executable Product
+
+- ``executable(name:targets:)``
+- ``Executable``
+
+### Creating a Plugin Product
+
+- ``Product/plugin(name:targets:)``
+- ``Plugin``
+
+### Naming the Product
+
+- ``name``
+
+### Encoding and Decoding
+
+- ``encode(to:)``

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Resource-Localization.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Resource-Localization.md
@@ -1,0 +1,30 @@
+# ``PackageDescription/Resource/Localization``
+
+## Topics
+
+### Enumeration Cases
+
+- ``base``
+- ``default``
+
+### Encoding and Decoding
+
+- ``encode(to:)``
+
+### Hashing
+
+- ``hash(into:)``
+- ``hashValue``
+
+### Operator Functions
+
+- ``!=(_:_:)``
+
+### Creating a Value
+
+- ``init(rawValue:)``
+
+### Accessing the Raw Value
+
+- ``rawValue-swift.property``
+- ``RawValue-swift.typealias``

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Resource.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Resource.md
@@ -1,0 +1,13 @@
+# ``PackageDescription/Resource``
+
+## Topics
+
+### Applying Rules
+
+- ``process(_:localization:)``
+- ``Localization``
+- ``copy(_:)``
+
+### Encoding and Decoding
+
+- ``encode(to:)``

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/SupportedPlatforms-encode.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/SupportedPlatforms-encode.md
@@ -1,0 +1,10 @@
+# ``PackageDescription/SupportedPlatform/encode(to:)``
+
+@Metadata {
+   @DocumentationExtension(mergeBehavior: override)
+}
+
+Encodes this value into the given encoder.
+
+If the value fails to encode anything, `encoder` will encode an empty keyed container in its place.
+This function throws an error if any values are invalid for the given encoder’s format.

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/SupportedPlatforms-notEqual.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/SupportedPlatforms-notEqual.md
@@ -1,0 +1,15 @@
+# ``PackageDescription/SupportedPlatform/!=(_:_:)``
+
+@Metadata {
+   @DocumentationExtension(mergeBehavior: override)
+}
+
+Returns a Boolean value indicating whether two values are not equal.
+
+- Parameters:
+  - lhs: A value to compare.
+  - rhs: Another value to compare.
+
+Inequality is the inverse of equality. For any values a and b, `a != b` implies that `a == b` is `false`.
+
+This is the default implementation of the not-equal-to operator (`!=`) for any type that conforms to `Equatable`.

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/SupportedPlatforms.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/SupportedPlatforms.md
@@ -1,0 +1,62 @@
+# ``PackageDescription/SupportedPlatform``
+
+## Topics
+
+### Supporting iOS
+
+- ``iOS(_:)-5pvv5``
+- ``iOS(_:)-83bbf``
+- <doc:/documentation/PackageDescription/Platform/iOS>
+- ``IOSVersion``
+
+### Supporting macOS
+
+- ``macOS(_:)-2wthp``
+- ``macOS(_:)-9771f``
+- <doc:/documentation/PackageDescription/Platform/macOS>
+- ``MacOSVersion``
+
+### Supporting watchOS
+
+- ``watchOS(_:)-t998``
+- ``watchOS(_:)-4lrx0``
+- <doc:/documentation/PackageDescription/Platform/watchOS>
+- ``WatchOSVersion``
+
+### Supporting tvOS
+
+- ``tvOS(_:)-6931l``
+- ``tvOS(_:)-3k8sy``
+- <doc:/documentation/PackageDescription/Platform/tvOS>
+- ``TVOSVersion``
+
+### Supporting MacCatalyst
+
+- ``macCatalyst(_:)-6bh40``
+- ``macCatalyst(_:)-9wbz``
+- <doc:/documentation/PackageDescription/Platform/macCatalyst>
+- ``MacCatalystVersion``
+
+### Supporting DriverKit
+
+- ``driverKit(_:)-jxlz``
+- ``driverKit(_:)-6evdd``
+- <doc:/documentation/PackageDescription/Platform/driverKit>
+- ``DriverKitVersion``
+
+### Supporting Linux
+
+- <doc:/documentation/PackageDescription/Platform/linux>
+
+### Encoding and Decoding
+
+- ``encode(to:)``
+
+### Type Methods
+
+- ``custom(_:versionString:)``
+
+### Operator Functions
+
+- ``!=(_:_:)``
+- ``==(_:_:)``

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/SwiftSetting.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/SwiftSetting.md
@@ -1,0 +1,12 @@
+# ``PackageDescription/SwiftSetting``
+
+## Topics
+
+### Configuring Swift Settings
+
+- ``define(_:_:)``
+- ``unsafeFlags(_:_:)``
+
+### Encoding and Decoding
+
+- ``encode(to:)``

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/SwiftVersion.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/SwiftVersion.md
@@ -1,0 +1,15 @@
+# ``PackageDescription/SwiftVersion``
+
+## Topics
+
+### Enumeration Cases
+
+- ``v3``
+- ``v4``
+- ``v4_2``
+- ``v5``
+- ``version(_:)``
+
+### Encoding and Decoding
+
+- ``encode(to:)``

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/SystemPackageProvider.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/SystemPackageProvider.md
@@ -1,0 +1,13 @@
+# ``PackageDescription/SystemPackageProvider``
+
+## Topics
+
+### Providing Hints to Users of System Packages
+
+- ``brew(_:)``
+- ``apt(_:)``
+- ``yum(_:)``
+
+### Encoding and Decoding
+
+- ``encode(to:)``

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Target-Dependency.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Target-Dependency.md
@@ -1,0 +1,29 @@
+# ``PackageDescription/Target/Dependency``
+
+## Topics
+
+### Creating a Target Dependency
+
+- ``product(name:package:condition:)``
+- ``product(name:package:)-fp0j``
+- ``product(name:package:)-2nako``
+- ``product(name:package:moduleAliases:)``
+- ``product(name:package:moduleAliases:condition:)``
+- ``target(name:condition:)``
+- ``target(name:)``
+- ``byName(name:condition:)``
+- ``byName(name:)``
+- ``TargetDependencyCondition``
+- ``init(stringLiteral:)``
+- ``init(extendedGraphemeClusterLiteral:)``
+- ``init(unicodeScalarLiteral:)``
+
+### Encoding and Decoding
+
+- ``encode(to:)``
+
+### Identifying Related Types
+
+- ``ExtendedGraphemeClusterLiteralType``
+- ``StringLiteralType``
+- ``UnicodeScalarLiteralType``

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Target-TargetDependencyCondition.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Target-TargetDependencyCondition.md
@@ -1,0 +1,12 @@
+# ``PackageDescription/TargetDependencyCondition``
+
+## Topics
+
+### Creating a Dependency Condition
+
+- ``when(platforms:)-5bxhc``
+- ``when(platforms:)-4djh6``
+
+### Encoding and Decoding
+
+- ``encode(to:)``

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Target-TargetType.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Target-TargetType.md
@@ -1,0 +1,35 @@
+# ``PackageDescription/Target/TargetType``
+
+## Topics
+
+### Enumeration Cases
+
+- ``regular``
+- ``binary``
+- ``system``
+- ``test``
+- ``executable``
+- ``plugin``
+
+### Creating a Value
+
+- ``init(rawValue:)``
+
+### Encoding and Decoding
+
+- ``encode(to:)``
+
+### Hashing
+
+- ``hash(into:)``
+- ``hashValue``
+
+### Operator Functions
+
+- ``!=(_:_:)``
+
+### Accessing the Raw Value
+
+- ``rawValue-swift.property``
+- ``RawValue-swift.typealias``
+

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Target.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Target.md
@@ -1,0 +1,73 @@
+#  ``PackageDescription/Target``
+
+## Topics
+
+### Naming the Target
+
+- ``name``
+
+### Configuring File Locations
+
+- ``path``
+- ``exclude``
+- ``sources``
+- ``resources``
+- ``Resource``
+- ``publicHeadersPath``
+
+### Creating a Binary Target
+
+- ``binaryTarget(name:path:)``
+- ``binaryTarget(name:url:checksum:)``
+- ``url``
+- ``checksum``
+
+### Creating a System Target
+
+- ``systemLibrary(name:path:pkgConfig:providers:)``
+- ``pkgConfig``
+- ``providers``
+
+### Creating an Executable Target
+
+- ``executableTarget(name:dependencies:path:exclude:sources:resources:publicHeadersPath:cSettings:cxxSettings:swiftSettings:linkerSettings:)``
+- ``executableTarget(name:dependencies:path:exclude:sources:resources:publicHeadersPath:cSettings:cxxSettings:swiftSettings:linkerSettings:plugins:)``
+
+### Creating a Plugin Target
+
+- ``plugin(name:capability:dependencies:path:exclude:sources:)``
+- ``pluginCapability-swift.property``
+- ``PluginCapability-swift.enum``
+- ``PluginCommandIntent``
+- ``PluginPermission``
+
+### Declaring a Dependency Target
+
+- ``dependencies``
+- ``Dependency``
+- ``TargetDependencyCondition``
+
+### Configuring the Target
+
+- ``cSettings``
+- ``cxxSettings``
+- ``swiftSettings``
+- ``linkerSettings``
+- ``plugins``
+- ``BuildConfiguration``
+- ``BuildSettingCondition``
+- ``CSetting``
+- ``CXXSetting``
+- ``SwiftSetting``
+- ``LinkerSetting``
+- ``PluginUsage``
+
+### Describing the Target Type
+
+- ``isTest``
+- ``type``
+- ``TargetType``
+
+### Encoding and Decoding
+
+- ``encode(to:)``

--- a/Sources/PackageDescription/PackageDescription.docc/PackageDescription.md
+++ b/Sources/PackageDescription/PackageDescription.docc/PackageDescription.md
@@ -1,46 +1,50 @@
 # ``PackageDescription``
 
-Swift package manifest configuration.
+Create reusable code, organize it in a lightweight way, and share it across your projects and with other developers.
 
-## Overview
+Swift packages are reusable components of Swift, Objective-C, Objective-C++, C, or C++ code that developers can use in their projects. They bundle source files, binaries, and resources in a way that’s easy to use in your app’s project. 
 
-Swift packages are configured using `Package.swift` manifest files. The manifest file, or package manifest, defines the package's name and its contents using ``Package`` from the `PackageDescription` module. A package has one or more targets, defined using ``Target``. Each target specifies a ``Product`` and may declare one or more dependencies, defined using ``Package/Dependency``.
+Each Swift package requires a `Package.swift` file in the main directory of the package — referred to as the package manifest. When you create a Swift package, you use the PackageDescription library in the package manifest to list dependencies, configure localized resources, and set other configuration options.
 
-### About the Swift Tools Version
+For example, the package manifest from the [SlothCreator: Building DocC Documentation in Xcode](https://developer.apple.com/documentation/xcode/slothcreator_building_docc_documentation_in_xcode) sample project below defines the SlothCreator package, with the SlothCreator library in it. It specifies the deployment targets, and that its resources are in the `Resources` folder.
 
-A `Package.swift` manifest file must begin with the string `// swift-tools-version:` followed by a version number specifier. The following code listing shows a few examples of valid declarations
-of the Swift tools version:
+```swift
+import PackageDescription
 
-    // swift-tools-version:3.0.2
-    // swift-tools-version:3.1
-    // swift-tools-version:4.0
-    // swift-tools-version:5.0
-    // swift-tools-version:5.1
-    // ...
-    // swift-tools-version:5.6
+let package = Package(
+    name: "SlothCreator",
+    platforms: [
+        .macOS(.v11),
+        .iOS(.v14),
+        .watchOS(.v7),
+        .tvOS(.v13)
+    ],
+    products: [
+        .library(
+            name: "SlothCreator",
+            targets: ["SlothCreator"]
+        )
+    ],
+    targets: [
+        .target(
+            name: "SlothCreator",
+            resources: [
+                .process("Resources/")
+            ]
+        )
+    ]
+)
+```
 
-The Swift tools version declares the version of the `PackageDescription` library, the minimum version of the Swift tools and Swift language compatibility version to process the manifest, and the minimum version of the Swift tools that are needed to use the Swift package. Each version of Swift can introduce updates to the `PackageDescription` framework, but the previous API version will continue to be available to packages which declare a prior tools version. This behavior lets you take advantage of new releases of Swift, the Swift tools, and the `PackageDescription` library, without having to update your package's manifest or losing access to existing packages.
+The package manifest also allows you to define executable products, as well as plugins that Swift Package Manager can use to build other products in the manifest.
+
+For more information about adding a package dependency to your app project and creating Swift packages with Xcode, see [Adding Package Dependencies to Your App](https://developer.apple.com/documentation/xcode/adding_package_dependencies_to_your_app), [Creating a Standalone Swift Package with Xcode](https://developer.apple.com/documentation/xcode/creating_a_standalone_swift_package_with_xcode/), and [Swift Packages](https://developer.apple.com/documentation/xcode/swift_packages).
+
+Support for Swift packages in Xcode builds on the open-source Swift Package Manager project. To learn more about the Swift Package Manager, visit [Swift.org](https://www.swift.org/package-manager/) and the Swift Package Manager repository on [GitHub](https://github.com/apple/swift-package-manager).
 
 ## Topics
 
-### Package Definition
+### Creating a Package
 
 - ``Package``
-- ``Product``
-- ``Package/Dependency``
-- ``Target``
-
-### Settings
-
-- ``BuildSettingCondition``
-- ``LinkerSetting``
-- ``SupportedPlatform``
-- ``SwiftSetting``
-- ``SwiftVersion``
-
-### C/C++ Settings
-
-- ``CSetting``
-- ``CXXSetting``
-- ``CLanguageStandard``
-- ``CXXLanguageStandard``
+- ``Context``

--- a/Sources/PackageDescription/PackageDescription.swift
+++ b/Sources/PackageDescription/PackageDescription.swift
@@ -27,50 +27,61 @@ import Foundation
 /// dependencies, and other configuration options.
 ///
 /// By convention, you need to define the properties of a package in a single
-/// nested initializer statement. Don’t modify it after initialization. The
+/// nested initializer statement. Don't modify it after initialization. The
 /// following package manifest shows the initialization of a simple package
 /// object for the MyLibrary Swift package:
 ///
-///     // swift-tools-version:5.3
-///     import PackageDescription
+/// ```swift
+/// // swift-tools-version:5.3
+/// import PackageDescription
 ///
-///     let package = Package(
-///         name: "MyLibrary",
-///         platforms: [
-///             .macOS(.v10_15),
-///         ],
-///         products: [
-///             .library(name: "MyLibrary", targets: ["MyLibrary"]),
-///         ],
-///         dependencies: [
-///             .package(url: "https://url/of/another/package/named/Utility", from: "1.0.0"),
-///         ],
-///         targets: [
-///             .target(name: "MyLibrary", dependencies: ["Utility"]),
-///             .testTarget(name: "MyLibraryTests", dependencies: ["MyLibrary"]),
-///         ]
-///     )
+/// let package = Package(
+///     name: "MyLibrary",
+///     platforms: [
+///         .macOS(.v10_15),
+///     ],
+///     products: [
+///         .library(name: "MyLibrary", targets: ["MyLibrary"])
+///     ],
+///     dependencies: [
+///         .package(url: "https://url/of/another/package/named/utility", from: "1.0.0")
+///     ],
+///     targets: [
+///         .target(name: "MyLibrary", dependencies: ["Utility"]),
+///         .testTarget(name: "MyLibraryTests", dependencies: ["MyLibrary"])
+///     ]
+/// )
+/// ```
 ///
-/// The package manifest must begin with the string `// swift-tools-version:`,
-/// followed by a version number such as `// swift-tools-version:5.3`.
+/// In Swift tools versions earlier than 5.4, the package manifest must begin with the string `// swift-tools-version:`
+/// followed by a version number specifier. Version 5.4 and later has relaxed the whitespace requirements.
+/// The following code listing shows a few examples of valid declarations of the Swift tools version:
 ///
-/// The Swift tools version declares:
+/// ```swift
+/// // swift-tools-version:3.0.2
+/// // swift-tools-version:3.1
+/// // swift-tools-version:4.0
+/// // swift-tools-version:5.3
+/// // swift-tools-version: 5.6
+/// ```
 ///
-///   - The version of the PackageDescription framework
-///   - The Swift language compatibility version to process the manifest
-///   - The required minimum version of the Swift tools to use the package
-///
-/// Each version of Swift can introduce updates to the PackageDescription
-/// library, but the previous API version is available to packages that declare
-/// a prior tools version. This behavior allows you take advantage of new
-/// releases of Swift, the Swift tools, and the PackageDescription framework,
-/// without having to update your package manifest and without losing access to
-/// existing packages.
+/// The Swift tools version declares the version of the `PackageDescription`
+/// library, the minimum version of the Swift tools and Swift language
+/// compatibility version to process the manifest, and the required minimum
+/// version of the Swift tools to use the Swift package. Each version of Swift
+/// can introduce updates to the PackageDescription framework, but the previous
+/// API version is available to packages which declare a prior tools version.
+/// This behavior means you can take advantage of new releases of Swift, the Swift
+/// tools, and the PackageDescription library, without having to update your
+/// package's manifest or losing access to existing packages.
 public final class Package {
     /// The name of the Swift package.
+    ///
+    /// If the name of the package is `nil`, Swift Package Manager deduces the name of the
+    /// package using its Git URL.
     public var name: String
 
-    /// The list of supported platforms with a custom deployment target.
+    /// The list of minimum versions for platforms supported by the package.
     @available(_PackageDescription, introduced: 5)
     public var platforms: [SupportedPlatform]? {
         get { return _platforms }
@@ -88,8 +99,8 @@ public final class Package {
 
     /// The name to use for C modules.
     ///
-    /// If present, the Swift Package Manager searches for a `<name>.pc` file
-    /// to get the required additional flags for a system target.
+    /// If present, the Swift Package Manager searches for a `<name>.pc` file to
+    /// get the required additional flags for a system target.
     public var pkgConfig: String?
 
     /// An array of providers for a system target.
@@ -104,7 +115,7 @@ public final class Package {
     /// The list of package dependencies.
     public var dependencies: [Dependency]
 
-    /// The list of Swift versions that this package is compatible with.
+    /// The list of Swift versions with which this package is compatible.
     public var swiftLanguageVersions: [SwiftVersion]?
 
     /// The C language standard to use for all C targets in this package.
@@ -116,18 +127,18 @@ public final class Package {
     /// Initializes a Swift package with configuration options you provide.
     ///
     /// - Parameters:
-    ///     - name: The name of the Swift package, or `nil`, if you want the Swift Package Manager to deduce the
-    ///           name from the package’s Git URL.
-    ///     - pkgConfig: The name to use for C modules. If present, the Swift
+    ///   - name: The name of the Swift package, or `nil`, if you want the Swift Package Manager to deduce the
+    ///           name from the package's Git URL.
+    ///   - pkgConfig: The name to use for C modules. If present, the Swift
     ///           Package Manager searches for a `<name>.pc` file to get the
     ///           additional flags required for a system target.
-    ///     - providers: The package providers for a system package.
-    ///     - products: The list of products that this package vends and that clients can use.
-    ///     - dependencies: The list of package dependencies.
-    ///     - targets: The list of targets that are part of this package.
-    ///     - swiftLanguageVersions: The list of Swift versions that this package is compatible with.
-    ///     - cLanguageStandard: The C language standard to use for all C targets in this package.
-    ///     - cxxLanguageStandard: The C++ language standard to use for all C++ targets in this package.
+    ///   - providers: The package providers for a system package.
+    ///   - products: The list of products that this package vends and that clients can use.
+    ///   - dependencies: The list of package dependencies.
+    ///   - targets: The list of targets that are part of this package.
+    ///   - swiftLanguageVersions: The list of Swift versions that this package is compatible with.
+    ///   - cLanguageStandard: The C language standard to use for all C targets in this package.
+    ///   - cxxLanguageStandard: The C++ language standard to use for all C++ targets in this package.
     @available(_PackageDescription, obsoleted: 4.2)
     public init(
         name: String,
@@ -155,17 +166,17 @@ public final class Package {
     /// Initializes a Swift package with configuration options you provide.
     ///
     /// - Parameters:
-    ///     - name: The name of the Swift package, or `nil`, if you want the Swift Package Manager to deduce the
-    ///           name from the package’s Git URL.
-    ///     - pkgConfig: The name to use for C modules. If present, the Swift
+    ///   - name: The name of the Swift package, or `nil`, if you want the Swift Package Manager to deduce the
+    ///           name from the package's Git URL.
+    ///   - pkgConfig: The name to use for C modules. If present, the Swift
     ///           Package Manager searches for a `<name>.pc` file to get the
     ///           additional flags required for a system target.
-    ///     - products: The list of products that this package makes available for clients to use.
-    ///     - dependencies: The list of package dependencies.
-    ///     - targets: The list of targets that are part of this package.
-    ///     - swiftLanguageVersions: The list of Swift versions that this package is compatible with.
-    ///     - cLanguageStandard: The C language standard to use for all C targets in this package.
-    ///     - cxxLanguageStandard: The C++ language standard to use for all C++ targets in this package.
+    ///   - products: The list of products that this package makes available for clients to use.
+    ///   - dependencies: The list of package dependencies.
+    ///   - targets: The list of targets that are part of this package.
+    ///   - swiftLanguageVersions: The list of Swift versions that this package is compatible with.
+    ///   - cLanguageStandard: The C language standard to use for all C targets in this package.
+    ///   - cxxLanguageStandard: The C++ language standard to use for all C++ targets in this package.
     @available(_PackageDescription, introduced: 4.2, obsoleted: 5)
     public init(
         name: String,
@@ -193,18 +204,18 @@ public final class Package {
     /// Initializes a Swift package with configuration options you provide.
     ///
     /// - Parameters:
-    ///     - name: The name of the Swift package, or `nil`, if you want the Swift Package Manager to deduce the
-    ///           name from the package’s Git URL.
-    ///     - platforms: The list of supported platforms that have a custom deployment target.
-    ///     - pkgConfig: The name to use for C modules. If present, the Swift
+    ///   - name: The name of the Swift package, or `nil`, if you want the Swift Package Manager to deduce the
+    ///           name from the package's Git URL.
+    ///   - platforms: The list of supported platforms that have a custom deployment target.
+    ///   - pkgConfig: The name to use for C modules. If present, the Swift
     ///           Package Manager searches for a `<name>.pc` file to get the
     ///           additional flags required for a system target.
-    ///     - products: The list of products that this package makes available for clients to use.
-    ///     - dependencies: The list of package dependencies.
-    ///     - targets: The list of targets that are part of this package.
-    ///     - swiftLanguageVersions: The list of Swift versions that this package is compatible with.
-    ///     - cLanguageStandard: The C language standard to use for all C targets in this package.
-    ///     - cxxLanguageStandard: The C++ language standard to use for all C++ targets in this package.
+    ///   - products: The list of products that this package makes available for clients to use.
+    ///   - dependencies: The list of package dependencies.
+    ///   - targets: The list of targets that are part of this package.
+    ///   - swiftLanguageVersions: The list of Swift versions that this package is compatible with.
+    ///   - cLanguageStandard: The C language standard to use for all C targets in this package.
+    ///   - cxxLanguageStandard: The C++ language standard to use for all C++ targets in this package.
     @available(_PackageDescription, introduced: 5, obsoleted: 5.3)
     public init(
         name: String,
@@ -234,19 +245,18 @@ public final class Package {
     /// Initializes a Swift package with configuration options you provide.
     ///
     /// - Parameters:
-    ///     - name: The name of the Swift package, or `nil`, if you want the Swift Package Manager to deduce the
-    ///           name from the package’s Git URL.
-    ///     - defaultLocalization: The default localization for resources.
-    ///     - platforms: The list of supported platforms that have a custom deployment target.
-    ///     - pkgConfig: The name to use for C modules. If present, the Swift
-    ///           Package Manager searches for a `<name>.pc` file to get the
-    ///           additional flags required for a system target.
-    ///     - products: The list of products that this package vends and that clients can use.
-    ///     - dependencies: The list of package dependencies.
-    ///     - targets: The list of targets that are part of this package.
-    ///     - swiftLanguageVersions: The list of Swift versions that this package is compatible with.
-    ///     - cLanguageStandard: The C language standard to use for all C targets in this package.
-    ///     - cxxLanguageStandard: The C++ language standard to use for all C++ targets in this package.
+    ///   - name: The name of the Swift package, or `nil` to use the package's Git URL to deduce the name.
+    ///   - defaultLocalization: The default localization for resources.
+    ///   - platforms: The list of supported platforms with a custom deployment target.
+    ///   - pkgConfig: The name to use for C modules. If present, Swift Package Manager searches for a
+    ///   `<name>.pc` file to get the additional flags required for a system target.
+    ///   - providers: The package providers for a system target.
+    ///   - products: The list of products that this package makes available for clients to use.
+    ///   - dependencies: The list of package dependencies.
+    ///   - targets: The list of targets that are part of this package.
+    ///   - swiftLanguageVersions: The list of Swift versions with which this package is compatible.
+    ///   - cLanguageStandard: The C language standard to use for all C targets in this package.
+    ///   - cxxLanguageStandard: The C++ language standard to use for all C++ targets in this package.
     @available(_PackageDescription, introduced: 5.3)
     public init(
         name: String,
@@ -309,13 +319,16 @@ public final class Package {
 
 /// A wrapper around an IETF language tag.
 ///
-/// To learn more about the IETF worldwide standard for language tags, see [RFC5646](https://tools.ietf.org/html/rfc5646).
+/// To learn more about the IETF worldwide standard for language tags, see
+/// [RFC5646](https://tools.ietf.org/html/rfc5646).
 public struct LanguageTag: Hashable {
 
     /// An IETF language tag.
     public let tag: String
 
     /// Creates a language tag from its IETF string representation.
+    ///
+    /// - Parameter tag: The string representation of an IETF language tag.
     public init(_ tag: String) {
         self.tag = tag
     }
@@ -324,20 +337,36 @@ public struct LanguageTag: Hashable {
 extension LanguageTag: RawRepresentable {
     public var rawValue: String { tag }
 
+    /// Creates a new instance with the specified raw value.
+    ///
+    /// If there's no value of the type that corresponds with the specified raw
+    /// value, this initializer returns `nil`.
+    ///
+    /// - Parameter rawValue: The raw value to use for the new instance.
     public init?(rawValue: String) {
         tag = rawValue
     }
 }
 
+/// ExpressibleByStringLiteral implementation.
 extension LanguageTag: ExpressibleByStringLiteral {
+    
+    /// Creates an instance initialized to the given value.
+    ///
+    /// - Parameter value: The value of the new instance.
     public init(stringLiteral value: String) {
         tag = value
     }
 
+    /// Creates an instance initialized to the given value.
+    /// - Parameter value: The value of the new instance.
     public init(extendedGraphemeClusterLiteral value: String) {
         self.init(stringLiteral: value)
     }
 
+    /// Creates an instance initialized to the given value.
+    ///
+    /// - Parameter value: The value of the new instance.
     public init(unicodeScalarLiteral value: String) {
         self.init(stringLiteral: value)
     }
@@ -345,23 +374,27 @@ extension LanguageTag: ExpressibleByStringLiteral {
 
 extension LanguageTag: CustomStringConvertible {
 
-    /// A textual description of the language tag.
+    /// A textual representation of the language tag.
     public var description: String { tag }
 }
 
-/// The system package providers used in this Swift package.
+/// The system package providers that this package uses.
 public enum SystemPackageProvider {
 
+    /// Packages installable by the HomeBrew package manager.
     case brewItem([String])
+    /// Packages installable by the apt-get package manager.
     case aptItem([String])
+    /// Packages installable by the yum package manager.
     @available(_PackageDescription, introduced: 5.3)
     case yumItem([String])
 
     /// Creates a system package provider with a list of installable packages
     /// for users of the HomeBrew package manager on macOS.
     ///
-    /// - Parameters:
-    ///     - packages: The list of package names.
+    /// - Parameter packages: The list of package names.
+    ///
+    /// - Returns: A package provider.
     public static func brew(_ packages: [String]) -> SystemPackageProvider {
         return .brewItem(packages)
     }
@@ -369,17 +402,20 @@ public enum SystemPackageProvider {
     /// Creates a system package provider with a list of installable packages
     /// for users of the apt-get package manager on Ubuntu Linux.
     ///
-    /// - Parameters:
-    ///     - packages: The list of package names.
+    /// - Parameter packages: The list of package names.
+    ///
+    /// - Returns: A package provider.
     public static func apt(_ packages: [String]) -> SystemPackageProvider {
         return .aptItem(packages)
     }
 
     /// Creates a system package provider with a list of installable packages
-    /// for users of the yum package manager on Red Hat Enterprise Linux or CentOS.
+    /// for users of the yum package manager on Red Hat Enterprise Linux or
+    /// CentOS.
     ///
-    /// - Parameters:
-    ///     - packages: The list of package names.
+    /// - Parameter packages: The list of package names.
+    ///
+    /// - Returns: A package provider.
     @available(_PackageDescription, introduced: 5.3)
     public static func yum(_ packages: [String]) -> SystemPackageProvider {
         return .yumItem(packages)

--- a/Sources/PackageDescription/PackageDescriptionSerialization.swift
+++ b/Sources/PackageDescription/PackageDescriptionSerialization.swift
@@ -37,6 +37,15 @@ extension Package: Encodable {
         case cxxLanguageStandard
     }
 
+    /// Encodes this value into the given encoder.
+    ///
+    /// If the value fails to encode anything, `encoder` will encode an empty
+    /// keyed container in its place.
+    ///
+    /// This function throws an error if any values are invalid for the given
+    /// encoder's format.
+    ///
+    /// - Parameter encoder: The encoder to write data to.
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(name, forKey: .name)
@@ -76,6 +85,12 @@ extension Package.Dependency.Requirement: Encodable {
         case localPackage
     }
 
+    /// Encodes this value into the given encoder.
+    ///
+    /// This function throws an error if any values are invalid for the given
+    /// encoder's format.
+    ///
+    /// - Parameter encoder: The encoder to write data to.
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {
@@ -208,6 +223,15 @@ extension SystemPackageProvider: Encodable {
         case yum
     }
 
+    /// Encodes this value into the given encoder.
+    ///
+    /// If the value fails to encode anything, `encoder` will encode an empty
+    /// keyed container in its place.
+    ///
+    /// This function throws an error if any values are invalid for the given
+    /// encoder's format.
+    ///
+    /// - Parameter encoder: The encoder to write data to.
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {
@@ -270,6 +294,7 @@ extension PluginCommandIntent: Encodable {
     }
 }
 
+/// `Encodable` conformance.
 extension PluginPermission: Encodable {
     private enum CodingKeys: CodingKey {
         case type, reason
@@ -279,6 +304,9 @@ extension PluginPermission: Encodable {
         case writeToPackageDirectory
     }
 
+    /// Encode the `PluginPermission` into the given encoder.
+    ///
+    /// - Parameter to: The encoder to write data to.
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {
@@ -304,6 +332,15 @@ extension Target.Dependency: Encodable {
         case byName = "byname"
     }
 
+    /// Encodes the `Target.Dependency` into the given encoder.
+    ///
+    /// If the value fails to encode anything, `encoder` will encode an empty
+    /// keyed container in its place.
+    ///
+    /// This function throws an error if any values are invalid for the given
+    /// encoder's format.
+    ///
+    /// - Parameter encoder: The encoder to write data to.
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {
@@ -347,6 +384,15 @@ extension Target: Encodable {
         case pluginUsages
     }
 
+    /// Encodes this value into the given encoder.
+    ///
+    /// If the value fails to encode anything, `encoder` will encode an empty
+    /// keyed container in its place.
+    ///
+    /// This function throws an error if any values are invalid for the given
+    /// encoder's format.
+    ///
+    /// - Parameter encoder: The encoder to write data to.
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
@@ -407,6 +453,12 @@ extension Target.PluginUsage: Encodable {
 }
 
 extension SwiftVersion: Encodable {
+    /// Encodes this value into the given encoder.
+    ///
+    /// This function throws an error if any values are invalid for the given
+    /// encoder's format.
+    ///
+    /// - Parameter encoder: The encoder to write data to.
     public func encode(to encoder: Encoder) throws {
         let value: String
 
@@ -429,6 +481,12 @@ extension SwiftVersion: Encodable {
 }
 
 extension Version: Encodable {
+    /// Encodes this value into the given encoder.
+    ///
+    /// This function throws an error if any values are invalid for the given
+    /// encoder's format.
+    ///
+    /// - Parameter encoder: The encoder to write data to.
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(description)

--- a/Sources/PackageDescription/PackageRequirement.swift
+++ b/Sources/PackageDescription/PackageRequirement.swift
@@ -13,46 +13,46 @@
 extension Package.Dependency {
     /// An enum that represents the requirement for a package dependency.
     ///
-    /// The dependency requirement can be defined as one of three different version requirements:
+    /// The dependency requirement can be defined as one of three different
+    /// version requirements:
     ///
-    /// **A version-based requirement.**
+    /// - term A version-based requirement: Decide whether your project accepts
+    /// updates to a package dependency up to the next major version or up to
+    /// the next minor version. To be more restrictive, select a specific
+    /// version range or an exact version. Major versions tend to have more
+    /// significant changes than minor versions, and may require you to modify
+    /// your code when they update.
     ///
-    /// Decide whether your project accepts updates to a package dependency up
-    /// to the next major version or up to the next minor version. To be more
-    /// restrictive, select a specific version range or an exact version.
-    /// Major versions tend to have more significant changes than minor
-    /// versions, and may require you to modify your code when they update.
     /// The version rule requires Swift packages to conform to semantic
-    /// versioning. To learn more about the semantic versioning standard,
-    /// visit [semver.org](https://semver.org).
+    /// versioning. To learn more about the semantic versioning standard, visit the
+    /// [Semantic Versioning 2.0.0](https://semver.org) website.
     ///
-    /// Selecting the version requirement is the recommended way to add a package dependency. It allows you to create a balance between restricting changes and obtaining improvements and features.
+    /// Selecting the version requirement is the recommended way to add a
+    /// package dependency. It allows you to create a balance between
+    /// restricting changes and obtaining improvements and features. - term A
+    /// branch-based requirement: Select the name of the branch for your package
+    /// dependency to follow. Use branch-based dependencies when you're
+    /// developing multiple packages in tandem or when you don't want to publish
+    /// versions of your package dependencies.
     ///
-    /// **A branch-based requirement**
-    ///
-    /// Select the name of the branch for your package dependency to follow.
-    /// Use branch-based dependencies when you're developing multiple packages
-    /// in tandem or when you don't want to publish versions of your package dependencies.
-    ///
-    /// Note that packages which use branch-based dependency requirements
-    /// can't be added as dependencies to packages that use version-based dependency
+    /// Note that packages which use branch-based dependency requirements can't
+    /// be added as dependencies to packages that use version-based dependency
     /// requirements; you should remove branch-based dependency requirements
-    /// before publishing a version of your package.
+    /// before publishing a version of your package. - term A commit-based
+    /// requirement: Select the commit hash for your package dependency to
+    /// follow.
     ///
-    /// **A commit-based requirement**
-    ///
-    /// Select the commit hash for your package dependency to follow.
     /// Choosing this option isn't recommended, and should be limited to
     /// exceptional cases. While pinning your package dependency to a specific
-    /// commit ensures that the package dependency doesn't change and your
-    /// code remains stable, you don't receive any updates at all. If you worry about
-    /// the stability of a remote package, consider one of the more
-    /// restrictive options of the version-based requirement.
+    /// commit ensures that the package dependency doesn't change and your code
+    /// remains stable, you don't receive any updates at all. If you worry about
+    /// the stability of a remote package, consider one of the more restrictive
+    /// options of the version-based requirement.
     ///
-    /// Note that packages which use commit-based dependency requirements
-    /// can't be added as dependencies to packages that use version-based
-    /// dependency requirements; you should remove commit-based dependency
-    /// requirements before publishing a version of your package.
+    /// Note that packages which use commit-based dependency requirements can't
+    /// be added as dependencies to packages that use version-based dependency
+    /// requirements; you should remove commit-based dependency requirements
+    /// before publishing a version of your package.
     @available(_PackageDescription, deprecated: 5.6)
     public enum Requirement {
         case exactItem(Version)
@@ -72,35 +72,40 @@ extension Package.Dependency {
 extension Package.Dependency.Requirement {
     /// Returns a requirement for the given exact version.
     ///
-    /// Specifying exact version requirements are not recommended as
-    /// they can cause conflicts in your dependency graph when multiple other packages depend on a package.
-    /// As Swift packages follow the semantic versioning convention,
-    /// think about specifying a version range instead.
+    /// Specifying exact version requirements are not recommended as they can
+    /// cause conflicts in your dependency graph when multiple other packages
+    /// depend on a package. As Swift packages follow the semantic versioning
+    /// convention, think about specifying a version range instead.
     ///
-    /// The following example defines a version requirement that requires version 1.2.3 of a package.
+    /// The following example defines a version requirement that requires
+    /// version 1.2.3 of a package.
     ///
-    ///   .exact("1.2.3")
+    /// ```swift
+    /// .exact(“1.2.3”)
+    /// ```
     ///
-    /// - Parameters:
-    ///      - version: The exact version of the dependency for this requirement.
+    /// - Parameter version: The exact version of the dependency for this requirement.
     @available(_PackageDescription, deprecated: 5.6)
     public static func exact(_ version: Version) -> Package.Dependency.Requirement {
         return .exactItem(version)
     }
 
-    /// Returns a requirement for a source control revision such as the hash of a commit.
+    /// Returns a requirement for a source control revision such as the hash of
+    /// a commit.
     ///
-    /// Note that packages that use commit-based dependency requirements
-    /// can't be depended upon by packages that use version-based dependency
+    /// Note that packages that use commit-based dependency requirements can't
+    /// be depended upon by packages that use version-based dependency
     /// requirements; you should remove commit-based dependency requirements
     /// before publishing a version of your package.
     ///
-    /// The following example defines a version requirement for a specific commit hash.
+    /// The following example defines a version requirement for a specific
+    /// commit hash.
     ///
-    ///   .revision("e74b07278b926c9ec6f9643455ea00d1ce04a021")
+    ///```swift
+    /// .revision(“e74b07278b926c9ec6f9643455ea00d1ce04a021”)
+    /// ```
     ///
-    /// - Parameters:
-    ///     - ref: The Git revision, usually a commit hash.
+    /// - Parameter ref: The Git revision, usually a commit hash.
     @available(_PackageDescription, deprecated: 5.6)
     public static func revision(_ ref: String) -> Package.Dependency.Requirement {
         return .revisionItem(ref)
@@ -108,18 +113,19 @@ extension Package.Dependency.Requirement {
 
     /// Returns a requirement for a source control branch.
     ///
-    /// Note that packages that use branch-based dependency requirements
-    /// can't be depended upon by packages that use version-based dependency
+    /// Note that packages that use branch-based dependency requirements can't
+    /// be depended upon by packages that use version-based dependency
     /// requirements; you should remove branch-based dependency requirements
     /// before publishing a version of your package.
     ///
     /// The following example defines a version requirement that accepts any
     /// change in the develop branch.
     ///
-    ///    .branch("develop")
+    ///```swift
+    /// .branch(“develop”)
+    /// ```
     ///
-    /// - Parameters:
-    ///     - name: The name of the branch.
+    /// - Parameter name: The name of the branch.
     @available(_PackageDescription, deprecated: 5.6)
     public static func branch(_ name: String) -> Package.Dependency.Requirement {
         return .branchItem(name)
@@ -142,7 +148,7 @@ extension Package.Dependency {
     /// versions, and may require you to modify your code when they update.
     /// The version rule requires Swift packages to conform to semantic
     /// versioning. To learn more about the semantic versioning standard,
-    /// visit [semver.org](https://semver.org).
+    /// see the [Semantic Versioning 2.0.0](https://semver.org) website.
     ///
     /// Selecting the version requirement is the recommended way to add a package dependency. It allows you to create a balance between restricting changes and obtaining improvements and features.
     ///
@@ -173,9 +179,13 @@ extension Package.Dependency {
     /// requirements before publishing a version of your package.
     @available(_PackageDescription, introduced: 5.6)
     public enum SourceControlRequirement {
+        /// An exact version based requirement.
         case exact(Version)
+        /// A requirement based on a range of versions.
         case range(Range<Version>)
+        /// A commit based requirement.
         case revision(String)
+        /// A branch based requirement.
         case branch(String)
     }
 }
@@ -192,10 +202,12 @@ extension Package.Dependency {
     /// versions, and may require you to modify your code when they update.
     /// The version rule requires Swift packages to conform to semantic
     /// versioning. To learn more about the semantic versioning standard,
-    /// visit [semver.org](https://semver.org).
+    /// visit the [Semantic Versioning 2.0.0](https://semver.org) website.
     @available(_PackageDescription, introduced: 999)
     public enum RegistryRequirement {
+        /// A requirement based on an exact version.
         case exact(Version)
+        /// A requirement based on a range of versions.
         case range(Range<Version>)
     }
 }
@@ -204,8 +216,7 @@ extension Range {
     /// Returns a requirement for a version range, starting at the given minimum
     /// version and going up to the next major version. This is the recommended version requirement.
     ///
-    /// - Parameters:
-    ///     - version: The minimum version for the version range.
+    /// - Parameter version: The minimum version for the version range.
     public static func upToNextMajor(from version: Version) -> Range<Bound> where Bound == Version {
         return version ..< Version(version.major + 1, 0, 0)
     }
@@ -214,8 +225,7 @@ extension Range {
     /// Returns a requirement for a version range, starting at the given minimum
     /// version and going up to the next minor version.
     ///
-    /// - Parameters:
-    ///     - version: The minimum version for the version range.
+    /// - Parameter version: The minimum version for the version range.
     public static func upToNextMinor(from version: Version) -> Range<Bound> where Bound == Version {
         return version ..< Version(version.major, version.minor + 1, 0)
     }
@@ -223,10 +233,27 @@ extension Range {
 
 @available(_PackageDescription, deprecated: 5.6)
 extension Package.Dependency.Requirement {
+    /// A source control requirement bounded to the given version's major version number.
+    ///
+    /// Returns a requirement for a version range, starting at the given minimum
+    /// version and going up to but not including the next major version. This is the recommended
+    /// version requirement.
+    ///
+    /// - Parameter version: The minimum version for the version range.
+    ///
+    /// - Returns: A source control requirement instance.
     @_disfavoredOverload
     public static func upToNextMajor(from version: Version) -> Self {
         return .rangeItem(.upToNextMajor(from: version))
     }
+    /// A source control requirement bounded to the given version's minor version number.
+    ///
+    /// Returns a requirement for a version range, starting at the given minimum
+    /// version and going up to but not including the next minor version.
+    ///
+    /// - Parameter version: The minimum version for the version range.
+    ///
+    /// - Returns: A source control requirement instance.
     @_disfavoredOverload
     public static func upToNextMinor(from version: Version) -> Self {
         return .rangeItem(.upToNextMinor(from: version))

--- a/Sources/PackageDescription/Product.swift
+++ b/Sources/PackageDescription/Product.swift
@@ -13,47 +13,52 @@
 /// The object that defines a package product.
 ///
 /// A package product defines an externally visible build artifact that's
-/// available to clients of a package. The product is assembled from the build
-/// artifacts of one or more of the package's targets.
+/// available to clients of a package. Swift Package Manager assembles the product from the
+/// build artifacts of one or more of the package's targets. A package product
+/// can be one of three types:
 ///
-/// A package product can be one of two types:
+/// - term Library: Use a _library product_ to vend library targets. This makes
+/// a target's public APIs available to clients that integrate the Swift
+/// package.
+/// - term Executable: Use an _executable product_ to vend an
+/// executable target. Use this only if you want to make the executable
+/// available to clients.
+/// - term Plugin: Use a _plugin product_ to vend plugin targets. This makes
+/// the plugin available to clients that integrate the Swift package.
 ///
-/// 1. **Library**. Use a library product to vend library targets. This makes a target's public APIs
-/// available to clients that integrate the Swift package.
-/// 2. **Executable**. Use an executable product to vend an executable target.
-/// Use this only if you want to make the executable available to clients.
-///
-/// The following example shows a package manifest for a library called "Paper"
+/// The following example shows a package manifest for a library called “Paper”
 /// that defines multiple products:
 ///
-///     let package = Package(
-///         name: "Paper",
-///         products: [
-///             .executable(name: "tool", targets: ["tool"]),
-///             .library(name: "Paper", targets: ["Paper"]),
-///             .library(name: "PaperStatic", type: .static, targets: ["Paper"]),
-///             .library(name: "PaperDynamic", type: .dynamic, targets: ["Paper"]),
-///         ],
-///         dependencies: [
-///             .package(url: "http://example.com.com/ExamplePackage/ExamplePackage", from: "1.2.3"),
-///             .package(url: "http://some/other/lib", .exact("1.2.3")),
-///         ],
-///         targets: [
-///             .target(
-///                 name: "tool",
-///                 dependencies: [
-///                     "Paper",
-///                     "ExamplePackage"
-///                 ]),
-///             .target(
-///                 name: "Paper",
-///                 dependencies: [
-///                     "Basic",
-///                     .target(name: "Utility"),
-///                     .product(name: "AnotherExamplePackage"),
-///                 ])
-///         ]
-///     )
+/// ```swift
+/// let package = Package(
+///     name: "Paper",
+///     products: [
+///         .executable(name: "tool", targets: ["tool"]),
+///         .library(name: "Paper", targets: ["Paper"]),
+///         .library(name: "PaperStatic", type: .static, targets: ["Paper"]),
+///         .library(name: "PaperDynamic", type: .dynamic, targets: ["Paper"]),
+///     ],
+///     dependencies: [
+///         .package(url: "http://example.com.com/ExamplePackage/ExamplePackage", from: "1.2.3"),
+///         .package(url: "http://some/other/lib", .exact("1.2.3")),
+///     ],
+///     targets: [
+///         .executableTarget(
+///             name: "tool",
+///             dependencies: [
+///                 "Paper",
+///                 "ExamplePackage"
+///             ]),
+///         .target(
+///             name: "Paper",
+///             dependencies: [
+///                 "Basic",
+///                 .target(name: "Utility"),
+///                 .product(name: "AnotherExamplePackage"),
+///             ])
+///     ]
+/// )
+/// ```
 public class Product: Encodable {
     private enum ProductCodingKeys: String, CodingKey {
         case name
@@ -81,6 +86,14 @@ public class Product: Encodable {
             super.init(name: name)
         }
 
+        /// Encodes this executable product type into the given encoder.
+        ///
+        /// This function throws an error if any values are invalid for the
+        /// given encoder's format.
+        ///
+        /// - Note: Do not call this function directly. It is public to satisfy conformance to Codable, but it is only for use by internal Swift Package Manager processes.
+        ///
+        /// - Parameter encoder: The encoder to write data to.
         public override func encode(to encoder: Encoder) throws {
             try super.encode(to: encoder)
             var productContainer = encoder.container(keyedBy: ProductCodingKeys.self)
@@ -110,8 +123,8 @@ public class Product: Encodable {
 
         /// The type of the library.
         ///
-        /// If the type is unspecified, the Swift Package Manager automatically
-        /// chooses a type based on the client's preference.
+        /// If the type is unspecified, the Swift Package Manager automatically chooses a type
+        /// based on the client's preference.
         public let type: LibraryType?
 
         init(name: String, type: LibraryType? = nil, targets: [String]) {
@@ -120,6 +133,15 @@ public class Product: Encodable {
             super.init(name: name)
         }
 
+        /// Encodes this value into the given encoder.
+        ///
+        /// If the value fails to encode anything, `encoder` will encode an
+        /// empty keyed container in its place.
+        ///
+        /// This function throws an error if any values are invalid for the
+        /// given encoder's format.
+        ///
+        /// - Parameter encoder: The encoder to write data to.
         public override func encode(to encoder: Encoder) throws {
             try super.encode(to: encoder)
             var productContainer = encoder.container(keyedBy: ProductCodingKeys.self)
@@ -153,20 +175,26 @@ public class Product: Encodable {
         }
     }
 
-    /// Creates a library product to allow clients that declare a dependency on this package
-    /// to use the package's functionality.
+    /// Creates a library product to allow clients that declare a dependency on
+    /// this package to use the package's functionality.
     ///
-    /// A library's product can either be statically or dynamically linked.
-    /// If possible, don't declare the type of library explicitly to let
-    /// the Swift Package Manager choose between static or dynamic linking based
-    /// on the preference of the package's consumer.
+    /// A library's product can be either statically or dynamically linked. It's recommended
+    /// that you don't explicity declare the type of library, so Swift Package Manager can
+    /// choose between static or dynamic linking based on the preference of the
+    /// package's consumer.
     ///
     /// - Parameters:
-    ///     - name: The name of the library product.
-    ///     - type: The optional type of the library that's used to determine how to link to the library.
-    ///         Leave this parameter unspecified to let the Swift Package Manager choose between static or dynamic linking (recommended).
-    ///         If you don't support both linkage types, use `.static` or `.dynamic` for this parameter.
-    ///     - targets: The targets that are bundled into a library product.
+    ///   - name: The name of the library product.
+    ///   - type: The optional type of the library that's used to determine how to
+    ///     link to the library. Leave this parameter so
+    ///     Swift Package Manager can choose between static or dynamic linking (recommended). If you
+    ///     don't support both linkage types, use
+    ///     ``Product/Library/LibraryType/static`` or
+    ///     ``Product/Library/LibraryType/dynamic`` for this parameter.
+    ///
+    ///  - targets: The targets that are bundled into a library product.
+    ///
+    /// - Returns: A `Product` instance.
     public static func library(
         name: String,
         type: Library.LibraryType? = nil,
@@ -178,21 +206,28 @@ public class Product: Encodable {
     /// Creates an executable package product.
     ///
     /// - Parameters:
-    ///     - name: The name of the executable product.
-    ///     - targets: The targets to bundle into an executable product.
-    public static func executable(
+    ///   - name: The name of the executable product.
+    ///   - targets: The targets to bundle into an executable product.
+    /// - Returns: A `Product` instance.
+public static func executable(
         name: String,
         targets: [String]
     ) -> Product {
         return Executable(name: name, targets: targets)
     }
 
-    /// Creates an plugin package product.
+    /// Defines a product that vends a package plugin target for use by clients of the package.
     ///
+    /// It is not necessary to define a product for a plugin that
+    /// is only used within the same package where you define it. All the targets
+    /// listed must be plugin targets in the same package as the product. Swift Package Manager
+    /// will apply them to any client targets of the product in the order
+    /// they are listed.
     /// - Parameters:
-    ///     - name: The name of the plugin product.
-    ///     - targets: The plugin targets to vend as a product.
-    @available(_PackageDescription, introduced: 5.5)
+    ///   - name: The name of the plugin product.
+    ///   - targets: The plugin targets to vend as a product.
+    /// - Returns: A `Product` instance.
+@available(_PackageDescription, introduced: 5.5)
     public static func plugin(
         name: String,
         targets: [String]
@@ -200,6 +235,15 @@ public class Product: Encodable {
         return Plugin(name: name, targets: targets)
     }
 
+    /// Encodes this value into the given encoder.
+    ///
+    /// If the value fails to encode anything, `encoder` will encode an empty
+    /// keyed container in its place.
+    ///
+    /// This function throws an error if any values are invalid for the given
+    /// encoder's format.
+    ///
+    /// - Parameter encoder: The encoder to write data to.
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: ProductCodingKeys.self)
         try container.encode(name, forKey: .name)

--- a/Sources/PackageDescription/Resource.swift
+++ b/Sources/PackageDescription/Resource.swift
@@ -12,19 +12,26 @@
 
 /// A resource to bundle with the Swift package.
 ///
-/// If a Swift package declares a Swift tools version of 5.3 or later, it can include resource files.
-/// Similar to source code, the Swift Package Manager scopes resources to a target, so you must put them
-/// into the folder that corresponds to the target they belong to.
-/// For example, any resources for the `MyLibrary` target must reside in `Sources/MyLibrary`.
-/// Use subdirectories to organize your resource files in a way that simplifies file identification and management.
-/// For example, put all resource files into a directory named `Resources`,
-/// so they reside at `Sources/MyLibrary/Resources`.
-/// By default, the Swift Package Manager handles common resources types for Apple platforms automatically.
-/// For example, you don’t need to declare XIB files, storyboards, Core Data file types, and asset catalogs
-/// as resources in your package manifest.
-/// However, you must explicitly declare other file types  (such as image files) as resources
-/// using the ``process(_:localization:)`` or ``copy(_:)`` rules. Alternatively, exclude resource files from a target
-/// by passing them to the target initializer’s `exclude` parameter.
+/// If a Swift package declares a Swift tools version of 5.3 or later, it can
+/// include resource files. Similar to source code, Swift Package Manager scopes resources to a
+/// target, so you must put them into the folder that corresponds to the target
+/// they belong to. For example, any resources for the `MyLibrary` target must
+/// reside in `Sources/MyLibrary`. Use subdirectories to organize your resource
+/// files in a way that simplifies file identification and management. For
+/// example, put all resource files into a directory named `Resources`, so they
+/// reside at `Sources/MyLibrary/Resources`.
+///
+/// By default, Swift Package Manager handles common resources types for Apple platforms
+/// automatically. For example, you don't need to declare XIB files,
+/// storyboards, Core Data file types, and asset catalogs as resources in your
+/// package manifest. However, you must explicitly declare other file types — for
+/// example, image files — as resources using the
+/// ``Resource/process(_:localization:)`` or ``Resource/copy(_:)`` rules.
+/// Alternatively, exclude resource files from a target by passing them to the
+/// target initializer's ``Target/exclude`` parameter.
+///
+/// To learn more about package resources, see
+/// <doc:bundling-resources-with-a-swift-package>.
 public struct Resource: Encodable {
 
     /// Defines the explicit type of localization for resources.
@@ -52,36 +59,38 @@ public struct Resource: Encodable {
         self.localization = localization
     }
 
-    /// Applies a platform-specific rule to the resource at the given path.
+    /// Applies a platform-specific rules to the resource at the given path.
     ///
-    /// Use the `process` rule to process resources at the given path
-    /// according to the platform it builds the target for. For example, the
-    /// Swift Package Manager may optimize image files for platforms that
-    /// support such optimizations. If no optimization is available for a file
-    /// type, the Swift Package Manager copies the file.
+    /// Use the `process` rule to process resources at the given path according
+    /// to the platform Swift Package Manager builds the target for. For example, Swift Package Manager may
+    /// optimize image files for platforms that support such optimizations. If
+    /// no optimization is available for a file type, Swift Package Manager copies the file.
     ///
-    /// If the given path represents a directory, the Swift Package Manager
-    /// applies the process rule recursively to each file in the directory.
+    /// If the given path represents a directory, Swift Package Manager applies the process rule
+    /// recursively to each file in the directory.
     ///
-    /// If possible use this rule instead of ``copy(_:)``.
+    /// If possible, use this rule instead of ``Resource/copy(_:)``.
     ///
     /// - Parameters:
-    ///     - path: The path for a resource.
-    ///     - localization: The explicit localization type for the resource.
+    ///   - path: The path for a resource.
+    ///   - localization: The explicit localization type for the resource.
+    /// - Returns: A `Resource` instance.
     public static func process(_ path: String, localization: Localization? = nil) -> Resource {
         return Resource(rule: "process", path: path, localization: localization)
     }
 
     /// Applies the copy rule to a resource at the given path.
     ///
-    /// If possible, use ``process(_:localization:)`` and automatically apply optimizations
-    /// to resources.
+    /// If possible, use ``Resource/process(_:localization:)`` and automatically
+    /// apply optimizations to resources.
     ///
-    /// If your resources must remain untouched or must retain a specific folder structure,
-    /// use the ``copy(_:)`` rule. It copies resources at the given path, as is, to the top level
-    /// in the package’s resource bundle. If the given path represents a directory, Xcode preserves its structure.
+    /// If your resources must remain untouched or must retain a specific folder
+    /// structure, use the `copy` rule. It copies resources at the given `path`,
+    /// as is, to the top level in the package's resource bundle. If the given
+    /// path represents a directory, Swift Package Manager preserves its structure.
     ///
     /// - Parameter path: The path for a resource.
+    /// - Returns: A `Resource` instance.
     public static func copy(_ path: String) -> Resource {
         return Resource(rule: "copy", path: path, localization: nil)
     }

--- a/Sources/PackageDescription/Resource.swift
+++ b/Sources/PackageDescription/Resource.swift
@@ -81,8 +81,7 @@ public struct Resource: Encodable {
     /// use the ``copy(_:)`` rule. It copies resources at the given path, as is, to the top level
     /// in the package’s resource bundle. If the given path represents a directory, Xcode preserves its structure.
     ///
-    /// - Parameters:
-    ///     - path: The path for a resource.
+    /// - Parameter path: The path for a resource.
     public static func copy(_ path: String) -> Resource {
         return Resource(rule: "copy", path: path, localization: nil)
     }

--- a/Sources/PackageDescription/SupportedPlatforms.swift
+++ b/Sources/PackageDescription/SupportedPlatforms.swift
@@ -10,8 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// A platform that usually corresponds to an operating system such as
-/// iOS, macOS, or Linux.
+/// A platform supported by Swift Package Manager.
 public struct Platform: Encodable, Equatable {
 
     /// The name of the platform.
@@ -21,6 +20,11 @@ public struct Platform: Encodable, Equatable {
         self.name = name
     }
 
+    /// Creates a custom platform.
+    ///
+    /// Use this function if none of the predefined platform names match the platform you are targeting.
+    /// - Parameter platformName: The name of the platform.
+    /// - Returns: A `Platform` instance.
     @available(_PackageDescription, introduced: 5.6)
     public static func custom(_ platformName: String) -> Platform {
         return Platform(name: platformName)
@@ -66,20 +70,20 @@ public struct Platform: Encodable, Equatable {
 
 /// A platform that the Swift package supports.
 ///
-/// By default, the Swift Package Manager assigns a predefined minimum deployment
-/// version for each supported platforms unless you configure supported platforms using the `platforms`
-/// API. This predefined deployment version is the oldest deployment target
-/// version that the installed SDK supports for a given platform. One exception
-/// to this rule is macOS, for which the minimum deployment target version
-/// starts from 10.10. Packages can choose to configure the minimum deployment
-/// target version for a platform by using the APIs defined in this struct. The
-/// Swift Package Manager emits appropriate errors when an invalid value is
-/// provided for supported platforms, such as an empty array, multiple declarations
-/// for the same platform, or an invalid version specification.
+/// By default, Swift Package Manager assigns a predefined minimum deployment version for each
+/// supported platforms unless you configure supported platforms using the
+/// `platforms` API. This predefined deployment version is the oldest deployment
+/// target version that the installed SDK supports for a given platform. One
+/// exception to this rule is macOS, for which the minimum deployment target
+/// version starts from 10.10. Packages can choose to configure the minimum
+/// deployment target version for a platform by using the APIs defined in this
+/// struct. Swift Package Manager emits appropriate errors when an invalid value is provided for
+/// supported platforms, such as an empty array, multiple declarations for the
+/// same platform, or an invalid version specification.
 ///
-/// The Swift Package Manager emits an error if a dependency isn’t compatible
-/// with the top-level package’s deployment version. The deployment
-/// target of a package's dependencies must be lower than or equal to the top-level package's
+/// Swift Package Manager emits an error if a dependency isn't compatible with the top-level
+/// package's deployment version. The deployment target of a package's
+/// dependencies must be lower than or equal to the top-level package's
 /// deployment target version for a particular platform.
 public struct SupportedPlatform: Encodable, Equatable {
 
@@ -107,11 +111,15 @@ public struct SupportedPlatform: Encodable, Equatable {
     /// Configures the minimum deployment target version for the macOS platform
     /// using a version string.
     ///
-    /// The version string must be a series of two or three dot-separated integers, such as `10.10` or `10.10.1`.
+    /// The version string must be a series of two or three dot-separated
+    /// integers, such as `10.10` or `10.10.1`.
     ///
-    /// - Since: First available in PackageDescription 5.0
+    /// - Since: First available in PackageDescription 5.0.
     ///
-    /// - Parameter versionString: The minimum deployment target as a string representation of two or three dot-separated integers, such as `10.10.1`.
+    /// - Parameter versionString: The minimum deployment target as a string
+    ///     representation of two or three dot-separated integers, such as
+    ///     `10.10.1`.
+    /// - Returns: A `SupportedPlatform` instance.
     public static func macOS(_ versionString: String) -> SupportedPlatform {
         return SupportedPlatform(platform: .macOS, version: SupportedPlatform.MacOSVersion(string: versionString).version)
     }
@@ -121,6 +129,7 @@ public struct SupportedPlatform: Encodable, Equatable {
     /// - Since: First available in PackageDescription 5.5
     ///
     /// - Parameter version: The minimum deployment target that the package supports.
+    /// - Returns: A `SupportedPlatform` instance.
     @available(_PackageDescription, introduced: 5.5)
     public static func macCatalyst(_ version: SupportedPlatform.MacCatalystVersion) -> SupportedPlatform {
         return SupportedPlatform(platform: .macCatalyst, version: version.version)
@@ -134,6 +143,7 @@ public struct SupportedPlatform: Encodable, Equatable {
     /// - Since: First available in PackageDescription 5.5
     ///
     /// - Parameter versionString: The minimum deployment target as a string representation of two or three dot-separated integers, such as `13.0.1`.
+    /// - Returns: A `SupportedPlatform` instance.
     @available(_PackageDescription, introduced: 5.5)
     public static func macCatalyst(_ versionString: String) -> SupportedPlatform {
         return SupportedPlatform(platform: .macCatalyst, version: SupportedPlatform.MacCatalystVersion(string: versionString).version)
@@ -141,9 +151,10 @@ public struct SupportedPlatform: Encodable, Equatable {
 
     /// Configures the minimum deployment target version for the iOS platform.
     ///
-    /// - Since: First available in PackageDescription 5.0
+    /// - Since: First available in PackageDescription 5.0.
     ///
     /// - Parameter version: The minimum deployment target that the package supports.
+    /// - Returns: A `SupportedPlatform` instance.
     public static func iOS(_ version: SupportedPlatform.IOSVersion) -> SupportedPlatform {
         return SupportedPlatform(platform: .iOS, version: version.version)
     }
@@ -151,11 +162,14 @@ public struct SupportedPlatform: Encodable, Equatable {
     /// Configures the minimum deployment target version for the iOS platform
     /// using a custom version string.
     ///
-    /// The version string must be a series of two or three dot-separated integers, such as `8.0` or `8.0.1`.
+    /// The version string must be a series of two or three dot-separated
+    /// integers, such as `8.0` or `8.0.1`.
     ///
     /// - Since: First available in PackageDescription 5.0
     ///
-    /// - Parameter versionString: The minimum deployment target as a string representation of two or three dot-separated integers, such as `8.0.1`.
+    /// - Parameter versionString: The minimum deployment target as a string
+    ///     representation of two or three dot-separated integers, such as `8.0.1`.
+    /// - Returns: A `SupportedPlatform` instance.
     public static func iOS(_ versionString: String) -> SupportedPlatform {
         return SupportedPlatform(platform: .iOS, version: SupportedPlatform.IOSVersion(string: versionString).version)
     }
@@ -165,6 +179,7 @@ public struct SupportedPlatform: Encodable, Equatable {
     /// - Since: First available in PackageDescription 5.0
     ///
     /// - Parameter version: The minimum deployment target that the package supports.
+    /// - Returns: A `SupportedPlatform` instance.
     public static func tvOS(_ version: SupportedPlatform.TVOSVersion) -> SupportedPlatform {
         return SupportedPlatform(platform: .tvOS, version: version.version)
     }
@@ -172,32 +187,39 @@ public struct SupportedPlatform: Encodable, Equatable {
     /// Configures the minimum deployment target version for the tvOS platform
     /// using a custom version string.
     ///
-    /// The version string must be a series of two or three dot-separated integers,such as `9.0` or `9.0.1`.
+    /// The version string must be a series of two or three dot-separated
+    /// integers,such as `9.0` or `9.0.1`.
     ///
     /// - Since: First available in PackageDescription 5.0
     ///
-    /// - Parameter versionString: The minimum deployment target as a string representation of two or three dot-separated integers, such as `9.0.1`.
+    /// - Parameter versionString: The minimum deployment target as a string
+    ///     representation of two or three dot-separated integers, such as `9.0.1`.
+    /// - Returns: A `SupportedPlatform` instance.
     public static func tvOS(_ versionString: String) -> SupportedPlatform {
         return SupportedPlatform(platform: .tvOS, version: SupportedPlatform.TVOSVersion(string: versionString).version)
     }
 
-    /// Configures the minimum deployment target version for the watchOS platform.
+    /// Configure the minimum deployment target version for the watchOS
+    /// platform.
     ///
     /// - Since: First available in PackageDescription 5.0
     ///
     /// - Parameter version: The minimum deployment target that the package supports.
+    /// - Returns: A `SupportedPlatform` instance.
     public static func watchOS(_ version: SupportedPlatform.WatchOSVersion) -> SupportedPlatform {
         return SupportedPlatform(platform: .watchOS, version: version.version)
     }
 
-    /// Configures the minimum deployment target version for the watchOS platform
-    /// using a custom version string.
+    /// Configure the minimum deployment target version for the watchOS
+    /// platform using a custom version string.
     ///
     /// The version string must be a series of two or three dot-separated integers, such as `2.0` or `2.0.1`.
     ///
     /// - Since: First available in PackageDescription 5.0
     ///
-    /// - Parameter versionString: The minimum deployment target as a string representation of two or three dot-separated integers, such as `2.0.1`.
+    /// - Parameter versionString: The minimum deployment target as a string
+    ///     representation of two or three dot-separated integers, such as `2.0.1`.
+    /// - Returns: A `SupportedPlatform` instance.
     public static func watchOS(_ versionString: String) -> SupportedPlatform {
         return SupportedPlatform(platform: .watchOS, version: SupportedPlatform.WatchOSVersion(string: versionString).version)
     }
@@ -213,9 +235,8 @@ public struct SupportedPlatform: Encodable, Equatable {
     /// Configures the minimum deployment target version for the DriverKit platform
     /// using a custom version string.
     ///
-    /// The version string must be a series of two or three dot-separated integers, such as `19.0` or `19.0.1`.
-    ///
     /// - Parameter versionString: The minimum deployment target as a string representation of two or three dot-separated integers, such as `19.0.1`.
+    /// - Returns: A `SupportedPlatform` instance.
     @available(_PackageDescription, introduced: 5.5)
     public static func driverKit(_ versionString: String) -> SupportedPlatform {
         return SupportedPlatform(platform: .driverKit, version: SupportedPlatform.DriverKitVersion(string: versionString).version)
@@ -225,7 +246,10 @@ public struct SupportedPlatform: Encodable, Equatable {
     ///
     /// - Since: First available in PackageDescription 5.6
     ///
-    /// - Parameter version: The minimum deployment target that the package supports.
+    /// - Parameters:
+    ///   - platformName: The name of the platform.
+    ///   - versionString: The minimum deployment target as a string representation of two or three dot-separated integers, such as `19.0.1`.
+    /// - Returns: A `SupportedPlatform` instance.
     @available(_PackageDescription, introduced: 5.6)
     public static func custom(_ platformName: String,  versionString: String) -> SupportedPlatform {
         return SupportedPlatform(platform: .custom(platformName), version: versionString)
@@ -249,51 +273,47 @@ extension SupportedPlatform {
 
         /// The value that represents macOS 10.10.
         ///
-        /// - Since: First available in PackageDescription 5.0
+        /// - Since: First available in PackageDescription 5.0.
         public static let v10_10: MacOSVersion = .init(string: "10.10")
 
         /// The value that represents macOS 10.11.
         ///
-        /// - Since: First available in PackageDescription 5.0
+        /// - Since: First available in PackageDescription 5.0.
         public static let v10_11: MacOSVersion = .init(string: "10.11")
 
         /// The value that represents macOS 10.12.
         ///
-        /// - Since: First available in PackageDescription 5.0
+        /// - Since: First available in PackageDescription 5.0.
         public static let v10_12: MacOSVersion = .init(string: "10.12")
 
         /// The value that represents macOS 10.13.
         ///
-        /// - Since: First available in PackageDescription 5.0
+        /// - Since: First available in PackageDescription 5.0.
         public static let v10_13: MacOSVersion = .init(string: "10.13")
 
         /// The value that represents macOS 10.14.
-        ///
-        /// - Since: First available in PackageDescription 5.0
         public static let v10_14: MacOSVersion = .init(string: "10.14")
 
         /// The value that represents macOS 10.15.
         ///
-        /// - Since: First available in PackageDescription 5.1
+        /// - Since: First available in PackageDescription 5.1.
         @available(_PackageDescription, introduced: 5.1)
         public static let v10_15: MacOSVersion = .init(string: "10.15")
 
         /// The value that represents macOS 10.16, which has been
         /// replaced by the value for macOS 11.0.
         ///
-        /// - Since: First available in PackageDescription 5.3
+        /// - Since: First available in PackageDescription 5.3.
         @available(*, unavailable, renamed: "v11")
         public static let v10_16: MacOSVersion = .init(string: "11.0")
 
         /// The value that represents macOS 11.0.
-        ///
-        /// - Since: First available in PackageDescription 5.3
         @available(_PackageDescription, introduced: 5.3)
         public static let v11: MacOSVersion = .init(string: "11.0")
 
         /// The value that represents macOS 12.0.
         ///
-        /// - Since: First available in PackageDescription 5.5
+        /// - Since: First available in PackageDescription 5.5.
         @available(_PackageDescription, introduced: 5.5)
         public static let v12: MacOSVersion = .init(string: "12.0")
     }
@@ -312,39 +332,39 @@ extension SupportedPlatform {
 
         /// The value that represents tvOS 9.0.
         ///
-        /// - Since: First available in PackageDescription 5.0
+        /// - Since: First available in PackageDescription 5.0.
         public static let v9: TVOSVersion = .init(string: "9.0")
 
         /// The value that represents tvOS 10.0.
         ///
-        /// - Since: First available in PackageDescription 5.0
+        /// - Since: First available in PackageDescription 5.0.
         public static let v10: TVOSVersion = .init(string: "10.0")
 
         /// The value that represents tvOS 11.0.
         ///
-        /// - Since: First available in PackageDescription 5.0
+        /// - Since: First available in PackageDescription 5.0.
         public static let v11: TVOSVersion = .init(string: "11.0")
 
         /// The value that represents tvOS 12.0.
         ///
-        /// - Since: First available in PackageDescription 5.0
+        /// - Since: First available in PackageDescription 5.0.
         public static let v12: TVOSVersion = .init(string: "12.0")
 
         /// The value that represents tvOS 13.0.
         ///
-        /// - Since: First available in PackageDescription 5.1
+        /// - Since: First available in PackageDescription 5.1.
         @available(_PackageDescription, introduced: 5.1)
         public static let v13: TVOSVersion = .init(string: "13.0")
 
         /// The value that represents tvOS 14.0.
         ///
-        /// - Since: First available in PackageDescription 5.3
+        /// - Since: First available in PackageDescription 5.3.
         @available(_PackageDescription, introduced: 5.3)
         public static let v14: TVOSVersion = .init(string: "14.0")
 
         /// The value that represents tvOS 15.0.
         ///
-        /// - Since: First available in PackageDescription 5.5
+        /// - Since: First available in PackageDescription 5.5.
         @available(_PackageDescription, introduced: 5.5)
         public static let v15: TVOSVersion = .init(string: "15.0")
     }
@@ -363,19 +383,19 @@ extension SupportedPlatform {
 
         /// The value that represents Mac Catalyst 13.0.
         ///
-        /// - Since: First available in PackageDescription 5.5
+        /// - Since: First available in PackageDescription 5.5.
         @available(_PackageDescription, introduced: 5.5)
         public static let v13: MacCatalystVersion = .init(string: "13.0")
 
         /// The value that represents Mac Catalyst 14.0.
         ///
-        /// - Since: First available in PackageDescription 5.5
+        /// - Since: First available in PackageDescription 5.5.
         @available(_PackageDescription, introduced: 5.5)
         public static let v14: MacCatalystVersion = .init(string: "14.0")
 
         /// The value that represents Mac Catalyst 15.0.
         ///
-        /// - Since: First available in PackageDescription 5.5
+        /// - Since: First available in PackageDescription 5.5.
         @available(_PackageDescription, introduced: 5.5)
         public static let v15: MacCatalystVersion = .init(string: "15.0")
     }
@@ -394,44 +414,44 @@ extension SupportedPlatform {
 
         /// The value that represents iOS 8.0.
         ///
-        /// - Since: First available in PackageDescription 5.0
+        /// - Since: First available in PackageDescription 5.0.
         public static let v8: IOSVersion = .init(string: "8.0")
 
         /// The value that represents iOS 9.0.
         ///
-        /// - Since: First available in PackageDescription 5.0
+        /// - Since: First available in PackageDescription 5.0.
         public static let v9: IOSVersion = .init(string: "9.0")
 
         /// The value that represents iOS 10.0.
         ///
-        /// - Since: First available in PackageDescription 5.0
+        /// - Since: First available in PackageDescription 5.0.
         public static let v10: IOSVersion = .init(string: "10.0")
 
         /// The value that represents iOS 11.0.
         ///
-        /// - Since: First available in PackageDescription 5.0
+        /// - Since: First available in PackageDescription 5.0.
         public static let v11: IOSVersion = .init(string: "11.0")
 
         /// The value that represents iOS 12.0.
         ///
-        /// - Since: First available in PackageDescription 5.0
+        /// - Since: First available in PackageDescription 5.0.
         public static let v12: IOSVersion = .init(string: "12.0")
 
         /// The value that represents iOS 13.0.
         ///
-        /// - Since: First available in PackageDescription 5.1
+        /// - Since: First available in PackageDescription 5.1.
         @available(_PackageDescription, introduced: 5.1)
         public static let v13: IOSVersion = .init(string: "13.0")
 
         /// The value that represents iOS 14.0.
         ///
-        /// - Since: First available in PackageDescription 5.3
+        /// - Since: First available in PackageDescription 5.3.
         @available(_PackageDescription, introduced: 5.3)
         public static let v14: IOSVersion = .init(string: "14.0")
 
         /// The value that represents iOS 15.0.
         ///
-        /// - Since: First available in PackageDescription 5.5
+        /// - Since: First available in PackageDescription 5.5.
         @available(_PackageDescription, introduced: 5.5)
         public static let v15: IOSVersion = .init(string: "15.0")
     }
@@ -450,39 +470,39 @@ extension SupportedPlatform {
 
         /// The value that represents watchOS 2.0.
         ///
-        /// - Since: First available in PackageDescription 5.0
+        /// - Since: First available in PackageDescription 5.0.
         public static let v2: WatchOSVersion = .init(string: "2.0")
 
         /// The value that represents watchOS 3.0.
         ///
-        /// - Since: First available in PackageDescription 5.0
+        /// - Since: First available in PackageDescription 5.0.
         public static let v3: WatchOSVersion = .init(string: "3.0")
 
         /// The value that represents watchOS 4.0.
         ///
-        /// - Since: First available in PackageDescription 5.0
+        /// - Since: First available in PackageDescription 5.0.
         public static let v4: WatchOSVersion = .init(string: "4.0")
 
         /// The value that represents watchOS 5.0.
         ///
-        /// - Since: First available in PackageDescription 5.0
+        /// - Since: First available in PackageDescription 5.0.
         public static let v5: WatchOSVersion = .init(string: "5.0")
 
         /// The value that represents watchOS 6.0.
         ///
-        /// - Since: First available in PackageDescription 5.1
+        /// - Since: First available in PackageDescription 5.1.
         @available(_PackageDescription, introduced: 5.1)
         public static let v6: WatchOSVersion = .init(string: "6.0")
 
         /// The value that represents watchOS 7.0.
         ///
-        /// - Since: First available in PackageDescription 5.3
+        /// - Since: First available in PackageDescription 5.3.
         @available(_PackageDescription, introduced: 5.3)
         public static let v7: WatchOSVersion = .init(string: "7.0")
 
         /// The value that represents watchOS 8.0.
         ///
-        /// - Since: First available in PackageDescription 5.5
+        /// - Since: First available in PackageDescription 5.5.
         @available(_PackageDescription, introduced: 5.5)
         public static let v8: WatchOSVersion = .init(string: "8.0")
     }

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -12,23 +12,26 @@
 
 import Foundation
 
-/// A target, the basic building block of a Swift package.
+/// The basic building block of a Swift package.
 ///
-/// Each target contains a set of source files that are compiled into a module or test suite.
-/// You can vend targets to other packages by defining products that include the targets.
+/// Each target contains a set of source files that Swift Package Manager compiles into a module
+/// or test suite. You can vend targets to other packages by defining products
+/// that include the targets.
 ///
-/// A target may depend on other targets within the same package and on products vended by the package's dependencies.
+/// A target may depend on other targets within the same package and on products
+/// vended by the package's dependencies.
 public final class Target {
 
     /// The different types of a target.
     public enum TargetType: String, Encodable {
-        /// A target that contains code for the Swift package’s functionality.
+        /// A target that contains code for the Swift package's functionality.
         case regular
         /// A target that contains code for an executable's main module.
         case executable
-        /// A target that contains tests for the Swift package’s other targets.
+        /// A target that contains tests for the Swift package's other targets.
         case test
-        /// A target that adapts a library on the system to work with Swift packages.
+        /// A target that adapts a library on the system to work with Swift
+        /// packages.
         case system
         /// A target that references a binary artifact.
         case binary
@@ -38,8 +41,27 @@ public final class Target {
 
     /// The different types of a target's dependency on another entity.
     public enum Dependency {
+        /// A denpendency on a target.
+        ///
+        ///  - Parameters:
+        ///    - name: The name of the target.
+        ///    - condition: A condition that limits the application of the target dependency. For example, only apply a dependency for a specific platform.
         case targetItem(name: String, condition: TargetDependencyCondition?)
+        /// A dependency on a product.
+        ///
+        /// - Parameters:
+        ///    - name: The name of the product.
+        ///    - package: The name of the package.
+        ///    - moduleAlias: The module aliases for targets in the product.
+        ///    - condition: A condition that limits the application of the target dependency. For example, only apply a dependency for a specific platform.
         case productItem(name: String, package: String?, moduleAliases: [String: String]?, condition: TargetDependencyCondition?)
+        /// A by-name dependency on either a target or a product.
+        ///
+        /// - Parameters:
+        ///   - name: The name of the dependency, either a target or a product.
+        ///   - condition: A condition that limits the application of the target
+        ///     dependency. For example, only apply a dependency for a specific
+        ///     platform.
         case byNameItem(name: String, condition: TargetDependencyCondition?)
     }
 
@@ -48,22 +70,28 @@ public final class Target {
 
     /// The path of the target, relative to the package root.
     ///
-    /// If the path is `nil`, the Swift Package Manager looks for a target's source files at predefined search paths
-    /// and in a subdirectory with the target's name.
+    /// If the path is `nil`, Swift Package Manager looks for a target's source files at
+    /// predefined search paths and in a subdirectory with the target's name.
     ///
-    /// The predefined search paths are the following directories under the package root:
-    ///   - `Sources`, `Source`, `src`, and `srcs` for regular targets
-    ///   - `Tests`, `Sources`, `Source`, `src`, and `srcs` for test targets
+    /// The predefined search paths are the following directories under the
+    /// package root:
     ///
-    /// For example, the Swift Package Manager looks for source files inside the `[PackageRoot]/Sources/[TargetName]` directory.
+    /// - `Sources`, `Source`, `src`, and `srcs` for regular targets
+    /// - `Tests`, `Sources`, `Source`, `src`, and `srcs` for test targets
     ///
-    /// Don't escape the package root; that is, values like `../Foo` or `/Foo` are invalid.
+    /// For example, Swift Package Manager looks for source files inside the
+    /// `[PackageRoot]/Sources/[TargetName]` directory.
+    ///
+    /// Don't escape the package root; that is, values like `../Foo` or `/Foo`
+    /// are invalid.
     public var path: String?
 
     /// The URL of a binary target.
     ///
-    /// The URL points to a ZIP file that contains an XCFramework at its root.
-    /// Binary targets are only available on Apple Platforms.
+    /// The URL points to an archive file that contains the referenced binary
+    /// artifact at its root.
+    ///
+    /// Binary targets are only available on Apple platforms.
     @available(_PackageDescription, introduced: 5.3)
     public var url: String? {
         get { _url }
@@ -73,10 +101,13 @@ public final class Target {
 
     /// The source files in this target.
     ///
-    /// If this property is `nil`, the Swift Package Manager includes all valid source files in the target's path and treats specified paths as relative to the target’s path.
+    /// If this property is `nil`, Swift Package Manager includes all valid source files in the
+    /// target's path and treats specified paths as relative to the target's
+    /// path.
     ///
-    /// A path can be a path to a directory or an individual source file. In case of a directory, the Swift Package Manager searches for valid source files
-    /// recursively inside it.
+    /// A path can be a path to a directory or an individual source file. In
+    /// case of a directory, Swift Package Manager searches for valid source files recursively
+    /// inside it.
     public var sources: [String]?
 
     /// The explicit list of resource files in the target.
@@ -87,13 +118,13 @@ public final class Target {
     }
     private var _resources: [Resource]?
 
-    /// The paths to source and resource files you don’t want to include in the target.
+    /// The paths to source and resource files that you don't want to include in the target.
     ///
-    /// Excluded paths are relative to the target path.
-    /// This property has precedence over the ``sources`` and ``resources`` properties.
+    /// Excluded paths are relative to the target path. This property has
+    /// precedence over the `sources` and `resources` properties.
     public var exclude: [String]
 
-    /// A boolean value that indicates if this is a test target.
+    /// A Boolean value that indicates whether this is a test target.
     public var isTest: Bool {
         return type == .test
     }
@@ -101,20 +132,19 @@ public final class Target {
     /// The target's dependencies on other entities inside or outside the package.
     public var dependencies: [Dependency]
 
-    /// The path to the directory containing public headers of a C-family target.
+    /// The path to the directory that contains public headers of a C-family target.
     ///
-    /// This path should be relative to the path specified in `path`.
     /// If this is `nil`, the directory is set to `include`.
     public var publicHeadersPath: String?
 
     /// The type of the target.
     public let type: TargetType
 
-    /// The `pkgconfig` name to use for a system library target.
+    /// The name of the package configuration file, without extension, for the system library target.
     ///
-    /// If present, the Swift Package Manager tries for every pkg-config
+    /// If present, the Swift Package Manager tries every package configuration
     /// name separated by a space to search for the `<name>.pc` file
-    /// to get the additional flags needed for the system target.
+    /// to get the additional flags needed for the system library target.
     public let pkgConfig: String?
 
     /// The providers array for a system library target.
@@ -128,8 +158,9 @@ public final class Target {
     }
     private var _pluginCapability: PluginCapability?
 
-    /// The different types of capability that a plugin can provide. In this
-    /// version of SwiftPM, only build tool and command plugins are supported;
+    /// The different types of capability that a plugin can provide.
+    ///
+    /// In this version of SwiftPM, only build tool and command plugins are supported;
     /// this enum will be extended as new plugin capabilities are added.
     public enum PluginCapability {
         case _buildTool
@@ -168,8 +199,18 @@ public final class Target {
         set { _linkerSettings = newValue }
     }
     private var _linkerSettings: [LinkerSetting]?
-
-    /// The checksum for the ZIP file that contains the referenced XCFramework.
+ 
+    /// The checksum for the archive file that contains the referenced binary
+    /// artifact.
+    ///
+    /// If you make a remote binary framework available as a Swift package,
+    /// declare a remote, or _URL-based_, binary target in your package manifest
+    /// with ``Target/binaryTarget(name:url:checksum:)``. Aways run `swift
+    /// package compute-checksum path/to/MyFramework.zip` at the command line to
+    /// make sure you create a correct SHA256 checksum.
+    ///
+    /// For more information, see
+    /// <doc:distributing-binary-frameworks-as-swift-packages>.
     @available(_PackageDescription, introduced: 5.3)
     public var checksum: String? {
         get { _checksum }
@@ -177,14 +218,15 @@ public final class Target {
     }
     private var _checksum: String?
 
-    /// The usages of package plugins by the target.
+    /// The uses of package plugins by the target.
     @available(_PackageDescription, introduced: 5.5)
     public var plugins: [PluginUsage]? {
         get { return _pluginUsages }
         set { _pluginUsages = newValue }
     }
     private var _pluginUsages: [PluginUsage]?
-
+    
+    /// A plugin used in a target.
     public enum PluginUsage {
         case _pluginItem(name: String, package: String?)
     }
@@ -782,15 +824,18 @@ public final class Target {
 
     /// Creates a system library target.
     ///
-    /// Use system library targets to adapt a library installed on the system to work with Swift packages.
-    /// Such libraries are generally installed by system package managers (such as Homebrew and apt-get)
-    /// and exposed to Swift packages by providing a `modulemap` file along with other metadata such as the library's `pkgConfig` name.
+    /// Use system library targets to adapt a library installed on the system to
+    /// work with Swift packages. Such libraries are generally installed by
+    /// system package managers (such as Homebrew and apt-get) and exposed to
+    /// Swift packages by providing a `modulemap` file along with other metadata
+    /// such as the library's `pkgConfig` name.
     ///
     /// - Parameters:
     ///   - name: The name of the target.
-    ///   - path: The custom path for the target. By default, the Swift Package Manager requires a target's sources to reside at predefined search paths;
-    ///       for example, `[PackageRoot]/Sources/[TargetName]`.
-    ///       Don't escape the package root; for example, values like `../Foo` or `/Foo` are invalid.
+    ///   - path: The custom path for the target. By default, a targets sources
+    ///     are expected to be located in the predefined search paths, such as
+    ///     `[PackageRoot]/Sources/[TargetName]`. Do not escape the package root;
+    ///     that is, values like `../Foo` or `/Foo` are invalid.
     ///   - pkgConfig: The name of the `pkg-config` file for this system library.
     ///   - providers: The providers for this system library.
     public static func systemLibrary(
@@ -813,16 +858,14 @@ public final class Target {
 
     /// Creates a binary target that references a remote artifact.
     ///
-    /// A binary target provides the url to a pre-built binary artifact for the target. Currently only supports
-    /// artifacts for Apple platforms.
+    /// Binary targets are only available on Apple platforms.
     ///
     /// - Parameters:
     ///   - name: The name of the target.
-    ///   - url: The URL to the binary artifact. This URL must point to an archive file
-    ///       that contains a binary artifact in its root directory.
-    ///   - checksum: The checksum of the archive file that contains the binary artifact.
-    ///
-    /// Binary targets are only available on Apple platforms.
+    ///   - url: The URL to the binary artifact. This URL must point to an archive
+    ///     file that contains a binary artifact in its root directory.
+    ///   - checksum: The checksum of the archive file that contains the binary
+    ///     artifact.
     @available(_PackageDescription, introduced: 5.3)
     public static func binaryTarget(
         name: String,
@@ -843,15 +886,13 @@ public final class Target {
 
     /// Creates a binary target that references an artifact on disk.
     ///
-    /// A binary target provides the path to a pre-built binary artifact for the target.
-    /// The Swift Package Manager only supports binary targets for Apple platforms.
+    /// Binary targets are only available on Apple platforms.
     ///
     /// - Parameters:
     ///   - name: The name of the target.
-    ///   - path: The path to the binary artifact. This path can point directly to a binary artifact
-    ///       or to an archive file that contains the binary artifact at its root.
-    ///
-    /// Binary targets are only available on Apple platforms.
+    ///   - path: The path to the binary artifact. This path can point directly to
+    ///     a binary artifact or to an archive file that contains the binary
+    ///     artifact at its root.
     @available(_PackageDescription, introduced: 5.3)
     public static func binaryTarget(
         name: String,
@@ -866,9 +907,10 @@ public final class Target {
             publicHeadersPath: nil,
             type: .binary)
     }
-
-    /// Defines a new package plugin target with a given name, declaring it as
-    /// providing a capability of adding custom build commands to SwiftPM (and to
+    
+    /// Defines a new package plugin target.
+    ///
+    /// A plugin target provides custom build commands to SwiftPM (and to
     /// any IDEs based on libSwiftPM).
     ///
     /// The capability determines what kind of build commands it can add. Besides
@@ -878,7 +920,7 @@ public final class Target {
     ///
     /// In the initial version of this proposal, three capabilities are provided:
     /// prebuild, build tool, and postbuild. See the declaration of each capability
-    /// under `PluginCapability` for more information.
+    /// under ``PluginCapability-swift.enum`` for more information.
     ///
     /// The package plugin itself is implemented using a Swift script that is
     /// invoked for each target that uses it. The script is invoked after the
@@ -889,17 +931,25 @@ public final class Target {
     /// Note that the role of the package plugin is only to define the commands
     /// that will run before, during, or after the build. It does not itself run
     /// those commands. The commands are defined in an IDE-neutral way, and are
-    /// run as appropriate by the build system that builds the package. The exten-
-    /// sion itself is only a procedural way of generating commands and their input
+    /// run as appropriate by the build system that builds the package. The extension
+    /// itself is only a procedural way of generating commands and their input
     /// and output dependencies.
     ///
     /// The package plugin may specify the executable targets or binary targets
     /// that provide the build tools that will be used by the generated commands
     /// during the build. In the initial implementation, prebuild actions can only
     /// depend on binary targets. Build tool and postbuild plugins can depend
-    /// on executables as well as binary targets. This is because of limitations
-    /// in how SwiftPM constructs its build plan, and the goal is to remove this
-    /// restriction in a future release.
+    /// on executables as well as binary targets. This is due to how
+    /// Swift Package Manager constructs its build plan.
+    ///
+    /// - Parameters:
+    ///   - name: The name of the plugin target.
+    ///   - capability: The type of capability the plugin target provides.
+    ///   - dependencies: The plugin target's dependencies.
+    ///   - path: The path of the plugin target, relative to the package root.
+    ///   - exclude: The paths to source and resource files you want to exclude from the plugin target.
+    ///   - sources: The source files in the plugin target.
+    /// - Returns: A `Target` instance.
     @available(_PackageDescription, introduced: 5.5)
     public static func plugin(
         name: String,
@@ -930,6 +980,7 @@ extension Target.Dependency {
     /// Creates a dependency on a target in the same package.
     ///
     /// - Parameter name: The name of the target.
+    /// - Returns: A `Target.Dependency` instance.
     @available(_PackageDescription, obsoleted: 5.3)
     public static func target(name: String) -> Target.Dependency {
         return .targetItem(name: name, condition: nil)
@@ -940,7 +991,8 @@ extension Target.Dependency {
     /// - Parameters:
     ///   - name: The name of the product.
     ///   - package: The name of the package.
-    @available(_PackageDescription, obsoleted: 5.2, message: "the 'package' argument is mandatory as of tools version 5.2")
+    /// - Returns: A `Target.Dependency` instance.
+@available(_PackageDescription, obsoleted: 5.2, message: "the 'package' argument is mandatory as of tools version 5.2")
     public static func product(name: String, package: String? = nil) -> Target.Dependency {
         return .productItem(name: name, package: package, moduleAliases: nil, condition: nil)
     }
@@ -951,6 +1003,7 @@ extension Target.Dependency {
     ///   - name: The name of the product.
     ///   - moduleAliases: The module aliases for targets in the product.
     ///   - package: The name of the package.
+    /// - Returns: A `Target.Dependency` instance.
     @available(_PackageDescription, introduced: 5.7)
     public static func product(name: String, package: String? = nil, moduleAliases: [String: String]? = nil) -> Target.Dependency {
         return .productItem(name: name, package: package, moduleAliases: moduleAliases, condition: nil)
@@ -958,10 +1011,10 @@ extension Target.Dependency {
 
     /// Creates a dependency that resolves to either a target or a product with the specified name.
     ///
-    /// - parameter name: The name of the dependency, either a target or a product.
-    ///
+    /// - Parameter name: The name of the dependency, either a target or a product.
+    /// - Returns: A `Target.Dependency` instance.
     /// The Swift Package Manager creates the by-name dependency after it has loaded the package graph.
-    @available(_PackageDescription, obsoleted: 5.3)
+@available(_PackageDescription, obsoleted: 5.3)
     public static func byName(name: String) -> Target.Dependency {
         return .byNameItem(name: name, condition: nil)
     }
@@ -971,7 +1024,8 @@ extension Target.Dependency {
     /// - Parameters:
     ///   - name: The name of the product.
     ///   - package: The name of the package.
-    @available(_PackageDescription, introduced: 5.2, obsoleted: 5.3)
+    /// - Returns: A `Target.Dependency` instance.
+@available(_PackageDescription, introduced: 5.2, obsoleted: 5.3)
     public static func product(
         name: String,
         package: String
@@ -983,9 +1037,11 @@ extension Target.Dependency {
     ///
     /// - Parameters:
     ///   - name: The name of the target.
-    ///   - condition: A condition that limits the application of the target dependency. For example, only apply a
-    ///       dependency for a specific platform.
-    @available(_PackageDescription, introduced: 5.3)
+    ///   - condition: A condition that limits the application of the target
+    ///     dependency. For example, only apply a dependency for a specific
+    ///     platform.
+    /// - Returns: A `Target.Dependency` instance.
+@available(_PackageDescription, introduced: 5.3)
     public static func target(name: String, condition: TargetDependencyCondition? = nil) -> Target.Dependency {
         return .targetItem(name: name, condition: condition)
     }
@@ -995,9 +1051,11 @@ extension Target.Dependency {
     /// - Parameters:
     ///   - name: The name of the product.
     ///   - package: The name of the package.
-    ///   - condition: A condition that limits the application of the target dependency. For example, only apply a
-    ///       dependency for a specific platform.
-    @_disfavoredOverload
+    ///   - condition: A condition that limits the application of the target
+    ///     dependency. For example, only apply a dependency for a specific
+    ///     platform.
+    /// - Returns: A `Target.Dependency` instance.
+@_disfavoredOverload
     @available(_PackageDescription, introduced: 5.3, obsoleted: 5.7)
     public static func product(
         name: String,
@@ -1015,7 +1073,8 @@ extension Target.Dependency {
     ///   - moduleAliases: The module aliases for targets in the product.
     ///   - condition: A condition that limits the application of the target dependency. For example, only apply a
     ///       dependency for a specific platform.
-    @available(_PackageDescription, introduced: 5.7)
+    /// - Returns: A `Target.Dependency` instance.
+@available(_PackageDescription, introduced: 5.7)
     public static func product(
       name: String,
       package: String,
@@ -1025,14 +1084,19 @@ extension Target.Dependency {
         return .productItem(name: name, package: package, moduleAliases: moduleAliases, condition: condition)
     }
 
-    /// Creates a by-name dependency that resolves to either a target or a product but after the Swift Package Manager
-    /// has loaded the package graph.
+    /// Creates a dependency that resolves to either a target or a product with
+    /// the specified name.
+    ///
+    /// Swift Package Manager creates the by-name dependency after it has loaded the package
+    /// graph.
     ///
     /// - Parameters:
     ///   - name: The name of the dependency, either a target or a product.
-    ///   - condition: A condition that limits the application of the target dependency. For example, only apply a
-    ///       dependency for a specific platform.
-    @available(_PackageDescription, introduced: 5.3)
+    ///   - condition: A condition that limits the application of the target
+    ///     dependency. For example, only apply a dependency for a specific
+    ///     platform.
+    /// - Returns: A `Target.Dependency` instance.
+@available(_PackageDescription, introduced: 5.3)
     public static func byName(name: String, condition: TargetDependencyCondition? = nil) -> Target.Dependency {
         return .byNameItem(name: name, condition: condition)
     }
@@ -1071,36 +1135,48 @@ public struct TargetDependencyCondition: Encodable {
 }
 
 extension Target.PluginCapability {
-
-    /// Specifies that the plugin provides a build tool capability. The plugin
-    /// will be applied to each target that uses it and should create commands
+    
+    /// Specifies that the plugin provides a build tool capability.
+    ///
+    /// The plugin will be applied to each target that uses it and should create commands
     /// that will run before or during the build of the target.
+    ///
+    ///  - Returns: A plugin capability that defines a build tool.
     @available(_PackageDescription, introduced: 5.5)
     public static func buildTool() -> Target.PluginCapability {
         return ._buildTool
     }
 
-    /// Specifies that the plugin provides a user command capability. It will
-    /// be available to invoke manually on one or more targets in a package.
+    /// Specifies that the plugin provides a user command capability.
+    ///
+    ///- Parameters:
+    ///   - intent: The semantic intent of the plugin (either one of the predefined intents,
+    ///     or a custom intent).
+    ///   - permissions: Any permissions needed by the command plugin. This affects what the
+    ///     sandbox in which the plugin is run allows. Some permissions may require
+    ///     approval by the user.
+    ///
+    /// - Returns: A plugin capability that defines a user command.
+    ///
+    /// Plugins that specify a `command` capability define commands that can be run
+    /// using the SwiftPM command line interface, or in an IDE that supports
+    /// Swift Packages. The command will be available to invoke manually on one or more targets in a package.
+    ///
+    ///```swift
+    ///swift package <verb>
+    ///```
+    ///
     /// The package can specify the verb that is used to invoke the command.
     @available(_PackageDescription, introduced: 5.6)
-    /// Plugins that specify a `command` capability define commands that can be run
-    /// using the SwiftPM CLI (`swift package <verb>`), or in an IDE that supports
-    /// Swift Packages.
     public static func command(
-        /// The semantic intent of the plugin (either one of the predefined intents,
-        /// or a custom intent).
         intent: PluginCommandIntent,
-
-        /// Any permissions needed by the command plugin. This affects what the
-        /// sandbox in which the plugin is run allows. Some permissions may require
-        /// approval by the user.
         permissions: [PluginPermission] = []
     ) -> Target.PluginCapability {
         return ._command(intent: intent, permissions: permissions)
     }
 }
 
+/// The intended use case of the command plugin.
 @available(_PackageDescription, introduced: 5.6)
 public enum PluginCommandIntent {
     case _documentationGeneration
@@ -1110,26 +1186,42 @@ public enum PluginCommandIntent {
 
 @available(_PackageDescription, introduced: 5.6)
 public extension PluginCommandIntent {
+    /// The plugin generates documentation.
+    ///
     /// The intent of the command is to generate documentation, either by parsing the
     /// package contents directly or by using the build system support for generating
     /// symbol graphs. Invoked by a `generate-documentation` verb to `swift package`.
+    ///
+    ///  - Returns: A `PluginCommandIntent` instance.
     static func documentationGeneration() -> PluginCommandIntent {
         return _documentationGeneration
     }
 
+    /// The plugin formats source code.
+    ///
     /// The intent of the command is to modify the source code in the package based
     /// on a set of rules. Invoked by a `format-source-code` verb to `swift package`.
+    ///
+    /// - Returns: A `PluginCommandIntent` instance.
     static func sourceCodeFormatting() -> PluginCommandIntent {
         return _sourceCodeFormatting
     }
 
-    /// An intent that doesn't fit into any of the other categories, with a custom
-    /// verb through which it can be invoked.
+    /// A custom command plugin intent.
+    ///
+    ///  Use this case when none of the predefined cases fit the role of the plugin.
+    ///  - Parameters:
+    ///    - verb: The invocation verb of the plugin.
+    ///    - description: A human readable description of the plugin's role.
+    /// - Returns: A `PluginCommandIntent` instance.
     static func custom(verb: String, description: String) -> PluginCommandIntent {
         return _custom(verb: verb, description: description)
     }
 }
 
+/// The type of permission a plugin requires.
+///
+/// Only one type of permission is supported. See ``writeToPackageDirectory(reason:)``.
 @available(_PackageDescription, introduced: 5.6)
 public enum PluginPermission {
     case _writeToPackageDirectory(reason: String)
@@ -1137,9 +1229,13 @@ public enum PluginPermission {
 
 @available(_PackageDescription, introduced: 5.6)
 public extension PluginPermission {
+    /// Create a permission to modify files in the package's directory.
+    ///
     /// The command plugin wants permission to modify the files under the package
     /// directory. The `reason` string is shown to the user at the time of request
     /// for approval, explaining why the plugin is requesting this access.
+    ///   - Parameter reason: A reason why the permission is needed. This will be shown to the user.
+    ///   - Returns: A `PluginPermission` instance.
     static func writeToPackageDirectory(reason: String) -> PluginPermission {
         return _writeToPackageDirectory(reason: reason)
     }
@@ -1149,6 +1245,7 @@ extension Target.PluginUsage {
     /// Specifies use of a plugin target in the same package.
     ///
     /// - Parameter name: The name of the plugin target.
+    /// - Returns: A `PluginUsage` instance.
     @available(_PackageDescription, introduced: 5.5)
     public static func plugin(name: String) -> Target.PluginUsage {
         return ._pluginItem(name: name, package: nil)
@@ -1157,8 +1254,9 @@ extension Target.PluginUsage {
     /// Specifies use of a plugin product in a package dependency.
     ///
     /// - Parameters:
-    ///   - name: The name of the plugin product.
-    ///   - package: The name of the package in which it is defined.
+    ///   - name: The name of the plugin target.
+    ///   - package: The name of the package in which the plugin target is defined.
+    /// - Returns: A `PluginUsage` instance.
     @available(_PackageDescription, introduced: 5.5)
     public static func plugin(name: String, package: String) -> Target.PluginUsage {
         return ._pluginItem(name: name, package: package)
@@ -1168,6 +1266,8 @@ extension Target.PluginUsage {
 
 // MARK: ExpressibleByStringLiteral
 
+/// `ExpressibleByStringLiteral` conformance.
+///
 extension Target.Dependency: ExpressibleByStringLiteral {
 
     /// Creates a target dependency instance with the given value.
@@ -1178,6 +1278,8 @@ extension Target.Dependency: ExpressibleByStringLiteral {
     }
 }
 
+/// `ExpressibleByStringLiteral` conformance.
+///
 extension Target.PluginUsage: ExpressibleByStringLiteral {
 
     /// Specifies use of a plugin target in the same package.

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -929,8 +929,7 @@ extension Target.Dependency {
 
     /// Creates a dependency on a target in the same package.
     ///
-    /// - parameters:
-    ///   - name: The name of the target.
+    /// - Parameter name: The name of the target.
     @available(_PackageDescription, obsoleted: 5.3)
     public static func target(name: String) -> Target.Dependency {
         return .targetItem(name: name, condition: nil)
@@ -938,7 +937,7 @@ extension Target.Dependency {
 
     /// Creates a dependency on a product from a package dependency.
     ///
-    /// - parameters:
+    /// - Parameters:
     ///   - name: The name of the product.
     ///   - package: The name of the package.
     @available(_PackageDescription, obsoleted: 5.2, message: "the 'package' argument is mandatory as of tools version 5.2")
@@ -948,7 +947,7 @@ extension Target.Dependency {
 
     /// Creates a dependency on a product from a dependent package.
     ///
-    /// - parameters:
+    /// - Parameters:
     ///   - name: The name of the product.
     ///   - moduleAliases: The module aliases for targets in the product.
     ///   - package: The name of the package.
@@ -959,8 +958,7 @@ extension Target.Dependency {
 
     /// Creates a dependency that resolves to either a target or a product with the specified name.
     ///
-    /// - parameters:
-    ///   - name: The name of the dependency, either a target or a product.
+    /// - parameter name: The name of the dependency, either a target or a product.
     ///
     /// The Swift Package Manager creates the by-name dependency after it has loaded the package graph.
     @available(_PackageDescription, obsoleted: 5.3)
@@ -970,7 +968,7 @@ extension Target.Dependency {
 
     /// Creates a dependency on a product from a package dependency.
     ///
-    /// - parameters:
+    /// - Parameters:
     ///   - name: The name of the product.
     ///   - package: The name of the package.
     @available(_PackageDescription, introduced: 5.2, obsoleted: 5.3)
@@ -983,7 +981,7 @@ extension Target.Dependency {
 
     /// Creates a dependency on a target in the same package.
     ///
-    /// - parameters:
+    /// - Parameters:
     ///   - name: The name of the target.
     ///   - condition: A condition that limits the application of the target dependency. For example, only apply a
     ///       dependency for a specific platform.
@@ -994,7 +992,7 @@ extension Target.Dependency {
 
     /// Creates a target dependency on a product from a package dependency.
     ///
-    /// - parameters:
+    /// - Parameters:
     ///   - name: The name of the product.
     ///   - package: The name of the package.
     ///   - condition: A condition that limits the application of the target dependency. For example, only apply a
@@ -1011,7 +1009,7 @@ extension Target.Dependency {
 
     /// Creates a target dependency on a product from a package dependency.
     ///
-    /// - parameters:
+    /// - Parameters:
     ///   - name: The name of the product.
     ///   - package: The name of the package.
     ///   - moduleAliases: The module aliases for targets in the product.
@@ -1030,7 +1028,7 @@ extension Target.Dependency {
     /// Creates a by-name dependency that resolves to either a target or a product but after the Swift Package Manager
     /// has loaded the package graph.
     ///
-    /// - parameters:
+    /// - Parameters:
     ///   - name: The name of the dependency, either a target or a product.
     ///   - condition: A condition that limits the application of the target dependency. For example, only apply a
     ///       dependency for a specific platform.
@@ -1050,8 +1048,7 @@ public struct TargetDependencyCondition: Encodable {
 
     /// Creates a target dependency condition.
     ///
-    /// - Parameters:
-    ///   - platforms: The applicable platforms for this target dependency condition.
+    /// - Parameter platforms: The applicable platforms for this target dependency condition.
     @_disfavoredOverload
     @available(_PackageDescription, obsoleted: 5.7, message: "using .when with nil platforms is obsolete")
     public static func when(
@@ -1064,8 +1061,7 @@ public struct TargetDependencyCondition: Encodable {
 
     /// Creates a target dependency condition.
     ///
-    /// - Parameters:
-    ///   - platforms: The applicable platforms for this target dependency condition.
+    /// - Parameter platforms: The applicable platforms for this target dependency condition.
     @available(_PackageDescription, introduced: 5.7)
     public static func when(
         platforms: [Platform]
@@ -1152,8 +1148,7 @@ public extension PluginPermission {
 extension Target.PluginUsage {
     /// Specifies use of a plugin target in the same package.
     ///
-    /// - parameters:
-    ///   - name: The name of the plugin target.
+    /// - Parameter name: The name of the plugin target.
     @available(_PackageDescription, introduced: 5.5)
     public static func plugin(name: String) -> Target.PluginUsage {
         return ._pluginItem(name: name, package: nil)
@@ -1161,7 +1156,7 @@ extension Target.PluginUsage {
 
     /// Specifies use of a plugin product in a package dependency.
     ///
-    /// - parameters:
+    /// - Parameters:
     ///   - name: The name of the plugin product.
     ///   - package: The name of the package in which it is defined.
     @available(_PackageDescription, introduced: 5.5)
@@ -1177,8 +1172,7 @@ extension Target.Dependency: ExpressibleByStringLiteral {
 
     /// Creates a target dependency instance with the given value.
     ///
-    /// - parameters:
-    ///   - value: A string literal.
+    /// - Parameter value: A string literal.
     public init(stringLiteral value: String) {
         self = .byNameItem(name: value, condition: nil)
     }
@@ -1188,8 +1182,7 @@ extension Target.PluginUsage: ExpressibleByStringLiteral {
 
     /// Specifies use of a plugin target in the same package.
     ///
-    /// - parameters:
-    ///   - value: A string literal.
+    /// - Parameter value: A string literal.
     public init(stringLiteral value: String) {
         self = ._pluginItem(name: value, package: nil)
     }

--- a/Sources/PackageDescription/Version+StringLiteralConvertible.swift
+++ b/Sources/PackageDescription/Version+StringLiteralConvertible.swift
@@ -12,6 +12,7 @@
 
 extension Version: ExpressibleByStringLiteral {
     /// Initializes a version struct with the provided string literal.
+    ///
     /// - Parameter version: A string literal to use for creating a new version struct.
     public init(stringLiteral value: String) {
         if let version = Version(value) {
@@ -28,16 +29,15 @@ extension Version: ExpressibleByStringLiteral {
 
     /// Initializes a version struct with the provided extended grapheme cluster.
     ///
-    /// - Parameters:
-    ///     - version: An extended grapheme cluster to use for creating a new version struct.
+    /// - Parameter version: An extended grapheme cluster to use for creating a new
+    ///   version struct.
     public init(extendedGraphemeClusterLiteral value: String) {
         self.init(stringLiteral: value)
     }
 
     /// Initializes a version struct with the provided Unicode string.
     ///
-    /// - Parameters:
-    ///     - version: A Unicode string to use for creating a new version struct.
+    /// - Parameter version: A Unicode string to use for creating a new version struct.
     public init(unicodeScalarLiteral value: String) {
         self.init(stringLiteral: value)
     }

--- a/Sources/PackageDescription/Version.swift
+++ b/Sources/PackageDescription/Version.swift
@@ -12,31 +12,29 @@
 
 /// A version according to the semantic versioning specification.
 ///
-/// A package version is a three period-separated integer, for example `1.0.0`. It must conform to the semantic versioning standard in order to ensure
+/// A package version consists of three integers separated by periods, for example `1.0.0`. It must conform to the semantic versioning standard in order to ensure
 /// that your package behaves in a predictable manner once developers update their
 /// package dependency to a newer version. To achieve predictability, the semantic versioning specification proposes a set of rules and
 /// requirements that dictate how version numbers are assigned and incremented. To learn more about the semantic versioning specification, visit
-/// [semver.org](www.semver.org).
+/// [Semantic Versioning 2.0.0](https://semver.org).
 ///
-/// **The Major Version**
+/// - term The major version: The first digit of a version, or _major version_,
+/// signifies breaking changes to the API that require updates to existing
+/// clients. For example, the semantic versioning specification considers
+/// renaming an existing type, removing a method, or changing a method's
+/// signature breaking changes. This also includes any backward-incompatible bug
+/// fixes or behavioral changes of the existing API.
 ///
-/// The first digit of a version, or  *major version*, signifies breaking changes to the API that require
-/// updates to existing clients. For example, the semantic versioning specification
-/// considers renaming an existing type, removing a method, or changing a method's signature
-/// breaking changes. This also includes any backward-incompatible bug fixes or
-/// behavioral changes of the existing API.
+/// - term The minor version:
+/// Update the second digit of a version, or _minor version_, if you add
+/// functionality in a backward-compatible manner. For example, the semantic
+/// versioning specification considers adding a new method or type without
+/// changing any other API to be backward-compatible.
 ///
-/// **The Minor Version**
-///
-/// Update the second digit of a version, or *minor version*, if you add functionality in a backward-compatible manner.
-/// For example, the semantic versioning specification considers adding a new method
-/// or type without changing any other API to be backward-compatible.
-///
-/// **The Patch Version**
-///
-/// Increase the third digit of a version, or *patch version*, if you are making a backward-compatible bug fix.
-/// This allows clients to benefit from bugfixes to your package without incurring
-/// any maintenance burden.
+/// - term The patch version:
+/// Increase the third digit of a version, or _patch version_, if you're making
+/// a backward-compatible bug fix. This allows clients to benefit from bugfixes
+/// to your package without incurring any maintenance burden.
 public struct Version {
 
     /// The major version according to the semantic versioning standard.
@@ -96,11 +94,30 @@ public struct Version {
 
 extension Version: Comparable {
     // Although `Comparable` inherits from `Equatable`, it does not provide a new default implementation of `==`, but instead uses `Equatable`'s default synthesised implementation. The compiler-synthesised `==`` is composed of [member-wise comparisons](https://github.com/apple/swift-evolution/blob/main/proposals/0185-synthesize-equatable-hashable.md#implementation-details), which leads to a false `false` when 2 semantic versions differ by only their build metadata identifiers, contradicting SemVer 2.0.0's [comparison rules](https://semver.org/#spec-item-10).
+    
+    /// Returns a Boolean value indicating whether two values are equal.
+    ///
+    /// Equality is the inverse of inequality. For any values `a` and `b`, `a ==
+    /// b` implies that `a != b` is `false`.
+    ///
+    /// - Parameters:
+    ///   - lhs: A value to compare.
+    ///   - rhs: Another value to compare.
+    ///
+    /// - Returns: A boolean value indicating the result of the equality test.
     @inlinable
     public static func == (lhs: Version, rhs: Version) -> Bool {
         !(lhs < rhs) && !(lhs > rhs)
     }
-
+    
+    /// Returns a Boolean value indicating whether the value of the first
+    /// argument is less than that of the second argument.
+    ///
+    /// The precedence is determined according to rules described in the [Semantic Versioning 2.0.0](https://semver.org) standard, paragraph 11.
+    ///
+    /// - Parameters:
+    ///   - lhs: A value to compare.
+    ///   - rhs: Another value to compare.
     public static func < (lhs: Version, rhs: Version) -> Bool {
         let lhsComparators = [lhs.major, lhs.minor, lhs.patch]
         let rhsComparators = [rhs.major, rhs.minor, rhs.patch]


### PR DESCRIPTION
Cherry picked the new DocC documentation from `main`.

### Motivation:

There is a desire that the DocC documentation be available in the 5.7 release.

### Modifications:

I cherry picked these two commits from `main`:
911556addd95f417c12b9e278323c30f51b8d3e6 originally from PR #4276 
5d9202f829c6c66bbae20f4750b85fe5011ad280 originally from PR #4277

Then I resolved a couple of merge conflicts in `Sources/PackageDescription/PackageDependency.swift`

All additions and changes are in the `Sources/PackageDescription` directory.

### Result:

There were no code changes, only DocC comment additions and changes, including in the PackageDescription documentation catalog. 
