### PR TITLE
Fix the output when compiling plugins before a build starts

### DIFF
--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -338,7 +338,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
                 self.buildSystemDelegate?.preparationStepFinished(preparationStepName, result: (cachedResult.succeeded ? .succeeded : .failed))
             }
         }
-        let delegate = Delegate(preparationStepName: "Compiling plugin \(plugin.targetName)...", buildSystemDelegate: self.buildSystemDelegate)
+        let delegate = Delegate(preparationStepName: "Compiling plugin \(plugin.targetName)", buildSystemDelegate: self.buildSystemDelegate)
         let result = try tsc_await {
             self.pluginScriptRunner.compilePluginScript(
                 sourceFiles: plugin.sources.paths,

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -1149,6 +1149,15 @@ final class PluginDelegate: PluginInvocationDelegate {
         self.lineBufferedOutput = Data()
     }
 
+    func pluginCompilationStarted(commandLine: [String], environment: EnvironmentVariables) {
+    }
+    
+    func pluginCompilationEnded(result: PluginCompilationResult) {
+    }
+        
+    func pluginCompilationWasSkipped(cachedResult: PluginCompilationResult) {
+    }
+
     func pluginEmittedOutput(_ data: Data) {
         lineBufferedOutput += data
         while let newlineIdx = lineBufferedOutput.firstIndex(of: UInt8(ascii: "\n")) {

--- a/Sources/SPMBuildCore/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/PluginInvocation.swift
@@ -121,7 +121,7 @@ extension PluginTarget {
         }
         
         // Handle messages and output from the plugin.
-        class ScriptRunnerDelegate: PluginScriptRunnerDelegate {
+        class ScriptRunnerDelegate: PluginScriptCompilerDelegate, PluginScriptRunnerDelegate {
             /// Delegate that should be told about events involving the plugin.
             let invocationDelegate: PluginInvocationDelegate
             
@@ -134,6 +134,18 @@ extension PluginTarget {
             init(invocationDelegate: PluginInvocationDelegate, observabilityScope: ObservabilityScope) {
                 self.invocationDelegate = invocationDelegate
                 self.observabilityScope = observabilityScope
+            }
+            
+            func willCompilePlugin(commandLine: [String], environment: EnvironmentVariables) {
+                invocationDelegate.pluginCompilationStarted(commandLine: commandLine, environment: environment)
+            }
+            
+            func didCompilePlugin(result: PluginCompilationResult) {
+                invocationDelegate.pluginCompilationEnded(result: result)
+            }
+            
+            func skippedCompilingPlugin(cachedResult: PluginCompilationResult) {
+                invocationDelegate.pluginCompilationWasSkipped(cachedResult: cachedResult)
             }
             
             /// Invoked when the plugin emits arbtirary data on its stdout/stderr. There is no guarantee that the data is split on UTF-8 character encoding boundaries etc.  The script runner delegate just passes it on to the invocation delegate.
@@ -381,6 +393,15 @@ extension PackageGraph {
                         self.toolPaths = toolPaths
                     }
                     
+                    func pluginCompilationStarted(commandLine: [String], environment: EnvironmentVariables) {
+                    }
+                    
+                    func pluginCompilationEnded(result: PluginCompilationResult) {
+                    }
+                    
+                    func pluginCompilationWasSkipped(cachedResult: PluginCompilationResult) {
+                    }
+
                     func pluginEmittedOutput(_ data: Data) {
                         dispatchPrecondition(condition: .onQueue(delegateQueue))
                         outputData.append(contentsOf: data)
@@ -577,6 +598,15 @@ public enum PluginEvaluationError: Swift.Error {
 
 
 public protocol PluginInvocationDelegate {
+    /// Called before a plugin is compiled. This call is always followed by a `pluginCompilationEnded()`, but is mutually exclusive with `pluginCompilationWasSkipped()` (which is called if the plugin didn't need to be recompiled).
+    func pluginCompilationStarted(commandLine: [String], environment: EnvironmentVariables)
+    
+    /// Called after a plugin is compiled. This call always follows a `pluginCompilationStarted()`, but is mutually exclusive with `pluginCompilationWasSkipped()` (which is called if the plugin didn't need to be recompiled).
+    func pluginCompilationEnded(result: PluginCompilationResult)
+    
+    /// Called if a plugin didn't need to be recompiled. This call is always mutually exclusive with `pluginCompilationStarted()` and `pluginCompilationEnded()`.
+    func pluginCompilationWasSkipped(cachedResult: PluginCompilationResult)
+    
     /// Called for each piece of textual output data emitted by the plugin. Note that there is no guarantee that the data begins and ends on a UTF-8 byte sequence boundary (much less on a line boundary) so the delegate should buffer partial data as appropriate.
     func pluginEmittedOutput(_: Data)
     

--- a/Sources/SPMBuildCore/PluginScriptRunner.swift
+++ b/Sources/SPMBuildCore/PluginScriptRunner.swift
@@ -28,6 +28,7 @@ public protocol PluginScriptRunner {
         toolsVersion: ToolsVersion,
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue,
+        delegate: PluginScriptCompilerDelegate,
         completion: @escaping (Result<PluginCompilationResult, Error>) -> Void
     )
 
@@ -52,7 +53,7 @@ public protocol PluginScriptRunner {
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue,
-        delegate: PluginScriptRunnerDelegate,
+        delegate: PluginScriptCompilerDelegate & PluginScriptRunnerDelegate,
         completion: @escaping (Result<Int32, Error>) -> Void
     )
 
@@ -61,7 +62,19 @@ public protocol PluginScriptRunner {
     var hostTriple: Triple { get }
 }
 
-/// Protocol by which `PluginScriptRunner.runPluginScript()` communicates back to the caller.
+/// Protocol by which `PluginScriptRunner` communicates back to the caller as it compiles plugins.
+public protocol PluginScriptCompilerDelegate {
+    /// Called immediately before compiling a plugin. Will not be called if the plugin didn't have to be compiled. This call is always followed by a `didCompilePlugin()` but is mutually exclusive with a `skippedCompilingPlugin()` call.
+    func willCompilePlugin(commandLine: [String], environment: EnvironmentVariables)
+    
+    /// Called immediately after compiling a plugin (regardless of whether it succeeded or failed). Will not be called if the plugin didn't have to be compiled. This call is always follows a `willCompilePlugin()` but is mutually exclusive with a `skippedCompilingPlugin()` call.
+    func didCompilePlugin(result: PluginCompilationResult)
+    
+    /// Called if a plugin didn't need to be compiled because previous compilation results were still valid. In this case neither `willCompilePlugin()` nor `didCompilePlugin()` will be called.
+    func skippedCompilingPlugin(cachedResult: PluginCompilationResult)
+}
+
+/// Protocol by which `PluginScriptRunner` communicates back to the caller as it runs plugins.
 public protocol PluginScriptRunnerDelegate {
     /// Called for each piece of textual output data emitted by the plugin. Note that there is no guarantee that the data begins and ends on a UTF-8 byte sequence boundary (much less on a line boundary) so the delegate should buffer partial data as appropriate.
     func handleOutput(data: Data)
@@ -70,9 +83,8 @@ public protocol PluginScriptRunnerDelegate {
     func handleMessage(data: Data, responder: @escaping (Data) -> Void) throws
 }
 
-
 /// The result of compiling a plugin. The executable path will only be present if the compilation succeeds, while the other properties are present in all cases.
-public struct PluginCompilationResult {
+public struct PluginCompilationResult: Equatable {
     /// Whether compilation succeeded.
     public var succeeded: Bool
     

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -2510,8 +2510,8 @@ final class PackageToolTests: CommandsTestCase {
                 let result = try SwiftPMProduct.SwiftBuild.executeProcess([], packagePath: packageDir)
                 let output = try result.utf8Output() + result.utf8stderrOutput()
                 XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
-                XCTAssertMatch(output, .contains("Compiling plugin MyBuildToolPlugin..."))
-                XCTAssertMatch(output, .contains("Compiling plugin MyCommandPlugin..."))
+                XCTAssertMatch(output, .contains("Compiling plugin MyBuildToolPlugin"))
+                XCTAssertMatch(output, .contains("Compiling plugin MyCommandPlugin"))
                 XCTAssertMatch(output, .contains("Building for debugging..."))
             }
 
@@ -2520,8 +2520,8 @@ final class PackageToolTests: CommandsTestCase {
                 let result = try SwiftPMProduct.SwiftBuild.executeProcess(["--target", "MyCommandPlugin"], packagePath: packageDir)
                 let output = try result.utf8Output() + result.utf8stderrOutput()
                 XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
-                XCTAssertNoMatch(output, .contains("Compiling plugin MyBuildToolPlugin..."))
-                XCTAssertMatch(output, .contains("Compiling plugin MyCommandPlugin..."))
+                XCTAssertNoMatch(output, .contains("Compiling plugin MyBuildToolPlugin"))
+                XCTAssertMatch(output, .contains("Compiling plugin MyCommandPlugin"))
                 XCTAssertNoMatch(output, .contains("Building for debugging..."))
             }
 
@@ -2545,8 +2545,8 @@ final class PackageToolTests: CommandsTestCase {
                 let result = try SwiftPMProduct.SwiftBuild.executeProcess([], packagePath: packageDir)
                 let output = try result.utf8Output() + result.utf8stderrOutput()
                 XCTAssertNotEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
-                XCTAssertMatch(output, .contains("Compiling plugin MyBuildToolPlugin..."))
-                XCTAssertMatch(output, .contains("Compiling plugin MyCommandPlugin..."))
+                XCTAssertMatch(output, .contains("Compiling plugin MyBuildToolPlugin"))
+                XCTAssertMatch(output, .contains("Compiling plugin MyCommandPlugin"))
                 #if false // sometimes this line isn't emitted; being investigated in https://bugs.swift.org/browse/SR-15831
                     XCTAssertMatch(output, .contains("MyCommandPlugin/plugin.swift:7:19: error: consecutive statements on a line must be separated by ';'"))
                 #endif

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -922,7 +922,7 @@ class PluginTests: XCTestCase {
 
         try fixture(name: "Miscellaneous/Plugins") { fixturePath in
             let (stdout, _) = try executeSwiftBuild(fixturePath.appending(component: "TransitivePluginOnlyDependency"))
-            XCTAssert(stdout.contains("Compiling plugin MyPlugin..."), "stdout:\n\(stdout)")
+            XCTAssert(stdout.contains("Compiling plugin MyPlugin"), "stdout:\n\(stdout)")
             XCTAssert(stdout.contains("Compiling Library Library.swift"), "stdout:\n\(stdout)")
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
@@ -947,7 +947,7 @@ class PluginTests: XCTestCase {
 
         try fixture(name: "Miscellaneous/Plugins") { fixturePath in
             let (stdout, _) = try executeSwiftBuild(fixturePath.appending(component: "PluginCanBeReferencedByProductName"))
-            XCTAssert(stdout.contains("Compiling plugin MyPlugin..."), "stdout:\n\(stdout)")
+            XCTAssert(stdout.contains("Compiling plugin MyPlugin"), "stdout:\n\(stdout)")
             XCTAssert(stdout.contains("Compiling PluginCanBeReferencedByProductName gen.swift"), "stdout:\n\(stdout)")
             XCTAssert(stdout.contains("Compiling PluginCanBeReferencedByProductName PluginCanBeReferencedByProductName.swift"), "stdout:\n\(stdout)")
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -374,6 +374,15 @@ class PluginTests: XCTestCase {
                     self.delegateQueue = delegateQueue
                 }
                 
+                func pluginCompilationStarted(commandLine: [String], environment: EnvironmentVariables) {
+                }
+                
+                func pluginCompilationEnded(result: PluginCompilationResult) {
+                }
+                    
+                func pluginCompilationWasSkipped(cachedResult: PluginCompilationResult) {
+                }
+
                 func pluginEmittedOutput(_ data: Data) {
                     // Add each line of emitted output as a `.info` diagnostic.
                     dispatchPrecondition(condition: .onQueue(delegateQueue))
@@ -601,6 +610,15 @@ class PluginTests: XCTestCase {
 
                 init(delegateQueue: DispatchQueue) {
                     self.delegateQueue = delegateQueue
+                }
+                
+                func pluginCompilationStarted(commandLine: [String], environment: EnvironmentVariables) {
+                }
+                
+                func pluginCompilationEnded(result: PluginCompilationResult) {
+                }
+                    
+                func pluginCompilationWasSkipped(cachedResult: PluginCompilationResult) {
                 }
                 
                 func pluginEmittedOutput(_ data: Data) {


### PR DESCRIPTION
Fixes the output for "Compile plugin" commands to use the progress tracker, just as for build commands.

### Motivation

This fixes potential output corruption in the console output.  No change in behaviour.

### Changes

- add delegate callbacks to the DefaultPluginScriptRunner so that clients can found out when compilation:
   1. will start
   2. did finish, or
   3. was skipped because the cache is already up-to-date
- change the printing of the output to use the same progress tracker as for build commands
- only show the direct compiler output in verbose mode, as for build commands

### Future improvements

An even better approach for a future PR would probably be to have the plugin compilation commands be registered as llbuild tasks, which would allow them to go through the regular dependency machinery.  This would still have to happen as a separate build step before the regular build, since prebuild commands etc have to run before the build and can contribute to target sources discovery etc (i.e. it can't be part of a regular build).

Meanwhile, this makes the output be like the others, and counts compiled plugins in the count of total and finished tasks.  I'll also extend this PR to do the same for running the plugins.

rdar://98367242