### PR TITLE
PackageLoading: support non-Unix platforms for PkgConfig

### DIFF
--- a/Tests/PackageLoadingTests/PkgConfigParserTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigParserTests.swift
@@ -43,7 +43,7 @@ final class PkgConfigParserTests: XCTestCase {
                 "exec_prefix": "/usr/local/Cellar/gtk+3/3.18.9",
                 "targets": "quartz",
                 "pcfiledir": parser.pcFile.parentDirectory.pathString,
-                "pc_sysrootdir": "/"
+                "pc_sysrootdir": AbsolutePath.root.pathString
             ])
             XCTAssertEqual(parser.dependencies, ["gdk-3.0", "atk", "cairo", "cairo-gobject", "gdk-pixbuf-2.0", "gio-2.0"])
             XCTAssertEqual(parser.privateDependencies, ["atk", "epoxy", "gio-unix-2.0"])
@@ -58,7 +58,7 @@ final class PkgConfigParserTests: XCTestCase {
                 "prefix": "/usr/local/bin",
                 "exec_prefix": "/usr/local/bin",
                 "pcfiledir": parser.pcFile.parentDirectory.pathString,
-                "pc_sysrootdir": "/"
+                "pc_sysrootdir": AbsolutePath.root.pathString
             ])
             XCTAssertEqual(parser.dependencies, ["gdk-3.0", "atk"])
             XCTAssertEqual(parser.cFlags, [])
@@ -73,7 +73,7 @@ final class PkgConfigParserTests: XCTestCase {
                 "exec_prefix": "/usr/local/bin",
                 "my_dep": "atk",
                 "pcfiledir": parser.pcFile.parentDirectory.pathString,
-                "pc_sysrootdir": "/"
+                "pc_sysrootdir": AbsolutePath.root.pathString
             ])
             XCTAssertEqual(parser.dependencies, ["gdk-3.0", "atk"])
             XCTAssertEqual(parser.cFlags, ["-I"])
@@ -97,7 +97,7 @@ final class PkgConfigParserTests: XCTestCase {
                 "exec_prefix": "/usr/local/bin",
                 "my_dep": "atk",
                 "pcfiledir": parser.pcFile.parentDirectory.pathString,
-                "pc_sysrootdir": "/"
+                "pc_sysrootdir": AbsolutePath.root.pathString
             ])
             XCTAssertEqual(parser.dependencies, ["gdk-3.0", "atk"])
             XCTAssertEqual(parser.cFlags, ["-I/usr/local/Wine Cellar/gtk+3/3.18.9/include/gtk-3.0", "-I/after/extra/spaces"])
@@ -117,22 +117,22 @@ final class PkgConfigParserTests: XCTestCase {
             "/usr/local/opt/foo/lib/pkgconfig/foo.pc",
             "/custom/foo.pc")
         XCTAssertEqual(
-            "/custom/foo.pc",
-            try PCFileFinder().locatePCFile(name: "foo", customSearchPaths: [AbsolutePath("/custom")], fileSystem: fs, observabilityScope: observability.topScope).pathString
+            AbsolutePath("/custom/foo.pc"),
+            try PCFileFinder().locatePCFile(name: "foo", customSearchPaths: [AbsolutePath("/custom")], fileSystem: fs, observabilityScope: observability.topScope)
         )
         XCTAssertEqual(
-            "/custom/foo.pc",
-            try PkgConfig(name: "foo", additionalSearchPaths: [AbsolutePath("/custom")], fileSystem: fs, observabilityScope: observability.topScope).pcFile.pathString
+            AbsolutePath("/custom/foo.pc"),
+            try PkgConfig(name: "foo", additionalSearchPaths: [AbsolutePath("/custom")], fileSystem: fs, observabilityScope: observability.topScope).pcFile
         )
         XCTAssertEqual(
-            "/usr/lib/pkgconfig/foo.pc",
+            AbsolutePath("/usr/lib/pkgconfig/foo.pc").pathString,
             try PCFileFinder().locatePCFile(name: "foo", customSearchPaths: [], fileSystem: fs, observabilityScope: observability.topScope).pathString
         )
         try withCustomEnv(["PKG_CONFIG_PATH": "/usr/local/opt/foo/lib/pkgconfig"]) {
-            XCTAssertEqual("/usr/local/opt/foo/lib/pkgconfig/foo.pc", try PkgConfig(name: "foo", fileSystem: fs, observabilityScope: observability.topScope).pcFile.pathString)
+            XCTAssertEqual(AbsolutePath("/usr/local/opt/foo/lib/pkgconfig/foo.pc"), try PkgConfig(name: "foo", fileSystem: fs, observabilityScope: observability.topScope).pcFile)
         }
         try withCustomEnv(["PKG_CONFIG_PATH": "/usr/local/opt/foo/lib/pkgconfig:/usr/lib/pkgconfig"]) {
-            XCTAssertEqual("/usr/local/opt/foo/lib/pkgconfig/foo.pc", try PkgConfig(name: "foo", fileSystem: fs, observabilityScope: observability.topScope).pcFile.pathString)
+            XCTAssertEqual(AbsolutePath("/usr/local/opt/foo/lib/pkgconfig/foo.pc"), try PkgConfig(name: "foo", fileSystem: fs, observabilityScope: observability.topScope).pcFile)
         }
     }
 
@@ -141,19 +141,33 @@ final class PkgConfigParserTests: XCTestCase {
         PCFileFinder.resetCachedPkgConfigPaths()
 
         try testWithTemporaryDirectory { tmpdir in
+#if os(Windows)
+            let fakePkgConfig = tmpdir.appending(components: "bin", "pkg-config.cmd")
+#else
             let fakePkgConfig = tmpdir.appending(components: "bin", "pkg-config")
+#endif
             try localFileSystem.createDirectory(fakePkgConfig.parentDirectory)
 
             let stream = BufferedOutputByteStream()
+#if os(Windows)
+            stream <<< """
+            @echo off
+            echo /Volumes/BestDrive/pkgconfig
+            """
+#else
             stream <<< """
             #!/bin/sh
             echo "/Volumes/BestDrive/pkgconfig"
             """
+#endif
             try localFileSystem.writeFileContents(fakePkgConfig, bytes: stream.bytes)
-            // `FileSystem` does not support `chmod` on Linux, so we shell out instead.
-            _ = try Process.popen(args: "chmod", "+x", fakePkgConfig.pathString)
+            try localFileSystem.chmod(.executable, path: fakePkgConfig, options: [])
 
+#if os(Windows)
+            _ = PCFileFinder(pkgConfig: fakePkgConfig)
+#else
             _ = PCFileFinder(brewPrefix: fakePkgConfig.parentDirectory.parentDirectory)
+#endif
         }
 
         XCTAssertEqual(PCFileFinder.pkgConfigPaths, [AbsolutePath("/Volumes/BestDrive/pkgconfig")])


### PR DESCRIPTION
pkg-config is a common utility on UNIX systems, but does not play very
well with Windows.  This adjusts the path separator character to match
the platform as well as uses `AbsolutePath` APIs to work with paths as
a means of getting the platform specific path separator character.  It
also introduces the ability to specify the pkgconfig tool itself which
is needed for Windows which does not support an arbitrary executable.