### PR TITLE
Tests: use `FileManager` instead of `cp`

### DIFF
--- a/IntegrationTests/Tests/IntegrationTests/Helpers.swift
+++ b/IntegrationTests/Tests/IntegrationTests/Helpers.swift
@@ -221,7 +221,11 @@ func fixture(
             if localFileSystem.isFile(fixtureDir.appending(component: "Package.swift")) {
                 // It's a single package, so copy the whole directory as-is.
                 let dstDir = tmpDirPath.appending(component: copyName)
+#if os(Windows)
+                try localFileSystem.copy(from: fixtureDir, to: dstDir)
+#else
                 try systemQuietly("cp", "-R", "-H", fixtureDir.pathString, dstDir.pathString)
+#endif
 
                 // Invoke the block, passing it the path of the copied fixture.
                 try body(dstDir)
@@ -231,7 +235,11 @@ func fixture(
                     let srcDir = fixtureDir.appending(component: fileName)
                     guard localFileSystem.isDirectory(srcDir) else { continue }
                     let dstDir = tmpDirPath.appending(component: fileName)
+#if os(Windows)
+                    try localFileSystem.copy(from: srcDir, to: dstDir)
+#else
                     try systemQuietly("cp", "-R", "-H", srcDir.pathString, dstDir.pathString)
+#endif
                     initGitRepo(dstDir, tag: "1.2.3", addFile: false)
                 }
 

--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -69,7 +69,11 @@ public func fixture(
             if localFileSystem.isFile(fixtureDir.appending(component: "Package.swift")) {
                 // It's a single package, so copy the whole directory as-is.
                 let dstDir = tmpDirPath.appending(component: copyName)
+#if os(Windows)
+                try localFileSystem.copy(from: fixtureDir, to: dstDir)
+#else
                 try systemQuietly("cp", "-R", "-H", fixtureDir.pathString, dstDir.pathString)
+#endif
 
                 // Invoke the block, passing it the path of the copied fixture.
                 try body(dstDir)
@@ -79,7 +83,11 @@ public func fixture(
                     let srcDir = fixtureDir.appending(component: fileName)
                     guard localFileSystem.isDirectory(srcDir) else { continue }
                     let dstDir = tmpDirPath.appending(component: fileName)
+#if os(Windows)
+                    try localFileSystem.copy(from: srcDir, to: dstDir)
+#else
                     try systemQuietly("cp", "-R", "-H", srcDir.pathString, dstDir.pathString)
+#endif
                     if createGitRepo {
                         initGitRepo(dstDir, tag: "1.2.3", addFile: false)
                     }


### PR DESCRIPTION
Rather than relying on UNIX semantics of `cp` which is inherently
platform dependent.  This is required to start experimenting with
getting the SPM test suite running on Windows.