### PR TITLE
Fix conditional dependencies in root packages

### DIFF
--- a/Fixtures/Miscellaneous/RootPackageWithConditionals/Package.swift
+++ b/Fixtures/Miscellaneous/RootPackageWithConditionals/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version: 5.7
+
+import PackageDescription
+
+let package = Package(
+    name: "client",
+    products: [
+        .library(name: "client", targets: ["client"]),
+    ],
+    dependencies: [
+    ],
+    targets: [
+        .target(name: "client", dependencies: [
+        	.target(name: "linuxOnly", condition: .when(platforms: [.linux]))
+        ]),
+        .target(name: "linuxOnly"),
+    ]
+)

--- a/Fixtures/Miscellaneous/RootPackageWithConditionals/Sources/client/client.swift
+++ b/Fixtures/Miscellaneous/RootPackageWithConditionals/Sources/client/client.swift
@@ -1,0 +1,6 @@
+public struct client {
+    public private(set) var text = "Hello, World!"
+
+    public init() {
+    }
+}

--- a/Fixtures/Miscellaneous/RootPackageWithConditionals/Sources/linuxOnly/linuxOnly.swift
+++ b/Fixtures/Miscellaneous/RootPackageWithConditionals/Sources/linuxOnly/linuxOnly.swift
@@ -1,0 +1,11 @@
+public struct linuxOnly {
+    public private(set) var text = "Hello, World!"
+
+    public init() {
+#if os(Linux)
+print("bestOS")
+#else
+#error("not linux")
+#endif
+    }
+}

--- a/Sources/Build/LLBuildManifestBuilder.swift
+++ b/Sources/Build/LLBuildManifestBuilder.swift
@@ -649,7 +649,7 @@ extension LLBuildManifestBuilder {
             inputs: cmdOutputs,
             outputs: [targetOutput]
         )
-        if plan.graph.isInRootPackages(target.target) {
+        if plan.graph.isInRootPackages(target.target, satisfying: self.buildEnvironment) {
             if !target.isTestTarget {
                 addNode(targetOutput, toTarget: .main)
             }
@@ -810,7 +810,7 @@ extension LLBuildManifestBuilder {
             outputs: [output]
         )
 
-        if plan.graph.isInRootPackages(target.target) {
+        if plan.graph.isInRootPackages(target.target, satisfying: self.buildEnvironment) {
             if !target.isTestTarget {
                 addNode(output, toTarget: .main)
             }

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -623,4 +623,12 @@ class MiscellaneousTestCase: XCTestCase {
             XCTAssertNoMatch(stdout + stderr, .contains("'Deprecated2' is deprecated"))
         }
     }
+
+    func testRootPackageWithConditionals() throws {
+        try fixture(name: "Miscellaneous/RootPackageWithConditionals") { path in
+            let (_, stderr) = try SwiftPMProduct.SwiftBuild.execute([], packagePath: path)
+            let errors = stderr.components(separatedBy: .newlines).filter { !$0.contains("[logging] misuse") && !$0.isEmpty }
+            XCTAssertEqual(errors, [], "unexpected errors: \(errors)")
+        }
+    }
 }


### PR DESCRIPTION
SwiftPM's build system always build every target that's part of a root package, regardless of its reachability in the graph, supposedly to ensure all the code in the root package will get exercised. This is of course fundamentally incompatible with the idea of conditional dependencies and therefore causes user confusion.

The most reasonable way to resolve this seems to be to exclude any target that's conditionally depended upon with a condition unfullfiled by the current build environment from building automatically because of its presence in the root package. This does not change what gets built based on dependencies, so degenerate cases where a target is depended upon both conditionally and unconditionally will not be affected. Because of this, it seems reasonable to not tie the new behavior to the tools-version.

rdar://97751068
