### PR TITLE
Revert "Add `nuget` package provider"

### DIFF
--- a/Sources/PackageDescription/PackageDescription.swift
+++ b/Sources/PackageDescription/PackageDescription.swift
@@ -388,8 +388,6 @@ public enum SystemPackageProvider {
     /// Packages installable by the yum package manager.
     @available(_PackageDescription, introduced: 5.3)
     case yumItem([String])
-    @available(_PackageDescription, introduced: 999.0)
-    case nugetItem([String])
 
     /// Creates a system package provider with a list of installable packages
     /// for users of the HomeBrew package manager on macOS.
@@ -421,17 +419,6 @@ public enum SystemPackageProvider {
     @available(_PackageDescription, introduced: 5.3)
     public static func yum(_ packages: [String]) -> SystemPackageProvider {
         return .yumItem(packages)
-    }
-
-    /// Creates a system package provider with a list of installable packages
-    /// for users of the nuget package manager on Linux or Windows.
-    ///
-    /// - Parameter packages: The list of package names.
-    ///
-    /// - Returns: A package provider.
-    @available(_PackageDescription, introduced: 999.0)
-    public static func nuget(_ packages: [String]) -> SystemPackageProvider {
-        return .nugetItem(packages)
     }
 }
 

--- a/Sources/PackageDescription/PackageDescriptionSerialization.swift
+++ b/Sources/PackageDescription/PackageDescriptionSerialization.swift
@@ -221,7 +221,6 @@ extension SystemPackageProvider: Encodable {
         case brew
         case apt
         case yum
-        case nuget
     }
 
     /// Encodes this value into the given encoder.
@@ -244,9 +243,6 @@ extension SystemPackageProvider: Encodable {
             try container.encode(packages, forKey: .values)
         case .yumItem(let packages):
             try container.encode(Name.yum, forKey: .name)
-            try container.encode(packages, forKey: .values)
-        case .nugetItem(let packages):
-            try container.encode(Name.nuget, forKey: .name)
             try container.encode(packages, forKey: .values)
         }
     }

--- a/Sources/PackageLoading/Target+PkgConfig.swift
+++ b/Sources/PackageLoading/Target+PkgConfig.swift
@@ -126,8 +126,6 @@ extension SystemPackageProviderDescription {
             return "    apt-get install \(packages.joined(separator: " "))\n"
         case .yum(let packages):
             return "    yum install \(packages.joined(separator: " "))\n"
-        case .nuget(let packages):
-            return "    nuget install \(packages.joined(separator: " "))\n"
         }
     }
 
@@ -149,13 +147,6 @@ extension SystemPackageProviderDescription {
         case .yum:
             if case .linux(.fedora) = platform {
                 return true
-            }
-        case .nuget:
-            switch platform {
-            case .darwin, .windows, .linux:
-                return true
-            case .android:
-                return false
             }
         }
         return false
@@ -186,8 +177,6 @@ extension SystemPackageProviderDescription {
         case .apt:
             return []
         case .yum:
-            return []
-        case .nuget:
             return []
         }
     }

--- a/Sources/PackageModel/Manifest/SystemPackageProviderDescription.swift
+++ b/Sources/PackageModel/Manifest/SystemPackageProviderDescription.swift
@@ -15,12 +15,11 @@ public enum SystemPackageProviderDescription: Equatable, Codable {
     case brew([String])
     case apt([String])
     case yum([String])
-    case nuget([String])
 }
 
 extension SystemPackageProviderDescription {
     private enum CodingKeys: String, CodingKey {
-        case brew, apt, yum, nuget
+        case brew, apt, yum
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -34,9 +33,6 @@ extension SystemPackageProviderDescription {
             try unkeyedContainer.encode(a1)
         case let .yum(a1):
             var unkeyedContainer = container.nestedUnkeyedContainer(forKey: .yum)
-            try unkeyedContainer.encode(a1)
-        case let .nuget(a1):
-            var unkeyedContainer = container.nestedUnkeyedContainer(forKey: .nuget)
             try unkeyedContainer.encode(a1)
         }
     }
@@ -59,10 +55,6 @@ extension SystemPackageProviderDescription {
             var unkeyedValues = try values.nestedUnkeyedContainer(forKey: key)
             let a1 = try unkeyedValues.decode([String].self)
             self = .yum(a1)
-        case .nuget:
-            var unkeyedValues = try values.nestedUnkeyedContainer(forKey: key)
-            let a1 = try unkeyedValues.decode([String].self)
-            self = .nuget(a1)
         }
     }
 }

--- a/Sources/PackageModel/ManifestSourceGeneration.swift
+++ b/Sources/PackageModel/ManifestSourceGeneration.swift
@@ -398,9 +398,6 @@ fileprivate extension SourceCodeFragment {
         case .yum(let names):
             let params = [SourceCodeFragment(strings: names)]
             self.init(enum: "yum", subnodes: params)
-        case .nuget(let names):
-            let params = [SourceCodeFragment(strings: names)]
-            self.init(enum: "nuget", subnodes: params)
         }
     }
 

--- a/Tests/PackageLoadingTests/PkgConfigTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigTests.swift
@@ -49,8 +49,7 @@ class PkgConfigTests: XCTestCase {
                 providers: [
                     .brew(["libFoo"]),
                     .apt(["libFoo-dev"]),
-                    .yum(["libFoo-devel"]),
-                    .nuget(["Foo"]),
+                    .yum(["libFoo-devel"])
                 ]
             )
             for result in pkgConfigArgs(for: target, fileSystem: fs, observabilityScope: observability.topScope) {
@@ -64,8 +63,6 @@ class PkgConfigTests: XCTestCase {
                     XCTAssertEqual(names, ["libFoo-dev"])
                 case .yum(let names)?:
                     XCTAssertEqual(names, ["libFoo-devel"])
-                case .nuget(let names)?:
-                    XCTAssertEqual(names, ["Foo"])
                 case nil:
                     XCTFail("Expected a provider here")
                 }


### PR DESCRIPTION
Reverts apple/swift-package-manager#5486

NuGet is being excessively used to support C# and .NET on multiple platforms, but SwiftPM can hardly consume its package in practice. NuGet works in a totally different way from the other package managers we supported before.

- NuGet cannot install packages globally, when you run `nuget install` you're actually downloading the packages into current working directory. The behavior diverges with the SwiftPM warning.
- NuGet packages contain only runtime resources, not development libraries. There's no header files and import libraries that SwiftPM can make use of. Supporting NuGet is non-sense.

Additionally, even if NuGet supports "native packages", these packages are not always vendored by trustable sources and only makes up a small set of the packages. Microsoft has already introduced Vcpkg to handle C/C++ libraries, and its products are directly usable for SwiftPM. Although @neonichu suggested that such support had better be implemented by a plugin, it seems impossible for now because binary and headers cannot be consumed.

I'm going to close apple/swift-package-manager#4369 as not planned too.

@compnerd If your purpose is to pass the test suite on Windows, I would suggest adding a dummy manager for all platforms, instead of any exact one.