### PR TITLE
[5.7] Mark the SwiftPM 5.7 branch as a release branch

### DIFF
--- a/Fixtures/Miscellaneous/ModuleAliasing/DirectDeps/AppPkg/Package.swift
+++ b/Fixtures/Miscellaneous/ModuleAliasing/DirectDeps/AppPkg/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:999.0
+// swift-tools-version: 5.7
 import PackageDescription
 
 let package = Package(
@@ -29,4 +29,3 @@ let package = Package(
             )
         ]
     )
-        

--- a/Sources/Basics/SwiftVersion.swift
+++ b/Sources/Basics/SwiftVersion.swift
@@ -55,7 +55,7 @@ extension SwiftVersion {
     /// The current version of the package manager.
     public static let current = SwiftVersion(
         version: (5, 7, 0),
-        isDevelopment: true,
+        isDevelopment: false,
         buildIdentifier: getBuildIdentifier()
     )
 }

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -849,6 +849,8 @@ class PluginTests: XCTestCase {
     func testSnippetSupport() throws {
         // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+        // Only run if feature is enabled
+        try XCTSkipIf(ProcessInfo.processInfo.environment["SWIFTPM_ENABLE_SNIPPETS"] != "1")
 
         try fixture(name: "Miscellaneous/Plugins") { path in
             let (stdout, stderr) = try executeSwiftPackage(path.appending(component: "PluginsAndSnippets"), configuration: .Debug, extraArgs: ["do-something"])


### PR DESCRIPTION
As we do with every release, we need to turn off the development bit in SwiftPM so that it disallows use of 999.0 package manifest tools versions and also (somewhat less importantly) shows the version without a `-dev` suffix in response to `swift package --version`.

Specific changes:
- change `development` from true to false in SwiftVersion.swift

rdar://92289630