### PR TITLE
Fix handling of build environment when planning

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -1782,6 +1782,10 @@ public class BuildPlan {
         for target in graph.allTargets.sorted(by: { $0.name < $1.name }) {
             // Validate the product dependencies of this target.
             for dependency in target.dependencies {
+                guard dependency.satisfies(buildParameters.buildEnvironment) else {
+                    continue
+                }
+
                 switch dependency {
                 case .target: break
                 case .product(let product, _):
@@ -2037,6 +2041,10 @@ public class BuildPlan {
             // For a product dependency, we only include its content only if we
             // need to statically link it or if it's a plugin.
             case .product(let product, _):
+                guard dependency.satisfies(self.buildEnvironment) else {
+                    return []
+                }
+
                 switch product.type {
                 case .library(.automatic), .library(.static), .plugin:
                     return product.targets.map { .target($0, conditions: []) }

--- a/Sources/Build/LLBuildManifestBuilder.swift
+++ b/Sources/Build/LLBuildManifestBuilder.swift
@@ -442,7 +442,7 @@ extension LLBuildManifestBuilder {
         for target: ResolvedTarget,
         dependencyModulePathMap: inout SwiftDriver.ExternalTargetModulePathMap
     ) throws {
-        for dependency in target.dependencies {
+        for dependency in target.dependencies(satisfying: self.buildEnvironment) {
             switch dependency {
                 case .product:
                     // Product dependencies are broken down into the targets that make them up.

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -223,7 +223,8 @@ final class BuildPlanTests: XCTestCase {
         let fs = InMemoryFileSystem(emptyFiles:
             Pkg.appending(components: "Sources", "exe", "main.swift").pathString,
             Pkg.appending(components: "Sources", "PkgLib", "lib.swift").pathString,
-            "/ExtPkg/Sources/ExtLib/lib.swift"
+            "/ExtPkg/Sources/ExtLib/lib.swift",
+            "/PlatformPkg/Sources/PlatformLib/lib.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -235,6 +236,7 @@ final class BuildPlanTests: XCTestCase {
                     path: .init(Pkg.pathString),
                     dependencies: [
                         .localSourceControl(path: .init("/ExtPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init("/PlatformPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe", dependencies: [
@@ -247,6 +249,9 @@ final class BuildPlanTests: XCTestCase {
                             .product(name: "ExtLib", package: "ExtPkg", condition: PackageConditionDescription(
                                 platformNames: [],
                                 config: "debug"
+                            )),
+                            .product(name: "PlatformLib", package: "PlatformPkg", condition: PackageConditionDescription(
+                                platformNames: ["linux"]
                             ))
                         ]),
                     ]
@@ -259,6 +264,17 @@ final class BuildPlanTests: XCTestCase {
                     ],
                     targets: [
                         TargetDescription(name: "ExtLib", dependencies: []),
+                    ]
+                ),
+                Manifest.createLocalSourceControlManifest(
+                    name: "PlatformPkg",
+                    path: .init("/PlatformPkg"),
+                    platforms: [PlatformDescription(name: "macos", version: "50.0")],
+                    products: [
+                        ProductDescription(name: "PlatformLib", type: .library(.automatic), targets: ["PlatformLib"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "PlatformLib", dependencies: []),
                     ]
                 ),
             ],


### PR DESCRIPTION
This fixes a few callsites that weren't taking conditionals into account, most notably the check for minimum deployment target.

rdar://70543422
