### PR TITLE
allow use of warnings-as-errors while dependencies have supressed warnings

### DIFF
--- a/Fixtures/Miscellaneous/DependenciesWarnings2/app/Package.swift
+++ b/Fixtures/Miscellaneous/DependenciesWarnings2/app/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 5.7
+import PackageDescription
+
+let package = Package(
+    name: "app",
+    products: [
+        .executable(name: "app", targets: ["app"])
+    ],
+    dependencies: [
+        .package(url: "../dep1", from: "1.0.0"),
+        .package(url: "../dep2", from: "1.0.0"),
+    ],
+    targets: [
+        .executableTarget(
+          name: "app",
+          dependencies: [
+            .product(name: "dep1", package: "dep1"),
+            .product(name: "dep2", package: "dep2")
+          ],
+          path: "./"
+        )
+    ]
+)

--- a/Fixtures/Miscellaneous/DependenciesWarnings2/app/app.swift
+++ b/Fixtures/Miscellaneous/DependenciesWarnings2/app/app.swift
@@ -1,0 +1,9 @@
+import dep1
+import dep2
+
+@main
+struct App {
+  public static func main() {
+    print("hello, world!")
+  }
+}

--- a/Fixtures/Miscellaneous/DependenciesWarnings2/dep1/Package.swift
+++ b/Fixtures/Miscellaneous/DependenciesWarnings2/dep1/Package.swift
@@ -1,0 +1,12 @@
+// swift-tools-version: 5.7
+import PackageDescription
+
+let package = Package(
+    name: "dep1",
+    products: [
+        .library(name: "dep1", targets: ["dep1"])
+    ],
+    targets: [
+        .target(name: "dep1", path: "./")
+    ]
+)

--- a/Fixtures/Miscellaneous/DependenciesWarnings2/dep1/code.swift
+++ b/Fixtures/Miscellaneous/DependenciesWarnings2/dep1/code.swift
@@ -1,0 +1,7 @@
+struct Dep1 {
+  var deprecated: Deprecated1
+}
+
+@available(*, deprecated)
+struct Deprecated1 {
+}

--- a/Fixtures/Miscellaneous/DependenciesWarnings2/dep2/Package.swift
+++ b/Fixtures/Miscellaneous/DependenciesWarnings2/dep2/Package.swift
@@ -1,0 +1,12 @@
+// swift-tools-version: 5.7
+import PackageDescription
+
+let package = Package(
+    name: "dep2",
+    products: [
+        .library(name: "dep2", targets: ["dep2"])
+    ],
+    targets: [
+        .target(name: "dep2", path: "./")
+    ]
+)

--- a/Fixtures/Miscellaneous/DependenciesWarnings2/dep2/code.swift
+++ b/Fixtures/Miscellaneous/DependenciesWarnings2/dep2/code.swift
@@ -1,0 +1,7 @@
+struct Dep2 {
+  var deprecated: Deprecated2
+}
+
+@available(*, deprecated)
+struct Deprecated2 {
+}

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -873,14 +873,19 @@ public final class SwiftTargetBuildDescription {
             args += ["-emit-module-interface-path", parseableModuleInterfaceOutputPath.pathString]
         }
 
-        // suppress warnings if the package is remote
-        if self.package.isRemote {
-            args += ["-suppress-warnings"]
-        }
-
         args += buildParameters.toolchain.extraSwiftCFlags
         // User arguments (from -Xswiftc) should follow generated arguments to allow user overrides
         args += buildParameters.swiftCompilerFlags
+
+        // suppress warnings if the package is remote
+        if self.package.isRemote {
+            args += ["-suppress-warnings"]
+            // suppress-warnings and warnings-as-errors are mutually exclusive
+            if let index = args.firstIndex(of: "-warnings-as-errors") {
+                args.remove(at: index)
+            }
+        }
+
         return args
     }
 

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -850,4 +850,20 @@ class MiscellaneousTestCase: XCTestCase {
             XCTAssertNoMatch(stdout + stderr, .contains("'Deprecated2' is deprecated"))
         }
     }
+
+    func testNoWarningFromRemoteDependenciesWithWarningsAsErrors() throws {
+        try fixture(name: "Miscellaneous/DependenciesWarnings2") { path in
+            // prepare the deps as git sources
+            let dependency1Path = path.appending(component: "dep1")
+            initGitRepo(dependency1Path, tag: "1.0.0")
+            let dependency2Path = path.appending(component: "dep2")
+            initGitRepo(dependency2Path, tag: "1.0.0")
+
+            let appPath = path.appending(component: "app")
+            let (stdout, stderr) = try SwiftPMProduct.SwiftBuild.execute(["-Xswiftc", "-warnings-as-errors"], packagePath: appPath)
+            XCTAssertDirectoryExists(appPath.appending(component: ".build"))
+            XCTAssertNoMatch(stdout + stderr, .contains("'Deprecated1' is deprecated"))
+            XCTAssertNoMatch(stdout + stderr, .contains("'Deprecated2' is deprecated"))
+        }
+    }
 }


### PR DESCRIPTION
motivation: warnings-as-errors and suppress-warnings are mutually exclusive

changes:
* do not pass warnings-as-errors for remote dependencies which use suppress-warnings
* add test
