### PR TITLE
Explicit target dependency check needs to take into account conditionals

### DIFF
--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -266,7 +266,7 @@ public struct BuildDescription: Codable {
         self.copyCommands = copyCommands
         self.explicitTargetDependencyImportCheckingMode = plan.buildParameters.explicitTargetDependencyImportCheckingMode
         self.targetDependencyMap = try plan.targets.reduce(into: [TargetName: [TargetName]]()) {
-            let deps = try $1.target.recursiveTargetDependencies().map { $0.c99name }
+            let deps = try $1.target.recursiveDependencies(satisfying: plan.buildParameters.buildEnvironment).compactMap { $0.target }.map { $0.c99name }
             $0[$1.target.c99name] = deps
         }
         var targetCommandLines: [TargetName: [CommandLineFlag]] = [:]


### PR DESCRIPTION
This ensures we're erroring when there's an import of a module that is excluded via a target conditional in the package manifest.

rdar://81587673