### PR TITLE
refactor handling of binary artifacts such that they do not depend on naming conventions

### DIFF
--- a/Sources/PackageModel/Target.swift
+++ b/Sources/PackageModel/Target.swift
@@ -631,13 +631,6 @@ public final class BinaryTarget: Target {
                 return "unknown"
             }
         }
-
-        public static func forFileExtension(_ fileExtension: String) throws -> Kind {
-            guard let kind = Kind.allCases.first(where: { $0.fileExtension == fileExtension }) else {
-                throw StringError("unknown binary artifact file extension '\(fileExtension)'")
-            }
-            return kind
-        }
     }
 
     public enum Origin: Equatable, Codable {

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -667,7 +667,7 @@ public final class MockWorkspace {
             line: UInt = #line
         ) {
             guard let artifact = managedArtifacts[packageIdentity: packageIdentity, targetName: targetName] else {
-                XCTFail("\(packageIdentity).\(targetName) does not exists", file: file, line: line)
+                XCTFail("managed artifact '\(packageIdentity).\(targetName)' does not exists", file: file, line: line)
                 return
             }
             XCTAssertEqual(artifact.path, path, file: file, line: line)

--- a/Sources/Workspace/Diagnostics.swift
+++ b/Sources/Workspace/Diagnostics.swift
@@ -140,7 +140,7 @@ extension Basics.Diagnostic {
         .error("failed validating archive from '\(artifactURL.absoluteString)' which is required by binary target '\(targetName)': \(reason)")
     }
 
-    static func artifactFailedExtraction(artifactURL: URL, targetName: String, reason: String) -> Self {
+    static func remoteArtifactFailedExtraction(artifactURL: URL, targetName: String, reason: String) -> Self {
         .error("failed extracting '\(artifactURL.absoluteString)' which is required by binary target '\(targetName)': \(reason)")
     }
 
@@ -148,16 +148,16 @@ extension Basics.Diagnostic {
         .error("failed extracting '\(artifactPath)' which is required by binary target '\(targetName)': \(reason)")
     }
 
-    static func artifactDirectoryNotFound(targetName: String, expectedDirectoryName: String) -> Self {
-        .error("downloaded archive of binary target '\(targetName)' does not contain expected binary artifact directory named '\(expectedDirectoryName)'")
+    static func remoteArtifactNotFound(artifactURL: URL, targetName: String) -> Self {
+        .error("downloaded archive of binary target '\(targetName)' from '\(artifactURL.absoluteString)' does not contain a binary artifact.")
     }
 
-    static func localArchivedArtifactDirectoryNotFound(targetName: String, expectedDirectoryName: String) -> Self {
-        .error("local archive of binary target '\(targetName)' does not contain expected binary artifact directory named '\(expectedDirectoryName)'")
+    static func localArchivedArtifactNotFound(archivePath: AbsolutePath, targetName: String) -> Self {
+        .error("local archive of binary target '\(targetName)' at '\(archivePath)' does not contain a binary artifact.")
     }
 
-    static func localArtifactDirectoryNotFound(targetName: String, expectedDirectoryName: String) -> Self {
-        .error("local binary target '\(targetName)' does not contain expected binary artifact directory named '\(expectedDirectoryName)'")
+    static func localArtifactNotFound(artifactPath: AbsolutePath, targetName: String) -> Self {
+        .error("local binary target '\(targetName)' at '\(artifactPath)' does not contain a binary artifact.")
     }
 }
 

--- a/Sources/Workspace/ManagedArtifact.swift
+++ b/Sources/Workspace/ManagedArtifact.swift
@@ -30,16 +30,20 @@ extension Workspace {
         /// The path of the artifact on disk
         public let path: AbsolutePath
 
+        public let kind: BinaryTarget.Kind
+
         public init(
             packageRef: PackageReference,
             targetName: String,
             source: Source,
-            path: AbsolutePath
+            path: AbsolutePath,
+            kind: BinaryTarget.Kind
         ) {
             self.packageRef = packageRef
             self.targetName = targetName
             self.source = source
             self.path = path
+            self.kind = kind
         }
 
         /// Create an artifact downloaded from a remote url.
@@ -48,13 +52,15 @@ extension Workspace {
             targetName: String,
             url: String,
             checksum: String,
-            path: AbsolutePath
+            path: AbsolutePath,
+            kind: BinaryTarget.Kind
         ) -> ManagedArtifact {
             return ManagedArtifact(
                 packageRef: packageRef,
                 targetName: targetName,
                 source: .remote(url: url, checksum: checksum),
-                path: path
+                path: path,
+                kind: kind
             )
         }
 
@@ -63,13 +69,15 @@ extension Workspace {
             packageRef: PackageReference,
             targetName: String,
             path: AbsolutePath,
+            kind: BinaryTarget.Kind,
             checksum: String? = nil
         ) -> ManagedArtifact {
             return ManagedArtifact(
                 packageRef: packageRef,
                 targetName: targetName,
                 source: .local(checksum: checksum),
-                path: path
+                path: path,
+                kind: kind
             )
         }
 

--- a/Sources/Workspace/Workspace+State.swift
+++ b/Sources/Workspace/Workspace+State.swift
@@ -114,6 +114,11 @@ fileprivate struct WorkspaceStateStorage {
                 let dependencies = try v5.object.dependencies.map{ try Workspace.ManagedDependency($0) }
                 let artifacts = try v5.object.artifacts.map{ try Workspace.ManagedArtifact($0) }
                 return try (dependencies: .init(dependencies), artifacts: .init(artifacts))
+            case 6:
+                let v6 = try self.decoder.decode(path: self.path, fileSystem: self.fileSystem, as: V6.self)
+                let dependencies = try v6.object.dependencies.map{ try Workspace.ManagedDependency($0) }
+                let artifacts = try v6.object.artifacts.map{ try Workspace.ManagedArtifact($0) }
+                return try (dependencies: .init(dependencies), artifacts: .init(artifacts))
             default:
                 throw StringError("unknown 'WorkspaceStateStorage' version '\(version.version)' at '\(self.path)'")
             }
@@ -126,7 +131,7 @@ fileprivate struct WorkspaceStateStorage {
         }
 
         try self.fileSystem.withLock(on: self.path, type: .exclusive) {
-            let storage = V5(dependencies: dependencies, artifacts: artifacts)
+            let storage = V6(dependencies: dependencies, artifacts: artifacts)
 
             let data = try self.encoder.encode(storage)
             try self.fileSystem.writeFileContents(self.path, data: data)
@@ -154,7 +159,356 @@ extension WorkspaceStateStorage {
     }
 }
 
-// MARK: - V5 format
+// MARK: - V6 format
+
+extension WorkspaceStateStorage {
+    // v6 storage format
+    struct V6: Codable {
+        let version: Int
+        let object: Container
+
+        init (dependencies: Workspace.ManagedDependencies, artifacts: Workspace.ManagedArtifacts) {
+            self.version = 6
+            self.object = .init(
+                dependencies: dependencies.map { .init($0) }.sorted { $0.packageRef.identity < $1.packageRef.identity },
+                artifacts: artifacts.map { .init($0) }.sorted { $0.packageRef.identity < $1.packageRef.identity }
+            )
+        }
+
+        struct Container: Codable {
+            var dependencies: [Dependency]
+            var artifacts: [Artifact]
+        }
+
+        struct Dependency: Codable {
+            let packageRef: PackageReference
+            let state: State
+            let subpath: String
+
+            init(packageRef: PackageReference, state: State, subpath: String) {
+                self.packageRef = packageRef
+                self.state = state
+                self.subpath = subpath
+            }
+
+            init(_ dependency: Workspace.ManagedDependency) {
+                self.packageRef = .init(dependency.packageRef)
+                self.state = .init(underlying: dependency.state)
+                self.subpath = dependency.subpath.pathString
+            }
+
+            init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                let packageRef = try container.decode(PackageReference.self, forKey: .packageRef)
+                let subpath = try container.decode(String.self, forKey: .subpath)
+                let basedOn = try container.decode(Dependency?.self, forKey: .basedOn)
+                let state = try State.decode(
+                    container: container.nestedContainer(keyedBy: State.CodingKeys.self, forKey: .state),
+                    basedOn: basedOn
+                )
+
+                self.init(
+                    packageRef: packageRef,
+                    state: state,
+                    subpath: subpath
+                )
+            }
+
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encode(self.packageRef, forKey: .packageRef)
+                try container.encode(self.state, forKey: .state)
+                try container.encode(self.subpath, forKey: .subpath)
+                var basedOn: Dependency? = .none
+                if case .edited(let _basedOn, _) = self.state.underlying {
+                    basedOn = _basedOn.map { .init($0) }
+                }
+                try container.encode(basedOn, forKey: .basedOn)
+            }
+
+            enum CodingKeys: CodingKey {
+                case packageRef
+                case state
+                case subpath
+                case basedOn
+            }
+
+            struct State: Encodable {
+                let underlying: Workspace.ManagedDependency.State
+
+                init(underlying: Workspace.ManagedDependency.State) {
+                    self.underlying = underlying
+                }
+
+                static func decode(container: KeyedDecodingContainer<Self.CodingKeys>, basedOn: Dependency?) throws -> State {
+                    let kind = try container.decode(String.self, forKey: .name)
+                    switch kind {
+                    case "local", "fileSystem":
+                        let path = try container.decode(AbsolutePath.self, forKey: .path)
+                        return self.init(underlying: .fileSystem(path))
+                    case "checkout", "sourceControlCheckout":
+                        let checkout = try container.decode(CheckoutInfo.self, forKey: .checkoutState)
+                        return try self.init(underlying: .sourceControlCheckout(.init(checkout)))
+                    case "registryDownload":
+                        let version = try container.decode(String.self, forKey: .version)
+                        return try self.init(underlying: .registryDownload(version: TSCUtility.Version(versionString: version)))
+                    case "edited":
+                        let path = try container.decode(AbsolutePath?.self, forKey: .path)
+                        return try self.init(underlying: .edited(basedOn: basedOn.map { try .init($0) }, unmanagedPath: path))
+                    case "custom":
+                        let version = try container.decode(String.self, forKey: .version)
+                        let path = try container.decode(AbsolutePath.self, forKey: .path)
+                        return try self.init(underlying: .custom(version: TSCUtility.Version(versionString: version), path: path))
+                    default:
+                        throw StringError("unknown dependency state \(kind)")
+                    }
+                }
+
+                func encode(to encoder: Encoder) throws {
+                    var container = encoder.container(keyedBy: CodingKeys.self)
+                    switch self.underlying {
+                    case .fileSystem(let path):
+                        try container.encode("fileSystem", forKey: .name)
+                        try container.encode(path, forKey: .path)
+                    case .sourceControlCheckout(let state):
+                        try container.encode("sourceControlCheckout", forKey: .name)
+                        try container.encode(CheckoutInfo(state), forKey: .checkoutState)
+                    case .registryDownload(let version):
+                        try container.encode("registryDownload", forKey: .name)
+                        try container.encode(version, forKey: .version)
+                    case .edited(_, let path):
+                        try container.encode("edited", forKey: .name)
+                        try container.encode(path, forKey: .path)
+                    case .custom(let version, let path):
+                        try container.encode("custom", forKey: .name)
+                        try container.encode(version, forKey: .version)
+                        try container.encode(path, forKey: .path)
+                    }
+                }
+
+                enum CodingKeys: CodingKey {
+                    case name
+                    case path
+                    case version
+                    case checkoutState
+                }
+
+                struct CheckoutInfo: Codable {
+                    let revision: String
+                    let branch: String?
+                    let version: String?
+
+                    init(_ state: CheckoutState) {
+                        switch state {
+                        case .version(let version, let revision):
+                            self.version = version.description
+                            self.branch = nil
+                            self.revision = revision.identifier
+                        case .branch(let branch, let revision):
+                            self.version = nil
+                            self.branch = branch
+                            self.revision = revision.identifier
+                        case .revision(let revision):
+                            self.version = nil
+                            self.branch = nil
+                            self.revision = revision.identifier
+                        }
+                    }
+                }
+            }
+        }
+
+        struct Artifact: Codable {
+            let packageRef: PackageReference
+            let targetName: String
+            let source: Source
+            let path: String
+            let kind: Kind
+
+            init(_ artifact: Workspace.ManagedArtifact) {
+                self.packageRef = .init(artifact.packageRef)
+                self.targetName = artifact.targetName
+                self.source = .init(underlying: artifact.source)
+                self.path = artifact.path.pathString
+                self.kind = .init(artifact.kind)
+            }
+
+            struct Source: Codable {
+                let underlying: Workspace.ManagedArtifact.Source
+
+                init(underlying: Workspace.ManagedArtifact.Source) {
+                    self.underlying = underlying
+                }
+
+                init(from decoder: Decoder) throws {
+                    let container = try decoder.container(keyedBy: CodingKeys.self)
+                    let kind = try container.decode(String.self, forKey: .type)
+                    switch kind {
+                    case "local":
+                        let checksum = try container.decodeIfPresent(String.self, forKey: .checksum)
+                        self.init(underlying: .local(checksum: checksum))
+                    case "remote":
+                        let url = try container.decode(String.self, forKey: .url)
+                        let checksum = try container.decode(String.self, forKey: .checksum)
+                        self.init(underlying: .remote(url: url, checksum: checksum))
+                    default:
+                        throw StringError("unknown artifact source \(kind)")
+                    }
+                }
+
+                func encode(to encoder: Encoder) throws {
+                    var container = encoder.container(keyedBy: CodingKeys.self)
+                    switch self.underlying {
+                    case .local(let checksum):
+                        try container.encode("local", forKey: .type)
+                        try container.encodeIfPresent(checksum, forKey: .checksum)
+                    case .remote(let url, let checksum):
+                        try container.encode("remote", forKey: .type)
+                        try container.encode(url, forKey: .url)
+                        try container.encode(checksum, forKey: .checksum)
+                    }
+                }
+
+                enum CodingKeys: CodingKey {
+                    case type
+                    case url
+                    case checksum
+                }
+            }
+
+            enum Kind: String, Codable {
+                case xcframework
+                case artifactsArchive
+                case unknown
+
+                init(_ underlying: BinaryTarget.Kind) {
+                    switch underlying {
+                    case .xcframework:
+                        self = .xcframework
+                    case .artifactsArchive:
+                        self = .artifactsArchive
+                    case .unknown:
+                        self = .unknown
+                    }
+                }
+
+                var underlying: BinaryTarget.Kind {
+                    switch self {
+                    case .xcframework:
+                        return .xcframework
+                    case .artifactsArchive:
+                        return .artifactsArchive
+                    case .unknown:
+                        return .unknown
+                    }
+                }
+            }
+        }
+
+        struct PackageReference: Codable {
+            let identity: String
+            let kind: Kind
+            let location: String
+            let name: String
+
+            init (_ reference: PackageModel.PackageReference) {
+                self.identity = reference.identity.description
+                switch reference.kind {
+                case .root(let path):
+                    self.kind = .root
+                    self.location = path.pathString
+                case .fileSystem(let path):
+                    self.kind = .fileSystem
+                    self.location = path.pathString
+                case .localSourceControl(let path):
+                    self.kind = .localSourceControl
+                    self.location = path.pathString
+                case .remoteSourceControl(let url):
+                    self.kind = .remoteSourceControl
+                    self.location = url.absoluteString
+                case .registry:
+                    self.kind = .registry
+                    // FIXME: placeholder
+                    self.location = self.identity.description
+                }
+                self.name = reference.deprecatedName
+            }
+
+            enum Kind: String, Codable {
+                case root
+                case fileSystem
+                case localSourceControl
+                case remoteSourceControl
+                case registry
+            }
+        }
+    }
+}
+
+extension Workspace.ManagedDependency {
+    fileprivate init(_ dependency: WorkspaceStateStorage.V6.Dependency) throws {
+        try self.init(
+            packageRef: .init(dependency.packageRef),
+            state: dependency.state.underlying,
+            subpath: RelativePath(dependency.subpath)
+        )
+    }
+}
+
+extension Workspace.ManagedArtifact {
+    fileprivate init(_ artifact: WorkspaceStateStorage.V6.Artifact) throws {
+        try self.init(
+            packageRef: .init(artifact.packageRef),
+            targetName: artifact.targetName,
+            source: artifact.source.underlying,
+            path: AbsolutePath(artifact.path),
+            kind: artifact.kind.underlying
+        )
+    }
+}
+
+extension PackageModel.PackageReference {
+    fileprivate init(_ reference: WorkspaceStateStorage.V6.PackageReference) throws {
+        let identity = PackageIdentity.plain(reference.identity)
+        let kind: PackageModel.PackageReference.Kind
+        switch reference.kind {
+        case .root:
+            kind = try .root(.init(validating: reference.location))
+        case .fileSystem:
+            kind = try .fileSystem(.init(validating: reference.location))
+        case .localSourceControl:
+            kind = try .localSourceControl(.init(validating: reference.location))
+        case .remoteSourceControl:
+            guard let url = URL(string: reference.location) else {
+                throw StringError("invalid url \(reference.location)")
+            }
+            kind = .remoteSourceControl(url)
+        case .registry:
+            kind = .registry(identity)
+        }
+
+        self.init(
+            identity: identity,
+            kind: kind,
+            name: reference.name
+        )
+    }
+}
+
+extension CheckoutState {
+    fileprivate init(_ state: WorkspaceStateStorage.V6.Dependency.State.CheckoutInfo) throws {
+        let revision: Revision = .init(identifier: state.revision)
+        if let branch = state.branch {
+            self = .branch(name: branch, revision: revision)
+        } else if let version = state.version {
+            self = try .version(Version(versionString: version), revision: revision)
+        } else {
+            self = .revision(revision)
+        }
+    }
+}
+
+// MARK: - V5 format (deprecated)
 
 extension WorkspaceStateStorage {
     // v5 storage format
@@ -422,11 +776,13 @@ extension Workspace.ManagedDependency {
 
 extension Workspace.ManagedArtifact {
     fileprivate init(_ artifact: WorkspaceStateStorage.V5.Artifact) throws {
+        let path = AbsolutePath(artifact.path)
         try self.init(
             packageRef: .init(artifact.packageRef),
             targetName: artifact.targetName,
             source: artifact.source.underlying,
-            path: AbsolutePath(artifact.path)
+            path: path,
+            kind: .forPath(path)
         )
     }
 }
@@ -473,7 +829,7 @@ extension CheckoutState {
 }
 
 
-// MARK: - V1...4 format
+// MARK: - V1...4 format (deprecated)
 
 extension WorkspaceStateStorage {
     /// * 4: Artifacts.
@@ -660,11 +1016,13 @@ extension Workspace.ManagedDependency {
 
 extension Workspace.ManagedArtifact {
     fileprivate init(_ artifact: WorkspaceStateStorage.V4.Artifact) throws {
+        let path = AbsolutePath(artifact.path)
         try self.init(
             packageRef: .init(artifact.packageRef),
             targetName: artifact.targetName,
             source: artifact.source.underlying,
-            path: AbsolutePath(artifact.path)
+            path: path,
+            kind: .forPath(path)
         )
     }
 }
@@ -708,5 +1066,16 @@ extension CheckoutState {
         } else {
             self = .revision(revision)
         }
+    }
+}
+
+// backwards compatibility for older formats
+
+extension BinaryTarget.Kind {
+    fileprivate static func forPath(_ path: AbsolutePath) -> Self {
+        if let kind = Self.allCases.first(where: { $0.fileExtension == path.extension }) {
+            return kind
+        }
+        return .unknown
     }
 }

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1093,8 +1093,8 @@ extension Workspace {
             )
         }
 
-        let binaryArtifacts = try self.state.artifacts.reduce(into: [PackageIdentity: [String: BinaryArtifact]]()) { partial, artifact in
-            partial[artifact.packageRef.identity, default: [:]][artifact.targetName] = try BinaryArtifact(kind: artifact.kind(), originURL: artifact.originURL, path: artifact.path)
+        let binaryArtifacts = self.state.artifacts.reduce(into: [PackageIdentity: [String: BinaryArtifact]]()) { partial, artifact in
+            partial[artifact.packageRef.identity, default: [:]][artifact.targetName] = BinaryArtifact(kind: artifact.kind, originURL: artifact.originURL, path: artifact.path)
         }
 
         // Load the graph.
@@ -1286,8 +1286,11 @@ extension Workspace {
                 // note this does not actually download remote artifacts and as such does not have the artifact's type or path
                 let binaryArtifacts = try manifest.targets.filter{ $0.type == .binary }.reduce(into: [String: BinaryArtifact]()) { partial, target in
                     if let path = target.path {
-                        let absolutePath = try manifest.path.parentDirectory.appending(RelativePath(validating: path))
-                        partial[target.name] = try BinaryArtifact(kind: .forFileExtension(absolutePath.extension ?? "unknown") , originURL: .none, path: absolutePath)
+                        let artifactPath = try manifest.path.parentDirectory.appending(RelativePath(validating: path))
+                        guard let (_, artifactKind) = try BinaryArtifactsManager.deriveBinaryArtifact(fileSystem: self.fileSystem, path: artifactPath) else {
+                            throw StringError("\(artifactPath) does not contain binary artifact")
+                        }
+                        partial[target.name] = BinaryArtifact(kind: artifactKind , originURL: .none, path: artifactPath)
                     } else if let url = target.url.flatMap(URL.init(string:)) {
                         let fakePath = try manifest.path.parentDirectory.appending(components: "remote", "archive").appending(RelativePath(validating: url.lastPathComponent))
                         partial[target.name] = BinaryArtifact(kind: .unknown, originURL: url.absoluteString, path: fakePath)
@@ -2215,8 +2218,8 @@ extension Workspace {
 
                 artifactsToExtract.append(artifact)
             } else {
-                guard self.fileSystem.isArtifactDirectory(artifact: artifact, path: artifact.path) else {
-                    observabilityScope.emit(.localArtifactDirectoryNotFound(targetName: artifact.targetName, expectedDirectoryName: artifact.targetName))
+                guard let _ = try BinaryArtifactsManager.deriveBinaryArtifact(fileSystem: self.fileSystem, path: artifact.path) else {
+                    observabilityScope.emit(.localArtifactNotFound(artifactPath: artifact.path, targetName: artifact.targetName))
                     continue
                 }
                 artifactsToAdd.append(artifact)
@@ -3397,10 +3400,6 @@ fileprivate extension Workspace.ManagedArtifact {
         case .local:
             return nil
         }
-    }
-
-    func kind() throws -> BinaryTarget.Kind {
-        return try BinaryTarget.Kind.forFileExtension(self.path.extension ?? "unknown")
     }
 }
 

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1287,7 +1287,7 @@ extension Workspace {
                 let binaryArtifacts = try manifest.targets.filter{ $0.type == .binary }.reduce(into: [String: BinaryArtifact]()) { partial, target in
                     if let path = target.path {
                         let artifactPath = try manifest.path.parentDirectory.appending(RelativePath(validating: path))
-                        guard let (_, artifactKind) = try BinaryArtifactsManager.deriveBinaryArtifact(fileSystem: self.fileSystem, path: artifactPath) else {
+                        guard let (_, artifactKind) = try BinaryArtifactsManager.deriveBinaryArtifact(fileSystem: self.fileSystem, path: artifactPath, observabilityScope: observabilityScope) else {
                             throw StringError("\(artifactPath) does not contain binary artifact")
                         }
                         partial[target.name] = BinaryArtifact(kind: artifactKind , originURL: .none, path: artifactPath)
@@ -2218,7 +2218,7 @@ extension Workspace {
 
                 artifactsToExtract.append(artifact)
             } else {
-                guard let _ = try BinaryArtifactsManager.deriveBinaryArtifact(fileSystem: self.fileSystem, path: artifact.path) else {
+                guard let _ = try BinaryArtifactsManager.deriveBinaryArtifact(fileSystem: self.fileSystem, path: artifact.path, observabilityScope: observabilityScope) else {
                     observabilityScope.emit(.localArtifactNotFound(artifactPath: artifact.path, targetName: artifact.targetName))
                     continue
                 }


### PR DESCRIPTION
motivation: imporve the experience of using binary dependencies

changes:
* track binary artifacts type in workspace state, requires new version (v6) of state file
* derive binary artifact type from content of artifact, not name of directory
* update callsites and tests

radar/93973163
