### PR TITLE
Basics: correct time handling

### DIFF
--- a/Sources/Basics/DispatchTimeInterval+Extensions.swift
+++ b/Sources/Basics/DispatchTimeInterval+Extensions.swift
@@ -98,7 +98,9 @@ extension DispatchTimeInterval {
 #if os(Linux) || os(Windows) || os(Android) || os(OpenBSD)
 extension DispatchTime {
     public func distance(to: DispatchTime) -> DispatchTimeInterval {
-        let duration = to.uptimeNanoseconds.subtractingReportingOverflow(self.uptimeNanoseconds).partialValue
+        let final = to.uptimeNanoseconds
+        let point = self.uptimeNanoseconds
+        let duration: Int64 = Int64(bitPattern: final.subtractingReportingOverflow(point).partialValue)
         return .nanoseconds(duration >= Int.max ? Int.max : Int(duration))
     }
 }


### PR DESCRIPTION
We would previously perform a `subtractingReportingOverflow` on the
nanosecond representation of the final time and a given point in time.
Furthermore, the directionality of time was unconsidered, that is, the
subtrahend may be greater than the minuend, which would give us negative
time.  The interface of `DispatchTimeInterval.uptimeNanoseconds` is a
value in `UInt64`.  Consequently, we would perform a difference
operation on `UInt64` values - unsigned values.  When the subtrahend was
greater than the minuend, we would get a value that is a 2s complement
representation of a negative value, which would then be converted to an
`Int` without a `bitPattern:` initializer, resulting in the negative
value being treated as a positive value.  Thus we were converting
negative time into a large positive time.  Explicitly convert the result
into a signed representation to ensure that we provide the correct
result.