### PR TITLE
Fix use of `extraCPPFlags`

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -2080,7 +2080,13 @@ public class BuildPlan {
         // Note: This will come from build settings in future.
         for target in dependencies.staticTargets {
             if case let target as ClangTarget = target.underlyingTarget, target.isCXX {
-                buildProduct.additionalFlags += self.buildParameters.toolchain.extraCPPFlags
+                if buildParameters.hostTriple.isDarwin() {
+                    buildProduct.additionalFlags += ["-lc++"]
+                } else if buildParameters.hostTriple.isWindows() {
+                    // Don't link any C++ library.
+                } else {
+                    buildProduct.additionalFlags += ["-lstdc++"]
+                }
                 break
             }
         }

--- a/Sources/PackageModel/Destination.swift
+++ b/Sources/PackageModel/Destination.swift
@@ -151,22 +151,13 @@ public struct Destination: Encodable, Equatable {
         extraCCFlags += ["-fPIC"]
 #endif
 
-        var extraCPPFlags: [String] = []
-#if os(macOS)
-        extraCPPFlags += ["-lc++"]
-#elseif os(Windows)
-        extraCPPFlags += []
-#else
-        extraCPPFlags += ["-lstdc++"]
-#endif
-
         return Destination(
             target: nil,
             sdk: sdkPath,
             binDir: binDir,
             extraCCFlags: extraCCFlags,
             extraSwiftCFlags: extraSwiftCFlags,
-            extraCPPFlags: extraCPPFlags
+            extraCPPFlags: []
         )
     }
 


### PR DESCRIPTION
We should not use `extraCPPFlags` as a vehicle for specifying linker flags, instead just decide on which C++ library to link based on the target triple in `BuildPlan`.
    
    Separately, it seems worthwhile to look into refactoring `Destination` to actually allow specifying linker flags since that seems to have been an accidental feature of `extraCPPFlags` (as long as one didn't pass compiler flags there as well).

rdar://100575898