### PR TITLE
Basics: use `AbsolutePath` to handle paths

### DIFF
--- a/Sources/Basics/VirtualFileSystem.swift
+++ b/Sources/Basics/VirtualFileSystem.swift
@@ -30,11 +30,7 @@ fileprivate enum DirectoryNode: Codable {
         switch self {
         case .directory(let name, _, _): return name
         case .file(let name, _, _, _): return name
-#if os(Windows)
-        case .root(_): return "\\"
-#else
-        case .root(_): return "/"
-#endif
+        case .root(_): return AbsolutePath.root.pathString
         }
     }
 
@@ -136,7 +132,8 @@ public class VirtualFileSystem: FileSystem {
 
     private func findNode(_ path: AbsolutePath, followSymlink: Bool) -> DirectoryNode? {
         var current: DirectoryNode? = self.root
-        for component in path.components.dropFirst() {
+        for component in path.components {
+            if component == AbsolutePath.root.pathString { continue }
             guard followSymlink, current?.isSymlink == false else { return nil }
             current = current?.children.first(where: { $0.name == component })
         }
@@ -187,11 +184,11 @@ public class VirtualFileSystem: FileSystem {
         throw Errors.readOnlyFileSystem
     }
 
-    public var homeDirectory = AbsolutePath("/")
+    public var homeDirectory = AbsolutePath.root
 
     public var cachesDirectory: AbsolutePath? = nil
 
-    public var tempDirectory = AbsolutePath("/")
+    public var tempDirectory = AbsolutePath.root
 
     public func createSymbolicLink(_ path: AbsolutePath, pointingAt destination: AbsolutePath, relative: Bool) throws {
         throw Errors.readOnlyFileSystem


### PR DESCRIPTION
This adjusts the VFS to make sure that it honors the path handling for
the target.  This is required for properly handling Windows paths.