### PR TITLE
[5.7] Add validation checking for having plugin targets in library or executable products (#5524)

### DIFF
--- a/Sources/PackageLoading/Diagnostics.swift
+++ b/Sources/PackageLoading/Diagnostics.swift
@@ -56,6 +56,10 @@ extension Basics.Diagnostic {
         .error("system library product \(product) shouldn't have a type and contain only one target")
     }
 
+    static func nonPluginProductWithPluginTargets(product: String, type: ProductType, pluginTargets: [String]) -> Self {
+        .error("\(type.description) product '\(product)' should not contain plugin targets (it has \(pluginTargets.map{ "'\($0)'" }.joined(separator: ", ")))")
+    }
+
     static func executableProductTargetNotExecutable(product: String, target: String) -> Self {
         .error("""
             executable product '\(product)' expects target '\(target)' to be executable; an executable target requires \

--- a/Sources/PackageModel/Product.swift
+++ b/Sources/PackageModel/Product.swift
@@ -182,11 +182,11 @@ extension ProductType: CustomStringConvertible {
         case .library(let type):
             switch type {
             case .automatic:
-                return "automatic"
+                return "library"
             case .dynamic:
-                return "dynamic"
+                return "dynamic library"
             case .static:
-                return "static"
+                return "static library"
             }
         case .plugin:
             return "plugin"


### PR DESCRIPTION
(cherry picked from commit a802f691aa578084acbeede4a008362a5284c044)

This is a 5.7 nomination of https://github.com/apple/swift-package-manager/pull/5524