### PR TITLE
Convert to `AbsolutePath(_:relativeTo:)`

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -340,9 +340,9 @@ public final class ClangTargetBuildDescription {
 
         return sources.flatMap { (root, relativePaths) in
             relativePaths.map { source in
-                let path = root.appending(source)
-                let object = AbsolutePath("\(source.pathString).o", relativeTo: tempsPath)
-                let deps = AbsolutePath("\(source.pathString).d", relativeTo: tempsPath)
+                let path = AbsolutePath(source.pathString, relativeTo: root)
+                let object = AbsolutePath("\(source.pathString).o", relativeTo: self.tempsPath)
+                let deps = AbsolutePath("\(source.pathString).d", relativeTo: self.tempsPath)
                 return (source, path, object, deps)
             }
         }
@@ -498,7 +498,7 @@ public final class ClangTargetBuildDescription {
         // Write this file out.
         // FIXME: We should generate this file during the actual build.
         try fileSystem.writeIfChanged(
-            path: derivedSources.root.appending(implFileSubpath),
+            path: AbsolutePath(implFileSubpath.pathString, relativeTo: derivedSources.root),
             bytes: implFileStream.bytes
         )
 
@@ -772,7 +772,7 @@ public final class SwiftTargetBuildDescription {
 
         // Write this file out.
         // FIXME: We should generate this file during the actual build.
-        let path = derivedSources.root.appending(subpath)
+        let path = AbsolutePath(subpath.pathString, relativeTo: derivedSources.root)
         try self.fileSystem.writeIfChanged(path: path, bytes: stream.bytes)
     }
 

--- a/Sources/Build/LLBuildManifestBuilder.swift
+++ b/Sources/Build/LLBuildManifestBuilder.swift
@@ -172,14 +172,14 @@ extension LLBuildManifestBuilder {
 
         // Create a copy command for each resource file.
         for resource in target.resources {
-            let destination = bundlePath.appending(resource.destination)
+            let destination = AbsolutePath(resource.destination.pathString, relativeTo: bundlePath)
             let (_, output) = addCopyCommand(from: resource.path, to: destination)
             outputs.append(output)
         }
 
         // Create a copy command for the Info.plist if a resource with the same name doesn't exist yet.
         if let infoPlistPath = target.resourceBundleInfoPlistPath {
-            let destination = bundlePath.appending(infoPlistDestination)
+            let destination = AbsolutePath(infoPlistDestination.pathString, relativeTo: bundlePath)
             let (_, output) = addCopyCommand(from: infoPlistPath, to: destination)
             outputs.append(output)
         }
@@ -960,7 +960,7 @@ extension TypedVirtualPath {
             guard let workingDirectory = fileSystem.currentWorkingDirectory else {
                 throw InternalError("unknown working directory")
             }
-            return Node.file(workingDirectory.appending(relativePath))
+            return Node.file(AbsolutePath(relativePath.pathString, relativeTo: workingDirectory))
         } else if let temporaryFileName = file.temporaryFileName {
             return Node.virtual(temporaryFileName.pathString)
         } else {

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -485,7 +485,7 @@ public final class PackageBuilder {
                     throw ModuleError.unsupportedTargetPath(subpath)
                 }
 
-                let path = packagePath.appending(relativeSubPath)
+                let path = AbsolutePath(relativeSubPath.pathString, relativeTo: packagePath)
                 // Make sure the target is inside the package root.
                 guard path.isDescendantOfOrEqual(to: packagePath) else {
                     throw ModuleError.targetOutsidePackage(package: self.identity.description, target: target.name)
@@ -740,7 +740,7 @@ public final class PackageBuilder {
 
         // Compute the path to public headers directory.
         let publicHeaderComponent = manifestTarget.publicHeadersPath ?? ClangTarget.defaultPublicHeadersComponent
-        let publicHeadersPath = potentialModule.path.appending(try RelativePath(validating: publicHeaderComponent))
+        let publicHeadersPath = AbsolutePath(publicHeaderComponent, relativeTo: potentialModule.path)
         guard publicHeadersPath.isDescendantOfOrEqual(to: potentialModule.path) else {
             throw ModuleError.invalidPublicHeadersDirectory(potentialModule.name)
         }
@@ -878,7 +878,7 @@ public final class PackageBuilder {
 
                 // Ensure that the search path is contained within the package.
                 let subpath = try RelativePath(validating: value)
-                guard targetRoot.appending(subpath).isDescendantOfOrEqual(to: packagePath) else {
+                guard AbsolutePath(subpath.pathString, relativeTo: targetRoot).isDescendantOfOrEqual(to: packagePath) else {
                     throw ModuleError.invalidHeaderSearchPath(subpath.pathString)
                 }
 

--- a/Sources/PackageModel/Sources.swift
+++ b/Sources/PackageModel/Sources.swift
@@ -22,7 +22,7 @@ public struct Sources: Codable {
 
     /// The list of absolute paths of all files.
     public var paths: [AbsolutePath] {
-        return relativePaths.map({ root.appending($0) })
+        return relativePaths.map { AbsolutePath($0.pathString, relativeTo: root) }
     }
 
     public init(paths: [AbsolutePath], root: AbsolutePath) {

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -69,8 +69,7 @@ public final class UserToolchain: Toolchain {
         // bootstrap script.
         let swiftCompiler = resolveSymlinks(self.swiftCompilerPath)
 
-        let runtime = swiftCompiler.appending(
-            RelativePath("../../lib/swift/clang/lib/darwin/libclang_rt.\(sanitizer.shortName)_osx_dynamic.dylib"))
+        let runtime = AbsolutePath("../../lib/swift/clang/lib/darwin/libclang_rt.\(sanitizer.shortName)_osx_dynamic.dylib", relativeTo: swiftCompiler)
 
         // Ensure that the runtime is present.
         guard localFileSystem.exists(runtime) else {

--- a/Sources/PackageRegistry/RegistryDownloadsManager.swift
+++ b/Sources/PackageRegistry/RegistryDownloadsManager.swift
@@ -62,7 +62,7 @@ public class RegistryDownloadsManager: Cancellable {
 
         do {
             packageRelativePath = try package.downloadPath(version: version)
-            packagePath = self.path.appending(packageRelativePath)
+            packagePath = AbsolutePath(packageRelativePath.pathString, relativeTo: self.path)
 
             // TODO: we can do some finger-print checking to improve the validation
             // already exists and valid, we can exit early
@@ -99,7 +99,9 @@ public class RegistryDownloadsManager: Cancellable {
 
             // inform delegate that we are starting to fetch
             // calculate if cached (for delegate call) outside queue as it may change while queue is processing
-            let isCached = self.cachePath.map{ self.fileSystem.exists($0.appending(packageRelativePath)) } ?? false
+            let isCached = self.cachePath.map {
+                self.fileSystem.exists(AbsolutePath(packageRelativePath.pathString, relativeTo: $0))
+            } ?? false
             delegateQueue.async {
                 let details = FetchDetails(fromCache: isCached, updatedCache: false)
                 self.delegate?.willFetch(package: package, version: version, fetchDetails: details)
@@ -150,7 +152,7 @@ public class RegistryDownloadsManager: Cancellable {
         if let cachePath = self.cachePath {
             do {
                 let relativePath = try package.downloadPath(version: version)
-                let cachedPackagePath = cachePath.appending(relativePath)
+                let cachedPackagePath = AbsolutePath(relativePath.pathString, relativeTo: cachePath)
 
                 try self.initializeCacheIfNeeded(cachePath: cachePath)
                 try self.fileSystem.withLock(on: cachedPackagePath, type: .exclusive) {
@@ -243,7 +245,7 @@ public class RegistryDownloadsManager: Cancellable {
 
     public func remove(package: PackageIdentity) throws {
         let relativePath = try package.downloadPath()
-        let packagesPath = self.path.appending(relativePath)
+        let packagesPath = AbsolutePath(relativePath.pathString, relativeTo: self.path)
         try self.fileSystem.removeFileTree(packagesPath)
     }
 

--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -297,7 +297,7 @@ public struct BuildParameters: Encodable {
 
     /// Returns the path to the binary of a product for the current build parameters.
     public func binaryPath(for product: ResolvedProduct) -> AbsolutePath {
-        return buildPath.appending(binaryRelativePath(for: product))
+        return AbsolutePath(binaryRelativePath(for: product).pathString, relativeTo: buildPath)
     }
 
     /// Returns the path to the binary of a product for the current build parameters, relative to the build directory.

--- a/Sources/SPMBuildCore/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/PluginInvocation.swift
@@ -348,7 +348,7 @@ extension PackageGraph {
                 let toolNamesToPaths = accessibleTools.reduce(into: [String: AbsolutePath](), { dict, tool in
                     switch tool {
                     case .builtTool(let name, let path):
-                        dict[name] = builtToolsDir.appending(path)
+                        dict[name] = AbsolutePath(path.pathString, relativeTo: builtToolsDir)
                     case .vendedTool(let name, let path):
                         dict[name] = path
                     }

--- a/Sources/SPMTestSupport/MockDependency.swift
+++ b/Sources/SPMTestSupport/MockDependency.swift
@@ -33,7 +33,7 @@ public struct MockDependency {
     public func convert(baseURL: AbsolutePath, identityResolver: IdentityResolver) throws -> PackageDependency {
         switch self.location {
         case .fileSystem(let path):
-            let path = baseURL.appending(path)
+            let path = AbsolutePath(path.pathString, relativeTo: baseURL)
             let remappedPath = try AbsolutePath(validating: identityResolver.mappedLocation(for: path.pathString))
             let identity = try identityResolver.resolveIdentity(for: remappedPath)
             return .fileSystem(
@@ -43,7 +43,7 @@ public struct MockDependency {
                 productFilter: self.products
             )
         case .localSourceControl(let path, let requirement):
-            let absolutePath = baseURL.appending(path)
+            let absolutePath = AbsolutePath(path.pathString, relativeTo: baseURL)
             let remappedPath = try AbsolutePath(validating: identityResolver.mappedLocation(for: absolutePath.pathString))
             let identity = try identityResolver.resolveIdentity(for: remappedPath)
             return .localSourceControl(

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -120,7 +120,7 @@ public final class MockWorkspace {
             let packagePath: AbsolutePath
             switch package.location {
             case .fileSystem(let path):
-                packagePath = basePath.appending(path)
+                packagePath = AbsolutePath(path.pathString, relativeTo: basePath)
             case .sourceControl(let url):
                 if let containerProvider = customPackageContainerProvider {
                     let observability = ObservabilitySystem.makeForTesting()
@@ -151,9 +151,9 @@ public final class MockWorkspace {
                 packageKind = .root(packagePath)
                 sourceControlSpecifier = RepositorySpecifier(path: packagePath)
             case (_, .fileSystem(let path)):
-                packageLocation = self.packagesDir.appending(path).pathString
+                packageLocation = AbsolutePath(path.pathString, relativeTo: self.packagesDir).pathString
                 packageKind = .fileSystem(packagePath)
-                sourceControlSpecifier = RepositorySpecifier(path: self.packagesDir.appending(path))
+                sourceControlSpecifier = RepositorySpecifier(path: AbsolutePath(path.pathString, relativeTo: self.packagesDir))
             case (_, .sourceControl(let url)):
                 packageLocation = url.absoluteString
                 packageKind = .remoteSourceControl(url)

--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -57,7 +57,7 @@ public func fixture(
 
             // Construct the expected path of the fixture.
             // FIXME: This seems quite hacky; we should provide some control over where fixtures are found.
-            let fixtureDir = AbsolutePath("../../../Fixtures", relativeTo: AbsolutePath(#file)).appending(fixtureSubpath)
+            let fixtureDir = AbsolutePath(fixtureSubpath.pathString, relativeTo: AbsolutePath("../../../Fixtures", relativeTo: AbsolutePath(#file)))
 
             // Check that the fixture is really there.
             guard localFileSystem.isDirectory(fixtureDir) else {

--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -191,7 +191,7 @@ public class RepositoryManager: Cancellable {
         delegateQueue: DispatchQueue
     ) throws -> RepositoryHandle {
         let relativePath = repository.storagePath()
-        let repositoryPath = self.path.appending(relativePath)
+        let repositoryPath = AbsolutePath(relativePath.pathString, relativeTo: self.path)
         let handle = RepositoryHandle(manager: self, repository: repository, subpath: relativePath)
 
         // check if a repository already exists
@@ -219,7 +219,9 @@ public class RepositoryManager: Cancellable {
 
         // inform delegate that we are starting to fetch
         // calculate if cached (for delegate call) outside queue as it may change while queue is processing
-        let isCached = self.cachePath.map{ self.fileSystem.exists($0.appending(handle.subpath)) } ?? false
+        let isCached = self.cachePath.map {
+            self.fileSystem.exists(AbsolutePath(handle.subpath.pathString, relativeTo: $0))
+        } ?? false
         delegateQueue.async {
             let details = FetchDetails(fromCache: isCached, updatedCache: false)
             self.delegate?.willFetch(package: package, repository: handle.repository, details: details)
@@ -301,7 +303,7 @@ public class RepositoryManager: Cancellable {
         let shouldCacheLocalPackages = ProcessEnv.vars["SWIFTPM_TESTS_PACKAGECACHE"] == "1" || cacheLocalPackages
 
         if let cachePath = self.cachePath, !(handle.repository.isLocal && !shouldCacheLocalPackages) {
-            let cachedRepositoryPath = cachePath.appending(handle.repository.storagePath())
+            let cachedRepositoryPath = AbsolutePath(handle.repository.storagePath().pathString, relativeTo: cachePath)
             do {
                 try self.initializeCacheIfNeeded(cachePath: cachePath)
                 try self.fileSystem.withLock(on: cachePath, type: .shared) {
@@ -349,7 +351,7 @@ public class RepositoryManager: Cancellable {
     private func open(_ handle: RepositoryHandle) throws -> Repository {
         try self.provider.open(
             repository: handle.repository,
-            at: self.path.appending(handle.subpath)
+            at: AbsolutePath(handle.subpath.pathString, relativeTo: self.path)
         )
     }
 
@@ -361,7 +363,7 @@ public class RepositoryManager: Cancellable {
     ) throws -> WorkingCheckout {
         try self.provider.createWorkingCopy(
             repository: handle.repository,
-            sourcePath: self.path.appending(handle.subpath),
+            sourcePath: AbsolutePath(handle.subpath.pathString, relativeTo: self.path),
             at: destinationPath,
             editable: editable)
     }
@@ -369,7 +371,7 @@ public class RepositoryManager: Cancellable {
     /// Removes the repository.
     public func remove(repository: RepositorySpecifier) throws {
         let relativePath = repository.storagePath()
-        let repositoryPath = self.path.appending(relativePath)
+        let repositoryPath = AbsolutePath(relativePath.pathString, relativeTo: self.path)
         try self.fileSystem.removeFileTree(repositoryPath)
     }
 

--- a/Sources/Workspace/Workspace+BinaryArtifacts.swift
+++ b/Sources/Workspace/Workspace+BinaryArtifacts.swift
@@ -73,7 +73,7 @@ extension Workspace {
                 for target in manifest.targets where target.type == .binary {
                     if let path = target.path {
                         // TODO: find a better way to get the base path (not via the manifest)
-                        let absolutePath = try manifest.path.parentDirectory.appending(RelativePath(validating: path))
+                        let absolutePath = AbsolutePath(path, relativeTo: manifest.path.parentDirectory)
                         localArtifacts.append(
                             .local(
                                 packageRef: packageReference,

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1281,10 +1281,10 @@ extension Workspace {
                 // note this does not actually download remote artifacts and as such does not have the artifact's type or path
                 let binaryArtifacts = try manifest.targets.filter{ $0.type == .binary }.reduce(into: [String: BinaryArtifact]()) { partial, target in
                     if let path = target.path {
-                        let absolutePath = try manifest.path.parentDirectory.appending(RelativePath(validating: path))
+                        let absolutePath = AbsolutePath(path, relativeTo: manifest.path.parentDirectory)
                         partial[target.name] = try BinaryArtifact(kind: .forFileExtension(absolutePath.extension ?? "unknown") , originURL: .none, path: absolutePath)
                     } else if let url = target.url.flatMap(URL.init(string:)) {
-                        let fakePath = try manifest.path.parentDirectory.appending(components: "remote", "archive").appending(RelativePath(validating: url.lastPathComponent))
+                        let fakePath = AbsolutePath(url.lastPathComponent, relativeTo: manifest.path.parentDirectory.appending(components: "remote", "archive"))
                         partial[target.name] = BinaryArtifact(kind: .unknown, originURL: url.absoluteString, path: fakePath)
                     } else {
                         throw InternalError("a binary target should have either a path or a URL and a checksum")
@@ -3650,17 +3650,17 @@ extension Workspace {
 extension Workspace.Location {
     /// Returns the path to the dependency's repository checkout directory.
     fileprivate func repositoriesCheckoutSubdirectory(for dependency: Workspace.ManagedDependency) -> AbsolutePath {
-        self.repositoriesCheckoutsDirectory.appending(dependency.subpath)
+        AbsolutePath(dependency.subpath.pathString, relativeTo: self.repositoriesCheckoutsDirectory)
     }
 
     /// Returns the path to the  dependency's download directory.
     fileprivate func registryDownloadSubdirectory(for dependency: Workspace.ManagedDependency) -> AbsolutePath {
-        self.registryDownloadDirectory.appending(dependency.subpath)
+        AbsolutePath(dependency.subpath.pathString, relativeTo: self.registryDownloadDirectory)
     }
 
     /// Returns the path to the dependency's edit directory.
     fileprivate func editSubdirectory(for dependency: Workspace.ManagedDependency) -> AbsolutePath {
-        self.editsDirectory.appending(dependency.subpath)
+        AbsolutePath(dependency.subpath.pathString, relativeTo: self.editsDirectory)
     }
 }
 

--- a/Tests/PackageRegistryTests/RegistryDownloadsManagerTests.swift
+++ b/Tests/PackageRegistryTests/RegistryDownloadsManagerTests.swift
@@ -59,7 +59,7 @@ class RegistryDownloadsManagerTests: XCTestCase {
             delegate.prepare(fetchExpected: true)
             let path = try manager.lookup(package: package, version: packageVersion, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
-            XCTAssertEqual(path, try downloadsPath.appending(package.downloadPath(version: packageVersion)))
+            XCTAssertEqual(path, try AbsolutePath(package.downloadPath(version: packageVersion).pathString, relativeTo: downloadsPath))
             XCTAssertTrue(fs.isDirectory(path))
 
             try delegate.wait(timeout: .now() + 2)
@@ -104,7 +104,7 @@ class RegistryDownloadsManagerTests: XCTestCase {
             delegate.prepare(fetchExpected: false)
             let path = try manager.lookup(package: package, version: packageVersion, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
-            XCTAssertEqual(path, try downloadsPath.appending(package.downloadPath(version: packageVersion)))
+            XCTAssertEqual(path, try AbsolutePath(package.downloadPath(version: packageVersion).pathString, relativeTo: downloadsPath))
             XCTAssertTrue(fs.isDirectory(path))
 
             try delegate.wait(timeout: .now() + 2)
@@ -130,7 +130,7 @@ class RegistryDownloadsManagerTests: XCTestCase {
             delegate.prepare(fetchExpected: true)
             let path = try manager.lookup(package: package, version: packageVersion, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
-            XCTAssertEqual(path, try downloadsPath.appending(package.downloadPath(version: packageVersion)))
+            XCTAssertEqual(path, try AbsolutePath(package.downloadPath(version: packageVersion).pathString, relativeTo: downloadsPath))
             XCTAssertTrue(fs.isDirectory(path))
 
             try delegate.wait(timeout: .now() + 2)
@@ -191,7 +191,7 @@ class RegistryDownloadsManagerTests: XCTestCase {
             delegate.prepare(fetchExpected: true)
             let path = try manager.lookup(package: package, version: packageVersion, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
-            XCTAssertEqual(path, try downloadsPath.appending(package.downloadPath(version: packageVersion)))
+            XCTAssertEqual(path, try AbsolutePath(package.downloadPath(version: packageVersion).pathString, relativeTo: downloadsPath))
             XCTAssertTrue(fs.isDirectory(path))
             XCTAssertTrue(fs.isDirectory(cachePath.appending(components: package.scopeAndName!.scope.description, package.scopeAndName!.name.description, packageVersion.description)))
 
@@ -214,7 +214,7 @@ class RegistryDownloadsManagerTests: XCTestCase {
             delegate.prepare(fetchExpected: true)
             let path = try manager.lookup(package: package, version: packageVersion, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
-            XCTAssertEqual(path, try downloadsPath.appending(package.downloadPath(version: packageVersion)))
+            XCTAssertEqual(path, try AbsolutePath(package.downloadPath(version: packageVersion).pathString, relativeTo: downloadsPath))
             XCTAssertTrue(fs.isDirectory(path))
 
             try delegate.wait(timeout: .now() + 2)
@@ -237,7 +237,7 @@ class RegistryDownloadsManagerTests: XCTestCase {
             delegate.prepare(fetchExpected: true)
             let path = try manager.lookup(package: package, version: packageVersion, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
-            XCTAssertEqual(path, try downloadsPath.appending(package.downloadPath(version: packageVersion)))
+            XCTAssertEqual(path, try AbsolutePath(package.downloadPath(version: packageVersion).pathString, relativeTo: downloadsPath))
             XCTAssertTrue(fs.isDirectory(path))
 
             try delegate.wait(timeout: .now() + 2)
@@ -310,7 +310,7 @@ class RegistryDownloadsManagerTests: XCTestCase {
 
             XCTAssertEqual(results.count, concurrency)
             for packageVersion in packageVersions {
-                let expectedPath = try downloadsPath.appending(package.downloadPath(version: packageVersion))
+                let expectedPath = try AbsolutePath(package.downloadPath(version: packageVersion).pathString, relativeTo: downloadsPath)
                 XCTAssertEqual(try results[packageVersion]?.get(), expectedPath)
             }
         }
@@ -354,7 +354,7 @@ class RegistryDownloadsManagerTests: XCTestCase {
 
             XCTAssertEqual(results.count, concurrency / repeatRatio)
             for packageVersion in packageVersions {
-                let expectedPath = try downloadsPath.appending(package.downloadPath(version: packageVersion))
+                let expectedPath = try AbsolutePath(package.downloadPath(version: packageVersion).pathString, relativeTo: downloadsPath)
                 XCTAssertEqual(try results[packageVersion]?.get(), expectedPath)
             }
         }

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -156,8 +156,8 @@ class RepositoryManagerTests: XCTestCase {
             delegate.prepare(fetchExpected: true, updateExpected: false)
             _ = try manager.lookup(repository: repo, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
-            XCTAssertDirectoryExists(cachePath.appending(repo.storagePath()))
-            XCTAssertDirectoryExists(repositoriesPath.appending(repo.storagePath()))
+            XCTAssertDirectoryExists(AbsolutePath(repo.storagePath().pathString, relativeTo: cachePath))
+            XCTAssertDirectoryExists(AbsolutePath(repo.storagePath().pathString, relativeTo: repositoriesPath))
             try delegate.wait(timeout: .now() + 2)
             XCTAssertEqual(delegate.willFetch[0].details,
                            RepositoryManager.FetchDetails(fromCache: false, updatedCache: false))
@@ -171,7 +171,7 @@ class RepositoryManagerTests: XCTestCase {
             delegate.prepare(fetchExpected: true, updateExpected: false)
             _ = try manager.lookup(repository: repo, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
-            XCTAssertDirectoryExists(repositoriesPath.appending(repo.storagePath()))
+            XCTAssertDirectoryExists(AbsolutePath(repo.storagePath().pathString, relativeTo: repositoriesPath))
             try delegate.wait(timeout: .now() + 2)
             XCTAssertEqual(delegate.willFetch[1].details,
                            RepositoryManager.FetchDetails(fromCache: true, updatedCache: false))
@@ -186,8 +186,8 @@ class RepositoryManagerTests: XCTestCase {
             delegate.prepare(fetchExpected: true, updateExpected: false)
             _ = try manager.lookup(repository: repo, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
-            XCTAssertDirectoryExists(cachePath.appending(repo.storagePath()))
-            XCTAssertDirectoryExists(repositoriesPath.appending(repo.storagePath()))
+            XCTAssertDirectoryExists(AbsolutePath(repo.storagePath().pathString, relativeTo: cachePath))
+            XCTAssertDirectoryExists(AbsolutePath(repo.storagePath().pathString, relativeTo: repositoriesPath))
             try delegate.wait(timeout: .now() + 2)
             XCTAssertEqual(delegate.willFetch[2].details,
                            RepositoryManager.FetchDetails(fromCache: false, updatedCache: false))
@@ -305,7 +305,7 @@ class RepositoryManagerTests: XCTestCase {
                     provider: provider,
                     delegate: delegate
                 )
-                try! fs.removeFileTree(path.appending(dummyRepo.storagePath()))
+                try! fs.removeFileTree(AbsolutePath(dummyRepo.storagePath().pathString, relativeTo: path))
                 manager = RepositoryManager(
                     fileSystem: fs,
                     path: path,


### PR DESCRIPTION
This silences the warnings from the deprecation of the relative path
concatenation to a form which provides an anchor for the concatenation.
This is purely a mechanical change, replacing all the instances
identified by a build of swift-package-manager.