### PR TITLE
[5.7] Migrate to python3

### DIFF
--- a/Utilities/Docker/Dockerfile
+++ b/Utilities/Docker/Dockerfile
@@ -40,6 +40,6 @@ RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/nul
 RUN apt-add-repository "deb https://apt.kitware.com/ubuntu/ $ubuntu_version main"
 
 RUN apt-get install -y \
-  python \
+  python3 \
   cmake \
   ninja-build

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # encoding: utf-8
 
 """

--- a/Utilities/helpers.py
+++ b/Utilities/helpers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##===----------------------------------------------------------------------===##
 ##
 ## This source file is part of the Swift open source project

--- a/Utilities/soundness.sh
+++ b/Utilities/soundness.sh
@@ -86,7 +86,7 @@ EOF
         exceptions=( -path "./Examples/*" -o -path "./Fixtures/*" -o -path "./IntegrationTests/*" )
         matching_files=( -name '*.py' )
         cat > "$tmp" <<"EOF"
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##===----------------------------------------------------------------------===##
 ##
 ## This source file is part of the Swift open source project

--- a/Utilities/test-toolchain
+++ b/Utilities/test-toolchain
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ##===----------------------------------------------------------------------===##
 ##
 ## This source file is part of the Swift open source project


### PR DESCRIPTION
release/5.7 swift project moved to python3, moving swiftpm build tools to
python3 to match.

(cherry picked from commit c0d5daa8fb43d87a6043a79c3cd132987eb40623)


To support Ubuntu 22.04 for Swift 5.7, we need to cherry-pick changes to support Python3. 