### PR TITLE
Basics: add a temporary workaround for Windows for archives

### DIFF
--- a/Sources/Basics/Archiver+Zip.swift
+++ b/Sources/Basics/Archiver+Zip.swift
@@ -46,7 +46,11 @@ public struct ZipArchiver: Archiver, Cancellable {
                 throw FileSystemError(.notDirectory, destinationPath)
             }
 
+#if os(Windows)
+            let process = Process(arguments: ["tar.exe", "xf", archivePath.pathString, "-C", destinationPath.pathString])
+#else
             let process = Process(arguments: ["unzip", archivePath.pathString, "-d", destinationPath.pathString])
+#endif
             guard let registrationKey = self.cancellator.register(process) else {
                 throw StringError("cancellation")
             }
@@ -72,7 +76,11 @@ public struct ZipArchiver: Archiver, Cancellable {
                 throw FileSystemError(.noEntry, path)
             }
 
+#if os(Windows)
+            let process = Process(arguments: ["tar.exe", "tf", path.pathString])
+#else
             let process = Process(arguments: ["unzip", "-t", path.pathString])
+#endif
             guard let registrationKey = self.cancellator.register(process) else {
                 throw StringError("cancellation")
             }

--- a/Tests/BasicsTests/ZipArchiverTests.swift
+++ b/Tests/BasicsTests/ZipArchiverTests.swift
@@ -61,7 +61,11 @@ class ZipArchiverTests: XCTestCase {
             let inputArchivePath = AbsolutePath(#file).parentDirectory
                 .appending(components: "Inputs", "invalid_archive.zip")
             XCTAssertThrowsError(try archiver.extract(from: inputArchivePath, to: tmpdir)) { error in
+#if os(Windows)
+                XCTAssertMatch((error as? StringError)?.description, .contains("Unrecognized archive format"))
+#else
                 XCTAssertMatch((error as? StringError)?.description, .contains("End-of-central-directory signature not found"))
+#endif
             }
         }
     }


### PR DESCRIPTION
The archive support currently assumes that it can invoke random tools
from the system.  There is no `unzip` available on Windows by default,
though we might be able to get away with the fact that there exists a
bundled copy in git.  However, that requires that we alter the search
path for the invocation which would get complicated.  Instead, we can
use a horrible hack of using `tar` to extract the archive given thats
built with libarchive and will simply use file detection and extracts
it.

Longer term it would be ideal to avoid the utility invocation and use
directly a library to extract archives.
