### PR TITLE
Tests: adjust test for real file systems

### DIFF
--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -421,7 +421,11 @@ class MiscellaneousTestCase: XCTestCase {
 
             // check for interrupt result
             let result = try process.waitUntilExit()
+#if os(Windows)
+            XCTAssertEqual(result.exitStatus, .abnormal(exception: 2))
+#else
             XCTAssertEqual(result.exitStatus, .signalled(signal: 2))
+#endif
         }
 
         class OutputHandler {

--- a/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
+++ b/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
@@ -154,7 +154,7 @@ class GenerateXcodeprojTests: XCTestCase {
             XCTAssertNoDiagnostics(observability.diagnostics)
 
             _ = try xcodeProject(
-                xcodeprojPath: AbsolutePath.root.appending(component: "xcodeproj"),
+                xcodeprojPath: dstdir.appending(component: "xcodeproj"),
                 graph: graph, extraDirs: [], extraFiles: [],
                 options: XcodeprojOptions(), fileSystem: localFileSystem,
                 observabilityScope: observability.topScope


### PR DESCRIPTION
There is no guarantee that there is a singular unified file system view.
Use the current directory for the root of the filesystem.  This is
required for platforms like macOS (classic) and Windows where a forest
of roots exist.