### PR TITLE
read pkg-config files case insensitive

### DIFF
--- a/Sources/PackageLoading/PkgConfig.swift
+++ b/Sources/PackageLoading/PkgConfig.swift
@@ -208,14 +208,14 @@ internal struct PkgConfigParser {
         }
         let (key, maybeValue) = line.spm_split(around: ":")
         let value = try resolveVariables(maybeValue?.spm_chuzzle() ?? "")
-        switch key {
-        case "Requires":
+        switch key.lowercased() {
+        case "requires":
             dependencies = try parseDependencies(value)
-        case "Requires.private":
+        case "requires.private":
             privateDependencies = try parseDependencies(value)
-        case "Libs":
+        case "libs":
             libs = try splitEscapingSpace(value)
-        case "Cflags":
+        case "cflags":
             cFlags = try splitEscapingSpace(value)
         default:
             break

--- a/Tests/PackageLoadingTests/PkgConfigParserTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigParserTests.swift
@@ -66,6 +66,12 @@ final class PkgConfigParserTests: XCTestCase {
         }
     }
 
+    func testCFlagsCaseInsensitveKeys() {
+        try! loadPCFile("case_insensitive.pc") { parser in
+            XCTAssertEqual(parser.cFlags, ["-I/usr/local/include"])
+        }
+    }
+
     func testVariableinDependency() {
         try! loadPCFile("deps_variable.pc") { parser in
             XCTAssertEqual(parser.variables, [

--- a/Tests/PackageLoadingTests/pkgconfigInputs/case_insensitive.pc
+++ b/Tests/PackageLoadingTests/pkgconfigInputs/case_insensitive.pc
@@ -1,0 +1,7 @@
+prefix=/usr/local/bin
+exec_prefix=${prefix}
+
+#some comment
+
+# upstream pkg-config parser allows Cflags & CFlags as key
+CFlags: -I/usr/local/include


### PR DESCRIPTION
Parse pkg-config keys case-insensitive

### Motivation:

I had a typo `CFlags` instead of `Cflags` in a pkg-config file. The command line tool `pkg-config` had no problem parsing and doing the right thing. This would have helped.

### Modifications:

Just lowercased the string in the switch statement.

### Result:

I am guessing that makes parsing a little closer to what users might expect.
