### PR TITLE
Tests: use `FileManager.default.createFile(atPath:contents:)`

### DIFF
--- a/IntegrationTests/Tests/IntegrationTests/Helpers.swift
+++ b/IntegrationTests/Tests/IntegrationTests/Helpers.swift
@@ -267,7 +267,7 @@ func initGitRepo(
     do {
         if addFile {
             let file = dir.appending(component: "file.swift")
-            try systemQuietly(["touch", file.pathString])
+            try localFileSystem.writeFileContents(file, bytes: "")
         }
 
         try systemQuietly([Git.tool, "-C", dir.pathString, "init"])

--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -120,7 +120,7 @@ public func initGitRepo(
     do {
         if addFile {
             let file = dir.appending(component: "file.swift")
-            try systemQuietly(["touch", file.pathString])
+            try localFileSystem.writeFileContents(file, bytes: "")
         }
 
         try systemQuietly([Git.tool, "-C", dir.pathString, "init"])


### PR DESCRIPTION
Rather than using `touch` which is not a universal command, use the
FileManager APIs to create the file.