### PR TITLE
Fix OpenAPI spec compliance issue

### DIFF
--- a/Documentation/Registry.md
+++ b/Documentation/Registry.md
@@ -1486,6 +1486,8 @@ components:
       properties:
         identifiers:
           type: array
+          items:
+            type: string
       required:
         - identifiers
     problem:


### PR DESCRIPTION
Properties with `type: array` MUST have an `items` property indicating the type of items in the array.

This is supposed to be a string array, right?