### PR TITLE
Build: initial pass to support static archives on Windows

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -1344,6 +1344,19 @@ public final class ProductBuildDescription {
         }
     }
 
+    /// The arguments to the librarian to create a static library.
+    public func archiveArguments() throws -> [String] {
+        let librarian = buildParameters.toolchain.librarianPath.pathString
+        let triple = buildParameters.triple
+        if triple.isWindows(), librarian.hasSuffix("link") || librarian.hasSuffix("link.exe") {
+            return [librarian, "/LIB", "/OUT:\(binary.pathString)", "@\(linkFileListPath.pathString)"]
+        }
+        if triple.isDarwin(), librarian.hasSuffix("libtool") {
+            return [librarian, "-o", binary.pathString, "@\(linkFileListPath.pathString)"]
+        }
+        return [librarian, "crs", binary.pathString, "@\(linkFileListPath.pathString)"]
+    }
+
     /// The arguments to link and create this product.
     public func linkArguments() throws -> [String] {
         var args = [buildParameters.toolchain.swiftCompilerPath.pathString]

--- a/Sources/Build/LLBuildManifestBuilder.swift
+++ b/Sources/Build/LLBuildManifestBuilder.swift
@@ -853,14 +853,17 @@ extension LLBuildManifestBuilder {
     private func createProductCommand(_ buildProduct: ProductBuildDescription) throws {
         let cmdName = try buildProduct.product.getCommandName(config: buildConfig)
 
-        // Create archive tool for static library and shell tool for rest of the products.
-        if buildProduct.product.type == .library(.static) {
-            manifest.addArchiveCmd(
+        switch buildProduct.product.type {
+        case .library(.static):
+            manifest.addShellCmd(
                 name: cmdName,
+                description: "Archiving \(buildProduct.binary.prettyPath())",
                 inputs: buildProduct.objects.map(Node.file),
-                outputs: [.file(buildProduct.binary)]
+                outputs: [.file(buildProduct.binary)],
+                arguments: try buildProduct.archiveArguments()
             )
-        } else {
+
+        default:
             let inputs = buildProduct.objects + buildProduct.dylibs.map({ $0.binary })
 
             manifest.addShellCmd(

--- a/Sources/LLBuildManifest/BuildManifest.swift
+++ b/Sources/LLBuildManifest/BuildManifest.swift
@@ -88,16 +88,6 @@ public struct BuildManifest {
         commands[name] = Command(name: name, tool: tool)
     }
 
-    public mutating func addArchiveCmd(
-        name: String,
-        inputs: [Node],
-        outputs: [Node]
-    ) {
-        assert(commands[name] == nil, "already had a command named '\(name)'")
-        let tool = ArchiveTool(inputs: inputs, outputs: outputs)
-        commands[name] = Command(name: name, tool: tool)
-    }
-
     public mutating func addShellCmd(
         name: String,
         description: String,

--- a/Sources/PackageModel/Toolchain.swift
+++ b/Sources/PackageModel/Toolchain.swift
@@ -13,6 +13,9 @@
 import TSCBasic
 
 public protocol Toolchain {
+    /// Path of the librarian.
+    var librarianPath: AbsolutePath { get }
+
     /// Path of the `swiftc` compiler.
     var swiftCompilerPath: AbsolutePath { get }
 

--- a/Sources/PackageModel/ToolchainConfiguration.swift
+++ b/Sources/PackageModel/ToolchainConfiguration.swift
@@ -18,6 +18,9 @@ import TSCBasic
 /// These requirements are abstracted out to make it easier to add support for
 /// using the package manager with alternate toolchains in the future.
 public struct ToolchainConfiguration {
+    /// The path of the librarian.
+    public var librarianPath: AbsolutePath
+
     /// The path of the swift compiler.
     public var swiftCompilerPath: AbsolutePath
 
@@ -43,13 +46,15 @@ public struct ToolchainConfiguration {
     /// Creates the set of manifest resources associated with a `swiftc` executable.
     ///
     /// - Parameters:
-    ///     - swiftCompilerPath: The absolute path of the associated swift compiler  executable (`swiftc`).
+    ///     - librarianPath: The absolute path to the librarian
+    ///     - swiftCompilerPath: The absolute path of the associated swift compiler executable (`swiftc`).
     ///     - swiftCompilerFlags: Extra flags to pass to the Swift compiler.
     ///     - swiftCompilerEnvironment: Environment variables to pass to the Swift compiler.
     ///     - swiftPMLibrariesRootPath: Custom path for SwiftPM libraries. Computed based on the compiler path by default.
     ///     - sdkRootPath: Optional path to SDK root.
     ///     - xctestPath: Optional path to XCTest.
     public init(
+        librarianPath: AbsolutePath,
         swiftCompilerPath: AbsolutePath,
         swiftCompilerFlags: [String] = [],
         swiftCompilerEnvironment: EnvironmentVariables = .process(),
@@ -61,6 +66,7 @@ public struct ToolchainConfiguration {
             return .init(swiftCompilerPath: swiftCompilerPath)
         }()
 
+        self.librarianPath = librarianPath
         self.swiftCompilerPath = swiftCompilerPath
         self.swiftCompilerFlags = swiftCompilerFlags
         self.swiftCompilerEnvironment = swiftCompilerEnvironment

--- a/Tests/BuildTests/MockBuildTestHelper.swift
+++ b/Tests/BuildTests/MockBuildTestHelper.swift
@@ -7,6 +7,15 @@ import TSCBasic
 import XCTest
 
 struct MockToolchain: PackageModel.Toolchain {
+#if os(Windows)
+    let librarianPath = AbsolutePath("/fake/path/to/link.exe")
+#elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    let librarianPath = AbsolutePath("/fake/path/to/libtool")
+#elseif os(Android)
+    let librarianPath = AbsolutePath("/fake/path/to/llvm-ar")
+#else
+    let librarianPath = AbsolutePath("/fake/path/to/ar")
+#endif
     let swiftCompilerPath = AbsolutePath("/fake/path/to/swiftc")
     let extraCCFlags: [String] = []
     let extraSwiftCFlags: [String] = []


### PR DESCRIPTION
Introduce a SPM controlled build rule for building static libraries.
This is the intended way to use llbuild to drive the generation of
static libraries.  We would previously rely on the static default
rule intended for testing to generate the static libraries.  Not only
did this tool not properly support Windows, it would actually cause
problems on macOS due to the use of `ar` for the creation of the library
over the preferred tool - `libtool`.  We now locally determine the
correct rule and generate the command.

This is incomplete support for Windows and in fact regresses
functionality.  We no longer honour `AR` as an environment variable on
Windows and thus cannot switch the implementation of the librarian.  We
now drive the archiving through `lld-link` unconditionally while we
should prefer `link` unless otherwise requested.  This is covered as
an issue in #5719.