### PR TITLE
Stop using `--gc-sections` for Wasm target to protect metadata sections

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -1290,6 +1290,15 @@ public final class ProductBuildDescription {
                 return ["-Xlinker", "-dead_strip"]
             } else if buildParameters.triple.isWindows() {
                 return ["-Xlinker", "/OPT:REF"]
+            } else if buildParameters.triple.arch == .wasm32 {
+                // FIXME: wasm-ld strips data segments referenced through __start/__stop symbols
+                // during GC, and it removes Swift metadata sections like swift5_protocols
+                // We should add support of SHF_GNU_RETAIN-like flag for __attribute__((retain))
+                // to LLVM and wasm-ld
+                // This workaround is required for not only WASI but also all WebAssembly archs
+                // using wasm-ld (e.g. wasm32-unknown-unknown). So this branch is conditioned by
+                // arch == .wasm32
+                return []
             } else {
                 return ["-Xlinker", "--gc-sections"]
             }


### PR DESCRIPTION
Stop using --gc-sections for Wasm target to protect metadata sections

### Motivation:

Now wasm-ld strips data segments referenced through __start/__stop symbols
during GC, and it removes Swift metadata sections like swift5_protocols.
This option has been added in https://github.com/apple/swift-package-manager/pull/4135

### Modifications:

We should add support for SHF_GNU_RETAIN-like flag for __attribute__((retain))
to LLVM and wasm-ld.
For now, just disable section GC for Wasm target.

Context
- https://github.com/llvm/llvm-project/issues/55839
- https://reviews.llvm.org/D126950#3558050

### Result:

Swift metadata sections are retained in the final executable in release configuration for Wasm target.


CC: @MaxDesiatov @keith 