### PR TITLE
suppress warnings from remote dependencies

### DIFF
--- a/Fixtures/Miscellaneous/DependenciesWarnings/app/Package.swift
+++ b/Fixtures/Miscellaneous/DependenciesWarnings/app/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 5.7
+import PackageDescription
+
+let package = Package(
+    name: "app",
+    products: [
+        .executable(name: "app", targets: ["app"])
+    ],
+    dependencies: [
+        .package(url: "../dep1", from: "1.0.0"),
+        .package(url: "../dep2", from: "1.0.0"),
+    ],
+    targets: [
+        .executableTarget(
+          name: "app",
+          dependencies: [
+            .product(name: "dep1", package: "dep1"),
+            .product(name: "dep2", package: "dep2")
+          ],
+          path: "./"
+        )
+    ]
+)

--- a/Fixtures/Miscellaneous/DependenciesWarnings/app/app.swift
+++ b/Fixtures/Miscellaneous/DependenciesWarnings/app/app.swift
@@ -1,0 +1,15 @@
+import dep1
+import dep2
+
+@main
+struct App {
+  var deprecated: DeprecatedApp
+
+  public static func main() {
+    print("hello, world!")
+  }
+}
+
+@available(*, deprecated)
+struct DeprecatedApp {
+}

--- a/Fixtures/Miscellaneous/DependenciesWarnings/dep1/Package.swift
+++ b/Fixtures/Miscellaneous/DependenciesWarnings/dep1/Package.swift
@@ -1,0 +1,12 @@
+// swift-tools-version: 5.7
+import PackageDescription
+
+let package = Package(
+    name: "dep1",
+    products: [
+        .library(name: "dep1", targets: ["dep1"])
+    ],
+    targets: [
+        .target(name: "dep1", path: "./")
+    ]
+)

--- a/Fixtures/Miscellaneous/DependenciesWarnings/dep1/code.swift
+++ b/Fixtures/Miscellaneous/DependenciesWarnings/dep1/code.swift
@@ -1,0 +1,7 @@
+struct Dep1 {
+  var deprecated: Deprecated1
+}
+
+@available(*, deprecated)
+struct Deprecated1 {
+}

--- a/Fixtures/Miscellaneous/DependenciesWarnings/dep2/Package.swift
+++ b/Fixtures/Miscellaneous/DependenciesWarnings/dep2/Package.swift
@@ -1,0 +1,12 @@
+// swift-tools-version: 5.7
+import PackageDescription
+
+let package = Package(
+    name: "dep2",
+    products: [
+        .library(name: "dep2", targets: ["dep2"])
+    ],
+    targets: [
+        .target(name: "dep2", path: "./")
+    ]
+)

--- a/Fixtures/Miscellaneous/DependenciesWarnings/dep2/code.swift
+++ b/Fixtures/Miscellaneous/DependenciesWarnings/dep2/code.swift
@@ -1,0 +1,7 @@
+struct Dep2 {
+  var deprecated: Deprecated2
+}
+
+@available(*, deprecated)
+struct Deprecated2 {
+}

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -833,4 +833,21 @@ class MiscellaneousTestCase: XCTestCase {
             XCTAssertNoMatch(stderr2, .contains("command_arguments"))
         }
     }
+
+    func testNoWarningFromRemoteDependencies() throws {
+        try fixture(name: "Miscellaneous/DependenciesWarnings") { path in
+            // prepare the deps as git sources
+            let dependency1Path = path.appending(component: "dep1")
+            initGitRepo(dependency1Path, tag: "1.0.0")
+            let dependency2Path = path.appending(component: "dep2")
+            initGitRepo(dependency2Path, tag: "1.0.0")
+
+            let appPath = path.appending(component: "app")
+            let (stdout, stderr) = try SwiftPMProduct.SwiftBuild.execute([], packagePath: appPath)
+            XCTAssertDirectoryExists(appPath.appending(component: ".build"))
+            XCTAssertMatch(stdout + stderr, .contains("'DeprecatedApp' is deprecated"))
+            XCTAssertNoMatch(stdout + stderr, .contains("'Deprecated1' is deprecated"))
+            XCTAssertNoMatch(stdout + stderr, .contains("'Deprecated2' is deprecated"))
+        }
+    }
 }


### PR DESCRIPTION
motivation: warnings from remote dependencies are not actionable and make the use of -warnings-as-errors difficult

changes:
* wire up the ResolvedPackage to SwiftTargetBuildDescription
* pass -suppress-warnings for remote dependencies
* add unit test
