### PR TITLE
Do not try to interrupt/terminate a process if it isn't running

### DIFF
--- a/Sources/Basics/Cancellator.swift
+++ b/Sources/Basics/Cancellator.swift
@@ -145,6 +145,10 @@ extension TSCBasic.Process {
 #if !os(iOS) && !os(watchOS) && !os(tvOS)
 extension Foundation.Process {
     fileprivate func terminate(timeout: DispatchTime) {
+        guard self.isRunning else {
+            return
+        }
+
         // send graceful shutdown signal (SIGINT)
         self.interrupt()
 
@@ -152,6 +156,10 @@ extension Foundation.Process {
         let forceKillSemaphore = DispatchSemaphore(value: 0)
         let forceKillThread = TSCBasic.Thread {
             if case .timedOut = forceKillSemaphore.wait(timeout: timeout) {
+                guard self.isRunning else {
+                    return
+                }
+
                 // force kill (SIGTERM)
                 self.terminate()
             }


### PR DESCRIPTION
Calling these on a process that isn't currently running results in

```
'NSInvalidArgumentException', reason: '*** -[NSConcreteTask terminate]: task not launched'
```

so we should check first.

rdar://96964401
