### PR TITLE
Add `@preconcurrency` to imports where suggested

### DIFF
--- a/Examples/package-info/Sources/package-info/example.swift
+++ b/Examples/package-info/Sources/package-info/example.swift
@@ -1,5 +1,10 @@
+#if swift(>=5.7)
+@preconcurrency import Basics
+@preconcurrency import TSCBasic
+#else
 import Basics
 import TSCBasic
+#endif
 import Workspace
 
 @main

--- a/Sources/Basics/TemporaryFile.swift
+++ b/Sources/Basics/TemporaryFile.swift
@@ -12,7 +12,11 @@
 
 import _Concurrency
 import Foundation
+#if swift(>=5.7)
+@preconcurrency import TSCBasic
+#else
 import TSCBasic
+#endif
 
 /// Creates a temporary directory and evaluates a closure with the directory path as an argument.
 /// The temporary directory will live on disk while the closure is evaluated and will be deleted when

--- a/Tests/BasicsTests/TemporaryFileTests.swift
+++ b/Tests/BasicsTests/TemporaryFileTests.swift
@@ -9,8 +9,11 @@
  */
 
 import XCTest
-
+#if swift(>=5.7)
+@preconcurrency import TSCBasic
+#else
 import TSCBasic
+#endif
 
 import Basics
 


### PR DESCRIPTION
A few warnings remain and from what I can see they aren't really addressable? We're using a bunch of types in async code that inherently can't be sendable.

rdar://100038401
