### PR TITLE
fixes ignoring the "--pretty-print" comand line argument

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -594,7 +594,9 @@ extension SwiftPackageTool {
                 skipSynthesizedMembers: skipSynthesizedMembers,
                 minimumAccessLevel: minimumAccessLevel,
                 skipInheritedDocs: skipInheritedDocs,
-                includeSPISymbols: includeSPISymbols)
+                includeSPISymbols: includeSPISymbols,
+                outputFormat: SymbolGraphExtract.OutputFormat.json(pretty: prettyPrint)
+            )
 
             // Run the tool once for every library and executable target in the root package.
             let buildPlan = buildOp.buildPlan!

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -595,7 +595,7 @@ extension SwiftPackageTool {
                 minimumAccessLevel: minimumAccessLevel,
                 skipInheritedDocs: skipInheritedDocs,
                 includeSPISymbols: includeSPISymbols,
-                outputFormat: SymbolGraphExtract.OutputFormat.json(pretty: prettyPrint)
+                outputFormat: .json(pretty: prettyPrint)
             )
 
             // Run the tool once for every library and executable target in the root package.

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -467,12 +467,7 @@ final class PackageToolTests: CommandsTestCase {
         // Returns symbol graph with or without pretty printing.
         func symbolGraph(atPath path: AbsolutePath, withPrettyPrinting: Bool, file: StaticString = #file, line: UInt = #line) throws -> Data? {
             let arguments = withPrettyPrinting ? ["dump-symbol-graph", "--pretty-print"] : ["dump-symbol-graph"]
-            let output = try SwiftPMProduct.SwiftPackage.executeProcess(arguments, packagePath: path).utf8Output()
-            guard output.contains("-- Emitting symbol graph for Bar") else {
-                XCTFail("Unexpected output for emitting symbol graph: \(output)", file: file, line: line)
-                return nil
-            }
-
+            _ = try SwiftPMProduct.SwiftPackage.executeProcess(arguments, packagePath: path)
             let enumerator = try XCTUnwrap(FileManager.default.enumerator(at: URL(fileURLWithPath: path.pathString), includingPropertiesForKeys: nil))
 
             var symbolGraphURL: URL?

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -488,6 +488,9 @@ final class PackageToolTests: CommandsTestCase {
     }
 
     func testDumpSymbolGraphCompactFormatting() throws {
+        // Depending on how the test is running, the `swift-symbolgraph-extract` tool might be unavailable.
+        try XCTSkipIf((try? UserToolchain.default.getSymbolGraphExtract()) == nil, "skipping test because the `swift-symbolgraph-extract` tools isn't available")
+
         try fixture(name: "DependencyResolution/Internal/Simple") { fixturePath in
             let compactGraphData = try XCTUnwrap(symbolGraph(atPath: fixturePath, withPrettyPrinting: false))
             let compactJSONText = try XCTUnwrap(String(data: compactGraphData, encoding: .utf8))
@@ -496,6 +499,9 @@ final class PackageToolTests: CommandsTestCase {
     }
 
     func testDumpSymbolGraphPrettyFormatting() throws {
+        // Depending on how the test is running, the `swift-symbolgraph-extract` tool might be unavailable.
+        try XCTSkipIf((try? UserToolchain.default.getSymbolGraphExtract()) == nil, "skipping test because the `swift-symbolgraph-extract` tools isn't available")
+
         try fixture(name: "DependencyResolution/Internal/Simple") { fixturePath in
             let prettyGraphData = try XCTUnwrap(symbolGraph(atPath: fixturePath, withPrettyPrinting: true))
             let prettyJSONText = try XCTUnwrap(String(data: prettyGraphData, encoding: .utf8))


### PR DESCRIPTION
The main branch ignores the `--pretty-print` command line parameter when dumping a symbol graph, this PR pipes it through to `SymbolGraphExtract`.

### Motivation:

Both `swift package dump-symbol-graph` and `swift package dump-symbol-graph --pretty-print` produce compact non-prettified JSON. The infrastructure to support pretty JSON, including the command line option are already on "main" but the option is ignored and always set to `false`. This behavior is erroneous as the options help advertises the availability of the `--pretty-print` option.

### Modifications:

There is a single line change passing the value of the command line parameter over to `SymbolGraphExtract`.

### Result:

The `--pretty-print` option will produce prettified symbol graph JSON output.

These are the steps that the unit test follows, you can try them in the console:

1. `swift package dump-symbol-graph --package-path Fixtures/DependencyResolution/Internal/Simple`
2. produces minified JSON output in Fixtures/DependencyResolution/Internal/Simple/.build/[platform]/symbolgraph/Bar.symbols.json
3. `swift package dump-symbol-graph --package-path Fixtures/DependencyResolution/Internal/Simple --pretty-print` 
4. produces human-friendly JSON output in Fixtures/DependencyResolution/Internal/Simple/.build/[platform]/symbolgraph/Bar.symbols.json