### PR TITLE
PackageLoading: correct relative path construction

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -877,9 +877,10 @@ public final class PackageBuilder {
                 }
 
                 // Ensure that the search path is contained within the package.
-                let subpath = try RelativePath(validating: value)
-                guard targetRoot.appending(subpath).isDescendantOfOrEqual(to: packagePath) else {
-                    throw ModuleError.invalidHeaderSearchPath(subpath.pathString)
+                _ = try RelativePath(validating: value)
+                guard AbsolutePath(value, relativeTo: targetRoot)
+                        .isDescendantOfOrEqual(to: packagePath) else {
+                    throw ModuleError.invalidHeaderSearchPath(value)
                 }
 
             case .define(let value):


### PR DESCRIPTION
We would construct a `RelativePath` without rooting it, which would then
be normalized and thus cause problems.  Alter the path to validate the
path is relative and then construct the `AbsolutePath` by rooting the
relative path.