### PR TITLE
Tests: disable SQLite test on Windows

### DIFF
--- a/Tests/BasicsTests/SQLiteBackedCacheTests.swift
+++ b/Tests/BasicsTests/SQLiteBackedCacheTests.swift
@@ -55,8 +55,11 @@ final class SQLiteBackedCacheTests: XCTestCase {
     }
 
     func testFileDeleted() throws {
+#if os(Windows)
+        try XCTSkipIf(true, "open file cannot be deleted on Windows")
+#endif
         try XCTSkipIf(is_tsan_enabled())
-        
+
         try testWithTemporaryDirectory { tmpPath in
             let path = tmpPath.appending(component: "test.db")
             let cache = SQLiteBackedCache<String>(tableName: "SQLiteBackedCacheTest", path: path)

--- a/Tests/PackageCollectionsTests/PackageCollectionsStorageTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsStorageTests.swift
@@ -73,8 +73,11 @@ class PackageCollectionsStorageTests: XCTestCase {
     }
 
     func testFileDeleted() throws {
+#if os(Windows)
+        try XCTSkipIf(true, "open files cannot be deleted on Windows")
+#endif
         try XCTSkipIf(is_tsan_enabled())
-        
+
         try testWithTemporaryDirectory { tmpPath in
             let path = tmpPath.appending(component: "test.db")
             let storage = SQLitePackageCollectionsStorage(path: path)
@@ -112,8 +115,11 @@ class PackageCollectionsStorageTests: XCTestCase {
     }
 
     func testFileCorrupt() throws {
+#if os(Windows)
+        try XCTSkipIf(true, "open files cannot be deleted on Windows")
+#endif
         try XCTSkipIf(is_tsan_enabled())
-        
+
         try testWithTemporaryDirectory { tmpPath in
             let path = tmpPath.appending(component: "test.db")
             let storage = SQLitePackageCollectionsStorage(path: path)


### PR DESCRIPTION
Windows does not permit deleting files with open handles.  This test
appears to rely on those semantics (expecting that the deletion
operation will succeed and the file will be marked for delete on close).
Because Windows does not provide such semantics for `rm`, simply skip
the test on Windows.