### PR TITLE
Remove --gc-sections for all targets for now

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -1334,17 +1334,12 @@ public final class ProductBuildDescription {
                 return ["-Xlinker", "-dead_strip"]
             } else if buildParameters.triple.isWindows() {
                 return ["-Xlinker", "/OPT:REF"]
-            } else if buildParameters.triple.arch == .wasm32 {
-                // FIXME: wasm-ld strips data segments referenced through __start/__stop symbols
+            } else {
+                // FIXME: wasm-ld / ld.lld strips data segments referenced through __start/__stop symbols
                 // during GC, and it removes Swift metadata sections like swift5_protocols
                 // We should add support of SHF_GNU_RETAIN-like flag for __attribute__((retain))
                 // to LLVM and wasm-ld
-                // This workaround is required for not only WASI but also all WebAssembly archs
-                // using wasm-ld (e.g. wasm32-unknown-unknown). So this branch is conditioned by
-                // arch == .wasm32
                 return []
-            } else {
-                return ["-Xlinker", "--gc-sections"]
             }
         }
     }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -446,7 +446,6 @@ final class BuildPlanTests: XCTestCase {
             "-o", buildPath.appending(components: "exe").pathString,
             "-module-name", "exe",
             "-emit-executable",
-            "-Xlinker", "--gc-sections",
             "-Xlinker", "-rpath=$ORIGIN",
             "@\(buildPath.appending(components: "exe.product", "Objects.LinkFileList"))",
             "-target", defaultTargetTriple,


### PR DESCRIPTION
Similar to the comment here about wasm-ld, lld recently switched a
default that broke this for all elf targets. This is a low risk fix
since we weren't passing this flag before either. People who really need
this behavior can still pass something like `-Xlinker --gc-sections
-Xlinker -z -Xlinker nostart-stop-gc`

Fixes https://github.com/apple/swift-package-manager/issues/5698