### PR TITLE
improve validation for binary artifacts

### DIFF
--- a/Sources/Workspace/Diagnostics.swift
+++ b/Sources/Workspace/Diagnostics.swift
@@ -148,16 +148,16 @@ extension Basics.Diagnostic {
         .error("failed extracting '\(artifactPath)' which is required by binary target '\(targetName)': \(reason)")
     }
 
-    static func artifactNotFound(targetName: String, expectedArtifactName: String) -> Self {
-        .error("downloaded archive of binary target '\(targetName)' does not contain expected binary artifact named '\(expectedArtifactName)'")
+    static func artifactDirectoryNotFound(targetName: String, expectedDirectoryName: String) -> Self {
+        .error("downloaded archive of binary target '\(targetName)' does not contain expected binary artifact directory named '\(expectedDirectoryName)'")
     }
 
-    static func localArchivedArtifactNotFound(targetName: String, expectedArtifactName: String) -> Self {
-        .error("local archive of binary target '\(targetName)' does not contain expected binary artifact named '\(expectedArtifactName)'")
+    static func localArchivedArtifactDirectoryNotFound(targetName: String, expectedDirectoryName: String) -> Self {
+        .error("local archive of binary target '\(targetName)' does not contain expected binary artifact directory named '\(expectedDirectoryName)'")
     }
 
-    static func localArtifactNotFound(targetName: String, expectedArtifactName: String) -> Self {
-        .error("local binary target '\(targetName)' does not contain expected binary artifact named '\(expectedArtifactName)'")
+    static func localArtifactDirectoryNotFound(targetName: String, expectedDirectoryName: String) -> Self {
+        .error("local binary target '\(targetName)' does not contain expected binary artifact directory named '\(expectedDirectoryName)'")
     }
 }
 

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -2215,8 +2215,8 @@ extension Workspace {
 
                 artifactsToExtract.append(artifact)
             } else {
-                guard artifact.isMatchingDirectory(artifact.path) else {
-                    observabilityScope.emit(.localArtifactNotFound(targetName: artifact.targetName, expectedArtifactName: artifact.targetName))
+                guard self.fileSystem.isArtifactDirectory(artifact: artifact, path: artifact.path) else {
+                    observabilityScope.emit(.localArtifactDirectoryNotFound(targetName: artifact.targetName, expectedDirectoryName: artifact.targetName))
                     continue
                 }
                 artifactsToAdd.append(artifact)


### PR DESCRIPTION
motivation: improve the diagnostics when binary artifacts do not follow the naming / directory strucuture convention

changes:
* validate that the path is actually a directory (as expected by downstream code)
* improve diagnostics language
* add tests
