### PR TITLE
Updated the links that point to using Swift packages with Xcode.

### DIFF
--- a/Sources/PackageDescription/PackageDescription.docc/PackageDescription.md
+++ b/Sources/PackageDescription/PackageDescription.docc/PackageDescription.md
@@ -38,7 +38,7 @@ let package = Package(
 
 The package manifest also allows you to define executable products, as well as plugins that Swift Package Manager can use to build other products in the manifest.
 
-For more information about adding a package dependency to your app project and creating Swift packages with Xcode, see [Adding Package Dependencies to Your App](https://developer.apple.com/documentation/xcode/adding_package_dependencies_to_your_app), [Creating a Standalone Swift Package with Xcode](https://developer.apple.com/documentation/xcode/creating_a_standalone_swift_package_with_xcode/), and [Swift Packages](https://developer.apple.com/documentation/xcode/swift_packages).
+For more information about adding a package dependency to your app project and creating Swift packages with Xcode, see [Adding Package Dependencies to Your App](https://developer.apple.com/documentation/xcode/adding-package-dependencies-to-your-app), [Creating a Standalone Swift Package with Xcode](https://developer.apple.com/documentation/xcode/creating-a-standalone-swift-package-with-xcode), and [Swift Packages](https://developer.apple.com/documentation/xcode/swift-packages).
 
 Support for Swift packages in Xcode builds on the open-source Swift Package Manager project. To learn more about the Swift Package Manager, visit [Swift.org](https://www.swift.org/package-manager/) and the Swift Package Manager repository on [GitHub](https://github.com/apple/swift-package-manager).
 


### PR DESCRIPTION
I updated the links in the `PackageDescription` DocC docs to point to the correct location.

### Motivation:

The links were incorrect in that they used `_` (underscore) to separate words, while the actual URLs used `-` (dash).

### Modifications:

I modified the `Sources/PackageDescription/PackageDescription.docc/PackageDescription.md` file.

### Result:

Only the above mentioned file was modified, and it now contains the correct links.