### PR TITLE
Adjust SwiftPM 5.7 to minimum supported deployment target changes

### DIFF
--- a/Sources/PackageDescription/SupportedPlatforms.swift
+++ b/Sources/PackageDescription/SupportedPlatforms.swift
@@ -274,16 +274,19 @@ extension SupportedPlatform {
         /// The value that represents macOS 10.10.
         ///
         /// - Since: First available in PackageDescription 5.0.
+        @available(_PackageDescription, deprecated: 5.7, message: "macOS 10.13 is the oldest supported version")
         public static let v10_10: MacOSVersion = .init(string: "10.10")
 
         /// The value that represents macOS 10.11.
         ///
         /// - Since: First available in PackageDescription 5.0.
+        @available(_PackageDescription, deprecated: 5.7, message: "macOS 10.13 is the oldest supported version")
         public static let v10_11: MacOSVersion = .init(string: "10.11")
 
         /// The value that represents macOS 10.12.
         ///
         /// - Since: First available in PackageDescription 5.0.
+        @available(_PackageDescription, deprecated: 5.7, message: "macOS 10.13 is the oldest supported version")
         public static let v10_12: MacOSVersion = .init(string: "10.12")
 
         /// The value that represents macOS 10.13.
@@ -339,11 +342,13 @@ extension SupportedPlatform {
         /// The value that represents tvOS 9.0.
         ///
         /// - Since: First available in PackageDescription 5.0.
+        @available(_PackageDescription, deprecated: 5.7, message: "tvOS 11.0 is the oldest supported version")
         public static let v9: TVOSVersion = .init(string: "9.0")
 
         /// The value that represents tvOS 10.0.
         ///
         /// - Since: First available in PackageDescription 5.0.
+        @available(_PackageDescription, deprecated: 5.7, message: "tvOS 11.0 is the oldest supported version")
         public static let v10: TVOSVersion = .init(string: "10.0")
 
         /// The value that represents tvOS 11.0.
@@ -433,16 +438,19 @@ extension SupportedPlatform {
         /// The value that represents iOS 8.0.
         ///
         /// - Since: First available in PackageDescription 5.0.
+        @available(_PackageDescription, deprecated: 5.7, message: "iOS 11.0 is the oldest supported version")
         public static let v8: IOSVersion = .init(string: "8.0")
 
         /// The value that represents iOS 9.0.
         ///
         /// - Since: First available in PackageDescription 5.0.
+        @available(_PackageDescription, deprecated: 5.7, message: "iOS 11.0 is the oldest supported version")
         public static let v9: IOSVersion = .init(string: "9.0")
 
         /// The value that represents iOS 10.0.
         ///
         /// - Since: First available in PackageDescription 5.0.
+        @available(_PackageDescription, deprecated: 5.7, message: "iOS 11.0 is the oldest supported version")
         public static let v10: IOSVersion = .init(string: "10.0")
 
         /// The value that represents iOS 11.0.
@@ -495,11 +503,13 @@ extension SupportedPlatform {
         /// The value that represents watchOS 2.0.
         ///
         /// - Since: First available in PackageDescription 5.0.
+        @available(_PackageDescription, deprecated: 5.7, message: "watchOS 4.0 is the oldest supported version")
         public static let v2: WatchOSVersion = .init(string: "2.0")
 
         /// The value that represents watchOS 3.0.
         ///
         /// - Since: First available in PackageDescription 5.0.
+        @available(_PackageDescription, deprecated: 5.7, message: "watchOS 4.0 is the oldest supported version")
         public static let v3: WatchOSVersion = .init(string: "3.0")
 
         /// The value that represents watchOS 4.0.

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -599,6 +599,11 @@ private func computePlatforms(
             version = xcTestMinimumDeploymentTarget
         }
 
+        // If the declared version is smaller than the oldest supported one, we raise the derived version to that.
+        if version < declaredPlatform.oldestSupportedVersion {
+            version = declaredPlatform.oldestSupportedVersion
+        }
+
         let supportedPlatform = SupportedPlatform(
             platform: declaredPlatform,
             version: version,

--- a/Sources/PackageModel/Platform.swift
+++ b/Sources/PackageModel/Platform.swift
@@ -31,11 +31,11 @@ public struct Platform: Equatable, Hashable, Codable {
         return Platform(name: name, oldestSupportedVersion: PlatformVersion(oldestSupportedVersion))
     }
 
-    public static let macOS: Platform = Platform(name: "macos", oldestSupportedVersion: "10.10")
+    public static let macOS: Platform = Platform(name: "macos", oldestSupportedVersion: "10.13")
     public static let macCatalyst: Platform = Platform(name: "maccatalyst", oldestSupportedVersion: "13.0")
-    public static let iOS: Platform = Platform(name: "ios", oldestSupportedVersion: "9.0")
-    public static let tvOS: Platform = Platform(name: "tvos", oldestSupportedVersion: "9.0")
-    public static let watchOS: Platform = Platform(name: "watchos", oldestSupportedVersion: "2.0")
+    public static let iOS: Platform = Platform(name: "ios", oldestSupportedVersion: "11.0")
+    public static let tvOS: Platform = Platform(name: "tvos", oldestSupportedVersion: "11.0")
+    public static let watchOS: Platform = Platform(name: "watchos", oldestSupportedVersion: "4.0")
     public static let driverKit: Platform = Platform(name: "driverkit", oldestSupportedVersion: "19.0")
     public static let linux: Platform = Platform(name: "linux", oldestSupportedVersion: .unknown)
     public static let android: Platform = Platform(name: "android", oldestSupportedVersion: .unknown)

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -2376,7 +2376,7 @@ final class BuildPlanTests: XCTestCase {
 
         let bTarget = try result.target(for: "BTarget").swiftTarget().compileArguments()
       #if os(macOS)
-        XCTAssertMatch(bTarget, [.equal("-target"), .equal(hostTriple.tripleString(forPlatformVersion: "10.12")), .anySequence])
+        XCTAssertMatch(bTarget, [.equal("-target"), .equal(hostTriple.tripleString(forPlatformVersion: "10.13")), .anySequence])
       #else
         XCTAssertMatch(bTarget, [.equal("-target"), .equal(defaultTargetTriple), .anySequence] )
       #endif

--- a/Tests/BuildTests/MockBuildTestHelper.swift
+++ b/Tests/BuildTests/MockBuildTestHelper.swift
@@ -45,7 +45,7 @@ extension AbsolutePath {
 
 let hostTriple = UserToolchain.default.triple
 #if os(macOS)
-    let defaultTargetTriple: String = hostTriple.tripleString(forPlatformVersion: "10.10")
+    let defaultTargetTriple: String = hostTriple.tripleString(forPlatformVersion: "10.13")
 #else
     let defaultTargetTriple: String = hostTriple.tripleString
 #endif

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -1911,12 +1911,12 @@ class PackageGraphTests: XCTestCase {
 
         let defaultDerivedPlatforms = [
             "linux": "0.0",
-            "macos": "10.10",
+            "macos": "10.13",
             "maccatalyst": "13.0",
-            "ios": "9.0",
-            "tvos": "9.0",
+            "ios": "11.0",
+            "tvos": "11.0",
             "driverkit": "19.0",
-            "watchos": "2.0",
+            "watchos": "4.0",
             "android": "0.0",
             "windows": "0.0",
             "wasi": "0.0",
@@ -1928,7 +1928,7 @@ class PackageGraphTests: XCTestCase {
             let manifest = Manifest.createRootManifest(
                 name: "pkg",
                 platforms: [
-                    PlatformDescription(name: "macos", version: "10.12", options: ["option1"]),
+                    PlatformDescription(name: "macos", version: "10.14", options: ["option1"]),
                 ],
                 products: [
                     try ProductDescription(name: "foo", type: .library(.automatic), targets: ["foo"]),
@@ -1946,9 +1946,9 @@ class PackageGraphTests: XCTestCase {
 
             let customXCTestMinimumDeploymentTargets = [
                 PackageModel.Platform.macOS: PlatformVersion("10.15"),
-                PackageModel.Platform.iOS: PlatformVersion("9.0"),
-                PackageModel.Platform.tvOS: PlatformVersion("9.0"),
-                PackageModel.Platform.watchOS: PlatformVersion("2.0"),
+                PackageModel.Platform.iOS: PlatformVersion("11.0"),
+                PackageModel.Platform.tvOS: PlatformVersion("11.0"),
+                PackageModel.Platform.watchOS: PlatformVersion("4.0"),
             ]
 
             let observability = ObservabilitySystem.makeForTesting()
@@ -1962,7 +1962,7 @@ class PackageGraphTests: XCTestCase {
 
             PackageGraphTester(graph) { result in
                 let expectedDeclaredPlatforms = [
-                    "macos": "10.12"
+                    "macos": "10.14"
                 ]
 
                 // default platforms will be auto-added during package build
@@ -2032,8 +2032,8 @@ class PackageGraphTests: XCTestCase {
             let manifest = Manifest.createRootManifest(
                 name: "pkg",
                 platforms: [
-                    PlatformDescription(name: "macos", version: "10.12"),
-                    PlatformDescription(name: "tvos", version: "10.0"),
+                    PlatformDescription(name: "macos", version: "10.14"),
+                    PlatformDescription(name: "tvos", version: "12.0"),
                 ],
                 products: [
                     try ProductDescription(name: "foo", type: .library(.automatic), targets: ["foo"]),
@@ -2057,8 +2057,8 @@ class PackageGraphTests: XCTestCase {
 
             PackageGraphTester(graph) { result in
                 let expectedDeclaredPlatforms = [
-                    "macos": "10.12",
-                    "tvos": "10.0",
+                    "macos": "10.14",
+                    "tvos": "12.0",
                 ]
 
                 // default platforms will be auto-added during package build
@@ -2099,12 +2099,12 @@ class PackageGraphTests: XCTestCase {
 
         let defaultDerivedPlatforms = [
             "linux": "0.0",
-            "macos": "10.10",
+            "macos": "10.13",
             "maccatalyst": "13.0",
-            "ios": "9.0",
-            "tvos": "9.0",
+            "ios": "11.0",
+            "tvos": "11.0",
             "driverkit": "19.0",
-            "watchos": "2.0",
+            "watchos": "4.0",
             "android": "0.0",
             "windows": "0.0",
             "wasi": "0.0",

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -186,10 +186,10 @@ class PIFBuilderTests: XCTestCase {
                         XCTAssertEqual(settings[.ENTITLEMENTS_REQUIRED], "NO")
                         XCTAssertEqual(settings[.GCC_OPTIMIZATION_LEVEL], "0")
                         XCTAssertEqual(settings[.GCC_PREPROCESSOR_DEFINITIONS], ["$(inherited)", "SWIFT_PACKAGE", "DEBUG=1"])
-                        XCTAssertEqual(settings[.IPHONEOS_DEPLOYMENT_TARGET], "9.0")
+                        XCTAssertEqual(settings[.IPHONEOS_DEPLOYMENT_TARGET], "11.0")
                         XCTAssertEqual(settings[.IPHONEOS_DEPLOYMENT_TARGET, for: .macCatalyst], "13.0")
                         XCTAssertEqual(settings[.KEEP_PRIVATE_EXTERNS], "NO")
-                        XCTAssertEqual(settings[.MACOSX_DEPLOYMENT_TARGET], "10.10")
+                        XCTAssertEqual(settings[.MACOSX_DEPLOYMENT_TARGET], "10.13")
                         XCTAssertEqual(settings[.ONLY_ACTIVE_ARCH], "YES")
                         XCTAssertEqual(settings[.OTHER_LDRFLAGS], [])
                         XCTAssertEqual(settings[.PRODUCT_NAME], "$(TARGET_NAME)")
@@ -201,9 +201,9 @@ class PIFBuilderTests: XCTestCase {
                         XCTAssertEqual(settings[.SWIFT_INSTALL_OBJC_HEADER], "NO")
                         XCTAssertEqual(settings[.SWIFT_OBJC_INTERFACE_HEADER_NAME], "")
                         XCTAssertEqual(settings[.SWIFT_OPTIMIZATION_LEVEL], "-Onone")
-                        XCTAssertEqual(settings[.TVOS_DEPLOYMENT_TARGET], "9.0")
+                        XCTAssertEqual(settings[.TVOS_DEPLOYMENT_TARGET], "11.0")
                         XCTAssertEqual(settings[.USE_HEADERMAP], "NO")
-                        XCTAssertEqual(settings[.WATCHOS_DEPLOYMENT_TARGET], "2.0")
+                        XCTAssertEqual(settings[.WATCHOS_DEPLOYMENT_TARGET], "4.0")
 
                         let frameworksSearchPaths = ["$(inherited)", "$(PLATFORM_DIR)/Developer/Library/Frameworks"]
                         for platform in [PIF.BuildSettings.Platform.macOS, .iOS, .tvOS] {
@@ -232,10 +232,10 @@ class PIFBuilderTests: XCTestCase {
                         XCTAssertEqual(settings[.ENTITLEMENTS_REQUIRED], "NO")
                         XCTAssertEqual(settings[.GCC_OPTIMIZATION_LEVEL], "s")
                         XCTAssertEqual(settings[.GCC_PREPROCESSOR_DEFINITIONS], ["$(inherited)", "SWIFT_PACKAGE"])
-                        XCTAssertEqual(settings[.IPHONEOS_DEPLOYMENT_TARGET], "9.0")
+                        XCTAssertEqual(settings[.IPHONEOS_DEPLOYMENT_TARGET], "11.0")
                         XCTAssertEqual(settings[.IPHONEOS_DEPLOYMENT_TARGET, for: .macCatalyst], "13.0")
                         XCTAssertEqual(settings[.KEEP_PRIVATE_EXTERNS], "NO")
-                        XCTAssertEqual(settings[.MACOSX_DEPLOYMENT_TARGET], "10.10")
+                        XCTAssertEqual(settings[.MACOSX_DEPLOYMENT_TARGET], "10.13")
                         XCTAssertEqual(settings[.OTHER_LDRFLAGS], [])
                         XCTAssertEqual(settings[.PRODUCT_NAME], "$(TARGET_NAME)")
                         XCTAssertEqual(settings[.SDK_VARIANT], "auto")
@@ -246,9 +246,9 @@ class PIFBuilderTests: XCTestCase {
                         XCTAssertEqual(settings[.SWIFT_INSTALL_OBJC_HEADER], "NO")
                         XCTAssertEqual(settings[.SWIFT_OBJC_INTERFACE_HEADER_NAME], "")
                         XCTAssertEqual(settings[.SWIFT_OPTIMIZATION_LEVEL], "-Owholemodule")
-                        XCTAssertEqual(settings[.TVOS_DEPLOYMENT_TARGET], "9.0")
+                        XCTAssertEqual(settings[.TVOS_DEPLOYMENT_TARGET], "11.0")
                         XCTAssertEqual(settings[.USE_HEADERMAP], "NO")
-                        XCTAssertEqual(settings[.WATCHOS_DEPLOYMENT_TARGET], "2.0")
+                        XCTAssertEqual(settings[.WATCHOS_DEPLOYMENT_TARGET], "4.0")
 
                         let frameworksSearchPaths = ["$(inherited)", "$(PLATFORM_DIR)/Developer/Library/Frameworks"]
                         for platform in [PIF.BuildSettings.Platform.macOS, .iOS, .tvOS] {


### PR DESCRIPTION
Update minimum supported deployment targets and mark older version constants as deprecated in tools-version 5.7.

If a package specifies a custom deployment target older than the minimum, the derived one in the model will be automatically raised, similar to how it was alreaady being done for test targets.

rdar://93920177

### Motivation:

Xcode 14.0 is raising the minimum supported deployment target versions for most platforms.
