### PR TITLE
Basics: alter the definition of root for Windows

### DIFF
--- a/Sources/Basics/VirtualFileSystem.swift
+++ b/Sources/Basics/VirtualFileSystem.swift
@@ -30,7 +30,11 @@ fileprivate enum DirectoryNode: Codable {
         switch self {
         case .directory(let name, _, _): return name
         case .file(let name, _, _, _): return name
+#if os(Windows)
+        case .root(_): return "\\"
+#else
         case .root(_): return "/"
+#endif
         }
     }
 


### PR DESCRIPTION
Rather than use a "root" for Windows, use the drive-relative path as a
"root" to terminate iteration/recursion.  Windows does not present the
file system as a unified singular rooted tree and instead has a forest
and thus the level-1 path is conceptually close to the root desired.