### PR TITLE
[alternative 2] reload workspace state before reloading package graph

### DIFF
--- a/Sources/Workspace/Workspace+State.swift
+++ b/Sources/Workspace/Workspace+State.swift
@@ -65,13 +65,21 @@ public final class WorkspaceState {
         try self.save()
     }
 
+    // marked public for testing
     public func save() throws {
         try self.storage.save(dependencies: self.dependencies, artifacts: self.artifacts)
     }
 
     /// Returns true if the state file exists on the filesystem.
-    public func stateFileExists() -> Bool {
+    func stateFileExists() -> Bool {
         return self.storage.fileExists()
+    }
+
+    /// Returns true if the state file exists on the filesystem.
+    func reload() throws  {
+        let storedState = try self.storage.load()
+        self.dependencies = storedState.dependencies
+        self.artifacts = storedState.artifacts
     }
 }
 

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1069,6 +1069,10 @@ extension Workspace {
         customXCTestMinimumDeploymentTargets: [PackageModel.Platform: PlatformVersion]? = .none,
         observabilityScope: ObservabilityScope
     ) throws -> PackageGraph {
+        // reload state in case it was modified externally (eg by another process) before reloading the graph
+        // long running host processes (ie IDEs) need this in case other SwiftPM processes (ie CLI) made changes to the state
+        // such hosts processes call loadPackageGraph to make sure the workspace state is correct
+        try self.state.reload()
 
         // Perform dependency resolution, if required.
         let manifests: DependencyManifests


### PR DESCRIPTION
motivation: long running host processes (ie IDEs) need this in case other SwiftPM processes (ie CLI) made changes to the state

changes:
* call reload state before reloading the graph
* add test

