### PR TITLE
improve  test discovery to include inherited tests

### DIFF
--- a/Fixtures/Miscellaneous/TestDiscovery/Subclass/Package.swift
+++ b/Fixtures/Miscellaneous/TestDiscovery/Subclass/Package.swift
@@ -5,6 +5,7 @@ let package = Package(
     name: "Subclass",
     targets: [
         .target(name: "Subclass"),
-        .testTarget(name: "SubclassTests", dependencies: ["Subclass"]),
+        .testTarget(name: "Module1Tests", dependencies: ["Subclass"]),
+        .testTarget(name: "Module2Tests", dependencies: ["Subclass"]),
     ]
 )

--- a/Fixtures/Miscellaneous/TestDiscovery/Subclass/Tests/Module1Tests/Tests1.swift
+++ b/Fixtures/Miscellaneous/TestDiscovery/Subclass/Tests/Module1Tests/Tests1.swift
@@ -1,0 +1,15 @@
+import XCTest
+
+class Tests1: XCTestCase {
+    func test11() {
+      print("->Tests1::test11")
+    }
+
+    func test12() {
+      print("->Tests1::test12")
+    }
+
+    func test13() {
+      print("->Tests1::test13")
+    }
+}

--- a/Fixtures/Miscellaneous/TestDiscovery/Subclass/Tests/Module1Tests/Tests2.swift
+++ b/Fixtures/Miscellaneous/TestDiscovery/Subclass/Tests/Module1Tests/Tests2.swift
@@ -1,0 +1,33 @@
+import XCTest
+
+class Tests3: Tests2 {
+    override func test11() {
+      print("->Tests3::test11")
+    }
+
+    override func test21() {
+      print("->Tests3::test21")
+    }
+
+    func test31() {
+      print("->Tests3::test31")
+    }
+
+    func test32() {
+      print("->Tests3::test32")
+    }
+
+    func test33() {
+      print("->Tests3::test33")
+    }
+}
+
+class Tests2: Tests1 {
+    func test21() {
+      print("->Tests2::test21")
+    }
+
+    func test22() {
+      print("->Tests2::test22")
+    }
+}

--- a/Fixtures/Miscellaneous/TestDiscovery/Subclass/Tests/Module1Tests/Tests2.swift
+++ b/Fixtures/Miscellaneous/TestDiscovery/Subclass/Tests/Module1Tests/Tests2.swift
@@ -2,32 +2,32 @@ import XCTest
 
 class Tests3: Tests2 {
     override func test11() {
-      print("->Tests3::test11")
+      print("->Module1::Tests3::test11")
     }
 
     override func test21() {
-      print("->Tests3::test21")
+      print("->Module1::Tests3::test21")
     }
 
     func test31() {
-      print("->Tests3::test31")
+      print("->Module1::Tests3::test31")
     }
 
     func test32() {
-      print("->Tests3::test32")
+      print("->Module1::Tests3::test32")
     }
 
     func test33() {
-      print("->Tests3::test33")
+      print("->Module1::Tests3::test33")
     }
 }
 
 class Tests2: Tests1 {
     func test21() {
-      print("->Tests2::test21")
+      print("->Module1::Tests2::test21")
     }
 
     func test22() {
-      print("->Tests2::test22")
+      print("->Module1::Tests2::test22")
     }
 }

--- a/Fixtures/Miscellaneous/TestDiscovery/Subclass/Tests/Module2Tests/Test1.swift
+++ b/Fixtures/Miscellaneous/TestDiscovery/Subclass/Tests/Module2Tests/Test1.swift
@@ -2,14 +2,14 @@ import XCTest
 
 class Tests1: XCTestCase {
     func test11() {
-      print("->Module1::Tests1::test11")
+      print("->Module2::Tests1::test11")
     }
 
     func test12() {
-      print("->Module1::Tests1::test12")
+      print("->Module2::Tests1::test12")
     }
 
     func test13() {
-      print("->Module1::Tests1::test13")
+      print("->Module2::Tests1::test13")
     }
 }

--- a/Fixtures/Miscellaneous/TestDiscovery/Subclass/Tests/SubclassTests/SubclassTestsBase.swift
+++ b/Fixtures/Miscellaneous/TestDiscovery/Subclass/Tests/SubclassTests/SubclassTestsBase.swift
@@ -1,7 +1,0 @@
-import XCTest
-@testable import Subclass
-
-class SubclassTestsBase: XCTestCase {
-    func test1() {
-    }
-}

--- a/Fixtures/Miscellaneous/TestDiscovery/Subclass/Tests/SubclassTests/SubclassTestsDerived.swift
+++ b/Fixtures/Miscellaneous/TestDiscovery/Subclass/Tests/SubclassTests/SubclassTestsDerived.swift
@@ -1,7 +1,0 @@
-import XCTest
-@testable import Subclass
-
-class SubclassTestsDerived: SubclassTestsBase {
-    override func test1() {
-    }
-}

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -113,9 +113,7 @@ final class TestDiscoveryCommand: CustomLLBuildCommand {
         let store = try IndexStore.open(store: index, api: api)
 
         // FIXME: We can speed this up by having one llbuild command per object file.
-        let tests = try tool.inputs.flatMap {
-            try store.listTests(inObjectFile: AbsolutePath($0.name))
-        }
+        let tests = try store.listTests(in: tool.inputs.map{ AbsolutePath($0.name) })
 
         let outputs = tool.outputs.compactMap{ try? AbsolutePath(validating: $0.name) }
         let testsByModule = Dictionary(grouping: tests, by: { $0.module.spm_mangledToC99ExtendedIdentifier() })

--- a/Tests/FunctionalTests/TestDiscoveryTests.swift
+++ b/Tests/FunctionalTests/TestDiscoveryTests.swift
@@ -131,16 +131,24 @@ class TestDiscoveryTests: XCTestCase {
             XCTAssertMatch(stderr, .contains("Build complete!"))
             // in "swift test" test output goes to stdout
             XCTAssertMatch(stdout, .contains("Tests3.test11"))
+            XCTAssertMatch(stdout, .contains("->Module1::Tests1::test11"))
             XCTAssertMatch(stdout, .contains("Tests3.test12"))
+            XCTAssertMatch(stdout, .contains("->Module1::Tests1::test12"))
             XCTAssertMatch(stdout, .contains("Tests3.test13"))
+            XCTAssertMatch(stdout, .contains("->Module1::Tests1::test13"))
             XCTAssertMatch(stdout, .contains("Tests3.test21"))
+            XCTAssertMatch(stdout, .contains("->Module1::Tests2::test21"))
             XCTAssertMatch(stdout, .contains("Tests3.test22"))
+            XCTAssertMatch(stdout, .contains("->Module1::Tests2::test22"))
             XCTAssertMatch(stdout, .contains("Tests3.test31"))
+            XCTAssertMatch(stdout, .contains("->Module1::Tests3::test31"))
             XCTAssertMatch(stdout, .contains("Tests3.test32"))
+            XCTAssertMatch(stdout, .contains("->Module1::Tests3::test32"))
             XCTAssertMatch(stdout, .contains("Tests3.test33"))
-            XCTAssertMatch(stdout, .contains("->Tests3::test11"))
-            XCTAssertMatch(stdout, .contains("->Tests3::test21"))
-            XCTAssertMatch(stdout, .contains("Executed 8 tests"))
+            XCTAssertMatch(stdout, .contains("->Module1::Tests3::test33"))
+
+            XCTAssertMatch(stdout, .contains("->Module2::Tests1::test11"))
+            XCTAssertMatch(stdout, .contains("->Module2::Tests1::test12"))
         }
     }
 }

--- a/Tests/FunctionalTests/TestDiscoveryTests.swift
+++ b/Tests/FunctionalTests/TestDiscoveryTests.swift
@@ -130,9 +130,17 @@ class TestDiscoveryTests: XCTestCase {
             // in "swift test" build output goes to stderr
             XCTAssertMatch(stderr, .contains("Build complete!"))
             // in "swift test" test output goes to stdout
-            XCTAssertMatch(stdout, .contains("SubclassTestsBase.test1"))
-            XCTAssertMatch(stdout, .contains("SubclassTestsDerived.test1"))
-            XCTAssertMatch(stdout, .contains("Executed 2 tests"))
+            XCTAssertMatch(stdout, .contains("Tests3.test11"))
+            XCTAssertMatch(stdout, .contains("Tests3.test12"))
+            XCTAssertMatch(stdout, .contains("Tests3.test13"))
+            XCTAssertMatch(stdout, .contains("Tests3.test21"))
+            XCTAssertMatch(stdout, .contains("Tests3.test22"))
+            XCTAssertMatch(stdout, .contains("Tests3.test31"))
+            XCTAssertMatch(stdout, .contains("Tests3.test32"))
+            XCTAssertMatch(stdout, .contains("Tests3.test33"))
+            XCTAssertMatch(stdout, .contains("->Tests3::test11"))
+            XCTAssertMatch(stdout, .contains("->Tests3::test21"))
+            XCTAssertMatch(stdout, .contains("Executed 8 tests"))
         }
     }
 }

--- a/Utilities/Docker/docker-compose.2004.56.yaml
+++ b/Utilities/Docker/docker-compose.2004.56.yaml
@@ -16,7 +16,6 @@ services:
       args:
         ubuntu_version: "focal"
         swift_version: "5.6"
-        base_image: "swiftlang/swift:nightly-5.6-focal"
 
   build:
     image: swift-package-manager:20.04-5.6

--- a/Utilities/Docker/docker-compose.2004.57.yaml
+++ b/Utilities/Docker/docker-compose.2004.57.yaml
@@ -1,0 +1,37 @@
+# This source file is part of the Swift open source project
+#
+# Copyright (c) 2022 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-package-manager:20.04-5.7
+    build:
+      args:
+        ubuntu_version: "focal"
+        swift_version: "5.7"
+        base_image: "swiftlang/swift:nightly-5.7-focal"
+
+  build:
+    image: swift-package-manager:20.04-5.7
+
+  test:
+    image: swift-package-manager:20.04-5.7
+
+  bootstrap-clean:
+    image: swift-package-manager:20.04-5.7
+
+  bootstrap-build:
+    image: swift-package-manager:20.04-5.7
+
+  bootstrap-test:
+    image: swift-package-manager:20.04-5.7
+
+  shell:
+    image: swift-package-manager:20.04-5.7


### PR DESCRIPTION
motivation: test discovery on linux depends on index store test listing

changes:
* use new API from TSC that fixes the issue
* adjust test
* add docker setup for 5.7

rdar://59655518