### PR TITLE
SourceControl: normalise repository basename computation

### DIFF
--- a/Sources/SourceControl/Repository.swift
+++ b/Sources/SourceControl/Repository.swift
@@ -42,7 +42,7 @@ public struct RepositorySpecifier: Hashable {
 
     /// Returns the cleaned basename for the specifier.
     public var basename: String {
-        var basename = self.url.pathComponents.dropFirst(1).last(where: { !$0.isEmpty }) ??  ""
+        var basename = self.url.pathComponents.dropFirst(1).last(where: { !$0.isEmpty }) ?? ""
         if basename.hasSuffix(".git") {
             basename = String(basename.dropLast(4))
         }

--- a/Sources/SourceControl/Repository.swift
+++ b/Sources/SourceControl/Repository.swift
@@ -42,7 +42,7 @@ public struct RepositorySpecifier: Hashable {
 
     /// Returns the cleaned basename for the specifier.
     public var basename: String {
-        var basename = self.location.description.components(separatedBy: "/").last(where: { !$0.isEmpty }) ?? ""
+        var basename = self.url.pathComponents.dropFirst(1).last(where: { !$0.isEmpty }) ??  ""
         if basename.hasSuffix(".git") {
             basename = String(basename.dropLast(4))
         }


### PR DESCRIPTION
Prefer using the `url` member to get a URL representation of the
location, and then use the `pathComponents` property rather than
splitting on `/` which may be an invalid path separator.