### PR TITLE
[5.7] Updates to chained aliases / Use direct-ref aliases and pre-chain aliases

### DIFF
--- a/Sources/PackageGraph/ModuleAliasTracker.swift
+++ b/Sources/PackageGraph/ModuleAliasTracker.swift
@@ -72,7 +72,7 @@ class ModuleAliasTracker {
     func trackTargetsPerProduct(product: Product,
                                 package: PackageIdentity) {
         let targetDeps = product.targets.map{$0.dependencies}.flatMap{$0}
-        var allTargetDeps = product.targets.map{$0.dependentTargets().map{$0.dependencies}}.flatMap{$0}.flatMap{$0}
+        var allTargetDeps = product.targets.map{$0.recurisveDependentTargets().map{$0.dependencies}}.flatMap{$0}.flatMap{$0}
         allTargetDeps.append(contentsOf: targetDeps)
         for dep in allTargetDeps {
             if case let .product(depRef, _) = dep {
@@ -111,16 +111,15 @@ class ModuleAliasTracker {
         guard let rootPkg = rootPkg else { return }
 
         if let productToAllTargets = idToProductToAllTargets[rootPkg] {
-            // First, propagate aliaes upstream
+            // First, propagate aliases upstream
             for productID in productToAllTargets.keys {
                 var aliasBuffer = [String: ModuleAliasModel]()
-                propagate(productID: productID, aliasBuffer: &aliasBuffer)
+                propagate(productID: productID, observabilityScope: observabilityScope, aliasBuffer: &aliasBuffer)
             }
-            
+
             // Then, merge or override upstream aliases downwards
             for productID in productToAllTargets.keys {
-                var parentList = [String: ModuleAliasModel]()
-                merge(productID: productID, aliasBuffer: &parentList, observabilityScope: observabilityScope)
+                merge(productID: productID, observabilityScope: observabilityScope)
             }
         }
         // Finally, fill in aliases for targets in products that are in the
@@ -131,232 +130,118 @@ class ModuleAliasTracker {
     // Propagate defined aliases upstream. If they are chained, the final
     // alias value will be applied
     func propagate(productID: String,
+                   observabilityScope: ObservabilityScope,
                    aliasBuffer: inout [String: ModuleAliasModel]) {
         let productAliases = aliasMap[productID] ?? []
         for aliasModel in productAliases {
             // Alias buffer is used to carry down aliases defined upstream
-            if aliasBuffer[aliasModel.name] == nil {
-                if let v = lookupAlias(key: aliasModel.alias, in: aliasBuffer),
-                   v != aliasModel.alias {
-                    let chainedModel = ModuleAliasModel(name: aliasModel.name, alias: v, originPackage: aliasModel.originPackage, consumingPackage: aliasModel.consumingPackage)
-                    aliasBuffer[aliasModel.name] = chainedModel
-                } else {
-                    aliasBuffer[aliasModel.name] = aliasModel
-                }
+            if let existing = aliasBuffer[aliasModel.name],
+               existing.alias != aliasModel.alias {
+                // check to allow only the most downstream alias is added
+            } else {
+                aliasBuffer[aliasModel.name] = aliasModel
             }
         }
-        var used = [String]()
-        if let curAllTargets = productToAllTargets[productID] {
-            // Apply aliases to targets that are renamable, i.e. eventually
-            // get renamed with an alias
-            let targetsToRename = curAllTargets.filter{ aliasBuffer[$0.name] != nil }
-            for curTarget in targetsToRename {
-                if let aliasVal = lookupAlias(key: curTarget.name, in: aliasBuffer) {
-                    let prechain = lookupAlias(value: aliasVal, in: aliasBuffer).filter { $0 != curTarget.name }
-                    if let prechainKey = prechain.first {
-                        used.append(prechainKey)
+
+        if let curDirectTargets = productToDirectTargets[productID] {
+            var relevantTargets = curDirectTargets.map{$0.recurisveDependentTargets()}.flatMap{$0}
+            relevantTargets.append(contentsOf: curDirectTargets)
+
+            for relTarget in relevantTargets {
+                if let val = lookupAlias(key: relTarget.name, in: aliasBuffer) {
+                    relTarget.addModuleAlias(for: relTarget.name, as: val)
+                    if let prechainVal = aliasBuffer[relTarget.name],
+                       prechainVal.alias != val {
+                        relTarget.addPrechainModuleAlias(for: relTarget.name, as: prechainVal.alias)
+                        relTarget.addPrechainModuleAlias(for: prechainVal.alias, as: val)
+                        observabilityScope.emit(info: "Module alias '\(prechainVal.alias)' defined in package '\(prechainVal.consumingPackage)' for target '\(relTarget.name)' in package/product '\(productID)' is overridden by alias '\(val)'; if this override is not intended, remove '\(val)' from 'moduleAliases' in its manifest")
+                        aliasBuffer.removeValue(forKey: prechainVal.alias)
                     }
-                    curTarget.addModuleAlias(for: curTarget.name, as: aliasVal)
-                    used.append(curTarget.name)
+                    aliasBuffer.removeValue(forKey: relTarget.name)
                 }
             }
         }
-        for usedKey in used {
-            aliasBuffer.removeValue(forKey: usedKey)
-        }
+
         guard let children = parentToChildProducts[productID] else {
             return
         }
         for childID in children {
-            propagate(productID: childID, aliasBuffer: &aliasBuffer)
+            propagate(productID: childID,
+                      observabilityScope: observabilityScope,
+                      aliasBuffer: &aliasBuffer)
         }
     }
 
     // Merge all the upstream aliases and override them if necessary
     func merge(productID: String,
-               aliasBuffer: inout [String: ModuleAliasModel],
                observabilityScope: ObservabilityScope) {
-        let productAliases = aliasMap[productID] ?? []
-        for aliasModel in productAliases {
-            if aliasBuffer[aliasModel.name] == nil {
-                aliasBuffer[aliasModel.name] = aliasModel
-            }
-        }
-
-        if let curDirectTargets = productToDirectTargets[productID],
-            let curAllTargets = productToAllTargets[productID] {
-            var targetsToRename = [Target]()
-            // Keep track of the aliases applied to renamable targets
-            // and remove the used aliases from the buffer
-            for curTarget in curAllTargets {
-                if let aliasVal = lookupAlias(key: curTarget.name, in: aliasBuffer),
-                   let appliedAlias = curTarget.moduleAliases?[curTarget.name],
-                   aliasVal == appliedAlias {
-                    targetsToRename.append(curTarget)
-                    aliasBuffer.removeValue(forKey: curTarget.name)
-                }
-            }
-            
-            let aliasesForTargetsToRename = targetsToRename.compactMap{$0.moduleAliases}.flatMap{$0}
-            let otherTargets = curDirectTargets.filter{!targetsToRename.map{$0.name}.contains($0.name)}
-            // Apply the aliases of the renamable targets to their depending targets
-            for otherTarget in otherTargets {
-                for (entryKey, entryVal) in aliasesForTargetsToRename {
-                    otherTarget.addModuleAlias(for: entryKey, as: entryVal)
-                }
-            }
-        }
         guard let children = parentToChildProducts[productID] else {
             return
         }
         for childID in children {
             merge(productID: childID,
-                  aliasBuffer: &aliasBuffer,
                   observabilityScope: observabilityScope)
         }
-        
-        if let curDirectTargets = productToDirectTargets[productID],
-           let curAllTargets = productToAllTargets[productID] {
-            // Create a per-target alias map that stores aliases of dependent
-            // targets and dependent product targets
-            let depTargets = curDirectTargets
-                .map{$0.dependentTargets()}.flatMap{$0}
-            let depProductTargets = curAllTargets
-                .map{$0.dependencies.compactMap{$0.product?.ID}}.flatMap{$0}
-                .compactMap{productToAllTargets[$0]}.flatMap{$0}
-            let depTargetsDepProductTargets = depTargets
-                .map{$0.dependencies.compactMap{$0.product?.ID}}.flatMap{$0}
-                .compactMap{productToAllTargets[$0]}.flatMap{$0}
-            let depTargetAliases = depTargets.compactMap{$0.moduleAliases}.flatMap{$0}
-            let depProductTargetAliases = depProductTargets.compactMap{$0.moduleAliases}.flatMap{$0}
-            let depTargetDepProductTargetAliases = depTargetsDepProductTargets.compactMap{$0.moduleAliases}.flatMap{$0}
-            var depAliasMap = [String: [String: [String]]]()
 
-            // Per-target alias map for the direct targets of this product
-            for directTarget in curDirectTargets {
-                depAliasMap[directTarget.name] = [:]
-                for (key, alias) in depTargetAliases + depProductTargetAliases {
-                    if depAliasMap[directTarget.name, default: [:]][key]?.contains(alias) ?? false {
-                        // do not add this alias if it's already in the list
-                    } else {
-                        depAliasMap[directTarget.name, default: [:]][key, default: []].append(alias)
-                    }
-                }
-            }
-            // Per-target alias map for dependent targets of the product direct targets
-            for depTarget in depTargets {
-                depAliasMap[depTarget.name] = [:]
-                for (key, alias) in depTargetAliases + depTargetDepProductTargetAliases {
-                    if depAliasMap[depTarget.name, default: [:]][key]?.contains(alias) ?? false {
-                        // do not add this alias if it's already in the list
-                    } else {
-                        depAliasMap[depTarget.name, default: [:]][key, default: []].append(alias)
-                    }
-                }
-            }
+        if let curDirectTargets = productToDirectTargets[productID] {
+            let depTargets = curDirectTargets.map{$0.recurisveDependentTargets()}.flatMap{$0}
+            let depTargetAliases = toDictionary(depTargets.compactMap{$0.moduleAliases})
+            let depChildTargets = dependencyProductTargets(of: depTargets)
+            let depChildAliases = toDictionary(depChildTargets.compactMap{$0.moduleAliases})
+            let depChildPrechainAliases = toDictionary(depChildTargets.compactMap{$0.prechainModuleAliases})
+            chainModuleAliases(targets: depTargets,
+                               checkedTargets: depTargets,
+                               targetAliases: depTargetAliases,
+                               childTargets: depChildTargets,
+                               childAliases: depChildAliases,
+                               childPrechainAliases: depChildPrechainAliases,
+                               observabilityScope: observabilityScope)
 
-            let targetList = curDirectTargets + depTargets
-            for targetToResolve in targetList {
-                guard let relevantAliasMap = depAliasMap[targetToResolve.name] else { continue }
-                for (key, aliases) in relevantAliasMap {
-                    // First check if there's a target named `key` in
-                    // the direct or dependent targets
-                    if targetList.map({$0.name}).contains(key) {
-                        // Check if those targets have module aliases for this `key`
-                        let existingAliases = targetList.filter{$0.name == key}.compactMap{$0.moduleAliases?[key]}
-                        for existingAlias in existingAliases {
-                            if let aliasVal = targetToResolve.moduleAliases?[key], aliasVal != existingAlias {
-                                // This check is added just out of precaution but
-                                // shoudln't be needed
-                            } else {
-                                targetToResolve.addModuleAlias(for: key, as: existingAlias)
-                                let prechain = lookupAlias(value: existingAlias, in: aliasBuffer).filter { $0 != key }
-                                if let prechainKey = prechain.first {
-                                    aliasBuffer.removeValue(forKey: prechainKey)
-                                }
-                            }
-                        }
-                        // Check if pre-chain aliases need to be added
-                        let unusedAliases = aliases.filter{!existingAliases.contains($0)}
-                        for alias in unusedAliases {
-                            let prechain = lookupAlias(value: alias, in: aliasBuffer).filter { $0 != key }
-                            if let prechainKey = prechain.first {
-                                observabilityScope.emit(info: "Target '\(targetToResolve.name)' already has a dependency target named '\(key)' but has a duplicate target in a dependency product; when referencing the latter in source code, use the aliased name '\(alias)' directly")
-                                // Add a prechain alias from the buffer
-                                targetToResolve.addModuleAlias(for: prechainKey, as: alias)
-                                aliasBuffer.removeValue(forKey: prechainKey)
-                            }
-                        }
+            let relevantTargets = depTargets + curDirectTargets
+            let targetAliases = toDictionary(relevantTargets.compactMap{$0.moduleAliases})
+            let depProductTargets = dependencyProductTargets(of: relevantTargets)
+            var depProductAliases = [String: [String]]()
+            let depProductPrechainAliases = toDictionary(depProductTargets.compactMap{$0.prechainModuleAliases})
+
+            for depProdTarget in depProductTargets {
+                let depProdTargetAliases = depProdTarget.moduleAliases ?? [:]
+                for (key, val) in depProdTargetAliases {
+                    var shouldAddAliases = false
+                    if depProdTarget.name == key {
+                        shouldAddAliases = true
+                    } else if !depProductTargets.map({$0.name}).contains(key) {
+                        shouldAddAliases = true
                     }
-                    else {
-                        let targetsNamedKeyInDepProduct = depProductTargets.filter{$0.name == key}
-                        if aliases.count == 1, let aliasVal = aliases.first {
-                            // There's only one alias to merge and targets with
-                            // name `key` in dependency products all have different
-                            // aliases
-                            if targetsNamedKeyInDepProduct.filter({$0.moduleAliases == nil}).isEmpty {
-                                let prechain = lookupAlias(value: aliasVal, in: aliasBuffer).filter { $0 != key }
-                                if let prechainKey = prechain.first {
-                                    aliasBuffer.removeValue(forKey: prechainKey)
-                                }
-                                targetToResolve.addModuleAlias(for: key, as: aliasVal)
-                                aliasBuffer.removeValue(forKey: key)
-                            }
+                    if shouldAddAliases {
+                        if depProductAliases[key]?.contains(val) ?? false {
+                            // don't add a duplicate
                         } else {
-                            if targetsNamedKeyInDepProduct.count == 1 {
-                                // There are multiple aliases for the `key`
-                                // and dependency products have targets named
-                                // `key`
-                                let aliasesInDepProductForKeyNamedTargets = targetsNamedKeyInDepProduct.compactMap{ $0.moduleAliases }.flatMap{$0}
-                                if aliasesInDepProductForKeyNamedTargets.isEmpty {
-                                    // This check is added out of precaution but
-                                    // shouldn't be needed
-                                    if targetToResolve.moduleAliases?[key] != nil {
-                                        targetToResolve.removeModuleAlias(for: key)
-                                    }
-                                } else {
-                                    // There should be only one alias to apply
-                                    for entry in aliasesInDepProductForKeyNamedTargets {
-                                        targetToResolve.addModuleAlias(for: entry.key, as: entry.value)
-                                        let prechain = lookupAlias(value: entry.value, in: aliasBuffer).filter { $0 != entry.key }
-                                        if let prechainKey = prechain.first {
-                                            aliasBuffer.removeValue(forKey: prechainKey)
-                                        }
-                                    }
-                                }
-                            } else {
-                                for alias in aliases {
-                                    let prechain = lookupAlias(value: alias, in: aliasBuffer).filter { $0 != key }
-                                    if let prechainKey = prechain.first {
-                                        // Add a prechain alias
-                                        if let existing = targetToResolve.moduleAliases?[prechainKey],
-                                           existing != alias {
-                                            targetToResolve.removeModuleAlias(for: prechainKey)
-                                        } else {
-                                            observabilityScope.emit(info: "Multiple module aliases \(aliases.sorted()) found for '\(targetToResolve.name)'; when referencing them in source code from target '\(targetToResolve.name)' or its depending targets, use the aliased names directly instead of the original name")
-                                            targetToResolve.addModuleAlias(for: prechainKey, as: alias)
-                                            aliasBuffer.removeValue(forKey: prechainKey)
-                                        }
-                                    }
-                                }
-                            }
+                            depProductAliases[key, default: []].append(val)
                         }
                     }
                 }
             }
+            chainModuleAliases(targets: curDirectTargets,
+                               checkedTargets: relevantTargets,
+                               targetAliases: targetAliases,
+                               childTargets: depProductTargets,
+                               childAliases: depProductAliases,
+                               childPrechainAliases: depProductPrechainAliases,
+                               observabilityScope: observabilityScope)
         }
     }
 
-    // This fills in aliases for targets in products that are in the dependency chain
-    // but not in a product consumed by other packages. Such targets still need to have
-    // aliases applied to them so they can be built with correct dependent binary names
+    // This fills in aliases for targets in products that are in the dependency
+    // chain but not in a product consumed by other packages. Such targets still
+    // need to have aliases applied to them so they can be built with correct
+    // dependent binary names
     func fillInRest(package: PackageIdentity) {
         if let productToTargets = idToProductToAllTargets[package] {
             for (_, productTargets) in productToTargets {
                 let unAliased = productTargets.contains{$0.moduleAliases == nil}
                 if unAliased {
                     for target in productTargets {
-                        let depAliases = target.dependentTargets().compactMap{$0.moduleAliases}.flatMap{$0}
+                        let depAliases = target.recurisveDependentTargets().compactMap{$0.moduleAliases}.flatMap{$0}
                         for (key, alias) in depAliases {
                             target.addModuleAlias(for: key, as: alias)
                         }
@@ -370,6 +255,89 @@ class ModuleAliasTracker {
         }
     }
 
+    private func chainModuleAliases(targets: [Target],
+                                    checkedTargets: [Target],
+                                    targetAliases: [String: [String]],
+                                    childTargets: [Target],
+                                    childAliases: [String: [String]],
+                                    childPrechainAliases: [String: [String]],
+                                    observabilityScope: ObservabilityScope) {
+        guard !targets.isEmpty else { return }
+        var aliasDict = [String: String]()
+        var prechainAliasDict = [String: [String]]()
+        var directRefAliasDict = [String: [String]]()
+        let childDirectRefAliases = toDictionary(childTargets.compactMap{$0.directRefAliases})
+        for (childTargetName, childTargetAliases) in childAliases {
+            // Tracks whether to add prechain aliases to targets
+            var addPrechainAliases = false
+            // Current targets and their dependents contain this child product
+            // target name
+            if checkedTargets.map({$0.name}).contains(childTargetName) {
+                addPrechainAliases = true
+            }
+            if let overlappingTargetAliases = targetAliases[childTargetName], !overlappingTargetAliases.isEmpty {
+                // Current target aliases have the same key as this child
+                // target name, so the child target alias should not be applied
+                addPrechainAliases = true
+                aliasDict[childTargetName] = overlappingTargetAliases.first
+            } else if childTargetAliases.count > 1 {
+                // Multiple aliases from different products for this child target
+                // name exist so they should not be applied; their aliases / new
+                // names should be used directly
+                addPrechainAliases = true
+            } else if childTargets.filter({$0.name == childTargetName}).count > 1 {
+                // Targets from different products have the same name as this child
+                // target name, so their aliases should not be applied
+                addPrechainAliases = true
+            }
+
+            if addPrechainAliases {
+                if let prechainAliases = childPrechainAliases[childTargetName] {
+                   for prechainAliasKey in prechainAliases {
+                       if let prechainAliasVals = childPrechainAliases[prechainAliasKey] {
+                           // If aliases are chained, keep track of prechain
+                           // aliases
+                           prechainAliasDict[prechainAliasKey, default: []].append(contentsOf: prechainAliasVals)
+                           // Add prechained aliases to the list of aliases
+                           // that should be directly referenced in source code
+                           directRefAliasDict[childTargetName, default: []].append(prechainAliasKey)
+                           directRefAliasDict[prechainAliasKey, default: []].append(contentsOf: prechainAliasVals)
+                       }
+                    }
+                } else if aliasDict[childTargetName] == nil {
+                    // If not added to aliasDict, use the renamed module directly
+                    directRefAliasDict[childTargetName, default: []].append(contentsOf: childTargetAliases)
+                }
+            } else if let productTargetAlias = childTargetAliases.first {
+                if childTargetAliases.count > 1 {
+                    observabilityScope.emit(warning: "There should be one alias for target '\(childTargetName)' but there are [\(childTargetAliases.map{"'\($0)'"}.joined(separator: ", "))]")
+                }
+                // Check if not in child targets' direct ref aliases list, then add
+                if lookupAlias(value: childTargetName, in: childDirectRefAliases).isEmpty,
+                   childDirectRefAliases[childTargetName] == nil {
+                    aliasDict[childTargetName] = productTargetAlias
+                }
+            }
+        }
+
+        for target in targets {
+            for (key, val) in aliasDict {
+                target.addModuleAlias(for: key, as: val)
+            }
+            for (key, valList) in prechainAliasDict {
+                if let val = valList.first,
+                    valList.count <= 1 {
+                    target.addModuleAlias(for: key, as: val)
+                    target.addPrechainModuleAlias(for: key, as: val)
+                }
+            }
+            for (key, list) in directRefAliasDict {
+                target.addDirectRefAliases(for: key, as: list)
+                observabilityScope.emit(info: "Target '\(target.name)' has a dependency on multiple targets named '\(key)'; the aliased names are [\(list.map{"'\($0)'"}.joined(separator: ", "))] and should be used directly in source code if referenced from '\(target.name)'")
+            }
+        }
+    }
+
     private func lookupAlias(key: String, in buffer: [String: ModuleAliasModel]) -> String? {
         var next = key
         while let nextValue = buffer[next] {
@@ -378,9 +346,38 @@ class ModuleAliasTracker {
         return next == key ? nil : next
     }
 
-    private func lookupAlias(value: String, in buffer: [String: ModuleAliasModel]) -> [String] {
-        let keys = buffer.filter{$0.value.alias == value}.map{$0.key}
+    private func lookupAlias(value: String, in dict: [String: [String]]) -> [String] {
+        let keys = dict.filter{$0.value.contains(value)}.map{$0.key}
         return keys
+    }
+
+    private func toDictionary(_ list: [[String: [String]]]) -> [String: [String]] {
+        var dict = [String: [String]]()
+        for entry in list {
+            for (entryKey, entryVal) in entry {
+                dict[entryKey, default: []].append(contentsOf: entryVal)
+            }
+        }
+        return dict
+    }
+
+    private func toDictionary(_ list: [[String: String]]) -> [String: [String]] {
+        var dict = [String: [String]]()
+        for entry in list {
+            for (entryKey, entryVal) in entry {
+                if let existing = dict[entryKey], existing.contains(entryVal) {
+                    // don't add a duplicate
+                } else {
+                    dict[entryKey, default: []].append(entryVal)
+                }
+            }
+        }
+        return dict
+    }
+
+    private func dependencyProductTargets(of targets: [Target]) -> [Target] {
+        let result = targets.map{$0.dependencies.compactMap{$0.product?.ID}}.flatMap{$0}.compactMap{productToAllTargets[$0]}.flatMap{$0}
+        return result
     }
 }
 
@@ -409,7 +406,14 @@ extension Target {
         }
     }
 
-    func dependentTargets() -> [Target] {
-        return dependencies.compactMap{$0.target}
+    func recurisveDependentTargets() -> [Target] {
+        var list = [Target]()
+        var nextDeps = dependencies
+        while !nextDeps.isEmpty {
+            let nextTargets = nextDeps.compactMap{$0.target}
+            list.append(contentsOf: nextTargets)
+            nextDeps = nextTargets.map{$0.dependencies}.flatMap{$0}
+        }
+        return list
     }
 }

--- a/Sources/PackageModel/Target.swift
+++ b/Sources/PackageModel/Target.swift
@@ -129,6 +129,10 @@ public class Target: PolymorphicCodableProtocol {
     /// dependent target and the value is a new unique name mapped to the name
     /// of its .swiftmodule binary.
     public private(set) var moduleAliases: [String: String]?
+    /// Used to store pre-chained / pre-overriden module aliases
+    public private(set) var prechainModuleAliases: [String: String]?
+    /// Used to store aliases that should be referenced directly in source code
+    public private(set) var directRefAliases: [String: [String]]?
 
     /// Add module aliases (if applicable) for dependencies of this target.
     ///
@@ -147,10 +151,26 @@ public class Target: PolymorphicCodableProtocol {
             moduleAliases?[name] = alias
         }
     }
+
     public func removeModuleAlias(for name: String) {
         moduleAliases?.removeValue(forKey: name)
         if moduleAliases?.isEmpty ?? false {
             moduleAliases = nil
+        }
+    }
+
+    public func addPrechainModuleAlias(for name: String, as alias: String) {
+        if prechainModuleAliases == nil {
+            prechainModuleAliases = [name: alias]
+        } else {
+            prechainModuleAliases?[name] = alias
+        }
+    }
+    public func addDirectRefAliases(for name: String, as aliases: [String]) {
+        if directRefAliases == nil {
+            directRefAliases = [name: aliases]
+        } else {
+            directRefAliases?[name] = aliases
         }
     }
 

--- a/Tests/BuildTests/ModuleAliasingBuildTests.swift
+++ b/Tests/BuildTests/ModuleAliasingBuildTests.swift
@@ -2455,7 +2455,519 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "MyLogging" && $0.target.moduleAliases == nil })
     }
 
-    func testModuleAliasingChainedAliases() throws {
+    func testModuleAliasingTargetAndProductTargetWithSameName() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+                                    "/appPkg/Sources/App/main.swift",
+                                    "/appPkg/Sources/Utils/file.swift",
+                                    "/xpkg/Sources/X/file.swift",
+                                    "/xpkg/Sources/Utils/file.swift"
+        )
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    name: "xpkg",
+                    path: .init("/xpkg"),
+                    products: [
+                        ProductDescription(name: "X", type: .library(.automatic), targets: ["X"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "X", dependencies: ["Utils"]),
+                        TargetDescription(name: "Utils", dependencies: []),
+                    ]),
+                Manifest.createRootManifest(
+                    name: "appPkg",
+                    path: .init("/appPkg"),
+                    dependencies: [
+                        .localSourceControl(path: .init("/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    targets: [
+                        TargetDescription(name: "App",
+                                          dependencies: ["Utils",
+                                                         .product(name: "X",
+                                                                  package: "xpkg",
+                                                                  moduleAliases: ["Utils": "XUtils"])
+                                          ]),
+                        TargetDescription(name: "Utils", dependencies: []),
+                    ]),
+            ],
+            observabilityScope: observability.topScope
+        )
+        XCTAssertNoDiagnostics(observability.diagnostics)
+        let result = try BuildPlanResult(plan: try BuildPlan(
+            buildParameters: mockBuildParameters(shouldLinkStaticSwiftStdlib: true),
+            graph: graph,
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        ))
+        result.checkProductsCount(1)
+        result.checkTargetsCount(4)
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "X" && $0.target.moduleAliases?["Utils"] == "XUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
+    }
+
+    func testModuleAliasingProductTargetsWithSameName1() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+                                    "/appPkg/Sources/App/main.swift",
+                                    "/xpkg/Sources/X/file.swift",
+                                    "/ypkg/Sources/Utils/file.swift",
+                                    "/apkg/Sources/A/file.swift",
+                                    "/bpkg/Sources/B/file.swift",
+                                    "/cpkg/Sources/Utils/file.swift"
+        )
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    name: "cpkg",
+                    path: .init("/cpkg"),
+                    products: [
+                        ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "Utils", dependencies: []),
+                    ]),
+                Manifest.createRootManifest(
+                    name: "bpkg",
+                    path: .init("/bpkg"),
+                    dependencies: [
+                        .localSourceControl(path: .init("/cpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    products: [
+                        ProductDescription(name: "B", type: .library(.automatic), targets: ["B"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "B",
+                                          dependencies: [
+                                            .product(name: "Utils",
+                                                     package: "cpkg"
+                                                    ),
+                                          ]),
+                    ]),
+                Manifest.createRootManifest(
+                    name: "apkg",
+                    path: .init("/apkg"),
+                    dependencies: [
+                        .localSourceControl(path: .init("/bpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    products: [
+                        ProductDescription(name: "A", type: .library(.automatic), targets: ["A"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "A",
+                                          dependencies: [
+                                            .product(name: "B",
+                                                     package: "bpkg"
+                                                    ),
+                                          ]),
+                    ]),
+                Manifest.createRootManifest(
+                    name: "ypkg",
+                    path: .init("/ypkg"),
+                    products: [
+                        ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "Utils", dependencies: []),
+                    ]),
+                Manifest.createRootManifest(
+                    name: "xpkg",
+                    path: .init("/xpkg"),
+                    dependencies: [
+                        .localSourceControl(path: .init("/ypkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    products: [
+                        ProductDescription(name: "X", type: .library(.automatic), targets: ["X"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "X",
+                                          dependencies: [
+                                            .product(name: "Utils",
+                                                     package: "ypkg"
+                                                    ),
+                                          ]),
+                    ]),
+                Manifest.createRootManifest(
+                    name: "appPkg",
+                    path: .init("/appPkg"),
+                    dependencies: [
+                        .localSourceControl(path: .init("/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init("/apkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    targets: [
+                        TargetDescription(name: "App",
+                                          dependencies: [
+                                            .product(name: "X",
+                                                     package: "xpkg",
+                                                     moduleAliases: ["Utils": "XUtils"]
+                                                    ),
+                                            .product(name: "A",
+                                                     package: "apkg",
+                                                     moduleAliases: ["Utils": "AUtils"]
+                                                     )
+                                          ]),
+                    ]),
+            ],
+            observabilityScope: observability.topScope
+        )
+        XCTAssertNoDiagnostics(observability.diagnostics)
+        let result = try BuildPlanResult(plan: try BuildPlan(
+            buildParameters: mockBuildParameters(shouldLinkStaticSwiftStdlib: true),
+            graph: graph,
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        ))
+        result.checkProductsCount(1)
+        result.checkTargetsCount(6)
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "X" && $0.target.moduleAliases?["Utils"] == "XUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "A" && $0.target.moduleAliases?["Utils"] == "AUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "B" && $0.target.moduleAliases?["Utils"] == "AUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "AUtils" && $0.target.moduleAliases?["Utils"] == "AUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
+        XCTAssertFalse(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases == nil })
+    }
+
+    func testModuleAliasingUpstreamProductTargetsWithSameName2() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+                                    "/appPkg/Sources/App/main.swift",
+                                    "/apkg/Sources/A/file.swift",
+                                    "/bpkg/Sources/Utils/file.swift",
+                                    "/cpkg/Sources/Utils/file.swift",
+                                    "/xpkg/Sources/X/file.swift",
+                                    "/ypkg/Sources/Utils/file.swift",
+                                    "/zpkg/Sources/Utils/file.swift"
+        )
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    name: "zpkg",
+                    path: .init("/zpkg"),
+                    products: [
+                        ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "Utils", dependencies: []),
+                    ]),
+                Manifest.createRootManifest(
+                    name: "ypkg",
+                    path: .init("/ypkg"),
+                    products: [
+                        ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "Utils", dependencies: []),
+                    ]),
+                Manifest.createRootManifest(
+                    name: "xpkg",
+                    path: .init("/xpkg"),
+                    dependencies: [
+                        .localSourceControl(path: .init("/ypkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init("/zpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    products: [
+                        ProductDescription(name: "X", type: .library(.automatic), targets: ["X"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "X",
+                                          dependencies: [
+                                            .product(name: "Utils",
+                                                     package: "zpkg"),
+                                            .product(name: "Utils",
+                                                     package: "ypkg",
+                                                     moduleAliases: ["Utils": "YUtils"]
+                                                     )
+                                          ]),
+                    ]),
+                Manifest.createRootManifest(
+                    name: "cpkg",
+                    path: .init("/cpkg"),
+                    products: [
+                        ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "Utils", dependencies: []),
+                    ]),
+                Manifest.createRootManifest(
+                    name: "bpkg",
+                    path: .init("/bpkg"),
+                    products: [
+                        ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "Utils", dependencies: []),
+                    ]),
+                Manifest.createRootManifest(
+                    name: "apkg",
+                    path: .init("/apkg"),
+                    dependencies: [
+                        .localSourceControl(path: .init("/bpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init("/cpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    products: [
+                        ProductDescription(name: "A", type: .library(.automatic), targets: ["A"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "A",
+                                          dependencies: [
+                                            .product(name: "Utils",
+                                                     package: "cpkg"),
+                                            .product(name: "Utils",
+                                                     package: "bpkg",
+                                                     moduleAliases: ["Utils": "BUtils"]
+                                                     )
+                                          ]),
+                    ]),
+                Manifest.createRootManifest(
+                    name: "appPkg",
+                    path: .init("/appPkg"),
+                    dependencies: [
+                        .localSourceControl(path: .init("/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init("/apkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    targets: [
+                        TargetDescription(name: "App",
+                                          dependencies: [
+                                            .product(name: "X",
+                                                     package: "xpkg",
+                                                     moduleAliases: ["Utils": "XUtils"]
+                                                    ),
+                                            .product(name: "A",
+                                                     package: "apkg",
+                                                     moduleAliases: ["Utils": "AUtils"]
+                                                    )
+                                          ]),
+                    ]),
+            ],
+            observabilityScope: observability.topScope
+        )
+        XCTAssertNoDiagnostics(observability.diagnostics)
+        let result = try BuildPlanResult(plan: try BuildPlan(
+            buildParameters: mockBuildParameters(shouldLinkStaticSwiftStdlib: true),
+            graph: graph,
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        ))
+        result.checkProductsCount(1)
+        result.checkTargetsCount(7)
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "X" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "YUtils" && $0.target.moduleAliases?["Utils"] == "YUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "A" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "AUtils" && $0.target.moduleAliases?["Utils"] == "AUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "BUtils" && $0.target.moduleAliases?["Utils"] == "BUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
+        XCTAssertFalse(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases == nil })
+    }
+    func testModuleAliasingUpstreamProductTargetsWithSameName3() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+                                    "/appPkg/Sources/App/main.swift",
+                                    "/apkg/Sources/A/file.swift",
+                                    "/apkg/Sources/Utils/file.swift",
+                                    "/xpkg/Sources/X/file.swift",
+                                    "/ypkg/Sources/Utils/file.swift",
+                                    "/zpkg/Sources/Utils/file.swift"
+        )
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    name: "zpkg",
+                    path: .init("/zpkg"),
+                    products: [
+                        ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "Utils", dependencies: []),
+                    ]),
+                Manifest.createRootManifest(
+                    name: "ypkg",
+                    path: .init("/ypkg"),
+                    products: [
+                        ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "Utils", dependencies: []),
+                    ]),
+                Manifest.createRootManifest(
+                    name: "xpkg",
+                    path: .init("/xpkg"),
+                    dependencies: [
+                        .localSourceControl(path: .init("/ypkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init("/zpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    products: [
+                        ProductDescription(name: "X", type: .library(.automatic), targets: ["X"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "X",
+                                          dependencies: [
+                                            .product(name: "Utils",
+                                                     package: "zpkg"),
+                                            .product(name: "Utils",
+                                                     package: "ypkg",
+                                                     moduleAliases: ["Utils": "YUtils"]
+                                                     )
+                                          ]),
+                    ]),
+                Manifest.createRootManifest(
+                    name: "apkg",
+                    path: .init("/apkg"),
+                    products: [
+                        ProductDescription(name: "A", type: .library(.automatic), targets: ["A"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "A", dependencies: ["Utils"]),
+                        TargetDescription(name: "Utils", dependencies: []),
+                    ]),
+                Manifest.createRootManifest(
+                    name: "appPkg",
+                    path: .init("/appPkg"),
+                    dependencies: [
+                        .localSourceControl(path: .init("/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init("/apkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    targets: [
+                        TargetDescription(name: "App",
+                                          dependencies: [
+                                            .product(name: "X",
+                                                     package: "xpkg"
+                                                    ),
+                                            .product(name: "A",
+                                                     package: "apkg",
+                                                     moduleAliases: ["Utils": "AUtils"]
+                                                    )
+                                          ]),
+                    ]),
+            ],
+            observabilityScope: observability.topScope
+        )
+        XCTAssertNoDiagnostics(observability.diagnostics)
+        let result = try BuildPlanResult(plan: try BuildPlan(
+            buildParameters: mockBuildParameters(shouldLinkStaticSwiftStdlib: true),
+            graph: graph,
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        ))
+        result.checkProductsCount(1)
+        result.checkTargetsCount(6)
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "X" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "YUtils" && $0.target.moduleAliases?["Utils"] == "YUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "A" && $0.target.moduleAliases?["Utils"] == "AUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "AUtils" && $0.target.moduleAliases?["Utils"] == "AUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
+    }
+
+    func testModuleAliasingUpstreamProductTargetsWithSameName4() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+                                    "/appPkg/Sources/App/main.swift",
+                                    "/apkg/Sources/A/file.swift",
+                                    "/apkg/Sources/Utils/file.swift",
+                                    "/xpkg/Sources/X/file.swift",
+                                    "/ypkg/Sources/Utils/file.swift",
+                                    "/zpkg/Sources/Utils/file.swift"
+        )
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    name: "zpkg",
+                    path: .init("/zpkg"),
+                    products: [
+                        ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "Utils", dependencies: []),
+                    ]),
+                Manifest.createRootManifest(
+                    name: "ypkg",
+                    path: .init("/ypkg"),
+                    products: [
+                        ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "Utils", dependencies: []),
+                    ]),
+                Manifest.createRootManifest(
+                    name: "xpkg",
+                    path: .init("/xpkg"),
+                    dependencies: [
+                        .localSourceControl(path: .init("/ypkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init("/zpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    products: [
+                        ProductDescription(name: "X", type: .library(.automatic), targets: ["X"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "X",
+                                          dependencies: [
+                                            .product(name: "Utils",
+                                                     package: "zpkg"),
+                                            .product(name: "Utils",
+                                                     package: "ypkg",
+                                                     moduleAliases: ["Utils": "YUtils"]
+                                                     )
+                                          ]),
+                    ]),
+                Manifest.createRootManifest(
+                    name: "apkg",
+                    path: .init("/apkg"),
+                    products: [
+                        ProductDescription(name: "A", type: .library(.automatic), targets: ["Utils"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "Utils", dependencies: []),
+                    ]),
+                Manifest.createRootManifest(
+                    name: "appPkg",
+                    path: .init("/appPkg"),
+                    dependencies: [
+                        .localSourceControl(path: .init("/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init("/apkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    targets: [
+                        TargetDescription(name: "App",
+                                          dependencies: [
+                                            .product(name: "X",
+                                                     package: "xpkg",
+                                                     moduleAliases: ["Utils": "XUtils"]
+                                                    ),
+                                            .product(name: "A",
+                                                     package: "apkg",
+                                                     moduleAliases: ["Utils": "AUtils"]
+                                                    )
+                                          ]),
+                    ]),
+            ],
+            observabilityScope: observability.topScope
+        )
+        XCTAssertNoDiagnostics(observability.diagnostics)
+        let result = try BuildPlanResult(plan: try BuildPlan(
+            buildParameters: mockBuildParameters(shouldLinkStaticSwiftStdlib: true),
+            graph: graph,
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        ))
+        result.checkProductsCount(1)
+        result.checkTargetsCount(5)
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "X" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "YUtils" && $0.target.moduleAliases?["Utils"] == "YUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "AUtils" && $0.target.moduleAliases?["Utils"] == "AUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
+        XCTAssertFalse(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases == nil })
+    }
+
+    func testModuleAliasingChainedAliases1() throws {
         let fs = InMemoryFileSystem(emptyFiles:
                                         "/appPkg/Sources/App/main.swift",
                                     "/apkg/Sources/A/file.swift",
@@ -2563,5 +3075,251 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "AFooUtils" && $0.target.moduleAliases?["Utils"] == "AFooUtils" })
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "XFooUtils" && $0.target.moduleAliases?["Utils"] == "XFooUtils" })
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
+    }
+
+    func testModuleAliasingChainedAliases2() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+                                        "/appPkg/Sources/App/main.swift",
+                                    "/apkg/Sources/A/file.swift",
+                                    "/apkg/Sources/Utils/file.swift",
+                                    "/bpkg/Sources/Utils/file.swift",
+                                    "/xpkg/Sources/X/file.swift",
+                                    "/xpkg/Sources/Utils/file.swift",
+                                    "/ypkg/Sources/Utils/file.swift",
+                                    "/zpkg/Sources/Utils/file.swift"
+        )
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createFileSystemManifest(
+                    name: "zpkg",
+                    path: .init("/zpkg"),
+                    products: [
+                        ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "Utils", dependencies: []),
+                    ]),
+                Manifest.createFileSystemManifest(
+                    name: "ypkg",
+                    path: .init("/ypkg"),
+                    products: [
+                        ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "Utils", dependencies: []),
+                    ]),
+                Manifest.createFileSystemManifest(
+                    name: "xpkg",
+                    path: .init("/xpkg"),
+                    dependencies: [
+                        .localSourceControl(path: .init("/ypkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init("/zpkg"), requirement: .upToNextMajor(from: "1.0.0"))
+                    ],
+                    products: [
+                        ProductDescription(name: "X", type: .library(.automatic), targets: ["X"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "X",
+                                          dependencies: [
+                                            .product(name: "Utils",
+                                                     package: "ypkg",
+                                                     moduleAliases: ["Utils" : "FooUtils"]
+                                                    ),
+                                            .product(name: "Utils",
+                                                     package: "zpkg"
+                                                    )
+                                            ]),
+                    ]),
+                Manifest.createFileSystemManifest(
+                    name: "bpkg",
+                    path: .init("/bpkg"),
+                    products: [
+                        ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "Utils", dependencies: []),
+                    ]),
+                Manifest.createFileSystemManifest(
+                    name: "apkg",
+                    path: .init("/apkg"),
+                    dependencies: [
+                        .localSourceControl(path: .init("/bpkg"), requirement: .upToNextMajor(from: "1.0.0"))
+                    ],
+                    products: [
+                        ProductDescription(name: "A", type: .library(.automatic), targets: ["A"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "A",
+                                          dependencies: [
+                                            "Utils",
+                                            .product(name: "Utils",
+                                                     package: "bpkg",
+                                                     moduleAliases: ["Utils" : "FooUtils"]
+                                                    )
+                                            ]),
+                        TargetDescription(name: "Utils", dependencies: []),
+                    ]),
+                Manifest.createRootManifest(
+                    name: "appPkg",
+                    path: .init("/appPkg"),
+                    dependencies: [
+                        .localSourceControl(path: .init("/apkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init("/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    targets: [
+                        TargetDescription(name: "App",
+                                          dependencies: [.product(name: "A",
+                                                                  package: "apkg",
+                                                                  moduleAliases: ["Utils": "AUtils", "FooUtils": "AFUtils"]),
+                                                         .product(name: "X",
+                                                                  package: "xpkg",
+                                                                  moduleAliases: ["FooUtils": "XFUtils"])
+                                          ]),
+                    ]),
+            ],
+            observabilityScope: observability.topScope
+        )
+        XCTAssertNoDiagnostics(observability.diagnostics)
+        let result = try BuildPlanResult(plan: try BuildPlan(
+            buildParameters: mockBuildParameters(shouldLinkStaticSwiftStdlib: true),
+            graph: graph,
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        ))
+        result.checkProductsCount(1)
+        result.checkTargetsCount(7)
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "A" && $0.target.moduleAliases?["Utils"] == "AUtils" && $0.target.moduleAliases?["FooUtils"] == "AFUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "AUtils" && $0.target.moduleAliases?["Utils"] == "AUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "AFUtils" && $0.target.moduleAliases?["Utils"] == "AFUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "X" && $0.target.moduleAliases?["FooUtils"] == "XFUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "XFUtils" && $0.target.moduleAliases?["Utils"] == "XFUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
+    }
+
+    func testModuleAliasingChainedAliases3() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+                                        "/appPkg/Sources/App/main.swift",
+                                    "/apkg/Sources/A/file.swift",
+                                    "/apkg/Sources/Utils/file.swift",
+                                    "/bpkg/Sources/Utils/file.swift",
+                                    "/xpkg/Sources/X/file.swift",
+                                    "/xpkg/Sources/Utils/file.swift",
+                                    "/ypkg/Sources/Utils/file.swift",
+                                    "/zpkg/Sources/Utils/file.swift"
+        )
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createFileSystemManifest(
+                    name: "zpkg",
+                    path: .init("/zpkg"),
+                    products: [
+                        ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "Utils", dependencies: []),
+                    ]),
+                Manifest.createFileSystemManifest(
+                    name: "ypkg",
+                    path: .init("/ypkg"),
+                    products: [
+                        ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "Utils", dependencies: []),
+                    ]),
+                Manifest.createFileSystemManifest(
+                    name: "xpkg",
+                    path: .init("/xpkg"),
+                    dependencies: [
+                        .localSourceControl(path: .init("/ypkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init("/zpkg"), requirement: .upToNextMajor(from: "1.0.0"))
+                    ],
+                    products: [
+                        ProductDescription(name: "X", type: .library(.automatic), targets: ["X"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "X",
+                                          dependencies: [
+                                            .product(name: "Utils",
+                                                     package: "ypkg",
+                                                     moduleAliases: ["Utils" : "FooUtils"]
+                                                    ),
+                                            .product(name: "Utils",
+                                                     package: "zpkg",
+                                                     moduleAliases: ["Utils" : "ZUtils"]
+                                                    )
+                                            ]),
+                    ]),
+                Manifest.createFileSystemManifest(
+                    name: "bpkg",
+                    path: .init("/bpkg"),
+                    products: [
+                        ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "Utils", dependencies: []),
+                    ]),
+                Manifest.createFileSystemManifest(
+                    name: "apkg",
+                    path: .init("/apkg"),
+                    dependencies: [
+                        .localSourceControl(path: .init("/bpkg"), requirement: .upToNextMajor(from: "1.0.0"))
+                    ],
+                    products: [
+                        ProductDescription(name: "A", type: .library(.automatic), targets: ["A"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "A",
+                                          dependencies: [
+                                            "Utils",
+                                            .product(name: "Utils",
+                                                     package: "bpkg",
+                                                     moduleAliases: ["Utils" : "FooUtils"]
+                                                    )
+                                            ]),
+                        TargetDescription(name: "Utils", dependencies: []),
+                    ]),
+                Manifest.createRootManifest(
+                    name: "appPkg",
+                    path: .init("/appPkg"),
+                    dependencies: [
+                        .localSourceControl(path: .init("/apkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init("/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    targets: [
+                        TargetDescription(name: "App",
+                                          dependencies: [.product(name: "A",
+                                                                  package: "apkg",
+                                                                  moduleAliases: ["Utils": "AUtils", "FooUtils": "AFooUtils"]),
+                                                         .product(name: "X",
+                                                                  package: "xpkg",
+                                                                  moduleAliases: ["ZUtils": "XUtils", "FooUtils": "XFooUtils"])
+                                          ]),
+                    ]),
+            ],
+            observabilityScope: observability.topScope
+        )
+        XCTAssertNoDiagnostics(observability.diagnostics)
+        let result = try BuildPlanResult(plan: try BuildPlan(
+            buildParameters: mockBuildParameters(shouldLinkStaticSwiftStdlib: true),
+            graph: graph,
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        ))
+        result.checkProductsCount(1)
+        result.checkTargetsCount(7)
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "A" && $0.target.moduleAliases?["Utils"] == "AUtils" && $0.target.moduleAliases?["FooUtils"] == "AFooUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "AUtils" && $0.target.moduleAliases?["Utils"] == "AUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "AFooUtils" && $0.target.moduleAliases?["Utils"] == "AFooUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "X" && $0.target.moduleAliases?["ZUtils"] == "XUtils" && $0.target.moduleAliases?["FooUtils"] == "XFooUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "XFooUtils" && $0.target.moduleAliases?["Utils"] == "XFooUtils" })
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
+        XCTAssertFalse(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases == nil })
     }
 }


### PR DESCRIPTION
-Keep track of aliases that should be referenced directly
-Keep track of pre-chain aliases separately from the final module aliases
-Use above lists when applying final aliases
-Update logic to determine when to apply aliases
-Added additional tests
Resolves rdar://95724629