### PR TITLE
Create helper functions for temporary directories which supports new concurrency features

### DIFF
--- a/Sources/Basics/TemporaryFile.swift
+++ b/Sources/Basics/TemporaryFile.swift
@@ -1,0 +1,106 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import TSCBasic
+import TSCLibc
+
+/// Creates a temporary directory and evaluates a closure with the directory path as an argument.
+/// The temporary directory will live on disk while the closure is evaluated and will be deleted when
+/// the cleanup closure is called. This allows the temporary directory to have an arbitrary lifetime.
+///
+/// This function is basically a wrapper over posix's mkdtemp() function.
+///
+/// - Parameters:
+///     - dir: If specified the temporary directory will be created in this directory otherwise environment
+///            variables TMPDIR, TEMP and TMP will be checked for a value (in that order). If none of the env
+///            variables are set, dir will be set to `/tmp/`.
+///     - prefix: The prefix to the temporary file name.
+///     - body: A closure to execute that receives the absolute path of the directory as an argument.
+///           If `body` has a return value, that value is also used as the
+///           return value for the `withTemporaryDirectory` function.
+///           The cleanup block should be called when the temporary directory is no longer needed.
+///
+/// - Throws: `MakeDirectoryError` and rethrows all errors from `body`.
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public func withTemporaryDirectory<Result>(
+  dir: AbsolutePath? = nil, prefix: String = "TemporaryDirectory" , _ body: (AbsolutePath, @escaping (AbsolutePath) -> Void) async throws -> Result
+) async throws -> Result {
+    let template = try createTemporaryDirectoryTemplate(dir: dir, prefix: prefix)
+  return try await body(AbsolutePath(String(cString: template))) { path in
+    _ = try? FileManager.default.removeItem(atPath: path.pathString)
+  }
+}
+
+/// Creates a temporary directory and evaluates a closure with the directory path as an argument.
+/// The temporary directory will live on disk while the closure is evaluated and will be deleted afterwards.
+///
+/// This function is basically a wrapper over posix's mkdtemp() function.
+///
+/// - Parameters:
+///     - dir: If specified the temporary directory will be created in this directory otherwise environment
+///            variables TMPDIR, TEMP and TMP will be checked for a value (in that order). If none of the env
+///            variables are set, dir will be set to `/tmp/`.
+///     - prefix: The prefix to the temporary file name.
+///     - removeTreeOnDeinit: If enabled try to delete the whole directory tree otherwise remove only if its empty.
+///     - body: A closure to execute that receives the absolute path of the directory as an argument.
+///             If `body` has a return value, that value is also used as the
+///             return value for the `withTemporaryDirectory` function.
+///
+/// - Throws: `MakeDirectoryError` and rethrows all errors from `body`.
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public func withTemporaryDirectory<Result>(
+  dir: AbsolutePath? = nil, prefix: String = "TemporaryDirectory", removeTreeOnDeinit: Bool = false , _ body: (AbsolutePath) async throws -> Result
+) async throws -> Result {
+  try await withTemporaryDirectory(dir: dir, prefix: prefix) { path, cleanup in
+    defer { if removeTreeOnDeinit { cleanup(path) } }
+    return try await body(path)
+  }
+}
+
+private func createTemporaryDirectoryTemplate(dir: AbsolutePath?, prefix: String) throws -> [Int8] {
+    // Construct path to the temporary directory.
+    let templatePath = try AbsolutePath(prefix + ".XXXXXX", relativeTo: determineTempDirectory(dir))
+
+    // Convert templatePath to a C style string terminating with null char to be an valid input
+    // to mkdtemp method. The XXXXXX in this string will be replaced by a random string
+    // which will be the actual path to the temporary directory.
+    var template = [UInt8](templatePath.pathString.utf8).map({ Int8($0) }) + [Int8(0)]
+
+    if TSCLibc.mkdtemp(&template) == nil {
+        throw MakeDirectoryError(errno: errno)
+    }
+    return template
+}
+
+private extension MakeDirectoryError {
+    init(errno: Int32) {
+        switch errno {
+        case TSCLibc.EEXIST:
+            self = .pathExists
+        case TSCLibc.ENAMETOOLONG:
+            self = .pathTooLong
+        case TSCLibc.EACCES, TSCLibc.EFAULT, TSCLibc.EPERM, TSCLibc.EROFS:
+            self = .permissionDenied
+        case TSCLibc.ELOOP, TSCLibc.ENOENT, TSCLibc.ENOTDIR:
+            self = .unresolvablePathComponent
+        case TSCLibc.ENOMEM:
+            self = .outOfMemory
+#if !os(Windows)
+        case TSCLibc.EDQUOT:
+            self = .outOfMemory
+#endif
+        default:
+            self = .other(errno)
+        }
+    }
+}

--- a/Sources/Basics/TemporaryFile.swift
+++ b/Sources/Basics/TemporaryFile.swift
@@ -12,15 +12,13 @@
 
 import Foundation
 import TSCBasic
-import TSCLibc
 
 /// Creates a temporary directory and evaluates a closure with the directory path as an argument.
 /// The temporary directory will live on disk while the closure is evaluated and will be deleted when
 /// the cleanup closure is called. This allows the temporary directory to have an arbitrary lifetime.
 ///
-/// This function is basically a wrapper over posix's mkdtemp() function.
-///
 /// - Parameters:
+///     - fileSystem: `FileSystem` which is used to construct temporary directory.
 ///     - dir: If specified the temporary directory will be created in this directory otherwise environment
 ///            variables TMPDIR, TEMP and TMP will be checked for a value (in that order). If none of the env
 ///            variables are set, dir will be set to `/tmp/`.
@@ -29,16 +27,16 @@ import TSCLibc
 ///           If `body` has a return value, that value is also used as the
 ///           return value for the `withTemporaryDirectory` function.
 ///           The cleanup block should be called when the temporary directory is no longer needed.
-/// - Returns: `Task<Result, Error>` which can be used
-/// - Throws: `MakeDirectoryError` and rethrows all errors from `body`.
+///
+/// - Throws: An error when creating directory and rethrows all errors from `body`.
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public func withTemporaryDirectory<Result>(
+    fileSystem: FileSystem = localFileSystem,
     dir: AbsolutePath? = nil,
     prefix: String = "TemporaryDirectory",
-    fileSystem: FileSystem = localFileSystem,
     _ body: @escaping (AbsolutePath, @escaping (AbsolutePath) -> Void) async throws -> Result
 ) throws -> Task<Result, Error> {
-    let temporaryDirectory = try createTemporaryDirectory(dir: dir, prefix: prefix, fileSystem: fileSystem)
+    let temporaryDirectory = try createTemporaryDirectory(fileSystem: fileSystem, dir: dir, prefix: prefix)
     
     let task: Task<Result, Error> = Task {
         try await withTaskCancellationHandler {
@@ -57,9 +55,8 @@ public func withTemporaryDirectory<Result>(
 /// Creates a temporary directory and evaluates a closure with the directory path as an argument.
 /// The temporary directory will live on disk while the closure is evaluated and will be deleted afterwards.
 ///
-/// This function is basically a wrapper over posix's mkdtemp() function.
-///
 /// - Parameters:
+///     - fileSystem: `FileSystem` which is used to construct temporary directory.
 ///     - dir: If specified the temporary directory will be created in this directory otherwise environment
 ///            variables TMPDIR, TEMP and TMP will be checked for a value (in that order). If none of the env
 ///            variables are set, dir will be set to `/tmp/`.
@@ -69,54 +66,36 @@ public func withTemporaryDirectory<Result>(
 ///             If `body` has a return value, that value is also used as the
 ///             return value for the `withTemporaryDirectory` function.
 ///
-/// - Throws: `MakeDirectoryError` and rethrows all errors from `body`.
+/// - Throws: An error when creating directory and rethrows all errors from `body`.
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public func withTemporaryDirectory<Result>(
+    fileSystem: FileSystem = localFileSystem,
     dir: AbsolutePath? = nil,
     prefix: String = "TemporaryDirectory",
-    fileSystem: FileSystem = localFileSystem,
     removeTreeOnDeinit: Bool = false,
     _ body: @escaping (AbsolutePath) async throws -> Result
 ) throws -> Task<Result, Error> {
-    try withTemporaryDirectory(dir: dir, prefix: prefix, fileSystem: fileSystem) { path, cleanup in
+    try withTemporaryDirectory(fileSystem: fileSystem, dir: dir, prefix: prefix) { path, cleanup in
         defer { if removeTreeOnDeinit { cleanup(path) } }
         return try await body(path)
     }
 }
 
-private func createTemporaryDirectory(dir: AbsolutePath?, prefix: String, fileSystem: FileSystem) throws -> AbsolutePath {
+private func createTemporaryDirectory(fileSystem: FileSystem, dir: AbsolutePath?, prefix: String) throws -> AbsolutePath {
     // This random generation is needed so that
     // it is more or less equal to generation using `mkdtemp` function
     let letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-
+    
     let randomSuffix = String((0..<6).map { _ in letters.randomElement()! })
     
-    // Construct path to the temporary directory.
-    let templatePath = try AbsolutePath(prefix + ".\(randomSuffix)", relativeTo: determineTempDirectory(dir))
+    let tempDirectory = dir ?? fileSystem.tempDirectory
+    guard fileSystem.isDirectory(tempDirectory) else {
+        throw TempFileError.couldNotFindTmpDir(tempDirectory.pathString)
+    }
 
+    // Construct path to the temporary directory.
+    let templatePath = AbsolutePath(prefix + ".\(randomSuffix)", relativeTo: tempDirectory)
+    
     try fileSystem.createDirectory(templatePath, recursive: true)
     return templatePath
-}
-
-private extension MakeDirectoryError {
-    init(errno: Int32) {
-        switch errno {
-        case TSCLibc.EEXIST:
-            self = .pathExists
-        case TSCLibc.ENAMETOOLONG:
-            self = .pathTooLong
-        case TSCLibc.EACCES, TSCLibc.EFAULT, TSCLibc.EPERM, TSCLibc.EROFS:
-            self = .permissionDenied
-        case TSCLibc.ELOOP, TSCLibc.ENOENT, TSCLibc.ENOTDIR:
-            self = .unresolvablePathComponent
-        case TSCLibc.ENOMEM:
-            self = .outOfMemory
-#if !os(Windows)
-        case TSCLibc.EDQUOT:
-            self = .outOfMemory
-#endif
-        default:
-            self = .other(errno)
-        }
-    }
 }

--- a/Tests/BasicsTests/TemporaryFileTests.swift
+++ b/Tests/BasicsTests/TemporaryFileTests.swift
@@ -10,8 +10,6 @@
 
 import XCTest
 
-import class Foundation.FileManager
-
 import TSCBasic
 
 import Basics

--- a/Tests/BasicsTests/TemporaryFileTests.swift
+++ b/Tests/BasicsTests/TemporaryFileTests.swift
@@ -22,10 +22,7 @@ class TemporaryAsyncFileTests: XCTestCase {
         // Test can create and remove temp directory.
         let path1: AbsolutePath = try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDirPath in
             // Do some async task
-            let task = Task {
-                return
-            }
-            await task.value
+            try await Task.sleep(nanoseconds: 1_000)
             
             XCTAssertTrue(localFileSystem.isDirectory(tempDirPath))
             return tempDirPath
@@ -38,17 +35,14 @@ class TemporaryAsyncFileTests: XCTestCase {
             // Create a file inside the temp directory.
             let filePath = tempDirPath.appending(component: "somefile")
             // Do some async task
-            let task = Task {
-                return
-            }
-            await task.value
+            try await Task.sleep(nanoseconds: 1_000)
             
             try localFileSystem.writeFileContents(filePath, bytes: ByteString())
             return tempDirPath
         }.value
         XCTAssertTrue(localFileSystem.isDirectory(path2))
         // Cleanup.
-        try FileManager.default.removeItem(atPath: path2.pathString)
+        try localFileSystem.removeFileTree(path2)
         XCTAssertFalse(localFileSystem.isDirectory(path2))
         
         // Test temp directory is removed when its not empty and removeTreeOnDeinit is enabled.
@@ -56,10 +50,7 @@ class TemporaryAsyncFileTests: XCTestCase {
             XCTAssertTrue(localFileSystem.isDirectory(tempDirPath))
             let filePath = tempDirPath.appending(component: "somefile")
             // Do some async task
-            let task = Task {
-                return
-            }
-            await task.value
+            try await Task.sleep(nanoseconds: 1_000)
             
             try localFileSystem.writeFileContents(filePath, bytes: ByteString())
             return tempDirPath
@@ -71,10 +62,7 @@ class TemporaryAsyncFileTests: XCTestCase {
         let (pathOne, pathTwo): (AbsolutePath, AbsolutePath) = try await withTemporaryDirectory(removeTreeOnDeinit: true) { pathOne in
             let pathTwo: AbsolutePath = try await withTemporaryDirectory(removeTreeOnDeinit: true) { pathTwo in
                 // Do some async task
-                let task = Task {
-                    return
-                }
-                await task.value
+                try await Task.sleep(nanoseconds: 1_000)
                 
                 XCTAssertTrue(localFileSystem.isDirectory(pathOne))
                 XCTAssertTrue(localFileSystem.isDirectory(pathTwo))

--- a/Tests/BasicsTests/TemporaryFileTests.swift
+++ b/Tests/BasicsTests/TemporaryFileTests.swift
@@ -1,0 +1,90 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+
+import class Foundation.FileManager
+
+import TSCBasic
+
+import Basics
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+class TemporaryAsyncFileTests: XCTestCase {
+    func testBasicTemporaryDirectory() async throws {
+        // Test can create and remove temp directory.
+        let path1: AbsolutePath = try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDirPath in
+            // Do some async task
+            let task = Task {
+                return
+            }
+            await task.value
+            
+            XCTAssertTrue(localFileSystem.isDirectory(tempDirPath))
+            return tempDirPath
+        }
+        XCTAssertFalse(localFileSystem.isDirectory(path1))
+
+        // Test temp directory is not removed when its not empty.
+        let path2: AbsolutePath = try await withTemporaryDirectory { tempDirPath in
+            XCTAssertTrue(localFileSystem.isDirectory(tempDirPath))
+            // Create a file inside the temp directory.
+            let filePath = tempDirPath.appending(component: "somefile")
+            // Do some async task
+            let task = Task {
+                return
+            }
+            await task.value
+
+            try localFileSystem.writeFileContents(filePath, bytes: ByteString())
+            return tempDirPath
+        }
+        XCTAssertTrue(localFileSystem.isDirectory(path2))
+        // Cleanup.
+        try FileManager.default.removeItem(atPath: path2.pathString)
+        XCTAssertFalse(localFileSystem.isDirectory(path2))
+
+        // Test temp directory is removed when its not empty and removeTreeOnDeinit is enabled.
+        let path3: AbsolutePath = try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDirPath in
+            XCTAssertTrue(localFileSystem.isDirectory(tempDirPath))
+            let filePath = tempDirPath.appending(component: "somefile")
+            // Do some async task
+            let task = Task {
+                return
+            }
+            await task.value
+
+            try localFileSystem.writeFileContents(filePath, bytes: ByteString())
+            return tempDirPath
+        }
+        XCTAssertFalse(localFileSystem.isDirectory(path3))
+    }
+
+    func testCanCreateUniqueTempDirectories() async throws {
+        let (pathOne, pathTwo): (AbsolutePath, AbsolutePath) = try await withTemporaryDirectory(removeTreeOnDeinit: true) { pathOne in
+            let pathTwo: AbsolutePath = try await withTemporaryDirectory(removeTreeOnDeinit: true) { pathTwo in
+                // Do some async task
+                let task = Task {
+                    return
+                }
+                await task.value
+
+                XCTAssertTrue(localFileSystem.isDirectory(pathOne))
+                XCTAssertTrue(localFileSystem.isDirectory(pathTwo))
+                // Their paths should be different.
+                XCTAssertTrue(pathOne != pathTwo)
+                return pathTwo
+            }
+            return (pathOne, pathTwo)
+        }
+        XCTAssertFalse(localFileSystem.isDirectory(pathOne))
+        XCTAssertFalse(localFileSystem.isDirectory(pathTwo))
+    }
+}

--- a/Tests/BasicsTests/TemporaryFileTests.swift
+++ b/Tests/BasicsTests/TemporaryFileTests.swift
@@ -1,12 +1,12 @@
 /*
  This source file is part of the Swift.org open source project
-
+ 
  Copyright (c) 2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
-
+ 
  See http://swift.org/LICENSE.txt for license information
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
-*/
+ */
 
 import XCTest
 
@@ -31,7 +31,7 @@ class TemporaryAsyncFileTests: XCTestCase {
             return tempDirPath
         }
         XCTAssertFalse(localFileSystem.isDirectory(path1))
-
+        
         // Test temp directory is not removed when its not empty.
         let path2: AbsolutePath = try await withTemporaryDirectory { tempDirPath in
             XCTAssertTrue(localFileSystem.isDirectory(tempDirPath))
@@ -42,7 +42,7 @@ class TemporaryAsyncFileTests: XCTestCase {
                 return
             }
             await task.value
-
+            
             try localFileSystem.writeFileContents(filePath, bytes: ByteString())
             return tempDirPath
         }
@@ -50,7 +50,7 @@ class TemporaryAsyncFileTests: XCTestCase {
         // Cleanup.
         try FileManager.default.removeItem(atPath: path2.pathString)
         XCTAssertFalse(localFileSystem.isDirectory(path2))
-
+        
         // Test temp directory is removed when its not empty and removeTreeOnDeinit is enabled.
         let path3: AbsolutePath = try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDirPath in
             XCTAssertTrue(localFileSystem.isDirectory(tempDirPath))
@@ -60,13 +60,13 @@ class TemporaryAsyncFileTests: XCTestCase {
                 return
             }
             await task.value
-
+            
             try localFileSystem.writeFileContents(filePath, bytes: ByteString())
             return tempDirPath
         }
         XCTAssertFalse(localFileSystem.isDirectory(path3))
     }
-
+    
     func testCanCreateUniqueTempDirectories() async throws {
         let (pathOne, pathTwo): (AbsolutePath, AbsolutePath) = try await withTemporaryDirectory(removeTreeOnDeinit: true) { pathOne in
             let pathTwo: AbsolutePath = try await withTemporaryDirectory(removeTreeOnDeinit: true) { pathTwo in
@@ -75,7 +75,7 @@ class TemporaryAsyncFileTests: XCTestCase {
                     return
                 }
                 await task.value
-
+                
                 XCTAssertTrue(localFileSystem.isDirectory(pathOne))
                 XCTAssertTrue(localFileSystem.isDirectory(pathTwo))
                 // Their paths should be different.


### PR DESCRIPTION
Create helper functions for creating temporary files in order to slowly migrate to async/await based approach to concurrency

### Motivation:

There are examples such as in ManifestLoading where async/await approach would be helpful to migrate from completionHandlers to async/await

### Modifications:

As mentioned in https://github.com/apple/swift-tools-support-core/pull/321#issuecomment-1132432209 it was advised to put this code inside SwiftPM/Basics module in order to not increase amount of code in TSCBasics.

### Result:

After that i would also create helper functions for creating temporary files, and maybe start to further investigate what kind of limitations exist to adopt async/await to manifest parsing. As far i can see `Process` also have to be migrated