### PR TITLE
Improve speed of finding dependency cycles

### DIFF
--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -872,6 +872,7 @@ fileprivate func findCycle(
 ) rethrows -> (path: [Manifest], cycle: [Manifest])? {
     // Ordered set to hold the current traversed path.
     var path = OrderedCollections.OrderedSet<Manifest>()
+    var validPackages = Set<Manifest>()
 
     // Function to visit nodes recursively.
     // FIXME: Convert to stack.
@@ -879,6 +880,8 @@ fileprivate func findCycle(
       _ node: GraphLoadingNode,
       _ successors: (GraphLoadingNode) throws -> [GraphLoadingNode]
     ) rethrows -> (path: [Manifest], cycle: [Manifest])? {
+        if validPackages.contains(node.manifest) { return nil }
+        
         // If this node is already in the current path then we have found a cycle.
         if !path.append(node.manifest).inserted {
             let index = path.firstIndex(of: node.manifest)! // forced unwrap safe
@@ -893,6 +896,7 @@ fileprivate func findCycle(
         // No cycle found for this node, remove it from the path.
         let item = path.removeLast()
         assert(item == node.manifest)
+        validPackages.insert(node.manifest)
         return nil
     }
 


### PR DESCRIPTION
Significantly improve speed of finding cycles in dependency tree

### Motivation:

At the moment, if dependencies are composed to layers, depending on graph size, it can take minutes and even hours to validate that there are no cycles. Take a look at [this issue](https://github.com/apple/swift-package-manager/issues/5580) and a [PR in swift-tools-support-core](https://github.com/apple/swift-tools-support-core/pull/332).

### Modifications:

Cache already checked graph nodes and reuse results in subsequent visits.

### Result:

This modification improved complexity to O(n) instead of O(n!). So package graph of 100 layers with 100 nodes in each layer is checked in 0.2 seconds instead of hours.
