### PR TITLE
Tests: adjust slack for concurrency tests

### DIFF
--- a/Tests/BasicsTests/ConcurrencyHelpersTests.swift
+++ b/Tests/BasicsTests/ConcurrencyHelpersTests.swift
@@ -42,7 +42,7 @@ final class ConcurrencyHelpersTest: XCTestCase {
                 }
             }
 
-            switch sync.wait(timeout: .now() + 1) {
+            switch sync.wait(timeout: .now() + .seconds(2)) {
             case .timedOut:
                 XCTFail("timeout")
             case .success:
@@ -72,7 +72,7 @@ final class ConcurrencyHelpersTest: XCTestCase {
                 }
             }
 
-            switch sync.wait(timeout: .now() + 1) {
+            switch sync.wait(timeout: .now() + .seconds(2)) {
             case .timedOut:
                 XCTFail("timeout")
             case .success:
@@ -109,7 +109,7 @@ final class ConcurrencyHelpersTest: XCTestCase {
                 }
             }
 
-            switch sync.wait(timeout: .now() + 1) {
+            switch sync.wait(timeout: .now() + .seconds(2)) {
             case .timedOut:
                 XCTFail("timeout")
             case .success:


### PR DESCRIPTION
The Windows time-slice is in units of 10ms.  This along with the high
contention can cause the concurrency tests to be flakey.  Increase the
timeout some to enable more machines to pass.
