### PR TITLE
Allow duplicate automatic library product names when module aliasing is used.

### DIFF
--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -556,6 +556,10 @@ private func createResolvedPackages(
             }
         }
     }
+
+    if moduleAliasingUsed {
+        productList.filter{ $0.isStaticLibrary }.forEach { $0.useIDAsName() }
+    }
     return try packageBuilders.map{ try $0.construct() }
 }
 

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -399,7 +399,7 @@ private func createResolvedPackages(
 
         // There are no shared dirs/files created for automatic library products, so look
         // up duplicates with the ID property for those products.
-        let staticLibProducts = productList
+        let autoLibProducts = productList
             .filter{ $0.isDefaultLibrary }
             .spm_findDuplicateElements(by: \.ID)
             .map({ $0[0] })
@@ -413,7 +413,7 @@ private func createResolvedPackages(
             .spm_findDuplicateElements(by: \.name)
             .map({ $0[0] })
 
-        let allProducts = staticLibProducts + otherProducts
+        let allProducts = autoLibProducts + otherProducts
         // Emit diagnostics for duplicate products.
         for dupProduct in allProducts {
             let packages = packageBuilders
@@ -423,10 +423,10 @@ private func createResolvedPackages(
             observabilityScope.emit(PackageGraphError.duplicateProduct(product: dupProduct.name, packages: packages))
         }
         // Remove the duplicate products from the builders.
-        let staticLibProductIDs = staticLibProducts.map{ $0.ID }
+        let autoLibProductIDs = autoLibProducts.map{ $0.ID }
         let otherProductNames = otherProducts.map{ $0.name }
         for packageBuilder in packageBuilders {
-            packageBuilder.products = packageBuilder.products.filter { $0.product.isDefaultLibrary ? !staticLibProductIDs.contains($0.product.ID) : !otherProductNames.contains($0.product.name) }
+            packageBuilder.products = packageBuilder.products.filter { $0.product.isDefaultLibrary ? !autoLibProductIDs.contains($0.product.ID) : !otherProductNames.contains($0.product.name) }
         }
     } else {
         let duplicateProducts = productList

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -731,7 +731,7 @@ public final class PackageBuilder {
         }
 
         // Check for duplicate target dependencies
-        dependencies.spm_findDuplicateElements(by: \.nameAndType).map(\.[0].name).forEach {
+        dependencies.filter{$0.product?.moduleAliases == nil}.spm_findDuplicateElements(by: \.nameAndType).map(\.[0].name).forEach {
             self.observabilityScope.emit(.duplicateTargetDependency(dependency: $0, target: potentialModule.name, package: self.identity.description))
         }
 
@@ -1070,7 +1070,7 @@ public final class PackageBuilder {
         // If enabled, create one test product for each test target.
         if self.shouldCreateMultipleTestProducts {
             for testTarget in testModules {
-                let product = try Product(name: testTarget.name, type: .test, targets: [testTarget])
+                let product = try Product(package: self.identity, name: testTarget.name, type: .test, targets: [testTarget])
                 append(product)
             }
         } else if !testModules.isEmpty {
@@ -1083,7 +1083,7 @@ public final class PackageBuilder {
             let productName = self.manifest.displayName + "PackageTests"
             let testManifest = try self.findTestManifest(in: testModules)
 
-            let product = try Product(name: productName, type: .test, targets: testModules, testManifest: testManifest)
+            let product = try Product(package: self.identity, name: productName, type: .test, targets: testModules, testManifest: testManifest)
             append(product)
         }
 
@@ -1140,7 +1140,7 @@ public final class PackageBuilder {
                 }
             }
 
-            try append(Product(name: product.name, type: product.type, targets: targets))
+            try append(Product(package: self.identity, name: product.name, type: product.type, targets: targets))
         }
 
         // Add implicit executables - for root packages and for dependency plugins.
@@ -1184,7 +1184,7 @@ public final class PackageBuilder {
             } else {
                 if self.manifest.packageKind.isRoot || implicitPlugInExecutables.contains(target.name) {
                     // Generate an implicit product for the executable target
-                    let product = try Product(name: target.name, type: .executable, targets: [target])
+                    let product = try Product(package: self.identity, name: target.name, type: .executable, targets: [target])
                     append(product)
                 }
             }
@@ -1198,6 +1198,7 @@ public final class PackageBuilder {
                 self.observabilityScope.emit(.noLibraryTargetsForREPL)
             } else {
                 let replProduct = try Product(
+                    package: self.identity,
                     name: self.identity.description + Product.replProductSuffix,
                     type: .library(.dynamic),
                     targets: libraryTargets
@@ -1209,7 +1210,7 @@ public final class PackageBuilder {
         // Create implicit snippet products
         try targets
             .filter { $0.type == .snippet }
-            .map { try Product(name: $0.name, type: .snippet, targets: [$0]) }
+            .map { try Product(package: self.identity, name: $0.name, type: .snippet, targets: [$0]) }
             .forEach(append)
 
         return products.map{ $0.item }

--- a/Sources/PackageModel/Product.swift
+++ b/Sources/PackageModel/Product.swift
@@ -19,6 +19,9 @@ public class Product: Codable {
     /// The name of the product.
     public let name: String
 
+    /// Fully qualified name for this product: package ID + name of this product
+    public let ID: String
+
     /// The type of product to create.
     public let type: ProductType
 
@@ -35,7 +38,7 @@ public class Product: Codable {
     /// The suffix for REPL product name.
     public static let replProductSuffix: String = "__REPL"
 
-    public init(name: String, type: ProductType, targets: [Target], testManifest: AbsolutePath? = nil) throws {
+    public init(package: PackageIdentity, name: String, type: ProductType, targets: [Target], testManifest: AbsolutePath? = nil) throws {
         guard !targets.isEmpty else {
             throw InternalError("Targets cannot be empty")
         }
@@ -51,6 +54,7 @@ public class Product: Codable {
         }
         self.name = name
         self.type = type
+        self.ID = package.description.lowercased() + "_" + name
         self._targets = .init(wrappedValue: targets)
         self.testManifest = testManifest
     }

--- a/Sources/PackageModel/Product.swift
+++ b/Sources/PackageModel/Product.swift
@@ -17,7 +17,7 @@ import struct TSCUtility.PolymorphicCodableArray
 
 public class Product: Codable {
     /// The name of the product.
-    public let name: String
+    public private(set) var name: String
 
     /// Fully qualified name for this product: package ID + name of this product
     public let ID: String
@@ -57,6 +57,10 @@ public class Product: Codable {
         self.ID = package.description.lowercased() + "_" + name
         self._targets = .init(wrappedValue: targets)
         self.testManifest = testManifest
+    }
+
+    public func useIDAsName() {
+        name = ID
     }
 }
 

--- a/Sources/PackageModel/Product.swift
+++ b/Sources/PackageModel/Product.swift
@@ -17,7 +17,7 @@ import struct TSCUtility.PolymorphicCodableArray
 
 public class Product: Codable {
     /// The name of the product.
-    public private(set) var name: String
+    public let name: String
 
     /// Fully qualified name for this product: package ID + name of this product
     public let ID: String
@@ -57,10 +57,6 @@ public class Product: Codable {
         self.ID = package.description.lowercased() + "_" + name
         self._targets = .init(wrappedValue: targets)
         self.testManifest = testManifest
-    }
-
-    public func useIDAsName() {
-        name = ID
     }
 }
 

--- a/Sources/PackageModel/Target.swift
+++ b/Sources/PackageModel/Target.swift
@@ -49,6 +49,15 @@ public class Target: PolymorphicCodableProtocol {
         /// becomes the name of its .swiftmodule binary.
         public let moduleAliases: [String: String]?
 
+        /// Fully qualified name for this product dependency: package ID + name of the product
+        public var ID: String {
+            if let pkg = package {
+                return pkg.lowercased() + "_" + name
+            }
+            // package ID won't be included for products referenced only by name
+            return name
+        }
+
         /// Creates a product reference instance.
         public init(name: String, package: String?, moduleAliases: [String: String]? = nil) {
             self.name = name

--- a/Tests/BuildTests/ModuleAliasingBuildTests.swift
+++ b/Tests/BuildTests/ModuleAliasingBuildTests.swift
@@ -276,10 +276,12 @@ final class ModuleAliasingBuildTests: XCTestCase {
         ))
         result.checkProductsCount(2)
         result.checkTargetsCount(3)
-        let dylib = try result.buildProduct(for: "Logging")
-        XCTAssertTrue(dylib.binary.basename == "libLogging.dylib" && dylib.package.identity.description == "barpkg")
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil })
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "BarLogging" && $0.target.moduleAliases?["Logging"] == "BarLogging" })
+        #if os(macOS)
+        let dylib = try result.buildProduct(for: "Logging")
+        XCTAssertTrue(dylib.binary.basename == "libLogging.dylib" && dylib.package.identity.description == "barpkg")
+        #endif
     }
 
     func testModuleAliasingDuplicateProductNamesUpstream() throws {
@@ -375,12 +377,14 @@ final class ModuleAliasingBuildTests: XCTestCase {
         ))
         result.checkProductsCount(4)
         result.checkTargetsCount(5)
-        let dylib = try result.buildProduct(for: "Logging")
-        XCTAssertTrue(dylib.binary.basename == "libLogging.dylib" && dylib.package.identity.description == "xpkg")
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "ALogging" && $0.target.moduleAliases?["Logging"] == "ALogging" })
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "A" && $0.target.moduleAliases?["Logging"] == "ALogging" })
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil })
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "B" && $0.target.moduleAliases == nil })
+        #if os(macOS)
+        let dylib = try result.buildProduct(for: "Logging")
+        XCTAssertTrue(dylib.binary.basename == "libLogging.dylib" && dylib.package.identity.description == "xpkg")
+        #endif
     }
 
     func testModuleAliasingDirectDeps() throws {
@@ -1287,7 +1291,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ],
                     targets: [
                         TargetDescription(name: "A",
-                                          dependencies: [ //"Utils",
+                                          dependencies: [
                                             .product(name: "G",
                                                      package: "gPkg"),
                                             .product(name: "B",

--- a/Tests/BuildTests/ModuleAliasingBuildTests.swift
+++ b/Tests/BuildTests/ModuleAliasingBuildTests.swift
@@ -218,7 +218,61 @@ final class ModuleAliasingBuildTests: XCTestCase {
         }
     }
 
-    func testModuleAliasingDuplicateProductNamesWithDifferentTypes() throws {
+    func testModuleAliasingDuplicateDylibStaticLibProductNames() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+                                        "/thisPkg/Sources/exe/main.swift",
+                                    "/fooPkg/Sources/Logging/fileLogging.swift",
+                                    "/barPkg/Sources/Logging/fileLogging.swift"
+        )
+        let observability = ObservabilitySystem.makeForTesting()
+        let _ = try loadPackageGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createFileSystemManifest(
+                    name: "fooPkg",
+                    path: .init("/fooPkg"),
+                    products: [
+                        ProductDescription(name: "Logging", type: .library(.dynamic), targets: ["Logging"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "Logging", dependencies: []),
+                    ]),
+                Manifest.createFileSystemManifest(
+                    name: "barPkg",
+                    path: .init("/barPkg"),
+                    products: [
+                        ProductDescription(name: "Logging", type: .library(.static), targets: ["Logging"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "Logging", dependencies: []),
+                    ]),
+                Manifest.createRootManifest(
+                    name: "thisPkg",
+                    path: .init("/thisPkg"),
+                    dependencies: [
+                        .localSourceControl(path: .init("/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init("/barPkg"), requirement: .upToNextMajor(from: "2.0.0")),
+                    ],
+                    targets: [
+                        TargetDescription(name: "exe",
+                                          dependencies: [.product(name: "Logging",
+                                                                  package: "fooPkg"
+                                                                 ),
+                                                         .product(name: "Logging",
+                                                                  package: "barPkg",
+                                                                  moduleAliases: ["Logging": "BarLogging"]
+                                                                 )
+                                          ]),
+                    ]),
+            ],
+            observabilityScope: observability.topScope
+        )
+        testDiagnostics(observability.diagnostics) { result in
+            result.check(diagnostic: .contains("multiple products named 'Logging' in: 'barpkg', 'foopkg'"), severity: .error)
+        }
+    }
+
+    func testModuleAliasingDuplicateDylibAutomaticProductNames() throws {
         let fs = InMemoryFileSystem(emptyFiles:
                                         "/thisPkg/Sources/exe/main.swift",
                                     "/fooPkg/Sources/Logging/fileLogging.swift",
@@ -247,6 +301,63 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     targets: [
                         TargetDescription(name: "Logging", dependencies: []),
                     ]),
+                Manifest.createRootManifest(
+                    name: "thisPkg",
+                    path: .init("/thisPkg"),
+                    dependencies: [
+                        .localSourceControl(path: .init("/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init("/barPkg"), requirement: .upToNextMajor(from: "2.0.0")),
+                    ],
+                    targets: [
+                        TargetDescription(name: "exe",
+                                          dependencies: [.product(name: "Logging",
+                                                                  package: "fooPkg"
+                                                                 ),
+                                                         .product(name: "Logging",
+                                                                  package: "barPkg",
+                                                                  moduleAliases: ["Logging": "BarLogging"]
+                                                                 ),
+                                          ]),
+                    ]),
+            ],
+            observabilityScope: observability.topScope
+        )
+        XCTAssertNoDiagnostics(observability.diagnostics)
+        let result = try BuildPlanResult(plan: try BuildPlan(
+            buildParameters: mockBuildParameters(shouldLinkStaticSwiftStdlib: true),
+            graph: graph,
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        ))
+        result.checkProductsCount(2)
+        result.checkTargetsCount(3)
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "BarLogging" && $0.target.moduleAliases?["Logging"] == "BarLogging" })
+        #if os(macOS)
+        let dylib = try result.buildProduct(for: "Logging")
+        XCTAssertTrue(dylib.binary.basename == "libLogging.dylib" && dylib.package.identity.description == "barpkg")
+        #endif
+    }
+
+    func testModuleAliasingDuplicateStaticLibAutomaticProductNames() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+                                        "/thisPkg/Sources/exe/main.swift",
+                                    "/fooPkg/Sources/Logging/fileLogging.swift",
+                                    "/bazPkg/Sources/Logging/fileLogging.swift"
+        )
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createFileSystemManifest(
+                    name: "fooPkg",
+                    path: .init("/fooPkg"),
+                    products: [
+                        ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "Logging", dependencies: []),
+                    ]),
                 Manifest.createFileSystemManifest(
                     name: "bazPkg",
                     path: .init("/bazPkg"),
@@ -261,18 +372,12 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     path: .init("/thisPkg"),
                     dependencies: [
                         .localSourceControl(path: .init("/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/barPkg"), requirement: .upToNextMajor(from: "2.0.0")),
                         .localSourceControl(path: .init("/bazPkg"), requirement: .upToNextMajor(from: "2.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe",
                                           dependencies: [.product(name: "Logging",
-                                                                  package: "fooPkg",
-                                                                  moduleAliases: ["Logging": "FooLogging"]
-                                                                 ),
-                                                         .product(name: "Logging",
-                                                                  package: "barPkg",
-                                                                  moduleAliases: ["Logging": "BarLogging"]
+                                                                  package: "fooPkg"
                                                                  ),
                                                          .product(name: "Logging",
                                                                   package: "bazPkg",
@@ -291,16 +396,13 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             observabilityScope: observability.topScope
         ))
-        result.checkProductsCount(3)
-        result.checkTargetsCount(4)
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "FooLogging" && $0.target.moduleAliases?["Logging"] == "FooLogging" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "BarLogging" && $0.target.moduleAliases?["Logging"] == "BarLogging" })
+        result.checkProductsCount(2)
+        result.checkTargetsCount(3)
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil })
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "BazLogging" && $0.target.moduleAliases?["Logging"] == "BazLogging" })
         #if os(macOS)
-        let dylib = try result.buildProduct(for: "Logging")
-        XCTAssertTrue(dylib.binary.basename == "libLogging.dylib" && dylib.package.identity.description == "barpkg")
-        let staticlib = try result.buildProduct(for: "bazpkg_Logging")
-        XCTAssertTrue(staticlib.binary.basename == "libbazpkg_Logging.a" && staticlib.package.identity.description == "bazpkg")
+        let staticlib = try result.buildProduct(for: "Logging")
+        XCTAssertTrue(staticlib.binary.basename == "libLogging.a" && staticlib.package.identity.description == "bazpkg")
         #endif
     }
 

--- a/Tests/BuildTests/ModuleAliasingBuildTests.swift
+++ b/Tests/BuildTests/ModuleAliasingBuildTests.swift
@@ -102,6 +102,287 @@ final class ModuleAliasingBuildTests: XCTestCase {
         }
     }
 
+    func testModuleAliasingDuplicateProductNames() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+                                        "/thisPkg/Sources/exe/main.swift",
+                                    "/fooPkg/Sources/Logging/fileLogging.swift",
+                                    "/barPkg/Sources/Logging/fileLogging.swift"
+        )
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createFileSystemManifest(
+                    name: "fooPkg",
+                    path: .init("/fooPkg"),
+                    products: [
+                        ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "Logging", dependencies: []),
+                    ]),
+                Manifest.createFileSystemManifest(
+                    name: "barPkg",
+                    path: .init("/barPkg"),
+                    products: [
+                        ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "Logging", dependencies: []),
+                    ]),
+                Manifest.createRootManifest(
+                    name: "thisPkg",
+                    path: .init("/thisPkg"),
+                    dependencies: [
+                        .localSourceControl(path: .init("/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init("/barPkg"), requirement: .upToNextMajor(from: "2.0.0")),
+                    ],
+                    targets: [
+                        TargetDescription(name: "exe",
+                                          dependencies: [.product(name: "Logging",
+                                                                  package: "fooPkg"
+                                                                 ),
+                                                         .product(name: "Logging",
+                                                                  package: "barPkg",
+                                                                  moduleAliases: ["Logging": "BarLogging"]
+                                                                 )
+                                          ]),
+                    ]),
+            ],
+            observabilityScope: observability.topScope
+        )
+        XCTAssertNoDiagnostics(observability.diagnostics)
+        let result = try BuildPlanResult(plan: try BuildPlan(
+            buildParameters: mockBuildParameters(shouldLinkStaticSwiftStdlib: true),
+            graph: graph,
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        ))
+        result.checkProductsCount(1)
+        result.checkTargetsCount(3)
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "BarLogging" && $0.target.moduleAliases?["Logging"] == "BarLogging" })
+    }
+
+    func testModuleAliasingDuplicateDylibProductNames() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+                                        "/thisPkg/Sources/exe/main.swift",
+                                    "/fooPkg/Sources/Logging/fileLogging.swift",
+                                    "/barPkg/Sources/Logging/fileLogging.swift"
+        )
+        let observability = ObservabilitySystem.makeForTesting()
+        let _ = try loadPackageGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createFileSystemManifest(
+                    name: "fooPkg",
+                    path: .init("/fooPkg"),
+                    products: [
+                        ProductDescription(name: "Logging", type: .library(.dynamic), targets: ["Logging"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "Logging", dependencies: []),
+                    ]),
+                Manifest.createFileSystemManifest(
+                    name: "barPkg",
+                    path: .init("/barPkg"),
+                    products: [
+                        ProductDescription(name: "Logging", type: .library(.dynamic), targets: ["Logging"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "Logging", dependencies: []),
+                    ]),
+                Manifest.createRootManifest(
+                    name: "thisPkg",
+                    path: .init("/thisPkg"),
+                    dependencies: [
+                        .localSourceControl(path: .init("/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init("/barPkg"), requirement: .upToNextMajor(from: "2.0.0")),
+                    ],
+                    targets: [
+                        TargetDescription(name: "exe",
+                                          dependencies: [.product(name: "Logging",
+                                                                  package: "fooPkg"
+                                                                 ),
+                                                         .product(name: "Logging",
+                                                                  package: "barPkg",
+                                                                  moduleAliases: ["Logging": "BarLogging"]
+                                                                 )
+                                          ]),
+                    ]),
+            ],
+            observabilityScope: observability.topScope
+        )
+        testDiagnostics(observability.diagnostics) { result in
+            result.check(diagnostic: .contains("multiple products named 'Logging' in: 'barpkg', 'foopkg'"), severity: .error)
+        }
+    }
+
+    func testModuleAliasingDuplicateProductNamesWithDifferentTypes() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+                                        "/thisPkg/Sources/exe/main.swift",
+                                    "/fooPkg/Sources/Logging/fileLogging.swift",
+                                    "/barPkg/Sources/Logging/fileLogging.swift"
+        )
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createFileSystemManifest(
+                    name: "fooPkg",
+                    path: .init("/fooPkg"),
+                    products: [
+                        ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "Logging", dependencies: []),
+                    ]),
+                Manifest.createFileSystemManifest(
+                    name: "barPkg",
+                    path: .init("/barPkg"),
+                    products: [
+                        ProductDescription(name: "Logging", type: .library(.dynamic), targets: ["Logging"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "Logging", dependencies: []),
+                    ]),
+                Manifest.createRootManifest(
+                    name: "thisPkg",
+                    path: .init("/thisPkg"),
+                    dependencies: [
+                        .localSourceControl(path: .init("/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init("/barPkg"), requirement: .upToNextMajor(from: "2.0.0")),
+                    ],
+                    targets: [
+                        TargetDescription(name: "exe",
+                                          dependencies: [.product(name: "Logging",
+                                                                  package: "fooPkg"
+                                                                 ),
+                                                         .product(name: "Logging",
+                                                                  package: "barPkg",
+                                                                  moduleAliases: ["Logging": "BarLogging"]
+                                                                 )
+                                          ]),
+                    ]),
+            ],
+            observabilityScope: observability.topScope
+        )
+        XCTAssertNoDiagnostics(observability.diagnostics)
+        let result = try BuildPlanResult(plan: try BuildPlan(
+            buildParameters: mockBuildParameters(shouldLinkStaticSwiftStdlib: true),
+            graph: graph,
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        ))
+        result.checkProductsCount(2)
+        result.checkTargetsCount(3)
+        let dylib = try result.buildProduct(for: "Logging")
+        XCTAssertTrue(dylib.binary.basename == "libLogging.dylib" && dylib.package.identity.description == "barpkg")
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "BarLogging" && $0.target.moduleAliases?["Logging"] == "BarLogging" })
+    }
+
+    func testModuleAliasingDuplicateProductNamesUpstream() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+                                        "/thisPkg/Sources/exe/main.swift",
+                                    "/aPkg/Sources/A/file.swift",
+                                    "/xPkg/Sources/Logging/fileLogging.swift",
+                                    "/bPkg/Sources/B/file.swift",
+                                    "/yPkg/Sources/Logging/fileLogging.swift"
+        )
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createFileSystemManifest(
+                name: "xPkg",
+                path: .init("/xPkg"),
+                products: [
+                    ProductDescription(name: "Logging", type: .library(.dynamic), targets: ["Logging"]),
+                ],
+                targets: [
+                    TargetDescription(name: "Logging",
+                                      dependencies: []),
+                ]),
+                Manifest.createFileSystemManifest(
+                    name: "yPkg",
+                    path: .init("/yPkg"),
+                    products: [
+                        ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "Logging",
+                                          dependencies: []),
+
+                    ]),
+                Manifest.createFileSystemManifest(
+                    name: "aPkg",
+                    path: .init("/aPkg"),
+                    dependencies: [
+                        .localSourceControl(path: .init("/xPkg"), requirement: .upToNextMajor(from: "1.0.0"))
+                    ],
+                    products: [
+                        ProductDescription(name: "A", type: .library(.dynamic), targets: ["A"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "A",
+                                          dependencies: [
+                                            .product(name: "Logging", package: "xPkg")
+                                          ]),
+                    ]),
+                Manifest.createFileSystemManifest(
+                    name: "bPkg",
+                    path: .init("/bPkg"),
+                    dependencies: [
+                        .localSourceControl(path: .init("/yPkg"), requirement: .upToNextMajor(from: "1.0.0"))
+                    ],
+                    products: [
+                        ProductDescription(name: "B", type: .library(.dynamic), targets: ["B"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "B",
+                                          dependencies: [
+                                            .product(name: "Logging", package: "yPkg")
+                                          ]),
+                    ]),
+                Manifest.createRootManifest(
+                    name: "thisPkg",
+                    path: .init("/thisPkg"),
+                    dependencies: [
+                        .localSourceControl(path: .init("/aPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init("/bPkg"), requirement: .upToNextMajor(from: "2.0.0")),
+                    ],
+                    targets: [
+                        TargetDescription(name: "exe",
+                                          dependencies: [.product(name: "A",
+                                                                  package: "aPkg",
+                                                                  moduleAliases: ["Logging": "ALogging"]
+                                                                 ),
+                                                         .product(name: "B",
+                                                                  package: "bPkg"
+                                                                 )
+                                          ]),
+                    ]),
+            ],
+            observabilityScope: observability.topScope
+        )
+        XCTAssertNoDiagnostics(observability.diagnostics)
+        let result = try BuildPlanResult(plan: try BuildPlan(
+            buildParameters: mockBuildParameters(shouldLinkStaticSwiftStdlib: true),
+            graph: graph,
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        ))
+        result.checkProductsCount(4)
+        result.checkTargetsCount(5)
+        let dylib = try result.buildProduct(for: "Logging")
+        XCTAssertTrue(dylib.binary.basename == "libLogging.dylib" && dylib.package.identity.description == "xpkg")
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "ALogging" && $0.target.moduleAliases?["Logging"] == "ALogging" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "A" && $0.target.moduleAliases?["Logging"] == "ALogging" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "B" && $0.target.moduleAliases == nil })
+    }
+
     func testModuleAliasingDirectDeps() throws {
         let fs = InMemoryFileSystem(emptyFiles:
                                         "/thisPkg/Sources/exe/main.swift",
@@ -118,7 +399,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     name: "fooPkg",
                     path: .init("/fooPkg"),
                     products: [
-                        ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Logging"]),
+                        ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
                     ],
                     targets: [
                         TargetDescription(name: "Logging", dependencies: []),
@@ -127,7 +408,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     name: "barPkg",
                     path: .init("/barPkg"),
                     products: [
-                        ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Logging"]),
+                        ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
                     ],
                     targets: [
                         TargetDescription(name: "Logging", dependencies: []),
@@ -142,11 +423,11 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     targets: [
                         TargetDescription(name: "exe",
                                           dependencies: ["Logging",
-                                                         .product(name: "Foo",
+                                                         .product(name: "Logging",
                                                                   package: "fooPkg",
                                                                   moduleAliases: ["Logging": "FooLogging"]
                                                                  ),
-                                                         .product(name: "Bar",
+                                                         .product(name: "Logging",
                                                                   package: "barPkg",
                                                                   moduleAliases: ["Logging": "BarLogging"]
                                                                  )


### PR DESCRIPTION
This change is for automatic library products only. No product names are altered.
Add an ID property to Product and ProductReference: combine package ID and product name to make it fully qualified.
Pass packageID to Product/Reference initializers.
Use product IDs to look up duplicates if the product is an automatic library type. 
Use product IDs to compute aliasing related logic in ModuleAliasTracker.
Resolves rdar://89836609.
