### PR TITLE
Transition away from deprecated protocol requirement in llbuild's Tool

### DIFF
--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -205,7 +205,12 @@ private final class InProcessTool: Tool {
         self.type = type
     }
 
+    @available(*, deprecated, message: "Use the overload that returns an Optional")
     func createCommand(_ name: String) -> ExternalCommand {
+        return type.init(self.context)
+    }
+
+    func createCommand(_ name: String) -> ExternalCommand? {
         return type.init(self.context)
     }
 }


### PR DESCRIPTION
createCommand now returns an Optional, since command creation may fail.

rdar://99298420