### PR TITLE
Tests: use `Thread.sleep(forTimeInterval:)` rather than `sleep`

### DIFF
--- a/Tests/BasicsTests/CancellatorTests.swift
+++ b/Tests/BasicsTests/CancellatorTests.swift
@@ -340,7 +340,7 @@ final class CancellatorTests: XCTestCase {
             func work()  {}
 
             func cancel() {
-                sleep(5)
+                Thread.sleep(forTimeInterval: 5)
             }
         }
 


### PR DESCRIPTION
`sleep` is non-portable; prefer `Thread.sleep(forTimeInterval:)`.