### PR TITLE
[PkgConfig] Avoid creating dummy dependency

### DIFF
--- a/Sources/PackageLoading/PkgConfig.swift
+++ b/Sources/PackageLoading/PkgConfig.swift
@@ -271,7 +271,7 @@ internal struct PkgConfigParser {
                         \(pcFile)
                         """)
                 }
-            } else {
+            } else if !arg.isEmpty {
                 // Otherwise it is a dependency.
                 deps.append(arg)
             }

--- a/Tests/PackageLoadingTests/PkgConfigParserTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigParserTests.swift
@@ -105,6 +105,20 @@ final class PkgConfigParserTests: XCTestCase {
         }
     }
 
+    func testDummyDependency() throws {
+        try loadPCFile("dummy_dependency.pc") { parser in
+            XCTAssertEqual(parser.variables, [
+                "prefix": "/usr/local/bin",
+                "exec_prefix": "/usr/local/bin",
+                "pcfiledir": parser.pcFile.parentDirectory.pathString,
+                "pc_sysrootdir": AbsolutePath.root.pathString
+            ])
+            XCTAssertEqual(parser.dependencies, ["pango", "fontconfig"])
+            XCTAssertEqual(parser.cFlags, [])
+            XCTAssertEqual(parser.libs, ["-L/usr/local/bin", "-lpangoft2-1.0"])
+        }
+    }
+
     /// Test custom search path get higher priority for locating pc files.
     func testCustomPcFileSearchPath() throws {
         let observability = ObservabilitySystem.makeForTesting()

--- a/Tests/PackageLoadingTests/pkgconfigInputs/dummy_dependency.pc
+++ b/Tests/PackageLoadingTests/pkgconfigInputs/dummy_dependency.pc
@@ -1,0 +1,7 @@
+prefix=/usr/local/bin
+exec_prefix=${prefix}
+
+#some comment
+
+Requires: pango, , fontconfig >=  2.13.0
+Libs:-L${prefix} -lpangoft2-1.0


### PR DESCRIPTION
Dummy dependency can be seen in some awkwardly generated `.pc` files and it can crash SwiftPM silently at least on Windows.

### Motivation:

To enhance robustness and avoid silent crashes on Windows.

### Modifications:

Ignore parsed dependency with an empty name from a `.pc` file.

### Result:

SwiftPM will not crash when parsing dependency list like `dep1, , dep2`.