### PR TITLE
Use < 3.7 compatible API for marking subparsers as required

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -37,7 +37,8 @@ def main():
         This script will build a bootstrapped copy of the Swift Package Manager, and optionally perform extra
         actions like installing the result (with 'install') to a location ('--prefix').
         """)
-    subparsers = parser.add_subparsers(dest='command', required=True)
+    subparsers = parser.add_subparsers(dest='command')
+    subparsers.required = True
 
     # clean
     parser_clean = subparsers.add_parser("clean", help="cleans build artifacts")


### PR DESCRIPTION
`required` was only added as a parameter to `add_subparsers` in Python
3.7. Explicitly set `required` on `subparsers` after instead, which is
supported on all versions.