### PR TITLE
SwiftPM does not build all dependency executables before invoking plugin build command

### DIFF
--- a/Fixtures/Miscellaneous/Plugins/MyBuildToolPluginDependencies/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/MyBuildToolPluginDependencies/Package.swift
@@ -1,0 +1,34 @@
+// swift-tools-version: 5.7
+import PackageDescription
+
+let package = Package(
+    name: "MyBuildToolPluginDependencies",
+    targets: [
+        // A local tool that uses a build tool plugin.
+        .executableTarget(
+            name: "MyLocalTool",
+            plugins: [
+                "MySourceGenBuildToolPlugin",
+            ]
+        ),
+        // The plugin that generates build tool commands to invoke MySourceGenBuildTool.
+        .plugin(
+            name: "MySourceGenBuildToolPlugin",
+            capability: .buildTool(),
+            dependencies: [
+                "MySourceGenBuildTool",
+            ]
+        ),
+        // A command line tool that generates source files.
+        .executableTarget(
+            name: "MySourceGenBuildTool",
+            dependencies: [
+                "MySourceGenBuildToolLib",
+            ]
+        ),
+        // A library used by MySourceGenBuildTool (not the client).
+        .target(
+            name: "MySourceGenBuildToolLib"
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/Plugins/MyBuildToolPluginDependencies/Plugins/MySourceGenBuildToolPlugin/plugin.swift
+++ b/Fixtures/Miscellaneous/Plugins/MyBuildToolPluginDependencies/Plugins/MySourceGenBuildToolPlugin/plugin.swift
@@ -1,0 +1,38 @@
+import PackagePlugin
+
+@main
+struct MyPlugin: BuildToolPlugin {
+    
+    // Create build commands that don't invoke the MySourceGenBuildTool source generator
+    // tool directly, but instead invoke a system tool that invokes it indirectly.  We
+    // want to test that we still end up with a dependency on not only that tool but also
+    // on the library it depends on, even without including an explicit dependency on it.
+    func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
+        print("Hello from the Build Tool Plugin!")
+        guard let target = target as? SourceModuleTarget else { return [] }
+        let inputFiles = target.sourceFiles.filter({ $0.path.extension == "dat" })
+        return try inputFiles.map {
+            let inputFile = $0
+            let inputPath = inputFile.path
+            let outputName = inputPath.stem + ".swift"
+            let outputPath = context.pluginWorkDirectory.appending(outputName)
+            return .buildCommand(
+                displayName:
+                    "Generating \(outputName) from \(inputPath.lastComponent)",
+                executable:
+                    Path("/usr/bin/env"),
+                arguments: [
+                    try context.tool(named: "MySourceGenBuildTool").path,
+                    "\(inputPath)",
+                    "\(outputPath)"
+                ],
+                inputFiles: [
+                    inputPath,
+                ],
+                outputFiles: [
+                    outputPath
+                ]
+            )
+        }
+    }
+}

--- a/Fixtures/Miscellaneous/Plugins/MyBuildToolPluginDependencies/Sources/MyLocalTool/foo.dat
+++ b/Fixtures/Miscellaneous/Plugins/MyBuildToolPluginDependencies/Sources/MyLocalTool/foo.dat
@@ -1,0 +1,1 @@
+let foo = "I am Foo!"

--- a/Fixtures/Miscellaneous/Plugins/MyBuildToolPluginDependencies/Sources/MyLocalTool/main.swift
+++ b/Fixtures/Miscellaneous/Plugins/MyBuildToolPluginDependencies/Sources/MyLocalTool/main.swift
@@ -1,0 +1,1 @@
+print("Generated string Foo: '\(foo)'")

--- a/Fixtures/Miscellaneous/Plugins/MyBuildToolPluginDependencies/Sources/MySourceGenBuildTool/main.swift
+++ b/Fixtures/Miscellaneous/Plugins/MyBuildToolPluginDependencies/Sources/MySourceGenBuildTool/main.swift
@@ -1,0 +1,18 @@
+import Foundation
+import MySourceGenBuildToolLib
+
+// Sample source generator tool that emits a Swift variable declaration of a string containing the hex representation of the contents of a file as a quoted string.  The variable name is the base name of the input file.  The input file is the first argument and the output file is the second.
+if ProcessInfo.processInfo.arguments.count != 3 {
+    print("usage: MySourceGenBuildTool <input> <output>")
+    exit(1)
+}
+let inputFile = ProcessInfo.processInfo.arguments[1]
+let outputFile = ProcessInfo.processInfo.arguments[2]
+
+let variableName = URL(fileURLWithPath: inputFile).deletingPathExtension().lastPathComponent
+
+let inputData = FileManager.default.contents(atPath: inputFile) ?? Data()
+let dataAsHex = inputData.map { String(format: "%02hhx", $0) }.joined()
+let outputString = "public var \(variableName) = \(dataAsHex.quotedForSourceCode)\n"
+let outputData = outputString.data(using: .utf8)
+FileManager.default.createFile(atPath: outputFile, contents: outputData)

--- a/Fixtures/Miscellaneous/Plugins/MyBuildToolPluginDependencies/Sources/MySourceGenBuildToolLib/library.swift
+++ b/Fixtures/Miscellaneous/Plugins/MyBuildToolPluginDependencies/Sources/MySourceGenBuildToolLib/library.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension String {
+    
+    public var quotedForSourceCode: String {
+        return "\"" + self
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            + "\""
+    }
+}

--- a/Sources/Build/LLBuildManifestBuilder.swift
+++ b/Sources/Build/LLBuildManifestBuilder.swift
@@ -625,7 +625,7 @@ extension LLBuildManifestBuilder {
                 manifest.addShellCmd(
                     name: displayName + "-" + ByteString(encodingAsUTF8: uniquedName).sha256Checksum,
                     description: displayName,
-                    inputs: [.file(execPath)] + command.inputFiles.map{ .file($0) },
+                    inputs: command.inputFiles.map{ .file($0) },
                     outputs: command.outputFiles.map{ .file($0) },
                     arguments: commandLine,
                     environment: command.configuration.environment,

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -102,6 +102,20 @@ class PluginTests: XCTestCase {
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
     }
+    
+    func testBuildToolPluginDependencies() throws {        
+        // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
+        try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+        
+        try fixture(name: "Miscellaneous/Plugins") { fixturePath in
+            let (stdout, _) = try executeSwiftBuild(fixturePath.appending(component: "MyBuildToolPluginDependencies"))
+            XCTAssert(stdout.contains("Compiling MySourceGenBuildTool main.swift"), "stdout:\n\(stdout)")
+            XCTAssert(stdout.contains("Linking MySourceGenBuildTool"), "stdout:\n\(stdout)")
+            XCTAssert(stdout.contains("Generating foo.swift from foo.dat"), "stdout:\n\(stdout)")
+            XCTAssert(stdout.contains("Compiling MyLocalTool foo.swift"), "stdout:\n\(stdout)")
+            XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
+        }
+    }
 
     func testContrivedTestCases() throws {
         // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -212,7 +212,7 @@ class PluginInvocationTests: XCTestCase {
         XCTAssertEqual(evalFirstCommand.configuration.arguments, ["-c", "/Foo/Sources/Foo/SomeFile.abc"])
         XCTAssertEqual(evalFirstCommand.configuration.environment, ["X": "Y"])
         XCTAssertEqual(evalFirstCommand.configuration.workingDirectory, AbsolutePath("/Foo/Sources/Foo"))
-        XCTAssertEqual(evalFirstCommand.inputFiles, [])
+        XCTAssertEqual(evalFirstCommand.inputFiles, [builtToolsDir.appending(component: "FooTool")])
         XCTAssertEqual(evalFirstCommand.outputFiles, [])
 
         XCTAssertEqual(evalFirstResult.diagnostics.count, 1)


### PR DESCRIPTION
### Background & Motivation

Plugins can specify dependencies on executables.  Currently, those executables get built before running build tool commands returned by the plugin if those dependencies were either:
- the path of the executable of a build tool command returned by the plugin, or
- explicitly included by the plugin in the list of input dependencies to a build command returned by the plugin

This could potentially be more efficient than building all dependencies, since a plugin could depend on two separate executables and then return commands that only used one or the other of them.  This would result in SwiftPM only building the executables that were actually mentioned by build commands.

However:  This led to confusion and multiple bug reports of failures resulting from not building the executables before trying to use them.  One common case is with SwiftProtobuf, which uses `protoc` as the executable and then a SwiftPM-built executable as one of the parameters to `protoc`.  If the plugin didn't explicitly include the code generation executable in the list of input dependencies in the build tools command it returns, the build would fail and it wouldn't be clear why.

### Changes

Make the list of input dependencies of an llbuild command that runs a plugin-provided build tool include the paths of all the tools on which the plugin has declared a dependency, not just the one that appears as an executable in the build command.

This can cause more command line tools to be built but is less confusing overall since a dependency on an executable by a plugin understandably implies that the executable should be built no matter what.

Note that if the plugin doesn't return _any_ build commands, none of the dependencies need to be built.  That behavior is preserved.

### Specific Modifications:

- include the paths of the depended-upon tools in the input dependencies to the plugin-provided build tool commands
- stop special-casing the executable path of build tool commands (any tool there is now included in the list of input dependencies from tools)
- add a unit test

### Results

The executables declared by a plugin are built before _any_ build command returned by the plugin (though not if the plugin doesn't return any commands, which is a no-op).

Note also that this new behavior of building the executables up-front more closely matches the behavior in Xcode 14.

rdar://93679015
