### PR TITLE
Use product IDs to allow duplicate product names in package graph

### DIFF
--- a/Sources/PackageGraph/ModuleAliasTracker.swift
+++ b/Sources/PackageGraph/ModuleAliasTracker.swift
@@ -25,7 +25,7 @@ class ModuleAliasTracker {
                 if let aliasList = productRef.moduleAliases {
                     // Track aliases for this product
                     try addAliases(aliasList,
-                                   productID: productRef.ID,
+                                   productID: productRef.identity,
                                    productName: productRef.name,
                                    originPackage: productPkgID,
                                    consumingPackage: package)
@@ -76,20 +76,20 @@ class ModuleAliasTracker {
         allTargetDeps.append(contentsOf: targetDeps)
         for dep in allTargetDeps {
             if case let .product(depRef, _) = dep {
-                parentToChildProducts[product.ID, default: []].append(depRef.ID)
+                parentToChildProducts[product.identity, default: []].append(depRef.identity)
             }
         }
 
         var allTargetsInProduct = targetDeps.compactMap{$0.target}
         allTargetsInProduct.append(contentsOf: product.targets)
-        idToProductToAllTargets[package, default: [:]][product.ID] = allTargetsInProduct
-        productToDirectTargets[product.ID] = product.targets
-        productToAllTargets[product.ID] = allTargetsInProduct
+        idToProductToAllTargets[package, default: [:]][product.identity] = allTargetsInProduct
+        productToDirectTargets[product.identity] = product.targets
+        productToAllTargets[product.identity] = allTargetsInProduct
     }
 
     func validateAndApplyAliases(product: Product,
                                  package: PackageIdentity) throws {
-        guard let targets = idToProductToAllTargets[package]?[product.ID] else { return }
+        guard let targets = idToProductToAllTargets[package]?[product.identity] else { return }
         let targetsWithAliases = targets.filter{ $0.moduleAliases != nil }
         for target in targetsWithAliases {
             if target.sources.containsNonSwiftFiles {
@@ -376,7 +376,7 @@ class ModuleAliasTracker {
     }
 
     private func dependencyProductTargets(of targets: [Target]) -> [Target] {
-        let result = targets.map{$0.dependencies.compactMap{$0.product?.ID}}.flatMap{$0}.compactMap{productToAllTargets[$0]}.flatMap{$0}
+        let result = targets.map{$0.dependencies.compactMap{$0.product?.identity}}.flatMap{$0}.compactMap{productToAllTargets[$0]}.flatMap{$0}
         return result
     }
 }
@@ -400,7 +400,7 @@ extension Target {
     func dependsOn(productID: String) -> Bool {
         return dependencies.contains { dep in
             if case let .product(prodRef, _) = dep {
-                return prodRef.ID == productID
+                return prodRef.identity == productID
             }
             return false
         }

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -418,10 +418,11 @@ private func createResolvedPackages(
         let productDependencies = packageBuilder.dependencies
             .flatMap({ (dependency: ResolvedPackageBuilder) -> [ResolvedProductBuilder] in
                 // Filter out synthesized products such as tests and implicit executables.
+                // Check if a dependency product is explicitly declared as a product in its package manifest
                 let manifestProducts = dependency.package.manifest.products.lazy.map { $0.name }
-                let filteredProducts = dependency.package.products.filter { manifestProducts.contains($0.name) }
-                let explicit = Set(filteredProducts.lazy.map({ lookupByProductIDs ?  $0.identity : $0.name }))
-                return dependency.products.filter({ lookupByProductIDs ? explicit.contains($0.product.identity) : explicit.contains($0.product.name) })
+                let explicitProducts = dependency.package.products.filter { manifestProducts.contains($0.name) }
+                let explicitIdsOrNames = Set(explicitProducts.lazy.map({ lookupByProductIDs ? $0.identity : $0.name }))
+                return dependency.products.filter({ lookupByProductIDs ? explicitIdsOrNames.contains($0.product.identity) : explicitIdsOrNames.contains($0.product.name) })
             })
         let productDependencyMap = lookupByProductIDs ? productDependencies.spm_createDictionary({ ($0.product.identity, $0) }) : productDependencies.spm_createDictionary({ ($0.product.name, $0) })
 

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -418,7 +418,9 @@ private func createResolvedPackages(
         let productDependencies = packageBuilder.dependencies
             .flatMap({ (dependency: ResolvedPackageBuilder) -> [ResolvedProductBuilder] in
                 // Filter out synthesized products such as tests and implicit executables.
-                let explicit = Set(dependency.package.products.lazy.map({ lookupByProductIDs ?  $0.identity : $0.name }))
+                let manifestProducts = dependency.package.manifest.products.lazy.map { $0.name }
+                let filteredProducts = dependency.package.products.filter { manifestProducts.contains($0.name) }
+                let explicit = Set(filteredProducts.lazy.map({ lookupByProductIDs ?  $0.identity : $0.name }))
                 return dependency.products.filter({ lookupByProductIDs ? explicit.contains($0.product.identity) : explicit.contains($0.product.name) })
             })
         let productDependencyMap = lookupByProductIDs ? productDependencies.spm_createDictionary({ ($0.product.identity, $0) }) : productDependencies.spm_createDictionary({ ($0.product.name, $0) })

--- a/Sources/PackageLoading/Diagnostics.swift
+++ b/Sources/PackageLoading/Diagnostics.swift
@@ -40,8 +40,8 @@ extension Basics.Diagnostic {
         return .warning("ignoring duplicate product '\(product.name)'\(typeString)")
     }
 
-    static func duplicateProduct(productID: String) -> Self {
-        return .warning("ignoring duplicate product '\(productID)'")
+    static func duplicateProduct(name: String, package: String) -> Self {
+        return .warning("ignoring duplicate product '\(name)' from package '\(package)'")
     }
 
     static func duplicateTargetDependency(dependency: String, target: String, package: String) -> Self {

--- a/Sources/PackageLoading/Diagnostics.swift
+++ b/Sources/PackageLoading/Diagnostics.swift
@@ -40,6 +40,10 @@ extension Basics.Diagnostic {
         return .warning("ignoring duplicate product '\(product.name)'\(typeString)")
     }
 
+    static func duplicateProduct(productID: String) -> Self {
+        return .warning("ignoring duplicate product '\(productID)'")
+    }
+
     static func duplicateTargetDependency(dependency: String, target: String, package: String) -> Self {
         .warning("invalid duplicate target dependency declaration '\(dependency)' in target '\(target)' from package '\(package)'")
     }

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -762,8 +762,19 @@ public final class PackageBuilder {
         }
 
         // Check for duplicate target dependencies
-        dependencies.filter{$0.product?.moduleAliases == nil}.spm_findDuplicateElements(by: \.nameAndType).map(\.[0].name).forEach {
-            self.observabilityScope.emit(.duplicateTargetDependency(dependency: $0, target: potentialModule.name, package: self.identity.description))
+        if self.manifest.toolsVersion < .vNext {
+            dependencies.filter{$0.product?.moduleAliases == nil}.spm_findDuplicateElements(by: \.nameAndType).map(\.[0].name).forEach {
+                self.observabilityScope.emit(.duplicateTargetDependency(dependency: $0, target: potentialModule.name, package: self.identity.description))
+            }
+        } else {
+            let dupProductIDs = dependencies.compactMap{$0.product?.ID}.spm_findDuplicates()
+            for dupProductID in dupProductIDs {
+                self.observabilityScope.emit(.duplicateProduct(productID: dupProductID))
+            }
+            let dupTargetNames = dependencies.compactMap{$0.target?.name}.spm_findDuplicates()
+            for dupTargetName in dupTargetNames {
+                self.observabilityScope.emit(.duplicateTargetDependency(dependency: dupTargetName, target: potentialModule.name, package: self.identity.description))
+            }
         }
 
         // Create the build setting assignment table for this target.

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -762,7 +762,7 @@ public final class PackageBuilder {
         }
 
         // Check for duplicate target dependencies
-        if self.manifest.diambiguateByProductIDs {
+        if self.manifest.disambiguateByProductIDs {
             let dupProductIDs = dependencies.compactMap{$0.product?.identity}.spm_findDuplicates()
             for dupProductID in dupProductIDs {
                 let comps = dupProductID.components(separatedBy: "_")

--- a/Sources/PackageModel/PackageModel.swift
+++ b/Sources/PackageModel/PackageModel.swift
@@ -130,8 +130,8 @@ extension Package.Error: CustomStringConvertible {
 }
 
 extension Manifest {
-    public var diambiguateByProductIDs: Bool {
-        return self.toolsVersion > .vNext
+    public var disambiguateByProductIDs: Bool {
+        return self.toolsVersion >= .vNext
     }
 }
 

--- a/Sources/PackageModel/PackageModel.swift
+++ b/Sources/PackageModel/PackageModel.swift
@@ -129,6 +129,12 @@ extension Package.Error: CustomStringConvertible {
     }
 }
 
+extension Manifest {
+    public var diambiguateByProductIDs: Bool {
+        return self.toolsVersion > .vNext
+    }
+}
+
 extension ObservabilityMetadata {
     public static func packageMetadata(identity: PackageIdentity, kind: PackageReference.Kind) -> Self {
         var metadata = ObservabilityMetadata()

--- a/Sources/PackageModel/Product.swift
+++ b/Sources/PackageModel/Product.swift
@@ -20,7 +20,7 @@ public class Product: Codable {
     public let name: String
 
     /// Fully qualified name for this product: package ID + name of this product
-    public let ID: String
+    public let identity: String
 
     /// The type of product to create.
     public let type: ProductType
@@ -54,7 +54,7 @@ public class Product: Codable {
         }
         self.name = name
         self.type = type
-        self.ID = package.description.lowercased() + "_" + name
+        self.identity = package.description.lowercased() + "_" + name
         self._targets = .init(wrappedValue: targets)
         self.testEntryPointPath = testEntryPointPath
     }

--- a/Sources/PackageModel/Target.swift
+++ b/Sources/PackageModel/Target.swift
@@ -50,7 +50,7 @@ public class Target: PolymorphicCodableProtocol {
         public let moduleAliases: [String: String]?
 
         /// Fully qualified name for this product dependency: package ID + name of the product
-        public var ID: String {
+        public var identity: String {
             if let pkg = package {
                 return pkg.lowercased() + "_" + name
             }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -421,7 +421,7 @@ final class BuildPlanTests: XCTestCase {
         )
         let observability = ObservabilitySystem.makeForTesting()
 
-        let _ = try loadPackageGraph(
+        XCTAssertThrowsError(try loadPackageGraph(
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
@@ -463,10 +463,13 @@ final class BuildPlanTests: XCTestCase {
                     ]),
             ],
             observabilityScope: observability.topScope
-        )
-        testDiagnostics(observability.diagnostics) { result in
-            result.check(diagnostic: .contains("invalid duplicate target dependency declaration 'Logging' in target 'exe' from package 'thispkg'"), severity: .warning)
-            result.check(diagnostic: .contains("multiple products named 'Logging' in: 'barpkg', 'foopkg'"), severity: .error)
+        )) { error in
+            var diagnosed = false
+            if let realError = error as? PackageGraphError,
+               realError.description == "multiple products named 'Logging' in: 'barpkg', 'foopkg'" {
+                diagnosed = true
+            }
+            XCTAssertTrue(diagnosed)
         }
     }
 

--- a/Tests/BuildTests/ModuleAliasingBuildTests.swift
+++ b/Tests/BuildTests/ModuleAliasingBuildTests.swift
@@ -171,7 +171,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                     "/barPkg/Sources/Logging/fileLogging.swift"
         )
         let observability = ObservabilitySystem.makeForTesting()
-        let _ = try loadPackageGraph(
+        XCTAssertThrowsError(try loadPackageGraph(
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
@@ -212,9 +212,13 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
             ],
             observabilityScope: observability.topScope
-        )
-        testDiagnostics(observability.diagnostics) { result in
-            result.check(diagnostic: .contains("multiple products named 'Logging' in: 'barpkg', 'foopkg'"), severity: .error)
+        )) { error in
+            var diagnosed = false
+            if let realError = error as? PackageGraphError,
+               realError.description == "multiple products named 'Logging' in: 'barpkg', 'foopkg'" {
+                diagnosed = true
+            }
+            XCTAssertTrue(diagnosed)
         }
     }
 
@@ -225,7 +229,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                     "/barPkg/Sources/Logging/fileLogging.swift"
         )
         let observability = ObservabilitySystem.makeForTesting()
-        let _ = try loadPackageGraph(
+        XCTAssertThrowsError(try loadPackageGraph(
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
@@ -266,9 +270,13 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
             ],
             observabilityScope: observability.topScope
-        )
-        testDiagnostics(observability.diagnostics) { result in
-            result.check(diagnostic: .contains("multiple products named 'Logging' in: 'barpkg', 'foopkg'"), severity: .error)
+        )) { error in
+            var diagnosed = false
+            if let realError = error as? PackageGraphError,
+               realError.description == "multiple products named 'Logging' in: 'barpkg', 'foopkg'" {
+                diagnosed = true
+            }
+            XCTAssertTrue(diagnosed)
         }
     }
 

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
-import PackageGraph
+@testable import PackageGraph
 import PackageModel
 import SPMTestSupport
 import TSCBasic
@@ -964,7 +964,7 @@ class PackageGraphTests: XCTestCase {
         )
 
         let observability = ObservabilitySystem.makeForTesting()
-        _ = try loadPackageGraph(
+        XCTAssertThrowsError(try loadPackageGraph(
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
@@ -997,10 +997,13 @@ class PackageGraphTests: XCTestCase {
                     ]),
             ],
             observabilityScope: observability.topScope
-        )
-
-        testDiagnostics(observability.diagnostics) { result in
-            result.check(diagnostic: "multiple products named 'Bar' in: 'bar', 'baz'", severity: .error)
+        )) { error in
+            var diagnosed = false
+            if let realError = error as? PackageGraphError,
+               realError.description == "multiple products named 'Bar' in: 'bar', 'baz'" {
+                diagnosed = true
+            }
+            XCTAssertTrue(diagnosed)
         }
     }
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -12,7 +12,7 @@
 
 import Basics
 import PackageFingerprint
-import PackageGraph
+@testable import PackageGraph
 import PackageLoading
 import PackageModel
 import PackageRegistry
@@ -10471,14 +10471,8 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .disabled
 
-            try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+            XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
                 testDiagnostics(diagnostics) { result in
-                    result.check(
-                        diagnostic: .contains("""
-                        multiple products named 'FooProduct' in: 'foo', 'org.foo'
-                        """),
-                        severity: .error
-                    )
                     result.check(
                         diagnostic: .contains("""
                         multiple targets named 'FooTarget' in: 'foo', 'org.foo'
@@ -10486,6 +10480,13 @@ final class WorkspaceTests: XCTestCase {
                         severity: .error
                     )
                 }
+            }) { error in
+                var diagnosed = false
+                if let realError = error as? PackageGraphError,
+                    realError.description == "multiple products named 'FooProduct' in: 'foo', 'org.foo'" {
+                    diagnosed = true
+                }
+                XCTAssertTrue(diagnosed)
             }
         }
 
@@ -10597,14 +10598,8 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .disabled
 
-            try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+            XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
                 testDiagnostics(diagnostics) { result in
-                    result.check(
-                        diagnostic: .contains("""
-                        multiple products named 'FooProduct' in: 'foo', 'org.foo'
-                        """),
-                        severity: .error
-                    )
                     result.check(
                         diagnostic: .contains("""
                         multiple targets named 'FooTarget' in: 'foo', 'org.foo'
@@ -10612,7 +10607,15 @@ final class WorkspaceTests: XCTestCase {
                         severity: .error
                     )
                 }
+            }) { error in
+                var diagnosed = false
+                if let realError = error as? PackageGraphError,
+                   realError.description == "multiple products named 'FooProduct' in: 'foo', 'org.foo'" {
+                    diagnosed = true
+                }
+                XCTAssertTrue(diagnosed)
             }
+
         }
 
         // reset
@@ -10764,14 +10767,8 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .disabled
 
-            try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+            XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
                 testDiagnostics(diagnostics) { result in
-                    result.check(
-                        diagnostic: .contains("""
-                        multiple products named 'FooProduct' in: 'foo', 'org.foo'
-                        """),
-                        severity: .error
-                    )
                     result.check(
                         diagnostic: .contains("""
                         multiple targets named 'FooTarget' in: 'foo', 'org.foo'
@@ -10779,6 +10776,13 @@ final class WorkspaceTests: XCTestCase {
                         severity: .error
                     )
                 }
+            }) { error in
+                var diagnosed = false
+                if let realError = error as? PackageGraphError,
+                    realError.description == "multiple products named 'FooProduct' in: 'foo', 'org.foo'" {
+                    diagnosed = true
+                }
+                XCTAssertTrue(diagnosed)
             }
         }
 
@@ -10907,14 +10911,8 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .disabled
 
-            try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+            XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
                 testDiagnostics(diagnostics) { result in
-                    result.check(
-                        diagnostic: .contains("""
-                        multiple products named 'FooProduct' in: 'foo', 'org.foo'
-                        """),
-                        severity: .error
-                    )
                     result.check(
                         diagnostic: .contains("""
                         multiple targets named 'FooTarget' in: 'foo', 'org.foo'
@@ -10922,6 +10920,13 @@ final class WorkspaceTests: XCTestCase {
                         severity: .error
                     )
                 }
+            }) { error in
+                var diagnosed = false
+                if let realError = error as? PackageGraphError,
+                    realError.description == "multiple products named 'FooProduct' in: 'foo', 'org.foo'" {
+                    diagnosed = true
+                }
+                XCTAssertTrue(diagnosed)
             }
         }
 
@@ -11039,14 +11044,8 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .disabled
 
-            try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+            XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
                 testDiagnostics(diagnostics) { result in
-                    result.check(
-                        diagnostic: .contains("""
-                        multiple products named 'FooProduct' in: 'foo', 'org.foo'
-                        """),
-                        severity: .error
-                    )
                     result.check(
                         diagnostic: .contains("""
                         multiple targets named 'FooTarget' in: 'foo', 'org.foo'
@@ -11054,6 +11053,13 @@ final class WorkspaceTests: XCTestCase {
                         severity: .error
                     )
                 }
+            }) { error in
+                var diagnosed = false
+                if let realError = error as? PackageGraphError,
+                    realError.description == "multiple products named 'FooProduct' in: 'foo', 'org.foo'" {
+                    diagnosed = true
+                }
+                XCTAssertTrue(diagnosed)
             }
         }
 
@@ -11182,14 +11188,8 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .disabled
 
-            try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+            XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
                 testDiagnostics(diagnostics) { result in
-                    result.check(
-                        diagnostic: .contains("""
-                        multiple products named 'FooProduct' in: 'foo', 'org.foo'
-                        """),
-                        severity: .error
-                    )
                     result.check(
                         diagnostic: .contains("""
                         multiple targets named 'FooTarget' in: 'foo', 'org.foo'
@@ -11197,6 +11197,13 @@ final class WorkspaceTests: XCTestCase {
                         severity: .error
                     )
                 }
+            }) { error in
+                var diagnosed = false
+                if let realError = error as? PackageGraphError,
+                    realError.description == "multiple products named 'FooProduct' in: 'foo', 'org.foo'" {
+                    diagnosed = true
+                }
+                XCTAssertTrue(diagnosed)
             }
         }
 
@@ -11329,15 +11336,8 @@ final class WorkspaceTests: XCTestCase {
 
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .disabled
-
-            try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+            XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
                 testDiagnostics(diagnostics) { result in
-                    result.check(
-                        diagnostic: .contains("""
-                        multiple products named 'BazProduct' in: 'baz', 'org.baz'
-                        """),
-                        severity: .error
-                    )
                     result.check(
                         diagnostic: .contains("""
                         multiple targets named 'BazTarget' in: 'baz', 'org.baz'
@@ -11345,6 +11345,13 @@ final class WorkspaceTests: XCTestCase {
                         severity: .error
                     )
                 }
+            }) { error in
+                var diagnosed = false
+                if let realError = error as? PackageGraphError,
+                    realError.description == "multiple products named 'BazProduct' in: 'baz', 'org.baz'" {
+                    diagnosed = true
+                }
+                XCTAssertTrue(diagnosed)
             }
         }
 
@@ -11495,14 +11502,8 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .disabled
 
-            try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+            XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
                 testDiagnostics(diagnostics) { result in
-                    result.check(
-                        diagnostic: .contains("""
-                        multiple products named 'BazProduct' in: 'baz', 'org.baz'
-                        """),
-                        severity: .error
-                    )
                     result.check(
                         diagnostic: .contains("""
                         multiple targets named 'BazTarget' in: 'baz', 'org.baz'
@@ -11510,6 +11511,13 @@ final class WorkspaceTests: XCTestCase {
                         severity: .error
                     )
                 }
+            }) { error in
+                var diagnosed = false
+                if let realError = error as? PackageGraphError,
+                    realError.description == "multiple products named 'BazProduct' in: 'baz', 'org.baz'" {
+                    diagnosed = true
+                }
+                XCTAssertTrue(diagnosed)
             }
         }
 
@@ -11627,14 +11635,8 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .disabled
 
-            try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+            XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
                 testDiagnostics(diagnostics) { result in
-                    result.check(
-                        diagnostic: .contains("""
-                        multiple products named 'FooProduct' in: 'foo', 'org.foo'
-                        """),
-                        severity: .error
-                    )
                     result.check(
                         diagnostic: .contains("""
                         multiple targets named 'FooTarget' in: 'foo', 'org.foo'
@@ -11642,6 +11644,13 @@ final class WorkspaceTests: XCTestCase {
                         severity: .error
                     )
                 }
+            }) { error in
+                var diagnosed = false
+                if let realError = error as? PackageGraphError,
+                    realError.description == "multiple products named 'FooProduct' in: 'foo', 'org.foo'" {
+                    diagnosed = true
+                }
+                XCTAssertTrue(diagnosed)
             }
         }
 


### PR DESCRIPTION
Resolves rdar://94744134

Use product IDs to distinguish products to allow duplicate product names.
Add a tool version check. 