### PR TITLE
Fix MacCatalyst minimum deployment fallback

### DIFF
--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -617,14 +617,19 @@ private func computePlatforms(
     for platformName in remainingPlatforms.sorted() {
         let platform = platformRegistry.platformByName[platformName]!
 
-        let oldestSupportedVersion: PlatformVersion
+        let minimumSupportedVersion: PlatformVersion
         if usingXCTest, let xcTestMinimumDeploymentTarget = xcTestMinimumDeploymentTargets[platform] {
-            oldestSupportedVersion = xcTestMinimumDeploymentTarget
-        } else if platform == .macCatalyst, let iOS = derivedPlatforms.first(where: { $0.platform == .iOS }) {
-            // If there was no deployment target specified for Mac Catalyst, fall back to the iOS deployment target.
-            oldestSupportedVersion = max(platform.oldestSupportedVersion, iOS.version)
+            minimumSupportedVersion = xcTestMinimumDeploymentTarget
         } else {
-            oldestSupportedVersion = platform.oldestSupportedVersion
+            minimumSupportedVersion = platform.oldestSupportedVersion
+        }
+
+        let oldestSupportedVersion: PlatformVersion
+        if platform == .macCatalyst, let iOS = derivedPlatforms.first(where: { $0.platform == .iOS }) {
+            // If there was no deployment target specified for Mac Catalyst, fall back to the iOS deployment target.
+            oldestSupportedVersion = max(minimumSupportedVersion, iOS.version)
+        } else {
+            oldestSupportedVersion = minimumSupportedVersion
         }
 
         let supportedPlatform = SupportedPlatform(


### PR DESCRIPTION
If a package does not specify a custom deployment target for MacCatalyst, we are supposed to fallback to the iOS one, if declared. This currently does not work for test targets, because we prefer the minimum XCTest deployment target, even if it may be lower than the customized iOS one.
