### PR TITLE
Lift manifest name restrictions on `swift package edit`

### DIFF
--- a/Sources/SPMTestSupport/MockManifestLoader.swift
+++ b/Sources/SPMTestSupport/MockManifestLoader.swift
@@ -63,11 +63,16 @@ public final class MockManifestLoader: ManifestLoaderProtocol {
         completion: @escaping (Result<Manifest, Error>) -> Void
     ) {
         callbackQueue.async {
-            let key = Key(url: packageLocation, version: packageVersion?.version)
-            if let result = self.manifests[key] {
+            let manifestKey = Key(url: packageLocation, version: packageVersion?.version)
+            let possiblyEditedManifestKey = Key(url: manifestPath.parentDirectory.pathString, version: nil)
+
+            if possiblyEditedManifestKey != manifestKey && packageVersion == nil,
+                let result = self.manifests[possiblyEditedManifestKey] {
+                return completion(.success(result))
+            } else if let result = self.manifests[manifestKey] {
                 return completion(.success(result))
             } else {
-                return completion(.failure(MockManifestLoaderError.unknownRequest("\(key)")))
+                return completion(.failure(MockManifestLoaderError.unknownRequest("\(manifestKey)")))
             }
         }
     }

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1378,8 +1378,8 @@ extension Workspace {
                                   completion: $0)
             }
 
-            guard manifest.displayName == packageName else {
-                return observabilityScope.emit(error: "package at '\(destination)' is \(manifest.displayName) but was expecting \(packageName)")
+            if manifest.displayName.lowercased() != packageName.lowercased() {
+                observabilityScope.emit(warning: "package at '\(destination)' is \(manifest.displayName) but was expecting \(packageName)")
             }
 
             // Emit warnings for branch and revision, if they're present.


### PR DESCRIPTION
Lift package manifest name restrictions on `swift package edit`, since it's already replaced with package identity.

### Motivation:

Package manifest name no longer has actual usage, and it is replaced by a case-insensitive package identity. There's no reason to forbid users from editing a package with a different manifest name than expected identity.

### Modifications:

- Switch to case-insensitive comparison between manifest name and package identity;
- Emit a warning instead of an error if these two don't match.

### Result:

`swift package edit` will get far fewer restrictions, making it more usable.
