### PR TITLE
Import _Concurrency where needed

### DIFF
--- a/Sources/Basics/TemporaryFile.swift
+++ b/Sources/Basics/TemporaryFile.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import _Concurrency
 import Foundation
 import TSCBasic
 

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import _Concurrency
 import Basics
 import Foundation
 import OrderedCollections


### PR DESCRIPTION
In some environments we have to disable the implicit import of concurrency for reasons, so we need to explicitly import the module where needed.

Note: ideally, we would catch this by adding `-disable-implicit-concurrency-module-import` to the bootstrap invocation of `swift-build`, but I wasn't able to get that working locally without the inferior `swift-build` crashing on me. I'll open a separate draft PR for that change that we can land once that has been figured out.

rdar://97387827
