### PR TITLE
Prepare SPM Targets for Process migration by specifying that callee should use TSCBasic.Process

### DIFF
--- a/Sources/Basics/Archiver+Zip.swift
+++ b/Sources/Basics/Archiver+Zip.swift
@@ -47,9 +47,9 @@ public struct ZipArchiver: Archiver, Cancellable {
             }
 
 #if os(Windows)
-            let process = Process(arguments: ["tar.exe", "xf", archivePath.pathString, "-C", destinationPath.pathString])
+            let process = TSCBasic.Process(arguments: ["tar.exe", "xf", archivePath.pathString, "-C", destinationPath.pathString])
 #else
-            let process = Process(arguments: ["unzip", archivePath.pathString, "-d", destinationPath.pathString])
+            let process = TSCBasic.Process(arguments: ["unzip", archivePath.pathString, "-d", destinationPath.pathString])
 #endif
             guard let registrationKey = self.cancellator.register(process) else {
                 throw StringError("cancellation")
@@ -77,9 +77,9 @@ public struct ZipArchiver: Archiver, Cancellable {
             }
 
 #if os(Windows)
-            let process = Process(arguments: ["tar.exe", "tf", path.pathString])
+            let process = TSCBasic.Process(arguments: ["tar.exe", "tf", path.pathString])
 #else
-            let process = Process(arguments: ["unzip", "-t", path.pathString])
+            let process = TSCBasic.Process(arguments: ["unzip", "-t", path.pathString])
 #endif
             guard let registrationKey = self.cancellator.register(process) else {
                 throw StringError("cancellation")

--- a/Sources/Basics/Cancellator.swift
+++ b/Sources/Basics/Cancellator.swift
@@ -51,7 +51,7 @@ public class Cancellator: Cancellable {
     }
 
     public func register(_ process: TSCBasic.Process) -> RegistrationKey? {
-        self.register(name: "\(process.arguments.joined(separator: " "))", handler:  process.terminate)
+        self.register(name: "\(process.arguments.joined(separator: " "))", handler: process.terminate)
     }
 
     #if !os(iOS) && !os(watchOS) && !os(tvOS)

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -454,7 +454,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
                 if !self.disableSandboxForPluginCommands {
                     commandLine = Sandbox.apply(command: commandLine, strictness: .writableTemporaryDirectory, writableDirectories: [pluginResult.pluginOutputDirectory])
                 }
-                let processResult = try Process.popen(arguments: commandLine, environment: command.configuration.environment)
+                let processResult = try TSCBasic.Process.popen(arguments: commandLine, environment: command.configuration.environment)
                 let output = try processResult.utf8Output() + processResult.utf8stderrOutput()
                 if processResult.exitStatus != .terminated(code: 0) {
                     throw StringError("failed: \(command)\n\n\(output)")

--- a/Sources/Build/SPMSwiftDriverExecutor.swift
+++ b/Sources/Build/SPMSwiftDriverExecutor.swift
@@ -16,78 +16,78 @@ import Foundation
 @_implementationOnly import SwiftDriver
 
 final class SPMSwiftDriverExecutor: DriverExecutor {
-
-  private enum Error: Swift.Error, CustomStringConvertible {
-    case inPlaceExecutionUnsupported
-
-    var description: String {
-      switch self {
-      case .inPlaceExecutionUnsupported:
-        return "the integrated Swift driver does not support in-place execution"
-      }
+    
+    private enum Error: Swift.Error, CustomStringConvertible {
+        case inPlaceExecutionUnsupported
+        
+        var description: String {
+            switch self {
+            case .inPlaceExecutionUnsupported:
+                return "the integrated Swift driver does not support in-place execution"
+            }
+        }
     }
-  }
-
-  let resolver: ArgsResolver
-  let fileSystem: FileSystem
-  let env: EnvironmentVariables
-
-  init(resolver: ArgsResolver,
-       fileSystem: FileSystem,
-       env: EnvironmentVariables) {
-    self.resolver = resolver
-    self.fileSystem = fileSystem
-    self.env = env
-  }
-
-  func execute(job: Job,
-               forceResponseFiles: Bool,
-               recordedInputModificationDates: [TypedVirtualPath : Date]) throws -> ProcessResult {
-    let arguments: [String] = try resolver.resolveArgumentList(for: job,
-                                                               forceResponseFiles: forceResponseFiles)
-
-    try job.verifyInputsNotModified(since: recordedInputModificationDates,
-                                    fileSystem: fileSystem)
-
-    if job.requiresInPlaceExecution {
-      throw Error.inPlaceExecutionUnsupported
+    
+    let resolver: ArgsResolver
+    let fileSystem: FileSystem
+    let env: EnvironmentVariables
+    
+    init(resolver: ArgsResolver,
+         fileSystem: FileSystem,
+         env: EnvironmentVariables) {
+        self.resolver = resolver
+        self.fileSystem = fileSystem
+        self.env = env
     }
-
-    var childEnv = env
-    childEnv.merge(job.extraEnvironment, uniquingKeysWith: { (_, new) in new })
-
-    let process = try Process.launchProcess(arguments: arguments, env: childEnv)
-    return try process.waitUntilExit()
-  }
-
-  func execute(workload: DriverExecutorWorkload,
-               delegate: JobExecutionDelegate,
-               numParallelJobs: Int, forceResponseFiles: Bool,
-               recordedInputModificationDates: [TypedVirtualPath : Date]) throws {
-    throw InternalError("Multi-job build plans should be lifted into the SPM build graph.")
-  }
-
-  func checkNonZeroExit(args: String..., environment: [String : String]) throws -> String {
-    return try Process.checkNonZeroExit(arguments: args, environment: environment)
-  }
-
-  func description(of job: Job, forceResponseFiles: Bool) throws -> String {
-    // FIXME: This is duplicated from SwiftDriver, maybe it shouldn't be a protocol requirement.
-    let (args, usedResponseFile) = try resolver.resolveArgumentList(for: job,
-                                                                    forceResponseFiles: forceResponseFiles)
-    var result = args.joined(separator: " ")
-
-    if usedResponseFile {
-      // Print the response file arguments as a comment.
-      result += " # \(job.commandLine.joinedUnresolvedArguments)"
+    
+    func execute(job: Job,
+                 forceResponseFiles: Bool,
+                 recordedInputModificationDates: [TypedVirtualPath : Date]) throws -> ProcessResult {
+        let arguments: [String] = try resolver.resolveArgumentList(for: job,
+                                                                   forceResponseFiles: forceResponseFiles)
+        
+        try job.verifyInputsNotModified(since: recordedInputModificationDates,
+                                        fileSystem: fileSystem)
+        
+        if job.requiresInPlaceExecution {
+            throw Error.inPlaceExecutionUnsupported
+        }
+        
+        var childEnv = env
+        childEnv.merge(job.extraEnvironment, uniquingKeysWith: { (_, new) in new })
+        
+        let process = try Process.launchProcess(arguments: arguments, env: childEnv)
+        return try process.waitUntilExit()
     }
-
-    if !job.extraEnvironment.isEmpty {
-      result += " #"
-      for (envVar, val) in job.extraEnvironment {
-        result += " \(envVar)=\(val)"
-      }
+    
+    func execute(workload: DriverExecutorWorkload,
+                 delegate: JobExecutionDelegate,
+                 numParallelJobs: Int, forceResponseFiles: Bool,
+                 recordedInputModificationDates: [TypedVirtualPath : Date]) throws {
+        throw InternalError("Multi-job build plans should be lifted into the SPM build graph.")
     }
-    return result
-  }
+    
+    func checkNonZeroExit(args: String..., environment: [String : String]) throws -> String {
+        return try TSCBasic.Process.checkNonZeroExit(arguments: args, environment: environment)
+    }
+    
+    func description(of job: Job, forceResponseFiles: Bool) throws -> String {
+        // FIXME: This is duplicated from SwiftDriver, maybe it shouldn't be a protocol requirement.
+        let (args, usedResponseFile) = try resolver.resolveArgumentList(for: job,
+                                                                        forceResponseFiles: forceResponseFiles)
+        var result = args.joined(separator: " ")
+        
+        if usedResponseFile {
+            // Print the response file arguments as a comment.
+            result += " # \(job.commandLine.joinedUnresolvedArguments)"
+        }
+        
+        if !job.extraEnvironment.isEmpty {
+            result += " #"
+            for (envVar, val) in job.extraEnvironment {
+                result += " \(envVar)=\(val)"
+            }
+        }
+        return result
+    }
 }

--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -139,9 +139,9 @@ public struct SwiftBuildTool: SwiftCommand {
 
     private func checkClangVersion(observabilityScope: ObservabilityScope) {
         // We only care about this on Ubuntu 14.04
-        guard let uname = try? Process.checkNonZeroExit(args: "lsb_release", "-r").spm_chomp(),
+        guard let uname = try? TSCBasic.Process.checkNonZeroExit(args: "lsb_release", "-r").spm_chomp(),
               uname.hasSuffix("14.04"),
-              let clangVersionOutput = try? Process.checkNonZeroExit(args: "clang", "--version").spm_chomp(),
+              let clangVersionOutput = try? TSCBasic.Process.checkNonZeroExit(args: "clang", "--version").spm_chomp(),
               let clang = getClangVersion(versionOutput: clangVersionOutput) else {
             return
         }

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -331,7 +331,7 @@ extension SwiftPackageTool {
             let args = [swiftFormat.pathString] + formatOptions + [packagePath.pathString] + paths
             print("Running:", args.map{ $0.spm_shellEscaped() }.joined(separator: " "))
 
-            let result = try Process.popen(arguments: args)
+            let result = try TSCBasic.Process.popen(arguments: args)
             let output = try (result.utf8Output() + result.utf8stderrOutput())
 
             if result.exitStatus != .terminated(code: 0) {
@@ -1358,7 +1358,7 @@ final class PluginDelegate: PluginInvocationDelegate {
                 llvmProfCommand.append(filePath.pathString)
             }
             llvmProfCommand += ["-o", mergedCovFile.pathString]
-            try Process.checkNonZeroExit(arguments: llvmProfCommand)
+            try TSCBasic.Process.checkNonZeroExit(arguments: llvmProfCommand)
 
             // Use `llvm-cov` to export the merged `.profdata` file contents in JSON form.
             var llvmCovCommand = [try toolchain.getLLVMCov().pathString]
@@ -1368,7 +1368,7 @@ final class PluginDelegate: PluginInvocationDelegate {
                 llvmCovCommand.append(product.binaryPath.pathString)
             }
             // We get the output on stdout, and have to write it to a JSON ourselves.
-            let jsonOutput = try Process.checkNonZeroExit(arguments: llvmCovCommand)
+            let jsonOutput = try TSCBasic.Process.checkNonZeroExit(arguments: llvmCovCommand)
             let jsonCovFile = buildParameters.codeCovDataFile.parentDirectory.appending(component: buildParameters.codeCovDataFile.basenameWithoutExt + ".json")
             try swiftTool.fileSystem.writeFileContents(jsonCovFile, string: jsonOutput)
 

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -436,7 +436,7 @@ public struct SwiftTestTool: SwiftCommand {
         }
         args += ["-o", buildParameters.codeCovDataFile.pathString]
 
-        try Process.checkNonZeroExit(arguments: args)
+        try TSCBasic.Process.checkNonZeroExit(arguments: args)
     }
 
     private func codeCovAsJSONPath(buildParameters: BuildParameters, packageName: String) -> AbsolutePath {
@@ -454,7 +454,7 @@ public struct SwiftTestTool: SwiftCommand {
             "-instr-profile=\(buildParameters.codeCovDataFile)",
             testBinary.pathString
         ]
-        let result = try Process.popen(arguments: args)
+        let result = try TSCBasic.Process.popen(arguments: args)
 
         if result.exitStatus != .terminated(code: 0) {
             let output = try result.utf8Output() + result.utf8stderrOutput()
@@ -621,7 +621,7 @@ final class TestRunner {
                 stdout: outputHandler,
                 stderr: outputHandler
             )
-            let process = Process(arguments: try args(forTestAt: path), environment: self.testEnv, outputRedirection: outputRedirection)
+            let process = TSCBasic.Process(arguments: try args(forTestAt: path), environment: self.testEnv, outputRedirection: outputRedirection)
             guard let terminationKey = self.cancellator.register(process) else {
                 return false // terminating
             }

--- a/Sources/Commands/Utilities/APIDigester.swift
+++ b/Sources/Commands/Utilities/APIDigester.swift
@@ -234,7 +234,7 @@ public struct SwiftAPIDigester {
 
     private func runTool(_ args: [String]) throws {
         let arguments = [tool.pathString] + args
-        let process = Process(
+        let process = TSCBasic.Process(
             arguments: arguments,
             outputRedirection: .collect
         )

--- a/Sources/Commands/Utilities/SymbolGraphExtract.swift
+++ b/Sources/Commands/Utilities/SymbolGraphExtract.swift
@@ -45,7 +45,7 @@ public struct SymbolGraphExtract {
     public func extractSymbolGraph(
         target: ResolvedTarget,
         buildPlan: BuildPlan,
-        outputRedirection: Process.OutputRedirection = .none,
+        outputRedirection: TSCBasic.Process.OutputRedirection = .none,
         outputDirectory: AbsolutePath,
         verboseOutput: Bool
     ) throws {
@@ -80,7 +80,7 @@ public struct SymbolGraphExtract {
         commandLine += ["-output-dir", outputDirectory.pathString]
 
         // Run the extraction.
-        let process = Process(
+        let process = TSCBasic.Process(
             arguments: commandLine,
             outputRedirection: outputRedirection
         )

--- a/Sources/Commands/Utilities/TestingSupport.swift
+++ b/Sources/Commands/Utilities/TestingSupport.swift
@@ -88,7 +88,7 @@ enum TestingSupport {
                 env.appendPath("DYLD_FRAMEWORK_PATH", value: sdkPlatformFrameworksPath.fwk.pathString)
                 env.appendPath("DYLD_LIBRARY_PATH", value: sdkPlatformFrameworksPath.lib.pathString)
             }
-            try Process.checkNonZeroExit(arguments: args, environment: env)
+            try TSCBasic.Process.checkNonZeroExit(arguments: args, environment: env)
             // Read the temporary file's content.
             return try swiftTool.fileSystem.readFileContents(tempFile.path)
         }

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -588,7 +588,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                     cmd += ["-o", compiledManifestFile.pathString]
 
                     // Compile the manifest.
-                    Process.popen(arguments: cmd, environment: self.toolchain.swiftCompilerEnvironment, queue: callbackQueue) { result in
+                    TSCBasic.Process.popen(arguments: cmd, environment: self.toolchain.swiftCompilerEnvironment, queue: callbackQueue) { result in
                         dispatchPrecondition(condition: .onQueue(callbackQueue))
 
                         var cleanupIfError = DelayableAction(target: tmpDir, action: cleanupTmpDir)
@@ -648,7 +648,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                         #endif
 
                         let cleanupAfterRunning = cleanupIfError.delay()
-                        Process.popen(arguments: cmd, environment: environment, queue: callbackQueue) { result in
+                        TSCBasic.Process.popen(arguments: cmd, environment: environment, queue: callbackQueue) { result in
                             dispatchPrecondition(condition: .onQueue(callbackQueue))
 
                             defer { cleanupAfterRunning.perform() }
@@ -697,7 +697,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         var sdkRootPath: AbsolutePath? = nil
         // Find SDKROOT on macOS using xcrun.
         #if os(macOS)
-        let foundPath = try? Process.checkNonZeroExit(
+        let foundPath = try? TSCBasic.Process.checkNonZeroExit(
             args: "/usr/bin/xcrun", "--sdk", "macosx", "--show-sdk-path")
         guard let sdkRoot = foundPath?.spm_chomp(), !sdkRoot.isEmpty else {
             return nil

--- a/Sources/PackageLoading/PkgConfig.swift
+++ b/Sources/PackageLoading/PkgConfig.swift
@@ -392,7 +392,7 @@ internal struct PCFileFinder {
     private init(pkgConfigPath: String) {
         if PCFileFinder.pkgConfigPaths == nil {
             do {
-                let searchPaths = try Process.checkNonZeroExit(args:
+                let searchPaths = try TSCBasic.Process.checkNonZeroExit(args:
                     pkgConfigPath, "--variable", "pc_path", "pkg-config"
                 ).spm_chomp()
 

--- a/Sources/PackageLoading/Target+PkgConfig.swift
+++ b/Sources/PackageLoading/Target+PkgConfig.swift
@@ -174,7 +174,7 @@ extension SystemPackageProviderDescription {
                 // to the latest version. Instead use the version as symlinked
                 // in /usr/local/opt/(NAME)/lib/pkgconfig.
                 struct Static {
-                    static let value = { try? Process.checkNonZeroExit(args: "brew", "--prefix").spm_chomp() }()
+                    static let value = { try? TSCBasic.Process.checkNonZeroExit(args: "brew", "--prefix").spm_chomp() }()
                 }
                 if let value = Static.value {
                     brewPrefix = value

--- a/Sources/PackageModel/Destination.swift
+++ b/Sources/PackageModel/Destination.swift
@@ -124,7 +124,7 @@ public struct Destination: Encodable, Equatable {
             sdkPath = value
         } else {
             // No value in env, so search for it.
-            let sdkPathStr = try Process.checkNonZeroExit(
+            let sdkPathStr = try TSCBasic.Process.checkNonZeroExit(
                 arguments: ["/usr/bin/xcrun", "--sdk", "macosx", "--show-sdk-path"], environment: environment).spm_chomp()
             guard !sdkPathStr.isEmpty else {
                 throw DestinationError.invalidInstallation("default SDK not found")
@@ -177,7 +177,7 @@ public struct Destination: Encodable, Equatable {
         if let path = _sdkPlatformFrameworkPath {
             return path
         }
-        let platformPath = try? Process.checkNonZeroExit(
+        let platformPath = try? TSCBasic.Process.checkNonZeroExit(
             arguments: ["/usr/bin/xcrun", "--sdk", "macosx", "--show-sdk-platform-path"],
             environment: environment).spm_chomp()
 

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -98,7 +98,7 @@ public final class UserToolchain: Toolchain {
     private static func findTool(_ name: String, envSearchPaths: [AbsolutePath], useXcrun: Bool) throws -> AbsolutePath {
         if useXcrun {
 #if os(macOS)
-            let foundPath = try Process.checkNonZeroExit(arguments: ["/usr/bin/xcrun", "--find", name]).spm_chomp()
+            let foundPath = try TSCBasic.Process.checkNonZeroExit(arguments: ["/usr/bin/xcrun", "--find", name]).spm_chomp()
             return try AbsolutePath(validating: foundPath)
 #endif
         }
@@ -477,7 +477,7 @@ public final class UserToolchain: Toolchain {
         if triple.isDarwin() {
             // XCTest is optional on macOS, for example when Xcode is not installed
             let xctestFindArgs = ["/usr/bin/xcrun", "--sdk", "macosx", "--find", "xctest"]
-            if let path = try? Process.checkNonZeroExit(arguments: xctestFindArgs, environment: environment).spm_chomp() {
+            if let path = try? TSCBasic.Process.checkNonZeroExit(arguments: xctestFindArgs, environment: environment).spm_chomp() {
                 return try AbsolutePath(validating: path)
             }
         } else if triple.isWindows() {

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -31,8 +31,8 @@ private struct GitShellHelper {
     /// Private function to invoke the Git tool with its default environment and given set of arguments.  The specified
     /// failure message is used only in case of error.  This function waits for the invocation to finish and returns the
     /// output as a string.
-    func run(_ args: [String], environment: EnvironmentVariables = Git.environment, outputRedirection: Process.OutputRedirection = .collect) throws -> String {
-        let process = Process(arguments: [Git.tool] + args, environment: environment, outputRedirection: outputRedirection)
+    func run(_ args: [String], environment: EnvironmentVariables = Git.environment, outputRedirection: TSCBasic.Process.OutputRedirection = .collect) throws -> String {
+        let process = TSCBasic.Process(arguments: [Git.tool] + args, environment: environment, outputRedirection: outputRedirection)
         let result: ProcessResult
         do {
             guard let terminationKey = self.cancellator.register(process) else {

--- a/Sources/Workspace/DefaultPluginScriptRunner.swift
+++ b/Sources/Workspace/DefaultPluginScriptRunner.swift
@@ -312,7 +312,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
         }
         
         // Now invoke the compiler asynchronously.
-        Process.popen(arguments: commandLine, environment: toolchain.swiftCompilerEnvironment, queue: callbackQueue) {
+        TSCBasic.Process.popen(arguments: commandLine, environment: toolchain.swiftCompilerEnvironment, queue: callbackQueue) {
             // We are now on our caller's requested callback queue, so we just call the completion handler directly.
             dispatchPrecondition(condition: .onQueue(callbackQueue))
             completion($0.tryMap { process in
@@ -359,7 +359,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
         var sdkRootPath: AbsolutePath?
         // Find SDKROOT on macOS using xcrun.
         #if os(macOS)
-        let foundPath = try? Process.checkNonZeroExit(
+        let foundPath = try? TSCBasic.Process.checkNonZeroExit(
             args: "/usr/bin/xcrun", "--sdk", "macosx", "--show-sdk-path"
         )
         guard let sdkRoot = foundPath?.spm_chomp(), !sdkRoot.isEmpty else {

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -78,7 +78,7 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
         if let xcbuildTool = ProcessEnv.vars["XCBUILD_TOOL"] {
             xcbuildPath = try AbsolutePath(validating: xcbuildTool)
         } else {
-            let xcodeSelectOutput = try Process.popen(args: "xcode-select", "-p").utf8Output().spm_chomp()
+            let xcodeSelectOutput = try TSCBasic.Process.popen(args: "xcode-select", "-p").utf8Output().spm_chomp()
             let xcodeDirectory = try AbsolutePath(validating: xcodeSelectOutput)
             xcbuildPath = AbsolutePath("../SharedFrameworks/XCBuild.framework/Versions/A/Support/xcbuild", relativeTo: xcodeDirectory)
         }
@@ -122,7 +122,7 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
         var hasStdout = false
         var stdoutBuffer: [UInt8] = []
         var stderrBuffer: [UInt8] = []
-        let redirection: Process.OutputRedirection = .stream(stdout: { bytes in
+        let redirection: TSCBasic.Process.OutputRedirection = .stream(stdout: { bytes in
             hasStdout = hasStdout || !bytes.isEmpty
             delegate.parse(bytes: bytes)
 
@@ -133,7 +133,7 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
             stderrBuffer.append(contentsOf: bytes)
         })
 
-        let process = Process(arguments: arguments, outputRedirection: redirection)
+        let process = TSCBasic.Process(arguments: arguments, outputRedirection: redirection)
         try process.launch()
         let result = try process.waitUntilExit()
 

--- a/Tests/BasicsTests/SandboxTests.swift
+++ b/Tests/BasicsTests/SandboxTests.swift
@@ -23,7 +23,7 @@ final class SandboxTest: XCTestCase {
 #else
             let command = Sandbox.apply(command: ["echo", "0"], strictness: .default, writableDirectories: [])
 #endif
-            XCTAssertNoThrow(try Process.checkNonZeroExit(arguments: command))
+            XCTAssertNoThrow(try TSCBasic.Process.checkNonZeroExit(arguments: command))
         }
     }
 
@@ -34,7 +34,7 @@ final class SandboxTest: XCTestCase {
 
         let command = Sandbox.apply(command: ["ping", "-t", "1", "localhost"], strictness: .default, writableDirectories: [])
 
-        XCTAssertThrowsError(try Process.checkNonZeroExit(arguments: command)) { error in
+        XCTAssertThrowsError(try TSCBasic.Process.checkNonZeroExit(arguments: command)) { error in
             guard case ProcessResult.Error.nonZeroExit(let result) = error else {
                 return XCTFail("invalid error \(error)")
             }
@@ -49,7 +49,7 @@ final class SandboxTest: XCTestCase {
 
         try withTemporaryDirectory { path in
             let command = Sandbox.apply(command: ["touch", path.appending(component: UUID().uuidString).pathString], strictness: .default, writableDirectories: [path])
-            XCTAssertNoThrow(try Process.checkNonZeroExit(arguments: command))
+            XCTAssertNoThrow(try TSCBasic.Process.checkNonZeroExit(arguments: command))
         }
     }
 
@@ -60,7 +60,7 @@ final class SandboxTest: XCTestCase {
 
         try withTemporaryDirectory { path in
             let command = Sandbox.apply(command: ["touch", path.appending(component: UUID().uuidString).pathString], strictness: .default, writableDirectories: [])
-            XCTAssertThrowsError(try Process.checkNonZeroExit(arguments: command)) { error in
+            XCTAssertThrowsError(try TSCBasic.Process.checkNonZeroExit(arguments: command)) { error in
                 guard case ProcessResult.Error.nonZeroExit(let result) = error else {
                     return XCTFail("invalid error \(error)")
                 }
@@ -76,10 +76,10 @@ final class SandboxTest: XCTestCase {
 
         try withTemporaryDirectory { path in
             let file = path.appending(component: UUID().uuidString)
-            XCTAssertNoThrow(try Process.checkNonZeroExit(arguments: ["touch", file.pathString]))
+            XCTAssertNoThrow(try TSCBasic.Process.checkNonZeroExit(arguments: ["touch", file.pathString]))
 
             let command = Sandbox.apply(command: ["rm", file.pathString], strictness: .default, writableDirectories: [])
-            XCTAssertThrowsError(try Process.checkNonZeroExit(arguments: command)) { error in
+            XCTAssertThrowsError(try TSCBasic.Process.checkNonZeroExit(arguments: command)) { error in
                 guard case ProcessResult.Error.nonZeroExit(let result) = error else {
                     return XCTFail("invalid error \(error)")
                 }
@@ -96,10 +96,10 @@ final class SandboxTest: XCTestCase {
 
         try withTemporaryDirectory { path in
             let file = path.appending(component: UUID().uuidString)
-            XCTAssertNoThrow(try Process.checkNonZeroExit(arguments: ["touch", file.pathString]))
+            XCTAssertNoThrow(try TSCBasic.Process.checkNonZeroExit(arguments: ["touch", file.pathString]))
 
             let command = Sandbox.apply(command: ["cat", file.pathString], strictness: .default, writableDirectories: [])
-            XCTAssertNoThrow(try Process.checkNonZeroExit(arguments: command))
+            XCTAssertNoThrow(try TSCBasic.Process.checkNonZeroExit(arguments: command))
         }
     }
 
@@ -111,11 +111,11 @@ final class SandboxTest: XCTestCase {
 
         try withTemporaryDirectory { path in
             let file = path.appending(component: UUID().uuidString)
-            XCTAssertNoThrow(try Process.checkNonZeroExit(arguments: ["touch", file.pathString]))
-            XCTAssertNoThrow(try Process.checkNonZeroExit(arguments: ["chmod", "+x", file.pathString]))
+            XCTAssertNoThrow(try TSCBasic.Process.checkNonZeroExit(arguments: ["touch", file.pathString]))
+            XCTAssertNoThrow(try TSCBasic.Process.checkNonZeroExit(arguments: ["chmod", "+x", file.pathString]))
 
             let command = Sandbox.apply(command: [file.pathString], strictness: .default, writableDirectories: [])
-            XCTAssertNoThrow(try Process.checkNonZeroExit(arguments: command))
+            XCTAssertNoThrow(try TSCBasic.Process.checkNonZeroExit(arguments: command))
         }
     }
 
@@ -127,12 +127,12 @@ final class SandboxTest: XCTestCase {
         // Try writing to the per-user temporary directory, which is under /var/folders/.../TemporaryItems.
         let tmpFile1 = NSTemporaryDirectory() + "/" + UUID().uuidString
         let command1 = Sandbox.apply(command: ["touch", tmpFile1], strictness: .writableTemporaryDirectory)
-        XCTAssertNoThrow(try Process.checkNonZeroExit(arguments: command1))
+        XCTAssertNoThrow(try TSCBasic.Process.checkNonZeroExit(arguments: command1))
         try? FileManager.default.removeItem(atPath: tmpFile1)
 
         let tmpFile2 = "/tmp" + "/" + UUID().uuidString
         let command2 = Sandbox.apply(command: ["touch", tmpFile2], strictness: .writableTemporaryDirectory)
-        XCTAssertNoThrow(try Process.checkNonZeroExit(arguments: command2))
+        XCTAssertNoThrow(try TSCBasic.Process.checkNonZeroExit(arguments: command2))
         try? FileManager.default.removeItem(atPath: tmpFile2)
     }
 
@@ -146,13 +146,13 @@ final class SandboxTest: XCTestCase {
             let writableDir = tmpDir.appending(component: "ShouldBeWritable")
             try localFileSystem.createDirectory(writableDir)
             let allowedCommand = Sandbox.apply(command: ["touch", writableDir.pathString], strictness: .default, writableDirectories: [writableDir])
-            XCTAssertNoThrow(try Process.checkNonZeroExit(arguments: allowedCommand))
+            XCTAssertNoThrow(try TSCBasic.Process.checkNonZeroExit(arguments: allowedCommand))
 
             // Check that we cannot write into a read-only directory inside a writable temporary directory.
             let readOnlyDir = writableDir.appending(component: "ShouldBeReadOnly")
             try localFileSystem.createDirectory(readOnlyDir)
             let deniedCommand = Sandbox.apply(command: ["touch", readOnlyDir.pathString], strictness: .writableTemporaryDirectory, readOnlyDirectories: [readOnlyDir])
-            XCTAssertThrowsError(try Process.checkNonZeroExit(arguments: deniedCommand)) { error in
+            XCTAssertThrowsError(try TSCBasic.Process.checkNonZeroExit(arguments: deniedCommand)) { error in
                 guard case ProcessResult.Error.nonZeroExit(let result) = error else {
                     return XCTFail("invalid error \(error)")
                 }
@@ -171,7 +171,7 @@ final class SandboxTest: XCTestCase {
              let readOnlyDir = tmpDir.appending(component: "ShouldBeReadOnly")
              try localFileSystem.createDirectory(readOnlyDir)
              let deniedCommand = Sandbox.apply(command: ["touch", readOnlyDir.pathString], strictness: .writableTemporaryDirectory, readOnlyDirectories: [readOnlyDir])
-             XCTAssertThrowsError(try Process.checkNonZeroExit(arguments: deniedCommand)) { error in
+             XCTAssertThrowsError(try TSCBasic.Process.checkNonZeroExit(arguments: deniedCommand)) { error in
                  guard case ProcessResult.Error.nonZeroExit(let result) = error else {
                      return XCTFail("invalid error \(error)")
                  }
@@ -182,7 +182,7 @@ final class SandboxTest: XCTestCase {
              let writableDir = readOnlyDir.appending(component: "ShouldBeWritable")
              try localFileSystem.createDirectory(writableDir)
              let allowedCommand = Sandbox.apply(command: ["touch", writableDir.pathString], strictness: .default, writableDirectories:[writableDir], readOnlyDirectories: [readOnlyDir])
-             XCTAssertNoThrow(try Process.checkNonZeroExit(arguments: allowedCommand))
+             XCTAssertNoThrow(try TSCBasic.Process.checkNonZeroExit(arguments: allowedCommand))
          }
      }
 }

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -793,7 +793,7 @@ final class PackageToolTests: CommandsTestCase {
 
             XCTAssertMatch(stderr, .contains("dependency 'baz' was being edited but is missing; falling back to original checkout"))
             // We should be able to see that modification now.
-            XCTAssertEqual(try Process.checkNonZeroExit(arguments: exec), "88888\n")
+            XCTAssertEqual(try TSCBasic.Process.checkNonZeroExit(arguments: exec), "88888\n")
             // The branch of edited package should be the one we provided when putting it in edit mode.
             let editsRepo = GitRepository(path: editsPath)
             XCTAssertEqual(try editsRepo.currentBranch(), "bugfix")
@@ -943,7 +943,7 @@ final class PackageToolTests: CommandsTestCase {
 
             // Build and check.
             _ = try build()
-            XCTAssertEqual(try Process.checkNonZeroExit(arguments: exec).spm_chomp(), "\(5)")
+            XCTAssertEqual(try TSCBasic.Process.checkNonZeroExit(arguments: exec).spm_chomp(), "\(5)")
 
             // Get path to bar checkout.
             let barPath = try SwiftPMProduct.packagePath(for: "bar", packageRoot: fooPath)

--- a/Tests/XcodeprojTests/FunctionalTests.swift
+++ b/Tests/XcodeprojTests/FunctionalTests.swift
@@ -116,7 +116,7 @@ class FunctionalTests: XCTestCase {
         try write(path: AbsolutePath("/tmp/fake.c")) { stream in
             stream <<< "const char * GetFakeString(void) { return \"abc\"; }\n"
         }
-        try Process.checkNonZeroExit(
+        try TSCBasic.Process.checkNonZeroExit(
             args: "env", "-u", "TOOLCHAINS", "xcrun", "clang", "-dynamiclib", "/tmp/fake.c", "-o", "/tmp/libfake.dylib")
         // Now we use a fixture for both the system library wrapper and the text executable.
         try fixture(name: "Miscellaneous/SystemModules") { fixturePath in
@@ -167,7 +167,7 @@ func XCTAssertXcodeBuild(project: AbsolutePath, file: StaticString = #file, line
         let scheme = packageName + "-Package"
 
         let buildDir = project.parentDirectory.appending(component: "build")
-        try Process.checkNonZeroExit(
+        try TSCBasic.Process.checkNonZeroExit(
             args: "xcodebuild",
               "-project", project.pathString,
               "-scheme", scheme,

--- a/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
+++ b/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
@@ -69,7 +69,7 @@ class GenerateXcodeprojTests: XCTestCase {
 
             // We can only validate this on OS X.
             // Don't allow TOOLCHAINS to be overridden here, as it breaks the test below.
-            let output = try Process.checkNonZeroExit(
+            let output = try TSCBasic.Process.checkNonZeroExit(
                 args: "env", "-u", "TOOLCHAINS", "xcodebuild", "-list", "-project", outpath.pathString).spm_chomp()
 
             XCTAssertMatch(output, .contains("""


### PR DESCRIPTION
Basically it marks all usage of Process as TSCBasic.Process

### Motivation:

It is to address a problem of disambiguation that occurs when creating `Process` inside SwiftBasics library. The motivation overall is driven by comment https://github.com/apple/swift-package-manager/pull/5532#issuecomment-1133212593

### Modifications:

Specify explicitly that current `Process` is from `TSCBasic` library. It is done in source code and tests

### Result:

The result is to make sure that adoption by targets of future `Process` inside SwiftBasics to be incremental
