### PR TITLE
[5.7] Add an API to reload the workspace state from workspace-state.json

### DIFF
--- a/Sources/Workspace/Workspace+State.swift
+++ b/Sources/Workspace/Workspace+State.swift
@@ -39,14 +39,20 @@ public final class WorkspaceState {
         self.storagePath = storageDirectory.appending(component: "workspace-state.json")
         self.storage = WorkspaceStateStorage(path: self.storagePath, fileSystem: fileSystem)
 
-        // Load the state from disk, if possible.
-        //
-        // If the disk operation here fails, we ignore the error here.
-        // This means if managed dependencies data is corrupted or out of date,
-        // clients will not see the old data and managed dependencies will be
-        // reset.  However there could be other errors, like permission issues,
-        // these errors will also be ignored but will surface when clients try
-        // to save the state.
+        self.dependencies = Workspace.ManagedDependencies()
+        self.artifacts = Workspace.ManagedArtifacts()
+        load(warningHandler: initializationWarningHandler)
+    }
+
+    /// Load the state from disk, if possible.
+    ///
+    /// If the disk operation here fails, we ignore the error here.
+    /// This means if managed dependencies data is corrupted or out of date,
+    /// clients will not see the old data and managed dependencies will be
+    /// reset.  However there could be other errors, like permission issues,
+    /// these errors will also be ignored but will surface when clients try
+    /// to save the state.
+    func load(warningHandler: (String) -> Void) {
         do {
             let storedState = try self.storage.load()
             self.dependencies = storedState.dependencies
@@ -55,7 +61,7 @@ public final class WorkspaceState {
             self.dependencies = Workspace.ManagedDependencies()
             self.artifacts = Workspace.ManagedArtifacts()
             try? self.storage.reset()
-            initializationWarningHandler("unable to restore workspace state: \(error)")
+            warningHandler("unable to restore workspace state: \(error)")
         }
     }
 

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -720,6 +720,11 @@ public class Workspace {
 
 extension Workspace {
 
+    /// Reload the workspace state from the workspace-state.json file on disk.
+    public func reloadWorkspaceState(warningHandler: (String) -> Void) {
+        self.state.load(warningHandler: warningHandler)
+    }
+
     // deprecated 10/2021
     @available(*, deprecated, message: "use observability system APIs instead")
     public func edit(packageName: String, path: AbsolutePath? = nil, revision: Revision? = nil, checkoutBranch: String? = nil, diagnostics: DiagnosticsEngine) {


### PR DESCRIPTION
Cherry-picks https://github.com/apple/swift-package-manager/pull/4310 to release/5.7

* **Explanation**: Adds an API to reload the workspace state, which will be used by SourceKit-LSP in https://github.com/apple/sourcekit-lsp/pull/484
* **Scope**: Just moving code around in SwiftPM to create a new entry point for SourceKit-LSP
* **Risk**: Very low, no functionality change, just moving code around
* **Testing**: Ran test suite
* **Issue**: rdar://89551074
* **Reviewer**: Awaiting review on https://github.com/apple/swift-package-manager/pull/4310