### PR TITLE
Add .snippet target to @main heuristics for including -parse-as-library

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -640,7 +640,7 @@ public final class SwiftTargetBuildDescription {
         switch self.target.type {
         case .library, .test:
             return true
-        case .executable:
+        case .executable, .snippet:
             // This deactivates heuristics in the Swift compiler that treats single-file modules and source files
             // named "main.swift" specially w.r.t. whether they can have an entry point.
             //

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -1395,7 +1395,7 @@ extension PackageBuilder {
             return []
         }
 
-        return try walk(snippetsDirectory)
+        return try walk(snippetsDirectory, fileSystem: self.fileSystem)
             .filter { fileSystem.isFile($0) && $0.extension == "swift" }
             .map { sourceFile in
                 let name = sourceFile.basenameWithoutExt


### PR DESCRIPTION
The heuristics for deciding whether to include the `-parse-as-library` flag
were recently improved in #5687 (rdar://97297732).

### Motivation

This change allows
`.snippet` target types to benefit from those improved heuristics.

### Modifications

Added `.snippet` to the cases allowed for `SwiftTargetBuildDescription.needsToBeParsedAsLibrary`.

Testing: Changed the walk when searching for snippets to explicitly use the
`PackageBuilder.fileSystem`; the default argument uses the local filesystem,
which won't work for in-memory filesystems used in tests.

Testing: Added additional snippet files, one with `@main` and one without, to
`BuildPlanTests.testParseAsLibraryFlagForExe`.

### Results

According to the same rules, snippets with `@main` should get
`-parse-as-library`, while those assumed to have top-level code should not.

rdar://97802934