### PR TITLE
Pass `-Xfrontend -disable-implicit-string-processing-module-imports` to manifest and plugin compilation

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -918,6 +918,10 @@ public class SwiftTool {
             if SwiftTargetBuildDescription.checkSupportedFrontendFlags(flags: ["disable-implicit-concurrency-module-import"], fileSystem: self.fileSystem) {
                 extraManifestFlags += ["-Xfrontend", "-disable-implicit-concurrency-module-import"]
             }
+            // Disable the implicit string processing import if the compiler in use supports it to avoid warnings if we are building against an older SDK that does not contain a StringProcessing module.
+            if SwiftTargetBuildDescription.checkSupportedFrontendFlags(flags: ["disable-implicit-string-processing-module-import"], fileSystem: self.fileSystem) {
+                extraManifestFlags += ["-Xfrontend", "-disable-implicit-string-processing-module-import"]
+            }
 
             if self.logLevel <= .info {
                 extraManifestFlags.append("-v")


### PR DESCRIPTION
### Motivation:

This is to avoid warnings of the form `warning build: unable to perform implicit import of "_StringProcessing" module: no such module found`.

### Modifications:

- pass ["-Xfrontend", "-disable-implicit-string-processing-module-import"] when compiling manifests if the compiler supports it

### Result:

Avoid warnings when the `_StringProcessing` module isn't available.