### PR TITLE
Tests: normalize the repository path

### DIFF
--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -670,7 +670,7 @@ private class DummyRepositoryProvider: RepositoryProvider {
         }
 
         // We only support one dummy URL.
-        let basename = repository.location.description.components(separatedBy: "/").last!
+        let basename = repository.url.pathComponents.last!
         if basename != "dummy" {
             throw DummyError.invalidRepository
         }


### PR DESCRIPTION
Use `url` rather than converting the path description to a string and
processing it on a specified path separator.  This will ensure that we
properly handle the path on Windows.