### PR TITLE
bootstrap: generalize check for cross-compilation on Darwin

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -815,7 +815,7 @@ def get_swiftpm_flags(args):
 
     build_target = get_build_target(args)
     cross_compile_hosts = args.cross_compile_hosts
-    if build_target == 'x86_64-apple-macosx' and "macosx-arm64" in cross_compile_hosts:
+    if cross_compile_hosts and re.match('macosx-', cross_compile_hosts):
         build_flags += ["--arch", "x86_64", "--arch", "arm64"]
     elif cross_compile_hosts and re.match('android-', cross_compile_hosts):
         build_flags.extend(["--destination", args.cross_compile_config])

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -815,12 +815,13 @@ def get_swiftpm_flags(args):
 
     build_target = get_build_target(args)
     cross_compile_hosts = args.cross_compile_hosts
-    if cross_compile_hosts and re.match('macosx-', cross_compile_hosts):
-        build_flags += ["--arch", "x86_64", "--arch", "arm64"]
-    elif cross_compile_hosts and re.match('android-', cross_compile_hosts):
-        build_flags.extend(["--destination", args.cross_compile_config])
-    elif cross_compile_hosts:
-        error("cannot cross-compile for %s" % cross_compile_hosts)
+    if cross_compile_hosts:
+        if re.search('-apple-macosx', build_target) and re.match('macosx-', cross_compile_hosts):
+            build_flags += ["--arch", "x86_64", "--arch", "arm64"]
+        elif re.match('android-', cross_compile_hosts):
+            build_flags.extend(["--destination", args.cross_compile_config])
+        else:
+            error("cannot cross-compile for %s" % cross_compile_hosts)
 
     # Ensure we are not sharing the module cache with concurrent builds in CI
     local_module_cache_path=os.path.join(args.build_dir, "module-cache")


### PR DESCRIPTION
...so that the build with swiftpm can start.

This will allow to build a Swift toolchain on Apple Silicon

Addresses rdar://99484030

### Motivation:

We are ironing out the current issues we are having when building a toolchain on Apple Silicon, and after #5754 we are now hitting

```
--- bootstrap: note: Building SwiftPM (with a freshly built swift-build)
--- bootstrap: error: cannot cross-compile for macosx-x86_64 
```

### Modifications:

Amend a check so not to assume any particular architecture when assessing if we are cross compiling on Darwin.

### Result:

We should be able to build swiftpm as part of a Swift toolchain on Apple Silicon
