### PR TITLE
[5.7] Revert 'Remove --gc-sections for all targets for now (#5708)'

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -1321,12 +1321,17 @@ public final class ProductBuildDescription {
                 return ["-Xlinker", "-dead_strip"]
             } else if buildParameters.triple.isWindows() {
                 return ["-Xlinker", "/OPT:REF"]
-            } else {
-                // FIXME: wasm-ld / ld.lld strips data segments referenced through __start/__stop symbols
+            } else if buildParameters.triple.arch == .wasm32 {
+                // FIXME: wasm-ld strips data segments referenced through __start/__stop symbols
                 // during GC, and it removes Swift metadata sections like swift5_protocols
                 // We should add support of SHF_GNU_RETAIN-like flag for __attribute__((retain))
                 // to LLVM and wasm-ld
+                // This workaround is required for not only WASI but also all WebAssembly archs
+                // using wasm-ld (e.g. wasm32-unknown-unknown). So this branch is conditioned by
+                // arch == .wasm32
                 return []
+            } else {
+                return ["-Xlinker", "--gc-sections"]
             }
         }
     }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -402,7 +402,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
             "/fake/path/to/swiftc", "-g", "-L", "/path/to/build/release",
             "-o", "/path/to/build/release/exe", "-module-name", "exe", "-emit-executable",
-            "-Xlinker", "-rpath=$ORIGIN",
+            "-Xlinker", "--gc-sections", "-Xlinker", "-rpath=$ORIGIN",
             "@/path/to/build/release/exe.product/Objects.LinkFileList",
             "-target", defaultTargetTriple,
         ])


### PR DESCRIPTION
Cherrypick of #5735

__Explanation:__ [lld 13 changed how `--gc-sections` works last year](https://reviews.llvm.org/D96914), which was then [flipped on by default](https://reviews.llvm.org/rG6d2d3bd0a61f5fc7fd9f61f48bc30e9ca77cc619), and causes all Swift code on ELF platforms not to link with lld 13 and 14 anymore if stripping is enabled.

__Scope:__ Only affects ELF platforms

__SR Issue:__ #5698 and apple/swift#60406

__Risk:__ low, since it only affects ELF platforms with lld, with nobody else complaining since this was merged six months ago in #4135

__Testing:__ I [just built the last August 2 source snapshot of the 5.7 toolchain for Android AArch64](https://github.com/buttaface/termux-packages/actions/runs/2886129294), where lld 14 is the default linker, with this flag enabled back then and it worked well.

__Reviewer:__ @Keith

This depends on apple/swift#60653 and apple/swift-driver#1158 getting merged first.