### PR TITLE
Allow bootstrap to work when building a toolchain on Apple Silicon

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -213,7 +213,7 @@ def parse_build_args(args):
     args.cmake_path = get_cmake_path(args)
     args.ninja_path = get_ninja_path(args)
     if args.cross_compile_hosts:
-        if "macosx-arm64" in args.cross_compile_hosts:
+        if re.match("macosx-", args.cross_compile_hosts):
             # Use XCBuild target directory when building for multiple arches.
             args.target_dir = os.path.join(args.build_dir, "apple/Products")
         elif re.match('android-', args.cross_compile_hosts):


### PR DESCRIPTION
Allow bootstrap to work when building a toolchain on Apple Silicon

### Motivation:

We are ironing out the current issues we are having when building a toolchain on Apple Silicon, and currently we are hitting the following exception when bootstrap starts (rdar://99040114)

```
Traceback (most recent call last):
  File "/Volumes/Storage/swift_public/swift-arm64/swiftpm/Utilities/bootstrap", line 825, in <module>
    main()
  File "/Volumes/Storage/swift_public/swift-arm64/swiftpm/Utilities/bootstrap", line 65, in main
    args.func(args)
  File "/Volumes/Storage/swift_public/swift-arm64/swiftpm/Utilities/bootstrap", line 329, in build
    parse_build_args(args)
  File "/Volumes/Storage/swift_public/swift-arm64/swiftpm/Utilities/bootstrap", line 225, in parse_build_args
    args.bootstrap_dir = os.path.join(args.target_dir, "bootstrap")
AttributeError: 'Namespace' object has no attribute 'target_dir'
```

### Modifications:

Generalization of a check in bootstrap

### Result:

We should be able to start the CMake builds for swiftpm
