### PR TITLE
[5.7] Use llbuild's new `content-exclusion-patterns` node attribute to prevent it from descending into `.build` and `.git` directories (#5594)

### DIFF
--- a/Fixtures/Miscellaneous/FlatPackage/MyExec.swift
+++ b/Fixtures/Miscellaneous/FlatPackage/MyExec.swift
@@ -1,0 +1,8 @@
+@main
+public struct MyExec {
+    public private(set) var text = "Hello, World!"
+
+    public static func main() {
+        print(MyExec().text)
+    }
+}

--- a/Fixtures/Miscellaneous/FlatPackage/MyTest.swift
+++ b/Fixtures/Miscellaneous/FlatPackage/MyTest.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import MyExec
+
+final class MyTest: XCTestCase {
+    func testExample() throws {
+        XCTAssertEqual(MyExec().text, "Hello, World!")
+    }
+}

--- a/Fixtures/Miscellaneous/FlatPackage/Package.swift
+++ b/Fixtures/Miscellaneous/FlatPackage/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version: 5.5
+import PackageDescription
+
+let execSrcFiles = ["MyExec.swift"]
+let testSrcFiles = ["MyTest.swift"]
+let variousFiles = ["README.md"]
+
+let package = Package(
+    name: "FlatPackage",
+    dependencies: [
+    ],
+    targets: [
+        .executableTarget(
+            name: "MyExec",
+            dependencies: [],
+            path: ".",
+            exclude: testSrcFiles + variousFiles,
+            sources: execSrcFiles
+        ),
+        .testTarget(
+            name: "MyTest",
+            dependencies: ["MyExec"],
+            path: ".",
+            exclude: execSrcFiles + variousFiles,
+            sources: testSrcFiles
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/FlatPackage/README.md
+++ b/Fixtures/Miscellaneous/FlatPackage/README.md
@@ -1,0 +1,3 @@
+# FlatPackage
+
+A description of this package.

--- a/Sources/LLBuildManifest/ManifestWriter.swift
+++ b/Sources/LLBuildManifest/ManifestWriter.swift
@@ -48,9 +48,11 @@ public struct ManifestWriter {
         if !directoryStructureNodes.isEmpty {
             stream <<< "nodes:\n"
         }
+        let namesToExclude = [".git", ".build"]
         for node in directoryStructureNodes.sorted(by: { $0.name < $1.name }) {
             stream <<< "  " <<< Format.asJSON(node) <<< ":\n"
             stream <<< "    is-directory-structure: true\n"
+            stream <<< "    content-exclusion-patterns: " <<< Format.asJSON(namesToExclude) <<< "\n"
         }
 
         stream <<< "commands:\n"

--- a/Tests/BuildTests/LLBuildManifestTests.swift
+++ b/Tests/BuildTests/LLBuildManifestTests.swift
@@ -48,6 +48,7 @@ final class LLBuildManifestTests: XCTestCase {
             nodes:
               "/some/dir/structure/":
                 is-directory-structure: true
+                content-exclusion-patterns: [".git",".build"]
             commands:
               "C.Foo":
                 tool: phony

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -811,4 +811,20 @@ class MiscellaneousTestCase: XCTestCase {
             XCTAssertTrue(result.stderr.contains("Copying best.txt\n"), "build log is missing message about copying resource file")
         }
     }
+    
+    func testNoJSONOutputWithFlatPackageStructure() throws {
+        try fixture(name: "Miscellaneous/FlatPackage") { package in
+            // First build, make sure we got the `.build` directory where we expect it, and that there is no JSON output (by looking for known output).
+            let (stdout1, stderr1) = try SwiftPMProduct.SwiftBuild.execute([], packagePath: package)
+            XCTAssertDirectoryExists(package.appending(component: ".build"))
+            XCTAssertNoMatch(stdout1, .contains("command_arguments"))
+            XCTAssertNoMatch(stderr1, .contains("command_arguments"))
+            
+            // Now test, make sure we got the `.build` directory where we expect it, and that there is no JSON output (by looking for known output).
+            let (stdout2, stderr2) = try SwiftPMProduct.SwiftTest.execute([], packagePath: package)
+            XCTAssertDirectoryExists(package.appending(component: ".build"))
+            XCTAssertNoMatch(stdout2, .contains("command_arguments"))
+            XCTAssertNoMatch(stderr2, .contains("command_arguments"))
+        }
+    }
 }


### PR DESCRIPTION
This is the 5.7 nomination of #5594.

rdar://93982172
(cherry picked from commit fb032acf252a36917df3f1d780b78195d570ed8b)
