### PR TITLE
Simplify `testCompileCXX17CrashWithFModules`

### DIFF
--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -570,21 +570,6 @@ class MiscellaneousTestCase: XCTestCase {
     }
 
     func testCompileCXX17CrashWithFModules() throws {
-        // We disabled fmodules for macOS, thus, this only crash on Linux.
-        #if os(Linux)
-        try fixture(name: "Miscellaneous/CXX17CompilerCrash/v5_7") { fixturePath in
-            XCTAssertThrowsCommandExecutionError(try executeSwiftBuild(fixturePath)) { error in
-                guard error.result.exitStatus == .terminated(code: 1) else {
-                    return XCTFail("failed in an unexpected manner: \(error)")
-                }
-                // Make sure it contains both std=c++17 and fmodules
-                XCTAssertMatch(error.stdout + error.stderr, .contains("-std=c++17"))
-                XCTAssertMatch(error.stdout + error.stderr, .contains("-fmodules"))
-                // Check for clang crash, which will manifest itself into "PLEASE submit a bug report to"
-                XCTAssertMatch(error.stdout + error.stderr, .contains("PLEASE submit a bug report to"))
-            }
-        }
-        #endif
         try fixture(name: "Miscellaneous/CXX17CompilerCrash/v5_8") { fixturePath in
             XCTAssertBuilds(fixturePath)
         }


### PR DESCRIPTION
Seems like this is not necessarily failing when passing `-fmodules`, e.g. on Ubuntu 18.04. I don't think testing that this crashes in older tools-versions is important enough for the test to come up with more complex logic here, the important part is that it'll pass in newer tools-versions.
