### PR TITLE
PackageRegistry: use `parentDirectory` to get the parent directory

### DIFF
--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -878,7 +878,7 @@ fileprivate extension AbsolutePath {
     func withExtension(_ extension: String) -> AbsolutePath {
         guard !self.isRoot else { return self }
         let `extension` = `extension`.spm_dropPrefix(".")
-        return AbsolutePath(self, RelativePath("..")).appending(component: "\(basename).\(`extension`)")
+        return self.parentDirectory.appending(component: "\(basename).\(`extension`)")
     }
 }
 


### PR DESCRIPTION
This uses `parentDirectory` to get the dirname of the path which will
also fix the path construction for Windows.  The construction of the
relative path is normalized and `..` cannot be normalized without an
anchor.
