### PR TITLE
Tests: correct some test cases for path separator

### DIFF
--- a/Tests/BasicsTests/EnvironmentVariablesTests.swift
+++ b/Tests/BasicsTests/EnvironmentVariablesTests.swift
@@ -53,10 +53,10 @@ final class EnvironmentVariablesTests: XCTestCase {
         XCTAssertEqual(env[key], ["a", "b"].joined(separator: pathDelimiter))
         
         env.appendPath(key, value: "c")
-        XCTAssertEqual(env[key], ["a:b:c"].joined(separator: pathDelimiter))
+        XCTAssertEqual(env[key], ["a", "b", "c"].joined(separator: pathDelimiter))
         
         env.appendPath(key, value: "")
-        XCTAssertEqual(env[key], ["a:b:c"].joined(separator: pathDelimiter))
+        XCTAssertEqual(env[key], ["a", "b", "c"].joined(separator: pathDelimiter))
     }
     
     func testProcess() throws {


### PR DESCRIPTION
The test expectations were pre-constructed with `:` ignoring the path
separator.  Alter the expectation to construct the value at run time to
match the actual results.