### PR TITLE
[5.7] set `relatedDependenciesBranch` to `release/5.7`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -569,7 +569,7 @@ let package = Package(
 // this right now.
 
 /// When not using local dependencies, the branch to use for llbuild and TSC repositories.
-let relatedDependenciesBranch = "main"
+let relatedDependenciesBranch = "release/5.7"
 
 if ProcessInfo.processInfo.environment["SWIFTPM_LLBUILD_FWK"] == nil {
     if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {


### PR DESCRIPTION
This allows packages depending on SwiftPM to correctly resolve dependencies.
