### PR TITLE
fix an edge case where dependecy resolution can go into endless loop

### DIFF
--- a/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
+++ b/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
@@ -578,7 +578,13 @@ public struct PubgrubDependencyResolver {
             newTerms += priorCause.terms.filter { $0.node != _mostRecentSatisfier.term.node }
 
             if let _difference = difference {
-                newTerms.append(_difference.inverse)
+                // rdar://93335995
+                // do not add the exact inverse of a requirement as it can lead to endless loops
+                if _difference.inverse != mostRecentTerm {
+                    newTerms.append(_difference.inverse)
+                } else {
+                    print("uggg")
+                }
             }
 
             incompatibility = try Incompatibility(

--- a/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
+++ b/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
@@ -583,6 +583,7 @@ public struct PubgrubDependencyResolver {
                 if _difference.inverse != mostRecentTerm {
                     newTerms.append(_difference.inverse)
                 } else {
+                    // FIXME: debug
                     print("uggg")
                 }
             }

--- a/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
+++ b/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
@@ -526,6 +526,11 @@ public struct PubgrubDependencyResolver {
         var incompatibility = conflict
         var createdIncompatibility = false
 
+        // rdar://93335995
+        // hard protection from infinite loops
+        let maxIterations = 1000
+        var iterations: Int = 0
+
         while !isCompleteFailure(incompatibility, root: state.root) {
             var mostRecentTerm: Term?
             var mostRecentSatisfier: Assignment?
@@ -582,9 +587,6 @@ public struct PubgrubDependencyResolver {
                 // do not add the exact inverse of a requirement as it can lead to endless loops
                 if _difference.inverse != mostRecentTerm {
                     newTerms.append(_difference.inverse)
-                } else {
-                    // FIXME: debug
-                    print("uggg")
                 }
             }
 
@@ -601,6 +603,13 @@ public struct PubgrubDependencyResolver {
                 } else {
                     self.delegate?.satisfied(term: term, by: _mostRecentSatisfier, incompatibility: incompatibility)
                 }
+            }
+
+            // rdar://93335995
+            // hard protection from infinite loops
+            iterations = iterations + 1
+            if iterations >= maxIterations {
+                break
             }
         }
 

--- a/Sources/SPMTestSupport/Observability.swift
+++ b/Sources/SPMTestSupport/Observability.swift
@@ -17,8 +17,8 @@ import func XCTest.XCTFail
 import func XCTest.XCTAssertEqual
 
 extension ObservabilitySystem {
-    public static func makeForTesting() -> TestingObservability {
-        let collector = TestingObservability.Collector()
+    public static func makeForTesting(verbose: Bool = true) -> TestingObservability {
+        let collector = TestingObservability.Collector(verbose: verbose)
         let observabilitySystem = ObservabilitySystem(collector)
         return TestingObservability(collector: collector, topScope: observabilitySystem.topScope)
     }
@@ -53,13 +53,18 @@ public struct TestingObservability {
         var diagnosticsHandler: DiagnosticsHandler { return self }
 
         let diagnostics: ThreadSafeArrayStore<Basics.Diagnostic>
+        private let verbose: Bool
 
-        init() {
+        init(verbose: Bool) {
+            self.verbose = verbose
             self.diagnostics = .init()
         }
 
         // TODO: do something useful with scope
         func handleDiagnostic(scope: ObservabilityScope, diagnostic: Basics.Diagnostic) {
+            if self.verbose {
+                print(diagnostic.description)
+            }
             self.diagnostics.append(diagnostic)
         }
 


### PR DESCRIPTION
motivation: reliable dependency resolution

changes:
* before adding a synthesized requirement, check if the negative requirement already exists
* add hard protection from infinite loop 

rdar://93335995

