### PR TITLE
workspace-state.json will be really saved until changes happened

### DIFF
--- a/Sources/Workspace/ManagedArtifact.swift
+++ b/Sources/Workspace/ManagedArtifact.swift
@@ -93,6 +93,11 @@ extension Workspace.ManagedArtifact: CustomStringConvertible {
     }
 }
 
+extension Workspace.ManagedArtifact: Equatable {
+    
+}
+
+
 extension Workspace.ManagedArtifact.Source: CustomStringConvertible {
     public var description: String {
         switch self {
@@ -170,5 +175,11 @@ extension Workspace.ManagedArtifacts: Collection {
 extension Workspace.ManagedArtifacts: CustomStringConvertible {
     public var description: String {
         "<ManagedArtifacts: \(Array(self.artifacts))>"
+    }
+}
+
+extension Workspace.ManagedArtifacts: Equatable {
+    public static func == (lhs: Workspace.ManagedArtifacts, rhs: Workspace.ManagedArtifacts) -> Bool {
+        lhs.artifactMap == rhs.artifactMap
     }
 }

--- a/Sources/Workspace/ManagedDependency.swift
+++ b/Sources/Workspace/ManagedDependency.swift
@@ -239,3 +239,9 @@ extension Workspace.ManagedDependencies: CustomStringConvertible {
         "<ManagedDependencies: \(Array(self.dependencies.values))>"
     }
 }
+
+extension Workspace.ManagedDependencies: Equatable {
+    public static func == (lhs: Workspace.ManagedDependencies, rhs: Workspace.ManagedDependencies) -> Bool {
+        lhs.dependencies == rhs.dependencies
+    }
+}


### PR DESCRIPTION
cache `dependencies` and `artifacts`, workspace-state.json will be really saved until changes happened

### Motivation:

here is the original issue #5693 

It would be a pain for extension development because there is no file that can be watched for updating the dependency list

* `workspace-state.json` is changed all the time even if there is no change
* `show-dependencies` will trigger the change
* the worst case which may be quite general case 
  *  watching `Package.swift` and `Package.resolved` to trigger `package resolve`
  * watching `workspace-state.json` to trigger `show-dependencies`
 
  1. `Package.resolved` is modified
  2. workspace-state.json will be updated soon
  3. `workspace-state.json` change will trigger `show-dependencies`
  4. [go to step 2], `show-dependencies` will update `workspace-state.json` again


### Modifications:

cache `dependencies` and `artifacts`,  when call save(), file will be saved if there is a real change

### Result:

`workspace-state.json` is not updated until there is a change