### PR TITLE
Add `nuget` package provider

### DIFF
--- a/Sources/PackageDescription/PackageDescription.swift
+++ b/Sources/PackageDescription/PackageDescription.swift
@@ -388,7 +388,7 @@ public enum SystemPackageProvider {
     /// Packages installable by the yum package manager.
     @available(_PackageDescription, introduced: 5.3)
     case yumItem([String])
-    @available(_PackageDescription, introduced: 9999)
+    @available(_PackageDescription, introduced: 999.0)
     case nugetItem([String])
 
     /// Creates a system package provider with a list of installable packages
@@ -429,7 +429,7 @@ public enum SystemPackageProvider {
     /// - Parameter packages: The list of package names.
     ///
     /// - Returns: A package provider.
-    @available(_PackageDescription, introduced: 9999)
+    @available(_PackageDescription, introduced: 999.0)
     public static func nuget(_ packages: [String]) -> SystemPackageProvider {
         return .nugetItem(packages)
     }

--- a/Sources/PackageDescription/PackageDescription.swift
+++ b/Sources/PackageDescription/PackageDescription.swift
@@ -388,6 +388,8 @@ public enum SystemPackageProvider {
     /// Packages installable by the yum package manager.
     @available(_PackageDescription, introduced: 5.3)
     case yumItem([String])
+    @available(_PackageDescription, introduced: 9999)
+    case nugetItem([String])
 
     /// Creates a system package provider with a list of installable packages
     /// for users of the HomeBrew package manager on macOS.
@@ -419,6 +421,17 @@ public enum SystemPackageProvider {
     @available(_PackageDescription, introduced: 5.3)
     public static func yum(_ packages: [String]) -> SystemPackageProvider {
         return .yumItem(packages)
+    }
+
+    /// Creates a system package provider with a list of installable packages
+    /// for users of the nuget package manager on Linux or Windows.
+    ///
+    /// - Parameter packages: The list of package names.
+    ///
+    /// - Returns: A package provider.
+    @available(_PackageDescription, introduced: 9999)
+    public static func nuget(_ packages: [String]) -> SystemPackageProvider {
+        return .nugetItem(packages)
     }
 }
 

--- a/Sources/PackageDescription/PackageDescriptionSerialization.swift
+++ b/Sources/PackageDescription/PackageDescriptionSerialization.swift
@@ -221,6 +221,7 @@ extension SystemPackageProvider: Encodable {
         case brew
         case apt
         case yum
+        case nuget
     }
 
     /// Encodes this value into the given encoder.
@@ -243,6 +244,9 @@ extension SystemPackageProvider: Encodable {
             try container.encode(packages, forKey: .values)
         case .yumItem(let packages):
             try container.encode(Name.yum, forKey: .name)
+            try container.encode(packages, forKey: .values)
+        case .nugetItem(let packages):
+            try container.encode(Name.nuget, forKey: .name)
             try container.encode(packages, forKey: .values)
         }
     }

--- a/Sources/PackageLoading/Target+PkgConfig.swift
+++ b/Sources/PackageLoading/Target+PkgConfig.swift
@@ -126,6 +126,8 @@ extension SystemPackageProviderDescription {
             return "    apt-get install \(packages.joined(separator: " "))\n"
         case .yum(let packages):
             return "    yum install \(packages.joined(separator: " "))\n"
+        case .nuget(let packages):
+            return "    nuget install \(packages.joined(separator: " "))\n"
         }
     }
 
@@ -147,6 +149,13 @@ extension SystemPackageProviderDescription {
         case .yum:
             if case .linux(.fedora) = platform {
                 return true
+            }
+        case .nuget:
+            switch platform {
+            case .darwin, .windows, .linux:
+                return true
+            case .android:
+                return false
             }
         }
         return false
@@ -177,6 +186,8 @@ extension SystemPackageProviderDescription {
         case .apt:
             return []
         case .yum:
+            return []
+        case .nuget:
             return []
         }
     }

--- a/Sources/PackageModel/Manifest/SystemPackageProviderDescription.swift
+++ b/Sources/PackageModel/Manifest/SystemPackageProviderDescription.swift
@@ -15,11 +15,12 @@ public enum SystemPackageProviderDescription: Equatable, Codable {
     case brew([String])
     case apt([String])
     case yum([String])
+    case nuget([String])
 }
 
 extension SystemPackageProviderDescription {
     private enum CodingKeys: String, CodingKey {
-        case brew, apt, yum
+        case brew, apt, yum, nuget
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -33,6 +34,9 @@ extension SystemPackageProviderDescription {
             try unkeyedContainer.encode(a1)
         case let .yum(a1):
             var unkeyedContainer = container.nestedUnkeyedContainer(forKey: .yum)
+            try unkeyedContainer.encode(a1)
+        case let .nuget(a1):
+            var unkeyedContainer = container.nestedUnkeyedContainer(forKey: .nuget)
             try unkeyedContainer.encode(a1)
         }
     }
@@ -55,6 +59,10 @@ extension SystemPackageProviderDescription {
             var unkeyedValues = try values.nestedUnkeyedContainer(forKey: key)
             let a1 = try unkeyedValues.decode([String].self)
             self = .yum(a1)
+        case .nuget:
+            var unkeyedValues = try values.nestedUnkeyedContainer(forKey: key)
+            let a1 = try unkeyedValues.decode([String].self)
+            self = .nuget(a1)
         }
     }
 }

--- a/Sources/PackageModel/ManifestSourceGeneration.swift
+++ b/Sources/PackageModel/ManifestSourceGeneration.swift
@@ -398,6 +398,9 @@ fileprivate extension SourceCodeFragment {
         case .yum(let names):
             let params = [SourceCodeFragment(strings: names)]
             self.init(enum: "yum", subnodes: params)
+        case .nuget(let names):
+            let params = [SourceCodeFragment(strings: names)]
+            self.init(enum: "nuget", subnodes: params)
         }
     }
 

--- a/Tests/PackageLoadingTests/PkgConfigTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigTests.swift
@@ -49,7 +49,8 @@ class PkgConfigTests: XCTestCase {
                 providers: [
                     .brew(["libFoo"]),
                     .apt(["libFoo-dev"]),
-                    .yum(["libFoo-devel"])
+                    .yum(["libFoo-devel"]),
+                    .nuget(["Foo"]),
                 ]
             )
             for result in pkgConfigArgs(for: target, fileSystem: fs, observabilityScope: observability.topScope) {
@@ -63,6 +64,8 @@ class PkgConfigTests: XCTestCase {
                     XCTAssertEqual(names, ["libFoo-dev"])
                 case .yum(let names)?:
                     XCTAssertEqual(names, ["libFoo-devel"])
+                case .nuget(let names)?:
+                    XCTAssertEqual(names, ["Foo"])
                 case nil:
                     XCTFail("Expected a provider here")
                 }


### PR DESCRIPTION
Introduce the `nuget` package provider, which is the only option on
Windows, but is portable to other systems as well. This is required
for enabling the test suite on Windows.

Refs: #4369
