### PR TITLE
Improve CompositeAuthorizationProvider

### DIFF
--- a/Sources/Basics/AuthorizationProvider.swift
+++ b/Sources/Basics/AuthorizationProvider.swift
@@ -255,15 +255,15 @@ public struct KeychainAuthorizationProvider: AuthorizationProvider {
 public struct CompositeAuthorizationProvider: AuthorizationProvider {
     // marked internal for testing
     internal let providers: [AuthorizationProvider]
-    private let observabilityScope: ObservabilityScope
+    private let diagnosticsEmitter: DiagnosticsEmitterProtocol
 
-    public init(_ providers: AuthorizationProvider..., observabilityScope: ObservabilityScope) {
-        self.init(providers, observabilityScope: observabilityScope)
+    public init(_ providers: AuthorizationProvider..., diagnosticsEmitter: DiagnosticsEmitterProtocol) {
+        self.init(providers, diagnosticsEmitter: diagnosticsEmitter)
     }
 
-    public init(_ providers: [AuthorizationProvider], observabilityScope: ObservabilityScope) {
+    public init(_ providers: [AuthorizationProvider], diagnosticsEmitter: DiagnosticsEmitterProtocol) {
         self.providers = providers
-        self.observabilityScope = observabilityScope
+        self.diagnosticsEmitter = diagnosticsEmitter
     }
 
     public func authentication(for url: URL) -> (user: String, password: String)? {
@@ -271,13 +271,13 @@ public struct CompositeAuthorizationProvider: AuthorizationProvider {
             if let authentication = provider.authentication(for: url) {
                 switch provider {
                 case let provider as NetrcAuthorizationProvider:
-                    self.observabilityScope.emit(info: "Credentials for \(url) found in netrc file at \(provider.path)")
+                    self.diagnosticsEmitter.emit(info: "Credentials for \(url) found in netrc file at \(provider.path)")
                 #if canImport(Security)
                 case is KeychainAuthorizationProvider:
-                    self.observabilityScope.emit(info: "Credentials for \(url) found in keychain")
+                    self.diagnosticsEmitter.emit(info: "Credentials for \(url) found in keychain")
                 #endif
                 default:
-                    self.observabilityScope.emit(info: "Credentials for \(url) found in \(provider)")
+                    self.diagnosticsEmitter.emit(info: "Credentials for \(url) found in \(provider)")
                 }
                 return authentication
             }

--- a/Sources/Workspace/Workspace+Configuration.swift
+++ b/Sources/Workspace/Workspace+Configuration.swift
@@ -336,7 +336,7 @@ extension Workspace.Configuration {
                 break
             }
 
-            return providers.isEmpty ? .none : CompositeAuthorizationProvider(providers, observabilityScope: observabilityScope)
+            return providers.isEmpty ? .none : CompositeAuthorizationProvider(providers, diagnosticsEmitter: observabilityScope)
         }
 
         private func loadOptionalNetrc(

--- a/Tests/BasicsTests/AuthorizationProviderTests.swift
+++ b/Tests/BasicsTests/AuthorizationProviderTests.swift
@@ -103,20 +103,20 @@ final class AuthorizationProviderTests: XCTestCase {
 
         do {
             // providerOne's password is returned first
-            let provider = CompositeAuthorizationProvider(providerOne, providerTwo, observabilityScope: ObservabilitySystem.NOOP)
+            let provider = CompositeAuthorizationProvider(providerOne, providerTwo, diagnosticsEmitter: ObservabilitySystem.NOOP)
             self.assertAuthentication(provider, for: url, expected: (user, passwordOne))
         }
 
         do {
             // providerTwo's password is returned first
-            let provider = CompositeAuthorizationProvider(providerTwo, providerOne, observabilityScope: ObservabilitySystem.NOOP)
+            let provider = CompositeAuthorizationProvider(providerTwo, providerOne, diagnosticsEmitter: ObservabilitySystem.NOOP)
             self.assertAuthentication(provider, for: url, expected: (user, passwordTwo))
         }
 
         do {
             // Neither has password
             let unknownURL = URL(string: "http://\(UUID().uuidString)")!
-            let provider = CompositeAuthorizationProvider(providerOne, providerTwo, observabilityScope: ObservabilitySystem.NOOP)
+            let provider = CompositeAuthorizationProvider(providerOne, providerTwo, diagnosticsEmitter: ObservabilitySystem.NOOP)
             XCTAssertNil(provider.authentication(for: unknownURL))
         }
     }


### PR DESCRIPTION
Decouple CompositeAuthorizationProvider from ObservabilityScope and add unit test. 

### Motivation:

CompositeAuthorizationProvider currently uses the concrete componente ObservabilityScope to only send the message `emit(info: String, metadata: ObservabilityMetadata)` which is define in `DiagnosticsEmitterProtocol`. 

### Modifications:

Instead of using the concrete componente ObservabilityScope, I've change to use only the protocol `DiagnosticsEmitterProtocol`. 

Also added unit test for the communication between CompositeAuthorizationProvider and DiagnosticsEmitterProtocol. 

### Result:

Nothing changed 
