### PR TITLE
Fix typo in in-source for Target.Dependency

### DIFF
--- a/Sources/PackageDescription/Product.swift
+++ b/Sources/PackageDescription/Product.swift
@@ -179,7 +179,7 @@ public class Product: Encodable {
     /// this package to use the package's functionality.
     ///
     /// A library's product can be either statically or dynamically linked. It's recommended
-    /// that you don't explicity declare the type of library, so Swift Package Manager can
+    /// that you don't explicitly declare the type of library, so Swift Package Manager can
     /// choose between static or dynamic linking based on the preference of the
     /// package's consumer.
     ///

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -41,7 +41,7 @@ public final class Target {
 
     /// The different types of a target's dependency on another entity.
     public enum Dependency {
-        /// A denpendency on a target.
+        /// A dependency on a target.
         ///
         ///  - Parameters:
         ///    - name: The name of the target.


### PR DESCRIPTION
Fix typo in in-source for Target.Dependency

### Motivation:

Refine doc

### Modifications:
From
```A denpendency on a target.```
To
```A dependency on a target.```

### Result:

Better doc.
