### PR TITLE
fix concurrent access issue when running tests in parallel

### DIFF
--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -769,8 +769,9 @@ final class ParallelTestRunner {
                         observabilityScope: self.observabilityScope
                     )
                     var output = ""
+                    let outputLock = Lock()
                     let start = DispatchTime.now()
-                    let success = testRunner.test(outputHandler: { output += $0 })
+                    let success = testRunner.test(outputHandler: { _output in outputLock.withLock{ output += _output }})
                     let duration = start.distance(to: .now())
                     if !success {
                         self.ranSuccessfully = false


### PR DESCRIPTION
motivation: fix data race

changes: add lock when mutating test output as it may happen concurrently

rdar://92260631
