### PR TITLE
Improve warning for deprecated collections config

### DIFF
--- a/Sources/Commands/SwiftPackageCollectionsTool.swift
+++ b/Sources/Commands/SwiftPackageCollectionsTool.swift
@@ -384,6 +384,7 @@ private extension JSONEncoder {
 
 private extension ParsableCommand {
     func with<T>(_ swiftTool: SwiftTool, handler: (_ collections: PackageCollectionsProtocol) throws -> T) throws -> T {
+        _ = try? swiftTool.getActiveWorkspace(emitDeprecatedConfigurationWarning: true)
         let collections = PackageCollections(
             configuration: .init(
                 configurationDirectory: swiftTool.sharedConfigurationDirectory,

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -486,7 +486,7 @@ public class SwiftTool {
     }
 
     /// Returns the currently active workspace.
-    func getActiveWorkspace() throws -> Workspace {
+    func getActiveWorkspace(emitDeprecatedConfigurationWarning: Bool = false) throws -> Workspace {
         if let workspace = _workspace {
             return workspace
         }
@@ -506,7 +506,8 @@ public class SwiftTool {
                 localConfigurationDirectory: try self.getLocalConfigurationDirectory(),
                 sharedConfigurationDirectory: self.sharedConfigurationDirectory,
                 sharedSecurityDirectory: self.sharedSecurityDirectory,
-                sharedCacheDirectory: self.sharedCacheDirectory
+                sharedCacheDirectory: self.sharedCacheDirectory,
+                emitDeprecatedConfigurationWarning: emitDeprecatedConfigurationWarning
             ),
             authorizationProvider: self.getAuthorizationProvider(),
             configuration: .init(

--- a/Sources/Workspace/Workspace+Configuration.swift
+++ b/Sources/Workspace/Workspace+Configuration.swift
@@ -59,6 +59,9 @@ extension Workspace {
         /// Path to the shared cache directory
         public var sharedCacheDirectory: AbsolutePath?
 
+        /// Whether or not to emit a warning about the existence of deprecated configuration files
+        public var emitDeprecatedConfigurationWarning: Bool
+
         // working directories
 
         /// Path to the repositories clones.
@@ -154,6 +157,7 @@ extension Workspace {
             self.sharedConfigurationDirectory = sharedConfigurationDirectory
             self.sharedSecurityDirectory = sharedSecurityDirectory
             self.sharedCacheDirectory = sharedCacheDirectory
+            self.emitDeprecatedConfigurationWarning = true
         }
 
         /// Create a new workspace location.
@@ -172,7 +176,8 @@ extension Workspace {
             localConfigurationDirectory: AbsolutePath,
             sharedConfigurationDirectory: AbsolutePath?,
             sharedSecurityDirectory: AbsolutePath?,
-            sharedCacheDirectory: AbsolutePath?
+            sharedCacheDirectory: AbsolutePath?,
+            emitDeprecatedConfigurationWarning: Bool = true
         ) {
             self.scratchDirectory = scratchDirectory
             self.editsDirectory = editsDirectory
@@ -181,6 +186,7 @@ extension Workspace {
             self.sharedConfigurationDirectory = sharedConfigurationDirectory
             self.sharedSecurityDirectory = sharedSecurityDirectory
             self.sharedCacheDirectory = sharedCacheDirectory
+            self.emitDeprecatedConfigurationWarning = emitDeprecatedConfigurationWarning
         }
 
         /// Create a new workspace location.

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -3669,7 +3669,7 @@ extension Workspace.Location {
         if let sharedConfigurationDirectory = self.sharedConfigurationDirectory {
             // It may not always be possible to create default location (for example de to restricted sandbox),
             // in which case defaultDirectory would be nil.
-            let defaultDirectory = try? fileSystem.getOrCreateSwiftPMConfigurationDirectory(warningHandler: warningHandler)
+            let defaultDirectory = try? fileSystem.getOrCreateSwiftPMConfigurationDirectory(warningHandler: self.emitDeprecatedConfigurationWarning ? warningHandler : { _ in })
             if defaultDirectory != nil, sharedConfigurationDirectory != defaultDirectory {
                 // custom location _must_ be writable, throw if we cannot access it
                 guard fileSystem.isWritable(sharedConfigurationDirectory) else {


### PR DESCRIPTION
- Do not emit the warning for `swift build`, `swift test` etc, since these commands by definition to not work with package collections
- Do emit the warning for `swift package-collections` by request an active workspace
