### PR TITLE
[5.7] Module aliases override updates

### DIFF
--- a/Sources/PackageGraph/ModuleAliasTracker.swift
+++ b/Sources/PackageGraph/ModuleAliasTracker.swift
@@ -1,14 +1,15 @@
 import PackageModel
+import Basics
 
-// This class helps track module aliases in a package graph and override
-// upstream alises if needed
+// This is a helper class that tracks module aliases in a package dependency graph
+// and handles overriding upstream aliases where alises themselves conflict
 class ModuleAliasTracker {
-    var aliasMap = [PackageIdentity: [String: [ModuleAliasModel]]]()
+    var aliasMap = [String: [ModuleAliasModel]]()
+    var idToAliasMap = [PackageIdentity: [String: [ModuleAliasModel]]]()
     var idToProductToAllTargets = [PackageIdentity: [String: [Target]]]()
     var productToDirectTargets = [String: [Target]]()
     var productToAllTargets = [String: [Target]]()
     var parentToChildProducts = [String: [String]]()
-    var childToParentProducts = [String: [String]]()
     var parentToChildIDs = [PackageIdentity: [PackageIdentity]]()
     var childToParentID = [PackageIdentity: PackageIdentity]()
 
@@ -38,7 +39,7 @@ class ModuleAliasTracker {
                     productName: String,
                     originPackage: PackageIdentity,
                     consumingPackage: PackageIdentity) throws {
-        if let aliasDict = aliasMap[originPackage] {
+        if let aliasDict = idToAliasMap[originPackage] {
             let existingAliases = aliasDict.values.flatMap{$0}.filter {  aliases.keys.contains($0.name) }
             for existingAlias in existingAliases {
                 if let newAlias = aliases[existingAlias.name], newAlias != existingAlias.alias {
@@ -51,7 +52,8 @@ class ModuleAliasTracker {
 
         for (originalName, newName) in aliases {
             let model = ModuleAliasModel(name: originalName, alias: newName, originPackage: originPackage, consumingPackage: consumingPackage)
-            aliasMap[originPackage, default: [:]][productID, default: []].append(model)
+            idToAliasMap[originPackage, default: [:]][productID, default: []].append(model)
+            aliasMap[productID, default: []].append(model)
         }
     }
 
@@ -74,7 +76,6 @@ class ModuleAliasTracker {
         allTargetDeps.append(contentsOf: targetDeps)
         for dep in allTargetDeps {
             if case let .product(depRef, _) = dep {
-                childToParentProducts[depRef.ID, default: []].append(product.ID)
                 parentToChildProducts[product.ID, default: []].append(depRef.ID)
             }
         }
@@ -98,7 +99,7 @@ class ModuleAliasTracker {
         }
     }
 
-    func propagateAliases() {
+    func propagateAliases(observabilityScope: ObservabilityScope) {
         // First get the root package ID
         var pkgID = childToParentID.first?.key
         var rootPkg = pkgID
@@ -108,139 +109,278 @@ class ModuleAliasTracker {
             pkgID = childToParentID[pkgID!]
         }
         guard let rootPkg = rootPkg else { return }
-        // Propagate and override upstream aliases if needed
-        var aliasBuffer = [String: ModuleAliasModel]()
-        propagate(package: rootPkg, aliasBuffer: &aliasBuffer)
-        // Now merge overriden upstream aliases and add them to
-        // downstream targets
+
         if let productToAllTargets = idToProductToAllTargets[rootPkg] {
+            // First, propagate aliaes upstream
             for productID in productToAllTargets.keys {
-                mergeAliases(productID: productID)
+                var aliasBuffer = [String: ModuleAliasModel]()
+                propagate(productID: productID, aliasBuffer: &aliasBuffer)
+            }
+            
+            // Then, merge or override upstream aliases downwards
+            for productID in productToAllTargets.keys {
+                var parentList = [String: ModuleAliasModel]()
+                merge(productID: productID, aliasBuffer: &parentList, observabilityScope: observabilityScope)
             }
         }
+        // Finally, fill in aliases for targets in products that are in the
+        // dependency chain but not in a product consumed by other packages
+        fillInRest(package: rootPkg)
     }
 
-    // Traverse upstream and override aliases for the same targets if needed
-    func propagate(package: PackageIdentity, aliasBuffer: inout [String: ModuleAliasModel]) {
-        if let curProductToTargetAliases = aliasMap[package] {
-            let curAliasModels = curProductToTargetAliases.map {$0.value}.filter{!$0.isEmpty}.flatMap{$0}
-            for aliasModel in curAliasModels {
-                // A buffer is used to track the most downstream aliases
-                // (hence the nil check here) to allow overriding upstream
-                // aliases for targets; if the downstream aliases are applied
-                // to upstream targets, then they get removed
-                if aliasBuffer[aliasModel.name] == nil {
-                    // Add a target name as a key. The buffer only tracks
-                    // a target that needs to be renamed, not the depending
-                    // targets which might have multiple target dependencies
-                    // with their aliases, so add a single alias model as value.
+    // Propagate defined aliases upstream. If they are chained, the final
+    // alias value will be applied
+    func propagate(productID: String,
+                   aliasBuffer: inout [String: ModuleAliasModel]) {
+        let productAliases = aliasMap[productID] ?? []
+        for aliasModel in productAliases {
+            // Alias buffer is used to carry down aliases defined upstream
+            if aliasBuffer[aliasModel.name] == nil {
+                if let v = lookupAlias(key: aliasModel.alias, in: aliasBuffer),
+                   v != aliasModel.alias {
+                    let chainedModel = ModuleAliasModel(name: aliasModel.name, alias: v, originPackage: aliasModel.originPackage, consumingPackage: aliasModel.consumingPackage)
+                    aliasBuffer[aliasModel.name] = chainedModel
+                } else {
                     aliasBuffer[aliasModel.name] = aliasModel
                 }
             }
         }
-        if let curProductToTargets = idToProductToAllTargets[package] {
-            // Check if targets for the products in this package have
-            // aliases tracked by the buffer
-            let curProductToTargetsToAlias = curProductToTargets.filter { $0.value.contains { aliasBuffer[$0.name] != nil } }
-            if !curProductToTargetsToAlias.isEmpty {
-                var usedKeys = Set<String>()
-                for (curProductName, targetsForCurProduct) in curProductToTargets {
-                    if let targetListToAlias = curProductToTargetsToAlias[curProductName] {
-                        for targetToAlias in targetListToAlias {
-                            if let aliasModel = aliasBuffer[targetToAlias.name] {
-                                var didAlias = false
-                                for curTarget in targetsForCurProduct {
-                                    // Check if curTarget is relevant for aliasing
-                                    let canAlias = curTarget.name == aliasModel.name || curTarget.dependencies.contains { $0.name == aliasModel.name }
-                                    if canAlias {
-                                        curTarget.addModuleAlias(for: aliasModel.name, as: aliasModel.alias)
-                                        didAlias = true
+        var used = [String]()
+        if let curAllTargets = productToAllTargets[productID] {
+            // Apply aliases to targets that are renamable, i.e. eventually
+            // get renamed with an alias
+            let targetsToRename = curAllTargets.filter{ aliasBuffer[$0.name] != nil }
+            for curTarget in targetsToRename {
+                if let aliasVal = lookupAlias(key: curTarget.name, in: aliasBuffer) {
+                    let prechain = lookupAlias(value: aliasVal, in: aliasBuffer).filter { $0 != curTarget.name }
+                    if let prechainKey = prechain.first {
+                        used.append(prechainKey)
+                    }
+                    curTarget.addModuleAlias(for: curTarget.name, as: aliasVal)
+                    used.append(curTarget.name)
+                }
+            }
+        }
+        for usedKey in used {
+            aliasBuffer.removeValue(forKey: usedKey)
+        }
+        guard let children = parentToChildProducts[productID] else {
+            return
+        }
+        for childID in children {
+            propagate(productID: childID, aliasBuffer: &aliasBuffer)
+        }
+    }
+
+    // Merge all the upstream aliases and override them if necessary
+    func merge(productID: String,
+               aliasBuffer: inout [String: ModuleAliasModel],
+               observabilityScope: ObservabilityScope) {
+        let productAliases = aliasMap[productID] ?? []
+        for aliasModel in productAliases {
+            if aliasBuffer[aliasModel.name] == nil {
+                aliasBuffer[aliasModel.name] = aliasModel
+            }
+        }
+
+        if let curDirectTargets = productToDirectTargets[productID],
+            let curAllTargets = productToAllTargets[productID] {
+            var targetsToRename = [Target]()
+            // Keep track of the aliases applied to renamable targets
+            // and remove the used aliases from the buffer
+            for curTarget in curAllTargets {
+                if let aliasVal = lookupAlias(key: curTarget.name, in: aliasBuffer),
+                   let appliedAlias = curTarget.moduleAliases?[curTarget.name],
+                   aliasVal == appliedAlias {
+                    targetsToRename.append(curTarget)
+                    aliasBuffer.removeValue(forKey: curTarget.name)
+                }
+            }
+            
+            let aliasesForTargetsToRename = targetsToRename.compactMap{$0.moduleAliases}.flatMap{$0}
+            let otherTargets = curDirectTargets.filter{!targetsToRename.map{$0.name}.contains($0.name)}
+            // Apply the aliases of the renamable targets to their depending targets
+            for otherTarget in otherTargets {
+                for (entryKey, entryVal) in aliasesForTargetsToRename {
+                    otherTarget.addModuleAlias(for: entryKey, as: entryVal)
+                }
+            }
+        }
+        guard let children = parentToChildProducts[productID] else {
+            return
+        }
+        for childID in children {
+            merge(productID: childID,
+                  aliasBuffer: &aliasBuffer,
+                  observabilityScope: observabilityScope)
+        }
+        
+        if let curDirectTargets = productToDirectTargets[productID],
+           let curAllTargets = productToAllTargets[productID] {
+            // Create a per-target alias map that stores aliases of dependent
+            // targets and dependent product targets
+            let depTargets = curDirectTargets
+                .map{$0.dependentTargets()}.flatMap{$0}
+            let depProductTargets = curAllTargets
+                .map{$0.dependencies.compactMap{$0.product?.ID}}.flatMap{$0}
+                .compactMap{productToAllTargets[$0]}.flatMap{$0}
+            let depTargetsDepProductTargets = depTargets
+                .map{$0.dependencies.compactMap{$0.product?.ID}}.flatMap{$0}
+                .compactMap{productToAllTargets[$0]}.flatMap{$0}
+            let depTargetAliases = depTargets.compactMap{$0.moduleAliases}.flatMap{$0}
+            let depProductTargetAliases = depProductTargets.compactMap{$0.moduleAliases}.flatMap{$0}
+            let depTargetDepProductTargetAliases = depTargetsDepProductTargets.compactMap{$0.moduleAliases}.flatMap{$0}
+            var depAliasMap = [String: [String: [String]]]()
+
+            // Per-target alias map for the direct targets of this product
+            for directTarget in curDirectTargets {
+                depAliasMap[directTarget.name] = [:]
+                for (key, alias) in depTargetAliases + depProductTargetAliases {
+                    if depAliasMap[directTarget.name, default: [:]][key]?.contains(alias) ?? false {
+                        // do not add this alias if it's already in the list
+                    } else {
+                        depAliasMap[directTarget.name, default: [:]][key, default: []].append(alias)
+                    }
+                }
+            }
+            // Per-target alias map for dependent targets of the product direct targets
+            for depTarget in depTargets {
+                depAliasMap[depTarget.name] = [:]
+                for (key, alias) in depTargetAliases + depTargetDepProductTargetAliases {
+                    if depAliasMap[depTarget.name, default: [:]][key]?.contains(alias) ?? false {
+                        // do not add this alias if it's already in the list
+                    } else {
+                        depAliasMap[depTarget.name, default: [:]][key, default: []].append(alias)
+                    }
+                }
+            }
+
+            let targetList = curDirectTargets + depTargets
+            for targetToResolve in targetList {
+                guard let relevantAliasMap = depAliasMap[targetToResolve.name] else { continue }
+                for (key, aliases) in relevantAliasMap {
+                    // First check if there's a target named `key` in
+                    // the direct or dependent targets
+                    if targetList.map({$0.name}).contains(key) {
+                        // Check if those targets have module aliases for this `key`
+                        let existingAliases = targetList.filter{$0.name == key}.compactMap{$0.moduleAliases?[key]}
+                        for existingAlias in existingAliases {
+                            if let aliasVal = targetToResolve.moduleAliases?[key], aliasVal != existingAlias {
+                                // This check is added just out of precaution but
+                                // shoudln't be needed
+                            } else {
+                                targetToResolve.addModuleAlias(for: key, as: existingAlias)
+                                let prechain = lookupAlias(value: existingAlias, in: aliasBuffer).filter { $0 != key }
+                                if let prechainKey = prechain.first {
+                                    aliasBuffer.removeValue(forKey: prechainKey)
+                                }
+                            }
+                        }
+                        // Check if pre-chain aliases need to be added
+                        let unusedAliases = aliases.filter{!existingAliases.contains($0)}
+                        for alias in unusedAliases {
+                            let prechain = lookupAlias(value: alias, in: aliasBuffer).filter { $0 != key }
+                            if let prechainKey = prechain.first {
+                                observabilityScope.emit(info: "Target '\(targetToResolve.name)' already has a dependency target named '\(key)' but has a duplicate target in a dependency product; when referencing the latter in source code, use the aliased name '\(alias)' directly")
+                                // Add a prechain alias from the buffer
+                                targetToResolve.addModuleAlias(for: prechainKey, as: alias)
+                                aliasBuffer.removeValue(forKey: prechainKey)
+                            }
+                        }
+                    }
+                    else {
+                        let targetsNamedKeyInDepProduct = depProductTargets.filter{$0.name == key}
+                        if aliases.count == 1, let aliasVal = aliases.first {
+                            // There's only one alias to merge and targets with
+                            // name `key` in dependency products all have different
+                            // aliases
+                            if targetsNamedKeyInDepProduct.filter({$0.moduleAliases == nil}).isEmpty {
+                                let prechain = lookupAlias(value: aliasVal, in: aliasBuffer).filter { $0 != key }
+                                if let prechainKey = prechain.first {
+                                    aliasBuffer.removeValue(forKey: prechainKey)
+                                }
+                                targetToResolve.addModuleAlias(for: key, as: aliasVal)
+                                aliasBuffer.removeValue(forKey: key)
+                            }
+                        } else {
+                            if targetsNamedKeyInDepProduct.count == 1 {
+                                // There are multiple aliases for the `key`
+                                // and dependency products have targets named
+                                // `key`
+                                let aliasesInDepProductForKeyNamedTargets = targetsNamedKeyInDepProduct.compactMap{ $0.moduleAliases }.flatMap{$0}
+                                if aliasesInDepProductForKeyNamedTargets.isEmpty {
+                                    // This check is added out of precaution but
+                                    // shouldn't be needed
+                                    if targetToResolve.moduleAliases?[key] != nil {
+                                        targetToResolve.removeModuleAlias(for: key)
+                                    }
+                                } else {
+                                    // There should be only one alias to apply
+                                    for entry in aliasesInDepProductForKeyNamedTargets {
+                                        targetToResolve.addModuleAlias(for: entry.key, as: entry.value)
+                                        let prechain = lookupAlias(value: entry.value, in: aliasBuffer).filter { $0 != entry.key }
+                                        if let prechainKey = prechain.first {
+                                            aliasBuffer.removeValue(forKey: prechainKey)
+                                        }
                                     }
                                 }
-                                if didAlias {
-                                    usedKeys.insert(targetToAlias.name)
+                            } else {
+                                for alias in aliases {
+                                    let prechain = lookupAlias(value: alias, in: aliasBuffer).filter { $0 != key }
+                                    if let prechainKey = prechain.first {
+                                        // Add a prechain alias
+                                        if let existing = targetToResolve.moduleAliases?[prechainKey],
+                                           existing != alias {
+                                            targetToResolve.removeModuleAlias(for: prechainKey)
+                                        } else {
+                                            observabilityScope.emit(info: "Multiple module aliases \(aliases.sorted()) found for '\(targetToResolve.name)'; when referencing them in source code from target '\(targetToResolve.name)' or its depending targets, use the aliased names directly instead of the original name")
+                                            targetToResolve.addModuleAlias(for: prechainKey, as: alias)
+                                            aliasBuffer.removeValue(forKey: prechainKey)
+                                        }
+                                    }
                                 }
                             }
                         }
                     }
                 }
-                for used in usedKeys {
-                    // Remove an entry for a used alias
-                    aliasBuffer.removeValue(forKey: used)
+            }
+        }
+    }
+
+    // This fills in aliases for targets in products that are in the dependency chain
+    // but not in a product consumed by other packages. Such targets still need to have
+    // aliases applied to them so they can be built with correct dependent binary names
+    func fillInRest(package: PackageIdentity) {
+        if let productToTargets = idToProductToAllTargets[package] {
+            for (_, productTargets) in productToTargets {
+                let unAliased = productTargets.contains{$0.moduleAliases == nil}
+                if unAliased {
+                    for target in productTargets {
+                        let depAliases = target.dependentTargets().compactMap{$0.moduleAliases}.flatMap{$0}
+                        for (key, alias) in depAliases {
+                            target.addModuleAlias(for: key, as: alias)
+                        }
+                    }
                 }
             }
         }
         guard let children = parentToChildIDs[package] else { return }
-        for childID in children {
-            propagate(package: childID, aliasBuffer: &aliasBuffer)
+        for child in children {
+            fillInRest(package: child)
         }
     }
 
-    // Merge overriden upstream aliases and add them to downstream targets
-    func mergeAliases(productID: String) {
-        guard let childProducts = parentToChildProducts[productID] else { return }
-        for child in childProducts {
-            mergeAliases(productID: child)
-            // Filter out targets in the current product with names that are
-            // aliased with different values in the child products since they
-            // should either not be aliased or their existing aliases if any
-            // should not be overridden.
-            let allTargetNamesInCurProduct = productToAllTargets[productID]?.compactMap{$0.name} ?? []
-            let childTargetsAliases = productToDirectTargets[child]?.compactMap{$0.moduleAliases}.flatMap{$0}.filter{ !allTargetNamesInCurProduct.contains($0.key) }
-
-            if let childTargetsAliases = childTargetsAliases,
-               let directTargets = productToDirectTargets[productID] {
-                // Keep track of all targets in this product that directly
-                // or indirectly depend on the child product
-                let directRelevantTargets = directTargets.filter {$0.dependsOn(productID: child)}
-                var relevantTargets = directTargets.map{$0.dependentTargets()}.flatMap{$0}.filter {$0.dependsOn(productID: child)}
-                relevantTargets.append(contentsOf: directTargets)
-                relevantTargets.append(contentsOf: directRelevantTargets)
-                let relevantTargetSet = Set(relevantTargets)
-
-                // Used to compare with aliases defined in other child products
-                // and detect a conflict if any.
-                let allTargetsInOtherChildProducts = childProducts.filter{$0 != child }.compactMap{productToAllTargets[$0]}.flatMap{$0}
-                let allTargetNamesInChildProduct = productToAllTargets[child]?.map{$0.name} ?? []
-                for curTarget in relevantTargetSet {
-                    for (nameToBeAliased, aliasInChild) in childTargetsAliases {
-                        // If there are targets in other child products that
-                        // have the same name that's being aliased here, but
-                        // targets in this child product don't, we need to use
-                        // alias values of those targets as they take a precedence
-                        let otherAliasesInChildProducts = allTargetsInOtherChildProducts.filter{$0.name == nameToBeAliased}.compactMap{$0.moduleAliases}.flatMap{$0}.filter{$0.key == nameToBeAliased}
-                        if !otherAliasesInChildProducts.isEmpty,
-                           !allTargetNamesInChildProduct.contains(curTarget.name) {
-                            for (aliasKey, aliasValue) in otherAliasesInChildProducts {
-                                // Reset the old alias value with this aliasValue
-                                if curTarget.moduleAliases?[aliasKey] != aliasValue {
-                                    curTarget.addModuleAlias(for: aliasKey, as: aliasValue)
-                                }
-                            }
-                        } else {
-                            // If there are no aliases or conflicting aliases
-                            // for the same key defined in other child products,
-                            // those aliases should be removed from this target.
-                            let hasConflict = allTargetsInOtherChildProducts.contains{ otherTarget in
-                                if let otherAlias = otherTarget.moduleAliases?[nameToBeAliased] {
-                                    return otherAlias != aliasInChild
-                                } else {
-                                    return otherTarget.name == nameToBeAliased
-                                }
-                            }
-                            if hasConflict {
-                                // If there are aliases, remove as aliasing should
-                                // not be applied
-                                curTarget.removeModuleAlias(for: nameToBeAliased)
-                            } else if curTarget.moduleAliases?[nameToBeAliased] == nil {
-                                // Otherwise add the alias if none exists
-                                curTarget.addModuleAlias(for: nameToBeAliased, as: aliasInChild)
-                            }
-                        }
-                    }
-                }
-            }
+    private func lookupAlias(key: String, in buffer: [String: ModuleAliasModel]) -> String? {
+        var next = key
+        while let nextValue = buffer[next] {
+            next = nextValue.alias
         }
+        return next == key ? nil : next
+    }
+
+    private func lookupAlias(value: String, in buffer: [String: ModuleAliasModel]) -> [String] {
+        let keys = buffer.filter{$0.value.alias == value}.map{$0.key}
+        return keys
     }
 }
 
@@ -273,4 +413,3 @@ extension Target {
         return dependencies.compactMap{$0.target}
     }
 }
-

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -246,7 +246,7 @@ private func createResolvedPackages(
 
     // Resolve module aliases, if specified, for targets and their dependencies
     // across packages. Aliasing will result in target renaming.
-    let moduleAliasingUsed = try resolveModuleAliases(packageBuilders: packageBuilders)
+    let moduleAliasingUsed = try resolveModuleAliases(packageBuilders: packageBuilders, observabilityScope: observabilityScope)
 
     // Scan and validate the dependencies
     for packageBuilder in packageBuilders {
@@ -641,8 +641,8 @@ private func computePlatforms(
 }
 
 // Track and override module aliases specified for targets in a package graph
-private func resolveModuleAliases(packageBuilders: [ResolvedPackageBuilder]) throws -> Bool {
-
+private func resolveModuleAliases(packageBuilders: [ResolvedPackageBuilder],
+                                  observabilityScope: ObservabilityScope) throws -> Bool {
     // If there are no module aliases specified, return early
     let hasAliases = packageBuilders.contains { $0.package.targets.contains {
             $0.dependencies.contains { dep in
@@ -670,7 +670,7 @@ private func resolveModuleAliases(packageBuilders: [ResolvedPackageBuilder]) thr
     }
 
     // Override module aliases upstream if needed
-    aliasTracker.propagateAliases()
+    aliasTracker.propagateAliases(observabilityScope: observabilityScope)
 
     // Validate sources (Swift files only) for modules being aliased.
     // Needs to be done after `propagateAliases` since aliases defined

--- a/Tests/BuildTests/ModuleAliasingBuildTests.swift
+++ b/Tests/BuildTests/ModuleAliasingBuildTests.swift
@@ -1126,7 +1126,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                                          "Math",
                                                          .product(name: "Utils",
                                                                   package: "fooPkg",
-                                                                  moduleAliases: ["Logging": "FooLogging", "Math": "FooMath"])
+                                                                  moduleAliases: ["BarLogging": "FooLogging", "BarMath": "FooMath"])
                                                         ]),
                         TargetDescription(name: "Logging", dependencies: []),
                         TargetDescription(name: "Math", dependencies: []),
@@ -1146,13 +1146,13 @@ final class ModuleAliasingBuildTests: XCTestCase {
         result.checkProductsCount(1)
         result.checkTargetsCount(6)
 
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases?["Logging"] == "FooLogging" && $0.target.moduleAliases?["Math"] == "FooMath" })
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "FooLogging" && $0.target.moduleAliases?["Logging"] == "FooLogging" })
-        XCTAssertFalse(result.targetMap.values.contains { $0.target.name == "BarLogging" && $0.target.moduleAliases?["Logging"] == "BarLogging" })
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "FooMath" && $0.target.moduleAliases?["Math"] == "FooMath" })
-        XCTAssertFalse(result.targetMap.values.contains { $0.target.name == "BarMath" && $0.target.moduleAliases?["Math"] == "BarMath" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases?["Logging"] == "FooLogging" && $0.target.moduleAliases?["Math"] == "FooMath" })
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil })
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Math" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "exe" && $0.target.moduleAliases == nil})
+        XCTAssertFalse(result.targetMap.values.contains { $0.target.name == "BarLogging" })
     }
 
     func testModuleAliasingAliasSkipUpstreamTargets() throws {
@@ -1419,7 +1419,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                             .product(name: "B",
                                                      package: "bPkg",
                                                      moduleAliases: ["Utils": "XUtils",
-                                                                     "Log": "XLog"]
+                                                                     "YLog": "XLog"]
                                                     ),
                                           ]
                                          ),
@@ -1439,7 +1439,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
 
         result.checkProductsCount(1)
         result.checkTargetsCount(9)
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "A" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "A" && $0.target.moduleAliases?["Utils"] == "XUtils" })
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "B" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target.moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?.count == 2 })
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target.moduleAliases?.count == 1 })
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "C" && $0.target.moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?["Utils"] == "YUtils" && $0.target.moduleAliases?.count == 2 })
@@ -1539,7 +1539,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                             .product(name: "C",
                                                      package: "cPkg",
                                                      moduleAliases: ["Utils": "YUtils",
-                                                                     "Log": "YLog"
+                                                                     "ZLog": "YLog"
                                                                     ]
                                             ),
                                           ]),
@@ -1556,13 +1556,12 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           dependencies: [
                                             .product(name: "B",
                                                      package: "bPkg",
-                                                     moduleAliases: ["Utils": "XUtils",
-                                                                     "Log": "XLog"]
+                                                     moduleAliases: ["YUtils": "XUtils",
+                                                                     "YLog": "XLog"]
                                                     ),
                                             .product(name: "G",
                                                      package: "gPkg",
-                                                     moduleAliases: ["Utils": "GUtils",
-                                                                     "Log": "GLog"]),
+                                                     moduleAliases: ["Utils": "GUtils"]),
                                           ]
                                          ),
                     ]
@@ -1689,7 +1688,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                             .product(name: "C",
                                                      package: "cPkg",
                                                      moduleAliases: ["Utils": "YUtils",
-                                                                     "Log": "YLog"
+                                                                     "ZLog": "YLog"
                                                                     ]
                                             ),
                                           ]),
@@ -1708,8 +1707,8 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                                      package: "gPkg"),
                                             .product(name: "B",
                                                      package: "bPkg",
-                                                     moduleAliases: ["Utils": "XUtils",
-                                                                     "Log": "XLog"]
+                                                     moduleAliases: ["YUtils": "XUtils",
+                                                                     "YLog": "XLog"]
                                                     ),
                                             ]
                                          ),
@@ -1736,6 +1735,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target.moduleAliases?.count == 1 })
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "XLog" && $0.target.moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?.count == 1 })
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "G" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target.moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?.count == 2})
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "H" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target.moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?.count == 2})
     }
 
     func testModuleAliasingOverrideSameNameTargetAndDepWithAliases() throws {
@@ -1795,11 +1795,8 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ],
                     targets: [
                         TargetDescription(name: "Lib",
-                                          dependencies: [.product(name: "Game",
-                                                                  package: "gamePkg",
-                                                                  moduleAliases: ["Utils": "GameUtils"]
-                                                                 ),
-                                                         .product(name: "UtilsProd",
+                                          dependencies: [
+                                            .product(name: "Game",
                                                                   package: "gamePkg",
                                                                   moduleAliases: ["Utils": "GameUtils"]
                                                                  ),
@@ -1821,7 +1818,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                                          "Render",
                                                          .product(name: "LibProd",
                                                                   package: "libPkg",
-                                                                  moduleAliases: ["Utils": "LibUtils", "Render": "LibRender"]
+                                                                  moduleAliases: ["GameUtils": "LibUtils", "GameRender": "LibRender"]
                                                         )]),
                         TargetDescription(name: "Utils", dependencies: []),
                         TargetDescription(name: "Render", dependencies: []),
@@ -1849,6 +1846,8 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Render" && $0.target.moduleAliases == nil })
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases == nil })
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
+        XCTAssertFalse(result.targetMap.values.contains { $0.target.name == "GameUtils"})
+
     }
 
     func testModuleAliasingAddOverrideAliasesUpstream() throws {
@@ -2148,7 +2147,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                                          "Render",
                                                          .product(name: "LibProd",
                                                                   package: "libPkg",
-                                                                  moduleAliases: ["Utils": "LibUtils", "Render": "LibRender"]
+                                                                  moduleAliases: ["GameUtils": "LibUtils", "GameRender": "LibRender"]
                                                         )]),
                         TargetDescription(name: "Utils", dependencies: []),
                         TargetDescription(name: "Render", dependencies: []),
@@ -2172,9 +2171,10 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "LibRender" && $0.target.moduleAliases?["Render"] == "LibRender" })
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "LibUtils" && $0.target.moduleAliases?["Utils"] == "LibUtils" })
         XCTAssertFalse(result.targetMap.values.contains { $0.target.name == "DrawRender" || $0.target.moduleAliases?["Render"] == "DrawRender" })
-        XCTAssertTrue(result.targetMap.values.contains {  $0.target.name == "Game" && $0.target.moduleAliases?["Utils"] == "LibUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Game" && $0.target.moduleAliases?["Utils"] == "LibUtils" })
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Render" && $0.target.moduleAliases == nil })
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
     }
 
     func testModuleAliasingOverrideUpstreamTargetsWithAliasesDownstream() throws {
@@ -2262,7 +2262,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                                          "Render",
                                                          .product(name: "LibProd",
                                                                   package: "libPkg",
-                                                                  moduleAliases: ["Utils": "LibUtils", "Render": "LibRender"]
+                                                                  moduleAliases: ["GameUtils": "LibUtils", "GameRender": "LibRender"]
                                                         )]),
                         TargetDescription(name: "Utils", dependencies: []),
                         TargetDescription(name: "Render", dependencies: []),
@@ -2453,5 +2453,115 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "CarLogging" && $0.target.moduleAliases?["Logging"] == "CarLogging" })
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases?["Logging"] == "FooLogging" })
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "MyLogging" && $0.target.moduleAliases == nil })
+    }
+
+    func testModuleAliasingChainedAliases() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+                                        "/appPkg/Sources/App/main.swift",
+                                    "/apkg/Sources/A/file.swift",
+                                    "/apkg/Sources/Utils/file.swift",
+                                    "/bpkg/Sources/Utils/file.swift",
+                                    "/xpkg/Sources/X/file.swift",
+                                    "/xpkg/Sources/Utils/file.swift",
+                                    "/ypkg/Sources/Utils/file.swift"
+        )
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createFileSystemManifest(
+                    name: "ypkg",
+                    path: .init("/ypkg"),
+                    products: [
+                        ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "Utils", dependencies: []),
+                    ]),
+                Manifest.createFileSystemManifest(
+                    name: "xpkg",
+                    path: .init("/xpkg"),
+                    dependencies: [
+                        .localSourceControl(path: .init("/ypkg"), requirement: .upToNextMajor(from: "1.0.0"))
+                    ],
+                    products: [
+                        ProductDescription(name: "X", type: .library(.automatic), targets: ["X"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "X",
+                                          dependencies: [
+                                            "Utils",
+                                            .product(name: "Utils",
+                                                     package: "ypkg",
+                                                     moduleAliases: ["Utils" : "FooUtils"]
+                                                    )
+                                            ]),
+                        TargetDescription(name: "Utils", dependencies: []),
+                    ]),
+                Manifest.createFileSystemManifest(
+                    name: "bpkg",
+                    path: .init("/bpkg"),
+                    products: [
+                        ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "Utils", dependencies: []),
+                    ]),
+                Manifest.createFileSystemManifest(
+                    name: "apkg",
+                    path: .init("/apkg"),
+                    dependencies: [
+                        .localSourceControl(path: .init("/bpkg"), requirement: .upToNextMajor(from: "1.0.0"))
+                    ],
+                    products: [
+                        ProductDescription(name: "A", type: .library(.automatic), targets: ["A"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "A",
+                                          dependencies: [
+                                            "Utils",
+                                            .product(name: "Utils",
+                                                     package: "bpkg",
+                                                     moduleAliases: ["Utils" : "FooUtils"]
+                                                    )
+                                            ]),
+                        TargetDescription(name: "Utils", dependencies: []),
+                    ]),
+                Manifest.createRootManifest(
+                    name: "appPkg",
+                    path: .init("/appPkg"),
+                    dependencies: [
+                        .localSourceControl(path: .init("/apkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init("/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    targets: [
+                        TargetDescription(name: "App",
+                                          dependencies: [.product(name: "A",
+                                                                  package: "apkg",
+                                                                  moduleAliases: ["Utils": "AUtils", "FooUtils": "AFooUtils"]),
+                                                         .product(name: "X",
+                                                                  package: "xpkg",
+                                                                  moduleAliases: ["Utils": "XUtils", "FooUtils": "XFooUtils"])
+                                          ]),
+                    ]),
+            ],
+            observabilityScope: observability.topScope
+        )
+        XCTAssertNoDiagnostics(observability.diagnostics)
+        let result = try BuildPlanResult(plan: try BuildPlan(
+            buildParameters: mockBuildParameters(shouldLinkStaticSwiftStdlib: true),
+            graph: graph,
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        ))
+        result.checkProductsCount(1)
+        result.checkTargetsCount(7)
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "A" && $0.target.moduleAliases?["Utils"] == "AUtils" && $0.target.moduleAliases?["FooUtils"] == "AFooUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "X" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target.moduleAliases?["FooUtils"] == "XFooUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "AUtils" && $0.target.moduleAliases?["Utils"] == "AUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "AFooUtils" && $0.target.moduleAliases?["Utils"] == "AFooUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "XFooUtils" && $0.target.moduleAliases?["Utils"] == "XFooUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
     }
 }


### PR DESCRIPTION
* Use alias value defined upstream as a key downstream for overriding and chain them
* Add pre-chained aliases to targets when needed and show diags
Resolves rdar://93445417, rdar://93218209
