### PR TITLE
Upgrade Swift Argument Parser to version 1.1.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -592,7 +592,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         // The 'swift-argument-parser' version declared here must match that
         // used by 'swift-driver' and 'sourcekit-lsp'. Please coordinate
         // dependency version changes here with those projects.
-        .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.0.3")),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.1.2")),
         .package(url: "https://github.com/apple/swift-driver.git", .branch(relatedDependenciesBranch)),
         .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: minimumCryptoVersion)),
         .package(url: "https://github.com/apple/swift-system.git", .upToNextMinor(from: "1.1.1")),


### PR DESCRIPTION
This PR upgrades the Swift Argument Parser dependency to version 1.1.2.

### Motivation:

This is the latest version of the dependency and supports new features like async/await via the `AsyncParsableCommand` type. This dependency must be upgraded in order for packages that depend on both Swift Package Manager and Swift Argument Parser to use these new features of argument parser.

In order to upgrade this dependency, it must also be upgraded in swift-driver and sourcekit-lsp. I will edit this description with links to those PRs after they have been created.

* swift-driver PR [#1106](https://github.com/apple/swift-driver/pull/1106)
* sourcekit-lsp PR (Not yet created)

### Modifications:

The Package.swift file has been updated to use version 1.1.2 of Swift Argument Parser
