### PR TITLE
rdar://92275318 (Swift CI Unblock:OSS - Swift Incremental RA - macOS - Apple Silicon - testPluginGeneratedResources Failure)

### DIFF
--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -804,9 +804,8 @@ class MiscellaneousTestCase: XCTestCase {
     }
 
     func testPluginGeneratedResources() throws {
-        #if swift(<5.6)
-        try XCTSkipIf(true, "skipping because of potential concurrency back deployment issues")
-        #endif
+        // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
+        try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
 
         try fixture(name: "Miscellaneous/PluginGeneratedResources") { path in
             let result = try SwiftPMProduct.SwiftRun.execute([], packagePath: path)


### PR DESCRIPTION
We are seeing this issue on the particular bot:

```
'dyld: Library not loaded: @rpath/libswift_Concurrency.dylib
Referenced from: /Users/ec2-user/jenkins/workspace/oss-swift-incremental-RA-macos-apple-silicon/build/buildbot_incremental/swiftpm-macosx-arm64/arm64-apple-macosx/bootstrap/pm/PluginAPI/libPackagePlugin.dylib
 Reason: image not found
```

This speculatively bumps the minimum required toolchain for the test.
