### PR TITLE
Avoid loading duplicated packages if a root overrides a local dependency

### DIFF
--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -4060,6 +4060,57 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
+    func testForceResolveToResolvedVersionsDuplicateLocalDependency() throws {
+        let sandbox = AbsolutePath("/tmp/ws/")
+        let fs = InMemoryFileSystem()
+
+        let workspace = try MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                MockPackage(
+                    name: "Root",
+                    targets: [
+                        MockTarget(name: "Root", dependencies: ["Foo", "Bar"]),
+                    ],
+                    products: [],
+                    dependencies: [
+                        .sourceControl(path: "./Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .fileSystem(path: "./Bar"),
+                    ]
+                ),
+                MockPackage(
+                    name: "Bar",
+                    targets: [
+                        MockTarget(name: "Bar"),
+                    ],
+                    products: [
+                        MockProduct(name: "Bar", targets: ["Bar"]),
+                    ]
+                ),
+            ],
+            packages: [
+                MockPackage(
+                    name: "Foo",
+                    targets: [
+                        MockTarget(name: "Foo"),
+                    ],
+                    products: [
+                        MockProduct(name: "Foo", targets: ["Foo"]),
+                    ],
+                    versions: ["1.0.0", "1.2.0", "1.3.2"]
+                ),
+            ]
+        )
+
+        try workspace.checkPackageGraph(roots: ["Root", "Bar"]) { _, diagnostics in
+            XCTAssertNoDiagnostics(diagnostics)
+        }
+        try workspace.checkPackageGraph(roots: ["Root", "Bar"], forceResolvedVersions: true) { _, diagnostics in
+            XCTAssertNoDiagnostics(diagnostics)
+        }
+    }
+
     func testForceResolveWithNoResolvedFile() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()


### PR DESCRIPTION
This was quite subtle. 

Normally, we resolve before calling `loadDependencyManifests` and roots will override any type of dependency in such a way that they don't become part of managed dependencies which means if we try to load via `loadManagedManifest`, we will get no result, essentially filtering them from dependency manifests. Now when requiring a resolved file, we are producing managed dependencies from the resolved file, plus we were adding entries for any local dependencies unconditionally which would mean we would get results from `loadManagedManifest`, resulting in an additional entry in dependency manifests, compared to the "normal" mode. 

This PR changes the behavior such that we don't add a local dependency to managed dependencies if there's a root with the same identity which matches the results of the "normal" mode.

Fixes rdar://92622234, rdar://83337879

Note: I also moved this code to be based on `dependenciesToLoad` to make things a tiny bit simpler since we don't have to create the package reference on the fly.