### PR TITLE
improve heuristics for @main support 

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -626,21 +626,26 @@ public final class SwiftTargetBuildDescription {
     public let isTestDiscoveryTarget: Bool
 
     /// True if this module needs to be parsed as a library based on the target type and the configuration
-    /// of the source code (for example because it has a single source file whose name isn't "main.swift").
-    /// This deactivates heuristics in the Swift compiler that treats single-file modules and source files
-    /// named "main.swift" specially w.r.t. whether they can have an entry point.
-    ///
-    /// See https://bugs.swift.org/browse/SR-14488 for discussion about improvements so that SwiftPM can
-    /// convey the intent to build an executable module to the compiler regardless of the number of files
-    /// in the module or their names.
+    /// of the source code
     var needsToBeParsedAsLibrary: Bool {
-        switch target.type {
+        switch self.target.type {
         case .library, .test:
             return true
         case .executable:
-            guard toolsVersion >= .v5_5 else { return false }
-            let sources = self.sources
-            return sources.count == 1 && sources.first?.basename != "main.swift"
+            // This deactivates heuristics in the Swift compiler that treats single-file modules and source files
+            // named "main.swift" specially w.r.t. whether they can have an entry point.
+            //
+            // See https://bugs.swift.org/browse/SR-14488 for discussion about improvements so that SwiftPM can
+            // convey the intent to build an executable module to the compiler regardless of the number of files
+            // in the module or their names.
+            if self.toolsVersion < .v5_5 || self.sources.count != 1 {
+                return false
+            }
+            // looking into the file content to see if it is using the @main annotation which requires parse-as-library
+            // this is not bullet-proof since theoretically the file can contain the @main string for other reasons
+            // but it is the closest to accurate we can do at this point
+            let content: String = self.sources.first.flatMap({ try? self.fileSystem.readFileContents($0) }) ?? ""
+            return content.contains("@main")
         default:
             return false
         }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -1214,9 +1214,25 @@ final class BuildPlanTests: XCTestCase {
             "/Pkg/Sources/exe3/foo.swift",
             // executable has a single source file named `main.swift`, with @main
             "/Pkg/Sources/exe4/main.swift",
+            // executable has a single source file named `comments.swift`, with @main in comments
+            "/Pkg/Sources/exe5/comments.swift",
+            // executable has a single source file named `comments.swift`, with @main in comments
+            "/Pkg/Sources/exe6/comments.swift",
+            // executable has a single source file named `comments.swift`, with @main in comments
+            "/Pkg/Sources/exe7/comments.swift",
+            // executable has a single source file named `comments.swift`, with @main in comments
+            "/Pkg/Sources/exe8/comments.swift",
+            // executable has a single source file named `comments.swift`, with @main in comments
+            "/Pkg/Sources/exe9/comments.swift",
+            // executable has a single source file named `comments.swift`, with @main in comments and not in comments
+            "/Pkg/Sources/exe10/comments.swift",
+            // executable has a single source file named `comments.swift`, with @main in comments and not in comments
+            "/Pkg/Sources/exe11/comments.swift",
+            // executable has a single source file named `comments.swift`, with @main in comments and not in comments
+            "/Pkg/Sources/exe12/comments.swift",
             // executable has multiple source files.
-            "/Pkg/Sources/exe5/bar.swift",
-            "/Pkg/Sources/exe5/main.swift"
+            "/Pkg/Sources/exe13/bar.swift",
+            "/Pkg/Sources/exe13/main.swift"
         )
 
         try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe3/foo.swift")) {
@@ -1241,6 +1257,96 @@ final class BuildPlanTests: XCTestCase {
             """
         }
 
+        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe5/comments.swift")) {
+            """
+            // @main in comment
+            print("hello world")
+            """
+        }
+
+        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe6/comments.swift")) {
+            """
+            /* @main in comment */
+            print("hello world")
+            """
+        }
+
+        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe7/comments.swift")) {
+            """
+            /*
+            @main in comment
+            */
+            print("hello world")
+            """
+        }
+
+        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe8/comments.swift")) {
+            """
+            /*
+            @main
+            struct Runner {
+              static func main() {
+                print("hello world")
+              }
+            }
+            */
+            print("hello world")
+            """
+        }
+
+        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe9/comments.swift")) {
+            """
+            /*@main
+            struct Runner {
+              static func main() {
+                print("hello world")
+              }
+            }*/
+            """
+        }
+
+        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe10/comments.swift")) {
+            """
+            // @main in comment
+            @main
+            struct Runner {
+              static func main() {
+                print("hello world")
+              }
+            }
+            """
+        }
+
+        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe11/comments.swift")) {
+            """
+            /* @main in comment */
+            @main
+            struct Runner {
+              static func main() {
+                print("hello world")
+              }
+            }
+            """
+        }
+
+        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe12/comments.swift")) {
+            """
+            /*
+            @main
+            struct Runner {
+              static func main() {
+                print("hello world")
+              }
+            }*/
+            @main
+            struct Runner {
+              static func main() {
+                print("hello world")
+              }
+            }
+            """
+        }
+
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
             fileSystem: fs,
@@ -1255,6 +1361,14 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "exe3", type: .executable),
                         TargetDescription(name: "exe4", type: .executable),
                         TargetDescription(name: "exe5", type: .executable),
+                        TargetDescription(name: "exe6", type: .executable),
+                        TargetDescription(name: "exe7", type: .executable),
+                        TargetDescription(name: "exe8", type: .executable),
+                        TargetDescription(name: "exe9", type: .executable),
+                        TargetDescription(name: "exe10", type: .executable),
+                        TargetDescription(name: "exe11", type: .executable),
+                        TargetDescription(name: "exe12", type: .executable),
+                        TargetDescription(name: "exe13", type: .executable),
                     ]),
             ],
             observabilityScope: observability.topScope
@@ -1268,8 +1382,8 @@ final class BuildPlanTests: XCTestCase {
             observabilityScope: observability.topScope
         ))
 
-        result.checkProductsCount(5)
-        result.checkTargetsCount(5)
+        result.checkProductsCount(13)
+        result.checkTargetsCount(13)
 
         XCTAssertNoDiagnostics(observability.diagnostics)
 
@@ -1292,6 +1406,38 @@ final class BuildPlanTests: XCTestCase {
         // multiple source files should not have -parse-as-library.
         let exe5 = try result.target(for: "exe5").swiftTarget().emitCommandLine()
         XCTAssertNoMatch(exe5, ["-parse-as-library"])
+
+        // @main in comment should not have -parse-as-library.
+        let exe6 = try result.target(for: "exe6").swiftTarget().emitCommandLine()
+        XCTAssertNoMatch(exe6, ["-parse-as-library"])
+
+        // @main in comment should not have -parse-as-library.
+        let exe7 = try result.target(for: "exe7").swiftTarget().emitCommandLine()
+        XCTAssertNoMatch(exe7, ["-parse-as-library"])
+
+        // @main in comment should not have -parse-as-library.
+        let exe8 = try result.target(for: "exe8").swiftTarget().emitCommandLine()
+        XCTAssertNoMatch(exe8, ["-parse-as-library"])
+
+        // @main in comment should not have -parse-as-library.
+        let exe9 = try result.target(for: "exe9").swiftTarget().emitCommandLine()
+        XCTAssertNoMatch(exe9, ["-parse-as-library"])
+
+        // @main in comment + non-comment should have -parse-as-library.
+        let exe10 = try result.target(for: "exe10").swiftTarget().emitCommandLine()
+        XCTAssertMatch(exe10, ["-parse-as-library"])
+
+        // @main in comment + non-comment should have -parse-as-library.
+        let exe11 = try result.target(for: "exe11").swiftTarget().emitCommandLine()
+        XCTAssertMatch(exe11, ["-parse-as-library"])
+
+        // @main in comment + non-comment should have -parse-as-library.
+        let exe12 = try result.target(for: "exe12").swiftTarget().emitCommandLine()
+        XCTAssertMatch(exe12, ["-parse-as-library"])
+
+        // multiple source files should not have -parse-as-library.
+        let exe13 = try result.target(for: "exe13").swiftTarget().emitCommandLine()
+        XCTAssertNoMatch(exe13, ["-parse-as-library"])
     }
 
     func testCModule() throws {

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -1206,14 +1206,40 @@ final class BuildPlanTests: XCTestCase {
 
     func testParseAsLibraryFlagForExe() throws {
         let fs = InMemoryFileSystem(emptyFiles:
-            // First executable has a single source file not named `main.swift`.
+            // executable has a single source file not named `main.swift`, without @main.
             "/Pkg/Sources/exe1/foo.swift",
-            // Second executable has a single source file named `main.swift`.
+            // executable has a single source file named `main.swift`, without @main.
             "/Pkg/Sources/exe2/main.swift",
-            // Third executable has multiple source files.
-            "/Pkg/Sources/exe3/bar.swift",
-            "/Pkg/Sources/exe3/main.swift"
+            // executable has a single source file not named `main.swift`, with @main.
+            "/Pkg/Sources/exe3/foo.swift",
+            // executable has a single source file named `main.swift`, with @main
+            "/Pkg/Sources/exe4/main.swift",
+            // executable has multiple source files.
+            "/Pkg/Sources/exe5/bar.swift",
+            "/Pkg/Sources/exe5/main.swift"
         )
+
+        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe3/foo.swift")) {
+            """
+            @main
+            struct Runner {
+              static func main() {
+                print("hello world")
+              }
+            }
+            """
+        }
+
+        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe4/main.swift")) {
+            """
+            @main
+            struct Runner {
+              static func main() {
+                print("hello world")
+              }
+            }
+            """
+        }
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
@@ -1227,6 +1253,8 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "exe1", type: .executable),
                         TargetDescription(name: "exe2", type: .executable),
                         TargetDescription(name: "exe3", type: .executable),
+                        TargetDescription(name: "exe4", type: .executable),
+                        TargetDescription(name: "exe5", type: .executable),
                     ]),
             ],
             observabilityScope: observability.topScope
@@ -1240,22 +1268,30 @@ final class BuildPlanTests: XCTestCase {
             observabilityScope: observability.topScope
         ))
 
-        result.checkProductsCount(3)
-        result.checkTargetsCount(3)
+        result.checkProductsCount(5)
+        result.checkTargetsCount(5)
 
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        // Check that the first target (single source file not named main) has -parse-as-library.
+        // single source file not named main, and without @main should not have -parse-as-library.
         let exe1 = try result.target(for: "exe1").swiftTarget().emitCommandLine()
-        XCTAssertMatch(exe1, ["-parse-as-library"])
+        XCTAssertNoMatch(exe1, ["-parse-as-library"])
 
-        // Check that the second target (single source file named main) does not have -parse-as-library.
+         // single source file named main, and without @main should not have -parse-as-library.
         let exe2 = try result.target(for: "exe2").swiftTarget().emitCommandLine()
         XCTAssertNoMatch(exe2, ["-parse-as-library"])
 
-        // Check that the third target (multiple source files) does not have -parse-as-library.
+        // single source file not named main, with @main should have -parse-as-library.
         let exe3 = try result.target(for: "exe3").swiftTarget().emitCommandLine()
-        XCTAssertNoMatch(exe3, ["-parse-as-library"])
+        XCTAssertMatch(exe3, ["-parse-as-library"])
+
+        // single source file named main, with @main should have -parse-as-library.
+        let exe4 = try result.target(for: "exe4").swiftTarget().emitCommandLine()
+        XCTAssertMatch(exe4, ["-parse-as-library"])
+
+        // multiple source files should not have -parse-as-library.
+        let exe5 = try result.target(for: "exe5").swiftTarget().emitCommandLine()
+        XCTAssertNoMatch(exe5, ["-parse-as-library"])
     }
 
     func testCModule() throws {


### PR DESCRIPTION
motivation: heuristics was based on file name, which is not accurate enough and did not include files like LinuxMain.swift

changes:
* change heuristics to look into the ocntent of the source file and check for the @main annotation and decide on that
* update tests

radar/9729773