### PR TITLE
expose swift-package-registry as top level tool

### DIFF
--- a/Sources/swift-package/main.swift
+++ b/Sources/swift-package/main.swift
@@ -28,6 +28,8 @@ case "swift-run":
     SwiftRunTool.main()
 case "swift-package-collection":
     SwiftPackageCollectionsTool.main()
+case "swift-package-registry":
+    SwiftPackageRegistryTool.main()
 default:
     fatalError("swift-package launched with unexpected name: \(execName ?? "(unknown)")")
 }

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -424,7 +424,7 @@ def install_swiftpm(prefix, args):
     # Install the swift-package tool and create symlinks to it.
     cli_tool_dest = os.path.join(prefix, "bin")
     install_binary(args, "swift-package", cli_tool_dest)
-    for tool in ["swift-build", "swift-test", "swift-run", "swift-package-collection"]:
+    for tool in ["swift-build", "swift-test", "swift-run", "swift-package-collection", "swift-package-registry"]:
         src = "swift-package"
         dest = os.path.join(cli_tool_dest, tool)
         note("Creating tool symlink from %s to %s" % (src, dest))


### PR DESCRIPTION
motivation: support of package registry

changes:
* make sure swift-package-registry is installed (symlinked) via the bootstrap script
* add entry point in swift-package executable
