### PR TITLE
[5.7] Validation of package products should check that a library product doesn't try to include executable targets (#5625)

### DIFF
--- a/Fixtures/Miscellaneous/PackageWithMalformedLibraryProduct/Package.swift
+++ b/Fixtures/Miscellaneous/PackageWithMalformedLibraryProduct/Package.swift
@@ -1,0 +1,15 @@
+// swift-tools-version: 5.7
+import PackageDescription
+
+let package = Package(
+    name: "PackageWithMalformedLibraryProduct",
+    products: [
+        .library(
+            name: "PackageWithMalformedLibraryProduct",
+            targets: ["PackageWithMalformedLibraryProduct"]),
+    ],
+    targets: [
+        .executableTarget(
+            name: "PackageWithMalformedLibraryProduct")
+    ]
+)

--- a/Fixtures/Miscellaneous/PackageWithMalformedLibraryProduct/Sources/PackageWithMalformedLibraryProduct/main.swift
+++ b/Fixtures/Miscellaneous/PackageWithMalformedLibraryProduct/Sources/PackageWithMalformedLibraryProduct/main.swift
@@ -1,0 +1,1 @@
+print("Hello World")

--- a/Sources/PackageLoading/Diagnostics.swift
+++ b/Sources/PackageLoading/Diagnostics.swift
@@ -56,6 +56,10 @@ extension Basics.Diagnostic {
         .error("system library product \(product) shouldn't have a type and contain only one target")
     }
 
+    static func libraryProductWithExecutableTarget(product: String, executableTargets: [String]) -> Self {
+        .error("library product '\(product)' should not contain executable targets (it has \(executableTargets.map{ "'\($0)'" }.joined(separator: ", ")))")
+    }
+
     static func nonPluginProductWithPluginTargets(product: String, type: ProductType, pluginTargets: [String]) -> Self {
         .error("\(type.description) product '\(product)' should not contain plugin targets (it has \(pluginTargets.map{ "'\($0)'" }.joined(separator: ", ")))")
     }

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -1222,6 +1222,13 @@ public final class PackageBuilder {
             self.observabilityScope.emit(.nonPluginProductWithPluginTargets(product: product.name, type: product.type, pluginTargets: pluginTargets.map{ $0.name }))
             return false
         }
+        if manifest.toolsVersion >= .v5_7 {
+            let executableTargets = targets.filter { $0.type == .executable }
+            guard executableTargets.isEmpty else {
+                self.observabilityScope.emit(.libraryProductWithExecutableTarget(product: product.name, executableTargets: executableTargets.map{ $0.name }))
+                return false
+            }
+        }
         return true
     }
 

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -684,6 +684,18 @@ class MiscellaneousTestCase: XCTestCase {
         }
     }
 
+    func testLibraryTriesToIncludeExecutableTarget() throws {
+        try fixture(name: "Miscellaneous/PackageWithMalformedLibraryProduct") { path in
+            XCTAssertThrowsCommandExecutionError(try executeSwiftBuild(path)) { error in
+                // if our code crashes we'll get an exit code of 256
+                guard error.result.exitStatus == .terminated(code: 1) else {
+                    return XCTFail("failed in an unexpected manner: \(error)")
+                }
+                XCTAssertMatch(error.stdout + error.stderr, .contains("library product 'PackageWithMalformedLibraryProduct' should not contain executable targets (it has 'PackageWithMalformedLibraryProduct')"))
+            }
+        }
+    }
+
     func testEditModeEndToEnd() throws {
         try fixture(name: "Miscellaneous/Edit") { fixturePath in
             let prefix = resolveSymlinks(fixturePath)


### PR DESCRIPTION
This is the 5.7 nomination of https://github.com/apple/swift-package-manager/pull/5625.

rdar://95782540
(cherry picked from commit 5bd3355d7f76b0a899c83bbf8dee138af70298ab)