### PR TITLE
`swift package` should ask for plugin permissions interactively when on a TTY

### DIFF
--- a/Sources/Basics/CMakeLists.txt
+++ b/Sources/Basics/CMakeLists.txt
@@ -29,7 +29,8 @@ add_library(Basics
   Triple+Extensions.swift
   SwiftVersion.swift
   SQLiteBackedCache.swift
-  Version+Extensions.swift)
+  Version+Extensions.swift
+  WritableByteStream+Extensions.swift)
 target_link_libraries(Basics PUBLIC
   SwiftCollections::OrderedCollections
   SwiftSystem::SystemPackage

--- a/Sources/Basics/WritableByteStream+Extensions.swift
+++ b/Sources/Basics/WritableByteStream+Extensions.swift
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import TSCBasic
+
+extension WritableByteStream {
+    /// Returns true if an only if the output byte stream is attached to a TTY.
+    public var isTTY: Bool {
+        let stream: WritableByteStream
+        if let threadSafeStream = self as? ThreadSafeOutputByteStream {
+            stream = threadSafeStream.stream
+        } else {
+            stream = self
+        }
+        guard let fileStream = stream as? LocalFileOutputByteStream else {
+            return false
+        }
+        return TerminalController.isTTY(fileStream)
+    }
+}

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -584,21 +584,6 @@ extension BuildSubset {
     }
 }
 
-extension OutputByteStream {
-    fileprivate var isTTY: Bool {
-        let stream: OutputByteStream
-        if let threadSafeStream = self as? ThreadSafeOutputByteStream {
-            stream = threadSafeStream.stream
-        } else {
-            stream = self
-        }
-        guard let fileStream = stream as? LocalFileOutputByteStream else {
-            return false
-        }
-        return TerminalController.isTTY(fileStream)
-    }
-}
-
 extension Basics.Diagnostic.Severity {
     var isVerbose: Bool {
         return self <= .info

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -1762,7 +1762,9 @@ final class PackageToolTests: CommandsTestCase {
                 let result = try SwiftPMProduct.SwiftPackage.executeProcess(["plugin", "PackageScribbler"], packagePath: packageDir, env: ["DECLARE_PACKAGE_WRITING_PERMISSION": "1"])
                 XCTAssertNotEqual(result.exitStatus, .terminated(code: 0))
                 XCTAssertNoMatch(try result.utf8Output(), .contains("successfully created it"))
-                XCTAssertMatch(try result.utf8stderrOutput(), .contains("error: Plugin ‘MyPlugin’ needs permission to write to the package directory (stated reason: “For testing purposes”)"))
+                XCTAssertMatch(try result.utf8stderrOutput(), .contains("error: Plugin ‘MyPlugin’ needs permission to write to the package directory."))
+                XCTAssertMatch(try result.utf8stderrOutput(), .contains("Stated reason: “For testing purposes”."))
+                XCTAssertMatch(try result.utf8stderrOutput(), .contains("Use `--allow-writing-to-package-directory` to allow this."))
             }
           #endif
 


### PR DESCRIPTION
Command plugins can include a request for permission to modify the package directory.  In this case, `swift package` should:
a) if connected to a TTY, ask a "do you want to do this" question and wait for input
b) if not connected to a TTY, emit a message that you need to pass `--allow-writing-to-package-directory`

### Motivation:

The current message doesn't provide information about how to grant the permission the plugin wants.  Also, if the user is invoking it interactively, it makes more sense to ask permission than have them invoke it again.

### Modifications:

- if connected to a tty, ask the user
- if not, include the flag name in the error
- move down a extension to WritableOutputStream to detect whether it's connected to a TTY; this is now in Basics
- adjust unit test

### Results:

When on a TTY this now looks like:
```
Plugin ‘Reformat Code Using SwiftFormat’ wants permission to write to the package directory.
Stated reason: “This command modifies source files to apply formatting rules”.
Allow this plugin to write to the package directory? (yes/no) 
```
and then if you don't answer "yes":
```
error: Plugin was denied permission to write to the package directory.
```
When not on a TTY this now looks like:
```
error: Plugin ‘Reformat Code Using SwiftFormat’ wants permission to write to the package directory.
Stated reason: “This command modifies source files to apply formatting rules.”.
Use `--allow-writing-to-package-directory` to allow this.
```

rdar://89442616
