### PR TITLE
Improve search paths for XCFrameworks

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -2272,8 +2272,8 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
                 if case .xcframework = target.kind {
                     let libraries = try self.parseXCFramework(for: target)
                     for library in libraries {
-                        if let headersPath = library.headersPath {
-                            clangTarget.additionalFlags += ["-I", headersPath.pathString]
+                        library.headersPaths.forEach {
+                            clangTarget.additionalFlags += ["-I", $0.pathString]
                         }
                         clangTarget.libraryBinaryPaths.insert(library.libraryPath)
                     }
@@ -2309,8 +2309,8 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
                 if case .xcframework = target.kind {
                     let libraries = try self.parseXCFramework(for: target)
                     for library in libraries {
-                        if let headersPath = library.headersPath {
-                            swiftTarget.additionalFlags += ["-Xcc", "-I", "-Xcc", headersPath.pathString]
+                        library.headersPaths.forEach {
+                            swiftTarget.additionalFlags += ["-I", $0.pathString, "-Xcc", "-I", "-Xcc", $0.pathString]
                         }
                         swiftTarget.libraryBinaryPaths.insert(library.libraryPath)
                     }

--- a/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
+++ b/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
@@ -23,8 +23,8 @@ public struct LibraryInfo: Equatable {
     /// The path to the binary.
     public let libraryPath: AbsolutePath
 
-    /// The path to the headers directory, if one exists.
-    public let headersPath: AbsolutePath?
+    /// The paths to the headers directories.
+    public let headersPaths: [AbsolutePath]
 }
 
 
@@ -54,8 +54,8 @@ extension BinaryTarget {
         // Construct a LibraryInfo for the library.
         let libraryDir = self.artifactPath.appending(component: library.libraryIdentifier)
         let libraryFile = try AbsolutePath(validating: library.libraryPath, relativeTo: libraryDir)
-        let headersDir = try library.headersPath.map { try AbsolutePath(validating: $0, relativeTo: libraryDir) }
-        return [LibraryInfo(libraryPath: libraryFile, headersPath: headersDir)]
+        let headersDirs = try library.headersPath.map({ [try AbsolutePath(validating: $0, relativeTo: libraryDir)] }) ?? [] + [libraryDir]
+        return [LibraryInfo(libraryPath: libraryFile, headersPaths: headersDirs)]
     }
 
     public func parseArtifactArchives(for triple: Triple, fileSystem: FileSystem) throws -> [ExecutableInfo] {

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -4121,6 +4121,7 @@ final class BuildPlanTests: XCTestCase {
 
         let exeCompileArguments = try result.target(for: "exe").swiftTarget().compileArguments()
         XCTAssertMatch(exeCompileArguments, [.anySequence, "-F", "\(buildPath)", .anySequence])
+        XCTAssertMatch(exeCompileArguments, [.anySequence, "-I", "\(Pkg.appending(components: "Framework.xcframework", "\(platform)-\(arch)"))", .anySequence])
 
         let exeLinkArguments = try result.buildProduct(for: "exe").linkArguments()
         XCTAssertMatch(exeLinkArguments, [.anySequence, "-F", "\(buildPath)", .anySequence])


### PR DESCRIPTION
When packaging a Swift dylib as an XCFramework, its modules will be at the top-level, so that directory needs to become part of search paths.

fixes #5723
