### PR TITLE
Tests: use `tar` rather than `echo` for sandbox test on Windows

### DIFF
--- a/Tests/BasicsTests/SandboxTests.swift
+++ b/Tests/BasicsTests/SandboxTests.swift
@@ -18,7 +18,11 @@ import XCTest
 final class SandboxTest: XCTestCase {
     func testSandboxOnAllPlatforms() throws {
         try withTemporaryDirectory { path in
+#if os(Windows)
+            let command = Sandbox.apply(command: ["tar.exe", "-h"], strictness: .default, writableDirectories: [])
+#else
             let command = Sandbox.apply(command: ["echo", "0"], strictness: .default, writableDirectories: [])
+#endif
             XCTAssertNoThrow(try Process.checkNonZeroExit(arguments: command))
         }
     }


### PR DESCRIPTION
`echo` is a `cmd` shell builtin and not available as a standalone binary
as from coretuils on Linux.  It should be noted that `echo` is available
as a shell builtin on Linux and is not required to be provided as a core
binary.  `tar` is only available on more recent Windows releases with 10
or newer.