### PR TITLE
PackagePlugin: change the `setvbuf` usage

### DIFF
--- a/Sources/PackagePlugin/Plugin.swift
+++ b/Sources/PackagePlugin/Plugin.swift
@@ -84,8 +84,16 @@ extension Plugin {
         }
         
         // Turn off full buffering so printed text appears as soon as possible.
+        // Windows is much less forgiving than other platforms.  If line
+        // buffering is enabled, we must provide a buffer and the size of the
+        // buffer.  As a result, on Windows, we completely disable all
+        // buffering, which means that partial writes are possible.
+#if os(Windows)
+        setvbuf(stdout, nil, _IONBF, 0)
+#else
         setvbuf(stdout, nil, _IOLBF, 0)
-        
+#endif
+
         // Open a message channel for communicating with the plugin host.
         pluginHostConnection = PluginHostConnection(
             inputStream: FileHandle(fileDescriptor: inputFD),


### PR DESCRIPTION
Windows is much less lenient about handling and requires that a buffer
is provided if performing line buffering.  On Windows completely
disable all buffering instead which leaves us vulnerable to partial line
emissions if more than one thread is active.

Fixes: 5668