### PR TITLE
Skip tests which are flaky on CI

### DIFF
--- a/Sources/SPMTestSupport/XCTAssertHelpers.swift
+++ b/Sources/SPMTestSupport/XCTAssertHelpers.swift
@@ -20,6 +20,12 @@ import XCTest
 
 import struct TSCUtility.Version
 
+public func XCTSkipIfCI(file: StaticString = #filePath, line: UInt = #line) throws {
+    if let ci = ProcessInfo.processInfo.environment["CI"] as? NSString, ci.boolValue {
+        throw XCTSkip("Skipping because the test is being run on CI", file: file, line: line)
+    }
+}
+
 public func XCTAssertBuilds(
     _ path: AbsolutePath,
     configurations: Set<Configuration> = [.Debug, .Release],

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -385,7 +385,7 @@ class MiscellaneousTestCase: XCTestCase {
     }
 
     func testSwiftRunSIGINT() throws {
-        try XCTSkipIf(true, "rdar://96290746")
+        try XCTSkipIfCI()
         try fixture(name: "Miscellaneous/SwiftRun") { fixturePath in
             let mainFilePath = fixturePath.appending(component: "main.swift")
             try localFileSystem.removeFileTree(mainFilePath)

--- a/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
@@ -875,6 +875,8 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
         // platforms just getting lucky?  I'm feeling lucky.
         throw XCTSkip("Foundation Process.terminationStatus race condition (apple/swift-corelibs-foundation#4589")
 #else
+        try XCTSkipIfCI()
+
         try testWithTemporaryDirectory { path in
             let total = 100
             let observability = ObservabilitySystem.makeForTesting()


### PR DESCRIPTION
This introduces a new `XCTSkipIfCI` and uses it in two tests which are flaky on CI.

rdar://96517321
rdar://96290746
