### PR TITLE
PackageLoading: further portability changes for pkg-config

### DIFF
--- a/Tests/PackageLoadingTests/PkgConfigParserTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigParserTests.swift
@@ -131,7 +131,12 @@ final class PkgConfigParserTests: XCTestCase {
         try withCustomEnv(["PKG_CONFIG_PATH": "/usr/local/opt/foo/lib/pkgconfig"]) {
             XCTAssertEqual(AbsolutePath("/usr/local/opt/foo/lib/pkgconfig/foo.pc"), try PkgConfig(name: "foo", fileSystem: fs, observabilityScope: observability.topScope).pcFile)
         }
-        try withCustomEnv(["PKG_CONFIG_PATH": "/usr/local/opt/foo/lib/pkgconfig:/usr/lib/pkgconfig"]) {
+#if os(Windows)
+        let separator = ";"
+#else
+        let separator = ":"
+#endif
+        try withCustomEnv(["PKG_CONFIG_PATH": "/usr/local/opt/foo/lib/pkgconfig\(separator)/usr/lib/pkgconfig"]) {
             XCTAssertEqual(AbsolutePath("/usr/local/opt/foo/lib/pkgconfig/foo.pc"), try PkgConfig(name: "foo", fileSystem: fs, observabilityScope: observability.topScope).pcFile)
         }
     }


### PR DESCRIPTION
Windows and subsequently `pkg-config` (and `pkgconf`) use `;` as the
path delimiter rather than `:`.  Adjust the codepaths to account for
the difference in the sigil.  Additionally, because `\` is the preferred
path separator on windows, the pkg-config specification behaves slightly
differently for the treatment of `\`.  Unless we are escaping spaces or
the `\` literal, emit the `\` as a character rather than treat it as an
escape modifier.  This gives us the desired behaviour, even though it is
a slight bit more clever than the reference implementations.
