### PR TITLE
SR-10799: Introduce flag that can disable network requests

### DIFF
--- a/Sources/Basics/HTTPClient.swift
+++ b/Sources/Basics/HTTPClient.swift
@@ -87,6 +87,9 @@ public struct HTTPClient: Cancellable {
         progress: ProgressHandler? = nil,
         completion: @escaping CompletionHandler
     ) {
+        guard configuration.isEnabled else {
+            return completion(.failure(CancellationError()))
+        }
         // merge configuration
         var request = request
         if request.options.callbackQueue == nil {
@@ -319,6 +322,7 @@ public extension HTTPClient {
 public typealias HTTPClientAuthorizationProvider = (URL) -> String?
 
 public struct HTTPClientConfiguration {
+    public var isEnabled: Bool
     public var requestHeaders: HTTPClientHeaders?
     public var requestTimeout: DispatchTimeInterval?
     public var authorizationProvider: HTTPClientAuthorizationProvider?
@@ -327,14 +331,24 @@ public struct HTTPClientConfiguration {
     public var maxConcurrentRequests: Int?
     public var callbackQueue: DispatchQueue
 
-    public init() {
-        self.requestHeaders = .none
-        self.requestTimeout = .none
-        self.authorizationProvider = .none
-        self.retryStrategy = .none
-        self.circuitBreakerStrategy = .none
-        self.maxConcurrentRequests = .none
-        self.callbackQueue = .sharedConcurrent
+    public init(
+        isEnabled: Bool = true,
+        requestHeaders: HTTPClientHeaders? = nil,
+        requestTimeout: DispatchTimeInterval? = nil,
+        authorizationProvider: HTTPClientAuthorizationProvider? = nil,
+        retryStrategy: HTTPClientRetryStrategy? = nil,
+        circuitBreakerStrategy: HTTPClientCircuitBreakerStrategy? = nil,
+        maxConcurrentRequests: Int? = nil,
+        callbackQueue: DispatchQueue = .sharedConcurrent
+    ) {
+        self.isEnabled = isEnabled
+        self.requestHeaders = requestHeaders
+        self.requestTimeout = requestTimeout
+        self.authorizationProvider = authorizationProvider
+        self.retryStrategy = retryStrategy
+        self.circuitBreakerStrategy = circuitBreakerStrategy
+        self.maxConcurrentRequests = maxConcurrentRequests
+        self.callbackQueue = callbackQueue
     }
 }
 

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -112,7 +112,9 @@ final class TestDiscoveryCommand: CustomLLBuildCommand {
         let store = try IndexStore.open(store: index, api: api)
 
         // FIXME: We can speed this up by having one llbuild command per object file.
-        let tests = try store.listTests(in: tool.inputs.map{ AbsolutePath($0.name) })
+      let tests = try tool.inputs.flatMap {
+          try store.listTests(inObjectFile: AbsolutePath($0.name))
+      }
 
         let outputs = tool.outputs.compactMap{ try? AbsolutePath(validating: $0.name) }
         let testsByModule = Dictionary(grouping: tests, by: { $0.module.spm_mangledToC99ExtendedIdentifier() })

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -204,6 +204,9 @@ struct ResolverOptions: ParsableArguments {
     @Flag(help: "Define automatic transformation of source control based dependencies to registry based ones")
     var sourceControlToRegistryDependencyTransformation: SourceControlToRegistryDependencyTransformation = .disabled
 
+    @Flag(name: .customLong("no-network"), help: "Disable all outgouing network requests")
+    var disableNetworkRequests: Bool = false
+    
     /// Write dependency resolver trace to a file.
     @Flag(name: .customLong("trace-resolver"), help: .hidden)
     var _deprecated_enableResolverTrace: Bool = false

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -884,7 +884,7 @@ extension SwiftPackageTool {
                 authorizationProvider: swiftTool.getAuthorizationProvider(),
                 hostToolchain: swiftTool.getHostToolchain(),
                 checksumAlgorithm: SHA256(),
-                customHTTPClient: .none,
+                customHTTPClient: swiftTool.getCustomHTTPClient(),
                 customArchiver: .none,
                 delegate: .none
             )

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -264,7 +264,8 @@ public final class MockWorkspace {
                 additionalFileRules: WorkspaceConfiguration.default.additionalFileRules,
                 sharedDependenciesCacheEnabled: WorkspaceConfiguration.default.sharedDependenciesCacheEnabled,
                 fingerprintCheckingMode: .strict,
-                sourceControlToRegistryDependencyTransformation: self.sourceControlToRegistryDependencyTransformation
+                sourceControlToRegistryDependencyTransformation: self.sourceControlToRegistryDependencyTransformation,
+                disableNetworkRequests: WorkspaceConfiguration.default.disableNetworkRequests
             ),
             customFingerprints: self.fingerprints,
             customMirrors: self.mirrors,

--- a/Sources/Workspace/Workspace+BinaryArtifacts.swift
+++ b/Sources/Workspace/Workspace+BinaryArtifacts.swift
@@ -22,10 +22,10 @@ import PackageLoading
 extension Workspace {
     // marked public for testing
     public struct CustomBinaryArtifactsManager {
-        let httpClient: HTTPClient?
+        let httpClient: HTTPClient
         let archiver: Archiver?
 
-        public init(httpClient: HTTPClient? = .none, archiver: Archiver? = .none) {
+        public init(httpClient: HTTPClient, archiver: Archiver? = .none) {
             self.httpClient = httpClient
             self.archiver = archiver
         }
@@ -48,7 +48,7 @@ extension Workspace {
             authorizationProvider: AuthorizationProvider?,
             hostToolchain: UserToolchain,
             checksumAlgorithm: HashAlgorithm,
-            customHTTPClient: HTTPClient?,
+            customHTTPClient: HTTPClient,
             customArchiver: Archiver?,
             delegate: Delegate?
         ) {
@@ -56,7 +56,7 @@ extension Workspace {
             self.authorizationProvider = authorizationProvider
             self.hostToolchain = hostToolchain
             self.checksumAlgorithm = checksumAlgorithm
-            self.httpClient = customHTTPClient ?? HTTPClient()
+            self.httpClient = customHTTPClient
             self.archiver = customArchiver ?? ZipArchiver(fileSystem: fileSystem)
             self.delegate = delegate
         }

--- a/Sources/Workspace/Workspace+Configuration.swift
+++ b/Sources/Workspace/Workspace+Configuration.swift
@@ -699,13 +699,17 @@ public struct WorkspaceConfiguration {
     ///  Attempt to transform source control based dependencies to registry ones
     public var sourceControlToRegistryDependencyTransformation: SourceControlToRegistryDependencyTransformation
 
+    /// When disabled all network requests are cancelled before starting. Disabled by default
+    public var disableNetworkRequests: Bool
+    
     public init(
         skipDependenciesUpdates: Bool,
         prefetchBasedOnResolvedFile: Bool,
         additionalFileRules: [FileRuleDescription],
         sharedDependenciesCacheEnabled: Bool,
         fingerprintCheckingMode: FingerprintCheckingMode,
-        sourceControlToRegistryDependencyTransformation: SourceControlToRegistryDependencyTransformation
+        sourceControlToRegistryDependencyTransformation: SourceControlToRegistryDependencyTransformation,
+        disableNetworkRequests: Bool
     ) {
         self.skipDependenciesUpdates = skipDependenciesUpdates
         self.prefetchBasedOnResolvedFile = prefetchBasedOnResolvedFile
@@ -713,6 +717,7 @@ public struct WorkspaceConfiguration {
         self.sharedDependenciesCacheEnabled = sharedDependenciesCacheEnabled
         self.fingerprintCheckingMode = fingerprintCheckingMode
         self.sourceControlToRegistryDependencyTransformation = sourceControlToRegistryDependencyTransformation
+        self.disableNetworkRequests = disableNetworkRequests
     }
 
     /// Default instance of WorkspaceConfiguration
@@ -723,7 +728,8 @@ public struct WorkspaceConfiguration {
             additionalFileRules: [],
             sharedDependenciesCacheEnabled: true,
             fingerprintCheckingMode: .strict,
-            sourceControlToRegistryDependencyTransformation: .disabled
+            sourceControlToRegistryDependencyTransformation: .disabled,
+            disableNetworkRequests: false
         )
     }
 

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -330,6 +330,7 @@ public class Workspace {
         customManifestLoader: ManifestLoaderProtocol? = .none,
         customPackageContainerProvider: PackageContainerProvider? = .none,
         customRepositoryProvider: RepositoryProvider? = .none,
+        customBinaryArtifactsManager: CustomBinaryArtifactsManager? = .none,
         // delegate
         delegate: Delegate? = .none
     ) throws {
@@ -350,7 +351,7 @@ public class Workspace {
             customRepositoryManager: .none,
             customRepositoryProvider: customRepositoryProvider,
             customRegistryClient: .none,
-            customBinaryArtifactsManager: .none,
+            customBinaryArtifactsManager: customBinaryArtifactsManager,
             customIdentityResolver: .none,
             customChecksumAlgorithm: .none,
             delegate: delegate
@@ -385,6 +386,7 @@ public class Workspace {
         customManifestLoader: ManifestLoaderProtocol? = .none,
         customPackageContainerProvider: PackageContainerProvider? = .none,
         customRepositoryProvider: RepositoryProvider? = .none,
+        customBinaryArtifactsManager: CustomBinaryArtifactsManager? = .none,
         // delegate
         delegate: Delegate? = .none
     ) throws {
@@ -398,6 +400,7 @@ public class Workspace {
             customManifestLoader: customManifestLoader,
             customPackageContainerProvider: customPackageContainerProvider,
             customRepositoryProvider: customRepositoryProvider,
+            customBinaryArtifactsManager: customBinaryArtifactsManager,
             delegate: delegate
         )
     }
@@ -430,6 +433,7 @@ public class Workspace {
         customHostToolchain: UserToolchain,
         customPackageContainerProvider: PackageContainerProvider? = .none,
         customRepositoryProvider: RepositoryProvider? = .none,
+        customBinaryArtifactsManager: CustomBinaryArtifactsManager,
         // delegate
         delegate: Delegate? = .none
     ) throws {
@@ -450,6 +454,7 @@ public class Workspace {
             customManifestLoader: manifestLoader,
             customPackageContainerProvider: customPackageContainerProvider,
             customRepositoryProvider: customRepositoryProvider,
+            customBinaryArtifactsManager: customBinaryArtifactsManager,
             delegate: delegate
         )
     }
@@ -470,7 +475,7 @@ public class Workspace {
         customRepositoryProvider: RepositoryProvider? = .none,
         customRegistryClient: RegistryClient? = .none,
         customIdentityResolver: IdentityResolver? = .none,
-        customHTTPClient: HTTPClient? = .none,
+        customHTTPClient: HTTPClient,
         customArchiver: Archiver? = .none,
         customChecksumAlgorithm: HashAlgorithm? = .none,
         customFingerprintStorage: PackageFingerprintStorage? = .none,
@@ -487,7 +492,8 @@ public class Workspace {
             additionalFileRules: additionalFileRules ?? WorkspaceConfiguration.default.additionalFileRules,
             sharedDependenciesCacheEnabled: sharedRepositoriesCacheEnabled ?? WorkspaceConfiguration.default.sharedDependenciesCacheEnabled,
             fingerprintCheckingMode: resolverFingerprintCheckingMode,
-            sourceControlToRegistryDependencyTransformation: WorkspaceConfiguration.default.sourceControlToRegistryDependencyTransformation
+            sourceControlToRegistryDependencyTransformation: WorkspaceConfiguration.default.sourceControlToRegistryDependencyTransformation,
+            disableNetworkRequests: WorkspaceConfiguration.default.disableNetworkRequests
         )
         try self.init(
             fileSystem: fileSystem,
@@ -673,7 +679,7 @@ public class Workspace {
             authorizationProvider: authorizationProvider,
             hostToolchain: hostToolchain,
             checksumAlgorithm: checksumAlgorithm,
-            customHTTPClient: customBinaryArtifactsManager?.httpClient,
+            customHTTPClient: customBinaryArtifactsManager?.httpClient ?? HTTPClient(configuration: .init(isEnabled: !configuration.disableNetworkRequests)),
             customArchiver: customBinaryArtifactsManager?.archiver,
             delegate: delegate.map(WorkspaceBinaryArtifactsManagerDelegate.init(workspaceDelegate:))
         )

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -4887,7 +4887,10 @@ final class WorkspaceTests: XCTestCase {
                     versions: ["1.0.0"]
                 )
             ],
-            binaryArtifactsManager: .init(archiver: archiver)
+            binaryArtifactsManager: .init(
+                httpClient: .init(),
+                archiver: archiver
+            )
         )
 
         // Create dummy xcframework/artifactbundle zip files
@@ -5254,6 +5257,7 @@ final class WorkspaceTests: XCTestCase {
                 )
             ],
             binaryArtifactsManager: .init(
+                httpClient: .init(),
                 archiver: archiver
             )
         )
@@ -5298,6 +5302,7 @@ final class WorkspaceTests: XCTestCase {
                 )
             ],
             binaryArtifactsManager: .init(
+                httpClient: .init(),
                 archiver: archiver
             )
         )
@@ -5354,6 +5359,7 @@ final class WorkspaceTests: XCTestCase {
                 )
             ],
             binaryArtifactsManager: .init(
+                httpClient: HTTPClient(),
                 archiver: archiver
             )
         )
@@ -5421,7 +5427,7 @@ final class WorkspaceTests: XCTestCase {
                 ),
             ],
             binaryArtifactsManager: .init(
-                archiver: archiver
+                httpClient: HTTPClient(), archiver: archiver
             )
         )
 
@@ -5530,6 +5536,7 @@ final class WorkspaceTests: XCTestCase {
                 )
             ],
             binaryArtifactsManager: .init(
+                httpClient: .init(),
                 archiver: archiver
             )
         )
@@ -6502,7 +6509,7 @@ final class WorkspaceTests: XCTestCase {
             authorizationProvider: .none,
             hostToolchain: UserToolchain(destination: .hostDestination()),
             checksumAlgorithm: checksumAlgorithm,
-            customHTTPClient: .none,
+            customHTTPClient: HTTPClient(),
             customArchiver: .none,
             delegate: .none
         )


### PR DESCRIPTION
Introduce a flag that can when enabled - disables all network requests

### Motivation:

as stated https://github.com/apple/swift-package-manager/issues/4705 there is a need for a flag that can disable all network requests
### Modifications:

This is still a draft but i outlined the idea that we need to change workspace initialisation of HTTPClient based on a flag
