### PR TITLE
Workspace: adjust `Path` when executing plugins

### DIFF
--- a/Sources/Workspace/DefaultPluginScriptRunner.swift
+++ b/Sources/Workspace/DefaultPluginScriptRunner.swift
@@ -409,6 +409,16 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
         process.executableURL = URL(fileURLWithPath: command[0])
         process.arguments = Array(command.dropFirst())
         process.environment = ProcessInfo.processInfo.environment
+#if os(Windows)
+        let pluginLibraryPath = self.toolchain.swiftPMLibrariesLocation.pluginLibraryPath.pathString
+        var env = ProcessInfo.processInfo.environment
+        if let Path = env["Path"] {
+            env["Path"] = "\(pluginLibraryPath);\(Path)"
+        } else {
+            env["Path"] = pluginLibraryPath
+        }
+        process.environment = env
+#endif
         process.currentDirectoryURL = workingDirectory.asURL
         
         // Set up a pipe for sending structured messages to the plugin on its stdin.


### PR DESCRIPTION
Package plugins depend on the plugin library, which is not located in
the `Path` environment variable by default.  Adjust the path to ensure
that the plugin is able to locate the library.

Fixes: #5656

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
