### PR TITLE
Build: mark Windows for supporting link against executable

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -586,7 +586,7 @@ public final class SwiftTargetBuildDescription {
     /// The path to the swiftmodule file after compilation.
     var moduleOutputPath: AbsolutePath {
         // If we're an executable and we're not allowing test targets to link against us, we hide the module.
-        let allowLinkingAgainstExecutables = (buildParameters.triple.isDarwin() || buildParameters.triple.isLinux()) && toolsVersion >= .v5_5
+        let allowLinkingAgainstExecutables = (buildParameters.triple.isDarwin() || buildParameters.triple.isLinux() || buildParameters.triple.isWindows()) && toolsVersion >= .v5_5
         let dirPath = (target.type == .executable && !allowLinkingAgainstExecutables) ? tempsPath : buildParameters.buildPath
         return dirPath.appending(component: target.c99name + ".swiftmodule")
     }

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -101,7 +101,11 @@ class InitTests: XCTestCase {
             XCTAssertBuilds(path)
             let triple = UserToolchain.default.triple
             let binPath = path.appending(components: ".build", triple.platformBuildPathComponent(), "debug")
+#if os(Windows)
+            XCTAssertFileExists(binPath.appending(component: "Foo.exe"))
+#else
             XCTAssertFileExists(binPath.appending(component: "Foo"))
+#endif
             XCTAssertFileExists(binPath.appending(components: "Foo.swiftmodule"))
             #endif
         }


### PR DESCRIPTION
The `-rdynamic` link path works on Windows though requires that there
are exposed symbols.  In such a case, an import library will be emitted
along with the executable to permit the linking.  This marker changes
the location of the swiftmodule emission which enables the last test to
now pass.