### PR TITLE
fix regression where swift test list --skip-build is ignored

### DIFF
--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -265,4 +265,52 @@ final class TestToolTests: CommandsTestCase {
                 """)
         }
     }
+
+    func testList() throws {
+        try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
+            let (stdout, stderr) = try SwiftPMProduct.SwiftTest.execute(["list"], packagePath: fixturePath)
+            // build was run
+            XCTAssertMatch(stderr, .contains("Build complete!"))
+            // getting the lists
+            XCTAssertMatch(stdout, .contains("SimpleTests.SimpleTests/testExample1"))
+            XCTAssertMatch(stdout, .contains("SimpleTests.SimpleTests/test_Example2"))
+            XCTAssertMatch(stdout, .contains("SimpleTests.SimpleTests/testThrowing"))
+        }
+
+        try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
+            // build first
+            do {
+                let (stdout, _) = try SwiftPMProduct.SwiftBuild.execute(["--build-tests"], packagePath: fixturePath)
+                XCTAssertMatch(stdout, .contains("Build complete!"))
+            }
+            // list
+            do {
+                let (stdout, stderr) = try SwiftPMProduct.SwiftTest.execute(["list"], packagePath: fixturePath)
+                // build was run
+                XCTAssertMatch(stderr, .contains("Build complete!"))
+                // getting the lists
+                XCTAssertMatch(stdout, .contains("SimpleTests.SimpleTests/testExample1"))
+                XCTAssertMatch(stdout, .contains("SimpleTests.SimpleTests/test_Example2"))
+                XCTAssertMatch(stdout, .contains("SimpleTests.SimpleTests/testThrowing"))
+            }
+        }
+
+        try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
+            // build first
+            do {
+                let (stdout, _) = try SwiftPMProduct.SwiftBuild.execute(["--build-tests"], packagePath: fixturePath)
+                XCTAssertMatch(stdout, .contains("Build complete!"))
+            }
+            // list while skipping build
+            do {
+                let (stdout, stderr) = try SwiftPMProduct.SwiftTest.execute(["list", "--skip-build"], packagePath: fixturePath)
+                // build was not run
+                XCTAssertNoMatch(stderr, .contains("Build complete!"))
+                // getting the lists
+                XCTAssertMatch(stdout, .contains("SimpleTests.SimpleTests/testExample1"))
+                XCTAssertMatch(stdout, .contains("SimpleTests.SimpleTests/test_Example2"))
+                XCTAssertMatch(stdout, .contains("SimpleTests.SimpleTests/testThrowing"))
+            }
+        }
+    }
 }


### PR DESCRIPTION
motivation: listing tests should not require rebuilding

changes:
* update argument parser usage to avoid hiding flag by "super" command
* add argument to list command to skip builds (dropped by mistake)
* add tests
