### PR TITLE
Improve collections configuration warning

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -3661,7 +3661,7 @@ extension FileSystem {
 extension Workspace.Location {
     func validatingSharedLocations(
         fileSystem: FileSystem,
-        warningHandler: (String) -> Void
+        warningHandler: @escaping (String) -> Void
     ) throws -> Self {
         var location = self
 


### PR DESCRIPTION
If we just copied the config to the new location or if the configs at old and new location are identical, do not warn about the presence of both configs. The warning's purpose is making people aware of the fact that different versions of SwiftPM are using different configs, but if they are identical, there's no need for them to really know about it.

rdar://99721607
