### PR TITLE
Add validation checking for having plugin targets in library or executable products

### DIFF
--- a/Sources/PackageLoading/Diagnostics.swift
+++ b/Sources/PackageLoading/Diagnostics.swift
@@ -56,6 +56,10 @@ extension Basics.Diagnostic {
         .error("system library product \(product) shouldn't have a type and contain only one target")
     }
 
+    static func nonPluginProductWithPluginTargets(product: String, type: ProductType, pluginTargets: [String]) -> Self {
+        .error("\(type.description) product '\(product)' should not contain plugin targets (it has \(pluginTargets.map{ "'\($0)'" }.joined(separator: ", ")))")
+    }
+
     static func executableProductTargetNotExecutable(product: String, target: String) -> Self {
         .error("""
             executable product '\(product)' expects target '\(target)' to be executable; an executable target requires \

--- a/Sources/PackageModel/Product.swift
+++ b/Sources/PackageModel/Product.swift
@@ -182,11 +182,11 @@ extension ProductType: CustomStringConvertible {
         case .library(let type):
             switch type {
             case .automatic:
-                return "automatic"
+                return "library"
             case .dynamic:
-                return "dynamic"
+                return "dynamic library"
             case .static:
-                return "static"
+                return "static library"
             }
         case .plugin:
             return "plugin"


### PR DESCRIPTION
### Motivation:

Plugin targets can only be in plugin products, but right now there is no validation for this.  The plugin targets just get ignored, which is confusing.

### Modifications:

- add validation for library products
- clarified the product name in the description of libraries (e.g. "dynamic library" instead of just "dynamic" for the type of product)
- make both executable and library products check that there are no plugin targets
- add a new unit test for libraries, and modify one for executables

We could extend this to other kinds of products in the future, but libraries and executables are the ones that accept targets today.