### PR TITLE
refactor stream output and progress bars (part 1)

### DIFF
--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -298,7 +298,6 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
             fileSystem: self.fileSystem
         )
 
-
         // Surface any diagnostics from build tool plugins.
         for (target, results) in buildToolPluginInvocationResults {
             // There is one result for each plugin that gets applied to a target.

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -101,7 +101,7 @@ private class ToolWorkspaceDelegate: WorkspaceDelegate {
     }
 
     func fetchingPackage(package: PackageIdentity, packageLocation: String?, progress: Int64, total: Int64?) {
-       let (step, total, packages) = self.fetchProgressLock.withLock {
+        let (step, total, packages) = self.fetchProgressLock.withLock { () -> (Int64, Int64, String) in
             self.fetchProgress[package] = FetchProgress(
                 progress: progress,
                 total: total ?? progress
@@ -110,7 +110,7 @@ private class ToolWorkspaceDelegate: WorkspaceDelegate {
             let progress = self.fetchProgress.values.reduce(0) { $0 + $1.progress }
             let total = self.fetchProgress.values.reduce(0) { $0 + $1.total }
             let packages = self.fetchProgress.keys.map { $0.description }.joined(separator: ", ")
-           return (progress, total, packages)
+            return (progress, total, packages)
         }
         self.progressHandler(step, total, "Fetching \(packages)")
     }
@@ -175,7 +175,7 @@ private class ToolWorkspaceDelegate: WorkspaceDelegate {
     }
 
     func downloadingBinaryArtifact(from url: String, bytesDownloaded: Int64, totalBytesToDownload: Int64?) {
-        let (step, total, artifacts) = self.binaryDownloadProgressLock.withLock {
+        let (step, total, artifacts) = self.binaryDownloadProgressLock.withLock { () -> (Int64, Int64, String) in
             self.binaryDownloadProgress[url] = DownloadProgress(
                 bytesDownloaded: bytesDownloaded,
                 totalBytesToDownload: totalBytesToDownload ?? bytesDownloaded

--- a/Tests/CommandsTests/SwiftToolTests.swift
+++ b/Tests/CommandsTests/SwiftToolTests.swift
@@ -31,6 +31,8 @@ final class SwiftToolTests: CommandsTestCase {
                 tool.observabilityScope.emit(info: "info")
                 tool.observabilityScope.emit(debug: "debug")
 
+                tool.waitForObservabilityEvents(timeout: .now() + .seconds(1))
+
                 XCTAssertMatch(outputStream.bytes.validDescription, .contains("error: error"))
                 XCTAssertMatch(outputStream.bytes.validDescription, .contains("warning: warning"))
                 XCTAssertNoMatch(outputStream.bytes.validDescription, .contains("info: info"))
@@ -47,6 +49,8 @@ final class SwiftToolTests: CommandsTestCase {
                 tool.observabilityScope.emit(warning: "warning")
                 tool.observabilityScope.emit(info: "info")
                 tool.observabilityScope.emit(debug: "debug")
+
+                tool.waitForObservabilityEvents(timeout: .now() + .seconds(1))
 
                 XCTAssertMatch(outputStream.bytes.validDescription, .contains("error: error"))
                 XCTAssertMatch(outputStream.bytes.validDescription, .contains("warning: warning"))
@@ -65,6 +69,8 @@ final class SwiftToolTests: CommandsTestCase {
                 tool.observabilityScope.emit(info: "info")
                 tool.observabilityScope.emit(debug: "debug")
 
+                tool.waitForObservabilityEvents(timeout: .now() + .seconds(1))
+
                 XCTAssertMatch(outputStream.bytes.validDescription, .contains("error: error"))
                 XCTAssertMatch(outputStream.bytes.validDescription, .contains("warning: warning"))
                 XCTAssertMatch(outputStream.bytes.validDescription, .contains("info: info"))
@@ -82,6 +88,8 @@ final class SwiftToolTests: CommandsTestCase {
                 tool.observabilityScope.emit(info: "info")
                 tool.observabilityScope.emit(debug: "debug")
 
+                tool.waitForObservabilityEvents(timeout: .now() + .seconds(1))
+
                 XCTAssertMatch(outputStream.bytes.validDescription, .contains("error: error"))
                 XCTAssertMatch(outputStream.bytes.validDescription, .contains("warning: warning"))
                 XCTAssertMatch(outputStream.bytes.validDescription, .contains("info: info"))
@@ -98,6 +106,8 @@ final class SwiftToolTests: CommandsTestCase {
                 tool.observabilityScope.emit(warning: "warning")
                 tool.observabilityScope.emit(info: "info")
                 tool.observabilityScope.emit(debug: "debug")
+
+                tool.waitForObservabilityEvents(timeout: .now() + .seconds(1))
 
                 XCTAssertMatch(outputStream.bytes.validDescription, .contains("error: error"))
                 XCTAssertMatch(outputStream.bytes.validDescription, .contains("warning: warning"))


### PR DESCRIPTION
motivation: continue cleanup work, fixing issues when diagnositics output ay interleave with delegates writing directly to the output or reportig progress

changes:
* change ToolWorkspaceDelegate to use provided  output and progress handlers instead of wirting to OutputStream directly
* add print and progress handlers to SwiftToolObservabilityHandler, including a serial queue to maange the sequence of outputing to the output stream
* adjust tests to wait on diagnostics when necessary given the queue setup

