### PR TITLE
address warnings from using deprecated TSCBasic::Lock

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -14,6 +14,7 @@ import ArgumentParser
 import Basics
 import Build
 import Dispatch
+import class Foundation.NSLock
 import class Foundation.ProcessInfo
 import OrderedCollections
 import PackageGraph
@@ -56,11 +57,11 @@ private class ToolWorkspaceDelegate: WorkspaceDelegate {
 
     /// The progress of binary downloads.
     private var binaryDownloadProgress = OrderedCollections.OrderedDictionary<String, DownloadProgress>()
-    private let binaryDownloadProgressLock = Lock()
+    private let binaryDownloadProgressLock = NSLock()
 
     /// The progress of package  fetch operations.
     private var fetchProgress = OrderedCollections.OrderedDictionary<PackageIdentity, FetchProgress>()
-    private let fetchProgressLock = Lock()
+    private let fetchProgressLock = NSLock()
 
     private let observabilityScope: ObservabilityScope
 


### PR DESCRIPTION
motivation: no warnings

changes: use NSLock instead of deprecated TSCBasic::Lock
