### PR TITLE
Set rpath to compatibility libraries

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -559,6 +559,14 @@ def add_rpath_for_cmake_build(args, rpath):
     note(' '.join(add_rpath_cmd))
     subprocess.call(add_rpath_cmd, stderr=subprocess.PIPE)
 
+def get_swift_backdeploy_library_paths(args):
+    if platform.system() == 'Darwin':
+        # Need to include backwards compatibility libraries for Concurrency
+        # FIXME: Would be nice if we could get this from `swiftc -print-target-info`
+        return ['/usr/lib/swift', args.target_info["paths"]["runtimeLibraryPaths"][0] + '/../../swift-5.5/macosx']
+    else:
+        return []
+
 def build_swiftpm_with_cmake(args):
     """Builds SwiftPM using CMake."""
     note("Building SwiftPM (with CMake)")
@@ -589,6 +597,10 @@ def build_swiftpm_with_cmake(args):
         add_rpath_for_cmake_build(args, os.path.join(args.build_dirs["swift-crypto"],          "lib"))
         add_rpath_for_cmake_build(args, os.path.join(args.build_dirs["swift-system"],          "lib"))
         add_rpath_for_cmake_build(args, os.path.join(args.build_dirs["swift-collections"],     "lib"))
+
+        # rpaths for compatibility libraries
+        for lib_path in get_swift_backdeploy_library_paths(args):
+            add_rpath_for_cmake_build(args, lib_path)
 
 def build_swiftpm_with_swiftpm(args, integrated_swift_driver):
     """Builds SwiftPM using the version of SwiftPM built with CMake."""
@@ -739,6 +751,10 @@ def get_swiftpm_flags(args):
     # toolchains that include libraries not part of the OS (e.g. PythonKit or
     # TensorFlow).
     if platform.system() == "Darwin":
+        # rpaths for compatibility libraries
+        for lib_path in get_swift_backdeploy_library_paths(args):
+            build_flags.extend(["-Xlinker", "-rpath", "-Xlinker", lib_path])
+
         swift_library_rpath_prefix = "@executable_path/../"
     elif platform.system() == 'Linux' or platform.system() == 'OpenBSD':
         # `$ORIGIN` is an ELF construct.


### PR DESCRIPTION
We're currently loading the incorrect version of the concurrency compatibility libraries in OSS toolchains.

rdar://92270166
