### PR TITLE
Fix broken link in package description.

### DIFF
--- a/Documentation/PackageDescription.md
+++ b/Documentation/PackageDescription.md
@@ -476,7 +476,7 @@ A package version is a three period-separated integer, for example `1.0.0`. It m
 that your package behaves in a predictable manner once developers update their
 package dependency to a newer version. To achieve predictability, the semantic versioning specification proposes a set of rules and
 requirements that dictate how version numbers are assigned and incremented. To learn more about the semantic versioning specification, visit
-[semver.org](www.semver.org).
+[semver.org](https://semver.org).
 
 **The Major Version**
 


### PR DESCRIPTION
Without the "https://" if you click the link, it tries to open: https://github.com/apple/swift-package-manager/blob/main/Documentation/www.semver.org.

### Result:
- now the link works properly
- it also solves: https://github.com/apple/swift-org-website/issues/60
