### PR TITLE
[5.7] Mark plugin-only dependencies in required targets as required

### DIFF
--- a/Fixtures/Miscellaneous/Plugins/TransitivePluginOnlyDependency/Dependencies/Library/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/TransitivePluginOnlyDependency/Dependencies/Library/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version: 5.7
+
+import PackageDescription
+
+let package = Package(
+    name: "Library",
+    products: [
+        .library(name: "Library", targets: ["Library"]),
+    ],
+    dependencies: [
+        .package(path: "../PluginOnly")
+    ],
+    targets: [
+        .target(name: "Library", plugins: [.plugin(name: "MyPlugin", package: "PluginOnly")]),
+    ]
+)

--- a/Fixtures/Miscellaneous/Plugins/TransitivePluginOnlyDependency/Dependencies/Library/Sources/Library/Library.swift
+++ b/Fixtures/Miscellaneous/Plugins/TransitivePluginOnlyDependency/Dependencies/Library/Sources/Library/Library.swift
@@ -1,0 +1,6 @@
+public struct Library {
+    public private(set) var text = "Hello, World!"
+
+    public init() {
+    }
+}

--- a/Fixtures/Miscellaneous/Plugins/TransitivePluginOnlyDependency/Dependencies/PluginOnly/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/TransitivePluginOnlyDependency/Dependencies/PluginOnly/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version: 5.7
+
+import PackageDescription
+
+let package = Package(
+    name: "PluginOnly",
+    products: [
+        .plugin(name: "MyPlugin", targets: ["MyPlugin"]),
+    ],
+    targets: [
+        .plugin(name: "MyPlugin", capability: .buildTool()),
+    ]
+)

--- a/Fixtures/Miscellaneous/Plugins/TransitivePluginOnlyDependency/Dependencies/PluginOnly/Plugins/MyPlugin/plugin.swift
+++ b/Fixtures/Miscellaneous/Plugins/TransitivePluginOnlyDependency/Dependencies/PluginOnly/Plugins/MyPlugin/plugin.swift
@@ -1,0 +1,8 @@
+import PackagePlugin
+
+@main
+struct MyPlugin: BuildToolPlugin {
+    func createBuildCommands(context: PackagePlugin.PluginContext, target: PackagePlugin.Target) async throws -> [PackagePlugin.Command] {
+        return []
+    }
+}

--- a/Fixtures/Miscellaneous/Plugins/TransitivePluginOnlyDependency/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/TransitivePluginOnlyDependency/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version: 5.7
+
+import PackageDescription
+
+let package = Package(
+    name: "TransitivePluginOnlyDependency",
+    dependencies: [
+        .package(path: "Dependencies/Library"),
+    ],
+    targets: [
+        .target(name: "TransitivePluginOnlyDependency", dependencies: ["Library"]),
+    ]
+)

--- a/Fixtures/Miscellaneous/Plugins/TransitivePluginOnlyDependency/Sources/TransitivePluginOnlyDependency/TransitivePluginOnlyDependency.swift
+++ b/Fixtures/Miscellaneous/Plugins/TransitivePluginOnlyDependency/Sources/TransitivePluginOnlyDependency/TransitivePluginOnlyDependency.swift
@@ -1,0 +1,6 @@
+public struct TransitivePluginOnlyDependency {
+    public private(set) var text = "Hello, World!"
+
+    public init() {
+    }
+}

--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -200,6 +200,12 @@ public final class Manifest {
                     requiredDependencies.insert(dependency.identity)
                 }
             }
+
+            target.pluginUsages?.forEach {
+                if let dependency = self.packageDependency(referencedBy: $0) {
+                    requiredDependencies.insert(dependency.identity)
+                }
+            }
         }
 
         return self.dependencies.filter { requiredDependencies.contains($0.identity) }
@@ -307,6 +313,19 @@ public final class Manifest {
 
         return packageDependency(referencedBy: packageName)
     }
+
+    /// Finds the package dependency referenced by the specified plugin usage.
+    /// - Returns: Returns `nil` if  the used plugin is from the same package or if the package the used plugin is from cannot be found.
+    public func packageDependency(
+        referencedBy pluginUsage: TargetDescription.PluginUsage) -> PackageDependency? {
+        switch pluginUsage {
+        case .plugin(_, let .some(package)):
+            return packageDependency(referencedBy: package)
+        default:
+            return nil
+        }
+    }
+
     private func packageDependency(
         referencedBy packageName: String
     ) -> PackageDependency? {

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -899,4 +899,16 @@ class PluginTests: XCTestCase {
         }
 
     }
+
+    func testTransitivePluginOnlyDependency() throws {
+        // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
+        try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+
+        try fixture(name: "Miscellaneous/Plugins") { fixturePath in
+            let (stdout, _) = try executeSwiftBuild(fixturePath.appending(component: "TransitivePluginOnlyDependency"))
+            XCTAssert(stdout.contains("Compiling plugin MyPlugin..."), "stdout:\n\(stdout)")
+            XCTAssert(stdout.contains("Compiling Library Library.swift"), "stdout:\n\(stdout)")
+            XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
+        }
+    }
 }


### PR DESCRIPTION
5.7 cherry-pick of #5649