### PR TITLE
Add hash of source control URL to fingerprint filename to help disambiguate

### DIFF
--- a/Sources/PackageFingerprint/FilePackageFingerprintStorage.swift
+++ b/Sources/PackageFingerprint/FilePackageFingerprintStorage.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -35,13 +35,64 @@ public struct FilePackageFingerprintStorage: PackageFingerprintStorage {
                     version: Version,
                     observabilityScope: ObservabilityScope,
                     callbackQueue: DispatchQueue,
-                    callback: @escaping (Result<[Fingerprint.Kind: Fingerprint], Error>) -> Void)
-    {
+                    callback: @escaping (Result<[Fingerprint.Kind: Fingerprint], Error>) -> Void) {
+        self.get(reference: package,
+                 version: version,
+                 observabilityScope: observabilityScope,
+                 callbackQueue: callbackQueue,
+                 callback: callback)
+    }
+
+    public func put(package: PackageIdentity,
+                    version: Version,
+                    fingerprint: Fingerprint,
+                    observabilityScope: ObservabilityScope,
+                    callbackQueue: DispatchQueue,
+                    callback: @escaping (Result<Void, Error>) -> Void) {
+        self.put(reference: package,
+                 version: version,
+                 fingerprint: fingerprint,
+                 observabilityScope: observabilityScope,
+                 callbackQueue: callbackQueue,
+                 callback: callback)
+    }
+
+    public func get(package: PackageReference,
+                    version: Version,
+                    observabilityScope: ObservabilityScope,
+                    callbackQueue: DispatchQueue,
+                    callback: @escaping (Result<[Fingerprint.Kind: Fingerprint], Error>) -> Void) {
+        self.get(reference: package,
+                 version: version,
+                 observabilityScope: observabilityScope,
+                 callbackQueue: callbackQueue,
+                 callback: callback)
+    }
+
+    public func put(package: PackageReference,
+                    version: Version,
+                    fingerprint: Fingerprint,
+                    observabilityScope: ObservabilityScope,
+                    callbackQueue: DispatchQueue,
+                    callback: @escaping (Result<Void, Error>) -> Void) {
+        self.put(reference: package,
+                 version: version,
+                 fingerprint: fingerprint,
+                 observabilityScope: observabilityScope,
+                 callbackQueue: callbackQueue,
+                 callback: callback)
+    }
+
+    private func get(reference: FingerprintReference,
+                     version: Version,
+                     observabilityScope: ObservabilityScope,
+                     callbackQueue: DispatchQueue,
+                     callback: @escaping (Result<[Fingerprint.Kind: Fingerprint], Error>) -> Void) {
         let callback = self.makeAsync(callback, on: callbackQueue)
 
         do {
             let packageFingerprints = try self.withLock {
-                try self.loadFromDisk(package: package)
+                try self.loadFromDisk(reference: reference)
             }
 
             guard let fingerprints = packageFingerprints[version] else {
@@ -54,18 +105,17 @@ public struct FilePackageFingerprintStorage: PackageFingerprintStorage {
         }
     }
 
-    public func put(package: PackageIdentity,
-                    version: Version,
-                    fingerprint: Fingerprint,
-                    observabilityScope: ObservabilityScope,
-                    callbackQueue: DispatchQueue,
-                    callback: @escaping (Result<Void, Error>) -> Void)
-    {
+    private func put(reference: FingerprintReference,
+                     version: Version,
+                     fingerprint: Fingerprint,
+                     observabilityScope: ObservabilityScope,
+                     callbackQueue: DispatchQueue,
+                     callback: @escaping (Result<Void, Error>) -> Void) {
         let callback = self.makeAsync(callback, on: callbackQueue)
 
         do {
             try self.withLock {
-                var packageFingerprints = try self.loadFromDisk(package: package)
+                var packageFingerprints = try self.loadFromDisk(reference: reference)
 
                 if let existing = packageFingerprints[version]?[fingerprint.origin.kind] {
                     // Error if we try to write a different fingerprint
@@ -80,7 +130,7 @@ public struct FilePackageFingerprintStorage: PackageFingerprintStorage {
                 fingerprints[fingerprint.origin.kind] = fingerprint
                 packageFingerprints[version] = fingerprints
 
-                try self.saveToDisk(package: package, fingerprints: packageFingerprints)
+                try self.saveToDisk(reference: reference, fingerprints: packageFingerprints)
             }
             callback(.success(()))
         } catch {
@@ -88,8 +138,8 @@ public struct FilePackageFingerprintStorage: PackageFingerprintStorage {
         }
     }
 
-    private func loadFromDisk(package: PackageIdentity) throws -> PackageFingerprints {
-        let path = self.directoryPath.appending(component: package.fingerprintFilename)
+    private func loadFromDisk(reference: FingerprintReference) throws -> PackageFingerprints {
+        let path = self.directoryPath.appending(component: reference.fingerprintsFilename)
 
         guard self.fileSystem.exists(path) else {
             return .init()
@@ -104,7 +154,7 @@ public struct FilePackageFingerprintStorage: PackageFingerprintStorage {
         return try container.packageFingerprints()
     }
 
-    private func saveToDisk(package: PackageIdentity, fingerprints: PackageFingerprints) throws {
+    private func saveToDisk(reference: FingerprintReference, fingerprints: PackageFingerprints) throws {
         if !self.fileSystem.exists(self.directoryPath) {
             try self.fileSystem.createDirectory(self.directoryPath, recursive: true)
         }
@@ -112,7 +162,7 @@ public struct FilePackageFingerprintStorage: PackageFingerprintStorage {
         let container = try StorageModel.Container(fingerprints)
         let buffer = try encoder.encode(container)
 
-        let path = self.directoryPath.appending(component: package.fingerprintFilename)
+        let path = self.directoryPath.appending(component: reference.fingerprintsFilename)
         try self.fileSystem.writeFileContents(path, bytes: ByteString(buffer))
     }
 
@@ -179,9 +229,25 @@ private enum StorageModel {
     }
 }
 
-extension PackageIdentity {
-    var fingerprintFilename: String {
+protocol FingerprintReference {
+    var fingerprintsFilename: String { get }
+}
+
+extension PackageIdentity: FingerprintReference {
+    var fingerprintsFilename: String {
         "\(self.description).json"
+    }
+}
+
+extension PackageReference: FingerprintReference {
+    var fingerprintsFilename: String {
+        guard case .remoteSourceControl(let sourceControlURL) = self.kind else {
+            fatalError("Package kind [\(self.kind)] does not support fingerprints")
+        }
+
+        let canonicalLocation = CanonicalPackageLocation(sourceControlURL.absoluteString)
+        let locationHash = String(format: "%02x", canonicalLocation.description.hashValue)
+        return "\(self.identity.description)-\(locationHash).json"
     }
 }
 

--- a/Sources/PackageFingerprint/PackageFingerprintStorage.swift
+++ b/Sources/PackageFingerprint/PackageFingerprintStorage.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -27,6 +27,19 @@ public protocol PackageFingerprintStorage {
              observabilityScope: ObservabilityScope,
              callbackQueue: DispatchQueue,
              callback: @escaping (Result<Void, Error>) -> Void)
+
+    func get(package: PackageReference,
+             version: Version,
+             observabilityScope: ObservabilityScope,
+             callbackQueue: DispatchQueue,
+             callback: @escaping (Result<[Fingerprint.Kind: Fingerprint], Error>) -> Void)
+
+    func put(package: PackageReference,
+             version: Version,
+             fingerprint: Fingerprint,
+             observabilityScope: ObservabilityScope,
+             callbackQueue: DispatchQueue,
+             callback: @escaping (Result<Void, Error>) -> Void)
 }
 
 public extension PackageFingerprintStorage {
@@ -37,20 +50,37 @@ public extension PackageFingerprintStorage {
              callbackQueue: DispatchQueue,
              callback: @escaping (Result<Fingerprint, Error>) -> Void) {
         self.get(package: package, version: version, observabilityScope: observabilityScope, callbackQueue: callbackQueue) { result in
-            callback(result.tryMap { fingerprints in
-                guard let fingerprint = fingerprints[kind] else {
-                    throw PackageFingerprintStorageError.notFound
-                }
-                return fingerprint
-            })
+            self.get(kind: kind, result, callback: callback)
         }
+    }
+
+    func get(package: PackageReference,
+             version: Version,
+             kind: Fingerprint.Kind,
+             observabilityScope: ObservabilityScope,
+             callbackQueue: DispatchQueue,
+             callback: @escaping (Result<Fingerprint, Error>) -> Void) {
+        self.get(package: package, version: version, observabilityScope: observabilityScope, callbackQueue: callbackQueue) { result in
+            self.get(kind: kind, result, callback: callback)
+        }
+    }
+
+    private func get(kind: Fingerprint.Kind,
+                     _ fingerprintsResult: Result<[Fingerprint.Kind: Fingerprint], Error>,
+                     callback: @escaping (Result<Fingerprint, Error>) -> Void) {
+        callback(fingerprintsResult.tryMap { fingerprints in
+            guard let fingerprint = fingerprints[kind] else {
+                throw PackageFingerprintStorageError.notFound
+            }
+            return fingerprint
+        })
     }
 }
 
 public enum PackageFingerprintStorageError: Error, Equatable, CustomStringConvertible {
     case conflict(given: Fingerprint, existing: Fingerprint)
     case notFound
-    
+
     public var description: String {
         switch self {
         case .conflict(let given, let existing):

--- a/Sources/SPMTestSupport/MockPackageFingerprintStorage.swift
+++ b/Sources/SPMTestSupport/MockPackageFingerprintStorage.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -75,5 +75,31 @@ public class MockPackageFingerprintStorage: PackageFingerprintStorage {
                 callback(.failure(error))
             }
         }
+    }
+
+    public func get(package: PackageReference,
+                    version: Version,
+                    observabilityScope: ObservabilityScope,
+                    callbackQueue: DispatchQueue,
+                    callback: @escaping (Result<[Fingerprint.Kind: Fingerprint], Error>) -> Void) {
+        self.get(package: package.identity,
+                 version: version,
+                 observabilityScope: observabilityScope,
+                 callbackQueue: callbackQueue,
+                 callback: callback)
+    }
+
+    public func put(package: PackageReference,
+                    version: Version,
+                    fingerprint: Fingerprint,
+                    observabilityScope: ObservabilityScope,
+                    callbackQueue: DispatchQueue,
+                    callback: @escaping (Result<Void, Error>) -> Void) {
+        self.put(package: package.identity,
+                 version: version,
+                 fingerprint: fingerprint,
+                 observabilityScope: observabilityScope,
+                 callbackQueue: callbackQueue,
+                 callback: callback)
     }
 }

--- a/Tests/PackageFingerprintTests/FilePackageFingerprintStorageTests.swift
+++ b/Tests/PackageFingerprintTests/FilePackageFingerprintStorageTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -36,8 +36,8 @@ final class FilePackageFingerprintStorageTests: XCTestCase {
         try storage.put(package: otherPackage, version: Version("1.0.0"), fingerprint: .init(origin: .registry(registryURL), value: "checksum-1.0.0"))
 
         // A checksum file should have been created for each package
-        XCTAssertTrue(mockFileSystem.exists(storage.directoryPath.appending(component: package.fingerprintFilename)))
-        XCTAssertTrue(mockFileSystem.exists(storage.directoryPath.appending(component: otherPackage.fingerprintFilename)))
+        XCTAssertTrue(mockFileSystem.exists(storage.directoryPath.appending(component: package.fingerprintsFilename)))
+        XCTAssertTrue(mockFileSystem.exists(storage.directoryPath.appending(component: otherPackage.fingerprintsFilename)))
 
         // Fingerprints should be saved
         do {
@@ -115,6 +115,57 @@ final class FilePackageFingerprintStorageTests: XCTestCase {
         XCTAssertNoThrow(try storage.put(package: package, version: Version("1.0.0"),
                                          fingerprint: .init(origin: .registry(registryURL), value: "checksum-1.0.0")))
     }
+
+    func testHappyCase_PackageReferenceAPI() throws {
+        let mockFileSystem = InMemoryFileSystem()
+        let directoryPath = AbsolutePath("/fingerprints")
+        let storage = FilePackageFingerprintStorage(fileSystem: mockFileSystem, directoryPath: directoryPath)
+        let sourceControlURL = URL(string: "https://example.com/mona/LinkedList.git")!
+        let packageRef = PackageReference.remoteSourceControl(identity: PackageIdentity(url: sourceControlURL), url: sourceControlURL)
+
+        try storage.put(package: packageRef, version: Version("1.0.0"), fingerprint: .init(origin: .sourceControl(sourceControlURL), value: "gitHash-1.0.0"))
+        try storage.put(package: packageRef, version: Version("1.1.0"), fingerprint: .init(origin: .sourceControl(sourceControlURL), value: "gitHash-1.1.0"))
+
+        // Fingerprints should be saved
+        let fingerprints = try storage.get(package: packageRef, version: Version("1.1.0"))
+        XCTAssertEqual(1, fingerprints.count)
+
+        XCTAssertEqual(sourceControlURL, fingerprints[.sourceControl]?.origin.url)
+        XCTAssertEqual("gitHash-1.1.0", fingerprints[.sourceControl]?.value)
+    }
+
+    func testDifferentRepoURLsThatHaveSameIdentity() throws {
+        let mockFileSystem = InMemoryFileSystem()
+        let directoryPath = AbsolutePath("/fingerprints")
+        let storage = FilePackageFingerprintStorage(fileSystem: mockFileSystem, directoryPath: directoryPath)
+        let fooURL = URL(string: "https://example.com/foo/LinkedList.git")!
+        let barURL = URL(string: "https://example.com/bar/LinkedList.git")!
+
+        // foo and bar have the same identity `LinkedList`
+        let fooRef = PackageReference.remoteSourceControl(identity: PackageIdentity(url: fooURL), url: fooURL)
+        let barRef = PackageReference.remoteSourceControl(identity: PackageIdentity(url: barURL), url: barURL)
+
+        try storage.put(package: fooRef, version: Version("1.0.0"), fingerprint: .init(origin: .sourceControl(fooURL), value: "abcde-foo"))
+        // This should succeed because they get written to different files
+        try storage.put(package: barRef, version: Version("1.0.0"), fingerprint: .init(origin: .sourceControl(barURL), value: "abcde-bar"))
+
+        XCTAssertNotEqual(fooRef.fingerprintsFilename, barRef.fingerprintsFilename)
+
+        // A checksum file should have been created for each package
+        XCTAssertTrue(mockFileSystem.exists(storage.directoryPath.appending(component: fooRef.fingerprintsFilename)))
+        XCTAssertTrue(mockFileSystem.exists(storage.directoryPath.appending(component: barRef.fingerprintsFilename)))
+
+        // This should fail because fingerprint for 1.0.0 already exists and it's different
+        XCTAssertThrowsError(try storage.put(package: fooRef, version: Version("1.0.0"),
+                                             fingerprint: .init(origin: .sourceControl(fooURL), value: "abcde-foo-foo"))) { error in
+            guard case PackageFingerprintStorageError.conflict = error else {
+                return XCTFail("Expected PackageFingerprintStorageError.conflict, got \(error)")
+            }
+        }
+
+        // This should succeed because fingerprint for 2.0.0 doesn't exist yet
+        try storage.put(package: fooRef, version: Version("2.0.0"), fingerprint: .init(origin: .sourceControl(fooURL), value: "abcde-foo"))
+    }
 }
 
 private extension PackageFingerprintStorage {
@@ -130,6 +181,30 @@ private extension PackageFingerprintStorage {
     }
 
     func put(package: PackageIdentity,
+             version: Version,
+             fingerprint: Fingerprint) throws {
+        return try tsc_await {
+            self.put(package: package,
+                     version: version,
+                     fingerprint: fingerprint,
+                     observabilityScope: ObservabilitySystem.NOOP,
+                     callbackQueue: .sharedConcurrent,
+                     callback: $0)
+        }
+    }
+
+    func get(package: PackageReference,
+             version: Version) throws -> [Fingerprint.Kind: Fingerprint] {
+        return try tsc_await {
+            self.get(package: package,
+                     version: version,
+                     observabilityScope: ObservabilitySystem.NOOP,
+                     callbackQueue: .sharedConcurrent,
+                     callback: $0)
+        }
+    }
+
+    func put(package: PackageReference,
              version: Version,
              fingerprint: Fingerprint) throws {
         return try tsc_await {


### PR DESCRIPTION
rdar://100249231
