### PR TITLE
Improve handling of missing plugins

### DIFF
--- a/Fixtures/Miscellaneous/Plugins/MissingPlugin/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/MissingPlugin/Package.swift
@@ -1,0 +1,10 @@
+// swift-tools-version: 5.7
+
+import PackageDescription
+
+let package = Package(
+    name: "MissingPlugin",
+    targets: [
+        .target(name: "MissingPlugin", plugins: ["NonExistingPlugin"]),
+    ]
+)

--- a/Fixtures/Miscellaneous/Plugins/MissingPlugin/Sources/MissingPlugin/MissingPlugin.swift
+++ b/Fixtures/Miscellaneous/Plugins/MissingPlugin/Sources/MissingPlugin/MissingPlugin.swift
@@ -1,0 +1,6 @@
+public struct MissingPlugin {
+    public private(set) var text = "Hello, World!"
+
+    public init() {
+    }
+}

--- a/Fixtures/Miscellaneous/Plugins/PluginCanBeReferencedByProductName/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/PluginCanBeReferencedByProductName/Package.swift
@@ -1,0 +1,15 @@
+// swift-tools-version: 5.7
+
+import PackageDescription
+
+let package = Package(
+    name: "PluginCanBeReferencedByProductName",
+    products: [
+        .plugin(name: "MyPluginProduct", targets: ["MyPlugin"]),
+    ],
+    targets: [
+        .target(name: "PluginCanBeReferencedByProductName", plugins: ["MyPluginProduct"]),
+        .executableTarget(name: "Exec"),
+        .plugin(name: "MyPlugin", capability: .buildTool(), dependencies: ["Exec"]),
+    ]
+)

--- a/Fixtures/Miscellaneous/Plugins/PluginCanBeReferencedByProductName/Plugins/MyPlugin/plugin.swift
+++ b/Fixtures/Miscellaneous/Plugins/PluginCanBeReferencedByProductName/Plugins/MyPlugin/plugin.swift
@@ -1,0 +1,14 @@
+import PackagePlugin
+
+@main
+struct MyPlugin: BuildToolPlugin {
+    func createBuildCommands(context: PackagePlugin.PluginContext, target: PackagePlugin.Target) async throws -> [PackagePlugin.Command] {
+        let output = context.pluginWorkDirectory.appending("gen.swift")
+        return [
+            .buildCommand(displayName: "Generating code",
+                          executable: try context.tool(named: "Exec").path,
+                          arguments: [output.string],
+                          outputFiles: [output])
+        ]
+    }
+}

--- a/Fixtures/Miscellaneous/Plugins/PluginCanBeReferencedByProductName/Sources/Exec/main.swift
+++ b/Fixtures/Miscellaneous/Plugins/PluginCanBeReferencedByProductName/Sources/Exec/main.swift
@@ -1,0 +1,4 @@
+import Foundation
+
+let output = ProcessInfo.processInfo.arguments[1]
+try "let stringConstant = \"Hello, World!\"".write(to: URL(fileURLWithPath: output), atomically: true, encoding: .utf8)

--- a/Fixtures/Miscellaneous/Plugins/PluginCanBeReferencedByProductName/Sources/PluginCanBeReferencedByProductName/PluginCanBeReferencedByProductName.swift
+++ b/Fixtures/Miscellaneous/Plugins/PluginCanBeReferencedByProductName/Sources/PluginCanBeReferencedByProductName/PluginCanBeReferencedByProductName.swift
@@ -1,0 +1,6 @@
+public struct PluginCanBeReferencedByProductName {
+    public private(set) var text = stringConstant
+
+    public init() {
+    }
+}

--- a/Sources/PackageLoading/Diagnostics.swift
+++ b/Sources/PackageLoading/Diagnostics.swift
@@ -82,6 +82,10 @@ extension Basics.Diagnostic {
         .error("executable product '\(product)' should not have more than one executable target")
     }
 
+    static func pluginNotFound(name: String) -> Self {
+        .error("no plugin named '\(name)' found")
+    }
+
     static func pluginProductWithNoTargets(product: String) -> Self {
         .error("plugin product '\(product)' should have at least one plugin target")
     }

--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -214,6 +214,7 @@ public final class Manifest {
 
     /// Returns the targets required for building the provided products.
     public func targetsRequired(for products: [ProductDescription]) -> [TargetDescription] {
+        let productsByName = Dictionary(products.map({ ($0.name, $0) }), uniquingKeysWith: { $1 })
         let targetsByName = Dictionary(targets.map({ ($0.name, $0) }), uniquingKeysWith: { $1 })
         let productTargetNames = products.flatMap({ $0.targets })
 
@@ -233,7 +234,13 @@ public final class Manifest {
                 let plugins: [String] = target.pluginUsages?.compactMap { pluginUsage in
                     switch pluginUsage {
                     case .plugin(name: let name, package: nil):
-                        return targetsByName.keys.contains(name) ? name : nil
+                        if targetsByName.keys.contains(name) {
+                            return name
+                        } else if let targetName = productsByName[name]?.targets.first {
+                            return targetName
+                        } else {
+                            return nil
+                        }
                     default:
                         return nil
                     }

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -909,4 +909,30 @@ class PluginTests: XCTestCase {
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
     }
+
+    func testMissingPlugin() throws {
+        // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
+        try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+
+        try fixture(name: "Miscellaneous/Plugins") { fixturePath in
+            do {
+                try executeSwiftBuild(fixturePath.appending(component: "MissingPlugin"))
+            } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
+                XCTAssert(stderr.contains("error: 'missingplugin': no plugin named 'NonExistingPlugin' found"), "stderr:\n\(stderr)")
+            }
+        }
+    }
+
+    func testPluginCanBeReferencedByProductName() throws {
+        // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
+        try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+
+        try fixture(name: "Miscellaneous/Plugins") { fixturePath in
+            let (stdout, _) = try executeSwiftBuild(fixturePath.appending(component: "PluginCanBeReferencedByProductName"))
+            XCTAssert(stdout.contains("Compiling plugin MyPlugin..."), "stdout:\n\(stdout)")
+            XCTAssert(stdout.contains("Compiling PluginCanBeReferencedByProductName gen.swift"), "stdout:\n\(stdout)")
+            XCTAssert(stdout.contains("Compiling PluginCanBeReferencedByProductName PluginCanBeReferencedByProductName.swift"), "stdout:\n\(stdout)")
+            XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
+        }
+    }
 }


### PR DESCRIPTION
- if a plugin is referenced by its product name in the same package, automatically use the target instead
- if a plugin referenced in the same package doesn't exist, emit an error

fixes #5650
rdar://96664671