### PR TITLE
Avoid emitting a `.info` diagnostic with an empty message when there is no compiler output at all (#5566)

### DIFF
--- a/Sources/Workspace/DefaultPluginScriptRunner.swift
+++ b/Sources/Workspace/DefaultPluginScriptRunner.swift
@@ -318,7 +318,9 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
             completion($0.tryMap { process in
                 // Emit the compiler output as observable info.
                 let compilerOutput = ((try? process.utf8Output()) ?? "") + ((try? process.utf8stderrOutput()) ?? "")
-                observabilityScope.emit(info: compilerOutput)
+                if !compilerOutput.isEmpty {
+                    observabilityScope.emit(info: compilerOutput)
+                }
 
                 // Save the persisted compilation state for possible reuse next time.
                 let compilationState = PersistedCompilationState(

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -441,6 +441,11 @@ class PluginTests: XCTestCase {
                 catch {
                     XCTFail("error \(String(describing: error))", file: file, line: line)
                 }
+                
+                // Check that we didn't end up with any completely empty diagnostics.
+                XCTAssertNil(observability.diagnostics.first{ $0.message.isEmpty })
+
+                // Invoke the diagnostics checker for the plugin output.
                 testDiagnostics(delegate.diagnostics, problemsOnly: false, file: file, line: line, handler: diagnosticsChecker)
             }
 


### PR DESCRIPTION
This is a 5.7 cherry-pick of #5566.

rdar://94414151

(cherry picked from commit e22ea16cf2c3e0820f33c1f8ed54ce468acad101)
