### PR TITLE
Add experimental flag which allows providing a custom test entry point file while still performing test discovery

### DIFF
--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -611,6 +611,7 @@ extension BuildDescription {
         let swiftCommands = llbuild.manifest.getCmdToolMap(kind: SwiftCompilerTool.self)
         let swiftFrontendCommands = llbuild.manifest.getCmdToolMap(kind: SwiftFrontendTool.self)
         let testDiscoveryCommands = llbuild.manifest.getCmdToolMap(kind: TestDiscoveryTool.self)
+        let testManifestCommands = llbuild.manifest.getCmdToolMap(kind: TestManifestTool.self)
         let copyCommands = llbuild.manifest.getCmdToolMap(kind: CopyTool.self)
 
         // Create the build description.
@@ -619,6 +620,7 @@ extension BuildDescription {
             swiftCommands: swiftCommands,
             swiftFrontendCommands: swiftFrontendCommands,
             testDiscoveryCommands: testDiscoveryCommands,
+            testManifestCommands: testManifestCommands,
             copyCommands: copyCommands,
             pluginDescriptions: plan.pluginDescriptions
         )

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -611,7 +611,7 @@ extension BuildDescription {
         let swiftCommands = llbuild.manifest.getCmdToolMap(kind: SwiftCompilerTool.self)
         let swiftFrontendCommands = llbuild.manifest.getCmdToolMap(kind: SwiftFrontendTool.self)
         let testDiscoveryCommands = llbuild.manifest.getCmdToolMap(kind: TestDiscoveryTool.self)
-        let testManifestCommands = llbuild.manifest.getCmdToolMap(kind: TestManifestTool.self)
+        let testEntryPointCommands = llbuild.manifest.getCmdToolMap(kind: TestEntryPointTool.self)
         let copyCommands = llbuild.manifest.getCmdToolMap(kind: CopyTool.self)
 
         // Create the build description.
@@ -620,7 +620,7 @@ extension BuildDescription {
             swiftCommands: swiftCommands,
             swiftFrontendCommands: swiftFrontendCommands,
             testDiscoveryCommands: testDiscoveryCommands,
-            testManifestCommands: testManifestCommands,
+            testEntryPointCommands: testEntryPointCommands,
             copyCommands: copyCommands,
             pluginDescriptions: plan.pluginDescriptions
         )

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -59,7 +59,7 @@ private extension IndexStore.TestCaseClass.TestMethod {
     }
 }
 
-final class TestDiscoveryCommand: CustomLLBuildCommand {
+final class TestDiscoveryCommand: CustomLLBuildCommand, TestBuildCommand {
 
     private func write(
         tests: [IndexStore.TestCaseClass],
@@ -170,10 +170,6 @@ final class TestDiscoveryCommand: CustomLLBuildCommand {
         stream.flush()
     }
 
-    private func indent(_ spaces: Int) -> ByteStreamable {
-        return Format.asRepeating(string: " ", count: spaces)
-    }
-
     override func execute(
         _ command: SPMLLBuild.Command,
         _ buildSystemCommandInterface: SPMLLBuild.BuildSystemCommandInterface
@@ -184,7 +180,7 @@ final class TestDiscoveryCommand: CustomLLBuildCommand {
                 throw InternalError("unknown build description")
             }
             guard let tool = buildDescription.testDiscoveryCommands[command.name] else {
-                throw StringError("command \(command.name) not registered")
+                throw InternalError("command \(command.name) not registered")
             }
             try execute(fileSystem: self.context.fileSystem, tool: tool)
             return true
@@ -195,7 +191,7 @@ final class TestDiscoveryCommand: CustomLLBuildCommand {
     }
 }
 
-final class TestManifestCommand: CustomLLBuildCommand {
+final class TestManifestCommand: CustomLLBuildCommand, TestBuildCommand {
 
     private func execute(fileSystem: TSCBasic.FileSystem, tool: LLBuildManifest.TestManifestTool) throws {
         // Find the inputs, which are the names of the test discovery module(s)
@@ -231,10 +227,6 @@ final class TestManifestCommand: CustomLLBuildCommand {
         stream.flush()
     }
 
-    private func indent(_ spaces: Int) -> ByteStreamable {
-        return Format.asRepeating(string: " ", count: spaces)
-    }
-
     override func execute(
         _ command: SPMLLBuild.Command,
         _ buildSystemCommandInterface: SPMLLBuild.BuildSystemCommandInterface
@@ -254,6 +246,19 @@ final class TestManifestCommand: CustomLLBuildCommand {
             return false
         }
     }
+}
+
+private protocol TestBuildCommand {}
+
+/// Functionality common to all build commands related to test targets.
+extension TestBuildCommand {
+
+    /// Returns a value containing `spaces` number of space characters.
+    /// Intended to facilitate indenting generated code a specified number of levels.
+    fileprivate func indent(_ spaces: Int) -> ByteStreamable {
+        return Format.asRepeating(string: " ", count: spaces)
+    }
+
 }
 
 private final class InProcessTool: Tool {

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -156,7 +156,7 @@ final class TestDiscoveryCommand: CustomLLBuildCommand {
         stream <<< "import XCTest" <<< "\n\n"
 
         stream <<< "@available(*, deprecated, message: \"Not actually deprecated. Marked as deprecated to allow inclusion of deprecated tests (which test deprecated functionality) without warnings\")" <<< "\n"
-        stream <<< "public func __allModuleTests() -> [XCTestCaseEntry] {" <<< "\n"
+        stream <<< "public func __allDiscoveredTests() -> [XCTestCaseEntry] {" <<< "\n"
         stream <<< indent(4) <<< "\(testsKeyword) tests = [XCTestCaseEntry]()" <<< "\n\n"
 
         for module in testsByModule.keys {
@@ -224,7 +224,7 @@ final class TestManifestCommand: CustomLLBuildCommand {
         stream <<< "@available(*, deprecated, message: \"Not actually deprecated. Marked as deprecated to allow inclusion of deprecated tests (which test deprecated functionality) without warnings\")" <<< "\n"
         stream <<< "struct Runner" <<< " {" <<< "\n"
         stream <<< indent(4) <<< "static func main()" <<< " {" <<< "\n"
-        stream <<< indent(8) <<< "XCTMain(__allModuleTests())" <<< "\n"
+        stream <<< indent(8) <<< "XCTMain(__allDiscoveredTests())" <<< "\n"
         stream <<< indent(4) <<< "}" <<< "\n"
         stream <<< "}" <<< "\n"
 
@@ -343,7 +343,7 @@ public struct BuildDescription: Codable {
             targetCommandLines[target.c99name] =
                 try desc.emitCommandLine(scanInvocation: true) + ["-driver-use-frontend-path",
                                                                   plan.buildParameters.toolchain.swiftCompilerPath.pathString]
-            if desc.isTestDiscoveryTarget {
+            if case .discovery = desc.testTargetRole {
                 generatedSourceTargets.append(target.c99name)
             }
         }

--- a/Sources/Build/LLBuildManifestBuilder.swift
+++ b/Sources/Build/LLBuildManifestBuilder.swift
@@ -87,7 +87,7 @@ public class LLBuildManifestBuilder {
         }
 
         try self.addTestDiscoveryGenerationCommand()
-        try self.addTestManifestGenerationCommand()
+        try self.addTestEntryPointGenerationCommand()
 
         // Create command for all products in the plan.
         for (_, description) in plan.productMap {
@@ -841,21 +841,21 @@ extension LLBuildManifestBuilder {
         }
     }
 
-    fileprivate func addTestManifestGenerationCommand() throws {
+    fileprivate func addTestEntryPointGenerationCommand() throws {
         for target in plan.targets {
             guard case .swift(let target) = target,
-                  case .manifest(let isSynthesized) = target.testTargetRole,
+                  case .entryPoint(let isSynthesized) = target.testTargetRole,
                   isSynthesized else { continue }
 
-            let testManifestTarget = target
+            let testEntryPointTarget = target
             let inputs = testDiscoveryTargets.map { $0.moduleOutputPath }
-            let outputs = testManifestTarget.target.sources.paths
+            let outputs = testEntryPointTarget.target.sources.paths
 
-            guard let mainOutput = (outputs.first{ $0.basename == TestManifestTool.mainFileName }) else {
-                throw InternalError("main output (\(TestManifestTool.mainFileName)) not found")
+            guard let mainOutput = (outputs.first{ $0.basename == TestEntryPointTool.mainFileName }) else {
+                throw InternalError("main output (\(TestEntryPointTool.mainFileName)) not found")
             }
             let cmdName = mainOutput.pathString
-            manifest.addTestManifestCmd(
+            manifest.addTestEntryPointCmd(
                 name: cmdName,
                 inputs: inputs.map(Node.file),
                 outputs: outputs.map(Node.file)

--- a/Sources/Build/LLBuildManifestBuilder.swift
+++ b/Sources/Build/LLBuildManifestBuilder.swift
@@ -844,8 +844,8 @@ extension LLBuildManifestBuilder {
     fileprivate func addTestManifestGenerationCommand() throws {
         for target in plan.targets {
             guard case .swift(let target) = target,
-                  target.isTestTarget,
-                  target.isSynthesizedTestManifestTarget else { continue }
+                  case .manifest(let isSynthesized) = target.testTargetRole,
+                  isSynthesized else { continue }
 
             let testManifestTarget = target
             let inputs = testDiscoveryTargets.map { $0.moduleOutputPath }
@@ -867,8 +867,7 @@ extension LLBuildManifestBuilder {
     private var testDiscoveryTargets: [SwiftTargetBuildDescription] {
         plan.targets.compactMap { target in
             guard case .swift(let target) = target,
-                target.isTestTarget,
-                target.isTestDiscoveryTarget else { return nil }
+                  case .discovery = target.testTargetRole else { return nil }
             return target
         }
     }

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -362,10 +362,10 @@ struct BuildOptions: ParsableArguments {
     @Flag(help: .hidden)
     var enableTestDiscovery: Bool = false
 
-    /// Whether to allow having a custom test manifest, even if test discovery is enabled and ordinarily a test manifest would be generated automatically.
-    @Flag(name: .customLong("experimental-allow-custom-test-manifest"),
-          help: .hidden)
-    var allowCustomTestManifest: Bool = false
+    /// Path of custom test manifest file to use, instead of synthesizing a test manifest. This implies `--enable-test-discovery`
+    @Option(name: .customLong("experimental-test-manifest-path"),
+            help: .hidden)
+    var customTestManifestPath: AbsolutePath?
 
     // @Flag works best when there is a default value present
     // if true, false aren't enough and a third state is needed

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -362,6 +362,11 @@ struct BuildOptions: ParsableArguments {
     @Flag(help: .hidden)
     var enableTestDiscovery: Bool = false
 
+    /// Whether to allow having a custom test manifest, even if test discovery is enabled and ordinarily a test manifest would be generated automatically.
+    @Flag(name: .customLong("experimental-allow-custom-test-manifest"),
+          help: .hidden)
+    var allowCustomTestManifest: Bool = false
+
     // @Flag works best when there is a default value present
     // if true, false aren't enough and a third state is needed
     // nil should not be the goto. Instead create an enum

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -362,10 +362,11 @@ struct BuildOptions: ParsableArguments {
     @Flag(help: .hidden)
     var enableTestDiscovery: Bool = false
 
-    /// Path of custom test manifest file to use, instead of synthesizing a test manifest. This implies `--enable-test-discovery`
-    @Option(name: .customLong("experimental-test-manifest-path"),
+    /// Path of test entry point file to use, instead of synthesizing one or using `XCTMain.swift` in the package (if present).
+    /// This implies `--enable-test-discovery`
+    @Option(name: .customLong("experimental-test-entry-point-path"),
             help: .hidden)
-    var customTestManifestPath: AbsolutePath?
+    var testEntryPointPath: AbsolutePath?
 
     // @Flag works best when there is a default value present
     // if true, false aren't enough and a third state is needed

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -605,7 +605,7 @@ public class SwiftTool {
     func loadPackageGraph(
         explicitProduct: String? = nil,
         createMultipleTestProducts: Bool = false,
-        customTestManifestPath: AbsolutePath? = nil,
+        testEntryPointPath: AbsolutePath? = nil,
         createREPLProduct: Bool = false
     ) throws -> PackageGraph {
         do {
@@ -618,7 +618,7 @@ public class SwiftTool {
                 createMultipleTestProducts: createMultipleTestProducts,
                 createREPLProduct: createREPLProduct,
                 forceResolvedVersions: options.resolver.forceResolvedVersions,
-                customTestManifestPath: customTestManifestPath,
+                testEntryPointPath: testEntryPointPath,
                 observabilityScope: self.observabilityScope
             )
 
@@ -699,8 +699,8 @@ public class SwiftTool {
         customLogLevel: Diagnostic.Severity? = .none,
         customObservabilityScope: ObservabilityScope? = .none
     ) throws -> BuildOperation {
-        let customTestManifestPath = customBuildParameters?.customTestManifestPath
-        let graphLoader = { try self.loadPackageGraph(explicitProduct: explicitProduct, customTestManifestPath: customTestManifestPath) }
+        let testEntryPointPath = customBuildParameters?.testProductStyle.explicitlySpecifiedEntryPointPath
+        let graphLoader = { try self.loadPackageGraph(explicitProduct: explicitProduct, testEntryPointPath: testEntryPointPath) }
 
         // Construct the build operation.
         // FIXME: We need to implement the build tool invocation closure here so that build tool plugins work with dumping the symbol graph (the only case that currently goes through this path, as far as I can tell). rdar://86112934
@@ -799,8 +799,8 @@ public class SwiftTool {
                 useIntegratedSwiftDriver: options.build.useIntegratedSwiftDriver,
                 useExplicitModuleBuild: options.build.useExplicitModuleBuild,
                 isXcodeBuildSystemEnabled: options.build.buildSystem == .xcode,
-                forceTestDiscovery: options.build.customTestManifestPath != nil || options.build.enableTestDiscovery, // backwards compatibility, remove with --enable-test-discovery
-                customTestManifestPath: options.build.customTestManifestPath,
+                forceTestDiscovery: options.build.enableTestDiscovery, // backwards compatibility, remove with --enable-test-discovery
+                testEntryPointPath: options.build.testEntryPointPath,
                 explicitTargetDependencyImportCheckingMode: options.build.explicitTargetDependencyImportCheck.modeParameter,
                 linkerDeadStrip: options.linker.linkerDeadStrip,
                 verboseOutput: self.logLevel <= .info

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -456,6 +456,10 @@ public class SwiftTool {
         }
         #endif
 
+        if options.build.allowCustomTestManifest && !options.build.enableTestDiscovery {
+            observabilityScope.emit(error: "'--experimental-allow-custom-test-manifest' option requires '--enable-test-discovery'")
+        }
+
         if options.caching.shouldDisableManifestCaching {
             observabilityScope.emit(warning: "'--disable-package-manifest-caching' option is deprecated; use '--manifest-caching' instead")
         }
@@ -797,6 +801,7 @@ public class SwiftTool {
                 useExplicitModuleBuild: options.build.useExplicitModuleBuild,
                 isXcodeBuildSystemEnabled: options.build.buildSystem == .xcode,
                 forceTestDiscovery: options.build.enableTestDiscovery, // backwards compatibility, remove with --enable-test-discovery
+                allowCustomTestManifest: options.build.allowCustomTestManifest,
                 explicitTargetDependencyImportCheckingMode: options.build.explicitTargetDependencyImportCheck.modeParameter,
                 linkerDeadStrip: options.linker.linkerDeadStrip,
                 verboseOutput: self.logLevel <= .info

--- a/Sources/Commands/Utilities/GenerateLinuxMain.swift
+++ b/Sources/Commands/Utilities/GenerateLinuxMain.swift
@@ -105,7 +105,7 @@ final class LinuxMainGenerator {
         guard let testTarget = graph.reachableProducts.first(where: { $0.type == .test })?.targets.first else {
             throw Error.noTestTargets
         }
-        guard let linuxMainFileName = SwiftTarget.testManifestNames.first(where: { $0.lowercased().hasPrefix("linux") }) else {
+        guard let linuxMainFileName = SwiftTarget.testEntryPointNames.first(where: { $0.lowercased().hasPrefix("linux") }) else {
             throw InternalError("Unknown linux main file name")
         }
         let linuxMain = testTarget.sources.root.parentDirectory.appending(components: linuxMainFileName)

--- a/Sources/LLBuildManifest/BuildManifest.swift
+++ b/Sources/LLBuildManifest/BuildManifest.swift
@@ -68,13 +68,13 @@ public struct BuildManifest {
         commands[name] = Command(name: name, tool: tool)
     }
 
-    public mutating func addTestManifestCmd(
+    public mutating func addTestEntryPointCmd(
         name: String,
         inputs: [Node],
         outputs: [Node]
     ) {
         assert(commands[name] == nil, "already had a command named '\(name)'")
-        let tool = TestManifestTool(inputs: inputs, outputs: outputs)
+        let tool = TestEntryPointTool(inputs: inputs, outputs: outputs)
         commands[name] = Command(name: name, tool: tool)
     }
 

--- a/Sources/LLBuildManifest/BuildManifest.swift
+++ b/Sources/LLBuildManifest/BuildManifest.swift
@@ -68,6 +68,16 @@ public struct BuildManifest {
         commands[name] = Command(name: name, tool: tool)
     }
 
+    public mutating func addTestManifestCmd(
+        name: String,
+        inputs: [Node],
+        outputs: [Node]
+    ) {
+        assert(commands[name] == nil, "already had a command named '\(name)'")
+        let tool = TestManifestTool(inputs: inputs, outputs: outputs)
+        commands[name] = Command(name: name, tool: tool)
+    }
+
     public mutating func addCopyCmd(
         name: String,
         inputs: [Node],

--- a/Sources/LLBuildManifest/Tools.swift
+++ b/Sources/LLBuildManifest/Tools.swift
@@ -57,8 +57,8 @@ public struct TestDiscoveryTool: ToolProtocol {
     }
 }
 
-public struct TestManifestTool: ToolProtocol {
-    public static let name: String = "test-manifest-tool"
+public struct TestEntryPointTool: ToolProtocol {
+    public static let name: String = "test-entry-point-tool"
     public static let mainFileName: String = "runner.swift"
 
     public var inputs: [Node]

--- a/Sources/LLBuildManifest/Tools.swift
+++ b/Sources/LLBuildManifest/Tools.swift
@@ -46,6 +46,19 @@ public struct PhonyTool: ToolProtocol {
 
 public struct TestDiscoveryTool: ToolProtocol {
     public static let name: String = "test-discovery-tool"
+    public static let mainFileName: String = "all-module-tests.swift"
+
+    public var inputs: [Node]
+    public var outputs: [Node]
+
+    init(inputs: [Node], outputs: [Node]) {
+        self.inputs = inputs
+        self.outputs = outputs
+    }
+}
+
+public struct TestManifestTool: ToolProtocol {
+    public static let name: String = "test-manifest-tool"
     public static let mainFileName: String = "runner.swift"
 
     public var inputs: [Node]

--- a/Sources/LLBuildManifest/Tools.swift
+++ b/Sources/LLBuildManifest/Tools.swift
@@ -46,7 +46,7 @@ public struct PhonyTool: ToolProtocol {
 
 public struct TestDiscoveryTool: ToolProtocol {
     public static let name: String = "test-discovery-tool"
-    public static let mainFileName: String = "all-module-tests.swift"
+    public static let mainFileName: String = "all-discovered-tests.swift"
 
     public var inputs: [Node]
     public var outputs: [Node]

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -31,7 +31,7 @@ extension PackageGraph {
         createREPLProduct: Bool = false,
         customPlatformsRegistry: PlatformRegistry? = .none,
         customXCTestMinimumDeploymentTargets: [PackageModel.Platform: PlatformVersion]? = .none,
-        customTestManifestPath: AbsolutePath? = nil,
+        testEntryPointPath: AbsolutePath? = nil,
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope
     ) throws -> PackageGraph {
@@ -119,7 +119,7 @@ extension PackageGraph {
                     additionalFileRules: additionalFileRules,
                     binaryArtifacts: binaryArtifacts[node.identity] ?? [:],                
                     shouldCreateMultipleTestProducts: shouldCreateMultipleTestProducts,
-                    customTestManifestPath: customTestManifestPath,
+                    testEntryPointPath: testEntryPointPath,
                     createREPLProduct: manifest.packageKind.isRoot ? createREPLProduct : false,
                     fileSystem: node.fileSystem,
                     observabilityScope: nodeObservabilityScope

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -31,6 +31,7 @@ extension PackageGraph {
         createREPLProduct: Bool = false,
         customPlatformsRegistry: PlatformRegistry? = .none,
         customXCTestMinimumDeploymentTargets: [PackageModel.Platform: PlatformVersion]? = .none,
+        customTestManifestPath: AbsolutePath? = nil,
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope
     ) throws -> PackageGraph {
@@ -118,6 +119,7 @@ extension PackageGraph {
                     additionalFileRules: additionalFileRules,
                     binaryArtifacts: binaryArtifacts[node.identity] ?? [:],                
                     shouldCreateMultipleTestProducts: shouldCreateMultipleTestProducts,
+                    customTestManifestPath: customTestManifestPath,
                     createREPLProduct: manifest.packageKind.isRoot ? createREPLProduct : false,
                     fileSystem: node.fileSystem,
                     observabilityScope: nodeObservabilityScope

--- a/Sources/PackageGraph/ResolvedProduct.swift
+++ b/Sources/PackageGraph/ResolvedProduct.swift
@@ -31,8 +31,8 @@ public final class ResolvedProduct {
         return underlyingProduct.type
     }
 
-    /// Executable target for test manifest file.
-    public let testManifestTarget: ResolvedTarget?
+    /// Executable target for test entry point file.
+    public let testEntryPointTarget: ResolvedTarget?
 
     /// The default localization for resources.
     public let defaultLocalization: String?
@@ -55,10 +55,10 @@ public final class ResolvedProduct {
         self.underlyingProduct = product
         self.targets = targets
 
-        self.testManifestTarget = underlyingProduct.testManifest.map{ testManifest in
-            // Create an executable resolved target with the linux main, adding product's targets as dependencies.
+        self.testEntryPointTarget = underlyingProduct.testEntryPointPath.map { testEntryPointPath in
+            // Create an executable resolved target with the entry point file, adding product's targets as dependencies.
             let dependencies: [Target.Dependency] = product.targets.map { .target($0, conditions: []) }
-            let swiftTarget = SwiftTarget(name: product.name, dependencies: dependencies, testManifest: testManifest)
+            let swiftTarget = SwiftTarget(name: product.name, dependencies: dependencies, testEntryPointPath: testEntryPointPath)
             return ResolvedTarget(
                 target: swiftTarget,
                 dependencies: targets.map { .target($0, conditions: []) },

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -244,6 +244,9 @@ public final class PackageBuilder {
     /// If set to true, one test product will be created for each test target.
     private let shouldCreateMultipleTestProducts: Bool
 
+    /// Path to custom test manifest file, if specified.
+    private let customTestManifestPath: AbsolutePath?
+
     /// Temporary parameter controlling whether to warn about implicit executable targets when tools version is 5.4.
     private let warnAboutImplicitExecutableTargets: Bool
 
@@ -286,6 +289,7 @@ public final class PackageBuilder {
         additionalFileRules: [FileRuleDescription],
         binaryArtifacts: [String: BinaryArtifact],
         shouldCreateMultipleTestProducts: Bool = false,
+        customTestManifestPath: AbsolutePath? = nil,
         warnAboutImplicitExecutableTargets: Bool = true,
         createREPLProduct: Bool = false,
         fileSystem: FileSystem,
@@ -298,6 +302,7 @@ public final class PackageBuilder {
         self.additionalFileRules = additionalFileRules
         self.binaryArtifacts = binaryArtifacts
         self.shouldCreateMultipleTestProducts = shouldCreateMultipleTestProducts
+        self.customTestManifestPath = customTestManifestPath
         self.createREPLProduct = createREPLProduct
         self.warnAboutImplicitExecutableTargets = warnAboutImplicitExecutableTargets
         self.observabilityScope = observabilityScope.makeChildScope(
@@ -1024,6 +1029,10 @@ public final class PackageBuilder {
 
     /// Find the test manifest file for the package.
     private func findTestManifest(in testTargets: [Target]) throws -> AbsolutePath? {
+        if let customTestManifestPath {
+            return customTestManifestPath
+        }
+
         var testManifestFiles = Set<AbsolutePath>()
         var pathsSearched = Set<AbsolutePath>()
 

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -1029,7 +1029,7 @@ public final class PackageBuilder {
 
     /// Find the test manifest file for the package.
     private func findTestManifest(in testTargets: [Target]) throws -> AbsolutePath? {
-        if let customTestManifestPath {
+        if let customTestManifestPath = customTestManifestPath {
             return customTestManifestPath
         }
 

--- a/Sources/PackageModel/Product.swift
+++ b/Sources/PackageModel/Product.swift
@@ -32,13 +32,13 @@ public class Product: Codable {
     @PolymorphicCodableArray
     public var targets: [Target]
 
-    /// The path to test manifest file.
-    public let testManifest: AbsolutePath?
+    /// The path to test entry point file.
+    public let testEntryPointPath: AbsolutePath?
 
     /// The suffix for REPL product name.
     public static let replProductSuffix: String = "__REPL"
 
-    public init(package: PackageIdentity, name: String, type: ProductType, targets: [Target], testManifest: AbsolutePath? = nil) throws {
+    public init(package: PackageIdentity, name: String, type: ProductType, targets: [Target], testEntryPointPath: AbsolutePath? = nil) throws {
         guard !targets.isEmpty else {
             throw InternalError("Targets cannot be empty")
         }
@@ -47,16 +47,16 @@ public class Product: Codable {
                 throw InternalError("Executable products should have exactly one executable target.")
             }
         }
-        if testManifest != nil {
+        if testEntryPointPath != nil {
             guard type == .test else {
-                throw InternalError("Test manifest should only be set on test products")
+                throw InternalError("Test entry point path should only be set on test products")
             }
         }
         self.name = name
         self.type = type
         self.ID = package.description.lowercased() + "_" + name
         self._targets = .init(wrappedValue: targets)
-        self.testManifest = testManifest
+        self.testEntryPointPath = testEntryPointPath
     }
 }
 

--- a/Sources/PackageModel/Target.swift
+++ b/Sources/PackageModel/Target.swift
@@ -329,12 +329,12 @@ public final class SwiftTarget: Target {
         )
     }
 
-    public init(name: String, dependencies: [Target.Dependency], testManifestSrc sources: Sources) {
+    public init(name: String, type: Target.Kind? = nil, dependencies: [Target.Dependency], testManifestSrc sources: Sources) {
         self.swiftVersion = .v5
 
         super.init(
             name: name,
-            type: .executable,
+            type: type ?? .executable,
             path: .root,
             sources: sources,
             dependencies: dependencies,

--- a/Sources/PackageModel/Target.swift
+++ b/Sources/PackageModel/Target.swift
@@ -320,9 +320,23 @@ public final class SwiftTarget: Target {
 
         super.init(
             name: name,
-            type: .executable,
+            type: .library,
             path: .root,
             sources: testDiscoverySrc,
+            dependencies: dependencies,
+            buildSettings: .init(),
+            pluginUsages: []
+        )
+    }
+
+    public init(name: String, dependencies: [Target.Dependency], testManifestSrc sources: Sources) {
+        self.swiftVersion = .v5
+
+        super.init(
+            name: name,
+            type: .executable,
+            path: .root,
+            sources: sources,
             dependencies: dependencies,
             buildSettings: .init(),
             pluginUsages: []

--- a/Sources/PackageModel/Target.swift
+++ b/Sources/PackageModel/Target.swift
@@ -312,8 +312,8 @@ extension Target: CustomStringConvertible {
 
 public final class SwiftTarget: Target {
 
-    /// The file name of test manifest.
-    public static let testManifestNames = ["XCTMain.swift", "LinuxMain.swift"]
+    /// The list of supported names for the test entry point file located in a package.
+    public static let testEntryPointNames = ["XCTMain.swift", "LinuxMain.swift"]
 
     public init(name: String, dependencies: [Target.Dependency], testDiscoverySrc: Sources) {
         self.swiftVersion = .v5
@@ -329,7 +329,7 @@ public final class SwiftTarget: Target {
         )
     }
 
-    public init(name: String, type: Target.Kind? = nil, dependencies: [Target.Dependency], testManifestSrc sources: Sources) {
+    public init(name: String, type: Target.Kind? = nil, dependencies: [Target.Dependency], testEntryPointSources sources: Sources) {
         self.swiftVersion = .v5
 
         super.init(
@@ -376,8 +376,8 @@ public final class SwiftTarget: Target {
         )
     }
 
-    /// Create an executable Swift target from test manifest file.
-    public init(name: String, dependencies: [Target.Dependency], testManifest: AbsolutePath) {
+    /// Create an executable Swift target from test entry point file.
+    public init(name: String, dependencies: [Target.Dependency], testEntryPointPath: AbsolutePath) {
         // Look for the first swift test target and use the same swift version
         // for linux main target. This will need to change if we move to a model
         // where we allow per target swift language version build settings.
@@ -391,7 +391,7 @@ public final class SwiftTarget: Target {
         // satisfy the current tools version but there is not a good way to
         // do that currently.
         self.swiftVersion = swiftTestTarget?.swiftVersion ?? SwiftLanguageVersion(string: String(SwiftVersion.current.major)) ?? .v4
-        let sources = Sources(paths: [testManifest], root: testManifest.parentDirectory)
+        let sources = Sources(paths: [testEntryPointPath], root: testEntryPointPath.parentDirectory)
 
         super.init(
             name: name,

--- a/Sources/PackageModel/Target.swift
+++ b/Sources/PackageModel/Target.swift
@@ -312,8 +312,13 @@ extension Target: CustomStringConvertible {
 
 public final class SwiftTarget: Target {
 
-    /// The list of supported names for the test entry point file located in a package.
-    public static let testEntryPointNames = ["XCTMain.swift", "LinuxMain.swift"]
+    /// The default name for the test entry point file located in a package.
+    public static let defaultTestEntryPointName = "XCTMain.swift"
+
+    /// The list of all supported names for the test entry point file located in a package.
+    public static var testEntryPointNames: [String] {
+        [defaultTestEntryPointName, "LinuxMain.swift"]
+    }
 
     public init(name: String, dependencies: [Target.Dependency], testDiscoverySrc: Sources) {
         self.swiftVersion = .v5
@@ -323,20 +328,6 @@ public final class SwiftTarget: Target {
             type: .library,
             path: .root,
             sources: testDiscoverySrc,
-            dependencies: dependencies,
-            buildSettings: .init(),
-            pluginUsages: []
-        )
-    }
-
-    public init(name: String, type: Target.Kind? = nil, dependencies: [Target.Dependency], testEntryPointSources sources: Sources) {
-        self.swiftVersion = .v5
-
-        super.init(
-            name: name,
-            type: type ?? .executable,
-            path: .root,
-            sources: sources,
             dependencies: dependencies,
             buildSettings: .init(),
             pluginUsages: []

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1068,7 +1068,7 @@ extension Workspace {
         createREPLProduct: Bool = false,
         forceResolvedVersions: Bool = false,
         customXCTestMinimumDeploymentTargets: [PackageModel.Platform: PlatformVersion]? = .none,
-        customTestManifestPath: AbsolutePath? = nil,
+        testEntryPointPath: AbsolutePath? = nil,
         observabilityScope: ObservabilityScope
     ) throws -> PackageGraph {
         // reload state in case it was modified externally (eg by another process) before reloading the graph
@@ -1110,7 +1110,7 @@ extension Workspace {
             shouldCreateMultipleTestProducts: createMultipleTestProducts,
             createREPLProduct: createREPLProduct,
             customXCTestMinimumDeploymentTargets: customXCTestMinimumDeploymentTargets,
-            customTestManifestPath: customTestManifestPath,
+            testEntryPointPath: testEntryPointPath,
             fileSystem: fileSystem,
             observabilityScope: observabilityScope
         )

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1068,6 +1068,7 @@ extension Workspace {
         createREPLProduct: Bool = false,
         forceResolvedVersions: Bool = false,
         customXCTestMinimumDeploymentTargets: [PackageModel.Platform: PlatformVersion]? = .none,
+        customTestManifestPath: AbsolutePath? = nil,
         observabilityScope: ObservabilityScope
     ) throws -> PackageGraph {
         // reload state in case it was modified externally (eg by another process) before reloading the graph
@@ -1109,6 +1110,7 @@ extension Workspace {
             shouldCreateMultipleTestProducts: createMultipleTestProducts,
             createREPLProduct: createREPLProduct,
             customXCTestMinimumDeploymentTargets: customXCTestMinimumDeploymentTargets,
+            customTestManifestPath: customTestManifestPath,
             fileSystem: fileSystem,
             observabilityScope: observabilityScope
         )

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -1067,10 +1067,9 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testTestModule() throws {
-        let defaultEntryPointName = try XCTUnwrap(SwiftTarget.testEntryPointNames.first)
         let fs = InMemoryFileSystem(emptyFiles:
             "/Pkg/Sources/Foo/foo.swift",
-            "/Pkg/Tests/\(defaultEntryPointName)",
+            "/Pkg/Tests/\(SwiftTarget.defaultTestEntryPointName)",
             "/Pkg/Tests/FooTests/foo.swift"
         )
 

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -1067,9 +1067,10 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testTestModule() throws {
+        let defaultEntryPointName = try XCTUnwrap(SwiftTarget.testEntryPointNames.first)
         let fs = InMemoryFileSystem(emptyFiles:
             "/Pkg/Sources/Foo/foo.swift",
-            "/Pkg/Tests/\(SwiftTarget.testManifestNames.first!).swift",
+            "/Pkg/Tests/\(defaultEntryPointName)",
             "/Pkg/Tests/FooTests/foo.swift"
         )
 
@@ -1099,7 +1100,7 @@ final class BuildPlanTests: XCTestCase {
       #if os(macOS)
         result.checkTargetsCount(2)
       #else
-        // There are two additional targets on non-Apple platforms, for test discovery and test manifest
+        // There are two additional targets on non-Apple platforms, for test discovery and test entry point
         result.checkTargetsCount(4)
       #endif
 
@@ -2380,7 +2381,7 @@ final class BuildPlanTests: XCTestCase {
             observabilityScope: observability.topScope
         ))
         result.checkProductsCount(2)
-        result.checkTargetsCount(5) // There are two additional targets on non-Apple platforms, for test discovery and test manifest
+        result.checkTargetsCount(5) // There are two additional targets on non-Apple platforms, for test discovery and test entry point
 
         let buildPath: AbsolutePath = result.plan.buildParameters.dataPath.appending(components: "debug")
 

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -371,6 +371,7 @@ final class BuildPlanTests: XCTestCase {
       #else
         XCTAssertEqual(Set(result.targetMap.keys), [
             "APackageTests",
+            "APackageDiscoveredTests",
             "ATarget",
             "ATargetTests",
             "BTarget"
@@ -1098,8 +1099,8 @@ final class BuildPlanTests: XCTestCase {
       #if os(macOS)
         result.checkTargetsCount(2)
       #else
-        // We have an extra test discovery target on linux.
-        result.checkTargetsCount(3)
+        // There are two additional targets on non-Apple platforms, for test discovery and test manifest
+        result.checkTargetsCount(4)
       #endif
 
         let buildPath: AbsolutePath = result.plan.buildParameters.dataPath.appending(components: "debug")
@@ -2379,7 +2380,7 @@ final class BuildPlanTests: XCTestCase {
             observabilityScope: observability.topScope
         ))
         result.checkProductsCount(2)
-        result.checkTargetsCount(4)
+        result.checkTargetsCount(5) // There are two additional targets on non-Apple platforms, for test discovery and test manifest
 
         let buildPath: AbsolutePath = result.plan.buildParameters.dataPath.appending(components: "debug")
 

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -1100,8 +1100,8 @@ final class BuildPlanTests: XCTestCase {
       #if os(macOS)
         result.checkTargetsCount(2)
       #else
-        // There are two additional targets on non-Apple platforms, for test discovery and test entry point
-        result.checkTargetsCount(4)
+        // On non-Apple platforms, when a custom entry point file is present (e.g. XCTMain.swift), there is one additional target for the synthesized test entry point.
+        result.checkTargetsCount(3)
       #endif
 
         let buildPath: AbsolutePath = result.plan.buildParameters.dataPath.appending(components: "debug")

--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -181,6 +181,8 @@ final class TestToolTests: CommandsTestCase {
 
     func testEnableTestDiscoveryDeprecation() throws {
         let compilerDiagnosticFlags = ["-Xswiftc", "-Xfrontend", "-Xswiftc", "-Rmodule-interface-rebuild"]
+        let defaultTestEntryPointName = try XCTUnwrap(SwiftTarget.testEntryPointNames.first)
+
         #if canImport(Darwin)
         // should emit when LinuxMain is present
         try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
@@ -190,7 +192,7 @@ final class TestToolTests: CommandsTestCase {
 
         // should emit when LinuxMain is not present
         try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
-            try localFileSystem.writeFileContents(fixturePath.appending(components: "Tests", SwiftTarget.testManifestNames.first!), bytes: "fatalError(\"boom\")")
+            try localFileSystem.writeFileContents(fixturePath.appending(components: "Tests", defaultTestEntryPointName), bytes: "fatalError(\"boom\")")
             let (_, stderr) = try SwiftPMProduct.SwiftTest.execute(["--enable-test-discovery"] + compilerDiagnosticFlags, packagePath: fixturePath)
             XCTAssertMatch(stderr, .contains("warning: '--enable-test-discovery' option is deprecated"))
         }
@@ -202,7 +204,7 @@ final class TestToolTests: CommandsTestCase {
         }
         // should not emit when LinuxMain is present
         try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
-            try localFileSystem.writeFileContents(fixturePath.appending(components: "Tests", SwiftTarget.testManifestNames.first!), bytes: "fatalError(\"boom\")")
+            try localFileSystem.writeFileContents(fixturePath.appending(components: "Tests", defaultTestEntryPointName), bytes: "fatalError(\"boom\")")
             let (_, stderr) = try SwiftPMProduct.SwiftTest.execute(["--enable-test-discovery"] + compilerDiagnosticFlags, packagePath: fixturePath)
             XCTAssertNoMatch(stderr, .contains("warning: '--enable-test-discovery' option is deprecated"))
         }

--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -181,8 +181,6 @@ final class TestToolTests: CommandsTestCase {
 
     func testEnableTestDiscoveryDeprecation() throws {
         let compilerDiagnosticFlags = ["-Xswiftc", "-Xfrontend", "-Xswiftc", "-Rmodule-interface-rebuild"]
-        let defaultTestEntryPointName = try XCTUnwrap(SwiftTarget.testEntryPointNames.first)
-
         #if canImport(Darwin)
         // should emit when LinuxMain is present
         try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
@@ -192,7 +190,7 @@ final class TestToolTests: CommandsTestCase {
 
         // should emit when LinuxMain is not present
         try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
-            try localFileSystem.writeFileContents(fixturePath.appending(components: "Tests", defaultTestEntryPointName), bytes: "fatalError(\"boom\")")
+            try localFileSystem.writeFileContents(fixturePath.appending(components: "Tests", SwiftTarget.defaultTestEntryPointName), bytes: "fatalError(\"boom\")")
             let (_, stderr) = try SwiftPMProduct.SwiftTest.execute(["--enable-test-discovery"] + compilerDiagnosticFlags, packagePath: fixturePath)
             XCTAssertMatch(stderr, .contains("warning: '--enable-test-discovery' option is deprecated"))
         }
@@ -204,7 +202,7 @@ final class TestToolTests: CommandsTestCase {
         }
         // should not emit when LinuxMain is present
         try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
-            try localFileSystem.writeFileContents(fixturePath.appending(components: "Tests", defaultTestEntryPointName), bytes: "fatalError(\"boom\")")
+            try localFileSystem.writeFileContents(fixturePath.appending(components: "Tests", SwiftTarget.defaultTestEntryPointName), bytes: "fatalError(\"boom\")")
             let (_, stderr) = try SwiftPMProduct.SwiftTest.execute(["--enable-test-discovery"] + compilerDiagnosticFlags, packagePath: fixturePath)
             XCTAssertNoMatch(stderr, .contains("warning: '--enable-test-discovery' option is deprecated"))
         }

--- a/Tests/FunctionalTests/TestDiscoveryTests.swift
+++ b/Tests/FunctionalTests/TestDiscoveryTests.swift
@@ -69,11 +69,11 @@ class TestDiscoveryTests: XCTestCase {
         }
     }
 
-    func testManifestOverride() throws {
+    func testEntryPointOverride() throws {
         #if os(macOS)
         try XCTSkipIf(true)
         #endif
-        try SwiftTarget.testManifestNames.forEach { name in
+        try SwiftTarget.testEntryPointNames.forEach { name in
             try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
                 let random = UUID().uuidString
                 let manifestPath = fixturePath.appending(components: "Tests", name)
@@ -88,11 +88,11 @@ class TestDiscoveryTests: XCTestCase {
         }
     }
 
-    func testManifestOverrideIgnored() throws {
+    func testEntryPointOverrideIgnored() throws {
         #if os(macOS)
         try XCTSkipIf(true)
         #endif
-        let name = SwiftTarget.testManifestNames.first!
+        let name = try XCTUnwrap(SwiftTarget.testEntryPointNames.first)
         try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
             let manifestPath = fixturePath.appending(components: "Tests", name)
             try localFileSystem.writeFileContents(manifestPath, bytes: ByteString("fatalError(\"should not be called\")".utf8))

--- a/Tests/FunctionalTests/TestDiscoveryTests.swift
+++ b/Tests/FunctionalTests/TestDiscoveryTests.swift
@@ -92,9 +92,8 @@ class TestDiscoveryTests: XCTestCase {
         #if os(macOS)
         try XCTSkipIf(true)
         #endif
-        let name = try XCTUnwrap(SwiftTarget.testEntryPointNames.first)
         try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
-            let manifestPath = fixturePath.appending(components: "Tests", name)
+            let manifestPath = fixturePath.appending(components: "Tests", SwiftTarget.defaultTestEntryPointName)
             try localFileSystem.writeFileContents(manifestPath, bytes: ByteString("fatalError(\"should not be called\")".utf8))
             let (stdout, stderr) = try executeSwiftTest(fixturePath, extraArgs: ["--enable-test-discovery"])
             // in "swift test" build output goes to stderr

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -578,7 +578,7 @@ class PackageBuilderTests: XCTestCase {
     }
 
     func testMultipleTestEntryPointsError() throws {
-        let name = try XCTUnwrap(SwiftTarget.testEntryPointNames.first)
+        let name = SwiftTarget.defaultTestEntryPointName
         let swift: AbsolutePath = AbsolutePath("/swift")
 
         let fs = InMemoryFileSystem(emptyFiles:

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -510,8 +510,8 @@ class PackageBuilderTests: XCTestCase {
         }
     }
 
-    func testTestManifestFound() throws {
-        try SwiftTarget.testManifestNames.forEach { name in
+    func testTestEntryPointFound() throws {
+        try SwiftTarget.testEntryPointNames.forEach { name in
             let fs = InMemoryFileSystem(emptyFiles:
                 "/swift/exe/foo.swift",
                 "/\(name)",
@@ -538,7 +538,7 @@ class PackageBuilderTests: XCTestCase {
 
                 package.checkProduct("pkgPackageTests") { product in
                     product.check(type: .test, targets: ["tests"])
-                    product.check(testManifestPath: "/\(name)")
+                    product.check(testEntryPointPath: "/\(name)")
                 }
             }
         }
@@ -572,13 +572,13 @@ class PackageBuilderTests: XCTestCase {
 
             package.checkProduct("pkgPackageTests") { product in
                 product.check(type: .test, targets: ["tests"])
-                product.check(testManifestPath: nil)
+                product.check(testEntryPointPath: nil)
             }
         }
     }
 
-    func testMultipleTestManifestError() throws {
-        let name = SwiftTarget.testManifestNames.first!
+    func testMultipleTestEntryPointsError() throws {
+        let name = try XCTUnwrap(SwiftTarget.testEntryPointNames.first)
         let swift: AbsolutePath = AbsolutePath("/swift")
 
         let fs = InMemoryFileSystem(emptyFiles:
@@ -598,7 +598,7 @@ class PackageBuilderTests: XCTestCase {
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, diagnostics in
-            diagnostics.check(diagnostic: "package '\(package.packageIdentity)' has multiple test manifest files: \(AbsolutePath("/\(name)")), \(swift.appending(components: name))", severity: .error)
+            diagnostics.check(diagnostic: "package '\(package.packageIdentity)' has multiple test entry point files: \(AbsolutePath("/\(name)")), \(swift.appending(components: name))", severity: .error)
         }
     }
 
@@ -2382,8 +2382,8 @@ final class PackageBuilderTester {
             XCTAssertEqual(product.targets.map{$0.name}.sorted(), targets.sorted(), file: file, line: line)
         }
 
-        func check(testManifestPath: String?, file: StaticString = #file, line: UInt = #line) {
-            XCTAssertEqual(product.testManifest, testManifestPath.map({ AbsolutePath($0) }), file: file, line: line)
+        func check(testEntryPointPath: String?, file: StaticString = #file, line: UInt = #line) {
+            XCTAssertEqual(product.testEntryPointPath, testEntryPointPath.map({ AbsolutePath($0) }), file: file, line: line)
         }
     }
 


### PR DESCRIPTION
### Motivation:

There are situations where a user may wish to customize the entry point file used to run tests on non-Apple platforms via `swift test`. For example, to run custom code before invoking the `XCTMain(...)` function. But including a custom `XCTMain.swift` file (or its former name, `LinuxMain.swift`) causes `swift test` to solely rely on that file to run tests, and more importantly, it causes SwiftPM to skip automatic test discovery, so you end up needing to list all the tests to run in that file. Passing `--enable-test-discovery` explicitly does the opposite: it performs test discovery, synthesizes its own test entry point file, and ignores any custom entry point file present in the package.

This PR adds a way to both provide a custom test entry point file and still perform test discovery, allowing the custom entry point file to reference the automatically-discovered tests and pass them to `XCTMain(...)`. It enables this behavior when passing a new, experimental flag `--experimental-test-entry-point-path <file>`.

### Modifications:

- Add new CLI flag `--experimental-test-entry-point-path <file>`.
- Separate the logic for generating derived test targets: now, there are distinct internal targets for test discovery vs. test entry point code. The test discovery target may be independently enabled, and the test entry point target may either be synthesized entirely, contain the file at the path from the new CLI flag, or contain an `XCTMain.swift` file in the package source tree.
- Ensure the test entry point target depends on the test discovery target if the latter was generated.
- Include diagnostics to warn about unexpected configurations.

rdar://97940043
