### PR TITLE
Reduce use of `AbsolutePath` with precondition failure

### DIFF
--- a/Examples/package-info/Sources/package-info/example.swift
+++ b/Examples/package-info/Sources/package-info/example.swift
@@ -16,7 +16,7 @@ struct Example {
 
         // We need a package to work with.
         // This computes the path of this package root based on the file location
-        let packagePath = AbsolutePath(#file).parentDirectory.parentDirectory.parentDirectory
+        let packagePath = try AbsolutePath(validating: #file).parentDirectory.parentDirectory.parentDirectory
 
         // LOADING
         // =======

--- a/Sources/Basics/HTPClient+URLSession.swift
+++ b/Sources/Basics/HTPClient+URLSession.swift
@@ -179,7 +179,7 @@ private class DownloadTaskManager: NSObject, URLSessionDownloadDelegate {
         }
 
         do {
-            try task.fileSystem.move(from: AbsolutePath(location.path), to: task.destination)
+            try task.fileSystem.move(from: AbsolutePath(validating: location.path), to: task.destination)
         } catch {
             task.moveFileError = error
         }

--- a/Sources/Basics/TemporaryFile.swift
+++ b/Sources/Basics/TemporaryFile.swift
@@ -93,13 +93,13 @@ private func createTemporaryDirectory(fileSystem: FileSystem, dir: AbsolutePath?
     
     let randomSuffix = String((0..<6).map { _ in letters.randomElement()! })
     
-    let tempDirectory = dir ?? fileSystem.tempDirectory
+    let tempDirectory = try dir ?? fileSystem.tempDirectory
     guard fileSystem.isDirectory(tempDirectory) else {
         throw TempFileError.couldNotFindTmpDir(tempDirectory.pathString)
     }
 
     // Construct path to the temporary directory.
-    let templatePath = AbsolutePath(prefix + ".\(randomSuffix)", relativeTo: tempDirectory)
+    let templatePath = try AbsolutePath(validating: prefix + ".\(randomSuffix)", relativeTo: tempDirectory)
     
     try fileSystem.createDirectory(templatePath, recursive: true)
     return templatePath

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -543,7 +543,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
                 // TODO: We need to also use any working directory, but that support isn't yet available on all platforms at a lower level.
                 var commandLine = [command.configuration.executable.pathString] + command.configuration.arguments
                 if !self.disableSandboxForPluginCommands {
-                    commandLine = Sandbox.apply(command: commandLine, strictness: .writableTemporaryDirectory, writableDirectories: [pluginResult.pluginOutputDirectory])
+                    commandLine = try Sandbox.apply(command: commandLine, strictness: .writableTemporaryDirectory, writableDirectories: [pluginResult.pluginOutputDirectory])
                 }
                 let processResult = try TSCBasic.Process.popen(arguments: commandLine, environment: command.configuration.environment)
                 let output = try processResult.utf8Output() + processResult.utf8stderrOutput()

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -416,7 +416,10 @@ extension BuildConfiguration: ExpressibleByArgument {
 extension AbsolutePath: ExpressibleByArgument {
     public init?(argument: String) {
         if let cwd = localFileSystem.currentWorkingDirectory {
-            self.init(argument, relativeTo: cwd)
+            guard let path = try? AbsolutePath(validating: argument, relativeTo: cwd) else {
+                return nil
+            }
+            self = path
         } else {
             guard let path = try? AbsolutePath(validating: argument) else {
                 return nil

--- a/Sources/Commands/SwiftRunTool.swift
+++ b/Sources/Commands/SwiftRunTool.swift
@@ -133,7 +133,7 @@ public struct SwiftRunTool: SwiftCommand {
             try buildOp.build()
 
             // Execute the REPL.
-            let arguments = buildOp.buildPlan!.createREPLArguments()
+            let arguments = try buildOp.buildPlan!.createREPLArguments()
             print("Launching Swift REPL with arguments: \(arguments.joined(separator: " "))")
             try self.run(
                 fileSystem: swiftTool.fileSystem,
@@ -262,7 +262,11 @@ public struct SwiftRunTool: SwiftCommand {
         //FIXME: Return false when the path is not a valid path string.
         let absolutePath: AbsolutePath
         if path.first == "/" {
-            absolutePath = AbsolutePath(path)
+            do {
+                absolutePath = try AbsolutePath(validating: path)
+            } catch {
+                return false
+            }
         } else {
             guard let cwd = fileSystem.currentWorkingDirectory else {
                 return false

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -415,7 +415,7 @@ public class SwiftTool {
 
         self.packageRoot = packageRoot
         self.scratchDirectory =
-            getEnvBuildPath(workingDir: cwd) ??
+            try getEnvBuildPath(workingDir: cwd) ??
             options.locations.scratchDirectory ??
             (packageRoot ?? cwd).appending(component: ".build")
 
@@ -919,11 +919,11 @@ private func findPackageRoot(fileSystem: FileSystem) -> AbsolutePath? {
 }
 
 /// Returns the build path from the environment, if present.
-private func getEnvBuildPath(workingDir: AbsolutePath) -> AbsolutePath? {
+private func getEnvBuildPath(workingDir: AbsolutePath) throws -> AbsolutePath? {
     // Don't rely on build path from env for SwiftPM's own tests.
     guard ProcessEnv.vars["SWIFTPM_TESTS_MODULECACHE"] == nil else { return nil }
     guard let env = ProcessEnv.vars["SWIFTPM_BUILD_DIR"] else { return nil }
-    return AbsolutePath(env, relativeTo: workingDir)
+    return try AbsolutePath(validating: env, relativeTo: workingDir)
 }
 
 
@@ -936,7 +936,7 @@ private func getSharedSecurityDirectory(options: GlobalOptions, fileSystem: File
         return explicitSecurityDirectory
     } else {
         // further validation is done in workspace
-        return fileSystem.swiftPMSecurityDirectory
+        return try fileSystem.swiftPMSecurityDirectory
     }
 }
 
@@ -949,7 +949,7 @@ private func getSharedConfigurationDirectory(options: GlobalOptions, fileSystem:
         return explicitConfigurationDirectory
     } else {
         // further validation is done in workspace
-        return fileSystem.swiftPMConfigurationDirectory
+        return try fileSystem.swiftPMConfigurationDirectory
     }
 }
 
@@ -962,7 +962,7 @@ private func getSharedCacheDirectory(options: GlobalOptions, fileSystem: FileSys
         return explicitCacheDirectory
     } else {
         // further validation is done in workspace
-        return fileSystem.swiftPMCacheDirectory
+        return try fileSystem.swiftPMCacheDirectory
     }
 }
 

--- a/Sources/Commands/Utilities/APIDigester.swift
+++ b/Sources/Commands/Utilities/APIDigester.swift
@@ -188,7 +188,7 @@ public struct SwiftAPIDigester {
         buildPlan: BuildPlan
     ) throws {
         var args = ["-dump-sdk"]
-        args += buildPlan.createAPIToolCommonArgs(includeLibrarySearchPaths: false)
+        args += try buildPlan.createAPIToolCommonArgs(includeLibrarySearchPaths: false)
         args += ["-module", module, "-o", outputPath.pathString]
 
         try runTool(args)
@@ -204,13 +204,13 @@ public struct SwiftAPIDigester {
         for module: String,
         buildPlan: BuildPlan,
         except breakageAllowlistPath: AbsolutePath?
-    ) -> ComparisonResult? {
+    ) throws -> ComparisonResult? {
         var args = [
             "-diagnose-sdk",
             "-baseline-path", baselinePath.pathString,
             "-module", module
         ]
-        args.append(contentsOf: buildPlan.createAPIToolCommonArgs(includeLibrarySearchPaths: false))
+        args.append(contentsOf: try buildPlan.createAPIToolCommonArgs(includeLibrarySearchPaths: false))
         if let breakageAllowlistPath = breakageAllowlistPath {
             args.append(contentsOf: ["-breakage-allowlist-path", breakageAllowlistPath.pathString])
         }

--- a/Sources/Commands/Utilities/MultiRootSupport.swift
+++ b/Sources/Commands/Utilities/MultiRootSupport.swift
@@ -64,7 +64,7 @@ public struct XcodeWorkspaceLoader {
             case .absolute:
                 path = try AbsolutePath(validating: location.path)
             case .group:
-                path = AbsolutePath(location.path, relativeTo: workspace.parentDirectory)
+                path = try AbsolutePath(validating: location.path, relativeTo: workspace.parentDirectory)
             }
 
             if self.fileSystem.exists(path.appending(component: Manifest.filename)) {

--- a/Sources/Commands/Utilities/SymbolGraphExtract.swift
+++ b/Sources/Commands/Utilities/SymbolGraphExtract.swift
@@ -56,8 +56,8 @@ public struct SymbolGraphExtract {
         var commandLine = [self.tool.pathString]
         commandLine += ["-module-name", target.c99name]
         commandLine += try buildParameters.targetTripleArgs(for: target)
-        commandLine += buildPlan.createAPIToolCommonArgs(includeLibrarySearchPaths: true)
-        commandLine += ["-module-cache-path", buildParameters.moduleCache.pathString]
+        commandLine += try buildPlan.createAPIToolCommonArgs(includeLibrarySearchPaths: true)
+        commandLine += ["-module-cache-path", try buildParameters.moduleCache.pathString]
         if verboseOutput {
             commandLine += ["-v"]
         }

--- a/Sources/Commands/Utilities/TestingSupport.swift
+++ b/Sources/Commands/Utilities/TestingSupport.swift
@@ -29,7 +29,7 @@ enum TestingSupport {
     /// - Returns: Path to XCTestHelper tool.
     static func xctestHelperPath(swiftTool: SwiftTool) throws -> AbsolutePath {
         let xctestHelperBin = "swiftpm-xctest-helper"
-        let binDirectory = AbsolutePath(CommandLine.arguments.first!,
+        let binDirectory = try AbsolutePath(validating: CommandLine.arguments.first!,
             relativeTo: swiftTool.originalWorkingDirectory).parentDirectory
         // XCTestHelper tool is installed in libexec.
         let maybePath = binDirectory.parentDirectory.appending(components: "libexec", "swift", "pm", xctestHelperBin)
@@ -83,7 +83,7 @@ enum TestingSupport {
             )
             // Add the sdk platform path if we have it. If this is not present, we
             // might always end up failing.
-            if let sdkPlatformFrameworksPath = Destination.sdkPlatformFrameworkPaths() {
+            if let sdkPlatformFrameworksPath = try Destination.sdkPlatformFrameworkPaths() {
                 // appending since we prefer the user setting (if set) to the one we inject
                 env.appendPath("DYLD_FRAMEWORK_PATH", value: sdkPlatformFrameworksPath.fwk.pathString)
                 env.appendPath("DYLD_LIBRARY_PATH", value: sdkPlatformFrameworksPath.lib.pathString)

--- a/Sources/PackageCollections/PackageIndex+Configuration.swift
+++ b/Sources/PackageCollections/PackageIndex+Configuration.swift
@@ -33,7 +33,7 @@ public struct PackageIndexConfiguration: Equatable {
     ) {
         self.url = url
         self.searchResultMaxItemsCount = searchResultMaxItemsCount ?? 50
-        self.cacheDirectory = cacheDirectory.map(resolveSymlinks) ?? localFileSystem.swiftPMCacheDirectory.appending(components: "package-metadata")
+        self.cacheDirectory = (try? cacheDirectory.map(resolveSymlinks)) ?? (try? localFileSystem.swiftPMCacheDirectory.appending(components: "package-metadata")) ?? .root
         self.cacheTTLInSeconds = disableCache ? -1 : (cacheTTLInSeconds ?? 3600)
         self.cacheMaxSizeInMegabytes = cacheMaxSizeInMegabytes ?? 10
     }

--- a/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
@@ -299,7 +299,7 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider, Closable {
         ) {
             self.authTokens = authTokens
             self.apiLimitWarningThreshold = apiLimitWarningThreshold ?? 5
-            self.cacheDir = cacheDir.map(resolveSymlinks) ?? localFileSystem.swiftPMCacheDirectory.appending(components: "package-metadata")
+            self.cacheDir = (try? cacheDir.map(resolveSymlinks)) ?? (try? localFileSystem.swiftPMCacheDirectory.appending(components: "package-metadata")) ?? .root
             self.cacheTTLInSeconds = disableCache ? -1 : (cacheTTLInSeconds ?? 3600)
             self.cacheSizeInMegabytes = cacheSizeInMegabytes ?? 10
         }

--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -60,7 +60,7 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
         self.observabilityScope = observabilityScope
         self.httpClient = customHTTPClient ?? Self.makeDefaultHTTPClient()
         self.signatureValidator = customSignatureValidator ?? PackageCollectionSigning(
-            trustedRootCertsDir: configuration.trustedRootCertsDir ?? fileSystem.swiftPMConfigurationDirectory.appending(component: "trust-root-certs").asURL,
+            trustedRootCertsDir: configuration.trustedRootCertsDir ?? (try? fileSystem.swiftPMConfigurationDirectory.appending(component: "trust-root-certs").asURL) ?? AbsolutePath.root.asURL,
             additionalTrustedRootCerts: sourceCertPolicy.allRootCerts.map { Array($0) },
             observabilityScope: observabilityScope,
             callbackQueue: .sharedConcurrent

--- a/Sources/PackageCollections/Storage/FilePackageCollectionsSourcesStorage.swift
+++ b/Sources/PackageCollections/Storage/FilePackageCollectionsSourcesStorage.swift
@@ -28,7 +28,7 @@ struct FilePackageCollectionsSourcesStorage: PackageCollectionsSourcesStorage {
     init(fileSystem: FileSystem, path: AbsolutePath? = nil) {
         self.fileSystem = fileSystem
 
-        self.path = path ?? fileSystem.swiftPMConfigurationDirectory.appending(component: "collections.json")
+        self.path = path ?? (try? fileSystem.swiftPMConfigurationDirectory.appending(component: "collections.json")) ?? .root
         self.encoder = JSONEncoder.makeWithDefaults()
         self.decoder = JSONDecoder.makeWithDefaults()
     }

--- a/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
+++ b/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
@@ -53,7 +53,7 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
     private let populateTargetTrieLock = NSLock()
 
     init(location: SQLite.Location? = nil, configuration: Configuration = .init(), observabilityScope: ObservabilityScope) {
-        self.location = location ?? .path(localFileSystem.swiftPMCacheDirectory.appending(components: "package-collection.db"))
+        self.location = location ?? (try? .path(localFileSystem.swiftPMCacheDirectory.appending(components: "package-collection.db"))) ?? .memory
         switch self.location {
         case .path, .temporary:
             self.fileSystem = localFileSystem

--- a/Sources/PackageLoading/ManifestJSONParser.swift
+++ b/Sources/PackageLoading/ManifestJSONParser.swift
@@ -215,7 +215,7 @@ enum ManifestJSONParser {
     private static func sanitizeDependencyLocation(fileSystem: TSCBasic.FileSystem, packageKind: PackageReference.Kind, dependencyLocation: String) throws -> String {
         if dependencyLocation.hasPrefix("~/") {
             // If the dependency URL starts with '~/', try to expand it.
-            return AbsolutePath(String(dependencyLocation.dropFirst(2)), relativeTo: fileSystem.homeDirectory).pathString
+            return try AbsolutePath(validating: String(dependencyLocation.dropFirst(2)), relativeTo: fileSystem.homeDirectory).pathString
         } else if dependencyLocation.hasPrefix(filePrefix) {
             // FIXME: SwiftPM can't handle file locations with file:// scheme so we need to
             // strip that. We need to design a Location data structure for SwiftPM.
@@ -236,7 +236,7 @@ enum ManifestJSONParser {
             // If the URL has no scheme, we treat it as a path (either absolute or relative to the base URL).
             switch packageKind {
             case .root(let packagePath), .fileSystem(let packagePath), .localSourceControl(let packagePath):
-                return AbsolutePath(dependencyLocation, relativeTo: packagePath).pathString
+                return try AbsolutePath(validating: dependencyLocation, relativeTo: packagePath).pathString
             case .remoteSourceControl, .registry:
                 // nothing to "fix"
                 return dependencyLocation

--- a/Sources/PackageLoading/PkgConfig.swift
+++ b/Sources/PackageLoading/PkgConfig.swift
@@ -76,7 +76,7 @@ public struct PkgConfig {
             let pkgFileFinder = PCFileFinder(brewPrefix: brewPrefix)
             self.pcFile = try pkgFileFinder.locatePCFile(
                 name: name,
-                customSearchPaths: PkgConfig.envSearchPaths + additionalSearchPaths,
+                customSearchPaths: try PkgConfig.envSearchPaths + additionalSearchPaths,
                 fileSystem: fileSystem,
                 observabilityScope: observabilityScope
             )
@@ -122,14 +122,16 @@ public struct PkgConfig {
     }
 
     private static var envSearchPaths: [AbsolutePath] {
-        if let configPath = ProcessEnv.vars["PKG_CONFIG_PATH"] {
-#if os(Windows)
-            return configPath.split(separator: ";").map({ AbsolutePath(String($0)) })
-#else
-            return configPath.split(separator: ":").map({ AbsolutePath(String($0)) })
-#endif
+        get throws {
+            if let configPath = ProcessEnv.vars["PKG_CONFIG_PATH"] {
+                #if os(Windows)
+                return try configPath.split(separator: ";").map({ try AbsolutePath(validating: String($0)) })
+                #else
+                return try configPath.split(separator: ":").map({ try AbsolutePath(validating: String($0)) })
+                #endif
+            }
+            return []
         }
-        return []
     }
 }
 
@@ -379,11 +381,11 @@ internal struct PCFileFinder {
     /// By default, this is combined with the search paths inferred from
     /// `pkg-config` itself.
     static let searchPaths = [
-        AbsolutePath("/usr/local/lib/pkgconfig"),
-        AbsolutePath("/usr/local/share/pkgconfig"),
-        AbsolutePath("/usr/lib/pkgconfig"),
-        AbsolutePath("/usr/share/pkgconfig"),
-    ]
+        try? AbsolutePath(validating: "/usr/local/lib/pkgconfig"),
+        try? AbsolutePath(validating: "/usr/local/share/pkgconfig"),
+        try? AbsolutePath(validating: "/usr/lib/pkgconfig"),
+        try? AbsolutePath(validating: "/usr/share/pkgconfig"),
+    ].compactMap({ $0 })
 
     /// Get search paths from `pkg-config` itself to locate `.pc` files.
     ///
@@ -397,9 +399,9 @@ internal struct PCFileFinder {
                 ).spm_chomp()
 
 #if os(Windows)
-                PCFileFinder.pkgConfigPaths = searchPaths.split(separator: ";").map({ AbsolutePath(String($0)) })
+                PCFileFinder.pkgConfigPaths = try searchPaths.split(separator: ";").map({ try AbsolutePath(validating: String($0)) })
 #else
-                PCFileFinder.pkgConfigPaths = searchPaths.split(separator: ":").map({ AbsolutePath(String($0)) })
+                PCFileFinder.pkgConfigPaths = try searchPaths.split(separator: ":").map({ try AbsolutePath(validating: String($0)) })
 #endif
             } catch {
                 PCFileFinder.shouldEmitPkgConfigPathsDiagnostic = true

--- a/Sources/PackageLoading/Target+PkgConfig.swift
+++ b/Sources/PackageLoading/Target+PkgConfig.swift
@@ -58,13 +58,13 @@ public struct PkgConfigResult {
 }
 
 /// Get pkgConfig result for a system library target.
-public func pkgConfigArgs(for target: SystemLibraryTarget, brewPrefix: AbsolutePath? = .none, fileSystem: FileSystem, observabilityScope: ObservabilityScope) -> [PkgConfigResult] {
+public func pkgConfigArgs(for target: SystemLibraryTarget, brewPrefix: AbsolutePath? = .none, fileSystem: FileSystem, observabilityScope: ObservabilityScope) throws -> [PkgConfigResult] {
     // If there is no pkg config name defined, we're done.
     guard let pkgConfigNames = target.pkgConfig else { return [] }
 
     // Compute additional search paths for the provider, if any.
     let provider = target.providers?.first { $0.isAvailable }
-    let additionalSearchPaths = provider?.pkgConfigSearchPath(brewPrefixOverride: brewPrefix) ?? []
+    let additionalSearchPaths = try provider?.pkgConfigSearchPath(brewPrefixOverride: brewPrefix) ?? []
 
    var ret: [PkgConfigResult] = []
     // Get the pkg config flags.
@@ -161,7 +161,7 @@ extension SystemPackageProviderDescription {
         return false
     }
 
-    func pkgConfigSearchPath(brewPrefixOverride: AbsolutePath?) -> [AbsolutePath] {
+    func pkgConfigSearchPath(brewPrefixOverride: AbsolutePath?) throws -> [AbsolutePath] {
         switch self {
         case .brew(let packages):
             let brewPrefix: String
@@ -182,7 +182,7 @@ extension SystemPackageProviderDescription {
                     return []
                 }
             }
-            return packages.map({ AbsolutePath(brewPrefix).appending(components: "opt", $0, "lib", "pkgconfig") })
+            return try packages.map({ try AbsolutePath(validating: brewPrefix).appending(components: "opt", $0, "lib", "pkgconfig") })
         case .apt:
             return []
         case .yum:

--- a/Sources/PackageModel/Destination.swift
+++ b/Sources/PackageModel/Destination.swift
@@ -96,7 +96,7 @@ public struct Destination: Encodable, Equatable {
         guard let cwd = originalWorkingDirectory else {
             return try AbsolutePath(validating: CommandLine.arguments[0]).parentDirectory
         }
-        return AbsolutePath(CommandLine.arguments[0], relativeTo: cwd).parentDirectory
+        return try AbsolutePath(validating: CommandLine.arguments[0], relativeTo: cwd).parentDirectory
     }
 
     /// The destination describing the host OS.
@@ -129,7 +129,7 @@ public struct Destination: Encodable, Equatable {
             guard !sdkPathStr.isEmpty else {
                 throw DestinationError.invalidInstallation("default SDK not found")
             }
-            sdkPath = AbsolutePath(sdkPathStr)
+            sdkPath = try AbsolutePath(validating: sdkPathStr)
         }
 #else
         sdkPath = nil
@@ -139,7 +139,7 @@ public struct Destination: Encodable, Equatable {
         var extraCCFlags: [String] = []
         var extraSwiftCFlags: [String] = []
 #if os(macOS)
-        if let sdkPaths = Destination.sdkPlatformFrameworkPaths(environment: environment) {
+        if let sdkPaths = try Destination.sdkPlatformFrameworkPaths(environment: environment) {
             extraCCFlags += ["-F", sdkPaths.fwk.pathString]
             extraSwiftCFlags += ["-F", sdkPaths.fwk.pathString]
             extraSwiftCFlags += ["-I", sdkPaths.lib.pathString]
@@ -164,7 +164,7 @@ public struct Destination: Encodable, Equatable {
     /// Returns macosx sdk platform framework path.
     public static func sdkPlatformFrameworkPaths(
         environment: EnvironmentVariables = .process()
-    ) -> (fwk: AbsolutePath, lib: AbsolutePath)? {
+    ) throws -> (fwk: AbsolutePath, lib: AbsolutePath)? {
         if let path = _sdkPlatformFrameworkPath {
             return path
         }
@@ -174,11 +174,11 @@ public struct Destination: Encodable, Equatable {
 
         if let platformPath = platformPath, !platformPath.isEmpty {
             // For XCTest framework.
-            let fwk = AbsolutePath(platformPath).appending(
+            let fwk = try AbsolutePath(validating: platformPath).appending(
                 components: "Developer", "Library", "Frameworks")
 
             // For XCTest Swift library.
-            let lib = AbsolutePath(platformPath).appending(
+            let lib = try AbsolutePath(validating: platformPath).appending(
                 components: "Developer", "usr", "lib")
 
             _sdkPlatformFrameworkPath = (fwk, lib)

--- a/Sources/PackageModel/MinimumDeploymentTarget.swift
+++ b/Sources/PackageModel/MinimumDeploymentTarget.swift
@@ -44,7 +44,7 @@ public struct MinimumDeploymentTarget {
     static func computeXCTestMinimumDeploymentTarget(with runResult: ProcessResult, platform: PackageModel.Platform) throws -> PlatformVersion? {
         guard let output = try runResult.utf8Output().spm_chuzzle() else { return nil }
         let sdkPath = try AbsolutePath(validating: output)
-        let xcTestPath = AbsolutePath("Developer/Library/Frameworks/XCTest.framework/XCTest", relativeTo: sdkPath)
+        let xcTestPath = try AbsolutePath(validating: "Developer/Library/Frameworks/XCTest.framework/XCTest", relativeTo: sdkPath)
         return try computeMinimumDeploymentTarget(of: xcTestPath, platform: platform)
     }
 

--- a/Sources/PackageModel/Toolchain.swift
+++ b/Sources/PackageModel/Toolchain.swift
@@ -20,7 +20,7 @@ public protocol Toolchain {
     var swiftCompilerPath: AbsolutePath { get }
 
     /// Path containing the macOS Swift stdlib.
-    var macosSwiftStdlib: AbsolutePath { get }
+    var macosSwiftStdlib: AbsolutePath { get throws }
 
     /// Path of the `clang` compiler.
     func getClangCompiler() throws -> AbsolutePath
@@ -45,12 +45,16 @@ extension Toolchain {
         return nil
     }
 
-    public var macosSwiftStdlib: AbsolutePath { 
-        return AbsolutePath("../../lib/swift/macosx", relativeTo: resolveSymlinks(swiftCompilerPath))
+    public var macosSwiftStdlib: AbsolutePath {
+        get throws {
+            return try AbsolutePath(validating: "../../lib/swift/macosx", relativeTo: resolveSymlinks(swiftCompilerPath))
+        }
     }
 
     public var toolchainLibDir: AbsolutePath {
-        // FIXME: Not sure if it's better to base this off of Swift compiler or our own binary.
-        return AbsolutePath("../../lib", relativeTo: resolveSymlinks(swiftCompilerPath))
+        get throws {
+            // FIXME: Not sure if it's better to base this off of Swift compiler or our own binary.
+            return try AbsolutePath(validating: "../../lib", relativeTo: resolveSymlinks(swiftCompilerPath))
+        }
     }
 }

--- a/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
+++ b/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
@@ -53,8 +53,8 @@ extension BinaryTarget {
         }
         // Construct a LibraryInfo for the library.
         let libraryDir = self.artifactPath.appending(component: library.libraryIdentifier)
-        let libraryFile = AbsolutePath(library.libraryPath, relativeTo: libraryDir)
-        let headersDir = library.headersPath.map { AbsolutePath($0, relativeTo: libraryDir) }
+        let libraryFile = try AbsolutePath(validating: library.libraryPath, relativeTo: libraryDir)
+        let headersDir = try library.headersPath.map { try AbsolutePath(validating: $0, relativeTo: libraryDir) }
         return [LibraryInfo(libraryPath: libraryFile, headersPath: headersDir)]
     }
 
@@ -67,12 +67,12 @@ extension BinaryTarget {
         // TODO: Add support for libraries
         let executables = metadata.artifacts.filter { $0.value.type == .executable }
         // Construct an ExecutableInfo for each matching variant.
-        return executables.flatMap { entry in
+        return try executables.flatMap { entry in
             // FIXME: this filter needs to become more sophisticated
-            entry.value.variants.filter {
+            try entry.value.variants.filter {
                 return $0.supportedTriples.contains(versionLessTriple)
             }.map{
-                ExecutableInfo(name: entry.key, executablePath: AbsolutePath($0.path, relativeTo: self.artifactPath))
+                ExecutableInfo(name: entry.key, executablePath: try AbsolutePath(validating: $0.path, relativeTo: self.artifactPath))
             }
         }
     }

--- a/Sources/SPMBuildCore/PluginContextSerializer.swift
+++ b/Sources/SPMBuildCore/PluginContextSerializer.swift
@@ -105,7 +105,7 @@ internal struct PluginContextSerializer {
             var ldFlags: [String] = []
             // FIXME: What do we do with any diagnostics here?
             let observabilityScope = ObservabilitySystem({ _, _ in }).topScope
-            for result in pkgConfigArgs(for: target, fileSystem: self.fileSystem, observabilityScope: observabilityScope) {
+            for result in try pkgConfigArgs(for: target, fileSystem: self.fileSystem, observabilityScope: observabilityScope) {
                 if let error = result.error {
                     observabilityScope.emit(
                         warning: "\(error)",

--- a/Sources/SPMBuildCore/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/PluginInvocation.swift
@@ -356,7 +356,7 @@ extension PackageGraph {
             for pluginTarget in pluginTargets {
                 // Determine the tools to which this plugin has access, and create a name-to-path mapping from tool
                 // names to the corresponding paths. Built tools are assumed to be in the build tools directory.
-                let accessibleTools = pluginTarget.accessibleTools(fileSystem: fileSystem, environment: buildEnvironment, for: pluginScriptRunner.hostTriple)
+                let accessibleTools = pluginTarget.accessibleTools(fileSystem: fileSystem, environment: buildEnvironment, for: try pluginScriptRunner.hostTriple)
                 let toolNamesToPaths = accessibleTools.reduce(into: [String: AbsolutePath](), { dict, tool in
                     switch tool {
                     case .builtTool(let name, let path):

--- a/Sources/SPMBuildCore/PluginScriptRunner.swift
+++ b/Sources/SPMBuildCore/PluginScriptRunner.swift
@@ -59,7 +59,7 @@ public protocol PluginScriptRunner {
 
     /// Returns the Triple that represents the host for which plugin script tools should be built, or for which binary
     /// tools should be selected.
-    var hostTriple: Triple { get }
+    var hostTriple: Triple { get throws }
 }
 
 /// Protocol by which `PluginScriptRunner` communicates back to the caller as it compiles plugins.

--- a/Sources/SPMTestSupport/InMemoryGitRepository.swift
+++ b/Sources/SPMTestSupport/InMemoryGitRepository.swift
@@ -247,7 +247,7 @@ extension InMemoryGitRepository: FileSystem {
     }
 
     public var currentWorkingDirectory: AbsolutePath? {
-        return AbsolutePath("/")
+        return AbsolutePath(path: "/")
     }
 
     public func changeCurrentWorkingDirectory(to path: AbsolutePath) throws {

--- a/Sources/SPMTestSupport/MockPackageContainer.swift
+++ b/Sources/SPMTestSupport/MockPackageContainer.swift
@@ -100,16 +100,16 @@ public class MockPackageContainer: CustomPackageContainer {
     public convenience init(
         name: String,
         dependenciesByVersion: [Version: [(container: String, versionRequirement: VersionSetSpecifier)]]
-    ) {
+    ) throws {
         var dependencies: [String: [Dependency]] = [:]
         for (version, deps) in dependenciesByVersion {
-            dependencies[version.description] = deps.map {
-                let path = AbsolutePath("/\($0.container)")
+            dependencies[version.description] = try deps.map {
+                let path = try AbsolutePath(validating: "/\($0.container)")
                 let ref = PackageReference.localSourceControl(identity: .init(path: path), path: path)
                 return (ref, .versionSet($0.versionRequirement))
             }
         }
-        let path = AbsolutePath("/\(name)")
+        let path = try AbsolutePath(validating: "/\(name)")
         let ref = PackageReference.localSourceControl(identity: .init(path: path), path: path)
         self.init(package: ref, dependencies: dependencies)
     }
@@ -133,16 +133,16 @@ public class MockPackageContainer: CustomPackageContainer {
     public init(
         name: String,
         dependenciesByProductFilter: [ProductFilter: [(container: String, versionRequirement: VersionSetSpecifier)]]
-    ) {
+    ) throws {
         var dependencies: [ProductFilter: [Dependency]] = [:]
         for (filter, deps) in dependenciesByProductFilter {
-            dependencies[filter] = deps.map {
-                let path = AbsolutePath("/\($0.container)")
+            dependencies[filter] = try deps.map {
+                let path = try AbsolutePath(validating: "/\($0.container)")
                 let ref = PackageReference.localSourceControl(identity: .init(path: path), path: path)
                 return (ref, .versionSet($0.versionRequirement))
             }
         }
-        let path = AbsolutePath("/\(name)")
+        let path = try AbsolutePath(validating: "/\(name)")
         let ref = PackageReference.localSourceControl(identity: .init(path: path), path: path)
         self.package = ref
         self._versions = [Version(1, 0, 0)]

--- a/Sources/SPMTestSupport/MockRegistry.swift
+++ b/Sources/SPMTestSupport/MockRegistry.swift
@@ -348,11 +348,11 @@ private struct MockRegistryArchiver: Archiver {
             let rootPath = lines[1]
             for path in lines[2..<lines.count] {
                 let relativePath = String(path.dropFirst(rootPath.count + 1))
-                let targetPath = AbsolutePath(relativePath, relativeTo: destinationPath.appending(component: "package"))
+                let targetPath = try AbsolutePath(validating: relativePath, relativeTo: destinationPath.appending(component: "package"))
                 if !self.fileSystem.exists(targetPath.parentDirectory) {
                     try self.fileSystem.createDirectory(targetPath.parentDirectory, recursive: true)
                 }
-                try self.fileSystem.copy(from: AbsolutePath(path), to: targetPath)
+                try self.fileSystem.copy(from: try AbsolutePath(validating: path), to: targetPath)
             }
             completion(.success(()))
         } catch {

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -97,12 +97,12 @@ public final class MockWorkspace {
         return self.sandbox.appending(components: ".build", "artifacts")
     }
 
-    public func pathToRoot(withName name: String) -> AbsolutePath {
-        return AbsolutePath(name, relativeTo: self.rootsDir)
+    public func pathToRoot(withName name: String) throws -> AbsolutePath {
+        return try AbsolutePath(validating: name, relativeTo: self.rootsDir)
     }
 
-    public func pathToPackage(withName name: String) -> AbsolutePath {
-        return AbsolutePath(name, relativeTo: self.packagesDir)
+    public func pathToPackage(withName name: String) throws -> AbsolutePath {
+        return try AbsolutePath(validating: name, relativeTo: self.packagesDir)
     }
 
     private func create() throws {
@@ -293,8 +293,8 @@ public final class MockWorkspace {
         self._workspace = nil
     }
 
-    public func rootPaths(for packages: [String]) -> [AbsolutePath] {
-        return packages.map { AbsolutePath($0, relativeTo: rootsDir) }
+    public func rootPaths(for packages: [String]) throws -> [AbsolutePath] {
+        return try packages.map { try AbsolutePath(validating: $0, relativeTo: rootsDir) }
     }
 
     public func checkEdit(
@@ -325,8 +325,8 @@ public final class MockWorkspace {
         _ result: ([Basics.Diagnostic]) -> Void
     ) {
         let observability = ObservabilitySystem.makeForTesting()
-        let rootInput = PackageGraphRootInput(packages: rootPaths(for: roots))
         observability.topScope.trap {
+            let rootInput = PackageGraphRootInput(packages: try rootPaths(for: roots))
             let ws = try self.getOrCreateWorkspace()
             try ws.unedit(packageName: packageName, forceRemove: forceRemove, root: rootInput, observabilityScope: observability.topScope)
         }
@@ -335,8 +335,8 @@ public final class MockWorkspace {
 
     public func checkResolve(pkg: String, roots: [String], version: TSCUtility.Version, _ result: ([Basics.Diagnostic]) -> Void) {
         let observability = ObservabilitySystem.makeForTesting()
-        let rootInput = PackageGraphRootInput(packages: rootPaths(for: roots))
         observability.topScope.trap {
+            let rootInput = PackageGraphRootInput(packages: try rootPaths(for: roots))
             let workspace = try self.getOrCreateWorkspace()
             try workspace.resolve(packageName: pkg, root: rootInput, version: version, branch: nil, revision: nil, observabilityScope: observability.topScope)
         }
@@ -372,7 +372,7 @@ public final class MockWorkspace {
         let observability = ObservabilitySystem.makeForTesting()
         observability.topScope.trap {
             let rootInput = PackageGraphRootInput(
-                packages: rootPaths(for: roots),
+                packages: try rootPaths(for: roots),
                 dependencies: dependencies
             )
             let workspace = try self.getOrCreateWorkspace()
@@ -388,7 +388,7 @@ public final class MockWorkspace {
     ) throws {
         let dependencies = try deps.map { try $0.convert(baseURL: packagesDir, identityResolver: self.identityResolver) }
         let rootInput = PackageGraphRootInput(
-            packages: rootPaths(for: roots),
+            packages: try rootPaths(for: roots),
             dependencies: dependencies
         )
 
@@ -413,11 +413,11 @@ public final class MockWorkspace {
         roots: [String] = [],
         dependencies: [PackageDependency] = [],
         forceResolvedVersions: Bool = false,
-        _ result: (PackageGraph, [Basics.Diagnostic]) -> Void
+        _ result: (PackageGraph, [Basics.Diagnostic]) throws -> Void
     ) throws {
         let observability = ObservabilitySystem.makeForTesting()
         let rootInput = PackageGraphRootInput(
-            packages: rootPaths(for: roots), dependencies: dependencies
+            packages: try rootPaths(for: roots), dependencies: dependencies
         )
         let workspace = try self.getOrCreateWorkspace()
         do {
@@ -426,7 +426,7 @@ public final class MockWorkspace {
                 forceResolvedVersions: forceResolvedVersions,
                 observabilityScope: observability.topScope
             )
-            result(graph, observability.diagnostics)
+            try result(graph, observability.diagnostics)
         } catch {
             // helpful when graph fails to load
             if observability.hasErrorDiagnostics {
@@ -452,11 +452,11 @@ public final class MockWorkspace {
         _ result: ([Basics.Diagnostic]) -> Void
     ) {
         let observability = ObservabilitySystem.makeForTesting()
-        let rootInput = PackageGraphRootInput(
-            packages: rootPaths(for: roots),
-            dependencies: dependencies
-        )
         observability.topScope.trap {
+            let rootInput = PackageGraphRootInput(
+                packages: try rootPaths(for: roots),
+                dependencies: dependencies
+            )
             let workspace = try self.getOrCreateWorkspace()
             try workspace.loadPackageGraph(
                 rootInput: rootInput,
@@ -477,7 +477,7 @@ public final class MockWorkspace {
         let workspace = try self.getOrCreateWorkspace()
         let pinsStore = try workspace.pinsStore.load()
 
-        let rootInput = PackageGraphRootInput(packages: rootPaths(for: roots.map { $0.name }), dependencies: [])
+        let rootInput = PackageGraphRootInput(packages: try rootPaths(for: roots.map { $0.name }), dependencies: [])
         let rootManifests = try temp_await { workspace.loadRootManifests(packages: rootInput.packages, observabilityScope: observability.topScope, completion: $0) }
         let root = PackageGraphRoot(input: rootInput, manifests: rootManifests)
 
@@ -692,7 +692,7 @@ public final class MockWorkspace {
         let dependencies = try deps.map { try $0.convert(baseURL: packagesDir, identityResolver: self.identityResolver) }
         let workspace = try self.getOrCreateWorkspace()
         let rootInput = PackageGraphRootInput(
-            packages: rootPaths(for: roots), dependencies: dependencies
+            packages: try rootPaths(for: roots), dependencies: dependencies
         )
         let rootManifests = try tsc_await { workspace.loadRootManifests(packages: rootInput.packages, observabilityScope: observability.topScope, completion: $0) }
         let graphRoot = PackageGraphRoot(input: rootInput, manifests: rootManifests)

--- a/Sources/SPMTestSupport/Toolchain.swift
+++ b/Sources/SPMTestSupport/Toolchain.swift
@@ -16,19 +16,19 @@ import Workspace
 import TSCBasic
 
 #if os(macOS)
-private func macOSBundleRoot() -> AbsolutePath {
+private func macOSBundleRoot() throws -> AbsolutePath {
     for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
-        return AbsolutePath(bundle.bundlePath).parentDirectory
+        return try AbsolutePath(validating: bundle.bundlePath).parentDirectory
     }
     fatalError()
 }
 #endif
 
-private func resolveBinDir() -> AbsolutePath {
+private func resolveBinDir() throws -> AbsolutePath {
 #if os(macOS)
-    return macOSBundleRoot()
+    return try macOSBundleRoot()
 #else
-    return AbsolutePath(CommandLine.arguments[0], relativeTo: localFileSystem.currentWorkingDirectory!).parentDirectory
+    return try AbsolutePath(validating: CommandLine.arguments[0], relativeTo: localFileSystem.currentWorkingDirectory!).parentDirectory
 #endif
 }
 
@@ -36,7 +36,9 @@ extension UserToolchain {
 
 #if os(macOS)
     public var sdkPlatformFrameworksPath: AbsolutePath {
-        return Destination.sdkPlatformFrameworkPaths()!.fwk
+        get throws {
+            return try Destination.sdkPlatformFrameworkPaths()!.fwk
+        }
     }
 #endif
 
@@ -44,8 +46,8 @@ extension UserToolchain {
 
 extension Destination {
     public static var `default`: Self {
-        get {
-            let binDir = resolveBinDir()
+        get throws {
+            let binDir = try resolveBinDir()
             return try! Destination.hostDestination(binDir)
         }
     }
@@ -53,8 +55,8 @@ extension Destination {
 
 extension UserToolchain {
     public static var `default`: Self {
-        get {
-            return try! .init(destination: Destination.default)
+        get throws {
+            return try .init(destination: Destination.default)
         }
     }
 }

--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -57,7 +57,7 @@ public func fixture(
 
             // Construct the expected path of the fixture.
             // FIXME: This seems quite hacky; we should provide some control over where fixtures are found.
-            let fixtureDir = AbsolutePath("../../../Fixtures", relativeTo: AbsolutePath(#file)).appending(fixtureSubpath)
+            let fixtureDir = AbsolutePath(path: "../../../Fixtures", relativeTo: AbsolutePath(path: #file)).appending(fixtureSubpath)
 
             // Check that the fixture is really there.
             guard localFileSystem.isDirectory(fixtureDir) else {
@@ -255,3 +255,19 @@ public func loadPackageGraph(
 }
 
 public let emptyZipFile = ByteString([0x80, 0x75, 0x05, 0x06] + [UInt8](repeating: 0x00, count: 18))
+
+public extension AbsolutePath {
+    init(path: StaticString) {
+        let pathString = path.withUTF8Buffer {
+            String(decoding: $0, as: UTF8.self)
+        }
+        try! self.init(validating: pathString)
+    }
+
+    init(path: StaticString, relativeTo basePath: AbsolutePath) {
+        let pathString = path.withUTF8Buffer {
+            String(decoding: $0, as: UTF8.self)
+        }
+        try! self.init(validating: pathString, relativeTo: basePath)
+    }
+}

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -590,7 +590,7 @@ public final class GitRepository: Repository, WorkingCheckout {
         guard let firstLine = ByteString(split[0]).validDescription else {
             return false
         }
-        return localFileSystem.isDirectory(AbsolutePath(firstLine))
+        return (try? localFileSystem.isDirectory(AbsolutePath(validating: firstLine))) == true
     }
 
     /// Returns true if the file at `path` is ignored by `git`

--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -299,7 +299,7 @@ public final class InitPackage {
         try makeDirectories(moduleDir)
 
         let sourceFileName = "\(typeName).swift"
-        let sourceFile = AbsolutePath(sourceFileName, relativeTo: moduleDir)
+        let sourceFile = try AbsolutePath(validating: sourceFileName, relativeTo: moduleDir)
 
         let content: String
         switch packageType {
@@ -412,11 +412,11 @@ public final class InitPackage {
     }
 
     private func writeTestFileStubs(testsPath: AbsolutePath) throws {
-        let testModule = AbsolutePath(pkgname + Target.testModuleNameSuffix, relativeTo: testsPath)
+        let testModule = try AbsolutePath(validating: pkgname + Target.testModuleNameSuffix, relativeTo: testsPath)
         progressReporter?("Creating \(testModule.relative(to: destinationPath))/")
         try makeDirectories(testModule)
 
-        let testClassFile = AbsolutePath("\(moduleName)Tests.swift", relativeTo: testModule)
+        let testClassFile = try AbsolutePath(validating: "\(moduleName)Tests.swift", relativeTo: testModule)
         switch packageType {
         case .systemModule, .empty, .manifest, .`extension`: break
         case .library:

--- a/Sources/Workspace/Workspace+State.swift
+++ b/Sources/Workspace/Workspace+State.swift
@@ -461,7 +461,7 @@ extension Workspace.ManagedArtifact {
             packageRef: .init(artifact.packageRef),
             targetName: artifact.targetName,
             source: artifact.source.underlying,
-            path: AbsolutePath(artifact.path),
+            path: try AbsolutePath(validating: artifact.path),
             kind: artifact.kind.underlying
         )
     }
@@ -776,7 +776,7 @@ extension Workspace.ManagedDependency {
 
 extension Workspace.ManagedArtifact {
     fileprivate init(_ artifact: WorkspaceStateStorage.V5.Artifact) throws {
-        let path = AbsolutePath(artifact.path)
+        let path = try AbsolutePath(validating: artifact.path)
         try self.init(
             packageRef: .init(artifact.packageRef),
             targetName: artifact.targetName,
@@ -1016,7 +1016,7 @@ extension Workspace.ManagedDependency {
 
 extension Workspace.ManagedArtifact {
     fileprivate init(_ artifact: WorkspaceStateStorage.V4.Artifact) throws {
-        let path = AbsolutePath(artifact.path)
+        let path = try AbsolutePath(validating: artifact.path)
         try self.init(
             packageRef: .init(artifact.packageRef),
             targetName: artifact.targetName,

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -389,7 +389,7 @@ public class Workspace {
         delegate: Delegate? = .none
     ) throws {
         let fileSystem = fileSystem ?? localFileSystem
-        let location = Location(forRootPackage: packagePath, fileSystem: fileSystem)
+        let location = try Location(forRootPackage: packagePath, fileSystem: fileSystem)
         try self.init(
             fileSystem: fileSystem,
             location: location,
@@ -434,7 +434,7 @@ public class Workspace {
         delegate: Delegate? = .none
     ) throws {
         let fileSystem = fileSystem ?? localFileSystem
-        let location = Location(forRootPackage: packagePath, fileSystem: fileSystem)
+        let location = try Location(forRootPackage: packagePath, fileSystem: fileSystem)
         let manifestLoader = ManifestLoader(
             toolchain: customHostToolchain,
             cacheDir: location.sharedManifestsCacheDirectory
@@ -548,7 +548,7 @@ public class Workspace {
 
         let mirrors = try customMirrors ?? Workspace.Configuration.Mirrors(
             fileSystem: fileSystem,
-            localMirrorsFile: location.localMirrorsConfigurationFile,
+            localMirrorsFile: try location.localMirrorsConfigurationFile,
             sharedMirrorsFile: location.sharedMirrorsConfigurationFile
         ).mirrors
 
@@ -805,7 +805,7 @@ extension Workspace {
         // Remove all but protected paths.
         let contentsToRemove = Set(contents).subtracting(protectedAssets)
         for name in contentsToRemove {
-            try? fileSystem.removeFileTree(AbsolutePath(name, relativeTo: self.location.scratchDirectory))
+            try? fileSystem.removeFileTree(AbsolutePath(validating: name, relativeTo: self.location.scratchDirectory))
         }
     }
 

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -327,7 +327,7 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         addBuildConfiguration(name: "Release", settings: releaseSettings)
 
         for product in package.products.sorted(by: { $0.name < $1.name }) {
-            addTarget(for: product)
+            try addTarget(for: product)
         }
 
         for target in package.targets.sorted(by: { $0.name < $1.name }) {
@@ -339,10 +339,10 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         }
     }
 
-    private func addTarget(for product: ResolvedProduct) {
+    private func addTarget(for product: ResolvedProduct) throws {
         switch product.type {
         case .executable, .snippet, .test:
-            addMainModuleTarget(for: product)
+            try addMainModuleTarget(for: product)
         case .library:
             addLibraryTarget(for: product)
         case .plugin:
@@ -377,7 +377,7 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         return "\(productName)_\(String(productName.hash, radix: 16, uppercase: true))_PackageProduct"
     }
 
-    private func addMainModuleTarget(for product: ResolvedProduct) {
+    private func addMainModuleTarget(for product: ResolvedProduct) throws {
         let productType: PIF.Target.ProductType = product.type == .executable ? .executable : .unitTest
         let pifTarget = addTarget(
             guid: product.pifTargetGUID,
@@ -460,7 +460,7 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         var releaseSettings = settings
 
         var impartedSettings = PIF.BuildSettings()
-        addManifestBuildSettings(
+        try addManifestBuildSettings(
             from: mainTarget.underlyingTarget,
             debugSettings: &debugSettings,
             releaseSettings: &releaseSettings,
@@ -671,7 +671,7 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         var debugSettings = settings
         var releaseSettings = settings
 
-        addManifestBuildSettings(
+        try addManifestBuildSettings(
             from: target.underlyingTarget,
             debugSettings: &debugSettings,
             releaseSettings: &releaseSettings,
@@ -697,7 +697,7 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         var impartedSettings = PIF.BuildSettings()
 
         var cFlags: [String] = []
-        for result in pkgConfigArgs(for: systemTarget, fileSystem: fileSystem, observabilityScope: self.observabilityScope) {
+        for result in try pkgConfigArgs(for: systemTarget, fileSystem: fileSystem, observabilityScope: self.observabilityScope) {
             if let error = result.error {
                 self.observabilityScope.emit(
                     warning: "\(error)",
@@ -859,12 +859,12 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         debugSettings: inout PIF.BuildSettings,
         releaseSettings: inout PIF.BuildSettings,
         impartedSettings: inout PIF.BuildSettings
-    ) {
+    ) throws {
         for (setting, assignments) in target.buildSettings.pifAssignments {
             for assignment in assignments {
                 var value = assignment.value
                 if setting == .HEADER_SEARCH_PATHS {
-                    value = value.map { AbsolutePath($0, relativeTo: target.sources.root).pathString }
+                    value = try value.map { try AbsolutePath(validating: $0, relativeTo: target.sources.root).pathString }
                 }
 
                 if let platforms = assignment.platforms {

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -80,7 +80,7 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
         } else {
             let xcodeSelectOutput = try TSCBasic.Process.popen(args: "xcode-select", "-p").utf8Output().spm_chomp()
             let xcodeDirectory = try AbsolutePath(validating: xcodeSelectOutput)
-            xcbuildPath = AbsolutePath("../SharedFrameworks/XCBuild.framework/Versions/A/Support/xcbuild", relativeTo: xcodeDirectory)
+            xcbuildPath = try AbsolutePath(validating: "../SharedFrameworks/XCBuild.framework/Versions/A/Support/xcbuild", relativeTo: xcodeDirectory)
         }
 
         guard fileSystem.exists(xcbuildPath) else {
@@ -175,7 +175,7 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
         settings["CC"] = try? buildParameters.toolchain.getClangCompiler().pathString
         // Always specify the path of the effective Swift compiler, which was determined in the same way as for the native build system.
         settings["SWIFT_EXEC"] = buildParameters.toolchain.swiftCompilerPath.pathString
-        settings["LIBRARY_SEARCH_PATHS"] = "$(inherited) \(buildParameters.toolchain.toolchainLibDir.pathString)"
+        settings["LIBRARY_SEARCH_PATHS"] = "$(inherited) \(try buildParameters.toolchain.toolchainLibDir.pathString)"
         settings["OTHER_CFLAGS"] = (
             ["$(inherited)"]
             + buildParameters.toolchain.extraCCFlags
@@ -294,7 +294,7 @@ extension PIFBuilderParameters {
         self.init(
             enableTestability: buildParameters.enableTestability,
             shouldCreateDylibForDynamicProducts: buildParameters.shouldCreateDylibForDynamicProducts,
-            toolchainLibDir: buildParameters.toolchain.toolchainLibDir
+            toolchainLibDir: (try? buildParameters.toolchain.toolchainLibDir) ?? .root
         )
     }
 }

--- a/Tests/BasicsTests/FileSystemTests.swift
+++ b/Tests/BasicsTests/FileSystemTests.swift
@@ -20,7 +20,7 @@ final class FileSystemTests: XCTestCase {
     func testStripFirstLevelComponent() throws {
         let fileSystem = InMemoryFileSystem()
 
-        let rootPath = AbsolutePath("/root")
+        let rootPath = AbsolutePath(path: "/root")
         try fileSystem.createDirectory(rootPath)
 
         let totalDirectories = Int.random(in: 0 ..< 100)

--- a/Tests/BasicsTests/SandboxTests.swift
+++ b/Tests/BasicsTests/SandboxTests.swift
@@ -19,9 +19,9 @@ final class SandboxTest: XCTestCase {
     func testSandboxOnAllPlatforms() throws {
         try withTemporaryDirectory { path in
 #if os(Windows)
-            let command = Sandbox.apply(command: ["tar.exe", "-h"], strictness: .default, writableDirectories: [])
+            let command = try Sandbox.apply(command: ["tar.exe", "-h"], strictness: .default, writableDirectories: [])
 #else
-            let command = Sandbox.apply(command: ["echo", "0"], strictness: .default, writableDirectories: [])
+            let command = try Sandbox.apply(command: ["echo", "0"], strictness: .default, writableDirectories: [])
 #endif
             XCTAssertNoThrow(try TSCBasic.Process.checkNonZeroExit(arguments: command))
         }
@@ -32,7 +32,7 @@ final class SandboxTest: XCTestCase {
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
 
-        let command = Sandbox.apply(command: ["ping", "-t", "1", "localhost"], strictness: .default, writableDirectories: [])
+        let command = try Sandbox.apply(command: ["ping", "-t", "1", "localhost"], strictness: .default, writableDirectories: [])
 
         XCTAssertThrowsError(try TSCBasic.Process.checkNonZeroExit(arguments: command)) { error in
             guard case ProcessResult.Error.nonZeroExit(let result) = error else {
@@ -48,7 +48,7 @@ final class SandboxTest: XCTestCase {
         #endif
 
         try withTemporaryDirectory { path in
-            let command = Sandbox.apply(command: ["touch", path.appending(component: UUID().uuidString).pathString], strictness: .default, writableDirectories: [path])
+            let command = try Sandbox.apply(command: ["touch", path.appending(component: UUID().uuidString).pathString], strictness: .default, writableDirectories: [path])
             XCTAssertNoThrow(try TSCBasic.Process.checkNonZeroExit(arguments: command))
         }
     }
@@ -59,7 +59,7 @@ final class SandboxTest: XCTestCase {
         #endif
 
         try withTemporaryDirectory { path in
-            let command = Sandbox.apply(command: ["touch", path.appending(component: UUID().uuidString).pathString], strictness: .default, writableDirectories: [])
+            let command = try Sandbox.apply(command: ["touch", path.appending(component: UUID().uuidString).pathString], strictness: .default, writableDirectories: [])
             XCTAssertThrowsError(try TSCBasic.Process.checkNonZeroExit(arguments: command)) { error in
                 guard case ProcessResult.Error.nonZeroExit(let result) = error else {
                     return XCTFail("invalid error \(error)")
@@ -78,7 +78,7 @@ final class SandboxTest: XCTestCase {
             let file = path.appending(component: UUID().uuidString)
             XCTAssertNoThrow(try TSCBasic.Process.checkNonZeroExit(arguments: ["touch", file.pathString]))
 
-            let command = Sandbox.apply(command: ["rm", file.pathString], strictness: .default, writableDirectories: [])
+            let command = try Sandbox.apply(command: ["rm", file.pathString], strictness: .default, writableDirectories: [])
             XCTAssertThrowsError(try TSCBasic.Process.checkNonZeroExit(arguments: command)) { error in
                 guard case ProcessResult.Error.nonZeroExit(let result) = error else {
                     return XCTFail("invalid error \(error)")
@@ -98,7 +98,7 @@ final class SandboxTest: XCTestCase {
             let file = path.appending(component: UUID().uuidString)
             XCTAssertNoThrow(try TSCBasic.Process.checkNonZeroExit(arguments: ["touch", file.pathString]))
 
-            let command = Sandbox.apply(command: ["cat", file.pathString], strictness: .default, writableDirectories: [])
+            let command = try Sandbox.apply(command: ["cat", file.pathString], strictness: .default, writableDirectories: [])
             XCTAssertNoThrow(try TSCBasic.Process.checkNonZeroExit(arguments: command))
         }
     }
@@ -114,7 +114,7 @@ final class SandboxTest: XCTestCase {
             XCTAssertNoThrow(try TSCBasic.Process.checkNonZeroExit(arguments: ["touch", file.pathString]))
             XCTAssertNoThrow(try TSCBasic.Process.checkNonZeroExit(arguments: ["chmod", "+x", file.pathString]))
 
-            let command = Sandbox.apply(command: [file.pathString], strictness: .default, writableDirectories: [])
+            let command = try Sandbox.apply(command: [file.pathString], strictness: .default, writableDirectories: [])
             XCTAssertNoThrow(try TSCBasic.Process.checkNonZeroExit(arguments: command))
         }
     }
@@ -126,12 +126,12 @@ final class SandboxTest: XCTestCase {
 
         // Try writing to the per-user temporary directory, which is under /var/folders/.../TemporaryItems.
         let tmpFile1 = NSTemporaryDirectory() + "/" + UUID().uuidString
-        let command1 = Sandbox.apply(command: ["touch", tmpFile1], strictness: .writableTemporaryDirectory)
+        let command1 = try Sandbox.apply(command: ["touch", tmpFile1], strictness: .writableTemporaryDirectory)
         XCTAssertNoThrow(try TSCBasic.Process.checkNonZeroExit(arguments: command1))
         try? FileManager.default.removeItem(atPath: tmpFile1)
 
         let tmpFile2 = "/tmp" + "/" + UUID().uuidString
-        let command2 = Sandbox.apply(command: ["touch", tmpFile2], strictness: .writableTemporaryDirectory)
+        let command2 = try Sandbox.apply(command: ["touch", tmpFile2], strictness: .writableTemporaryDirectory)
         XCTAssertNoThrow(try TSCBasic.Process.checkNonZeroExit(arguments: command2))
         try? FileManager.default.removeItem(atPath: tmpFile2)
     }
@@ -145,13 +145,13 @@ final class SandboxTest: XCTestCase {
             // Check that we can write into the temporary directory, but not into a read-only directory underneath it.
             let writableDir = tmpDir.appending(component: "ShouldBeWritable")
             try localFileSystem.createDirectory(writableDir)
-            let allowedCommand = Sandbox.apply(command: ["touch", writableDir.pathString], strictness: .default, writableDirectories: [writableDir])
+            let allowedCommand = try Sandbox.apply(command: ["touch", writableDir.pathString], strictness: .default, writableDirectories: [writableDir])
             XCTAssertNoThrow(try TSCBasic.Process.checkNonZeroExit(arguments: allowedCommand))
 
             // Check that we cannot write into a read-only directory inside a writable temporary directory.
             let readOnlyDir = writableDir.appending(component: "ShouldBeReadOnly")
             try localFileSystem.createDirectory(readOnlyDir)
-            let deniedCommand = Sandbox.apply(command: ["touch", readOnlyDir.pathString], strictness: .writableTemporaryDirectory, readOnlyDirectories: [readOnlyDir])
+            let deniedCommand = try Sandbox.apply(command: ["touch", readOnlyDir.pathString], strictness: .writableTemporaryDirectory, readOnlyDirectories: [readOnlyDir])
             XCTAssertThrowsError(try TSCBasic.Process.checkNonZeroExit(arguments: deniedCommand)) { error in
                 guard case ProcessResult.Error.nonZeroExit(let result) = error else {
                     return XCTFail("invalid error \(error)")
@@ -170,7 +170,7 @@ final class SandboxTest: XCTestCase {
              // Check that we cannot write into a read-only directory, but into a writable directory underneath it.
              let readOnlyDir = tmpDir.appending(component: "ShouldBeReadOnly")
              try localFileSystem.createDirectory(readOnlyDir)
-             let deniedCommand = Sandbox.apply(command: ["touch", readOnlyDir.pathString], strictness: .writableTemporaryDirectory, readOnlyDirectories: [readOnlyDir])
+             let deniedCommand = try Sandbox.apply(command: ["touch", readOnlyDir.pathString], strictness: .writableTemporaryDirectory, readOnlyDirectories: [readOnlyDir])
              XCTAssertThrowsError(try TSCBasic.Process.checkNonZeroExit(arguments: deniedCommand)) { error in
                  guard case ProcessResult.Error.nonZeroExit(let result) = error else {
                      return XCTFail("invalid error \(error)")
@@ -181,7 +181,7 @@ final class SandboxTest: XCTestCase {
              // Check that we can write into a writable directory underneath it.
              let writableDir = readOnlyDir.appending(component: "ShouldBeWritable")
              try localFileSystem.createDirectory(writableDir)
-             let allowedCommand = Sandbox.apply(command: ["touch", writableDir.pathString], strictness: .default, writableDirectories:[writableDir], readOnlyDirectories: [readOnlyDir])
+             let allowedCommand = try Sandbox.apply(command: ["touch", writableDir.pathString], strictness: .default, writableDirectories:[writableDir], readOnlyDirectories: [readOnlyDir])
              XCTAssertNoThrow(try TSCBasic.Process.checkNonZeroExit(arguments: allowedCommand))
          }
      }

--- a/Tests/BasicsTests/VFSTests.swift
+++ b/Tests/BasicsTests/VFSTests.swift
@@ -56,62 +56,62 @@ class VFSTests: XCTestCase {
             let vfs = try VirtualFileSystem(path: vfsPath.path, fs: fs)
 
             // exists()
-            XCTAssertTrue(vfs.exists(AbsolutePath("/")))
-            XCTAssertFalse(vfs.exists(AbsolutePath("/does-not-exist")))
+            XCTAssertTrue(vfs.exists(AbsolutePath(path: "/")))
+            XCTAssertFalse(vfs.exists(AbsolutePath(path: "/does-not-exist")))
 
             // isFile()
-            let filePath = AbsolutePath("/best")
+            let filePath = AbsolutePath(path: "/best")
             XCTAssertTrue(vfs.exists(filePath))
             XCTAssertTrue(vfs.isFile(filePath))
             XCTAssertEqual(try vfs.getFileInfo(filePath).fileType, .typeRegular)
             XCTAssertFalse(vfs.isDirectory(filePath))
-            XCTAssertFalse(vfs.isFile(AbsolutePath("/does-not-exist")))
-            XCTAssertFalse(vfs.isSymlink(AbsolutePath("/does-not-exist")))
-            XCTAssertThrowsError(try vfs.getFileInfo(AbsolutePath("/does-not-exist")))
+            XCTAssertFalse(vfs.isFile(AbsolutePath(path: "/does-not-exist")))
+            XCTAssertFalse(vfs.isSymlink(AbsolutePath(path: "/does-not-exist")))
+            XCTAssertThrowsError(try vfs.getFileInfo(AbsolutePath(path: "/does-not-exist")))
 
             // isSymlink()
-            let symPath = AbsolutePath("/hello")
+            let symPath = AbsolutePath(path: "/hello")
             XCTAssertTrue(vfs.isSymlink(symPath))
             XCTAssertTrue(vfs.isFile(symPath))
             XCTAssertEqual(try vfs.getFileInfo(symPath).fileType, .typeSymbolicLink)
             XCTAssertFalse(vfs.isDirectory(symPath))
 
             // isExecutableFile
-            let executablePath = AbsolutePath("/exec-foo")
-            let executableSymPath = AbsolutePath("/exec-sym")
+            let executablePath = AbsolutePath(path: "/exec-foo")
+            let executableSymPath = AbsolutePath(path: "/exec-sym")
             XCTAssertTrue(vfs.isExecutableFile(executablePath))
             XCTAssertTrue(vfs.isExecutableFile(executableSymPath))
             XCTAssertTrue(vfs.isSymlink(executableSymPath))
             XCTAssertFalse(vfs.isExecutableFile(symPath))
             XCTAssertFalse(vfs.isExecutableFile(filePath))
-            XCTAssertFalse(vfs.isExecutableFile(AbsolutePath("/does-not-exist")))
-            XCTAssertFalse(vfs.isExecutableFile(AbsolutePath("/")))
+            XCTAssertFalse(vfs.isExecutableFile(AbsolutePath(path: "/does-not-exist")))
+            XCTAssertFalse(vfs.isExecutableFile(AbsolutePath(path: "/")))
 
             // readFileContents
             let execFileContents = try vfs.readFileContents(executablePath)
             XCTAssertEqual(execFileContents, ByteString(contents))
 
             // isDirectory()
-            XCTAssertTrue(vfs.isDirectory(AbsolutePath("/")))
-            XCTAssertFalse(vfs.isDirectory(AbsolutePath("/does-not-exist")))
+            XCTAssertTrue(vfs.isDirectory(AbsolutePath(path: "/")))
+            XCTAssertFalse(vfs.isDirectory(AbsolutePath(path: "/does-not-exist")))
 
             // getDirectoryContents()
             do {
-                _ = try vfs.getDirectoryContents(AbsolutePath("/does-not-exist"))
+                _ = try vfs.getDirectoryContents(AbsolutePath(path: "/does-not-exist"))
                 XCTFail("Unexpected success")
             } catch {
-                XCTAssertEqual(error.localizedDescription, "no such file or directory: \(AbsolutePath("/does-not-exist"))")
+                XCTAssertEqual(error.localizedDescription, "no such file or directory: \(AbsolutePath(path: "/does-not-exist"))")
             }
 
-            let thisDirectoryContents = try vfs.getDirectoryContents(AbsolutePath("/"))
+            let thisDirectoryContents = try vfs.getDirectoryContents(AbsolutePath(path: "/"))
             XCTAssertFalse(thisDirectoryContents.contains(where: { $0 == "." }))
             XCTAssertFalse(thisDirectoryContents.contains(where: { $0 == ".." }))
             XCTAssertEqual(thisDirectoryContents.sorted(), ["best", "dir", "exec-foo", "exec-sym", "hello"])
 
-            let contents = try vfs.getDirectoryContents(AbsolutePath("/dir"))
+            let contents = try vfs.getDirectoryContents(AbsolutePath(path: "/dir"))
             XCTAssertEqual(contents, ["file"])
 
-            let fileContents = try vfs.readFileContents(AbsolutePath("/dir/file"))
+            let fileContents = try vfs.readFileContents(AbsolutePath(path: "/dir/file"))
             XCTAssertEqual(fileContents, "")
         }
     }

--- a/Tests/BasicsTests/ZipArchiverTests.swift
+++ b/Tests/BasicsTests/ZipArchiverTests.swift
@@ -14,13 +14,12 @@ import Basics
 import TSCBasic
 import TSCTestSupport
 import XCTest
-import SPMTestSupport
 
 class ZipArchiverTests: XCTestCase {
     func testZipArchiverSuccess() throws {
         try testWithTemporaryDirectory { tmpdir in
             let archiver = ZipArchiver(fileSystem: localFileSystem)
-            let inputArchivePath = AbsolutePath(#file).parentDirectory.appending(components: "Inputs", "archive.zip")
+            let inputArchivePath = AbsolutePath(path: #file).parentDirectory.appending(components: "Inputs", "archive.zip")
             try archiver.extract(from: inputArchivePath, to: tmpdir)
             let content = tmpdir.appending(component: "file")
             XCTAssert(localFileSystem.exists(content))
@@ -31,8 +30,8 @@ class ZipArchiverTests: XCTestCase {
     func testZipArchiverArchiveDoesntExist() {
         let fileSystem = InMemoryFileSystem()
         let archiver = ZipArchiver(fileSystem: fileSystem)
-        let archive = AbsolutePath("/archive.zip")
-        XCTAssertThrowsError(try archiver.extract(from: archive, to: AbsolutePath("/"))) { error in
+        let archive = AbsolutePath(path: "/archive.zip")
+        XCTAssertThrowsError(try archiver.extract(from: archive, to: AbsolutePath(path: "/"))) { error in
             XCTAssertEqual(error as? FileSystemError, FileSystemError(.noEntry, archive))
         }
     }
@@ -40,8 +39,8 @@ class ZipArchiverTests: XCTestCase {
     func testZipArchiverDestinationDoesntExist() throws {
         let fileSystem = InMemoryFileSystem(emptyFiles: "/archive.zip")
         let archiver = ZipArchiver(fileSystem: fileSystem)
-        let destination = AbsolutePath("/destination")
-        XCTAssertThrowsError(try archiver.extract(from: AbsolutePath("/archive.zip"), to: destination)) { error in
+        let destination = AbsolutePath(path: "/destination")
+        XCTAssertThrowsError(try archiver.extract(from: AbsolutePath(path: "/archive.zip"), to: destination)) { error in
             XCTAssertEqual(error as? FileSystemError, FileSystemError(.notDirectory, destination))
         }
     }
@@ -49,8 +48,8 @@ class ZipArchiverTests: XCTestCase {
     func testZipArchiverDestinationIsFile() throws {
         let fileSystem = InMemoryFileSystem(emptyFiles: "/archive.zip", "/destination")
         let archiver = ZipArchiver(fileSystem: fileSystem)
-        let destination = AbsolutePath("/destination")
-        XCTAssertThrowsError(try archiver.extract(from: AbsolutePath("/archive.zip"), to: destination)) { error in
+        let destination = AbsolutePath(path: "/destination")
+        XCTAssertThrowsError(try archiver.extract(from: AbsolutePath(path: "/archive.zip"), to: destination)) { error in
             XCTAssertEqual(error as? FileSystemError, FileSystemError(.notDirectory, destination))
         }
     }
@@ -58,7 +57,7 @@ class ZipArchiverTests: XCTestCase {
     func testZipArchiverInvalidArchive() throws {
         try testWithTemporaryDirectory { tmpdir in
             let archiver = ZipArchiver(fileSystem: localFileSystem)
-            let inputArchivePath = AbsolutePath(#file).parentDirectory
+            let inputArchivePath = AbsolutePath(path: #file).parentDirectory
                 .appending(components: "Inputs", "invalid_archive.zip")
             XCTAssertThrowsError(try archiver.extract(from: inputArchivePath, to: tmpdir)) { error in
 #if os(Windows)
@@ -74,14 +73,14 @@ class ZipArchiverTests: XCTestCase {
         // valid
         try testWithTemporaryDirectory { tmpdir in
             let archiver = ZipArchiver(fileSystem: localFileSystem)
-            let path = AbsolutePath(#file).parentDirectory
+            let path = AbsolutePath(path: #file).parentDirectory
                 .appending(components: "Inputs", "archive.zip")
             XCTAssertTrue(try archiver.validate(path: path))
         }
         // invalid
         try testWithTemporaryDirectory { tmpdir in
             let archiver = ZipArchiver(fileSystem: localFileSystem)
-            let path = AbsolutePath(#file).parentDirectory
+            let path = AbsolutePath(path: #file).parentDirectory
                 .appending(components: "Inputs", "invalid_archive.zip")
             XCTAssertFalse(try archiver.validate(path: path))
         }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -26,7 +26,7 @@ import enum TSCUtility.Diagnostics
 import struct TSCUtility.Triple
 
 final class BuildPlanTests: XCTestCase {
-    let inputsDir = AbsolutePath(#file).parentDirectory.appending(components: "Inputs")
+    let inputsDir = AbsolutePath(path: #file).parentDirectory.appending(components: "Inputs")
 
     /// The j argument.
     private var j: String {
@@ -548,7 +548,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
-                    path: .init("/Pkg"),
+                    path: .init(path: "/Pkg"),
                     targets: [
                         TargetDescription(name: "exe", dependencies: ["lib"]),
                         TargetDescription(name: "lib", dependencies: []),
@@ -721,7 +721,7 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testSwiftConditionalDependency() throws {
-        let Pkg: AbsolutePath = AbsolutePath("/Pkg")
+        let Pkg: AbsolutePath = AbsolutePath(path: "/Pkg")
 
         let fs = InMemoryFileSystem(emptyFiles:
             Pkg.appending(components: "Sources", "exe", "main.swift").pathString,
@@ -736,10 +736,10 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
-                    path: .init(Pkg.pathString),
+                    path: try .init(validating: Pkg.pathString),
                     dependencies: [
-                        .localSourceControl(path: .init("/ExtPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/PlatformPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/ExtPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/PlatformPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe", dependencies: [
@@ -761,7 +761,7 @@ final class BuildPlanTests: XCTestCase {
                 ),
                 Manifest.createLocalSourceControlManifest(
                     name: "ExtPkg",
-                    path: .init("/ExtPkg"),
+                    path: .init(path: "/ExtPkg"),
                     products: [
                         ProductDescription(name: "ExtLib", type: .library(.automatic), targets: ["ExtLib"]),
                     ],
@@ -771,7 +771,7 @@ final class BuildPlanTests: XCTestCase {
                 ),
                 Manifest.createLocalSourceControlManifest(
                     name: "PlatformPkg",
-                    path: .init("/PlatformPkg"),
+                    path: .init(path: "/PlatformPkg"),
                     platforms: [PlatformDescription(name: "macos", version: "50.0")],
                     products: [
                         ProductDescription(name: "PlatformLib", type: .library(.automatic), targets: ["PlatformLib"]),
@@ -799,11 +799,11 @@ final class BuildPlanTests: XCTestCase {
 
             let buildPath: AbsolutePath = plan.buildParameters.dataPath.appending(components: "release")
 
-            let linkedFileList: String = try fs.readFileContents(AbsolutePath("/path/to/build/release/exe.product/Objects.LinkFileList"))
+            let linkedFileList: String = try fs.readFileContents(AbsolutePath(path: "/path/to/build/release/exe.product/Objects.LinkFileList"))
             XCTAssertMatch(linkedFileList, .contains("PkgLib"))
             XCTAssertNoMatch(linkedFileList, .contains("ExtLib"))
 
-            let yaml = fs.tempDirectory.appending(components: UUID().uuidString, "release.yaml")
+            let yaml = try fs.tempDirectory.appending(components: UUID().uuidString, "release.yaml")
             try fs.createDirectory(yaml.parentDirectory, recursive: true)
             let llbuild = LLBuildManifestBuilder(plan, fileSystem: fs, observabilityScope: observability.topScope)
             try llbuild.generateManifest(at: yaml)
@@ -825,11 +825,11 @@ final class BuildPlanTests: XCTestCase {
                 observabilityScope: observability.topScope
             )
 
-            let linkedFileList: String = try fs.readFileContents(AbsolutePath("/path/to/build/debug/exe.product/Objects.LinkFileList"))
+            let linkedFileList: String = try fs.readFileContents(AbsolutePath(path: "/path/to/build/debug/exe.product/Objects.LinkFileList"))
             XCTAssertNoMatch(linkedFileList, .contains("PkgLib"))
             XCTAssertNoMatch(linkedFileList, .contains("ExtLib"))
 
-            let yaml = fs.tempDirectory.appending(components: UUID().uuidString, "debug.yaml")
+            let yaml = try fs.tempDirectory.appending(components: UUID().uuidString, "debug.yaml")
             try fs.createDirectory(yaml.parentDirectory, recursive: true)
             let llbuild = LLBuildManifestBuilder(plan, fileSystem: fs, observabilityScope: observability.topScope)
             try llbuild.generateManifest(at: yaml)
@@ -854,9 +854,9 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "A",
-                    path: .init("/A"),
+                    path: .init(path: "/A"),
                     dependencies: [
-                        .localSourceControl(path: .init("/B"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/B"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "ATarget", dependencies: ["BLibrary"]),
@@ -864,7 +864,7 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "B",
-                    path: .init("/B"),
+                    path: .init(path: "/B"),
                     products: [
                         ProductDescription(name: "BLibrary", type: .library(.automatic), targets: ["BTarget"]),
                     ],
@@ -909,7 +909,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
-                    path: .init("/Pkg"),
+                    path: .init(path: "/Pkg"),
                     targets: [
                         TargetDescription(name: "exe", dependencies: []),
                     ]),
@@ -985,7 +985,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
-                    path: .init("/Pkg"),
+                    path: .init(path: "/Pkg"),
                     targets: [
                         TargetDescription(name: "exe", dependencies: []),
                     ]),
@@ -1049,8 +1049,8 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testBasicClangPackage() throws {
-        let Pkg: AbsolutePath = AbsolutePath("/Pkg")
-        let ExtPkg: AbsolutePath = AbsolutePath("/ExtPkg")
+        let Pkg: AbsolutePath = AbsolutePath(path: "/Pkg")
+        let ExtPkg: AbsolutePath = AbsolutePath(path: "/ExtPkg")
 
         let fs = InMemoryFileSystem(emptyFiles:
             Pkg.appending(components: "Sources", "exe", "main.c").pathString,
@@ -1067,9 +1067,9 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
-                    path: .init(Pkg.pathString),
+                    path: try .init(validating: Pkg.pathString),
                     dependencies: [
-                        .localSourceControl(path: .init(ExtPkg.pathString), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: try .init(validating: ExtPkg.pathString), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe", dependencies: ["lib"]),
@@ -1077,7 +1077,7 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "ExtPkg",
-                    path: .init(ExtPkg.pathString),
+                    path: try .init(validating: ExtPkg.pathString),
                     products: [
                         ProductDescription(name: "ExtPkg", type: .library(.automatic), targets: ["extlib"]),
                     ],
@@ -1122,7 +1122,7 @@ final class BuildPlanTests: XCTestCase {
         args += ["-fmodules-cache-path=\(buildPath.appending(components: "ModuleCache"))"]
 #endif
         XCTAssertEqual(try ext.basicArguments(isCXX: false), args)
-        XCTAssertEqual(ext.objects, [buildPath.appending(components: "extlib.build", "extlib.c.o")])
+        XCTAssertEqual(try ext.objects, [buildPath.appending(components: "extlib.build", "extlib.c.o")])
         XCTAssertEqual(ext.moduleMap, buildPath.appending(components: "extlib.build", "module.modulemap"))
 
         let exe = try result.target(for: "exe").clangTarget()
@@ -1154,7 +1154,7 @@ final class BuildPlanTests: XCTestCase {
         args += ["-fmodules-cache-path=\(buildPath.appending(components: "ModuleCache"))"]
 #endif
         XCTAssertEqual(try exe.basicArguments(isCXX: false), args)
-        XCTAssertEqual(exe.objects, [buildPath.appending(components: "exe.build", "main.c.o")])
+        XCTAssertEqual(try exe.objects, [buildPath.appending(components: "exe.build", "main.c.o")])
         XCTAssertEqual(exe.moduleMap, nil)
 
       #if os(macOS)
@@ -1219,9 +1219,9 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
-                    path: .init("/Pkg"),
+                    path: .init(path: "/Pkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/ExtPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/ExtPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe", dependencies: [
@@ -1239,7 +1239,7 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createLocalSourceControlManifest(
                     name: "ExtPkg",
-                    path: .init("/ExtPkg"),
+                    path: .init(path: "/ExtPkg"),
                     products: [
                         ProductDescription(name: "ExtPkg", type: .library(.automatic), targets: ["ExtLib"]),
                     ],
@@ -1291,7 +1291,7 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testCLanguageStandard() throws {
-        let Pkg: AbsolutePath = AbsolutePath("/Pkg")
+        let Pkg: AbsolutePath = AbsolutePath(path: "/Pkg")
 
         let fs = InMemoryFileSystem(emptyFiles:
             Pkg.appending(components: "Sources", "exe", "main.cpp").pathString,
@@ -1306,7 +1306,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
-                    path: .init(Pkg.pathString),
+                    path: try .init(validating: Pkg.pathString),
                     cLanguageStandard: "gnu99",
                     cxxLanguageStandard: "c++1z",
                     targets: [
@@ -1370,7 +1370,7 @@ final class BuildPlanTests: XCTestCase {
         ])
       #endif
 
-        let yaml = fs.tempDirectory.appending(components: UUID().uuidString, "debug.yaml")
+        let yaml = try fs.tempDirectory.appending(components: UUID().uuidString, "debug.yaml")
         try fs.createDirectory(yaml.parentDirectory, recursive: true)
         let llbuild = LLBuildManifestBuilder(plan, fileSystem: fs, observabilityScope: observability.topScope)
         try llbuild.generateManifest(at: yaml)
@@ -1380,7 +1380,7 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testSwiftCMixed() throws {
-        let Pkg: AbsolutePath = AbsolutePath("/Pkg")
+        let Pkg: AbsolutePath = AbsolutePath(path: "/Pkg")
 
         let fs = InMemoryFileSystem(emptyFiles:
             Pkg.appending(components: "Sources", "exe", "main.swift").pathString,
@@ -1394,7 +1394,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
-                    path: .init(Pkg.pathString),
+                    path: try .init(validating: Pkg.pathString),
                     targets: [
                         TargetDescription(name: "exe", dependencies: ["lib"]),
                         TargetDescription(name: "lib", dependencies: []),
@@ -1438,7 +1438,7 @@ final class BuildPlanTests: XCTestCase {
         args += ["-fmodules-cache-path=\(buildPath.appending(components: "ModuleCache"))"]
 #endif
         XCTAssertEqual(try lib.basicArguments(isCXX: false), args)
-        XCTAssertEqual(lib.objects, [buildPath.appending(components: "lib.build", "lib.c.o")])
+        XCTAssertEqual(try lib.objects, [buildPath.appending(components: "lib.build", "lib.c.o")])
         XCTAssertEqual(lib.moduleMap, buildPath.appending(components: "lib.build", "module.modulemap"))
 
         let exe = try result.target(for: "exe").swiftTarget().compileArguments()
@@ -1495,7 +1495,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
-                    path: .init("/Pkg"),
+                    path: .init(path: "/Pkg"),
                     toolsVersion: .v5,
                     targets: [
                         TargetDescription(name: "exe", dependencies: ["lib"]),
@@ -1516,14 +1516,14 @@ final class BuildPlanTests: XCTestCase {
         result.checkTargetsCount(2)
 
         let lib = try result.target(for: "lib").clangTarget()
-        XCTAssertEqual(lib.objects, [
-            AbsolutePath("/path/to/build/debug/lib.build/lib.S.o"),
-            AbsolutePath("/path/to/build/debug/lib.build/lib.c.o")
+        XCTAssertEqual(try lib.objects, [
+            AbsolutePath(path: "/path/to/build/debug/lib.build/lib.S.o"),
+            AbsolutePath(path: "/path/to/build/debug/lib.build/lib.c.o")
         ])
     }
 
     func testREPLArguments() throws {
-        let Dep: AbsolutePath = AbsolutePath("/Dep")
+        let Dep: AbsolutePath = AbsolutePath(path: "/Dep")
         let fs = InMemoryFileSystem(emptyFiles:
             "/Pkg/Sources/exe/main.swift",
             "/Pkg/Sources/swiftlib/lib.swift",
@@ -1541,9 +1541,9 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
-                    path: .init("/Pkg"),
+                    path: .init(path: "/Pkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/Dep"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/Dep"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe", dependencies: ["swiftlib"]),
@@ -1552,7 +1552,7 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "Dep",
-                    path: .init("/Dep"),
+                    path: .init(path: "/Dep"),
                     products: [
                         ProductDescription(name: "Dep", type: .library(.automatic), targets: ["Dep"]),
                     ],
@@ -1575,7 +1575,7 @@ final class BuildPlanTests: XCTestCase {
 
         let buildPath: AbsolutePath = plan.buildParameters.dataPath.appending(components: "debug")
 
-        XCTAssertEqual(plan.createREPLArguments().sorted(), ["-I\(Dep.appending(components: "Sources", "CDep", "include"))", "-I\(buildPath)", "-I\(buildPath.appending(components: "lib.build"))", "-L\(buildPath)", "-lpkg__REPL", "repl"])
+        XCTAssertEqual(try plan.createREPLArguments().sorted(), ["-I\(Dep.appending(components: "Sources", "CDep", "include"))", "-I\(buildPath)", "-I\(buildPath.appending(components: "lib.build"))", "-L\(buildPath)", "-lpkg__REPL", "repl"])
 
         XCTAssertEqual(plan.graph.allProducts.map({ $0.name }).sorted(), [
             "Dep",
@@ -1597,7 +1597,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
-                    path: .init("/Pkg"),
+                    path: .init(path: "/Pkg"),
                     targets: [
                         TargetDescription(name: "Foo", dependencies: []),
                         TargetDescription(name: "FooTests", dependencies: ["Foo"], type: .test),
@@ -1679,7 +1679,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
-                    path: .init("/Pkg"),
+                    path: .init(path: "/Pkg"),
                     platforms: [
                         PlatformDescription(name: "macos", version: "12.0"),
                     ],
@@ -1758,7 +1758,7 @@ final class BuildPlanTests: XCTestCase {
             "/Pkg/Snippets/AtMainSnippet.swift"
         )
 
-        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe3/foo.swift")) {
+        try fs.writeFileContents(AbsolutePath(path: "/Pkg/Sources/exe3/foo.swift")) {
             """
             @main
             struct Runner {
@@ -1769,7 +1769,7 @@ final class BuildPlanTests: XCTestCase {
             """
         }
 
-        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe4/main.swift")) {
+        try fs.writeFileContents(AbsolutePath(path: "/Pkg/Sources/exe4/main.swift")) {
             """
             @main
             struct Runner {
@@ -1780,21 +1780,21 @@ final class BuildPlanTests: XCTestCase {
             """
         }
 
-        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe5/comments.swift")) {
+        try fs.writeFileContents(AbsolutePath(path: "/Pkg/Sources/exe5/comments.swift")) {
             """
             // @main in comment
             print("hello world")
             """
         }
 
-        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe6/comments.swift")) {
+        try fs.writeFileContents(AbsolutePath(path: "/Pkg/Sources/exe6/comments.swift")) {
             """
             /* @main in comment */
             print("hello world")
             """
         }
 
-        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe7/comments.swift")) {
+        try fs.writeFileContents(AbsolutePath(path: "/Pkg/Sources/exe7/comments.swift")) {
             """
             /*
             @main in comment
@@ -1803,7 +1803,7 @@ final class BuildPlanTests: XCTestCase {
             """
         }
 
-        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe8/comments.swift")) {
+        try fs.writeFileContents(AbsolutePath(path: "/Pkg/Sources/exe8/comments.swift")) {
             """
             /*
             @main
@@ -1817,7 +1817,7 @@ final class BuildPlanTests: XCTestCase {
             """
         }
 
-        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe9/comments.swift")) {
+        try fs.writeFileContents(AbsolutePath(path: "/Pkg/Sources/exe9/comments.swift")) {
             """
             /*@main
             struct Runner {
@@ -1828,7 +1828,7 @@ final class BuildPlanTests: XCTestCase {
             """
         }
 
-        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe10/comments.swift")) {
+        try fs.writeFileContents(AbsolutePath(path: "/Pkg/Sources/exe10/comments.swift")) {
             """
             // @main in comment
             @main
@@ -1840,7 +1840,7 @@ final class BuildPlanTests: XCTestCase {
             """
         }
 
-        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe11/comments.swift")) {
+        try fs.writeFileContents(AbsolutePath(path: "/Pkg/Sources/exe11/comments.swift")) {
             """
             /* @main in comment */
             @main
@@ -1852,7 +1852,7 @@ final class BuildPlanTests: XCTestCase {
             """
         }
 
-        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe12/comments.swift")) {
+        try fs.writeFileContents(AbsolutePath(path: "/Pkg/Sources/exe12/comments.swift")) {
             """
             /*
             @main
@@ -1870,7 +1870,7 @@ final class BuildPlanTests: XCTestCase {
             """
         }
 
-        try fs.writeFileContents(AbsolutePath("/Pkg/Snippets/TopLevelCodeSnippet.swift")) {
+        try fs.writeFileContents(AbsolutePath(path: "/Pkg/Snippets/TopLevelCodeSnippet.swift")) {
             """
             struct Foo {
               init() {}
@@ -1881,7 +1881,7 @@ final class BuildPlanTests: XCTestCase {
             """
         }
 
-        try fs.writeFileContents(AbsolutePath("/Pkg/Snippets/AtMainSnippet.swift")) {
+        try fs.writeFileContents(AbsolutePath(path: "/Pkg/Snippets/AtMainSnippet.swift")) {
             """
             @main
             struct Runner {
@@ -1898,7 +1898,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
-                    path: .init("/Pkg"),
+                    path: .init(path: "/Pkg"),
                     toolsVersion: .v5_5,
                     targets: [
                         TargetDescription(name: "exe1", type: .executable),
@@ -1994,7 +1994,7 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testCModule() throws {
-        let Clibgit: AbsolutePath = AbsolutePath("/Clibgit")
+        let Clibgit: AbsolutePath = AbsolutePath(path: "/Clibgit")
 
         let fs = InMemoryFileSystem(emptyFiles:
             "/Pkg/Sources/exe/main.swift",
@@ -2007,16 +2007,16 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
-                    path: .init("/Pkg"),
+                    path: .init(path: "/Pkg"),
                     dependencies: [
-                        .localSourceControl(path: .init(Clibgit.pathString), requirement: .upToNextMajor(from: "1.0.0"))
+                        .localSourceControl(path: try .init(validating: Clibgit.pathString), requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     targets: [
                         TargetDescription(name: "exe", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "Clibgit",
-                    path: .init("/Clibgit")
+                    path: .init(path: "/Clibgit")
                 ),
             ],
             observabilityScope: observability.topScope
@@ -2086,7 +2086,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
-                    path: .init("/Pkg"),
+                    path: .init(path: "/Pkg"),
                     targets: [
                         TargetDescription(name: "lib", dependencies: []),
                         TargetDescription(name: "exe", dependencies: ["lib"]),
@@ -2125,7 +2125,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "Bar",
-                    path: .init("/Bar"),
+                    path: .init(path: "/Bar"),
                     products: [
                         ProductDescription(name: "Bar-Baz", type: .library(.dynamic), targets: ["Bar"]),
                     ],
@@ -2134,9 +2134,9 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "Foo",
-                    path: .init("/Foo"),
+                    path: .init(path: "/Foo"),
                     dependencies: [
-                        .localSourceControl(path: .init("/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Bar-Baz"]),
@@ -2257,7 +2257,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
-                    path: .init("/Pkg"),
+                    path: .init(path: "/Pkg"),
                     products: [
                         ProductDescription(name: "lib", type: .library(.dynamic), targets: ["lib"]),
                     ],
@@ -2329,7 +2329,7 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testClangTargets() throws {
-        let Pkg: AbsolutePath = AbsolutePath("/Pkg")
+        let Pkg: AbsolutePath = AbsolutePath(path: "/Pkg")
 
         let fs = InMemoryFileSystem(emptyFiles:
             Pkg.appending(components: "Sources", "exe", "main.c").pathString,
@@ -2343,7 +2343,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
-                    path: .init(Pkg.pathString),
+                    path: try .init(validating: Pkg.pathString),
                     products: [
                         ProductDescription(name: "lib", type: .library(.dynamic), targets: ["lib"]),
                     ],
@@ -2383,7 +2383,7 @@ final class BuildPlanTests: XCTestCase {
         expectedExeBasicArgs += ["-fmodules-cache-path=\(buildPath.appending(components: "ModuleCache"))"]
 #endif
         XCTAssertEqual(try exe.basicArguments(isCXX: false), expectedExeBasicArgs)
-        XCTAssertEqual(exe.objects, [buildPath.appending(components: "exe.build", "main.c.o")])
+        XCTAssertEqual(try exe.objects, [buildPath.appending(components: "exe.build", "main.c.o")])
         XCTAssertEqual(exe.moduleMap, nil)
 
         let lib = try result.target(for: "lib").clangTarget()
@@ -2402,7 +2402,7 @@ final class BuildPlanTests: XCTestCase {
         }
         XCTAssertEqual(try lib.basicArguments(isCXX: true), expectedLibBasicArgs)
 
-        XCTAssertEqual(lib.objects, [buildPath.appending(components: "lib.build", "lib.cpp.o")])
+        XCTAssertEqual(try lib.objects, [buildPath.appending(components: "lib.build", "lib.cpp.o")])
         XCTAssertEqual(lib.moduleMap, buildPath.appending(components: "lib.build", "module.modulemap"))
 
     #if os(macOS)
@@ -2495,10 +2495,10 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "A",
-                    path: .init("/A"),
+                    path: .init(path: "/A"),
                     dependencies: [
-                        .localSourceControl(path: .init("/B"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/C"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/B"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/C"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "aexec", type: .executable, targets: ["ATarget"])
@@ -2508,7 +2508,7 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "B",
-                    path: .init("/B"),
+                    path: .init(path: "/B"),
                     products: [
                         ProductDescription(name: "BLibrary", type: .library(.static), targets: ["BTarget1"]),
                         ProductDescription(name: "bexec", type: .executable, targets: ["BTarget2"]),
@@ -2519,7 +2519,7 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "C",
-                    path: .init("/C"),
+                    path: .init(path: "/C"),
                     products: [
                         ProductDescription(name: "cexec", type: .executable, targets: ["CTarget"])
                     ],
@@ -2581,10 +2581,10 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "A",
-                    path: .init("/A"),
+                    path: .init(path: "/A"),
                     dependencies: [
-                        .localSourceControl(path: .init("/B"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/C"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/B"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/C"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "aexec", type: .executable, targets: ["ATarget"]),
@@ -2608,7 +2608,7 @@ final class BuildPlanTests: XCTestCase {
                 ),
                 Manifest.createLocalSourceControlManifest(
                     name: "B",
-                    path: .init("/B"),
+                    path: .init(path: "/B"),
                     products: [
                         ProductDescription(name: "BLibrary1", type: .library(.static), targets: ["BTarget1"]),
                         ProductDescription(name: "BLibrary2", type: .library(.static), targets: ["BTarget2"]),
@@ -2626,7 +2626,7 @@ final class BuildPlanTests: XCTestCase {
                 ),
                 Manifest.createLocalSourceControlManifest(
                     name: "C",
-                    path: .init("/C"),
+                    path: .init(path: "/C"),
                     products: [
                         ProductDescription(name: "CLibrary", type: .library(.static), targets: ["CTarget"])
                     ],
@@ -2698,7 +2698,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
-                    path: .init("/Pkg")
+                    path: .init(path: "/Pkg")
                 )
             ],
             observabilityScope: observability.topScope
@@ -2727,7 +2727,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "A",
-                    path: .init("/A"),
+                    path: .init(path: "/A"),
                     targets: [
                         TargetDescription(name: "ATarget", dependencies: ["BTarget"]),
                         TargetDescription(
@@ -2772,7 +2772,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "A",
-                    path: .init("/A"),
+                    path: .init(path: "/A"),
                     targets: [
                         TargetDescription(name: "ATarget", dependencies: ["BTarget"]),
                         TargetDescription(
@@ -2801,7 +2801,7 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testWindowsTarget() throws {
-        let Pkg: AbsolutePath = AbsolutePath("/Pkg")
+        let Pkg: AbsolutePath = AbsolutePath(path: "/Pkg")
         let fs = InMemoryFileSystem(emptyFiles:
             Pkg.appending(components: "Sources", "exe", "main.swift").pathString,
             Pkg.appending(components: "Sources", "lib", "lib.c").pathString,
@@ -2814,7 +2814,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
-                    path: .init(Pkg.pathString),
+                    path: try .init(validating: Pkg.pathString),
                     targets: [
                     TargetDescription(name: "exe", dependencies: ["lib"]),
                     TargetDescription(name: "lib", dependencies: []),
@@ -2841,7 +2841,7 @@ final class BuildPlanTests: XCTestCase {
             "-DSWIFT_PACKAGE=1", "-DDEBUG=1", "-fblocks", "-I", Pkg.appending(components: "Sources", "lib", "include").pathString
         ]
         XCTAssertEqual(try lib.basicArguments(isCXX: false), args)
-        XCTAssertEqual(lib.objects, [buildPath.appending(components: "lib.build", "lib.c.o")])
+        XCTAssertEqual(try lib.objects, [buildPath.appending(components: "lib.build", "lib.c.o")])
         XCTAssertEqual(lib.moduleMap, buildPath.appending(components: "lib.build", "module.modulemap"))
 
         let exe = try result.target(for: "exe").swiftTarget().compileArguments()
@@ -2861,7 +2861,7 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testWASITarget() throws {
-        let Pkg: AbsolutePath = AbsolutePath("/Pkg")
+        let Pkg: AbsolutePath = AbsolutePath(path: "/Pkg")
 
         let fs = InMemoryFileSystem(emptyFiles:
             Pkg.appending(components: "Sources", "app", "main.swift").pathString,
@@ -2876,7 +2876,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
-                    path: .init(Pkg.pathString),
+                    path: try .init(validating: Pkg.pathString),
                     targets: [
                         TargetDescription(name: "app", dependencies: ["lib"]),
                         TargetDescription(name: "lib", dependencies: []),
@@ -2910,7 +2910,7 @@ final class BuildPlanTests: XCTestCase {
             "-fmodules-cache-path=\(buildPath.appending(components: "ModuleCache"))"
         ]
         XCTAssertEqual(try lib.basicArguments(isCXX: false), args)
-        XCTAssertEqual(lib.objects, [buildPath.appending(components: "lib.build", "lib.c.o")])
+        XCTAssertEqual(try lib.objects, [buildPath.appending(components: "lib.build", "lib.c.o")])
         XCTAssertEqual(lib.moduleMap, buildPath.appending(components: "lib.build", "module.modulemap"))
 
         let exe = try result.target(for: "app").swiftTarget().compileArguments()
@@ -2970,7 +2970,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
-                    path: .init("/Pkg"),
+                    path: .init(path: "/Pkg"),
                     toolsVersion: .v5_5,
                     targets: [
                         TargetDescription(name: "exe", type: .executable),
@@ -3017,7 +3017,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
-                    path: .init("/Pkg"),
+                    path: .init(path: "/Pkg"),
                     targets: [
                         TargetDescription(name: "exe", dependencies: ["lib"]),
                         TargetDescription(name: "lib", dependencies: []),
@@ -3065,20 +3065,20 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "A",
-                    path: .init("/A"),
+                    path: .init(path: "/A"),
                     platforms: [
                         PlatformDescription(name: "macos", version: "10.13"),
                     ],
                     toolsVersion: .v5,
                     dependencies: [
-                        .localSourceControl(path: .init("/B"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/B"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "ATarget", dependencies: ["BLibrary"]),
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "B",
-                    path: .init("/B"),
+                    path: .init(path: "/B"),
                     platforms: [
                         PlatformDescription(name: "macos", version: "10.12"),
                     ],
@@ -3128,21 +3128,21 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "A",
-                    path: .init("/A"),
+                    path: .init(path: "/A"),
                     platforms: [
                         PlatformDescription(name: "macos", version: "10.13"),
                         PlatformDescription(name: "ios", version: "10"),
                     ],
                     toolsVersion: .v5,
                     dependencies: [
-                        .localSourceControl(path: .init("/B"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/B"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "ATarget", dependencies: ["BLibrary"]),
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "B",
-                    path: .init("/B"),
+                    path: .init(path: "/B"),
                     platforms: [
                         PlatformDescription(name: "macos", version: "10.14"),
                         PlatformDescription(name: "ios", version: "11"),
@@ -3179,7 +3179,7 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testBuildSettings() throws {
-        let A: AbsolutePath = AbsolutePath("/A")
+        let A: AbsolutePath = AbsolutePath(path: "/A")
 
         let fs = InMemoryFileSystem(emptyFiles:
             "/A/Sources/exe/main.swift",
@@ -3195,10 +3195,10 @@ final class BuildPlanTests: XCTestCase {
 
         let aManifest = Manifest.createRootManifest(
             name: "A",
-            path: .init("/A"),
+            path: .init(path: "/A"),
             toolsVersion: .v5,
             dependencies: [
-                .localSourceControl(path: .init("/B"), requirement: .upToNextMajor(from: "1.0.0")),
+                .localSourceControl(path: .init(path: "/B"), requirement: .upToNextMajor(from: "1.0.0")),
             ],
             targets: [
                 try TargetDescription(
@@ -3236,7 +3236,7 @@ final class BuildPlanTests: XCTestCase {
 
         let bManifest = Manifest.createFileSystemManifest(
             name: "B",
-            path: .init("/B"),
+            path: .init(path: "/B"),
             toolsVersion: .v5,
             products: [
                 try ProductDescription(name: "Dep", type: .library(.automatic), targets: ["t1", "t2"]),
@@ -3311,7 +3311,7 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testExtraBuildFlags() throws {
-        let libpath: AbsolutePath = AbsolutePath("/fake/path/lib")
+        let libpath: AbsolutePath = AbsolutePath(path: "/fake/path/lib")
 
         let fs = InMemoryFileSystem(emptyFiles:
             "/A/Sources/exe/main.swift",
@@ -3321,7 +3321,7 @@ final class BuildPlanTests: XCTestCase {
 
         let aManifest = Manifest.createRootManifest(
             name: "A",
-            path: .init("/A"),
+            path: .init(path: "/A"),
             toolsVersion: .v5,
             targets: [
                 try TargetDescription(name: "exe", dependencies: []),
@@ -3362,7 +3362,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
-                    path: .init("/Pkg"),
+                    path: .init(path: "/Pkg"),
                     targets: [
                         TargetDescription(name: "exe", dependencies: ["lib"]),
                         TargetDescription(name: "lib", dependencies: []),
@@ -3372,8 +3372,8 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let userDestination = Destination(sdk: AbsolutePath("/fake/sdk"),
-            binDir: UserToolchain.default.destination.binDir,
+        let userDestination = Destination(sdk: AbsolutePath(path: "/fake/sdk"),
+            binDir: try UserToolchain.default.destination.binDir,
             extraCCFlags: ["-I/fake/sdk/sysroot", "-clang-flag-from-json"],
             extraSwiftCFlags: ["-swift-flag-from-json"])
         let mockToolchain = try UserToolchain(destination: userDestination)
@@ -3405,7 +3405,7 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testExecBuildTimeDependency() throws {
-        let PkgA: AbsolutePath = AbsolutePath("/PkgA")
+        let PkgA: AbsolutePath = AbsolutePath(path: "/PkgA")
 
         let fs = InMemoryFileSystem(emptyFiles:
             PkgA.appending(components: "Sources", "exe", "main.swift").pathString,
@@ -3419,7 +3419,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "PkgA",
-                    path: .init(PkgA.pathString),
+                    path: try .init(validating: PkgA.pathString),
                     products: [
                         ProductDescription(name: "swiftlib", type: .library(.automatic), targets: ["swiftlib"]),
                         ProductDescription(name: "exe", type: .executable, targets: ["exe"])
@@ -3430,9 +3430,9 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "PkgB",
-                    path: .init("/PkgB"),
+                    path: .init(path: "/PkgB"),
                     dependencies: [
-                        .localSourceControl(path: .init(PkgA.pathString), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: try .init(validating: PkgA.pathString), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "PkgB", dependencies: ["swiftlib"]),
@@ -3452,7 +3452,7 @@ final class BuildPlanTests: XCTestCase {
 
         let buildPath: AbsolutePath = plan.buildParameters.dataPath.appending(components: "debug")
 
-        let yaml = fs.tempDirectory.appending(components: UUID().uuidString, "debug.yaml")
+        let yaml = try fs.tempDirectory.appending(components: UUID().uuidString, "debug.yaml")
         try fs.createDirectory(yaml.parentDirectory, recursive: true)
         let llbuild = LLBuildManifestBuilder(plan, fileSystem: fs, observabilityScope: observability.topScope)
         try llbuild.generateManifest(at: yaml)
@@ -3471,7 +3471,7 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testObjCHeader1() throws {
-        let PkgA: AbsolutePath = AbsolutePath("/PkgA")
+        let PkgA: AbsolutePath = AbsolutePath(path: "/PkgA")
 
         // This has a Swift and ObjC target in the same package.
         let fs = InMemoryFileSystem(emptyFiles:
@@ -3485,7 +3485,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "PkgA",
-                    path: .init(PkgA.pathString),
+                    path: try .init(validating: PkgA.pathString),
                     targets: [
                         TargetDescription(name: "Foo", dependencies: []),
                         TargetDescription(name: "Bar", dependencies: ["Foo"]),
@@ -3519,7 +3519,7 @@ final class BuildPlanTests: XCTestCase {
           XCTAssertNoMatch(barTarget, [.anySequence, "-fmodule-map-file=/path/to/build/debug/Foo.build/module.modulemap", .anySequence])
         #endif
 
-        let yaml = fs.tempDirectory.appending(components: UUID().uuidString, "debug.yaml")
+        let yaml = try fs.tempDirectory.appending(components: UUID().uuidString, "debug.yaml")
         try fs.createDirectory(yaml.parentDirectory, recursive: true)
         let llbuild = LLBuildManifestBuilder(plan, fileSystem: fs, observabilityScope: observability.topScope)
         try llbuild.generateManifest(at: yaml)
@@ -3534,7 +3534,7 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testObjCHeader2() throws {
-        let PkgA: AbsolutePath = AbsolutePath("/PkgA")
+        let PkgA: AbsolutePath = AbsolutePath(path: "/PkgA")
 
         // This has a Swift and ObjC target in different packages with automatic product type.
         let fs = InMemoryFileSystem(emptyFiles:
@@ -3548,16 +3548,16 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "PkgA",
-                    path: .init(PkgA.pathString),
+                    path: try .init(validating: PkgA.pathString),
                     dependencies: [
-                        .localSourceControl(path: .init("/PkgB"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/PkgB"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Bar", dependencies: ["Foo"]),
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "PkgB",
-                    path: .init("/PkgB"),
+                    path: .init(path: "/PkgB"),
                     products: [
                         ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Foo"]),
                     ],
@@ -3593,7 +3593,7 @@ final class BuildPlanTests: XCTestCase {
            XCTAssertNoMatch(barTarget, [.anySequence, "-fmodule-map-file=/path/to/build/debug/Foo.build/module.modulemap", .anySequence])
          #endif
 
-        let yaml = fs.tempDirectory.appending(components: UUID().uuidString, "debug.yaml")
+        let yaml = try fs.tempDirectory.appending(components: UUID().uuidString, "debug.yaml")
         try fs.createDirectory(yaml.parentDirectory, recursive: true)
         let llbuild = LLBuildManifestBuilder(plan, fileSystem: fs, observabilityScope: observability.topScope)
         try llbuild.generateManifest(at: yaml)
@@ -3608,7 +3608,7 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testObjCHeader3() throws {
-        let PkgA: AbsolutePath = AbsolutePath("/PkgA")
+        let PkgA: AbsolutePath = AbsolutePath(path: "/PkgA")
 
         // This has a Swift and ObjC target in different packages with dynamic product type.
         let fs = InMemoryFileSystem(emptyFiles:
@@ -3622,16 +3622,16 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "PkgA",
-                    path: .init(PkgA.pathString),
+                    path: try .init(validating: PkgA.pathString),
                     dependencies: [
-                        .localSourceControl(path: .init("/PkgB"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/PkgB"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Bar", dependencies: ["Foo"]),
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "PkgB",
-                    path: .init("/PkgB"),
+                    path: .init(path: "/PkgB"),
                     products: [
                         ProductDescription(name: "Foo", type: .library(.dynamic), targets: ["Foo"]),
                     ],
@@ -3673,7 +3673,7 @@ final class BuildPlanTests: XCTestCase {
 
         let buildPath: AbsolutePath = result.plan.buildParameters.dataPath.appending(components: "debug")
 
-        let yaml = fs.tempDirectory.appending(components: UUID().uuidString, "debug.yaml")
+        let yaml = try fs.tempDirectory.appending(components: UUID().uuidString, "debug.yaml")
         try fs.createDirectory(yaml.parentDirectory, recursive: true)
         let llbuild = LLBuildManifestBuilder(plan, fileSystem: fs, observabilityScope: observability.topScope)
         try llbuild.generateManifest(at: yaml)
@@ -3699,7 +3699,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
-                    path: .init("/Pkg"),
+                    path: .init(path: "/Pkg"),
                     targets: [
                         TargetDescription(name: "exe", dependencies: ["lib"]),
                         TargetDescription(name: "lib", dependencies: []),
@@ -3723,7 +3723,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertTrue(objects.contains(buildPath.appending(components: "exe.build", "exe.swiftmodule.o")), objects.description)
         XCTAssertTrue(objects.contains(buildPath.appending(components: "lib.build", "lib.swiftmodule.o")), objects.description)
 
-        let yaml = fs.tempDirectory.appending(components: UUID().uuidString, "debug.yaml")
+        let yaml = try fs.tempDirectory.appending(components: UUID().uuidString, "debug.yaml")
         try fs.createDirectory(yaml.parentDirectory, recursive: true)
         let llbuild = LLBuildManifestBuilder(result.plan, fileSystem: fs, observabilityScope: observability.topScope)
         try llbuild.generateManifest(at: yaml)
@@ -3757,7 +3757,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Package",
-                    path: .init("/Package"),
+                    path: .init(path: "/Package"),
                     products: [
                         ProductDescription(name: "rary", type: .library(.static), targets: ["rary"]),
                     ],
@@ -3779,7 +3779,7 @@ final class BuildPlanTests: XCTestCase {
 
         let buildPath: AbsolutePath = result.plan.buildParameters.dataPath.appending(components: "debug")
 
-        let yaml = fs.tempDirectory.appending(components: UUID().uuidString, "debug.yaml")
+        let yaml = try fs.tempDirectory.appending(components: UUID().uuidString, "debug.yaml")
         try fs.createDirectory(yaml.parentDirectory, recursive: true)
 
         let llbuild = LLBuildManifestBuilder(result.plan, fileSystem: fs, observabilityScope: observability.topScope)
@@ -3833,7 +3833,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "PkgA",
-                    path: .init("/PkgA"),
+                    path: .init(path: "/PkgA"),
                     toolsVersion: .v5_2,
                     targets: [
                         TargetDescription(
@@ -3865,7 +3865,7 @@ final class BuildPlanTests: XCTestCase {
         let buildPath: AbsolutePath = result.plan.buildParameters.dataPath.appending(components: "debug")
 
         let fooTarget = try result.target(for: "Foo").swiftTarget()
-        XCTAssertEqual(fooTarget.objects.map{ $0.pathString }, [
+        XCTAssertEqual(try fooTarget.objects.map{ $0.pathString }, [
             buildPath.appending(components: "Foo.build", "Foo.swift.o").pathString,
             buildPath.appending(components: "Foo.build", "resource_bundle_accessor.swift.o").pathString,
         ])
@@ -3878,7 +3878,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertMatch(contents, .contains("let mainPath = Bundle.main."))
 
         let barTarget = try result.target(for: "Bar").swiftTarget()
-        XCTAssertEqual(barTarget.objects.map{ $0.pathString }, [
+        XCTAssertEqual(try barTarget.objects.map{ $0.pathString }, [
             buildPath.appending(components: "Bar.build", "Bar.swift.o").pathString,
         ])
     }
@@ -3899,7 +3899,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "PkgA",
-                    path: .init("/PkgA"),
+                    path: .init(path: "/PkgA"),
                     toolsVersion: .v5_2,
                     targets: [
                         TargetDescription(
@@ -3931,7 +3931,7 @@ final class BuildPlanTests: XCTestCase {
         let buildPath: AbsolutePath = result.plan.buildParameters.dataPath.appending(components: "debug")
 
         let fooTarget = try result.target(for: "Foo").swiftTarget()
-        XCTAssertEqual(fooTarget.objects.map{ $0.pathString }, [
+        XCTAssertEqual(try fooTarget.objects.map{ $0.pathString }, [
             buildPath.appending(components: "Foo.build", "Foo.swift.o").pathString,
             buildPath.appending(components: "Foo.build", "resource_bundle_accessor.swift.o").pathString
         ])
@@ -3944,7 +3944,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertMatch(contents, .contains("let mainPath = \""))
 
         let barTarget = try result.target(for: "Bar").swiftTarget()
-        XCTAssertEqual(barTarget.objects.map{ $0.pathString }, [
+        XCTAssertEqual(try barTarget.objects.map{ $0.pathString }, [
             buildPath.appending(components: "Bar.build", "Bar.swift.o").pathString,
         ])
     }
@@ -3962,7 +3962,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
-                    path: .init("/Pkg"),
+                    path: .init(path: "/Pkg"),
                     targets: [
                         TargetDescription(name: "exe", dependencies: ["lib"]),
                         TargetDescription(name: "lib", dependencies: []),
@@ -3990,7 +3990,7 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testXCFrameworkBinaryTargets(platform: String, arch: String, destinationTriple: TSCUtility.Triple) throws {
-        let Pkg: AbsolutePath = AbsolutePath("/Pkg")
+        let Pkg: AbsolutePath = AbsolutePath(path: "/Pkg")
 
         let fs = InMemoryFileSystem(emptyFiles:
             Pkg.appending(components: "Sources", "exe", "main.swift").pathString,
@@ -3999,9 +3999,9 @@ final class BuildPlanTests: XCTestCase {
             Pkg.appending(components: "Sources", "CLibrary", "include", "library.h").pathString
         )
 
-        try! fs.createDirectory(AbsolutePath("/Pkg/Framework.xcframework"), recursive: true)
+        try! fs.createDirectory(AbsolutePath(path: "/Pkg/Framework.xcframework"), recursive: true)
         try! fs.writeFileContents(
-            AbsolutePath("/Pkg/Framework.xcframework/Info.plist"),
+            AbsolutePath(path: "/Pkg/Framework.xcframework/Info.plist"),
             bytes: ByteString(encodingAsUTF8: """
                 <?xml version="1.0" encoding="UTF-8"?>
                 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -4030,9 +4030,9 @@ final class BuildPlanTests: XCTestCase {
                 </plist>
                 """))
 
-        try! fs.createDirectory(AbsolutePath("/Pkg/StaticLibrary.xcframework"), recursive: true)
+        try! fs.createDirectory(AbsolutePath(path: "/Pkg/StaticLibrary.xcframework"), recursive: true)
         try! fs.writeFileContents(
-            AbsolutePath("/Pkg/StaticLibrary.xcframework/Info.plist"),
+            AbsolutePath(path: "/Pkg/StaticLibrary.xcframework/Info.plist"),
             bytes: ByteString(encodingAsUTF8: """
                 <?xml version="1.0" encoding="UTF-8"?>
                 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -4070,7 +4070,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
-                    path: .init(Pkg.pathString),
+                    path: try .init(validating: Pkg.pathString),
                     products: [
                         ProductDescription(name: "exe", type: .executable, targets: ["exe"]),
                         ProductDescription(name: "Library", type: .library(.dynamic), targets: ["Library"]),
@@ -4087,8 +4087,8 @@ final class BuildPlanTests: XCTestCase {
             ],
             binaryArtifacts: [
                 .plain("pkg"): [
-                    "Framework": .init(kind: .xcframework, originURL: nil, path: AbsolutePath("/Pkg/Framework.xcframework")),
-                    "StaticLibrary": .init(kind: .xcframework, originURL: nil, path: AbsolutePath("/Pkg/StaticLibrary.xcframework"))
+                    "Framework": .init(kind: .xcframework, originURL: nil, path: AbsolutePath(path: "/Pkg/Framework.xcframework")),
+                    "StaticLibrary": .init(kind: .xcframework, originURL: nil, path: AbsolutePath(path: "/Pkg/StaticLibrary.xcframework"))
                 ]
             ],
             observabilityScope: observability.topScope
@@ -4154,7 +4154,7 @@ final class BuildPlanTests: XCTestCase {
         let fs = InMemoryFileSystem(emptyFiles: "/Pkg/Sources/exe/main.swift")
 
         let artifactName = "my-tool"
-        let toolPath = AbsolutePath("/Pkg/MyTool.artifactbundle")
+        let toolPath = AbsolutePath(path: "/Pkg/MyTool.artifactbundle")
         try fs.createDirectory(toolPath, recursive: true)
 
         try fs.writeFileContents(
@@ -4183,7 +4183,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
-                    path: .init("/Pkg"),
+                    path: .init(path: "/Pkg"),
                     products: [
                         ProductDescription(name: "exe", type: .executable, targets: ["exe"]),
                     ],
@@ -4261,7 +4261,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Pkg",
-                    path: .init("/Pkg"),
+                    path: .init(path: "/Pkg"),
                     targets: [
                         TargetDescription(name: "exe", dependencies: ["lib", "clib"]),
                         TargetDescription(name: "lib", dependencies: []),

--- a/Tests/BuildTests/LLBuildManifestTests.swift
+++ b/Tests/BuildTests/LLBuildManifestTests.swift
@@ -20,7 +20,7 @@ final class LLBuildManifestTests: XCTestCase {
     func testBasics() throws {
         var manifest = BuildManifest()
 
-        let root: AbsolutePath = AbsolutePath("/some")
+        let root: AbsolutePath = AbsolutePath(path: "/some")
 
         manifest.defaultTarget = "main"
         manifest.addPhonyCmd(
@@ -36,9 +36,9 @@ final class LLBuildManifestTests: XCTestCase {
         manifest.addNode(.virtual("Foo"), toTarget: "main")
 
         let fs = InMemoryFileSystem()
-        try ManifestWriter(fileSystem: fs).write(manifest, at: AbsolutePath("/manifest.yaml"))
+        try ManifestWriter(fileSystem: fs).write(manifest, at: AbsolutePath(path: "/manifest.yaml"))
 
-        let contents: String = try fs.readFileContents(AbsolutePath("/manifest.yaml"))
+        let contents: String = try fs.readFileContents(AbsolutePath(path: "/manifest.yaml"))
 
         // FIXME(#5475) - use the platform's preferred separator for directory
         // indicators
@@ -89,12 +89,12 @@ final class LLBuildManifestTests: XCTestCase {
             allowMissingInputs: true
         )
 
-        manifest.addNode(.file(AbsolutePath("/file.out")), toTarget: "main")
+        manifest.addNode(.file(AbsolutePath(path: "/file.out")), toTarget: "main")
 
         let fs = InMemoryFileSystem()
-        try ManifestWriter(fileSystem: fs).write(manifest, at: AbsolutePath("/manifest.yaml"))
+        try ManifestWriter(fileSystem: fs).write(manifest, at: AbsolutePath(path: "/manifest.yaml"))
 
-        let contents: String = try fs.readFileContents(AbsolutePath("/manifest.yaml"))
+        let contents: String = try fs.readFileContents(AbsolutePath(path: "/manifest.yaml"))
 
         XCTAssertEqual(contents.replacingOccurrences(of: "\\\\", with: "\\"), """
             client:

--- a/Tests/BuildTests/MockBuildTestHelper.swift
+++ b/Tests/BuildTests/MockBuildTestHelper.swift
@@ -8,15 +8,15 @@ import XCTest
 
 struct MockToolchain: PackageModel.Toolchain {
 #if os(Windows)
-    let librarianPath = AbsolutePath("/fake/path/to/link.exe")
+    let librarianPath = AbsolutePath(path: "/fake/path/to/link.exe")
 #elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    let librarianPath = AbsolutePath("/fake/path/to/libtool")
+    let librarianPath = AbsolutePath(path: "/fake/path/to/libtool")
 #elseif os(Android)
-    let librarianPath = AbsolutePath("/fake/path/to/llvm-ar")
+    let librarianPath = AbsolutePath(path: "/fake/path/to/llvm-ar")
 #else
-    let librarianPath = AbsolutePath("/fake/path/to/ar")
+    let librarianPath = AbsolutePath(path: "/fake/path/to/ar")
 #endif
-    let swiftCompilerPath = AbsolutePath("/fake/path/to/swiftc")
+    let swiftCompilerPath = AbsolutePath(path: "/fake/path/to/swiftc")
     let extraCCFlags: [String] = []
     let extraSwiftCFlags: [String] = []
     #if os(macOS)
@@ -25,7 +25,7 @@ struct MockToolchain: PackageModel.Toolchain {
     let extraCPPFlags: [String] = ["-lstdc++"]
     #endif
     func getClangCompiler() throws -> AbsolutePath {
-        return AbsolutePath("/fake/path/to/clang")
+        return AbsolutePath(path: "/fake/path/to/clang")
     }
 
     func _isClangCompilerVendorApple() throws -> Bool? {
@@ -52,7 +52,7 @@ extension AbsolutePath {
     }
 }
 
-let hostTriple = UserToolchain.default.triple
+let hostTriple = try! UserToolchain.default.triple
 #if os(macOS)
     let defaultTargetTriple: String = hostTriple.tripleString(forPlatformVersion: "10.13")
 #else
@@ -60,7 +60,7 @@ let hostTriple = UserToolchain.default.triple
 #endif
 
 func mockBuildParameters(
-    buildPath: AbsolutePath = AbsolutePath("/path/to/build"),
+    buildPath: AbsolutePath = AbsolutePath(path: "/path/to/build"),
     config: BuildConfiguration = .debug,
     toolchain: PackageModel.Toolchain = MockToolchain(),
     flags: BuildFlags = BuildFlags(),

--- a/Tests/BuildTests/ModuleAliasingBuildTests.swift
+++ b/Tests/BuildTests/ModuleAliasingBuildTests.swift
@@ -25,7 +25,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "fooPkg",
-                    path: .init("/fooPkg"),
+                    path: .init(path: "/fooPkg"),
                     products: [
                         ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Logging"]),
                     ],
@@ -34,9 +34,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "thisPkg",
-                    path: .init("/thisPkg"),
+                    path: .init(path: "/thisPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe",
@@ -70,7 +70,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "fooPkg",
-                    path: .init("/fooPkg"),
+                    path: .init(path: "/fooPkg"),
                     products: [
                         ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Logging"]),
                     ],
@@ -79,9 +79,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "thisPkg",
-                    path: .init("/thisPkg"),
+                    path: .init(path: "/thisPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe",
@@ -114,7 +114,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "fooPkg",
-                    path: .init("/fooPkg"),
+                    path: .init(path: "/fooPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
                     ],
@@ -123,7 +123,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "barPkg",
-                    path: .init("/barPkg"),
+                    path: .init(path: "/barPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
                     ],
@@ -132,10 +132,10 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "thisPkg",
-                    path: .init("/thisPkg"),
+                    path: .init(path: "/thisPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/barPkg"), requirement: .upToNextMajor(from: "2.0.0")),
+                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "2.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe",
@@ -176,7 +176,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "fooPkg",
-                    path: .init("/fooPkg"),
+                    path: .init(path: "/fooPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.dynamic), targets: ["Logging"]),
                     ],
@@ -185,7 +185,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "barPkg",
-                    path: .init("/barPkg"),
+                    path: .init(path: "/barPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.dynamic), targets: ["Logging"]),
                     ],
@@ -194,10 +194,10 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "thisPkg",
-                    path: .init("/thisPkg"),
+                    path: .init(path: "/thisPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/barPkg"), requirement: .upToNextMajor(from: "2.0.0")),
+                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "2.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe",
@@ -234,7 +234,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "fooPkg",
-                    path: .init("/fooPkg"),
+                    path: .init(path: "/fooPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.dynamic), targets: ["Logging"]),
                     ],
@@ -243,7 +243,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "barPkg",
-                    path: .init("/barPkg"),
+                    path: .init(path: "/barPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.static), targets: ["Logging"]),
                     ],
@@ -252,10 +252,10 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "thisPkg",
-                    path: .init("/thisPkg"),
+                    path: .init(path: "/thisPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/barPkg"), requirement: .upToNextMajor(from: "2.0.0")),
+                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "2.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe",
@@ -293,7 +293,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "fooPkg",
-                    path: .init("/fooPkg"),
+                    path: .init(path: "/fooPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
                     ],
@@ -302,7 +302,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "barPkg",
-                    path: .init("/barPkg"),
+                    path: .init(path: "/barPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.dynamic), targets: ["Logging"]),
                     ],
@@ -311,10 +311,10 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "thisPkg",
-                    path: .init("/thisPkg"),
+                    path: .init(path: "/thisPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/barPkg"), requirement: .upToNextMajor(from: "2.0.0")),
+                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "2.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe",
@@ -359,7 +359,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "fooPkg",
-                    path: .init("/fooPkg"),
+                    path: .init(path: "/fooPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
                     ],
@@ -368,7 +368,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "bazPkg",
-                    path: .init("/bazPkg"),
+                    path: .init(path: "/bazPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.static), targets: ["Logging"]),
                     ],
@@ -377,10 +377,10 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "thisPkg",
-                    path: .init("/thisPkg"),
+                    path: .init(path: "/thisPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/bazPkg"), requirement: .upToNextMajor(from: "2.0.0")),
+                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/bazPkg"), requirement: .upToNextMajor(from: "2.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe",
@@ -428,7 +428,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                 name: "xPkg",
-                path: .init("/xPkg"),
+                path: .init(path: "/xPkg"),
                 products: [
                     ProductDescription(name: "Logging", type: .library(.dynamic), targets: ["Logging"]),
                 ],
@@ -438,7 +438,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                 ]),
                 Manifest.createFileSystemManifest(
                     name: "yPkg",
-                    path: .init("/yPkg"),
+                    path: .init(path: "/yPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
                     ],
@@ -449,9 +449,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "aPkg",
-                    path: .init("/aPkg"),
+                    path: .init(path: "/aPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/xPkg"), requirement: .upToNextMajor(from: "1.0.0"))
+                        .localSourceControl(path: .init(path: "/xPkg"), requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     products: [
                         ProductDescription(name: "A", type: .library(.dynamic), targets: ["A"]),
@@ -464,9 +464,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "bPkg",
-                    path: .init("/bPkg"),
+                    path: .init(path: "/bPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/yPkg"), requirement: .upToNextMajor(from: "1.0.0"))
+                        .localSourceControl(path: .init(path: "/yPkg"), requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     products: [
                         ProductDescription(name: "B", type: .library(.dynamic), targets: ["B"]),
@@ -479,10 +479,10 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "thisPkg",
-                    path: .init("/thisPkg"),
+                    path: .init(path: "/thisPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/aPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/bPkg"), requirement: .upToNextMajor(from: "2.0.0")),
+                        .localSourceControl(path: .init(path: "/aPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/bPkg"), requirement: .upToNextMajor(from: "2.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe",
@@ -531,7 +531,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "fooPkg",
-                    path: .init("/fooPkg"),
+                    path: .init(path: "/fooPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
                     ],
@@ -540,7 +540,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "barPkg",
-                    path: .init("/barPkg"),
+                    path: .init(path: "/barPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
                     ],
@@ -549,10 +549,10 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "thisPkg",
-                    path: .init("/thisPkg"),
+                    path: .init(path: "/thisPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/barPkg"), requirement: .upToNextMajor(from: "2.0.0")),
+                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "2.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe",
@@ -618,7 +618,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "otherPkg",
-                    path: .init("/otherPkg"),
+                    path: .init(path: "/otherPkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                         ProductDescription(name: "Math", type: .library(.automatic), targets: ["Math"]),
@@ -631,9 +631,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "thisPkg",
-                    path: .init("/thisPkg"),
+                    path: .init(path: "/thisPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/otherPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/otherPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe",
@@ -690,7 +690,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "otherPkg",
-                    path: .init("/otherPkg"),
+                    path: .init(path: "/otherPkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                         ProductDescription(name: "LoggingProd", type: .library(.automatic), targets: ["Logging"]),
@@ -701,9 +701,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "thisPkg",
-                    path: .init("/thisPkg"),
+                    path: .init(path: "/thisPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/otherPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/otherPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe",
@@ -741,7 +741,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "swift-log",
-                    path: .init("/swift-log"),
+                    path: .init(path: "/swift-log"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
                     ],
@@ -750,7 +750,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "swift-metrics",
-                    path: .init("/swift-metrics"),
+                    path: .init(path: "/swift-metrics"),
                     products: [
                         ProductDescription(name: "Metrics", type: .library(.automatic), targets: ["Metrics"]),
                     ],
@@ -760,10 +760,10 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "appPkg",
-                    path: .init("/appPkg"),
+                    path: .init(path: "/appPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/swift-log"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/swift-metrics"), requirement: .upToNextMajor(from: "2.0.0")),
+                        .localSourceControl(path: .init(path: "/swift-log"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/swift-metrics"), requirement: .upToNextMajor(from: "2.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "App",
@@ -807,7 +807,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "fooPkg",
-                    path: .init("/fooPkg"),
+                    path: .init(path: "/fooPkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
@@ -817,9 +817,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "thisPkg",
-                    path: .init("/thisPkg"),
+                    path: .init(path: "/thisPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe",
@@ -857,7 +857,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "barPkg",
-                    path: .init("/barPkg"),
+                    path: .init(path: "/barPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
                     ],
@@ -866,9 +866,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "fooPkg",
-                    path: .init("/fooPkg"),
+                    path: .init(path: "/fooPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/barPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
@@ -879,9 +879,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "thisPkg",
-                    path: .init("/thisPkg"),
+                    path: .init(path: "/thisPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe",
@@ -920,7 +920,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "fooPkg",
-                    path: .init("/fooPkg"),
+                    path: .init(path: "/fooPkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                         ProductDescription(name: "Perf", type: .library(.automatic), targets: ["Perf"]),
@@ -932,9 +932,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "thisPkg",
-                    path: .init("/thisPkg"),
+                    path: .init(path: "/thisPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe",
@@ -967,7 +967,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "barPkg",
-                    path: .init("/barPkg"),
+                    path: .init(path: "/barPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
                         ProductDescription(name: "Perf", type: .library(.automatic), targets: ["Perf"]),
@@ -978,9 +978,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "fooPkg",
-                    path: .init("/fooPkg"),
+                    path: .init(path: "/fooPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/barPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
@@ -991,9 +991,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "thisPkg",
-                    path: .init("/thisPkg"),
+                    path: .init(path: "/thisPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe",
@@ -1022,7 +1022,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "barPkg",
-                    path: .init("/barPkg"),
+                    path: .init(path: "/barPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
                     ],
@@ -1031,9 +1031,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "fooPkg",
-                    path: .init("/fooPkg"),
+                    path: .init(path: "/fooPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/barPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
@@ -1044,9 +1044,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "thisPkg",
-                    path: .init("/thisPkg"),
+                    path: .init(path: "/thisPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe",
@@ -1093,7 +1093,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "barPkg",
-                    path: .init("/barPkg"),
+                    path: .init(path: "/barPkg"),
                     products: [
                         ProductDescription(name: "LoggingProd", type: .library(.automatic), targets: ["Logging"]),
                         ProductDescription(name: "MathProd", type: .library(.automatic), targets: ["Math"]),
@@ -1104,9 +1104,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "fooPkg",
-                    path: .init("/fooPkg"),
+                    path: .init(path: "/fooPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/barPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
@@ -1124,9 +1124,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "thisPkg",
-                    path: .init("/thisPkg"),
+                    path: .init(path: "/thisPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe",
@@ -1184,7 +1184,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "cPkg",
-                    path: .init("/cPkg"),
+                    path: .init(path: "/cPkg"),
                     products: [
                         ProductDescription(name: "C", type: .library(.automatic), targets: ["C"]),
                     ],
@@ -1194,7 +1194,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "dPkg",
-                    path: .init("/dPkg"),
+                    path: .init(path: "/dPkg"),
                     products: [
                         ProductDescription(name: "D", type: .library(.automatic), targets: ["D"]),
                     ],
@@ -1203,10 +1203,10 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "bPkg",
-                    path: .init("/bPkg"),
+                    path: .init(path: "/bPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/cPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/dPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/cPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/dPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "B", type: .library(.automatic), targets: ["B"]),
@@ -1222,9 +1222,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "aPkg",
-                    path: .init("/aPkg"),
+                    path: .init(path: "/aPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/bPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/bPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "A", type: .library(.automatic), targets: ["A"]),
@@ -1238,7 +1238,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "zPkg",
-                    path: .init("/zPkg"),
+                    path: .init(path: "/zPkg"),
                     products: [
                         ProductDescription(name: "Z", type: .library(.automatic), targets: ["Z"]),
                     ],
@@ -1248,9 +1248,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "yPkg",
-                    path: .init("/yPkg"),
+                    path: .init(path: "/yPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/zPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/zPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "Y", type: .library(.automatic), targets: ["Y"]),
@@ -1264,9 +1264,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "xPkg",
-                    path: .init("/xPkg"),
+                    path: .init(path: "/xPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/yPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/yPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "X", type: .library(.automatic), targets: ["X"]),
@@ -1280,10 +1280,10 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "appPkg",
-                    path: .init("/appPkg"),
+                    path: .init(path: "/appPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/aPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/xPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/aPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/xPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "App",
@@ -1345,9 +1345,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "gPkg",
-                    path: .init("/gPkg"),
+                    path: .init(path: "/gPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/dPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/dPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "G", type: .library(.automatic), targets: ["G"]),
@@ -1361,7 +1361,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "dPkg",
-                    path: .init("/dPkg"),
+                    path: .init(path: "/dPkg"),
                     products: [
                         ProductDescription(name: "D", type: .library(.automatic), targets: ["D"]),
                     ],
@@ -1372,9 +1372,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "cPkg",
-                    path: .init("/cPkg"),
+                    path: .init(path: "/cPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/dPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/dPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "C", type: .library(.automatic), targets: ["C"]),
@@ -1392,9 +1392,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "bPkg",
-                    path: .init("/bPkg"),
+                    path: .init(path: "/bPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/cPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/cPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "B", type: .library(.automatic), targets: ["B"]),
@@ -1414,10 +1414,10 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "aPkg",
-                    path: .init("/aPkg"),
+                    path: .init(path: "/aPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/bPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/gPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/bPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/gPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "A",
@@ -1477,7 +1477,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "hPkg",
-                    path: .init("/hPkg"),
+                    path: .init(path: "/hPkg"),
                     dependencies: [
                     ],
                     products: [
@@ -1489,9 +1489,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "gPkg",
-                    path: .init("/gPkg"),
+                    path: .init(path: "/gPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/hPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/hPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "G", type: .library(.automatic), targets: ["G"]),
@@ -1505,7 +1505,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "dPkg",
-                    path: .init("/dPkg"),
+                    path: .init(path: "/dPkg"),
                     products: [
                         ProductDescription(name: "D", type: .library(.automatic), targets: ["D"]),
                     ],
@@ -1516,9 +1516,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "cPkg",
-                    path: .init("/cPkg"),
+                    path: .init(path: "/cPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/dPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/dPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "C", type: .library(.automatic), targets: ["C"]),
@@ -1534,9 +1534,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "bPkg",
-                    path: .init("/bPkg"),
+                    path: .init(path: "/bPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/cPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/cPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "B", type: .library(.automatic), targets: ["B"]),
@@ -1554,10 +1554,10 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "aPkg",
-                    path: .init("/aPkg"),
+                    path: .init(path: "/aPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/bPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/gPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/bPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/gPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "A",
@@ -1618,9 +1618,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "hPkg",
-                    path: .init("/hPkg"),
+                    path: .init(path: "/hPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/dPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/dPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "H", type: .library(.automatic), targets: ["H"]),
@@ -1634,9 +1634,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "gPkg",
-                    path: .init("/gPkg"),
+                    path: .init(path: "/gPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/hPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/hPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "G", type: .library(.automatic), targets: ["G"]),
@@ -1654,7 +1654,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "dPkg",
-                    path: .init("/dPkg"),
+                    path: .init(path: "/dPkg"),
                     products: [
                         ProductDescription(name: "D", type: .library(.automatic), targets: ["D"]),
                     ],
@@ -1665,9 +1665,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "cPkg",
-                    path: .init("/cPkg"),
+                    path: .init(path: "/cPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/dPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/dPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "C", type: .library(.automatic), targets: ["C"]),
@@ -1683,9 +1683,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "bPkg",
-                    path: .init("/bPkg"),
+                    path: .init(path: "/bPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/cPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/cPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "B", type: .library(.automatic), targets: ["B"]),
@@ -1703,10 +1703,10 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "aPkg",
-                    path: .init("/aPkg"),
+                    path: .init(path: "/aPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/bPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/gPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/bPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/gPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "A",
@@ -1764,7 +1764,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "drawPkg",
-                    path: .init("/drawPkg"),
+                    path: .init(path: "/drawPkg"),
                     products: [
                         ProductDescription(name: "DrawProd", type: .library(.automatic), targets: ["Render"]),
                     ],
@@ -1773,9 +1773,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "gamePkg",
-                    path: .init("/gamePkg"),
+                    path: .init(path: "/gamePkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/drawPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/drawPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "Game", type: .library(.automatic), targets: ["Game"]),
@@ -1794,9 +1794,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "libPkg",
-                    path: .init("/libPkg"),
+                    path: .init(path: "/libPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/gamePkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/gamePkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "LibProd", type: .library(.automatic), targets: ["Lib"]),
@@ -1816,9 +1816,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "appPkg",
-                    path: .init("/appPkg"),
+                    path: .init(path: "/appPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/libPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/libPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "App",
@@ -1875,7 +1875,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "drawPkg",
-                    path: .init("/drawPkg"),
+                    path: .init(path: "/drawPkg"),
                     products: [
                         ProductDescription(name: "DrawProd", type: .library(.automatic), targets: ["Render"]),
                     ],
@@ -1884,9 +1884,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "gamePkg",
-                    path: .init("/gamePkg"),
+                    path: .init(path: "/gamePkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/drawPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/drawPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "Game", type: .library(.automatic), targets: ["Utils"]),
@@ -1905,9 +1905,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "libPkg",
-                    path: .init("/libPkg"),
+                    path: .init(path: "/libPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/gamePkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/gamePkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "LibProd", type: .library(.automatic), targets: ["Lib"]),
@@ -1926,9 +1926,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "appPkg",
-                    path: .init("/appPkg"),
+                    path: .init(path: "/appPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/libPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/libPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "App",
@@ -1982,7 +1982,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "drawPkg",
-                    path: .init("/drawPkg"),
+                    path: .init(path: "/drawPkg"),
                     products: [
                         ProductDescription(name: "DrawProd", type: .library(.automatic), targets: ["Render"]),
                     ],
@@ -1991,9 +1991,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "gamePkg",
-                    path: .init("/gamePkg"),
+                    path: .init(path: "/gamePkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/drawPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/drawPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "Game", type: .library(.automatic), targets: ["Utils"]),
@@ -2014,9 +2014,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "libPkg",
-                    path: .init("/libPkg"),
+                    path: .init(path: "/libPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/gamePkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/gamePkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "LibProd", type: .library(.automatic), targets: ["Lib"]),
@@ -2038,9 +2038,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "appPkg",
-                    path: .init("/appPkg"),
+                    path: .init(path: "/appPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/libPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/libPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "App",
@@ -2094,7 +2094,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "drawPkg",
-                    path: .init("/drawPkg"),
+                    path: .init(path: "/drawPkg"),
                     products: [
                         ProductDescription(name: "DrawProd", type: .library(.automatic), targets: ["Render"]),
                     ],
@@ -2103,9 +2103,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "gamePkg",
-                    path: .init("/gamePkg"),
+                    path: .init(path: "/gamePkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/drawPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/drawPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "GameProd", type: .library(.automatic), targets: ["Game"]),
@@ -2128,9 +2128,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "libPkg",
-                    path: .init("/libPkg"),
+                    path: .init(path: "/libPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/gamePkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/gamePkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "LibProd", type: .library(.automatic), targets: ["Lib"]),
@@ -2145,9 +2145,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "appPkg",
-                    path: .init("/appPkg"),
+                    path: .init(path: "/appPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/libPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/libPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "App",
@@ -2204,7 +2204,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "drawPkg",
-                    path: .init("/drawPkg"),
+                    path: .init(path: "/drawPkg"),
                     products: [
                         ProductDescription(name: "DrawProd", type: .library(.automatic), targets: ["Render"]),
                     ],
@@ -2213,9 +2213,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "gamePkg",
-                    path: .init("/gamePkg"),
+                    path: .init(path: "/gamePkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/drawPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/drawPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "Game", type: .library(.automatic), targets: ["Game"]),
@@ -2236,9 +2236,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "libPkg",
-                    path: .init("/libPkg"),
+                    path: .init(path: "/libPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/gamePkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/gamePkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "LibProd", type: .library(.automatic), targets: ["Lib"]),
@@ -2260,9 +2260,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "appPkg",
-                    path: .init("/appPkg"),
+                    path: .init(path: "/appPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/libPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/libPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "App",
@@ -2315,7 +2315,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "barPkg",
-                    path: .init("/barPkg"),
+                    path: .init(path: "/barPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
                     ],
@@ -2324,9 +2324,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "fooPkg",
-                    path: .init("/fooPkg"),
+                    path: .init(path: "/fooPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/barPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
@@ -2339,10 +2339,10 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "thisPkg",
-                    path: .init("/thisPkg"),
+                    path: .init(path: "/thisPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/barPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe",
@@ -2391,7 +2391,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "carPkg",
-                    path: .init("/carPkg"),
+                    path: .init(path: "/carPkg"),
                     products: [
                         ProductDescription(name: "CarLog", type: .library(.automatic), targets: ["Logging"]),
                     ],
@@ -2400,7 +2400,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "barPkg",
-                    path: .init("/barPkg"),
+                    path: .init(path: "/barPkg"),
                     products: [
                         ProductDescription(name: "BarLog", type: .library(.automatic), targets: ["Logging"]),
                     ],
@@ -2409,9 +2409,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "fooPkg",
-                    path: .init("/fooPkg"),
+                    path: .init(path: "/fooPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/barPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "UtilsProd", type: .library(.automatic), targets: ["Utils"]),
@@ -2424,10 +2424,10 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "thisPkg",
-                    path: .init("/thisPkg"),
+                    path: .init(path: "/thisPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/carPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/carPkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe",
@@ -2476,7 +2476,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "xpkg",
-                    path: .init("/xpkg"),
+                    path: .init(path: "/xpkg"),
                     products: [
                         ProductDescription(name: "X", type: .library(.automatic), targets: ["X"]),
                     ],
@@ -2486,9 +2486,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "appPkg",
-                    path: .init("/appPkg"),
+                    path: .init(path: "/appPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "App",
@@ -2532,7 +2532,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "cpkg",
-                    path: .init("/cpkg"),
+                    path: .init(path: "/cpkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
@@ -2541,9 +2541,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "bpkg",
-                    path: .init("/bpkg"),
+                    path: .init(path: "/bpkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/cpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/cpkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "B", type: .library(.automatic), targets: ["B"]),
@@ -2558,9 +2558,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "apkg",
-                    path: .init("/apkg"),
+                    path: .init(path: "/apkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/bpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/bpkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "A", type: .library(.automatic), targets: ["A"]),
@@ -2575,7 +2575,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "ypkg",
-                    path: .init("/ypkg"),
+                    path: .init(path: "/ypkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
@@ -2584,9 +2584,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "xpkg",
-                    path: .init("/xpkg"),
+                    path: .init(path: "/xpkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/ypkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/ypkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "X", type: .library(.automatic), targets: ["X"]),
@@ -2601,10 +2601,10 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "appPkg",
-                    path: .init("/appPkg"),
+                    path: .init(path: "/appPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/apkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/apkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "App",
@@ -2656,7 +2656,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "zpkg",
-                    path: .init("/zpkg"),
+                    path: .init(path: "/zpkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
@@ -2665,7 +2665,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "ypkg",
-                    path: .init("/ypkg"),
+                    path: .init(path: "/ypkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
@@ -2674,10 +2674,10 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "xpkg",
-                    path: .init("/xpkg"),
+                    path: .init(path: "/xpkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/ypkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/zpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/ypkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/zpkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "X", type: .library(.automatic), targets: ["X"]),
@@ -2695,7 +2695,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "cpkg",
-                    path: .init("/cpkg"),
+                    path: .init(path: "/cpkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
@@ -2704,7 +2704,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "bpkg",
-                    path: .init("/bpkg"),
+                    path: .init(path: "/bpkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
@@ -2713,10 +2713,10 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "apkg",
-                    path: .init("/apkg"),
+                    path: .init(path: "/apkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/bpkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/cpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/bpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/cpkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "A", type: .library(.automatic), targets: ["A"]),
@@ -2734,10 +2734,10 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "appPkg",
-                    path: .init("/appPkg"),
+                    path: .init(path: "/appPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/apkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/apkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "App",
@@ -2788,7 +2788,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "zpkg",
-                    path: .init("/zpkg"),
+                    path: .init(path: "/zpkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
@@ -2797,7 +2797,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "ypkg",
-                    path: .init("/ypkg"),
+                    path: .init(path: "/ypkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
@@ -2806,10 +2806,10 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "xpkg",
-                    path: .init("/xpkg"),
+                    path: .init(path: "/xpkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/ypkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/zpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/ypkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/zpkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "X", type: .library(.automatic), targets: ["X"]),
@@ -2827,7 +2827,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "apkg",
-                    path: .init("/apkg"),
+                    path: .init(path: "/apkg"),
                     products: [
                         ProductDescription(name: "A", type: .library(.automatic), targets: ["A"]),
                     ],
@@ -2837,10 +2837,10 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "appPkg",
-                    path: .init("/appPkg"),
+                    path: .init(path: "/appPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/apkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/apkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "App",
@@ -2889,7 +2889,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "zpkg",
-                    path: .init("/zpkg"),
+                    path: .init(path: "/zpkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
@@ -2898,7 +2898,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "ypkg",
-                    path: .init("/ypkg"),
+                    path: .init(path: "/ypkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
@@ -2907,10 +2907,10 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "xpkg",
-                    path: .init("/xpkg"),
+                    path: .init(path: "/xpkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/ypkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/zpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/ypkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/zpkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "X", type: .library(.automatic), targets: ["X"]),
@@ -2928,7 +2928,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "apkg",
-                    path: .init("/apkg"),
+                    path: .init(path: "/apkg"),
                     products: [
                         ProductDescription(name: "A", type: .library(.automatic), targets: ["Utils"]),
                     ],
@@ -2937,10 +2937,10 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "appPkg",
-                    path: .init("/appPkg"),
+                    path: .init(path: "/appPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/apkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/apkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "App",
@@ -2991,7 +2991,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "ypkg",
-                    path: .init("/ypkg"),
+                    path: .init(path: "/ypkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
@@ -3000,9 +3000,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "xpkg",
-                    path: .init("/xpkg"),
+                    path: .init(path: "/xpkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/ypkg"), requirement: .upToNextMajor(from: "1.0.0"))
+                        .localSourceControl(path: .init(path: "/ypkg"), requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     products: [
                         ProductDescription(name: "X", type: .library(.automatic), targets: ["X"]),
@@ -3020,7 +3020,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "bpkg",
-                    path: .init("/bpkg"),
+                    path: .init(path: "/bpkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
@@ -3029,9 +3029,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "apkg",
-                    path: .init("/apkg"),
+                    path: .init(path: "/apkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/bpkg"), requirement: .upToNextMajor(from: "1.0.0"))
+                        .localSourceControl(path: .init(path: "/bpkg"), requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     products: [
                         ProductDescription(name: "A", type: .library(.automatic), targets: ["A"]),
@@ -3049,10 +3049,10 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "appPkg",
-                    path: .init("/appPkg"),
+                    path: .init(path: "/appPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/apkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/apkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "App",
@@ -3102,7 +3102,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "zpkg",
-                    path: .init("/zpkg"),
+                    path: .init(path: "/zpkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
@@ -3111,7 +3111,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "ypkg",
-                    path: .init("/ypkg"),
+                    path: .init(path: "/ypkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
@@ -3120,10 +3120,10 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "xpkg",
-                    path: .init("/xpkg"),
+                    path: .init(path: "/xpkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/ypkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/zpkg"), requirement: .upToNextMajor(from: "1.0.0"))
+                        .localSourceControl(path: .init(path: "/ypkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/zpkg"), requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     products: [
                         ProductDescription(name: "X", type: .library(.automatic), targets: ["X"]),
@@ -3142,7 +3142,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "bpkg",
-                    path: .init("/bpkg"),
+                    path: .init(path: "/bpkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
@@ -3151,9 +3151,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "apkg",
-                    path: .init("/apkg"),
+                    path: .init(path: "/apkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/bpkg"), requirement: .upToNextMajor(from: "1.0.0"))
+                        .localSourceControl(path: .init(path: "/bpkg"), requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     products: [
                         ProductDescription(name: "A", type: .library(.automatic), targets: ["A"]),
@@ -3171,10 +3171,10 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "appPkg",
-                    path: .init("/appPkg"),
+                    path: .init(path: "/appPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/apkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/apkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "App",
@@ -3224,7 +3224,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "zpkg",
-                    path: .init("/zpkg"),
+                    path: .init(path: "/zpkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
@@ -3233,7 +3233,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "ypkg",
-                    path: .init("/ypkg"),
+                    path: .init(path: "/ypkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
@@ -3242,10 +3242,10 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "xpkg",
-                    path: .init("/xpkg"),
+                    path: .init(path: "/xpkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/ypkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/zpkg"), requirement: .upToNextMajor(from: "1.0.0"))
+                        .localSourceControl(path: .init(path: "/ypkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/zpkg"), requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     products: [
                         ProductDescription(name: "X", type: .library(.automatic), targets: ["X"]),
@@ -3265,7 +3265,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "bpkg",
-                    path: .init("/bpkg"),
+                    path: .init(path: "/bpkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
@@ -3274,9 +3274,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "apkg",
-                    path: .init("/apkg"),
+                    path: .init(path: "/apkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/bpkg"), requirement: .upToNextMajor(from: "1.0.0"))
+                        .localSourceControl(path: .init(path: "/bpkg"), requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     products: [
                         ProductDescription(name: "A", type: .library(.automatic), targets: ["A"]),
@@ -3294,10 +3294,10 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "appPkg",
-                    path: .init("/appPkg"),
+                    path: .init(path: "/appPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/apkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/apkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "App",
@@ -3346,7 +3346,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                 name: "apkg",
-                path: .init("/apkg"),
+                path: .init(path: "/apkg"),
                 products: [
                     ProductDescription(name: "A", type: .library(.automatic), targets: ["Utils"]),
                 ],
@@ -3355,7 +3355,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                 ]),
                 Manifest.createFileSystemManifest(
                     name: "wpkg",
-                    path: .init("/wpkg"),
+                    path: .init(path: "/wpkg"),
                     products: [
                         ProductDescription(name: "W", type: .library(.automatic), targets: ["Utils"]),
                     ],
@@ -3364,7 +3364,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "zpkg",
-                    path: .init("/zpkg"),
+                    path: .init(path: "/zpkg"),
                     products: [
                         ProductDescription(name: "Z", type: .library(.automatic), targets: ["Utils"]),
                     ],
@@ -3373,9 +3373,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "ypkg",
-                    path: .init("/ypkg"),
+                    path: .init(path: "/ypkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/zpkg"), requirement: .upToNextMajor(from: "1.0.0"))
+                        .localSourceControl(path: .init(path: "/zpkg"), requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     products: [
                         ProductDescription(name: "Y", type: .library(.automatic), targets: ["Utils"]),
@@ -3391,10 +3391,10 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "xpkg",
-                    path: .init("/xpkg"),
+                    path: .init(path: "/xpkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/ypkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/wpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/ypkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/wpkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "X", type: .library(.automatic), targets: ["Utils"]),
@@ -3414,10 +3414,10 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "appPkg",
-                    path: .init("/appPkg"),
+                    path: .init(path: "/appPkg"),
                     dependencies: [
-                        .localSourceControl(path: .init("/apkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/apkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "App",

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -40,7 +40,7 @@ final class BuildToolTests: CommandsTestCase {
         let (output, _) = try execute(args, packagePath: packagePath)
         defer { try! SwiftPMProduct.SwiftPackage.execute(["clean"], packagePath: packagePath) }
         let (binPathOutput, _) = try execute(["--show-bin-path"], packagePath: packagePath)
-        let binPath = AbsolutePath(binPathOutput.trimmingCharacters(in: .whitespacesAndNewlines))
+        let binPath = try AbsolutePath(validating: binPathOutput.trimmingCharacters(in: .whitespacesAndNewlines))
         let binContents = try localFileSystem.getDirectoryContents(binPath)
         return BuildResult(binPath: binPath, output: output, binContents: binContents)
     }
@@ -81,7 +81,7 @@ final class BuildToolTests: CommandsTestCase {
         #endif
         // Verify the warning flow
         try fixture(name: "Miscellaneous/ImportOfMissingDependency") { path in
-            let fullPath = resolveSymlinks(path)
+            let fullPath = try resolveSymlinks(path)
             XCTAssertThrowsError(try build(["--explicit-target-dependency-import-check=warn"], packagePath: fullPath)) { error in
                 guard case SwiftPMProductError.executionFailure(_, _, let stderr) = error else {
                     XCTFail()
@@ -94,7 +94,7 @@ final class BuildToolTests: CommandsTestCase {
 
         // Verify the error flow
         try fixture(name: "Miscellaneous/ImportOfMissingDependency") { path in
-            let fullPath = resolveSymlinks(path)
+            let fullPath = try resolveSymlinks(path)
             XCTAssertThrowsError(try build(["--explicit-target-dependency-import-check=error"], packagePath: fullPath)) { error in
                 guard case SwiftPMProductError.executionFailure(_, _, let stderr) = error else {
                     XCTFail()
@@ -107,7 +107,7 @@ final class BuildToolTests: CommandsTestCase {
 
         // Verify that the default does not run the check
         try fixture(name: "Miscellaneous/ImportOfMissingDependency") { path in
-            let fullPath = resolveSymlinks(path)
+            let fullPath = try resolveSymlinks(path)
             XCTAssertThrowsError(try build([], packagePath: fullPath)) { error in
                 guard case SwiftPMProductError.executionFailure(_, _, let stderr) = error else {
                     XCTFail()
@@ -120,8 +120,8 @@ final class BuildToolTests: CommandsTestCase {
 
     func testBinPathAndSymlink() throws {
         try fixture(name: "ValidLayouts/SingleModule/ExecutableNew") { fixturePath in
-            let fullPath = resolveSymlinks(fixturePath)
-            let targetPath = fullPath.appending(components: ".build", UserToolchain.default.triple.platformBuildPathComponent())
+            let fullPath = try resolveSymlinks(fixturePath)
+            let targetPath = fullPath.appending(components: ".build", try UserToolchain.default.triple.platformBuildPathComponent())
             let xcbuildTargetPath = fullPath.appending(components: ".build", "apple")
             XCTAssertEqual(try execute(["--show-bin-path"], packagePath: fullPath).stdout,
                            "\(targetPath.appending(component: "debug").pathString)\n")
@@ -141,17 +141,17 @@ final class BuildToolTests: CommandsTestCase {
 
             // Test symlink.
             _ = try execute([], packagePath: fullPath)
-            XCTAssertEqual(resolveSymlinks(fullPath.appending(components: ".build", "debug")),
+            XCTAssertEqual(try resolveSymlinks(fullPath.appending(components: ".build", "debug")),
                            targetPath.appending(component: "debug"))
             _ = try execute(["-c", "release"], packagePath: fullPath)
-            XCTAssertEqual(resolveSymlinks(fullPath.appending(components: ".build", "release")),
+            XCTAssertEqual(try resolveSymlinks(fullPath.appending(components: ".build", "release")),
                            targetPath.appending(component: "release"))
         }
     }
 
     func testProductAndTarget() throws {
         try fixture(name: "Miscellaneous/MultipleExecutables") { fixturePath in
-            let fullPath = resolveSymlinks(fixturePath)
+            let fullPath = try resolveSymlinks(fixturePath)
 
             do {
                 let result = try build(["--product", "exec1"], packagePath: fullPath)
@@ -199,7 +199,7 @@ final class BuildToolTests: CommandsTestCase {
     
     func testAtMainSupport() throws {
         try fixture(name: "Miscellaneous/AtMainSupport") { fixturePath in
-            let fullPath = resolveSymlinks(fixturePath)
+            let fullPath = try resolveSymlinks(fixturePath)
 
             do {
                 let result = try build(["--product", "ClangExecSingleFile"], packagePath: fullPath)
@@ -321,7 +321,7 @@ final class BuildToolTests: CommandsTestCase {
             let defaultOutput = try execute(["-c", "debug", "-v"], packagePath: fixturePath).stdout
             
             // Look for certain things in the output from XCBuild.
-            XCTAssertMatch(defaultOutput, .contains("-target \(UserToolchain.default.triple.tripleString(forPlatformVersion: ""))"))
+            XCTAssertMatch(defaultOutput, .contains("-target \(try UserToolchain.default.triple.tripleString(forPlatformVersion: ""))"))
         }
     }
 
@@ -360,7 +360,7 @@ final class BuildToolTests: CommandsTestCase {
         try fixture(name: "ValidLayouts/SingleModule/ExecutableNew") { fixturePath in
             // Try building using XCBuild without specifying overrides.  This should succeed, and should use the default compiler path.
             let defaultOutput = try execute(["-c", "debug", "--vv"], packagePath: fixturePath).stdout
-            XCTAssertMatch(defaultOutput, .contains(UserToolchain.default.swiftCompilerPath.pathString))
+            XCTAssertMatch(defaultOutput, .contains(try UserToolchain.default.swiftCompilerPath.pathString))
 
             // Now try building using XCBuild while specifying a faulty compiler override.  This should fail.  Note that we need to set the executable to use for the manifest itself to the default one, since it defaults to SWIFT_EXEC if not provided.
             var overriddenOutput = ""

--- a/Tests/CommandsTests/MultiRootSupportTests.swift
+++ b/Tests/CommandsTests/MultiRootSupportTests.swift
@@ -24,7 +24,7 @@ final class MultiRootSupportTests: CommandsTestCase {
             "/tmp/test/dep/Package.swift",
             "/tmp/test/local/Package.swift",
         ])
-        let path = AbsolutePath("/tmp/test/Workspace.xcworkspace")
+        let path = AbsolutePath(path: "/tmp/test/Workspace.xcworkspace")
         try fs.writeFileContents(path.appending(component: "contents.xcworkspacedata")) {
             $0 <<< """
                 <?xml version="1.0" encoding="UTF-8"?>

--- a/Tests/CommandsTests/PackageRegistryToolTests.swift
+++ b/Tests/CommandsTests/PackageRegistryToolTests.swift
@@ -52,7 +52,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
     func testLocalConfiguration() throws {
         try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
             let packageRoot = fixturePath.appending(component: "Bar")
-            let configurationFilePath = AbsolutePath(".swiftpm/configuration/registries.json", relativeTo: packageRoot)
+            let configurationFilePath = AbsolutePath(path: ".swiftpm/configuration/registries.json", relativeTo: packageRoot)
 
             XCTAssertFalse(localFileSystem.exists(configurationFilePath))
 
@@ -131,7 +131,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
     func testSetMissingURL() throws {
         try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
             let packageRoot = fixturePath.appending(component: "Bar")
-            let configurationFilePath = AbsolutePath(".swiftpm/configuration/registries.json", relativeTo: packageRoot)
+            let configurationFilePath = AbsolutePath(path: ".swiftpm/configuration/registries.json", relativeTo: packageRoot)
 
             XCTAssertFalse(localFileSystem.exists(configurationFilePath))
 
@@ -148,7 +148,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
     func testSetInvalidURL() throws {
         try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
             let packageRoot = fixturePath.appending(component: "Bar")
-            let configurationFilePath = AbsolutePath(".swiftpm/configuration/registries.json", relativeTo: packageRoot)
+            let configurationFilePath = AbsolutePath(path: ".swiftpm/configuration/registries.json", relativeTo: packageRoot)
 
             XCTAssertFalse(localFileSystem.exists(configurationFilePath))
 
@@ -165,7 +165,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
     func testSetInvalidScope() throws {
         try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
             let packageRoot = fixturePath.appending(component: "Bar")
-            let configurationFilePath = AbsolutePath(".swiftpm/configuration/registries.json", relativeTo: packageRoot)
+            let configurationFilePath = AbsolutePath(path: ".swiftpm/configuration/registries.json", relativeTo: packageRoot)
 
             XCTAssertFalse(localFileSystem.exists(configurationFilePath))
 
@@ -182,7 +182,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
     func testUnsetMissingEntry() throws {
         try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
             let packageRoot = fixturePath.appending(component: "Bar")
-            let configurationFilePath = AbsolutePath(".swiftpm/configuration/registries.json", relativeTo: packageRoot)
+            let configurationFilePath = AbsolutePath(path: ".swiftpm/configuration/registries.json", relativeTo: packageRoot)
 
             XCTAssertFalse(localFileSystem.exists(configurationFilePath))
 

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -535,7 +535,7 @@ final class PackageToolTests: CommandsTestCase {
             guard case let .string(name)? = contents["name"] else { XCTFail("unexpected result"); return }
             XCTAssertEqual(name, "Dealer")
             guard case let .string(path)? = contents["path"] else { XCTFail("unexpected result"); return }
-            XCTAssertEqual(resolveSymlinks(AbsolutePath(path)), resolveSymlinks(packageRoot))
+            XCTAssertEqual(try resolveSymlinks(try AbsolutePath(validating: path)), try resolveSymlinks(packageRoot))
         }
     }
 
@@ -552,11 +552,11 @@ final class PackageToolTests: CommandsTestCase {
 
         let manifestA = Manifest.createRootManifest(
             name: "PackageA",
-            path: .init("/PackageA"),
+            path: .init(path: "/PackageA"),
             toolsVersion: .v5_3,
             dependencies: [
-                .fileSystem(path: .init("/PackageB")),
-                .fileSystem(path: .init("/PackageC")),
+                .fileSystem(path: .init(path: "/PackageB")),
+                .fileSystem(path: .init(path: "/PackageC")),
             ],
             products: [
                 try .init(name: "exe", type: .executable, targets: ["TargetA"])
@@ -568,11 +568,11 @@ final class PackageToolTests: CommandsTestCase {
 
         let manifestB = Manifest.createFileSystemManifest(
             name: "PackageB",
-            path: .init("/PackageB"),
+            path: .init(path: "/PackageB"),
             toolsVersion: .v5_3,
             dependencies: [
-                .fileSystem(path: .init("/PackageC")),
-                .fileSystem(path: .init("/PackageD")),
+                .fileSystem(path: .init(path: "/PackageC")),
+                .fileSystem(path: .init(path: "/PackageD")),
             ],
             products: [
                 try .init(name: "PackageB", type: .library(.dynamic), targets: ["TargetB"])
@@ -584,10 +584,10 @@ final class PackageToolTests: CommandsTestCase {
 
         let manifestC = Manifest.createFileSystemManifest(
             name: "PackageC",
-            path: .init("/PackageC"),
+            path: .init(path: "/PackageC"),
             toolsVersion: .v5_3,
             dependencies: [
-                .fileSystem(path: .init("/PackageD")),
+                .fileSystem(path: .init(path: "/PackageD")),
             ],
             products: [
                 try .init(name: "PackageC", type: .library(.dynamic), targets: ["TargetC"])
@@ -599,7 +599,7 @@ final class PackageToolTests: CommandsTestCase {
 
         let manifestD = Manifest.createFileSystemManifest(
             name: "PackageD",
-            path: .init("/PackageD"),
+            path: .init(path: "/PackageD"),
             toolsVersion: .v5_3,
             products: [
                 try .init(name: "PackageD", type: .library(.dynamic), targets: ["TargetD"])
@@ -775,7 +775,7 @@ final class PackageToolTests: CommandsTestCase {
             _ = try SwiftPMProduct.SwiftPackage.execute(["edit", "baz", "--branch", "bugfix"], packagePath: fooPath)
 
             // Path to the executable.
-            let exec = [fooPath.appending(components: ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug", "foo").pathString]
+            let exec = [fooPath.appending(components: ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug", "foo").pathString]
 
             // We should see it now in packages directory.
             let editsPath = fooPath.appending(components: "Packages", "bar")
@@ -849,7 +849,7 @@ final class PackageToolTests: CommandsTestCase {
             // Build it.
             XCTAssertBuilds(packageRoot)
             let buildPath = packageRoot.appending(component: ".build")
-            let binFile = buildPath.appending(components: UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Bar")
+            let binFile = buildPath.appending(components: try UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Bar")
             XCTAssertFileExists(binFile)
             XCTAssert(localFileSystem.isDirectory(buildPath))
 
@@ -868,7 +868,7 @@ final class PackageToolTests: CommandsTestCase {
             // Build it.
             XCTAssertBuilds(packageRoot)
             let buildPath = packageRoot.appending(component: ".build")
-            let binFile = buildPath.appending(components: UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Bar")
+            let binFile = buildPath.appending(components: try UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Bar")
             XCTAssertFileExists(binFile)
             XCTAssert(localFileSystem.isDirectory(buildPath))
             // Clean, and check for removal of the build directory but not Packages.
@@ -938,7 +938,7 @@ final class PackageToolTests: CommandsTestCase {
             func build() throws -> String {
                 return try SwiftPMProduct.SwiftBuild.execute([], packagePath: fooPath).stdout
             }
-            let exec = [fooPath.appending(components: ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug", "foo").pathString]
+            let exec = [fooPath.appending(components: ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug", "foo").pathString]
 
             // Build and check.
             _ = try build()

--- a/Tests/CommandsTests/SwiftToolTests.swift
+++ b/Tests/CommandsTests/SwiftToolTests.swift
@@ -124,7 +124,7 @@ final class SwiftToolTests: CommandsTestCase {
 
             // custom .netrc file
             do {
-                let customPath = fs.homeDirectory.appending(component: UUID().uuidString)
+                let customPath = try fs.homeDirectory.appending(component: UUID().uuidString)
                 try fs.writeFileContents(customPath) {
                     "machine mymachine.labkey.org login custom@labkey.org password custom"
                 }
@@ -135,7 +135,7 @@ final class SwiftToolTests: CommandsTestCase {
                 let authorizationProvider = try tool.getAuthorizationProvider() as? CompositeAuthorizationProvider
                 let netrcProviders = authorizationProvider?.providers.compactMap{ $0 as? NetrcAuthorizationProvider } ?? []
                 XCTAssertEqual(netrcProviders.count, 1)
-                XCTAssertEqual(netrcProviders.first.map { resolveSymlinks($0.path) }, resolveSymlinks(customPath))
+                XCTAssertEqual(try netrcProviders.first.map { try resolveSymlinks($0.path) }, try resolveSymlinks(customPath))
 
                 let auth = try tool.getAuthorizationProvider()?.authentication(for: URL(string: "https://mymachine.labkey.org")!)
                 XCTAssertEqual(auth?.user, "custom@labkey.org")
@@ -160,7 +160,7 @@ final class SwiftToolTests: CommandsTestCase {
                 let authorizationProvider = try tool.getAuthorizationProvider() as? CompositeAuthorizationProvider
                 let netrcProviders = authorizationProvider?.providers.compactMap{ $0 as? NetrcAuthorizationProvider } ?? []
                 XCTAssertTrue(netrcProviders.count >= 1) // This might include .netrc in user's home dir
-                XCTAssertNotNil(netrcProviders.first { resolveSymlinks($0.path) == resolveSymlinks(localPath) })
+                XCTAssertNotNil(try netrcProviders.first { try resolveSymlinks($0.path) == resolveSymlinks(localPath) })
 
                 let auth = try tool.getAuthorizationProvider()?.authentication(for: URL(string: "https://mymachine.labkey.org")!)
                 XCTAssertEqual(auth?.user, "local@labkey.org")

--- a/Tests/FunctionalPerformanceTests/BuildPerfTests.swift
+++ b/Tests/FunctionalPerformanceTests/BuildPerfTests.swift
@@ -60,7 +60,7 @@ class BuildPerfTests: XCTestCasePerf {
     func runFullBuildTest(for name: String, app appString: String? = nil, product productString: String) throws {
         try fixture(name: name) { fixturePath in
             let app = fixturePath.appending(components: (appString ?? ""))
-            let triple = UserToolchain.default.triple
+            let triple = try UserToolchain.default.triple
             let product = app.appending(components: ".build", triple.platformBuildPathComponent(), "debug", productString)
             try self.execute(packagePath: app)
             measure {
@@ -74,7 +74,7 @@ class BuildPerfTests: XCTestCasePerf {
     func runNullBuildTest(for name: String, app appString: String? = nil, product productString: String) throws {
         try fixture(name: name) { fixturePath in
             let app = fixturePath.appending(components: (appString ?? ""))
-            let triple = UserToolchain.default.triple
+            let triple = try UserToolchain.default.triple
             let product = app.appending(components: ".build", triple.platformBuildPathComponent(), "debug", productString)
             try self.execute(packagePath: app)
             measure {

--- a/Tests/FunctionalTests/CFamilyTargetTests.swift
+++ b/Tests/FunctionalTests/CFamilyTargetTests.swift
@@ -39,7 +39,7 @@ class CFamilyTargetTestCase: XCTestCase {
     func testCLibraryWithSpaces() throws {
         try fixture(name: "CFamilyTargets/CLibraryWithSpaces") { fixturePath in
             XCTAssertBuilds(fixturePath)
-            let debugPath = fixturePath.appending(components: ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug")
+            let debugPath = fixturePath.appending(components: ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Bar.c.o")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Foo.c.o")
         }
@@ -49,7 +49,7 @@ class CFamilyTargetTestCase: XCTestCase {
         try fixture(name: "DependencyResolution/External/CUsingCDep") { fixturePath in
             let packageRoot = fixturePath.appending(component: "Bar")
             XCTAssertBuilds(packageRoot)
-            let debugPath = fixturePath.appending(components: "Bar", ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug")
+            let debugPath = fixturePath.appending(components: "Bar", ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Sea.c.o")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Foo.c.o")
             let path = try SwiftPMProduct.packagePath(for: "Foo", packageRoot: packageRoot)
@@ -60,7 +60,7 @@ class CFamilyTargetTestCase: XCTestCase {
     func testModuleMapGenerationCases() throws {
         try fixture(name: "CFamilyTargets/ModuleMapGenerationCases") { fixturePath in
             XCTAssertBuilds(fixturePath)
-            let debugPath = fixturePath.appending(components: ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug")
+            let debugPath = fixturePath.appending(components: ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Jaz.c.o")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "main.swift.o")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "FlatInclude.c.o")
@@ -83,7 +83,7 @@ class CFamilyTargetTestCase: XCTestCase {
         // Try building a fixture which needs extra flags to be able to build.
         try fixture(name: "CFamilyTargets/CDynamicLookup") { fixturePath in
             XCTAssertBuilds(fixturePath, Xld: ["-undefined", "dynamic_lookup"])
-            let debugPath = fixturePath.appending(components: ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug")
+            let debugPath = fixturePath.appending(components: ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Foo.c.o")
         }
     }
@@ -95,7 +95,7 @@ class CFamilyTargetTestCase: XCTestCase {
         try fixture(name: "CFamilyTargets/ObjCmacOSPackage") { fixturePath in
             // Build the package.
             XCTAssertBuilds(fixturePath)
-            XCTAssertDirectoryContainsFile(dir: fixturePath.appending(components: ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug"), filename: "HelloWorldExample.m.o")
+            XCTAssertDirectoryContainsFile(dir: fixturePath.appending(components: ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug"), filename: "HelloWorldExample.m.o")
             // Run swift-test on package.
             XCTAssertSwiftTest(fixturePath)
         }
@@ -104,7 +104,7 @@ class CFamilyTargetTestCase: XCTestCase {
     func testCanBuildRelativeHeaderSearchPaths() throws {
         try fixture(name: "CFamilyTargets/CLibraryParentSearchPath") { fixturePath in
             XCTAssertBuilds(fixturePath)
-            XCTAssertDirectoryContainsFile(dir: fixturePath.appending(components: ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug"), filename: "HeaderInclude.swiftmodule")
+            XCTAssertDirectoryContainsFile(dir: fixturePath.appending(components: ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug"), filename: "HeaderInclude.swiftmodule")
         }
     }
 }

--- a/Tests/FunctionalTests/DependencyResolutionTests.swift
+++ b/Tests/FunctionalTests/DependencyResolutionTests.swift
@@ -54,7 +54,7 @@ class DependencyResolutionTests: XCTestCase {
 
             let packageRoot = fixturePath.appending(component: "Bar")
             XCTAssertBuilds(packageRoot)
-            XCTAssertFileExists(fixturePath.appending(components: "Bar", ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Bar"))
+            XCTAssertFileExists(fixturePath.appending(components: "Bar", ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Bar"))
             let path = try SwiftPMProduct.packagePath(for: "Foo", packageRoot: packageRoot)
             XCTAssert(try GitRepository(path: path).getTags().contains("1.2.3"))
         }
@@ -79,7 +79,7 @@ class DependencyResolutionTests: XCTestCase {
 
     func testMirrors() throws {
         try fixture(name: "DependencyResolution/External/Mirror") { fixturePath in
-            let prefix = resolveSymlinks(fixturePath)
+            let prefix = try resolveSymlinks(fixturePath)
             let appPath = prefix.appending(component: "App")
             let appPinsPath = appPath.appending(component: "Package.resolved")
 

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -50,7 +50,7 @@ class MiscellaneousTestCase: XCTestCase {
 
         try fixture(name: "Miscellaneous/ExactDependencies") { fixturePath in
             XCTAssertBuilds(fixturePath.appending(component: "app"))
-            let buildDir = fixturePath.appending(components: "app", ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug")
+            let buildDir = fixturePath.appending(components: "app", ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug")
             XCTAssertFileExists(buildDir.appending(component: "FooExec"))
             XCTAssertFileExists(buildDir.appending(component: "FooLib1.swiftmodule"))
             XCTAssertFileExists(buildDir.appending(component: "FooLib2.swiftmodule"))
@@ -71,7 +71,7 @@ class MiscellaneousTestCase: XCTestCase {
     }
 
     func testNoArgumentsExitsWithOne() throws {
-        XCTAssertThrowsCommandExecutionError(try executeSwiftBuild(AbsolutePath("/"))) { error in
+        XCTAssertThrowsCommandExecutionError(try executeSwiftBuild(AbsolutePath(path: "/"))) { error in
             // if our code crashes we'll get an exit code of 256
             guard error.result.exitStatus == .terminated(code: 1) else {
                 return XCTFail("failed in an unexpected manner: \(error)")
@@ -105,7 +105,7 @@ class MiscellaneousTestCase: XCTestCase {
     */
     func testInternalDependencyEdges() throws {
         try fixture(name: "Miscellaneous/DependencyEdges/Internal") { fixturePath in
-            let execpath = fixturePath.appending(components: ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Foo").pathString
+            let execpath = fixturePath.appending(components: ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Foo").pathString
 
             XCTAssertBuilds(fixturePath)
             var output = try Process.checkNonZeroExit(args: execpath)
@@ -129,7 +129,7 @@ class MiscellaneousTestCase: XCTestCase {
     */
     func testExternalDependencyEdges1() throws {
         try fixture(name: "DependencyResolution/External/Complex") { fixturePath in
-            let execpath = fixturePath.appending(components: "app", ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Dealer").pathString
+            let execpath = fixturePath.appending(components: "app", ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Dealer").pathString
 
             let packageRoot = fixturePath.appending(component: "app")
             XCTAssertBuilds(packageRoot)
@@ -156,7 +156,7 @@ class MiscellaneousTestCase: XCTestCase {
      */
     func testExternalDependencyEdges2() throws {
         try fixture(name: "Miscellaneous/DependencyEdges/External") { fixturePath in
-            let execpath = [fixturePath.appending(components: "root", ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug", "dep2").pathString]
+            let execpath = [fixturePath.appending(components: "root", ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug", "dep2").pathString]
 
             let packageRoot = fixturePath.appending(component: "root")
             XCTAssertBuilds(fixturePath.appending(component: "root"))
@@ -180,7 +180,7 @@ class MiscellaneousTestCase: XCTestCase {
     func testSpaces() throws {
         try fixture(name: "Miscellaneous/Spaces Fixture") { fixturePath in
             XCTAssertBuilds(fixturePath)
-            XCTAssertFileExists(fixturePath.appending(components: ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Module_Name_1.build", "Foo.swift.o"))
+            XCTAssertFileExists(fixturePath.appending(components: ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Module_Name_1.build", "Foo.swift.o"))
         }
     }
 
@@ -203,7 +203,7 @@ class MiscellaneousTestCase: XCTestCase {
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
         try fixture(name: "Miscellaneous/DistantFutureDeploymentTarget") { fixturePath in
-            let hostTriple = UserToolchain.default.triple
+            let hostTriple = try UserToolchain.default.triple
             try executeSwiftBuild(fixturePath, Xswiftc: ["-target", "\(hostTriple.arch)-apple-macosx41.0"])
         }
     }
@@ -213,7 +213,7 @@ class MiscellaneousTestCase: XCTestCase {
             let systemModule = fixturePath.appending(component: "SystemModule")
             // Create a shared library.
             let input = systemModule.appending(components: "Sources", "SystemModule.c")
-            let triple = UserToolchain.default.triple
+            let triple = try UserToolchain.default.triple
             let output =  systemModule.appending(component: "libSystemModule\(triple.dynamicLibraryExtension)")
             try systemQuietly(["clang", "-shared", input.pathString, "-o", output.pathString])
 
@@ -356,7 +356,7 @@ class MiscellaneousTestCase: XCTestCase {
 
             // ••••• Set up dependency.
             let dependencyName = "UnicodeDependency‐\(complicatedString)"
-            let dependencyOrigin = AbsolutePath(#file).parentDirectory.parentDirectory.parentDirectory
+            let dependencyOrigin = AbsolutePath(path: #file).parentDirectory.parentDirectory.parentDirectory
                 .appending(component: "Fixtures")
                 .appending(component: "Miscellaneous")
                 .appending(component: dependencyName)
@@ -443,7 +443,7 @@ class MiscellaneousTestCase: XCTestCase {
 
     func testEditModeEndToEnd() throws {
         try fixture(name: "Miscellaneous/Edit") { fixturePath in
-            let prefix = resolveSymlinks(fixturePath)
+            let prefix = try resolveSymlinks(fixturePath)
             let appPath = fixturePath.appending(component: "App")
 
             // prepare the dependencies as git repos

--- a/Tests/FunctionalTests/ModuleAliasingFixtureTests.swift
+++ b/Tests/FunctionalTests/ModuleAliasingFixtureTests.swift
@@ -27,7 +27,7 @@ class ModuleAliasingFixtureTests: XCTestCase {
 
         try fixture(name: "ModuleAliasing/DirectDeps1") { fixturePath in
             let pkgPath = fixturePath.appending(components: "AppPkg")
-            let buildPath = pkgPath.appending(components: ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug")
+            let buildPath = pkgPath.appending(components: ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug")
             XCTAssertBuilds(pkgPath, extraArgs: ["--vv"])
             XCTAssertFileExists(buildPath.appending(components: "App"))
             XCTAssertFileExists(buildPath.appending(components: "GameUtils.swiftmodule"))
@@ -45,7 +45,7 @@ class ModuleAliasingFixtureTests: XCTestCase {
 
         try fixture(name: "ModuleAliasing/DirectDeps2") { fixturePath in
             let pkgPath = fixturePath.appending(components: "AppPkg")
-            let buildPath = pkgPath.appending(components: ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug")
+            let buildPath = pkgPath.appending(components: ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug")
             XCTAssertBuilds(pkgPath, extraArgs: ["--vv"])
             XCTAssertFileExists(buildPath.appending(components: "App"))
             XCTAssertFileExists(buildPath.appending(components: "AUtils.swiftmodule"))

--- a/Tests/FunctionalTests/ModuleMapTests.swift
+++ b/Tests/FunctionalTests/ModuleMapTests.swift
@@ -22,7 +22,7 @@ class ModuleMapsTestCase: XCTestCase {
     private func fixture(name: String, cModuleName: String, rootpkg: String, body: @escaping (AbsolutePath, [String]) throws -> Void) throws {
         try SPMTestSupport.fixture(name: name) { fixturePath in
             let input = fixturePath.appending(components: cModuleName, "C", "foo.c")
-            let triple = UserToolchain.default.triple
+            let triple = try UserToolchain.default.triple
             let outdir = fixturePath.appending(components: rootpkg, ".build", triple.platformBuildPathComponent(), "debug")
             try makeDirectories(outdir)
             let output = outdir.appending(component: "libfoo\(triple.dynamicLibraryExtension)")
@@ -42,7 +42,7 @@ class ModuleMapsTestCase: XCTestCase {
 
             XCTAssertBuilds(fixturePath.appending(component: "App"), Xld: Xld)
 
-            let triple = UserToolchain.default.triple
+            let triple = try UserToolchain.default.triple
             let targetPath = fixturePath.appending(components: "App", ".build", triple.platformBuildPathComponent())
             let debugout = try Process.checkNonZeroExit(args: targetPath.appending(components: "debug", "App").pathString)
             XCTAssertEqual(debugout, "123\n")
@@ -57,7 +57,7 @@ class ModuleMapsTestCase: XCTestCase {
             XCTAssertBuilds(fixturePath.appending(component: "packageA"), Xld: Xld)
 
             func verify(_ conf: String) throws {
-                let triple = UserToolchain.default.triple
+                let triple = try UserToolchain.default.triple
                 let out = try Process.checkNonZeroExit(args: fixturePath.appending(components: "packageA", ".build", triple.platformBuildPathComponent(), conf, "packageA").pathString)
                 XCTAssertEqual(out, """
                     calling Y.bar()

--- a/Tests/FunctionalTests/ResourcesTests.swift
+++ b/Tests/FunctionalTests/ResourcesTests.swift
@@ -37,7 +37,7 @@ class ResourcesTests: XCTestCase {
         try fixture(name: "Resources/Localized") { fixturePath in
             try executeSwiftBuild(fixturePath)
 
-            let exec = AbsolutePath(".build/debug/exe", relativeTo: fixturePath)
+            let exec = AbsolutePath(path: ".build/debug/exe", relativeTo: fixturePath)
             // Note: <rdar://problem/59738569> Source from LANG and -AppleLanguages on command line for Linux resources
             let output = try Process.checkNonZeroExit(args: exec.pathString, "-AppleLanguages", "(en_US)")
             XCTAssertEqual(output, """
@@ -58,7 +58,7 @@ class ResourcesTests: XCTestCase {
             executables.append("SeaResource")
             #endif
 
-            let binPath = try AbsolutePath(
+            let binPath = try AbsolutePath(validating:
                 executeSwiftBuild(fixturePath, configuration: .Release, extraArgs: ["--show-bin-path"]).stdout
                     .trimmingCharacters(in: .whitespacesAndNewlines)
             )

--- a/Tests/FunctionalTests/SwiftPMXCTestHelperTests.swift
+++ b/Tests/FunctionalTests/SwiftPMXCTestHelperTests.swift
@@ -25,7 +25,7 @@ class SwiftPMXCTestHelperTests: XCTestCase {
         try fixture(name: "Miscellaneous/SwiftPMXCTestHelper") { fixturePath in
             // Build the package.
             XCTAssertBuilds(fixturePath)
-            let triple = UserToolchain.default.triple
+            let triple = try UserToolchain.default.triple
             XCTAssertFileExists(fixturePath.appending(components: ".build", triple.platformBuildPathComponent(), "debug", "SwiftPMXCTestHelper.swiftmodule"))
             // Run swift-test on package.
             XCTAssertSwiftTest(fixturePath)
@@ -49,7 +49,7 @@ class SwiftPMXCTestHelperTests: XCTestCase {
 
     func XCTAssertXCTestHelper(_ bundlePath: AbsolutePath, testCases: NSDictionary) throws {
         #if os(macOS)
-        let env = ["DYLD_FRAMEWORK_PATH": UserToolchain.default.sdkPlatformFrameworksPath.pathString]
+        let env = ["DYLD_FRAMEWORK_PATH": try UserToolchain.default.sdkPlatformFrameworksPath.pathString]
         let outputFile = bundlePath.parentDirectory.appending(component: "tests.txt")
         let _ = try SwiftPMProduct.XCTestHelper.execute([bundlePath.pathString, outputFile.pathString], env: env)
         guard let data = NSData(contentsOfFile: outputFile.pathString) else {

--- a/Tests/FunctionalTests/ToolsVersionTests.swift
+++ b/Tests/FunctionalTests/ToolsVersionTests.swift
@@ -92,7 +92,7 @@ class ToolsVersionTests: XCTestCase {
 
             // Build the primary package.
             _ = try SwiftPMProduct.SwiftBuild.execute([], packagePath: primaryPath)
-            let exe = primaryPath.appending(components: ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Primary").pathString
+            let exe = primaryPath.appending(components: ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Primary").pathString
             // v1 should get selected because v1.0.1 depends on a (way) higher set of tools.
             XCTAssertEqual(try Process.checkNonZeroExit(args: exe).spm_chomp(), "foo@1.0")
 

--- a/Tests/PackageCollectionsTests/PackageIndexConfigurationTests.swift
+++ b/Tests/PackageCollectionsTests/PackageIndexConfigurationTests.swift
@@ -20,7 +20,7 @@ class PackageIndexConfigurationTests: XCTestCase {
         let configuration = PackageIndexConfiguration(url: url)
         
         let fileSystem = InMemoryFileSystem()
-        let storage = PackageIndexConfigurationStorage(path: fileSystem.swiftPMConfigurationDirectory.appending(component: "index.json"), fileSystem: fileSystem)
+        let storage = PackageIndexConfigurationStorage(path: try fileSystem.swiftPMConfigurationDirectory.appending(component: "index.json"), fileSystem: fileSystem)
         try storage.save(configuration)
         
         let loadedConfiguration = try storage.load()
@@ -29,7 +29,7 @@ class PackageIndexConfigurationTests: XCTestCase {
     
     func testLoad_fileDoesNotExist() throws {
         let fileSystem = InMemoryFileSystem()
-        let storage = PackageIndexConfigurationStorage(path: fileSystem.swiftPMConfigurationDirectory.appending(component: "index.json"), fileSystem: fileSystem)
+        let storage = PackageIndexConfigurationStorage(path: try fileSystem.swiftPMConfigurationDirectory.appending(component: "index.json"), fileSystem: fileSystem)
         let configuration = try storage.load()
         XCTAssertNil(configuration.url)
     }
@@ -45,7 +45,7 @@ class PackageIndexConfigurationTests: XCTestCase {
         """
         
         let fileSystem = InMemoryFileSystem()
-        let configPath = fileSystem.swiftPMConfigurationDirectory.appending(component: "index.json")
+        let configPath = try fileSystem.swiftPMConfigurationDirectory.appending(component: "index.json")
         if !fileSystem.exists(configPath.parentDirectory, followSymlink: false) {
             try fileSystem.createDirectory(configPath.parentDirectory, recursive: true)
         }

--- a/Tests/PackageFingerprintTests/FilePackageFingerprintStorageTests.swift
+++ b/Tests/PackageFingerprintTests/FilePackageFingerprintStorageTests.swift
@@ -21,7 +21,7 @@ import XCTest
 final class FilePackageFingerprintStorageTests: XCTestCase {
     func testHappyCase() throws {
         let mockFileSystem = InMemoryFileSystem()
-        let directoryPath = AbsolutePath("/fingerprints")
+        let directoryPath = AbsolutePath(path: "/fingerprints")
         let storage = FilePackageFingerprintStorage(fileSystem: mockFileSystem, directoryPath: directoryPath)
         let registryURL = URL(string: "https://example.packages.com")!
         let sourceControlURL = URL(string: "https://example.com/mona/LinkedList.git")!
@@ -70,7 +70,7 @@ final class FilePackageFingerprintStorageTests: XCTestCase {
 
     func testNotFound() throws {
         let mockFileSystem = InMemoryFileSystem()
-        let directoryPath = AbsolutePath("/fingerprints")
+        let directoryPath = AbsolutePath(path: "/fingerprints")
         let storage = FilePackageFingerprintStorage(fileSystem: mockFileSystem, directoryPath: directoryPath)
         let registryURL = URL(string: "https://example.packages.com")!
 
@@ -95,7 +95,7 @@ final class FilePackageFingerprintStorageTests: XCTestCase {
 
     func testSingleFingerprintPerKind() throws {
         let mockFileSystem = InMemoryFileSystem()
-        let directoryPath = AbsolutePath("/fingerprints")
+        let directoryPath = AbsolutePath(path: "/fingerprints")
         let storage = FilePackageFingerprintStorage(fileSystem: mockFileSystem, directoryPath: directoryPath)
         let registryURL = URL(string: "https://example.packages.com")!
 
@@ -118,7 +118,7 @@ final class FilePackageFingerprintStorageTests: XCTestCase {
 
     func testHappyCase_PackageReferenceAPI() throws {
         let mockFileSystem = InMemoryFileSystem()
-        let directoryPath = AbsolutePath("/fingerprints")
+        let directoryPath = AbsolutePath(path: "/fingerprints")
         let storage = FilePackageFingerprintStorage(fileSystem: mockFileSystem, directoryPath: directoryPath)
         let sourceControlURL = URL(string: "https://example.com/mona/LinkedList.git")!
         let packageRef = PackageReference.remoteSourceControl(identity: PackageIdentity(url: sourceControlURL), url: sourceControlURL)
@@ -136,7 +136,7 @@ final class FilePackageFingerprintStorageTests: XCTestCase {
 
     func testDifferentRepoURLsThatHaveSameIdentity() throws {
         let mockFileSystem = InMemoryFileSystem()
-        let directoryPath = AbsolutePath("/fingerprints")
+        let directoryPath = AbsolutePath(path: "/fingerprints")
         let storage = FilePackageFingerprintStorage(fileSystem: mockFileSystem, directoryPath: directoryPath)
         let fooURL = URL(string: "https://example.com/foo/LinkedList.git")!
         let barURL = URL(string: "https://example.com/bar/LinkedList.git")!

--- a/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
@@ -78,7 +78,7 @@ class DependencyResolverRealWorldPerfTests: XCTestCasePerf {
     }
 
     func mockGraph(for name: String) throws -> MockDependencyGraph {
-        let input = AbsolutePath(#file).parentDirectory.appending(component: "Inputs").appending(component: name)
+        let input = AbsolutePath(path: #file).parentDirectory.appending(component: "Inputs").appending(component: name)
         let jsonString: Data = try localFileSystem.readFileContents(input)
         let json = try JSON(data: jsonString)
         return MockDependencyGraph(json)
@@ -100,10 +100,10 @@ public extension MockDependencyGraph {
             name: name,
             constraints: constraints.map(PackageContainerConstraint.init(json:)),
             containers: containers.map(MockPackageContainer.init(json:)),
-            result: Dictionary(uniqueKeysWithValues: result.map { value in
+            result: Dictionary(uniqueKeysWithValues: try! result.map { value in
                 let (container, version) = value
                 guard case .string(let str) = version else { fatalError() }
-                let package = PackageReference.localSourceControl(identity: .plain(container.lowercased()), path: .init("/\(container)"))
+                let package = PackageReference.localSourceControl(identity: .plain(container.lowercased()), path: try .init(validating: "/\(container)"))
                 return (package, Version(str)!)
             })
         )
@@ -133,7 +133,7 @@ private extension MockPackageContainer {
                 }
         }
 
-        self.init(name: identifier, dependenciesByVersion: depByVersion)
+        try! self.init(name: identifier, dependenciesByVersion: depByVersion)
     }
 }
 

--- a/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
@@ -46,15 +46,15 @@ class PackageGraphPerfTests: XCTestCasePerf {
             } else {
                 let depName = "Foo\(pkg + 1)"
                 let depUrl = "/\(depName)"
-                dependencies = [.localSourceControl(deprecatedName: depName, path: .init(depUrl), requirement: .upToNextMajor(from: "1.0.0"))]
+                dependencies = [.localSourceControl(deprecatedName: depName, path: try .init(validating: depUrl), requirement: .upToNextMajor(from: "1.0.0"))]
                 targets = [try TargetDescription(name: name, dependencies: [.byName(name: depName, condition: nil)], path: ".")]
             }
             // Create manifest.
             let isRoot = pkg == 1
             let manifest = Manifest(
                 displayName: name,
-                path: AbsolutePath(location).appending(component: Manifest.filename),
-                packageKind: isRoot ? .root(.init(location)) : .localSourceControl(.init(location)),
+                path: try AbsolutePath(validating: location).appending(component: Manifest.filename),
+                packageKind: isRoot ? .root(try .init(validating: location)) : .localSourceControl(try .init(validating: location)),
                 packageLocation: location,
                 platforms: [],
                 version: "1.0.0",

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -35,7 +35,7 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "Foo",
-                    path: .init("/Foo"),
+                    path: .init(path: "/Foo"),
                     products: [
                         ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Foo"])
                     ],
@@ -45,9 +45,9 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "Bar",
-                    path: .init("/Bar"),
+                    path: .init(path: "/Bar"),
                     dependencies: [
-                        .localSourceControl(path: .init("/Foo"), requirement: .upToNextMajor(from: "1.0.0"))
+                        .localSourceControl(path: .init(path: "/Foo"), requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
@@ -57,9 +57,9 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "Baz",
-                    path: .init("/Baz"),
+                    path: .init(path: "/Baz"),
                     dependencies: [
-                        .localSourceControl(path: .init("/Bar"), requirement: .upToNextMajor(from: "1.0.0"))
+                        .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     targets: [
                         TargetDescription(name: "Baz", dependencies: ["Bar"]),
@@ -102,16 +102,16 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
-                    path: .init("/Foo"),
+                    path: .init(path: "/Foo"),
                     dependencies: [
-                        .localSourceControl(path: .init("/Bar"), requirement: .upToNextMajor(from: "1.0.0"))
+                        .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Bar", "CBar"]),
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "Bar",
-                    path: .init("/Bar"),
+                    path: .init(path: "/Bar"),
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"]),
                         ProductDescription(name: "CBar", type: .library(.automatic), targets: ["CBar"]),
@@ -146,18 +146,18 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
-                    path: .init("/Foo"),
+                    path: .init(path: "/Foo"),
                     dependencies: [
-                        .localSourceControl(path: .init("/Bar"), requirement: .upToNextMajor(from: "1.0.0"))
+                        .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Bar"]),
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "Bar",
-                    path: .init("/Bar"),
+                    path: .init(path: "/Bar"),
                     dependencies: [
-                        .localSourceControl(path: .init("/Baz"), requirement: .upToNextMajor(from: "1.0.0"))
+                        .localSourceControl(path: .init(path: "/Baz"), requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
@@ -167,9 +167,9 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "Baz",
-                    path: .init("/Baz"),
+                    path: .init(path: "/Baz"),
                     dependencies: [
-                        .localSourceControl(path: .init("/Bar"), requirement: .upToNextMajor(from: "1.0.0"))
+                        .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     products: [
                         ProductDescription(name: "Baz", type: .library(.automatic), targets: ["Baz"])
@@ -199,9 +199,9 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
-                    path: .init("/Foo"),
+                    path: .init(path: "/Foo"),
                     dependencies: [
-                        .localSourceControl(path: .init("/Foo"), requirement: .upToNextMajor(from: "1.0.0"))
+                        .localSourceControl(path: .init(path: "/Foo"), requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     targets: [
                         TargetDescription(name: "Foo"),
@@ -231,9 +231,9 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Bar",
-                    path: .init("/Bar"),
+                    path: .init(path: "/Bar"),
                     dependencies: [
-                        .localSourceControl(path: .init("/Foo"), requirement: .upToNextMajor(from: "1.0.0"))
+                        .localSourceControl(path: .init(path: "/Foo"), requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     targets: [
                         TargetDescription(name: "Bar", dependencies: ["Foo"]),
@@ -241,7 +241,7 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "Foo",
-                    path: .init("/Foo"),
+                    path: .init(path: "/Foo"),
                     products: [
                         ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Foo"]),
                     ],
@@ -273,16 +273,16 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
-                    path: .init("/Foo"),
+                    path: .init(path: "/Foo"),
                     dependencies: [
-                        .localSourceControl(path: .init("/Bar"), requirement: .upToNextMajor(from: "1.0.0"))
+                        .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     targets: [
                         TargetDescription(name: "Bar"),
                     ]),
                 Manifest.createRootManifest(
                     name: "Bar",
-                    path: .init("/Bar"),
+                    path: .init(path: "/Bar"),
                     targets: [
                         TargetDescription(name: "Bar"),
                     ]),
@@ -309,7 +309,7 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "Fourth",
-                    path: .init("/Fourth"),
+                    path: .init(path: "/Fourth"),
                     products: [
                         ProductDescription(name: "Fourth", type: .library(.automatic), targets: ["First"])
                     ],
@@ -318,7 +318,7 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "Third",
-                    path: .init("/Third"),
+                    path: .init(path: "/Third"),
                     products: [
                         ProductDescription(name: "Third", type: .library(.automatic), targets: ["First"])
                     ],
@@ -327,7 +327,7 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "Second",
-                    path: .init("/Second"),
+                    path: .init(path: "/Second"),
                     products: [
                         ProductDescription(name: "Second", type: .library(.automatic), targets: ["First"])
                     ],
@@ -336,11 +336,11 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "First",
-                    path: .init("/First"),
+                    path: .init(path: "/First"),
                     dependencies: [
-                        .localSourceControl(path: .init("/Second"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/Third"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/Fourth"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/Second"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/Third"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/Fourth"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "First", dependencies: ["Second", "Third", "Fourth"]),
@@ -368,7 +368,7 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "Fourth",
-                    path: .init("/Fourth"),
+                    path: .init(path: "/Fourth"),
                     products: [
                         ProductDescription(name: "Fourth", type: .library(.automatic), targets: ["Bar"])
                     ],
@@ -377,7 +377,7 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "Third",
-                    path: .init("/Third"),
+                    path: .init(path: "/Third"),
                     products: [
                         ProductDescription(name: "Third", type: .library(.automatic), targets: ["Bar"])
                     ],
@@ -386,7 +386,7 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "Second",
-                    path: .init("/Second"),
+                    path: .init(path: "/Second"),
                     products: [
                         ProductDescription(name: "Second", type: .library(.automatic), targets: ["Foo"])
                     ],
@@ -395,11 +395,11 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "First",
-                    path: .init("/First"),
+                    path: .init(path: "/First"),
                     dependencies: [
-                        .localSourceControl(path: .init("/Second"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/Third"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/Fourth"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/Second"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/Third"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/Fourth"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Second", "Third", "Fourth"]),
@@ -428,7 +428,7 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     name: "Fourth",
-                    path: .init("/Fourth"),
+                    path: .init(path: "/Fourth"),
                     products: [
                         ProductDescription(name: "Fourth", type: .library(.automatic), targets: ["First"])
                     ],
@@ -437,9 +437,9 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "Third",
-                    path: .init("/Third"),
+                    path: .init(path: "/Third"),
                     dependencies: [
-                        .localSourceControl(path: .init("/Fourth"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/Fourth"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "Third", type: .library(.automatic), targets: ["Third"])
@@ -449,9 +449,9 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "Second",
-                    path: .init("/Second"),
+                    path: .init(path: "/Second"),
                     dependencies: [
-                        .localSourceControl(path: .init("/Third"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/Third"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "Second", type: .library(.automatic), targets: ["Second"])
@@ -461,9 +461,9 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     name: "First",
-                    path: .init("/First"),
+                    path: .init(path: "/First"),
                     dependencies: [
-                        .localSourceControl(path: .init("/Second"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/Second"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "First", type: .library(.automatic), targets: ["First"])
@@ -481,7 +481,7 @@ class PackageGraphTests: XCTestCase {
     }
 
     func testEmptyDependency() throws {
-        let Bar: AbsolutePath = AbsolutePath("/Bar")
+        let Bar: AbsolutePath = AbsolutePath(path: "/Bar")
 
         let fs = InMemoryFileSystem(emptyFiles:
             "/Foo/Sources/Foo/foo.swift",
@@ -494,16 +494,16 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
-                    path: .init("/Foo"),
+                    path: .init(path: "/Foo"),
                     dependencies: [
-                        .localSourceControl(path: .init("/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Bar"]),
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "Bar",
-                    path: .init(Bar.pathString),
+                    path: try .init(validating: Bar.pathString),
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
                     ],
@@ -537,7 +537,7 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
-                    path: .init("/Foo"),
+                    path: .init(path: "/Foo"),
                     targets: [
                         TargetDescription(name: "FooTarget", dependencies: ["Barx"]),
                     ]),
@@ -565,7 +565,7 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
-                    path: .init("/Foo"),
+                    path: .init(path: "/Foo"),
                     products: [
                         ProductDescription(name: "Foo", type: .library(.automatic), targets: ["FooTarget"]),
                     ],
@@ -596,7 +596,7 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "XYZ",
-                    path: .init("/XYZ"),
+                    path: .init(path: "/XYZ"),
                     targets: [
                         TargetDescription(name: "XYZ", dependencies: [], type: .executable),
                         TargetDescription(name: "XYZTests", dependencies: ["XYZ"], type: .test),
@@ -620,7 +620,7 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
-                    path: .init("/Foo"),
+                    path: .init(path: "/Foo"),
                     products: [
                         ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Foo"]),
                     ],
@@ -645,7 +645,7 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
-                    path: .init("/Foo"),
+                    path: .init(path: "/Foo"),
                     toolsVersion: .v5_2,
                     targets: [
                         TargetDescription(name: "FooTarget", dependencies: [.product(name: "Barx", package: "Bar")]),
@@ -674,7 +674,7 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
-                    path: .init("/Foo"),
+                    path: .init(path: "/Foo"),
                     toolsVersion: .v5_2,
                     targets: [
                         TargetDescription(name: "FooTarget", dependencies: [.product(name: "Barx")]),
@@ -706,19 +706,19 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
-                    path: .init("/Foo"),
+                    path: .init(path: "/Foo"),
                     toolsVersion: .v5_2,
                     dependencies: [
-                        .localSourceControl(path: .init("/Bar"), requirement: .branch("master")),
-                        .localSourceControl(path: .init("/BizPath"), requirement: .exact("1.2.3")),
-                        .localSourceControl(path: .init("/FizPath"), requirement: .upToNextMajor(from: "1.1.2")),
+                        .localSourceControl(path: .init(path: "/Bar"), requirement: .branch("master")),
+                        .localSourceControl(path: .init(path: "/BizPath"), requirement: .exact("1.2.3")),
+                        .localSourceControl(path: .init(path: "/FizPath"), requirement: .upToNextMajor(from: "1.1.2")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["BarLib", "Biz", "FizLib"]),
                     ]),
                 Manifest.createLocalSourceControlManifest(
                     name: "Bar",
-                    path: .init("/Bar"),
+                    path: .init(path: "/Bar"),
                     products: [
                         ProductDescription(name: "BarLib", type: .library(.automatic), targets: ["BarLib"])
                     ],
@@ -727,7 +727,7 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createLocalSourceControlManifest(
                     name: "Biz",
-                    path: .init("/BizPath"),
+                    path: .init(path: "/BizPath"),
                     version: "1.2.3",
                     products: [
                         ProductDescription(name: "Biz", type: .library(.automatic), targets: ["Biz"])
@@ -737,7 +737,7 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createLocalSourceControlManifest(
                     name: "Fiz",
-                    path: .init("/FizPath"),
+                    path: .init(path: "/FizPath"),
                     version: "1.2.3",
                     products: [
                         ProductDescription(name: "FizLib", type: .library(.automatic), targets: ["FizLib"])
@@ -783,17 +783,17 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
-                    path: .init("/Foo"),
+                    path: .init(path: "/Foo"),
                     toolsVersion: .v5_2,
                     dependencies: [
-                        .localSourceControl(deprecatedName: "UnBar", path: .init("/Bar"), requirement: .branch("master")),
+                        .localSourceControl(deprecatedName: "UnBar", path: .init(path: "/Bar"), requirement: .branch("master")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: [.product(name: "BarProduct", package: "UnBar")]),
                     ]),
                 Manifest.createLocalSourceControlManifest(
                     name: "UnBar",
-                    path: .init("/Bar"),
+                    path: .init(path: "/Bar"),
                     products: [
                         ProductDescription(name: "BarProduct", type: .library(.automatic), targets: ["Bar"])
                     ],
@@ -822,18 +822,18 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
-                    path: .init("/Foo"),
+                    path: .init(path: "/Foo"),
                     dependencies: [
-                        .localSourceControl(path: .init("/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/Baz"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/Biz"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/Baz"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/Biz"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["BarLibrary"]),
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "Biz",
-                    path: .init("/Biz"),
+                    path: .init(path: "/Biz"),
                     products: [
                         ProductDescription(name: "biz", type: .executable, targets: ["Biz"])
                     ],
@@ -842,7 +842,7 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "Bar",
-                    path: .init("/Bar"),
+                    path: .init(path: "/Bar"),
                     products: [
                         ProductDescription(name: "BarLibrary", type: .library(.automatic), targets: ["Bar"])
                     ],
@@ -851,7 +851,7 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "Baz",
-                    path: .init("/Baz"),
+                    path: .init(path: "/Baz"),
                     products: [
                         ProductDescription(name: "BazLibrary", type: .library(.automatic), targets: ["Baz"])
                     ],
@@ -882,16 +882,16 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Bar",
-                    path: .init("/Bar"),
+                    path: .init(path: "/Bar"),
                     dependencies: [
-                        .localSourceControl(path: .init("/Foo"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/Foo"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Bar"),
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "Foo",
-                    path: .init("/Foo")
+                    path: .init(path: "/Foo")
                 ),
             ],
             observabilityScope: observability.topScope
@@ -916,9 +916,9 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Start",
-                    path: .init("/Start"),
+                    path: .init(path: "/Start"),
                     dependencies: [
-                        .localSourceControl(path: .init("/Dep1"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/Dep1"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["BazLibrary"]),
@@ -926,9 +926,9 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "Dep1",
-                    path: .init("/Dep1"),
+                    path: .init(path: "/Dep1"),
                     dependencies: [
-                        .localSourceControl(path: .init("/Dep2"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/Dep2"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "BazLibrary", type: .library(.automatic), targets: ["Baz"])
@@ -938,7 +938,7 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "Dep2",
-                    path: .init("/Dep2"),
+                    path: .init(path: "/Dep2"),
                     products: [
                         ProductDescription(name: "FooLibrary", type: .library(.automatic), targets: ["Foo"]),
                         ProductDescription(name: "BamLibrary", type: .library(.automatic), targets: ["Bam"]),
@@ -969,17 +969,17 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
-                    path: .init("/Foo"),
+                    path: .init(path: "/Foo"),
                     dependencies: [
-                        .localSourceControl(path: .init("/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/Baz"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/Baz"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Bar"]),
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "Bar",
-                    path: .init("/Bar"),
+                    path: .init(path: "/Bar"),
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
                     ],
@@ -988,7 +988,7 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "Baz",
-                    path: .init("/Baz"),
+                    path: .init(path: "/Baz"),
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Baz"])
                     ],
@@ -1024,9 +1024,9 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
-                    path: .init("/Foo"),
+                    path: .init(path: "/Foo"),
                     dependencies: [
-                        .localSourceControl(path: .init("/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Bar"]),
@@ -1034,7 +1034,7 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "Bar",
-                    path: .init("/Bar"),
+                    path: .init(path: "/Bar"),
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar", "Bar2", "Bar3"]),
                         ProductDescription(name: "TransitiveBar", type: .library(.automatic), targets: ["TransitiveBar"]),
@@ -1096,9 +1096,9 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
-                    path: .init("/Foo"),
+                    path: .init(path: "/Foo"),
                     dependencies: [
-                        .fileSystem(path: .init("/Biz")),
+                        .fileSystem(path: .init(path: "/Biz")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: [
@@ -1121,7 +1121,7 @@ class PackageGraphTests: XCTestCase {
                 ),
                 Manifest.createLocalSourceControlManifest(
                     name: "Biz",
-                    path: .init("/Biz"),
+                    path: .init(path: "/Biz"),
                     products: [
                         ProductDescription(name: "Biz", type: .library(.automatic), targets: ["Biz"])
                     ],
@@ -1178,10 +1178,10 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Root",
-                    path: .init("/Root"),
+                    path: .init(path: "/Root"),
                     toolsVersion: .v5_2,
                     dependencies: [
-                        .localSourceControl(path: .init("/Immediate"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/Immediate"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Root", dependencies: [
@@ -1191,15 +1191,15 @@ class PackageGraphTests: XCTestCase {
                 ),
                 Manifest.createFileSystemManifest(
                     name: "Immediate",
-                    path: .init("/Immediate"),
+                    path: .init(path: "/Immediate"),
                     toolsVersion: .v5_2,
                     dependencies: [
                         .localSourceControl(
-                            path: .init("/Transitive"),
+                            path: .init(path: "/Transitive"),
                             requirement: .upToNextMajor(from: "1.0.0")
                         ),
                         .localSourceControl(
-                            path: .init("/Nonexistent"),
+                            path: .init(path: "/Nonexistent"),
                             requirement: .upToNextMajor(from: "1.0.0")
                         )
                     ],
@@ -1219,11 +1219,11 @@ class PackageGraphTests: XCTestCase {
                 ),
                 Manifest.createFileSystemManifest(
                     name: "Transitive",
-                    path: .init("/Transitive"),
+                    path: .init(path: "/Transitive"),
                     toolsVersion: .v5_2,
                     dependencies: [
                         .localSourceControl(
-                            path: .init("/Nonexistent"),
+                            path: .init(path: "/Nonexistent"),
                             requirement: .upToNextMajor(from: "1.0.0")
                         )
                     ],
@@ -1275,7 +1275,7 @@ class PackageGraphTests: XCTestCase {
         let fs = InMemoryFileSystem(files: ["/pins": ByteString(encodingAsUTF8: json)])
 
         XCTAssertThrows(StringError("Package.resolved file is corrupted or malformed; fix or delete the file to continue: duplicated entry for package \"yams\""), {
-            _ = try PinsStore(pinsFile: AbsolutePath("/pins"), workingDirectory: .root, fileSystem: fs, mirrors: .init())
+            _ = try PinsStore(pinsFile: AbsolutePath(path: "/pins"), workingDirectory: .root, fileSystem: fs, mirrors: .init())
         })
     }
 
@@ -1297,20 +1297,20 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "A",
-                    path: .init("/A"),
+                    path: .init(path: "/A"),
                     dependencies: [
-                        .localSourceControl(path: .init("/B"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/C"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/D"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/E"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init("/F"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/B"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/C"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/D"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/E"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/F"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "A", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "B",
-                    path: .init("/B"),
+                    path: .init(path: "/B"),
                     products: [
                         ProductDescription(name: "B", type: .library(.automatic), targets: ["B"])
                     ],
@@ -1320,7 +1320,7 @@ class PackageGraphTests: XCTestCase {
                 ),
                 Manifest.createFileSystemManifest(
                     name: "C",
-                    path: .init("/C"),
+                    path: .init(path: "/C"),
                     products: [
                         ProductDescription(name: "C", type: .library(.automatic), targets: ["C"])
                     ],
@@ -1330,7 +1330,7 @@ class PackageGraphTests: XCTestCase {
                 ),
                 Manifest.createFileSystemManifest(
                     name: "D",
-                    path: .init("/D"),
+                    path: .init(path: "/D"),
                     products: [
                         ProductDescription(name: "D", type: .library(.automatic), targets: ["D"])
                     ],
@@ -1340,7 +1340,7 @@ class PackageGraphTests: XCTestCase {
                 ),
                 Manifest.createFileSystemManifest(
                     name: "E",
-                    path: .init("/E"),
+                    path: .init(path: "/E"),
                     products: [
                         ProductDescription(name: "E", type: .library(.automatic), targets: ["E"])
                     ],
@@ -1350,7 +1350,7 @@ class PackageGraphTests: XCTestCase {
                 ),
                 Manifest.createFileSystemManifest(
                     name: "F",
-                    path: .init("/F"),
+                    path: .init(path: "/F"),
                     products: [
                         ProductDescription(name: "F", type: .library(.automatic), targets: ["F"])
                     ],
@@ -1383,17 +1383,17 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
-                    path: .init("/Foo"),
+                    path: .init(path: "/Foo"),
                     toolsVersion: .v5,
                     dependencies: [
-                        .localSourceControl(path: .init("/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Bar"]),
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "Bar",
-                    path: .init("/Bar"),
+                    path: .init(path: "/Bar"),
                     toolsVersion: .v5,
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
@@ -1420,17 +1420,17 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
-                    path: .init("/Foo"),
+                    path: .init(path: "/Foo"),
                     toolsVersion: .v5,
                     dependencies: [
-                        .localSourceControl(path: .init("/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Unknown"]),
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "Bar",
-                    path: .init("/Bar"),
+                    path: .init(path: "/Bar"),
                     toolsVersion: .v5,
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
@@ -1464,17 +1464,17 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
-                    path: .init("/Foo"),
+                    path: .init(path: "/Foo"),
                     toolsVersion: .v5_2,
                     dependencies: [
-                        .localSourceControl(path: .init("/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Bar"]),
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "Bar",
-                    path: .init("/Bar"),
+                    path: .init(path: "/Bar"),
                     toolsVersion: .v5_2,
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
@@ -1501,17 +1501,17 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
-                    path: .init("/Foo"),
+                    path: .init(path: "/Foo"),
                     toolsVersion: .v5_2,
                     dependencies: [
-                        .localSourceControl(path: .init("/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Unknown"]),
                     ]),
                 Manifest.createFileSystemManifest(
                     name: "Bar",
-                    path: .init("/Bar"),
+                    path: .init(path: "/Bar"),
                     toolsVersion: .v5_2,
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
@@ -1542,17 +1542,17 @@ class PackageGraphTests: XCTestCase {
         let manifests = try [
             Manifest.createRootManifest(
                 name: "Foo",
-                path: .init("/Foo"),
+                path: .init(path: "/Foo"),
                 toolsVersion: .v5_2,
                 dependencies: [
-                    .localSourceControl(path: .init("/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
+                    .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
                 ],
                 targets: [
                     TargetDescription(name: "Foo", dependencies: ["ProductBar"]),
                 ]),
             Manifest.createFileSystemManifest(
                 name: "Bar",
-                path: .init("/Bar"),
+                path: .init(path: "/Bar"),
                 toolsVersion: .v5_2,
                 products: [
                     ProductDescription(name: "ProductBar", type: .library(.automatic), targets: ["Bar"])
@@ -1602,17 +1602,17 @@ class PackageGraphTests: XCTestCase {
         let manifests = try [
             Manifest.createRootManifest(
                 name: "Foo",
-                path: .init("/Foo"),
+                path: .init(path: "/Foo"),
                 toolsVersion: .v5_2,
                 dependencies: [
-                    .localSourceControl(deprecatedName: "Bar", path: .init("/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
+                    .localSourceControl(deprecatedName: "Bar", path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
                 ],
                 targets: [
                     TargetDescription(name: "Foo", dependencies: ["ProductBar"]),
                 ]),
             Manifest.createFileSystemManifest(
                 name: "Bar",
-                path: .init("/Bar"),
+                path: .init(path: "/Bar"),
                 toolsVersion: .v5_2,
                 products: [
                     ProductDescription(name: "ProductBar", type: .library(.automatic), targets: ["Bar"])
@@ -1661,17 +1661,17 @@ class PackageGraphTests: XCTestCase {
         let manifests = try [
             Manifest.createRootManifest(
                 name: "Foo",
-                path: .init("/Foo"),
+                path: .init(path: "/Foo"),
                 toolsVersion: .v5_2,
                 dependencies: [
-                    .localSourceControl(path: .init("/Some-Bar"), requirement: .upToNextMajor(from: "1.0.0")),
+                    .localSourceControl(path: .init(path: "/Some-Bar"), requirement: .upToNextMajor(from: "1.0.0")),
                 ],
                 targets: [
                     TargetDescription(name: "Foo", dependencies: ["Bar"]),
                 ]),
             Manifest.createFileSystemManifest(
                 name: "Bar",
-                path: .init("/Some-Bar"),
+                path: .init(path: "/Some-Bar"),
                 toolsVersion: .v5_2,
                 products: [
                     ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
@@ -1719,17 +1719,17 @@ class PackageGraphTests: XCTestCase {
         let manifests = try [
             Manifest.createRootManifest(
                 name: "Foo",
-                path: .init("/Foo"),
+                path: .init(path: "/Foo"),
                 toolsVersion: .v5_2,
                 dependencies: [
-                    .localSourceControl(path: .init("/Some-Bar"), requirement: .upToNextMajor(from: "1.0.0")),
+                    .localSourceControl(path: .init(path: "/Some-Bar"), requirement: .upToNextMajor(from: "1.0.0")),
                 ],
                 targets: [
                     TargetDescription(name: "Foo", dependencies: ["ProductBar"]),
                 ]),
             Manifest.createFileSystemManifest(
                 name: "Bar",
-                path: .init("/Some-Bar"),
+                path: .init(path: "/Some-Bar"),
                 toolsVersion: .v5_2,
                 products: [
                     ProductDescription(name: "ProductBar", type: .library(.automatic), targets: ["Bar"])
@@ -1780,17 +1780,17 @@ class PackageGraphTests: XCTestCase {
         let manifests = try [
             Manifest.createRootManifest(
                 name: "Foo",
-                path: .init("/Foo"),
+                path: .init(path: "/Foo"),
                 toolsVersion: .v5_2,
                 dependencies: [
-                    .localSourceControl(deprecatedName: "Bar", path: .init("/Some-Bar"), requirement: .upToNextMajor(from: "1.0.0")),
+                    .localSourceControl(deprecatedName: "Bar", path: .init(path: "/Some-Bar"), requirement: .upToNextMajor(from: "1.0.0")),
                 ],
                 targets: [
                     TargetDescription(name: "Foo", dependencies: ["Bar"]),
                 ]),
             Manifest.createFileSystemManifest(
                 name: "Bar",
-                path: .init("/Some-Bar"),
+                path: .init(path: "/Some-Bar"),
                 toolsVersion: .v5_2,
                 products: [
                     ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
@@ -1816,17 +1816,17 @@ class PackageGraphTests: XCTestCase {
         let manifests = try [
             Manifest.createRootManifest(
                 name: "Foo",
-                path: .init("/Foo"),
+                path: .init(path: "/Foo"),
                 toolsVersion: .v5_2,
                 dependencies: [
-                    .localSourceControl(deprecatedName: "Bar", path: .init("/Some-Bar"), requirement: .upToNextMajor(from: "1.0.0")),
+                    .localSourceControl(deprecatedName: "Bar", path: .init(path: "/Some-Bar"), requirement: .upToNextMajor(from: "1.0.0")),
                 ],
                 targets: [
                     TargetDescription(name: "Foo", dependencies: ["ProductBar"]),
                 ]),
             Manifest.createFileSystemManifest(
                 name: "Bar",
-                path: .init("/Some-Bar"),
+                path: .init(path: "/Some-Bar"),
                 toolsVersion: .v5_2,
                 products: [
                     ProductDescription(name: "ProductBar", type: .library(.automatic), targets: ["Bar"])
@@ -1871,16 +1871,16 @@ class PackageGraphTests: XCTestCase {
     func testTargetDependencies_Post52_AliasFindsIdentity() throws {
         let manifest = Manifest.createRootManifest(
             name: "Package",
-            path: .init("/Package"),
+            path: .init(path: "/Package"),
             toolsVersion: .v5_2,
             dependencies: [
                 .localSourceControl(
                     deprecatedName: "Alias",
-                    path: .init("/Identity"),
+                    path: .init(path: "/Identity"),
                     requirement: .upToNextMajor(from: "1.0.0")
                 ),
                 .localSourceControl(
-                    path: .init("/Unrelated"),
+                    path: .init(path: "/Unrelated"),
                     requirement: .upToNextMajor(from: "1.0.0")
                 )
             ],

--- a/Tests/PackageGraphTests/TargetTests.swift
+++ b/Tests/PackageGraphTests/TargetTests.swift
@@ -23,7 +23,7 @@ private extension ResolvedTarget {
                 name: name,
                 type: .library,
                 path: .root,
-                sources: Sources(paths: [], root: AbsolutePath("/")),
+                sources: Sources(paths: [], root: AbsolutePath(path: "/")),
                 dependencies: [],
                 swiftVersion: .v4
             ),

--- a/Tests/PackageLoadingPerformanceTests/ManifestLoadingTests.swift
+++ b/Tests/PackageLoadingPerformanceTests/ManifestLoadingTests.swift
@@ -18,7 +18,7 @@ import TSCBasic
 import XCTest
 
 class ManifestLoadingPerfTests: XCTestCasePerf {
-    let manifestLoader = ManifestLoader(toolchain: UserToolchain.default)
+    let manifestLoader = ManifestLoader(toolchain: try! UserToolchain.default)
 
     func write(_ bytes: ByteString, body: (AbsolutePath) -> ()) throws {
         try testWithTemporaryDirectory { tmpdir in
@@ -42,7 +42,7 @@ class ManifestLoadingPerfTests: XCTestCasePerf {
                 for _ in 0..<N {
                     let manifest = try! self.manifestLoader.load(
                         manifestPath: path,
-                        packageKind: .root(.init("/Trivial")),
+                        packageKind: .root(.init(path: "/Trivial")),
                         toolsVersion: .v4_2,
                         fileSystem: localFileSystem,
                         observabilityScope: ObservabilitySystem.NOOP
@@ -77,7 +77,7 @@ class ManifestLoadingPerfTests: XCTestCasePerf {
                 for _ in 0..<N {
                     let manifest = try! self.manifestLoader.load(
                         manifestPath: path,
-                        packageKind: .root(.init("/Trivial")),
+                        packageKind: .root(.init(path: "/Trivial")),
                         toolsVersion: .v4_2,
                         fileSystem: localFileSystem,
                         observabilityScope: ObservabilitySystem.NOOP

--- a/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
+++ b/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
@@ -144,7 +144,7 @@ class ModuleMapGeneration: XCTestCase {
     }
 
     func testUnsupportedLayouts() throws {
-        let include: AbsolutePath = AbsolutePath("/include")
+        let include: AbsolutePath = AbsolutePath(path: "/include")
 
         var fs = InMemoryFileSystem(emptyFiles:
             include.appending(components: "Foo", "Foo.h").pathString,

--- a/Tests/PackageLoadingTests/PDLoadingTests.swift
+++ b/Tests/PackageLoadingTests/PDLoadingTests.swift
@@ -18,7 +18,7 @@ import TSCBasic
 import XCTest
 
 class PackageDescriptionLoadingTests: XCTestCase, ManifestLoaderDelegate {
-    lazy var manifestLoader = ManifestLoader(toolchain: UserToolchain.default, delegate: self)
+    lazy var manifestLoader = ManifestLoader(toolchain: try! UserToolchain.default, delegate: self)
     var parsedManifest = ThreadSafeBox<AbsolutePath>()
     
     public func willLoad(manifest: AbsolutePath) {

--- a/Tests/PackageLoadingTests/PD_4_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_0_LoadingTests.swift
@@ -142,12 +142,12 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
             let package = Package(
                name: "Foo",
                dependencies: [
-                   .package(url: "\(AbsolutePath("/foo1").escapedPathString())", from: "1.0.0"),
-                   .package(url: "\(AbsolutePath("/foo2").escapedPathString())", .upToNextMajor(from: "1.0.0")),
-                   .package(url: "\(AbsolutePath("/foo3").escapedPathString())", .upToNextMinor(from: "1.0.0")),
-                   .package(url: "\(AbsolutePath("/foo4").escapedPathString())", .exact("1.0.0")),
-                   .package(url: "\(AbsolutePath("/foo5").escapedPathString())", .branch("main")),
-                   .package(url: "\(AbsolutePath("/foo6").escapedPathString())", .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")),
+                   .package(url: "\(AbsolutePath(path: "/foo1").escapedPathString())", from: "1.0.0"),
+                   .package(url: "\(AbsolutePath(path: "/foo2").escapedPathString())", .upToNextMajor(from: "1.0.0")),
+                   .package(url: "\(AbsolutePath(path: "/foo3").escapedPathString())", .upToNextMinor(from: "1.0.0")),
+                   .package(url: "\(AbsolutePath(path: "/foo4").escapedPathString())", .exact("1.0.0")),
+                   .package(url: "\(AbsolutePath(path: "/foo5").escapedPathString())", .branch("main")),
+                   .package(url: "\(AbsolutePath(path: "/foo6").escapedPathString())", .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")),
                ]
             )
             """
@@ -158,12 +158,12 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
         XCTAssertNoDiagnostics(validationDiagnostics)
 
         let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
-        XCTAssertEqual(deps["foo1"], .localSourceControl(path: .init("/foo1"), requirement: .upToNextMajor(from: "1.0.0")))
-        XCTAssertEqual(deps["foo2"], .localSourceControl(path: .init("/foo2"), requirement: .upToNextMajor(from: "1.0.0")))
-        XCTAssertEqual(deps["foo3"], .localSourceControl(path: .init("/foo3"), requirement: .upToNextMinor(from: "1.0.0")))
-        XCTAssertEqual(deps["foo4"], .localSourceControl(path: .init("/foo4"), requirement: .exact("1.0.0")))
-        XCTAssertEqual(deps["foo5"], .localSourceControl(path: .init("/foo5"), requirement: .branch("main")))
-        XCTAssertEqual(deps["foo6"], .localSourceControl(path: .init("/foo6"), requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
+        XCTAssertEqual(deps["foo1"], .localSourceControl(path: .init(path: "/foo1"), requirement: .upToNextMajor(from: "1.0.0")))
+        XCTAssertEqual(deps["foo2"], .localSourceControl(path: .init(path: "/foo2"), requirement: .upToNextMajor(from: "1.0.0")))
+        XCTAssertEqual(deps["foo3"], .localSourceControl(path: .init(path: "/foo3"), requirement: .upToNextMinor(from: "1.0.0")))
+        XCTAssertEqual(deps["foo4"], .localSourceControl(path: .init(path: "/foo4"), requirement: .exact("1.0.0")))
+        XCTAssertEqual(deps["foo5"], .localSourceControl(path: .init(path: "/foo5"), requirement: .branch("main")))
+        XCTAssertEqual(deps["foo6"], .localSourceControl(path: .init(path: "/foo6"), requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
     }
 
     func testProducts() throws {

--- a/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
@@ -39,7 +39,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                     .library(name: "Foo", targets: ["foo"]),
                 ],
                 dependencies: [
-                    .package(url: "\(AbsolutePath("/foo1").escapedPathString())", from: "1.0.0"),
+                    .package(url: "\(AbsolutePath(path: "/foo1").escapedPathString())", from: "1.0.0"),
                 ],
                 targets: [
                     .target(
@@ -74,7 +74,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
 
         // Check dependencies.
         let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
-        XCTAssertEqual(deps["foo1"], .localSourceControl(path: .init("/foo1"), requirement: .upToNextMajor(from: "1.0.0")))
+        XCTAssertEqual(deps["foo1"], .localSourceControl(path: .init(path: "/foo1"), requirement: .upToNextMajor(from: "1.0.0")))
 
         // Check products.
         let products = Dictionary(uniqueKeysWithValues: manifest.products.map{ ($0.name, $0) })
@@ -254,15 +254,15 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             let package = Package(
                name: "Foo",
                dependencies: [
-                   .package(url: "\(AbsolutePath("/foo1").escapedPathString())", from: "1.0.0"),
-                   .package(url: "\(AbsolutePath("/foo2").escapedPathString())", .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")),
+                   .package(url: "\(AbsolutePath(path: "/foo1").escapedPathString())", from: "1.0.0"),
+                   .package(url: "\(AbsolutePath(path: "/foo2").escapedPathString())", .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")),
                    .package(path: "../foo3"),
-                   .package(path: "\(AbsolutePath("/path/to/foo4").escapedPathString())"),
-                   .package(url: "\(AbsolutePath("/foo5").escapedPathString())", .exact("1.2.3")),
-                   .package(url: "\(AbsolutePath("/foo6").escapedPathString())", "1.2.3"..<"2.0.0"),
-                   .package(url: "\(AbsolutePath("/foo7").escapedPathString())", .branch("master")),
-                   .package(url: "\(AbsolutePath("/foo8").escapedPathString())", .upToNextMinor(from: "1.3.4")),
-                   .package(url: "\(AbsolutePath("/foo9").escapedPathString())", .upToNextMajor(from: "1.3.4")),
+                   .package(path: "\(AbsolutePath(path: "/path/to/foo4").escapedPathString())"),
+                   .package(url: "\(AbsolutePath(path: "/foo5").escapedPathString())", .exact("1.2.3")),
+                   .package(url: "\(AbsolutePath(path: "/foo6").escapedPathString())", "1.2.3"..<"2.0.0"),
+                   .package(url: "\(AbsolutePath(path: "/foo7").escapedPathString())", .branch("master")),
+                   .package(url: "\(AbsolutePath(path: "/foo8").escapedPathString())", .upToNextMinor(from: "1.3.4")),
+                   .package(url: "\(AbsolutePath(path: "/foo9").escapedPathString())", .upToNextMajor(from: "1.3.4")),
                    .package(path: "~/path/to/foo10"),
                    .package(path: "~foo11"),
                    .package(path: "~/path/to/~/foo12"),
@@ -278,54 +278,54 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
         XCTAssertNoDiagnostics(validationDiagnostics)
 
         let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
-        XCTAssertEqual(deps["foo1"], .localSourceControl(path: .init("/foo1"), requirement: .upToNextMajor(from: "1.0.0")))
-        XCTAssertEqual(deps["foo2"], .localSourceControl(path: .init("/foo2"), requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
+        XCTAssertEqual(deps["foo1"], .localSourceControl(path: .init(path: "/foo1"), requirement: .upToNextMajor(from: "1.0.0")))
+        XCTAssertEqual(deps["foo2"], .localSourceControl(path: .init(path: "/foo2"), requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
 
         if case .fileSystem(let dep) = deps["foo3"] {
-            XCTAssertEqual(dep.path, AbsolutePath("/foo3"))
+            XCTAssertEqual(dep.path, AbsolutePath(path: "/foo3"))
         } else {
             XCTFail("expected to be local dependency")
         }
 
         if case .fileSystem(let dep) = deps["foo4"] {
-            XCTAssertEqual(dep.path, AbsolutePath("/path/to/foo4"))
+            XCTAssertEqual(dep.path, AbsolutePath(path: "/path/to/foo4"))
         } else {
             XCTFail("expected to be local dependency")
         }
 
-        XCTAssertEqual(deps["foo5"], .localSourceControl(path: .init("/foo5"), requirement: .exact("1.2.3")))
-        XCTAssertEqual(deps["foo6"], .localSourceControl(path: .init("/foo6"), requirement: .range("1.2.3"..<"2.0.0")))
-        XCTAssertEqual(deps["foo7"], .localSourceControl(path: .init("/foo7"), requirement: .branch("master")))
-        XCTAssertEqual(deps["foo8"], .localSourceControl(path: .init("/foo8"), requirement: .upToNextMinor(from: "1.3.4")))
-        XCTAssertEqual(deps["foo9"], .localSourceControl(path: .init("/foo9"), requirement: .upToNextMajor(from: "1.3.4")))
+        XCTAssertEqual(deps["foo5"], .localSourceControl(path: .init(path: "/foo5"), requirement: .exact("1.2.3")))
+        XCTAssertEqual(deps["foo6"], .localSourceControl(path: .init(path: "/foo6"), requirement: .range("1.2.3"..<"2.0.0")))
+        XCTAssertEqual(deps["foo7"], .localSourceControl(path: .init(path: "/foo7"), requirement: .branch("master")))
+        XCTAssertEqual(deps["foo8"], .localSourceControl(path: .init(path: "/foo8"), requirement: .upToNextMinor(from: "1.3.4")))
+        XCTAssertEqual(deps["foo9"], .localSourceControl(path: .init(path: "/foo9"), requirement: .upToNextMajor(from: "1.3.4")))
 
         let homeDir = "/home/user"
         if case .fileSystem(let dep) = deps["foo10"] {
-            XCTAssertEqual(dep.path, AbsolutePath("\(homeDir)/path/to/foo10"))
+            XCTAssertEqual(dep.path, try AbsolutePath(validating: "\(homeDir)/path/to/foo10"))
         } else {
             XCTFail("expected to be local dependency")
         }
 
         if case .fileSystem(let dep) = deps["~foo11"] {
-            XCTAssertEqual(dep.path, AbsolutePath("/~foo11"))
+            XCTAssertEqual(dep.path, AbsolutePath(path: "/~foo11"))
         } else {
             XCTFail("expected to be local dependency")
         }
 
         if case .fileSystem(let dep) = deps["foo12"] {
-            XCTAssertEqual(dep.path, AbsolutePath("\(homeDir)/path/to/~/foo12"))
+            XCTAssertEqual(dep.path, try AbsolutePath(validating: "\(homeDir)/path/to/~/foo12"))
         } else {
             XCTFail("expected to be local dependency")
         }
 
         if case .fileSystem(let dep) = deps["~"] {
-            XCTAssertEqual(dep.path, AbsolutePath("/~"))
+            XCTAssertEqual(dep.path, AbsolutePath(path: "/~"))
         } else {
             XCTFail("expected to be local dependency")
         }
 
         if case .fileSystem(let dep) = deps["foo13"] {
-            XCTAssertEqual(dep.path, AbsolutePath("/path/to/foo13"))
+            XCTAssertEqual(dep.path, AbsolutePath(path: "/path/to/foo13"))
         } else {
             XCTFail("expected to be local dependency")
         }
@@ -593,7 +593,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
 
             let delegate = ManifestTestDelegate()
 
-            let manifestLoader = ManifestLoader(toolchain: UserToolchain.default, cacheDir: path, delegate: delegate)
+            let manifestLoader = ManifestLoader(toolchain: try UserToolchain.default, cacheDir: path, delegate: delegate)
 
             func check(loader: ManifestLoader, expectCached: Bool) {
                 delegate.clear()
@@ -653,7 +653,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
 
             let delegate = ManifestTestDelegate()
 
-            let manifestLoader = ManifestLoader(toolchain: UserToolchain.default, cacheDir: path, delegate: delegate)
+            let manifestLoader = ManifestLoader(toolchain: try UserToolchain.default, cacheDir: path, delegate: delegate)
 
             func check(loader: ManifestLoader, expectCached: Bool) {
                 delegate.clear()
@@ -701,7 +701,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                 check(loader: manifestLoader, expectCached: true)
             }
 
-            let noCacheLoader = ManifestLoader(toolchain: UserToolchain.default, delegate: delegate)
+            let noCacheLoader = ManifestLoader(toolchain: try UserToolchain.default, delegate: delegate)
             for _ in 0..<2 {
                 check(loader: noCacheLoader, expectCached: false)
             }
@@ -728,7 +728,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
 
             let delegate = ManifestTestDelegate()
 
-            let manifestLoader = ManifestLoader(toolchain: UserToolchain.default, cacheDir: path, delegate: delegate)
+            let manifestLoader = ManifestLoader(toolchain: try UserToolchain.default, cacheDir: path, delegate: delegate)
 
             func check(loader: ManifestLoader) throws {
                 let fs = InMemoryFileSystem()
@@ -820,7 +820,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
 
             let observability = ObservabilitySystem.makeForTesting()
             let delegate = ManifestTestDelegate()
-            let manifestLoader = ManifestLoader(toolchain: UserToolchain.default, cacheDir: path, delegate: delegate)
+            let manifestLoader = ManifestLoader(toolchain: try UserToolchain.default, cacheDir: path, delegate: delegate)
             let identityResolver = DefaultIdentityResolver()
 
             // warm up caches
@@ -901,7 +901,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             let total = 100
             let observability = ObservabilitySystem.makeForTesting()
             let delegate = ManifestTestDelegate()
-            let manifestLoader = ManifestLoader(toolchain: UserToolchain.default, cacheDir: path, delegate: delegate)
+            let manifestLoader = ManifestLoader(toolchain: try UserToolchain.default, cacheDir: path, delegate: delegate)
             let identityResolver = DefaultIdentityResolver()
 
             let sync = DispatchGroup()

--- a/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
@@ -67,7 +67,7 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
 
         // Check dependencies.
         let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
-        XCTAssertEqual(deps["foo1"], .localSourceControl(path: .init("/foo1"), requirement: .upToNextMajor(from: "1.0.0")))
+        XCTAssertEqual(deps["foo1"], .localSourceControl(path: .init(path: "/foo1"), requirement: .upToNextMajor(from: "1.0.0")))
 
         // Check products.
         let products = Dictionary(uniqueKeysWithValues: manifest.products.map{ ($0.name, $0) })
@@ -366,7 +366,7 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
             let manifestPath = path.appending(components: "pkg", "Package.swift")
 
             let loader = ManifestLoader(
-                toolchain: UserToolchain.default,
+                toolchain: try UserToolchain.default,
                 serializedDiagnostics: true,
                 cacheDir: path)
 

--- a/Tests/PackageLoadingTests/PD_5_5_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_5_LoadingTests.swift
@@ -41,8 +41,8 @@ class PackageDescription5_5LoadingTests: PackageDescriptionLoadingTests {
         XCTAssertNoDiagnostics(validationDiagnostics)
 
         let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
-        XCTAssertEqual(deps["foo5"], .localSourceControl(path: .init("/foo5"), requirement: .branch("main")))
-        XCTAssertEqual(deps["foo7"], .localSourceControl(path: .init("/foo7"), requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
+        XCTAssertEqual(deps["foo5"], .localSourceControl(path: .init(path: "/foo5"), requirement: .branch("main")))
+        XCTAssertEqual(deps["foo7"], .localSourceControl(path: .init(path: "/foo7"), requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
     }
 
     func testPlatforms() throws {

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -41,7 +41,7 @@ class PackageBuilderTests: XCTestCase {
     }
 
     func testMixedSources() throws {
-        let foo: AbsolutePath = AbsolutePath("/Sources/foo")
+        let foo: AbsolutePath = AbsolutePath(path: "/Sources/foo")
 
         let fs = InMemoryFileSystem(emptyFiles:
             foo.appending(components: "main.swift").pathString,
@@ -220,13 +220,13 @@ class PackageBuilderTests: XCTestCase {
             package.checkModule("clib") { module in
                 module.check(c99name: "clib", type: .library)
                 module.checkSources(root: "/Sources/clib", paths: "clib.c")
-                module.check(moduleMapType: .custom(AbsolutePath("/Sources/clib/include/module.modulemap")))
+                module.check(moduleMapType: .custom(AbsolutePath(path: "/Sources/clib/include/module.modulemap")))
             }
         }
     }
 
     func testPublicIncludeDirMixedWithSources() throws {
-        let Sources: AbsolutePath = AbsolutePath("/Sources")
+        let Sources: AbsolutePath = AbsolutePath(path: "/Sources")
 
         let fs = InMemoryFileSystem(emptyFiles:
             Sources.appending(components: "clib", "nested", "nested.h").pathString,
@@ -566,7 +566,7 @@ class PackageBuilderTests: XCTestCase {
                 ),
             ]
         )
-        PackageBuilderTester(manifest, path: AbsolutePath("/pkg"), in: fs) { package, _ in
+        PackageBuilderTester(manifest, path: AbsolutePath(path: "/pkg"), in: fs) { package, _ in
             package.checkModule("exe") { _ in }
             package.checkModule("tests") { _ in }
 
@@ -597,7 +597,7 @@ class PackageBuilderTests: XCTestCase {
 
     func testMultipleTestEntryPointsError() throws {
         let name = SwiftTarget.defaultTestEntryPointName
-        let swift: AbsolutePath = AbsolutePath("/swift")
+        let swift: AbsolutePath = AbsolutePath(path: "/swift")
 
         let fs = InMemoryFileSystem(emptyFiles:
             AbsolutePath.root.appending(components: name).pathString,
@@ -616,14 +616,14 @@ class PackageBuilderTests: XCTestCase {
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, diagnostics in
-            diagnostics.check(diagnostic: "package '\(package.packageIdentity)' has multiple test entry point files: \(AbsolutePath("/\(name)")), \(swift.appending(components: name))", severity: .error)
+            diagnostics.check(diagnostic: "package '\(package.packageIdentity)' has multiple test entry point files: \(try! AbsolutePath(validating: "/\(name)")), \(swift.appending(components: name))", severity: .error)
         }
     }
 
     func testCustomTargetPaths() throws {
-        let Sources: AbsolutePath = AbsolutePath("/Sources")
+        let Sources: AbsolutePath = AbsolutePath(path: "/Sources")
         let swift: RelativePath = RelativePath("swift")
-        let bar: AbsolutePath = AbsolutePath("/bar")
+        let bar: AbsolutePath = AbsolutePath(path: "/bar")
 
         let fs = InMemoryFileSystem(emptyFiles:
             "/mah/target/exe/swift/exe/main.swift",
@@ -659,7 +659,7 @@ class PackageBuilderTests: XCTestCase {
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, _ in
-            package.checkPredefinedPaths(target: Sources.pathString, testTarget: AbsolutePath("/Tests").pathString)
+            package.checkPredefinedPaths(target: Sources.pathString, testTarget: AbsolutePath(path: "/Tests").pathString)
 
             package.checkModule("exe") { module in
                 module.check(c99name: "exe", type: .executable)
@@ -687,7 +687,7 @@ class PackageBuilderTests: XCTestCase {
     }
 
     func testCustomTargetPathsOverlap() throws {
-        let bar: AbsolutePath = AbsolutePath("/target/bar")
+        let bar: AbsolutePath = AbsolutePath(path: "/target/bar")
 
         let fs = InMemoryFileSystem(emptyFiles:
             bar.appending(components: "bar.swift").pathString,
@@ -724,7 +724,7 @@ class PackageBuilderTests: XCTestCase {
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, _ in
-            package.checkPredefinedPaths(target: AbsolutePath("/Sources").pathString, testTarget: AbsolutePath("/Tests").pathString)
+            package.checkPredefinedPaths(target: AbsolutePath(path: "/Sources").pathString, testTarget: AbsolutePath(path: "/Tests").pathString)
 
             package.checkModule("bar") { module in
                 module.check(c99name: "bar", type: .library)
@@ -741,8 +741,8 @@ class PackageBuilderTests: XCTestCase {
     }
 
     func testPublicHeadersPath() throws {
-        let Sources: AbsolutePath = AbsolutePath("/Sources")
-        let Tests: AbsolutePath = AbsolutePath("/Tests")
+        let Sources: AbsolutePath = AbsolutePath(path: "/Sources")
+        let Tests: AbsolutePath = AbsolutePath(path: "/Tests")
 
         let fs = InMemoryFileSystem(emptyFiles:
             Sources.appending(components: "Foo", "inc", "module.modulemap").pathString,
@@ -813,7 +813,7 @@ class PackageBuilderTests: XCTestCase {
     }
 
     func testTestsLayoutsv4() throws {
-        let Sources: AbsolutePath = AbsolutePath("/Sources")
+        let Sources: AbsolutePath = AbsolutePath(path: "/Sources")
 
         let fs = InMemoryFileSystem(emptyFiles:
             Sources.appending(components: "A", "main.swift").pathString,
@@ -832,7 +832,7 @@ class PackageBuilderTests: XCTestCase {
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, _ in
-            package.checkPredefinedPaths(target: Sources.pathString, testTarget: AbsolutePath("/Tests").pathString)
+            package.checkPredefinedPaths(target: Sources.pathString, testTarget: AbsolutePath(path: "/Tests").pathString)
 
             package.checkModule("A") { module in
                 module.check(c99name: "A", type: .executable)
@@ -960,7 +960,7 @@ class PackageBuilderTests: XCTestCase {
     }
 
     func testTargetDependencies() throws {
-        let Sources: AbsolutePath = AbsolutePath("/Sources")
+        let Sources: AbsolutePath = AbsolutePath(path: "/Sources")
 
         let fs = InMemoryFileSystem(emptyFiles:
             Sources.appending(components: "Foo", "Foo.swift").pathString,
@@ -980,7 +980,7 @@ class PackageBuilderTests: XCTestCase {
         )
         PackageBuilderTester(manifest, in: fs) { package, _ in
 
-            package.checkPredefinedPaths(target: Sources.pathString, testTarget: AbsolutePath("/Tests").pathString)
+            package.checkPredefinedPaths(target: Sources.pathString, testTarget: AbsolutePath(path: "/Tests").pathString)
 
             package.checkModule("Foo") { module in
                 module.check(c99name: "Foo", type: .library)
@@ -1086,11 +1086,11 @@ class PackageBuilderTests: XCTestCase {
                 ]
             )
 
-            try fs.writeFileContents(AbsolutePath("/foo2.zip"), bytes: "")
+            try fs.writeFileContents(AbsolutePath(path: "/foo2.zip"), bytes: "")
 
             let binaryArtifacts = [
-                "foo": BinaryArtifact(kind: .xcframework, originURL: "https://foo.com/foo.zip", path: AbsolutePath("/foo.xcframework")),
-                "foo2": BinaryArtifact(kind: .xcframework, originURL: nil, path: AbsolutePath("/foo2.xcframework"))
+                "foo": BinaryArtifact(kind: .xcframework, originURL: "https://foo.com/foo.zip", path: AbsolutePath(path: "/foo.xcframework")),
+                "foo2": BinaryArtifact(kind: .xcframework, originURL: nil, path: AbsolutePath(path: "/foo2.xcframework"))
             ]
             PackageBuilderTester(manifest, binaryArtifacts: binaryArtifacts, in: fs) { package, _ in
                 package.checkModule("foo")
@@ -1131,7 +1131,7 @@ class PackageBuilderTests: XCTestCase {
         }
 
         do {
-            let pkg2: AbsolutePath = AbsolutePath("/Sources/pkg2")
+            let pkg2: AbsolutePath = AbsolutePath(path: "/Sources/pkg2")
 
             // Reference a target which doesn't have sources.
             let fs = InMemoryFileSystem(emptyFiles:
@@ -1196,7 +1196,7 @@ class PackageBuilderTests: XCTestCase {
                     try TargetDescription(name: "Foo", path: "../foo"),
                 ]
             )
-            PackageBuilderTester(manifest, path: AbsolutePath("/pkg"), in: fs) { package, diagnostics in
+            PackageBuilderTester(manifest, path: AbsolutePath(path: "/pkg"), in: fs) { package, diagnostics in
                 diagnostics.check(diagnostic: "target 'Foo' in package '\(package.packageIdentity)' is outside the package root", severity: .error)
             }
         }
@@ -1211,7 +1211,7 @@ class PackageBuilderTests: XCTestCase {
                     try TargetDescription(name: "Foo", path: "/foo"),
                 ]
             )
-            PackageBuilderTester(manifest, path: AbsolutePath("/pkg"), in: fs) { _, diagnostics in
+            PackageBuilderTester(manifest, path: AbsolutePath(path: "/pkg"), in: fs) { _, diagnostics in
                 diagnostics.check(diagnostic: "target path \'/foo\' is not supported; it should be relative to package root", severity: .error)
             }
         }
@@ -1227,7 +1227,7 @@ class PackageBuilderTests: XCTestCase {
                     try TargetDescription(name: "Foo", path: "~/foo"),
                 ]
             )
-            PackageBuilderTester(manifest, path: AbsolutePath("/pkg"), in: fs) { _, diagnostics in
+            PackageBuilderTester(manifest, path: AbsolutePath(path: "/pkg"), in: fs) { _, diagnostics in
                 diagnostics.check(diagnostic: "target path \'~/foo\' is not supported; it should be relative to package root", severity: .error)
             }
         }
@@ -1441,7 +1441,7 @@ class PackageBuilderTests: XCTestCase {
     }
 
     func testSpecialTargetDir() throws {
-        let src: AbsolutePath = AbsolutePath("/src")
+        let src: AbsolutePath = AbsolutePath(path: "/src")
         // Special directory should be src because both target and test target are under it.
         let fs = InMemoryFileSystem(emptyFiles:
             src.appending(components: "A", "Foo.swift").pathString,
@@ -1592,7 +1592,7 @@ class PackageBuilderTests: XCTestCase {
     }
 
     func testSystemLibraryTargetDiagnostics() throws {
-        let Sources: AbsolutePath = AbsolutePath("/Sources")
+        let Sources: AbsolutePath = AbsolutePath(path: "/Sources")
 
         let fs = InMemoryFileSystem(emptyFiles:
             Sources.appending(components: "foo", "module.modulemap").pathString,
@@ -1811,7 +1811,7 @@ class PackageBuilderTests: XCTestCase {
     }
 
     func testUnknownSourceFilesUnderDeclaredSourcesIgnoredInV5_2Manifest() throws {
-        let lib: AbsolutePath = AbsolutePath("/Sources/lib")
+        let lib: AbsolutePath = AbsolutePath(path: "/Sources/lib")
 
         // Files with unknown suffixes under declared sources are not considered valid sources in 5.2 manifest.
         let fs = InMemoryFileSystem(emptyFiles:
@@ -1838,7 +1838,7 @@ class PackageBuilderTests: XCTestCase {
     }
 
     func testUnknownSourceFilesUnderDeclaredSourcesCompiledInV5_3Manifest() throws {
-        let lib: AbsolutePath = AbsolutePath("/Sources/lib")
+        let lib: AbsolutePath = AbsolutePath(path: "/Sources/lib")
 
         // Files with unknown suffixes under declared sources are treated as compilable in 5.3 manifest.
         let fs = InMemoryFileSystem(emptyFiles:
@@ -2070,7 +2070,7 @@ class PackageBuilderTests: XCTestCase {
             ]
         )
 
-        PackageBuilderTester(manifest1, path: AbsolutePath("/pkg"), in: fs) { package, diagnostics in
+        PackageBuilderTester(manifest1, path: AbsolutePath(path: "/pkg"), in: fs) { package, diagnostics in
             diagnostics.check(diagnostic: "invalid relative path '/Sources/headers'; relative path should not begin with '\(AbsolutePath.root)' or '~'", severity: .error)
         }
 
@@ -2087,7 +2087,7 @@ class PackageBuilderTests: XCTestCase {
             ]
         )
 
-        PackageBuilderTester(manifest2, path: AbsolutePath("/pkg"), in: fs) { _, diagnostics in
+        PackageBuilderTester(manifest2, path: AbsolutePath(path: "/pkg"), in: fs) { _, diagnostics in
             diagnostics.check(diagnostic: "invalid header search path '../../..'; header search path should not be outside the package root", severity: .error)
         }
     }
@@ -2107,7 +2107,7 @@ class PackageBuilderTests: XCTestCase {
             name: "Foo",
             toolsVersion: .v5,
             dependencies: [
-                .localSourceControl(path: .init("/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
+                .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
             ],
             targets: [
                 try TargetDescription(
@@ -2139,7 +2139,7 @@ class PackageBuilderTests: XCTestCase {
             ]
         )
 
-        PackageBuilderTester(manifest, path: AbsolutePath("/Foo"), in: fs) { package, diagnostics in
+        PackageBuilderTester(manifest, path: AbsolutePath(path: "/Foo"), in: fs) { package, diagnostics in
             package.checkModule("Foo")
             package.checkModule("Foo2")
             package.checkModule("Foo3")
@@ -2174,7 +2174,7 @@ class PackageBuilderTests: XCTestCase {
             name: "Foo",
             toolsVersion: .v5,
             dependencies: [
-                .fileSystem(path: .init("/Biz")),
+                .fileSystem(path: .init(path: "/Biz")),
             ],
             targets: [
                 try TargetDescription(
@@ -2244,13 +2244,13 @@ class PackageBuilderTests: XCTestCase {
             ]
         )
 
-        PackageBuilderTester(manifest, path: AbsolutePath("/Foo"), in: fs) { _, diagnostics in
+        PackageBuilderTester(manifest, path: AbsolutePath(path: "/Foo"), in: fs) { _, diagnostics in
             diagnostics.check(diagnostic: "manifest property 'defaultLocalization' not set; it is required in the presence of localized resources", severity: .error)
         }
     }
 
     func testXcodeResources() throws {
-        let root: AbsolutePath = AbsolutePath("/Foo")
+        let root: AbsolutePath = AbsolutePath(path: "/Foo")
         let Foo: AbsolutePath = root.appending(components: "Sources", "Foo")
 
         let fs = InMemoryFileSystem(emptyFiles:
@@ -2401,7 +2401,7 @@ final class PackageBuilderTester {
         }
 
         func check(testEntryPointPath: String?, file: StaticString = #file, line: UInt = #line) {
-            XCTAssertEqual(product.testEntryPointPath, testEntryPointPath.map({ AbsolutePath($0) }), file: file, line: line)
+            XCTAssertEqual(product.testEntryPointPath, testEntryPointPath.map({ try! AbsolutePath(validating: $0) }), file: file, line: line)
         }
     }
 
@@ -2437,7 +2437,7 @@ final class PackageBuilderTester {
 
         func checkSources(root: String? = nil, sources paths: [String], file: StaticString = #file, line: UInt = #line) {
             if let root = root {
-                XCTAssertEqual(target.sources.root, AbsolutePath(root), file: file, line: line)
+                XCTAssertEqual(target.sources.root, try! AbsolutePath(validating: root), file: file, line: line)
             }
             let sources = Set(self.target.sources.relativePaths.map({ $0.pathString }))
             XCTAssertEqual(sources, Set(paths), "unexpected source files in \(target.name)", file: file, line: line)

--- a/Tests/PackageLoadingTests/PkgConfigParserTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigParserTests.swift
@@ -22,7 +22,7 @@ final class PkgConfigParserTests: XCTestCase {
 
         _ = try PkgConfig(
             name: "harfbuzz",
-            additionalSearchPaths: [AbsolutePath(#file).parentDirectory.appending(components: "pkgconfigInputs")],
+            additionalSearchPaths: [AbsolutePath(path: #file).parentDirectory.appending(components: "pkgconfigInputs")],
             fileSystem: localFileSystem,
             observabilityScope: observability.topScope
         )
@@ -137,19 +137,19 @@ final class PkgConfigParserTests: XCTestCase {
             "/usr/local/opt/foo/lib/pkgconfig/foo.pc",
             "/custom/foo.pc")
         XCTAssertEqual(
-            AbsolutePath("/custom/foo.pc"),
-            try PCFileFinder().locatePCFile(name: "foo", customSearchPaths: [AbsolutePath("/custom")], fileSystem: fs, observabilityScope: observability.topScope)
+            AbsolutePath(path: "/custom/foo.pc"),
+            try PCFileFinder().locatePCFile(name: "foo", customSearchPaths: [AbsolutePath(path: "/custom")], fileSystem: fs, observabilityScope: observability.topScope)
         )
         XCTAssertEqual(
-            AbsolutePath("/custom/foo.pc"),
-            try PkgConfig(name: "foo", additionalSearchPaths: [AbsolutePath("/custom")], fileSystem: fs, observabilityScope: observability.topScope).pcFile
+            AbsolutePath(path: "/custom/foo.pc"),
+            try PkgConfig(name: "foo", additionalSearchPaths: [AbsolutePath(path: "/custom")], fileSystem: fs, observabilityScope: observability.topScope).pcFile
         )
         XCTAssertEqual(
-            AbsolutePath("/usr/lib/pkgconfig/foo.pc"),
+            AbsolutePath(path: "/usr/lib/pkgconfig/foo.pc"),
             try PCFileFinder().locatePCFile(name: "foo", customSearchPaths: [], fileSystem: fs, observabilityScope: observability.topScope)
         )
         try withCustomEnv(["PKG_CONFIG_PATH": "/usr/local/opt/foo/lib/pkgconfig"]) {
-            XCTAssertEqual(AbsolutePath("/usr/local/opt/foo/lib/pkgconfig/foo.pc"), try PkgConfig(name: "foo", fileSystem: fs, observabilityScope: observability.topScope).pcFile)
+            XCTAssertEqual(AbsolutePath(path: "/usr/local/opt/foo/lib/pkgconfig/foo.pc"), try PkgConfig(name: "foo", fileSystem: fs, observabilityScope: observability.topScope).pcFile)
         }
 #if os(Windows)
         let separator = ";"
@@ -157,7 +157,7 @@ final class PkgConfigParserTests: XCTestCase {
         let separator = ":"
 #endif
         try withCustomEnv(["PKG_CONFIG_PATH": "/usr/local/opt/foo/lib/pkgconfig\(separator)/usr/lib/pkgconfig"]) {
-            XCTAssertEqual(AbsolutePath("/usr/local/opt/foo/lib/pkgconfig/foo.pc"), try PkgConfig(name: "foo", fileSystem: fs, observabilityScope: observability.topScope).pcFile)
+            XCTAssertEqual(AbsolutePath(path: "/usr/local/opt/foo/lib/pkgconfig/foo.pc"), try PkgConfig(name: "foo", fileSystem: fs, observabilityScope: observability.topScope).pcFile)
         }
     }
 
@@ -195,7 +195,7 @@ final class PkgConfigParserTests: XCTestCase {
 #endif
         }
 
-        XCTAssertEqual(PCFileFinder.pkgConfigPaths, [AbsolutePath("/Volumes/BestDrive/pkgconfig")])
+        XCTAssertEqual(PCFileFinder.pkgConfigPaths, [AbsolutePath(path: "/Volumes/BestDrive/pkgconfig")])
     }
 
     func testAbsolutePathDependency() throws {
@@ -224,8 +224,8 @@ final class PkgConfigParserTests: XCTestCase {
         XCTAssertNoThrow(
             try PkgConfig(
                 name: "gobject-2.0",
-                additionalSearchPaths: [AbsolutePath("/usr/local/opt/glib/lib/pkgconfig")],
-                brewPrefix: AbsolutePath("/usr/local"),
+                additionalSearchPaths: [AbsolutePath(path: "/usr/local/opt/glib/lib/pkgconfig")],
+                brewPrefix: AbsolutePath(path: "/usr/local"),
                 fileSystem: fileSystem,
                 observabilityScope: observability.topScope
             )
@@ -242,7 +242,7 @@ final class PkgConfigParserTests: XCTestCase {
     }
 
     private func pcFilePath(_ inputName: String) -> AbsolutePath {
-        return AbsolutePath(#file).parentDirectory.appending(components: "pkgconfigInputs", inputName)
+        return AbsolutePath(path: #file).parentDirectory.appending(components: "pkgconfigInputs", inputName)
     }
 
     private func loadPCFile(_ inputName: String, body: ((PkgConfigParser) -> Void)? = nil) throws {

--- a/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
+++ b/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
@@ -62,13 +62,13 @@ class TargetSourcesBuilderTests: XCTestCase {
         let contents = builder.computeContents().sorted()
 
         XCTAssertEqual(contents, [
-            AbsolutePath("/Bar.swift"),
-            AbsolutePath("/Foo.swift"),
-            AbsolutePath("/Hello.something/hello.txt"),
-            AbsolutePath("/file"),
-            AbsolutePath("/path/to/somefile.txt"),
-            AbsolutePath("/some/path.swift"),
-            AbsolutePath("/some/path/toBeCopied"),
+            AbsolutePath(path: "/Bar.swift"),
+            AbsolutePath(path: "/Foo.swift"),
+            AbsolutePath(path: "/Hello.something/hello.txt"),
+            AbsolutePath(path: "/file"),
+            AbsolutePath(path: "/path/to/somefile.txt"),
+            AbsolutePath(path: "/some/path.swift"),
+            AbsolutePath(path: "/some/path/toBeCopied"),
         ])
 
         XCTAssertNoDiagnostics(observability.diagnostics)
@@ -106,8 +106,8 @@ class TargetSourcesBuilderTests: XCTestCase {
         let contents = builder.computeContents().sorted()
 
         XCTAssertEqual(contents, [
-            AbsolutePath("/some.thing"),
-            AbsolutePath("/some/hello.swift"),
+            AbsolutePath(path: "/some.thing"),
+            AbsolutePath(path: "/some/hello.swift"),
         ])
 
         XCTAssertNoDiagnostics(observability.diagnostics)
@@ -145,8 +145,8 @@ class TargetSourcesBuilderTests: XCTestCase {
         let contents = builder.computeContents().sorted()
 
         XCTAssertEqual(contents, [
-            AbsolutePath("/some.thing/hello.txt"),
-            AbsolutePath("/some/hello.swift"),
+            AbsolutePath(path: "/some.thing/hello.txt"),
+            AbsolutePath(path: "/some/hello.swift"),
         ])
 
         XCTAssertNoDiagnostics(observability.diagnostics)
@@ -244,9 +244,9 @@ class TargetSourcesBuilderTests: XCTestCase {
         )
 
         let files = [
-            AbsolutePath("/Foo.swift").pathString,
-            AbsolutePath("/Bar.swift").pathString,
-            AbsolutePath("/Baz.something").pathString,
+            AbsolutePath(path: "/Foo.swift").pathString,
+            AbsolutePath(path: "/Bar.swift").pathString,
+            AbsolutePath(path: "/Baz.something").pathString,
         ]
 
         let fs = InMemoryFileSystem()
@@ -591,15 +591,15 @@ class TargetSourcesBuilderTests: XCTestCase {
 
         build(target: target, defaultLocalization: "fr", toolsVersion: .v5_3, fs: fs) { _, resources, _,  _, _, _, _, diagnostics in
             XCTAssertEqual(resources.sorted(by: { $0.path < $1.path }), [
-                Resource(rule: .process(localization: .none), path: AbsolutePath("/Processed/foo.txt")),
-                Resource(rule: .process(localization: "en-us"), path: AbsolutePath("/Processed/En-uS.lproj/Localizable.stringsdict")),
-                Resource(rule: .process(localization: "en-us"), path: AbsolutePath("/Processed/en-US.lproj/Localizable.strings")),
-                Resource(rule: .process(localization: "fr"), path: AbsolutePath("/Processed/fr.lproj/Localizable.strings")),
-                Resource(rule: .process(localization: "fr"), path: AbsolutePath("/Processed/fr.lproj/Localizable.stringsdict")),
-                Resource(rule: .process(localization: "Base"), path: AbsolutePath("/Processed/Base.lproj/Storyboard.storyboard")),
-                Resource(rule: .copy, path: AbsolutePath("/Copied")),
-                Resource(rule: .process(localization: "Base"), path: AbsolutePath("/Other/Launch.storyboard")),
-                Resource(rule: .process(localization: "fr"), path: AbsolutePath("/Other/Image.png")),
+                Resource(rule: .process(localization: .none), path: AbsolutePath(path: "/Processed/foo.txt")),
+                Resource(rule: .process(localization: "en-us"), path: AbsolutePath(path: "/Processed/En-uS.lproj/Localizable.stringsdict")),
+                Resource(rule: .process(localization: "en-us"), path: AbsolutePath(path: "/Processed/en-US.lproj/Localizable.strings")),
+                Resource(rule: .process(localization: "fr"), path: AbsolutePath(path: "/Processed/fr.lproj/Localizable.strings")),
+                Resource(rule: .process(localization: "fr"), path: AbsolutePath(path: "/Processed/fr.lproj/Localizable.stringsdict")),
+                Resource(rule: .process(localization: "Base"), path: AbsolutePath(path: "/Processed/Base.lproj/Storyboard.storyboard")),
+                Resource(rule: .copy, path: AbsolutePath(path: "/Copied")),
+                Resource(rule: .process(localization: "Base"), path: AbsolutePath(path: "/Other/Launch.storyboard")),
+                Resource(rule: .process(localization: "fr"), path: AbsolutePath(path: "/Other/Image.png")),
             ].sorted(by: { $0.path < $1.path }))
         }
     }
@@ -612,8 +612,8 @@ class TargetSourcesBuilderTests: XCTestCase {
 
         build(target: try TargetDescription(name: "Foo"), defaultLocalization: "fr", toolsVersion: .v5_3, fs: fs) { _, resources, _, _, _, _, _, diagnostics in
             XCTAssertEqual(resources.sorted(by: { $0.path < $1.path }), [
-                Resource(rule: .process(localization: "fr"), path: AbsolutePath("/Foo/fr.lproj/Image.png")),
-                Resource(rule: .process(localization: "es"), path: AbsolutePath("/Foo/es.lproj/Image.png")),
+                Resource(rule: .process(localization: "fr"), path: AbsolutePath(path: "/Foo/fr.lproj/Image.png")),
+                Resource(rule: .process(localization: "es"), path: AbsolutePath(path: "/Foo/es.lproj/Image.png")),
             ].sorted(by: { $0.path < $1.path }))
         }
     }
@@ -687,8 +687,8 @@ class TargetSourcesBuilderTests: XCTestCase {
 
             let builder = TargetSourcesBuilder(
                 packageIdentity: .plain("test"),
-                packageKind: .root(.init("/test")),
-                packagePath: .init("/test"),
+                packageKind: .root(.init(path: "/test")),
+                packagePath: .init(path: "/test"),
                 target: target,
                 path: .root,
                 toolsVersion: .v5,
@@ -699,8 +699,8 @@ class TargetSourcesBuilderTests: XCTestCase {
 
             testDiagnostics(observability.diagnostics) { result in
                 var diagnosticsFound = [Basics.Diagnostic?]()
-                diagnosticsFound.append(result.checkUnordered(diagnostic: "Invalid Exclude '\(AbsolutePath("/fileOutsideRoot.py"))': File not found.", severity: .warning))
-                diagnosticsFound.append(result.checkUnordered(diagnostic: "Invalid Exclude '\(AbsolutePath("/fakeDir"))': File not found.", severity: .warning))
+                diagnosticsFound.append(result.checkUnordered(diagnostic: "Invalid Exclude '\(AbsolutePath(path: "/fileOutsideRoot.py"))': File not found.", severity: .warning))
+                diagnosticsFound.append(result.checkUnordered(diagnostic: "Invalid Exclude '\(AbsolutePath(path: "/fakeDir"))': File not found.", severity: .warning))
 
                 for diagnostic in diagnosticsFound {
                     XCTAssertEqual(diagnostic?.metadata?.packageIdentity, builder.packageIdentity)
@@ -718,7 +718,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             let builder = TargetSourcesBuilder(
                 packageIdentity: .plain("test"),
                 packageKind: .remoteSourceControl(URL(string: "https://some.where/foo/bar")!),
-                packagePath: .init("/test"),
+                packagePath: .init(path: "/test"),
                 target: target,
                 path: .root,
                 toolsVersion: .v5,
@@ -822,7 +822,7 @@ class TargetSourcesBuilderTests: XCTestCase {
 
         let builder = TargetSourcesBuilder(
             packageIdentity: .plain("test"),
-            packageKind: .root(.init("/test")),
+            packageKind: .root(.init(path: "/test")),
             packagePath: .root,
             target: target,
             path: .root,
@@ -833,9 +833,9 @@ class TargetSourcesBuilderTests: XCTestCase {
 
         testDiagnostics(observability.diagnostics) { result in
             var diagnosticsFound = [Basics.Diagnostic?]()
-            diagnosticsFound.append(result.checkUnordered(diagnostic: "Invalid Source '\(AbsolutePath("/InvalidPackage.swift"))': File not found.", severity: .warning))
-            diagnosticsFound.append(result.checkUnordered(diagnostic: "Invalid Source '\(AbsolutePath("/DoesNotExist.swift"))': File not found.", severity: .warning))
-            diagnosticsFound.append(result.checkUnordered(diagnostic: "Invalid Source '\(AbsolutePath("/Tests/InvalidPackageTests/InvalidPackageTests.swift"))': File not found.", severity: .warning))
+            diagnosticsFound.append(result.checkUnordered(diagnostic: "Invalid Source '\(AbsolutePath(path: "/InvalidPackage.swift"))': File not found.", severity: .warning))
+            diagnosticsFound.append(result.checkUnordered(diagnostic: "Invalid Source '\(AbsolutePath(path: "/DoesNotExist.swift"))': File not found.", severity: .warning))
+            diagnosticsFound.append(result.checkUnordered(diagnostic: "Invalid Source '\(AbsolutePath(path: "/Tests/InvalidPackageTests/InvalidPackageTests.swift"))': File not found.", severity: .warning))
 
             for diagnostic in diagnosticsFound {
                 XCTAssertEqual(diagnostic?.metadata?.packageIdentity, builder.packageIdentity)
@@ -866,7 +866,7 @@ class TargetSourcesBuilderTests: XCTestCase {
 
         let builder = TargetSourcesBuilder(
             packageIdentity: .plain("test"),
-            packageKind: .root(.init("/test")),
+            packageKind: .root(.init(path: "/test")),
             packagePath: .root,
             target: target,
             path: .root,
@@ -875,10 +875,10 @@ class TargetSourcesBuilderTests: XCTestCase {
             observabilityScope: observability.topScope
         )
         let outputs = try builder.run()
-        XCTAssertEqual(outputs.sources.paths, [AbsolutePath("/File.swift")])
+        XCTAssertEqual(outputs.sources.paths, [AbsolutePath(path: "/File.swift")])
         XCTAssertEqual(outputs.resources, [])
         XCTAssertEqual(outputs.ignored, [])
-        XCTAssertEqual(outputs.others, [AbsolutePath("/Foo.xcdatamodel")])
+        XCTAssertEqual(outputs.others, [AbsolutePath(path: "/Foo.xcdatamodel")])
 
         XCTAssertFalse(observability.hasWarningDiagnostics)
         XCTAssertFalse(observability.hasErrorDiagnostics)
@@ -906,7 +906,7 @@ class TargetSourcesBuilderTests: XCTestCase {
 
             let builder = TargetSourcesBuilder(
                 packageIdentity: .plain("test"),
-                packageKind: .root(.init("/test")),
+                packageKind: .root(.init(path: "/test")),
                 packagePath: .root,
                 target: target,
                 path: .root,
@@ -915,10 +915,10 @@ class TargetSourcesBuilderTests: XCTestCase {
                 observabilityScope: observability.topScope
             )
             let outputs = try builder.run()
-            XCTAssertEqual(outputs.sources.paths, [AbsolutePath("/File.swift")])
+            XCTAssertEqual(outputs.sources.paths, [AbsolutePath(path: "/File.swift")])
             XCTAssertEqual(outputs.resources, [])
             XCTAssertEqual(outputs.ignored, [])
-            XCTAssertEqual(outputs.others, [AbsolutePath("/foo.bar")])
+            XCTAssertEqual(outputs.others, [AbsolutePath(path: "/foo.bar")])
 
             XCTAssertFalse(observability.hasWarningDiagnostics)
             XCTAssertFalse(observability.hasErrorDiagnostics)
@@ -977,9 +977,9 @@ class TargetSourcesBuilderTests: XCTestCase {
             observabilityScope: observability.topScope
         )
         let outputs = try builder.run()
-        XCTAssertEqual(outputs.sources.paths, [AbsolutePath("/File.swift")])
+        XCTAssertEqual(outputs.sources.paths, [AbsolutePath(path: "/File.swift")])
         XCTAssertEqual(outputs.resources, [])
-        XCTAssertEqual(outputs.ignored, [AbsolutePath("/Foo.docc")])
+        XCTAssertEqual(outputs.ignored, [AbsolutePath(path: "/Foo.docc")])
         XCTAssertEqual(outputs.others, [])
 
         XCTAssertNoDiagnostics(observability.diagnostics)

--- a/Tests/PackageLoadingTests/ToolsVersionParserTests.swift
+++ b/Tests/PackageLoadingTests/ToolsVersionParserTests.swift
@@ -652,7 +652,7 @@ class ToolsVersionParserTests: XCTestCase {
 
     func testVersionSpecificManifest() throws {
         let fs = InMemoryFileSystem()
-        let root = AbsolutePath("/pkg")
+        let root = AbsolutePath(path: "/pkg")
         try fs.createDirectory(root, recursive: true)
 
         /// Loads the tools version of root pkg.
@@ -696,7 +696,7 @@ class ToolsVersionParserTests: XCTestCase {
         let fs = InMemoryFileSystem(emptyFiles:
             "/pkg/foo"
         )
-        let root = AbsolutePath("/pkg")
+        let root = AbsolutePath(path: "/pkg")
 
         func parse(currentToolsVersion: ToolsVersion, _ body: (ToolsVersion) -> Void) throws {
             let manifestPath = try ManifestLoader.findManifest(packagePath: root, fileSystem: fs, currentToolsVersion: currentToolsVersion)

--- a/Tests/PackageModelTests/ManifestTests.swift
+++ b/Tests/PackageModelTests/ManifestTests.swift
@@ -32,7 +32,7 @@ class ManifestTests: XCTestCase {
         do {
             let manifest = Manifest.createRootManifest(
                 name: "Foo",
-                path: .init("/Foo"),
+                path: .init(path: "/Foo"),
                 toolsVersion: .v5_2,
                 products: products,
                 targets: targets
@@ -50,7 +50,7 @@ class ManifestTests: XCTestCase {
         do {
             let manifest = Manifest.createLocalSourceControlManifest(
                 name: "Foo",
-                path: .init("/Foo"),
+                path: .init(path: "/Foo"),
                 toolsVersion: .v5_2,
                 products: products,
                 targets: targets
@@ -67,9 +67,9 @@ class ManifestTests: XCTestCase {
 
     func testRequiredDependencies() throws {
         let dependencies: [PackageDependency] = [
-            .localSourceControl(path: .init("/Bar1"), requirement: .upToNextMajor(from: "1.0.0")),
-            .localSourceControl(path: .init("/Bar2"), requirement: .upToNextMajor(from: "1.0.0")),
-            .localSourceControl(path: .init("/Bar3"), requirement: .upToNextMajor(from: "1.0.0")),
+            .localSourceControl(path: .init(path: "/Bar1"), requirement: .upToNextMajor(from: "1.0.0")),
+            .localSourceControl(path: .init(path: "/Bar2"), requirement: .upToNextMajor(from: "1.0.0")),
+            .localSourceControl(path: .init(path: "/Bar3"), requirement: .upToNextMajor(from: "1.0.0")),
         ]
 
         let products = [
@@ -85,7 +85,7 @@ class ManifestTests: XCTestCase {
         do {
             let manifest = Manifest.createRootManifest(
                 name: "Foo",
-                path: .init("/Foo"),
+                path: .init(path: "/Foo"),
                 toolsVersion: .v5,
                 dependencies: dependencies,
                 products: products,
@@ -102,7 +102,7 @@ class ManifestTests: XCTestCase {
         do {
             let manifest = Manifest.createLocalSourceControlManifest(
                 name: "Foo",
-                path: .init("/Foo"),
+                path: .init(path: "/Foo"),
                 toolsVersion: .v5,
                 dependencies: dependencies,
                 products: products,
@@ -119,7 +119,7 @@ class ManifestTests: XCTestCase {
         do {
             let manifest = Manifest.createRootManifest(
                 name: "Foo",
-                path: .init("/Foo"),
+                path: .init(path: "/Foo"),
                 toolsVersion: .v5_2,
                 dependencies: dependencies,
                 products: products,
@@ -136,7 +136,7 @@ class ManifestTests: XCTestCase {
         do {
             let manifest = Manifest.createLocalSourceControlManifest(
                 name: "Foo",
-                path: .init("/Foo"),
+                path: .init(path: "/Foo"),
                 toolsVersion: .v5_2,
                 dependencies: dependencies,
                 products: products,

--- a/Tests/PackageModelTests/PackageModelTests.swift
+++ b/Tests/PackageModelTests/PackageModelTests.swift
@@ -57,8 +57,8 @@ class PackageModelTests: XCTestCase {
 
     func testAndroidCompilerFlags() throws {
         let target = try Triple("x86_64-unknown-linux-android")
-        let sdk = AbsolutePath("/some/path/to/an/SDK.sdk")
-        let toolchainPath = AbsolutePath("/some/path/to/a/toolchain.xctoolchain")
+        let sdk = AbsolutePath(path: "/some/path/to/an/SDK.sdk")
+        let toolchainPath = AbsolutePath(path: "/some/path/to/a/toolchain.xctoolchain")
 
         let destination = Destination(
             target: target,
@@ -66,7 +66,7 @@ class PackageModelTests: XCTestCase {
             binDir: toolchainPath.appending(components: "usr", "bin")
         )
 
-        XCTAssertEqual(UserToolchain.deriveSwiftCFlags(triple: target, destination: destination, environment: .process()), [
+        XCTAssertEqual(try UserToolchain.deriveSwiftCFlags(triple: target, destination: destination, environment: .process()), [
             // Needed when cross‐compiling for Android. 2020‐03‐01
             "-sdk", sdk.pathString,
         ])

--- a/Tests/PackageModelTests/SnippetTests.swift
+++ b/Tests/PackageModelTests/SnippetTests.swift
@@ -15,7 +15,7 @@ import TSCBasic
 import XCTest
 
 class SnippetTests: XCTestCase {
-    let fakeSourceFilePath = AbsolutePath("/fake/path/to/test.swift")
+    let fakeSourceFilePath = AbsolutePath(path: "/fake/path/to/test.swift")
 
     /// Test the contents of the ``Snippet`` model when parsing an empty file.
     /// Currently, no errors are emitted and most things are either nil or empty.

--- a/Tests/PackageRegistryTests/RegistryClientTests.swift
+++ b/Tests/PackageRegistryTests/RegistryClientTests.swift
@@ -532,7 +532,7 @@ final class RegistryClientTests: XCTestCase {
         )
 
         let fileSystem = InMemoryFileSystem()
-        let path = AbsolutePath("/LinkedList-1.1.1")
+        let path = AbsolutePath(path: "/LinkedList-1.1.1")
 
         try registryClient.downloadSourceArchive(
             package: identity,
@@ -610,7 +610,7 @@ final class RegistryClientTests: XCTestCase {
         )
 
         let fileSystem = InMemoryFileSystem()
-        let path = AbsolutePath("/LinkedList-1.1.1")
+        let path = AbsolutePath(path: "/LinkedList-1.1.1")
 
         XCTAssertThrowsError(
             try registryClient.downloadSourceArchive(
@@ -693,7 +693,7 @@ final class RegistryClientTests: XCTestCase {
         )
 
         let fileSystem = InMemoryFileSystem()
-        let path = AbsolutePath("/LinkedList-1.1.1")
+        let path = AbsolutePath(path: "/LinkedList-1.1.1")
         let observability = ObservabilitySystem.makeForTesting()
 
         // The checksum differs from that in storage, but error is not thrown
@@ -808,7 +808,7 @@ final class RegistryClientTests: XCTestCase {
         )
 
         let fileSystem = InMemoryFileSystem()
-        let path = AbsolutePath("/LinkedList-1.1.1")
+        let path = AbsolutePath(path: "/LinkedList-1.1.1")
 
         try registryClient.downloadSourceArchive(
             package: identity,

--- a/Tests/PackageRegistryTests/RegistryDownloadsManagerTests.swift
+++ b/Tests/PackageRegistryTests/RegistryDownloadsManagerTests.swift
@@ -17,7 +17,6 @@ import PackageLoading
 import SPMTestSupport
 import TSCBasic
 import XCTest
-import SwiftDriver
 
 class RegistryDownloadsManagerTests: XCTestCase {
     func testNoCache() throws {

--- a/Tests/SPMBuildCoreTests/ArtifactsArchiveMetadataTests.swift
+++ b/Tests/SPMBuildCoreTests/ArtifactsArchiveMetadataTests.swift
@@ -20,7 +20,7 @@ final class ArtifactsArchiveMetadataTests: XCTestCase {
     func testParseMetadata() throws {
         let fileSystem = InMemoryFileSystem()
         try fileSystem.writeFileContents(
-            AbsolutePath("/info.json"),
+            AbsolutePath(path: "/info.json"),
             bytes: ByteString(encodingAsUTF8: """
             {
                 "schemaVersion": "1.0",

--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -35,9 +35,9 @@ class GitRepositoryTests: XCTestCase {
         }
 
         do {
-            let s1 = RepositorySpecifier(path: .init("/a"))
-            let s2 = RepositorySpecifier(path: .init("/a"))
-            let s3 = RepositorySpecifier(path: .init("/b"))
+            let s1 = RepositorySpecifier(path: .init(path: "/a"))
+            let s2 = RepositorySpecifier(path: .init(path: "/a"))
+            let s3 = RepositorySpecifier(path: .init(path: "/b"))
 
             XCTAssertEqual(s1, s1)
             XCTAssertEqual(s1, s2)
@@ -118,7 +118,7 @@ class GitRepositoryTests: XCTestCase {
 #endif
         try testWithTemporaryDirectory { path in
             // Unarchive the static test repository.
-            let inputArchivePath = AbsolutePath(#file).parentDirectory.appending(components: "Inputs", "TestRepo.tgz")
+            let inputArchivePath = AbsolutePath(path: #file).parentDirectory.appending(components: "Inputs", "TestRepo.tgz")
 #if os(Windows)
             try systemQuietly(["tar.exe", "-x", "-v", "-C", path.pathString, "-f", inputArchivePath.pathString])
 #else
@@ -229,21 +229,21 @@ class GitRepositoryTests: XCTestCase {
             let view = try repository.openFileView(revision: repository.resolveRevision(tag: "test-tag"))
 
             // Check basic predicates.
-            XCTAssert(view.isDirectory(AbsolutePath("/")))
-            XCTAssert(view.isDirectory(AbsolutePath("/subdir")))
-            XCTAssert(!view.isDirectory(AbsolutePath("/does-not-exist")))
-            XCTAssert(view.exists(AbsolutePath("/test-file-1.txt")))
-            XCTAssert(!view.exists(AbsolutePath("/does-not-exist")))
-            XCTAssert(view.isFile(AbsolutePath("/test-file-1.txt")))
-            XCTAssert(!view.isSymlink(AbsolutePath("/test-file-1.txt")))
-            XCTAssert(!view.isExecutableFile(AbsolutePath("/does-not-exist")))
+            XCTAssert(view.isDirectory(AbsolutePath(path: "/")))
+            XCTAssert(view.isDirectory(AbsolutePath(path: "/subdir")))
+            XCTAssert(!view.isDirectory(AbsolutePath(path: "/does-not-exist")))
+            XCTAssert(view.exists(AbsolutePath(path: "/test-file-1.txt")))
+            XCTAssert(!view.exists(AbsolutePath(path: "/does-not-exist")))
+            XCTAssert(view.isFile(AbsolutePath(path: "/test-file-1.txt")))
+            XCTAssert(!view.isSymlink(AbsolutePath(path: "/test-file-1.txt")))
+            XCTAssert(!view.isExecutableFile(AbsolutePath(path: "/does-not-exist")))
 #if !os(Windows)
-            XCTAssert(view.isExecutableFile(AbsolutePath("/test-file-3.sh")))
+            XCTAssert(view.isExecutableFile(AbsolutePath(path: "/test-file-3.sh")))
 #endif
 
             // Check read of a directory.
-            let subdirPath = AbsolutePath("/subdir")
-            XCTAssertEqual(try view.getDirectoryContents(AbsolutePath("/")).sorted(), ["file.swift", "subdir", "test-file-1.txt", "test-file-3.sh"])
+            let subdirPath = AbsolutePath(path: "/subdir")
+            XCTAssertEqual(try view.getDirectoryContents(AbsolutePath(path: "/")).sorted(), ["file.swift", "subdir", "test-file-1.txt", "test-file-3.sh"])
             XCTAssertEqual(try view.getDirectoryContents(subdirPath).sorted(), ["test-file-2.txt"])
             XCTAssertThrows(FileSystemError(.isDirectory, subdirPath)) {
                 _ = try view.readFileContents(subdirPath)
@@ -255,28 +255,28 @@ class GitRepositoryTests: XCTestCase {
             }
 
             // Check read through a non-directory.
-            let notDirectoryPath1 = AbsolutePath("/test-file-1.txt")
+            let notDirectoryPath1 = AbsolutePath(path: "/test-file-1.txt")
             XCTAssertThrows(FileSystemError(.notDirectory, notDirectoryPath1)) {
                 _ = try view.getDirectoryContents(notDirectoryPath1)
             }
-            let notDirectoryPath2 = AbsolutePath("/test-file-1.txt/thing")
+            let notDirectoryPath2 = AbsolutePath(path: "/test-file-1.txt/thing")
             XCTAssertThrows(FileSystemError(.notDirectory, notDirectoryPath2)) {
                 _ = try view.readFileContents(notDirectoryPath2)
             }
 
             // Check read/write into a missing directory.
-            let noEntryPath1 = AbsolutePath("/does-not-exist")
+            let noEntryPath1 = AbsolutePath(path: "/does-not-exist")
             XCTAssertThrows(FileSystemError(.noEntry, noEntryPath1)) {
                 _ = try view.getDirectoryContents(noEntryPath1)
             }
-            let noEntryPath2 = AbsolutePath("/does/not/exist")
+            let noEntryPath2 = AbsolutePath(path: "/does/not/exist")
             XCTAssertThrows(FileSystemError(.noEntry, noEntryPath2)) {
                 _ = try view.readFileContents(noEntryPath2)
             }
 
             // Check read of a file.
-            XCTAssertEqual(try view.readFileContents(AbsolutePath("/test-file-1.txt")), test1FileContents)
-            XCTAssertEqual(try view.readFileContents(AbsolutePath("/subdir/test-file-2.txt")), test2FileContents)
+            XCTAssertEqual(try view.readFileContents(AbsolutePath(path: "/test-file-1.txt")), test1FileContents)
+            XCTAssertEqual(try view.readFileContents(AbsolutePath(path: "/subdir/test-file-2.txt")), test2FileContents)
         }
     }
 

--- a/Tests/SourceControlTests/InMemoryGitRepositoryTests.swift
+++ b/Tests/SourceControlTests/InMemoryGitRepositoryTests.swift
@@ -22,9 +22,9 @@ class InMemoryGitRepositoryTests: XCTestCase {
         let fs = InMemoryFileSystem()
         let repo = InMemoryGitRepository(path: .root, fs: fs)
 
-        try repo.createDirectory(AbsolutePath("/new-dir/subdir"), recursive: true)
+        try repo.createDirectory(AbsolutePath(path: "/new-dir/subdir"), recursive: true)
         XCTAssertTrue(!repo.hasUncommittedChanges())
-        let filePath = AbsolutePath("/new-dir/subdir").appending(component: "new-file.txt")
+        let filePath = AbsolutePath(path: "/new-dir/subdir").appending(component: "new-file.txt")
 
         try repo.writeFileContents(filePath, bytes: "one")
         XCTAssertEqual(try repo.readFileContents(filePath), "one")
@@ -78,9 +78,9 @@ class InMemoryGitRepositoryTests: XCTestCase {
         let v2 = "2.0.0"
         let repo = InMemoryGitRepository(path: .root, fs: InMemoryFileSystem())
 
-        let specifier = RepositorySpecifier(path: .init("/foo"))
-        try repo.createDirectory(AbsolutePath("/new-dir/subdir"), recursive: true)
-        let filePath = AbsolutePath("/new-dir/subdir").appending(component: "new-file.txt")
+        let specifier = RepositorySpecifier(path: .init(path: "/foo"))
+        try repo.createDirectory(AbsolutePath(path: "/new-dir/subdir"), recursive: true)
+        let filePath = AbsolutePath(path: "/new-dir/subdir").appending(component: "new-file.txt")
         try repo.writeFileContents(filePath, bytes: "one")
         try repo.commit()
         try repo.tag(name: v1)
@@ -91,7 +91,7 @@ class InMemoryGitRepositoryTests: XCTestCase {
         let provider = InMemoryGitRepositoryProvider()
         provider.add(specifier: specifier, repository: repo)
 
-        let fooRepoPath = AbsolutePath("/fooRepo")
+        let fooRepoPath = AbsolutePath(path: "/fooRepo")
         try provider.fetch(repository: specifier, to: fooRepoPath)
         let fooRepo = try provider.open(repository: specifier, at: fooRepoPath)
 
@@ -100,7 +100,7 @@ class InMemoryGitRepositoryTests: XCTestCase {
         XCTAssertEqual(try fooRepo.getTags().sorted(), [v1, v2])
         XCTAssert(fooRepo.exists(revision: try fooRepo.resolveRevision(tag: v1)))
 
-        let fooCheckoutPath = AbsolutePath("/fooCheckout")
+        let fooCheckoutPath = AbsolutePath(path: "/fooCheckout")
         XCTAssertFalse(try provider.workingCopyExists(at: fooCheckoutPath))
         _ = try provider.createWorkingCopy(repository: specifier, sourcePath: fooRepoPath, at: fooCheckoutPath, editable: false)
         XCTAssertTrue(try provider.workingCopyExists(at: fooCheckoutPath))

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -33,8 +33,8 @@ class RepositoryManagerTests: XCTestCase {
                 delegate: delegate
             )
 
-            let dummyRepo = RepositorySpecifier(path: .init("/dummy"))
-            let badDummyRepo = RepositorySpecifier(path: .init("/badDummy"))
+            let dummyRepo = RepositorySpecifier(path: .init(path: "/dummy"))
+            let badDummyRepo = RepositorySpecifier(path: .init(path: "/badDummy"))
             var prevHandle: RepositoryManager.RepositoryHandle?
 
             // Check that we can "fetch" a repository.
@@ -220,7 +220,7 @@ class RepositoryManagerTests: XCTestCase {
                 provider: provider,
                 delegate: delegate
             )
-            let dummyRepo = RepositorySpecifier(path: .init("/dummy"))
+            let dummyRepo = RepositorySpecifier(path: .init(path: "/dummy"))
 
             delegate.prepare(fetchExpected: true, updateExpected: false)
             _ = try manager.lookup(repository: dummyRepo, observabilityScope: observability.topScope)
@@ -252,7 +252,7 @@ class RepositoryManagerTests: XCTestCase {
 
         try testWithTemporaryDirectory { path in
             let provider = DummyRepositoryProvider(fileSystem: fs)
-            let dummyRepo = RepositorySpecifier(path: .init("/dummy"))
+            let dummyRepo = RepositorySpecifier(path: .init(path: "/dummy"))
 
             // Do the initial fetch.
             do {
@@ -312,7 +312,7 @@ class RepositoryManagerTests: XCTestCase {
                     provider: provider,
                     delegate: delegate
                 )
-                let dummyRepo = RepositorySpecifier(path: .init("/dummy"))
+                let dummyRepo = RepositorySpecifier(path: .init(path: "/dummy"))
 
                 delegate.prepare(fetchExpected: true, updateExpected: false)
                 _ = try manager.lookup(repository: dummyRepo, observabilityScope: observability.topScope)
@@ -340,7 +340,7 @@ class RepositoryManagerTests: XCTestCase {
                 provider: provider,
                 delegate: delegate
             )
-            let dummyRepo = RepositorySpecifier(path: .init("/dummy"))
+            let dummyRepo = RepositorySpecifier(path: .init(path: "/dummy"))
 
             let group = DispatchGroup()
             let results = ThreadSafeKeyValueStore<Int, Result<RepositoryManager.RepositoryHandle, Error>>()
@@ -397,7 +397,7 @@ class RepositoryManagerTests: XCTestCase {
                 provider: provider,
                 delegate: delegate
             )
-            let dummyRepo = RepositorySpecifier(path: .init("/dummy"))
+            let dummyRepo = RepositorySpecifier(path: .init(path: "/dummy"))
 
             delegate.prepare(fetchExpected: true, updateExpected: false)
             _ = try manager.lookup(repository: dummyRepo, observabilityScope: observability.topScope)
@@ -450,7 +450,7 @@ class RepositoryManagerTests: XCTestCase {
         let finishGroup = DispatchGroup()
         let results = ThreadSafeKeyValueStore<RepositorySpecifier, Result<RepositoryManager.RepositoryHandle, Error>>()
         for index in 0 ..< total {
-            let repository = RepositorySpecifier(path: .init("/repo/\(index)"))
+            let repository = RepositorySpecifier(path: try .init(validating: "/repo/\(index)"))
             provider.startGroup.enter()
             finishGroup.enter()
             manager.lookup(

--- a/Tests/WorkspaceTests/AuthorizationProviderTests.swift
+++ b/Tests/WorkspaceTests/AuthorizationProviderTests.swift
@@ -26,7 +26,7 @@ final class AuthorizationConfigurationTests: XCTestCase {
         do {
             let fileSystem = InMemoryFileSystem()
 
-            let customPath = fileSystem.homeDirectory.appending(components: UUID().uuidString, "custom-netrc-file")
+            let customPath = try fileSystem.homeDirectory.appending(components: UUID().uuidString, "custom-netrc-file")
             try fileSystem.createDirectory(customPath.parentDirectory, recursive: true)
             try fileSystem.writeFileContents(customPath) {
                 "machine mymachine.labkey.org login custom@labkey.org password custom"
@@ -37,7 +37,7 @@ final class AuthorizationConfigurationTests: XCTestCase {
             let netrcProviders = authorizationProvider?.providers.compactMap{ $0 as? NetrcAuthorizationProvider }
 
             XCTAssertEqual(netrcProviders?.count, 1)
-            XCTAssertEqual(netrcProviders?.first.map { resolveSymlinks($0.path) }, resolveSymlinks(customPath))
+            XCTAssertEqual(try netrcProviders?.first.map { try resolveSymlinks($0.path) }, try resolveSymlinks(customPath))
 
             let auth = authorizationProvider?.authentication(for: URL(string: "https://mymachine.labkey.org")!)
             XCTAssertEqual(auth?.user, "custom@labkey.org")
@@ -55,7 +55,7 @@ final class AuthorizationConfigurationTests: XCTestCase {
         do {
             let fileSystem = InMemoryFileSystem()
 
-            let userPath = fileSystem.homeDirectory.appending(component: ".netrc")
+            let userPath = try fileSystem.homeDirectory.appending(component: ".netrc")
             try fileSystem.createDirectory(userPath.parentDirectory, recursive: true)
             try fileSystem.writeFileContents(userPath) {
                 "machine mymachine.labkey.org login user@labkey.org password user"
@@ -66,7 +66,7 @@ final class AuthorizationConfigurationTests: XCTestCase {
             let netrcProviders = authorizationProvider?.providers.compactMap{ $0 as? NetrcAuthorizationProvider }
 
             XCTAssertEqual(netrcProviders?.count, 1)
-            XCTAssertEqual(netrcProviders?.first.map { resolveSymlinks($0.path) }, resolveSymlinks(userPath))
+            XCTAssertEqual(try netrcProviders?.first.map { try resolveSymlinks($0.path) }, try resolveSymlinks(userPath))
 
             let auth = authorizationProvider?.authentication(for: URL(string: "https://mymachine.labkey.org")!)
             XCTAssertEqual(auth?.user, "user@labkey.org")
@@ -85,7 +85,7 @@ final class AuthorizationConfigurationTests: XCTestCase {
         do {
             let fileSystem = InMemoryFileSystem()
 
-            let userPath = fileSystem.homeDirectory.appending(component: ".netrc")
+            let userPath = try fileSystem.homeDirectory.appending(component: ".netrc")
             try fileSystem.createDirectory(userPath.parentDirectory, recursive: true)
             try fileSystem.writeFileContents(userPath) {
                 "machine mymachine.labkey.org login user@labkey.org password user"
@@ -102,8 +102,8 @@ final class AuthorizationConfigurationTests: XCTestCase {
             let netrcProviders = authorizationProvider?.providers.compactMap{ $0 as? NetrcAuthorizationProvider }
 
             XCTAssertEqual(netrcProviders?.count, 2)
-            XCTAssertEqual(netrcProviders?.first.map { resolveSymlinks($0.path) }, resolveSymlinks(workspacePath))
-            XCTAssertEqual(netrcProviders?.last.map { resolveSymlinks($0.path) }, resolveSymlinks(userPath))
+            XCTAssertEqual(try netrcProviders?.first.map { try resolveSymlinks($0.path) }, try resolveSymlinks(workspacePath))
+            XCTAssertEqual(try netrcProviders?.last.map { try resolveSymlinks($0.path) }, try resolveSymlinks(userPath))
 
             let auth = authorizationProvider?.authentication(for: URL(string: "https://mymachine.labkey.org")!)
             XCTAssertEqual(auth?.user, "workspace@labkey.org")

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -99,7 +99,7 @@ class InitTests: XCTestCase {
             // If we have a compiler that supports `-entry-point-function-name`, we try building it (we need that flag now).
             #if swift(>=5.5)
             XCTAssertBuilds(path)
-            let triple = UserToolchain.default.triple
+            let triple = try UserToolchain.default.triple
             let binPath = path.appending(components: ".build", triple.platformBuildPathComponent(), "debug")
 #if os(Windows)
             XCTAssertFileExists(binPath.appending(component: "Foo.exe"))
@@ -162,7 +162,7 @@ class InitTests: XCTestCase {
 
             // Try building it
             XCTAssertBuilds(path)
-            let triple = UserToolchain.default.triple
+            let triple = try UserToolchain.default.triple
             XCTAssertFileExists(path.appending(components: ".build", triple.platformBuildPathComponent(), "debug", "Foo.swiftmodule"))
         }
     }
@@ -260,7 +260,7 @@ class InitTests: XCTestCase {
 
             // Try building it.
             XCTAssertBuilds(packageRoot)
-            let triple = UserToolchain.default.triple
+            let triple = try UserToolchain.default.triple
             XCTAssertFileExists(packageRoot.appending(components: ".build", triple.platformBuildPathComponent(), "debug", "some_package.swiftmodule"))
         }
     }

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -36,7 +36,7 @@ class ManifestSourceGenerationTests: XCTestCase {
             // Write the original manifest file contents, and load it.
             let manifestPath = packageDir.appending(component: Manifest.filename)
             try fs.writeFileContents(manifestPath, string: manifestContents)
-            let manifestLoader = ManifestLoader(toolchain: UserToolchain.default)
+            let manifestLoader = ManifestLoader(toolchain: try UserToolchain.default)
             let identityResolver = DefaultIdentityResolver()
             let manifest = try tsc_await {
                 manifestLoader.load(
@@ -404,11 +404,11 @@ class ManifestSourceGenerationTests: XCTestCase {
 
     func testCustomProductSourceGeneration() throws {
         // Create a manifest containing a product for which we'd like to do custom source fragment generation.
-        let packageDir = AbsolutePath("/tmp/MyLibrary")
+        let packageDir = AbsolutePath(path: "/tmp/MyLibrary")
         let manifest = Manifest(
             displayName: "MyLibrary",
             path: packageDir.appending(component: "Package.swift"),
-            packageKind: .root(AbsolutePath("/tmp/MyLibrary")),
+            packageKind: .root(AbsolutePath(path: "/tmp/MyLibrary")),
             packageLocation: packageDir.pathString,
             platforms: [],
             toolsVersion: .v5_5,
@@ -444,11 +444,11 @@ class ManifestSourceGenerationTests: XCTestCase {
     func testModuleAliasGeneration() throws {
         let manifest = Manifest.createRootManifest(
             name: "thisPkg",
-            path: .init("/thisPkg"),
+            path: .init(path: "/thisPkg"),
             toolsVersion: .v5_7,
             dependencies: [
-                .localSourceControl(path: .init("/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                .localSourceControl(path: .init("/barPkg"), requirement: .upToNextMajor(from: "2.0.0")),
+                .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "2.0.0")),
             ],
             targets: [
                 try TargetDescription(name: "exe",

--- a/Tests/WorkspaceTests/MirrorsConfigurationTests.swift
+++ b/Tests/WorkspaceTests/MirrorsConfigurationTests.swift
@@ -18,7 +18,7 @@ import XCTest
 final class MirrorsConfigurationTests: XCTestCase {
     func testLoadingSchema1() throws {
         let fs = InMemoryFileSystem()
-        let configFile = AbsolutePath("/config/mirrors.json")
+        let configFile = AbsolutePath(path: "/config/mirrors.json")
 
         let originalURL = "https://github.com/apple/swift-argument-parser.git"
         let mirrorURL = "https://github.com/mona/swift-argument-parser.git"
@@ -46,7 +46,7 @@ final class MirrorsConfigurationTests: XCTestCase {
 
     func testThrowsWhenNotFound() throws {
         let fs = InMemoryFileSystem()
-        let configFile = AbsolutePath("/config/mirrors.json")
+        let configFile = AbsolutePath(path: "/config/mirrors.json")
 
         let config = Workspace.Configuration.MirrorsStorage(path: configFile, fileSystem: fs, deleteWhenEmpty: true)
         let mirrors = try config.get()
@@ -58,7 +58,7 @@ final class MirrorsConfigurationTests: XCTestCase {
 
     func testDeleteWhenEmpty() throws {
         let fs = InMemoryFileSystem()
-        let configFile = AbsolutePath("/config/mirrors.json")
+        let configFile = AbsolutePath(path: "/config/mirrors.json")
 
         let config = Workspace.Configuration.MirrorsStorage(path: configFile, fileSystem: fs, deleteWhenEmpty: true)
 
@@ -81,7 +81,7 @@ final class MirrorsConfigurationTests: XCTestCase {
 
     func testDontDeleteWhenEmpty() throws {
         let fs = InMemoryFileSystem()
-        let configFile = AbsolutePath("/config/mirrors.json")
+        let configFile = AbsolutePath(path: "/config/mirrors.json")
 
         let config = Workspace.Configuration.MirrorsStorage(path: configFile, fileSystem: fs, deleteWhenEmpty: false)
 
@@ -105,8 +105,8 @@ final class MirrorsConfigurationTests: XCTestCase {
 
     func testLocalAndShared() throws {
         let fs = InMemoryFileSystem()
-        let localConfigFile = AbsolutePath("/config/local-mirrors.json")
-        let sharedConfigFile = AbsolutePath("/config/shared-mirrors.json")
+        let localConfigFile = AbsolutePath(path: "/config/local-mirrors.json")
+        let sharedConfigFile = AbsolutePath(path: "/config/shared-mirrors.json")
 
         let config = try Workspace.Configuration.Mirrors(
             fileSystem: fs,

--- a/Tests/WorkspaceTests/PinsStoreTests.swift
+++ b/Tests/WorkspaceTests/PinsStoreTests.swift
@@ -25,14 +25,14 @@ final class PinsStoreTests: XCTestCase {
 
     func testBasics() throws {
         let fs = InMemoryFileSystem()
-        let pinsFile = AbsolutePath("/pinsfile.txt")
+        let pinsFile = AbsolutePath(path: "/pinsfile.txt")
 
         do {
-            let fooPath = AbsolutePath("/foo")
+            let fooPath = AbsolutePath(path: "/foo")
             let foo = PackageIdentity(path: fooPath)
             let fooRef = PackageReference.localSourceControl(identity: foo, path: fooPath)
 
-            let barPath = AbsolutePath("/bar")
+            let barPath = AbsolutePath(path: "/bar")
             let bar = PackageIdentity(path: barPath)
             let barRef = PackageReference.localSourceControl(identity: bar, path: barPath)
 
@@ -78,7 +78,7 @@ final class PinsStoreTests: XCTestCase {
         // Test source control version pin.
 
         do {
-            let path = AbsolutePath("/foo")
+            let path = AbsolutePath(path: "/foo")
             let identity = PackageIdentity(path: path)
             let revision = UUID().uuidString
 
@@ -98,7 +98,7 @@ final class PinsStoreTests: XCTestCase {
         // Test source control branch pin.
 
         do {
-            let path = AbsolutePath("/foo")
+            let path = AbsolutePath(path: "/foo")
             let identity = PackageIdentity(path: path)
             let revision = UUID().uuidString
 
@@ -118,7 +118,7 @@ final class PinsStoreTests: XCTestCase {
         // Test source control revision pin.
 
         do {
-            let path = AbsolutePath("/foo")
+            let path = AbsolutePath(path: "/foo")
             let identity = PackageIdentity(path: path)
             let revision = UUID().uuidString
 
@@ -156,7 +156,7 @@ final class PinsStoreTests: XCTestCase {
 
     func testLoadingSchema1() throws {
         let fs = InMemoryFileSystem()
-        let pinsFile = AbsolutePath("/pinsfile.txt")
+        let pinsFile = AbsolutePath(path: "/pinsfile.txt")
 
         try fs.writeFileContents(pinsFile, string:
             """
@@ -194,7 +194,7 @@ final class PinsStoreTests: XCTestCase {
 
     func testLoadingSchema2() throws {
         let fs = InMemoryFileSystem()
-        let pinsFile = AbsolutePath("/pinsfile.txt")
+        let pinsFile = AbsolutePath(path: "/pinsfile.txt")
 
         try fs.writeFileContents(pinsFile, string:
             """
@@ -238,7 +238,7 @@ final class PinsStoreTests: XCTestCase {
 
     func testLoadingUnknownSchemaVersion() throws {
         let fs = InMemoryFileSystem()
-        let pinsFile = AbsolutePath("/pinsfile.txt")
+        let pinsFile = AbsolutePath(path: "/pinsfile.txt")
 
         let version = -1
         try fs.writeFileContents(pinsFile, string: "{ \"version\": \(version) }");
@@ -251,7 +251,7 @@ final class PinsStoreTests: XCTestCase {
 
     func testLoadingBadFormat() throws {
         let fs = InMemoryFileSystem()
-        let pinsFile = AbsolutePath("/pinsfile.txt")
+        let pinsFile = AbsolutePath(path: "/pinsfile.txt")
 
         try fs.writeFileContents(pinsFile, string: "boom")
 
@@ -262,13 +262,13 @@ final class PinsStoreTests: XCTestCase {
 
     func testEmptyPins() throws {
         let fs = InMemoryFileSystem()
-        let pinsFile = AbsolutePath("/pinsfile.txt")
+        let pinsFile = AbsolutePath(path: "/pinsfile.txt")
         let store = try PinsStore(pinsFile: pinsFile, workingDirectory: .root, fileSystem: fs, mirrors: .init())
 
         try store.saveState(toolsVersion: ToolsVersion.current)
         XCTAssertFalse(fs.exists(pinsFile))
 
-        let fooPath = AbsolutePath("/foo")
+        let fooPath = AbsolutePath(path: "/foo")
         let foo = PackageIdentity(path: fooPath)
         let fooRef = PackageReference.localSourceControl(identity: foo, path: fooPath)
         let revision = "81513c8fd220cf1ed1452b98060cd80d3725c5b7"
@@ -302,7 +302,7 @@ final class PinsStoreTests: XCTestCase {
         mirrors.set(mirrorURL: barMirroredURL.absoluteString, forURL: barURL.absoluteString)
 
         let fileSystem = InMemoryFileSystem()
-        let pinsFile = AbsolutePath("/pins.txt")
+        let pinsFile = AbsolutePath(path: "/pins.txt")
 
         let store = try PinsStore(pinsFile: pinsFile, workingDirectory: .root, fileSystem: fileSystem, mirrors: mirrors)
 
@@ -354,7 +354,7 @@ final class PinsStoreTests: XCTestCase {
         mirrors.set(mirrorURL: fooMirroredURL.absoluteString, forURL: fooURL4.absoluteString)
 
         let fileSystem = InMemoryFileSystem()
-        let pinsFile = AbsolutePath("/pins.txt")
+        let pinsFile = AbsolutePath(path: "/pins.txt")
 
         let store1 = try PinsStore(pinsFile: pinsFile, workingDirectory: .root, fileSystem: fileSystem, mirrors: mirrors)
         store1.pin(

--- a/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
@@ -414,9 +414,9 @@ class SourceControlPackageContainerTests: XCTestCase {
 #endif
 
         let dependencies: [PackageDependency] = [
-            .localSourceControl(path: .init("/Bar1"), requirement: .upToNextMajor(from: "1.0.0")),
-            .localSourceControl(path: .init("/Bar2"), requirement: .upToNextMajor(from: "1.0.0")),
-            .localSourceControl(path: .init("/Bar3"), requirement: .upToNextMajor(from: "1.0.0")),
+            .localSourceControl(path: .init(path: "/Bar1"), requirement: .upToNextMajor(from: "1.0.0")),
+            .localSourceControl(path: .init(path: "/Bar2"), requirement: .upToNextMajor(from: "1.0.0")),
+            .localSourceControl(path: .init(path: "/Bar3"), requirement: .upToNextMajor(from: "1.0.0")),
         ]
 
         let products = [
@@ -457,7 +457,7 @@ class SourceControlPackageContainerTests: XCTestCase {
         do {
             let manifest = Manifest.createRootManifest(
                 name: "Foo",
-                path: .init("/Foo"),
+                path: .init(path: "/Foo"),
                 toolsVersion: .v5,
                 dependencies: dependencies,
                 products: products,
@@ -479,7 +479,7 @@ class SourceControlPackageContainerTests: XCTestCase {
         do {
             let manifest = Manifest.createFileSystemManifest(
                 name: "Foo",
-                path: .init("/Foo"),
+                path: .init(path: "/Foo"),
                 toolsVersion: .v5,
                 dependencies: dependencies,
                 products: products,
@@ -501,7 +501,7 @@ class SourceControlPackageContainerTests: XCTestCase {
         do {
             let manifest = Manifest.createRootManifest(
                 name: "Foo",
-                path: .init("/Foo"),
+                path: .init(path: "/Foo"),
                 toolsVersion: .v5_2,
                 dependencies: dependencies,
                 products: products,
@@ -523,7 +523,7 @@ class SourceControlPackageContainerTests: XCTestCase {
         do {
             let manifest = Manifest.createFileSystemManifest(
                 name: "Foo",
-                path: .init("/Foo"),
+                path: .init(path: "/Foo"),
                 toolsVersion: .v5_2,
                 dependencies: dependencies,
                 products: products,
@@ -643,7 +643,7 @@ class SourceControlPackageContainerTests: XCTestCase {
                 toolsVersion: .v5_2,
                 dependencies: [
                     .localSourceControl(
-                        path: .init("/Somewhere/Dependency"),
+                        path: .init(path: "/Somewhere/Dependency"),
                         requirement: .exact(version),
                         productFilter: .specific([])
                     )

--- a/Tests/WorkspaceTests/ToolsVersionSpecificationRewriterTests.swift
+++ b/Tests/WorkspaceTests/ToolsVersionSpecificationRewriterTests.swift
@@ -113,7 +113,7 @@ class ToolsVersionSpecificationRewriterTests: XCTestCase {
         let toolsVersion = ToolsVersion.v5_3
         
         let inMemoryFileSystem = InMemoryFileSystem()
-        let manifestFilePath = AbsolutePath("/pkg/Package.swift/Package.swift")
+        let manifestFilePath = AbsolutePath(path: "/pkg/Package.swift/Package.swift")
         try inMemoryFileSystem.createDirectory(manifestFilePath.parentDirectory, recursive: true) // /pkg/Package.swift/
         
         // Test `ManifestAccessError.Kind.isADirectory`
@@ -189,7 +189,7 @@ class ToolsVersionSpecificationRewriterTests: XCTestCase {
         do {
             let inMemoryFileSystem = InMemoryFileSystem()
 
-            let manifestFilePath = AbsolutePath("/pkg/Package.swift")
+            let manifestFilePath = AbsolutePath(path: "/pkg/Package.swift")
 
             try inMemoryFileSystem.createDirectory(manifestFilePath.parentDirectory, recursive: true)
             try inMemoryFileSystem.writeFileContents(manifestFilePath, bytes: stream.bytes)

--- a/Tests/WorkspaceTests/WorkspaceStateTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceStateTests.swift
@@ -19,7 +19,7 @@ final class WorkspaceStateTests: XCTestCase {
     func testV4Format() throws {
         let fs = InMemoryFileSystem()
 
-        let buildDir = AbsolutePath("/.build")
+        let buildDir = AbsolutePath(path: "/.build")
         try fs.createDirectory(buildDir, recursive: true)
 
         let statePath = buildDir.appending(component: "workspace-state.json")
@@ -93,7 +93,7 @@ final class WorkspaceStateTests: XCTestCase {
     func testV4FormatWithPath() throws {
         let fs = InMemoryFileSystem()
 
-        let buildDir = AbsolutePath("/.build")
+        let buildDir = AbsolutePath(path: "/.build")
         try fs.createDirectory(buildDir, recursive: true)
 
         let statePath = buildDir.appending(component: "workspace-state.json")
@@ -167,7 +167,7 @@ final class WorkspaceStateTests: XCTestCase {
     func testV5Format() throws {
         let fs = InMemoryFileSystem()
 
-        let buildDir = AbsolutePath("/.build")
+        let buildDir = AbsolutePath(path: "/.build")
         try fs.createDirectory(buildDir, recursive: true)
 
         let statePath = buildDir.appending(component: "workspace-state.json")
@@ -241,7 +241,7 @@ final class WorkspaceStateTests: XCTestCase {
     func testSavedDependenciesAreSorted() throws {
         let fs = InMemoryFileSystem()
 
-        let buildDir = AbsolutePath("/.build")
+        let buildDir = AbsolutePath(path: "/.build")
         try fs.createDirectory(buildDir, recursive: true)
 
         let statePath = buildDir.appending(component: "workspace-state.json")
@@ -306,7 +306,7 @@ final class WorkspaceStateTests: XCTestCase {
     func testArtifacts() throws {
         let fs = InMemoryFileSystem()
 
-        let buildDir = AbsolutePath("/.build")
+        let buildDir = AbsolutePath(path: "/.build")
         try fs.createDirectory(buildDir, recursive: true)
 
         let statePath = buildDir.appending(component: "workspace-state.json")
@@ -378,7 +378,7 @@ final class WorkspaceStateTests: XCTestCase {
     func testDuplicateDependenciesDoNotCrash() throws {
         let fs = InMemoryFileSystem()
 
-        let buildDir = AbsolutePath("/.build")
+        let buildDir = AbsolutePath(path: "/.build")
         try fs.createDirectory(buildDir, recursive: true)
 
         let statePath = buildDir.appending(component: "workspace-state.json")
@@ -439,7 +439,7 @@ final class WorkspaceStateTests: XCTestCase {
     func testDuplicateArtifactsDoNotCrash() throws {
         let fs = InMemoryFileSystem()
 
-        let buildDir = AbsolutePath("/.build")
+        let buildDir = AbsolutePath(path: "/.build")
         try fs.createDirectory(buildDir, recursive: true)
 
         let statePath = buildDir.appending(component: "workspace-state.json")

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -28,7 +28,7 @@ import struct TSCUtility.Triple
 
 final class WorkspaceTests: XCTestCase {
     func testBasics() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -138,7 +138,7 @@ final class WorkspaceTests: XCTestCase {
                     manifest($0)
                 }
 
-                let manifestLoader = ManifestLoader(toolchain: UserToolchain.default)
+                let manifestLoader = ManifestLoader(toolchain: try UserToolchain.default)
 
                 let sandbox = path.appending(component: "ws")
                 return try Workspace(
@@ -223,7 +223,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testMultipleRootPackages() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -280,7 +280,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testRootPackagesOverride() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -342,7 +342,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDuplicateRootPackages() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -379,7 +379,7 @@ final class WorkspaceTests: XCTestCase {
 
     /// Test that the explicit name given to a package is not used as its identity.
     func testExplicitPackageNameIsNotUsedAsPackageIdentity() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -428,7 +428,7 @@ final class WorkspaceTests: XCTestCase {
         try workspace.checkPackageGraph(
             roots: ["foo-package", "bar-package"],
             dependencies: [
-                .localSourceControl(path: .init("/tmp/ws/pkgs/bar-package"), requirement: .upToNextMajor(from: "1.0.0"))
+                .localSourceControl(path: .init(path: "/tmp/ws/pkgs/bar-package"), requirement: .upToNextMajor(from: "1.0.0"))
             ]
         ) { graph, diagnostics in
             PackageGraphTester(graph) { result in
@@ -442,7 +442,7 @@ final class WorkspaceTests: XCTestCase {
 
     /// Test that the remote repository is not resolved when a root package with same name is already present.
     func testRootAsDependency1() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -503,7 +503,7 @@ final class WorkspaceTests: XCTestCase {
 
     /// Test that a root package can be used as a dependency when the remote version was resolved previously.
     func testRootAsDependency2() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -581,7 +581,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testGraphRootDependencies() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -643,7 +643,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testCanResolveWithIncompatiblePins() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -739,7 +739,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testResolverCanHaveError() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -800,7 +800,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testPrecomputeResolution_empty() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
         let v1_5 = CheckoutState.version("1.0.5", revision: Revision(identifier: "hello"))
@@ -819,10 +819,10 @@ final class WorkspaceTests: XCTestCase {
             packages: []
         )
 
-        let bPackagePath = workspace.pathToPackage(withName: "B")
+        let bPackagePath = try workspace.pathToPackage(withName: "B")
         let bRef = PackageReference.localSourceControl(identity: PackageIdentity(path: bPackagePath), path: bPackagePath)
 
-        let cPackagePath = workspace.pathToPackage(withName: "C")
+        let cPackagePath = try workspace.pathToPackage(withName: "C")
         let cRef = PackageReference.localSourceControl(identity: PackageIdentity(path: cPackagePath), path: cPackagePath)
 
         try workspace.set(
@@ -840,7 +840,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testPrecomputeResolution_newPackages() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
         let v1Requirement: SourceControlRequirement = .range("1.0.0" ..< "2.0.0")
@@ -876,10 +876,10 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        let bPackagePath = workspace.pathToPackage(withName: "B")
+        let bPackagePath = try workspace.pathToPackage(withName: "B")
         let bRef = PackageReference.localSourceControl(identity: PackageIdentity(path: bPackagePath), path: bPackagePath)
 
-        let cPackagePath = workspace.pathToPackage(withName: "C")
+        let cPackagePath = try workspace.pathToPackage(withName: "C")
         let cRef = PackageReference.localSourceControl(identity: PackageIdentity(path: cPackagePath), path: cPackagePath)
 
         try workspace.set(
@@ -896,7 +896,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testPrecomputeResolution_requirementChange_versionToBranch() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
         let cPath = RelativePath("C")
@@ -934,10 +934,10 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        let bPackagePath = workspace.pathToPackage(withName: "B")
+        let bPackagePath = try workspace.pathToPackage(withName: "B")
         let bRef = PackageReference.localSourceControl(identity: PackageIdentity(path: bPackagePath), path: bPackagePath)
 
-        let cPackagePath = workspace.pathToPackage(withName: "C")
+        let cPackagePath = try workspace.pathToPackage(withName: "C")
         let cRef = PackageReference.localSourceControl(identity: PackageIdentity(path: cPackagePath), path: cPackagePath)
 
         try workspace.set(
@@ -959,7 +959,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testPrecomputeResolution_requirementChange_versionToRevision() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
         let cPath = RelativePath("C")
         let v1_5 = CheckoutState.version("1.0.5", revision: Revision(identifier: "hello"))
@@ -987,7 +987,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        let cPackagePath = testWorkspace.pathToPackage(withName: "C")
+        let cPackagePath = try testWorkspace.pathToPackage(withName: "C")
         let cRef = PackageReference.localSourceControl(identity: PackageIdentity(path: cPackagePath), path: cPackagePath)
 
         try testWorkspace.set(
@@ -1008,7 +1008,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testPrecomputeResolution_requirementChange_localToBranch() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
         let v1Requirement: SourceControlRequirement = .range("1.0.0" ..< "2.0.0")
@@ -1045,10 +1045,10 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        let bPackagePath = workspace.pathToPackage(withName: "B")
+        let bPackagePath = try workspace.pathToPackage(withName: "B")
         let bRef = PackageReference.localSourceControl(identity: PackageIdentity(path: bPackagePath), path: bPackagePath)
 
-        let cPackagePath = workspace.pathToPackage(withName: "C")
+        let cPackagePath = try workspace.pathToPackage(withName: "C")
         let cRef = PackageReference.localSourceControl(identity: PackageIdentity(path: cPackagePath), path: cPackagePath)
 
         try workspace.set(
@@ -1070,7 +1070,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testPrecomputeResolution_requirementChange_versionToLocal() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
         let cPath = RelativePath("C")
@@ -1107,10 +1107,10 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        let bPackagePath = workspace.pathToPackage(withName: "B")
+        let bPackagePath = try workspace.pathToPackage(withName: "B")
         let bRef = PackageReference.localSourceControl(identity: PackageIdentity(path: bPackagePath), path: bPackagePath)
 
-        let cPackagePath = workspace.pathToPackage(withName: "C")
+        let cPackagePath = try workspace.pathToPackage(withName: "C")
         let cRef = PackageReference.localSourceControl(identity: PackageIdentity(path: cPackagePath), path: cPackagePath)
 
         try workspace.set(
@@ -1132,7 +1132,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testPrecomputeResolution_requirementChange_branchToLocal() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
         let cPath = RelativePath("C")
@@ -1170,10 +1170,10 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        let bPackagePath = workspace.pathToPackage(withName: "B")
+        let bPackagePath = try workspace.pathToPackage(withName: "B")
         let bRef = PackageReference.localSourceControl(identity: PackageIdentity(path: bPackagePath), path: bPackagePath)
 
-        let cPackagePath = workspace.pathToPackage(withName: "C")
+        let cPackagePath = try workspace.pathToPackage(withName: "C")
         let cRef = PackageReference.localSourceControl(identity: PackageIdentity(path: cPackagePath), path: cPackagePath)
 
 
@@ -1196,7 +1196,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testPrecomputeResolution_other() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
         let cPath = RelativePath("C")
@@ -1234,10 +1234,10 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        let bPackagePath = workspace.pathToPackage(withName: "B")
+        let bPackagePath = try workspace.pathToPackage(withName: "B")
         let bRef = PackageReference.localSourceControl(identity: PackageIdentity(path: bPackagePath), path: bPackagePath)
 
-        let cPackagePath = workspace.pathToPackage(withName: "C")
+        let cPackagePath = try workspace.pathToPackage(withName: "C")
         let cRef = PackageReference.localSourceControl(identity: PackageIdentity(path: cPackagePath), path: cPackagePath)
 
         try workspace.set(
@@ -1258,7 +1258,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testPrecomputeResolution_notRequired() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
         let cPath = RelativePath("C")
@@ -1297,10 +1297,10 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        let bPackagePath = workspace.pathToPackage(withName: "B")
+        let bPackagePath = try workspace.pathToPackage(withName: "B")
         let bRef = PackageReference.localSourceControl(identity: PackageIdentity(path: bPackagePath), path: bPackagePath)
 
-        let cPackagePath = workspace.pathToPackage(withName: "C")
+        let cPackagePath = try workspace.pathToPackage(withName: "C")
         let cRef = PackageReference.localSourceControl(identity: PackageIdentity(path: cPackagePath), path: cPackagePath)
 
         try workspace.set(
@@ -1318,7 +1318,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testLoadingRootManifests() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -1342,7 +1342,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testUpdate() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -1440,7 +1440,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testUpdateDryRun() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -1509,7 +1509,7 @@ final class WorkspaceTests: XCTestCase {
             let stateChange = Workspace.PackageStateChange.updated(.init(requirement: .version(Version("1.5.0")), products: .everything))
             #endif
 
-            let path = AbsolutePath("/tmp/ws/pkgs/Foo")
+            let path = AbsolutePath(path: "/tmp/ws/pkgs/Foo")
             let expectedChange = (
                 PackageReference.localSourceControl(identity: PackageIdentity(path: path), path: path),
                 stateChange
@@ -1533,7 +1533,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testPartialUpdate() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -1637,7 +1637,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testCleanAndReset() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -1716,7 +1716,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDependencyManifestLoading() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -1786,7 +1786,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDependencyManifestsOrder() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -1852,7 +1852,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testBranchAndRevision() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -1895,7 +1895,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         // Get some revision identifier of Bar.
-        let bar = RepositorySpecifier(path: .init("/tmp/ws/pkgs/Bar"))
+        let bar = RepositorySpecifier(path: .init(path: "/tmp/ws/pkgs/Bar"))
         let barRevision = workspace.repositoryProvider.specifierMap[bar]!.revisions[0]
 
         // We request Bar via revision.
@@ -1916,7 +1916,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testResolve() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -1989,7 +1989,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDeletedCheckoutDirectory() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -2035,7 +2035,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testMinimumRequiredToolsVersionInDependencyResolution() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -2076,7 +2076,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testToolsVersionRootPackages() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -2109,7 +2109,7 @@ final class WorkspaceTests: XCTestCase {
             toolsVersion: .v4
         )
 
-        let roots = workspace.rootPaths(for: ["Foo", "Bar", "Baz"]).map { $0.appending(component: "Package.swift") }
+        let roots = try workspace.rootPaths(for: ["Foo", "Bar", "Baz"]).map { $0.appending(component: "Package.swift") }
 
         try fs.writeFileContents(roots[0], bytes: "// swift-tools-version:4.0")
         try fs.writeFileContents(roots[1], bytes: "// swift-tools-version:4.1.0")
@@ -2150,7 +2150,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testEditDependency() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -2236,7 +2236,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // Edit bar at a custom path and branch (ToT).
-        let barPath = AbsolutePath("/tmp/ws/custom/bar")
+        let barPath = AbsolutePath(path: "/tmp/ws/custom/bar")
         workspace.checkEdit(packageName: "Bar", path: barPath, checkoutBranch: "dev") { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
@@ -2258,7 +2258,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testMissingEditCanRestoreOriginalCheckout() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -2316,7 +2316,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testCanUneditRemovedDependencies() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -2387,7 +2387,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDependencyResolutionWithEdit() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -2508,7 +2508,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testPrefetchingWithOverridenPackage() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -2593,7 +2593,7 @@ final class WorkspaceTests: XCTestCase {
 
     // Test that changing a particular dependency re-resolves the graph.
     func testChangeOneDependency() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -2678,7 +2678,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testResolutionFailureWithEditedDependency() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -2758,7 +2758,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testStateModified() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -2844,7 +2844,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testSkipUpdate() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -2893,7 +2893,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testLocalDependencyBasics() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -2971,7 +2971,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testLocalDependencyTransitive() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -3030,7 +3030,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testLocalDependencyWithPackageUpdate() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -3094,7 +3094,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testMissingLocalDependencyDiagnostic() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -3129,7 +3129,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testRevisionVersionSwitch() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -3198,7 +3198,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testLocalVersionSwitch() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -3267,7 +3267,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testLocalLocalSwitch() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -3340,7 +3340,7 @@ final class WorkspaceTests: XCTestCase {
     // Test that switching between two same local packages placed at
     // different locations works correctly.
     func testDependencySwitchLocalWithSameIdentity() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -3411,7 +3411,7 @@ final class WorkspaceTests: XCTestCase {
     // Test that switching between two remote packages at
     // different locations works correctly.
     func testDependencySwitchRemoteWithSameIdentity() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -3487,7 +3487,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testResolvedFileUpdate() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -3545,7 +3545,7 @@ final class WorkspaceTests: XCTestCase {
         let fs = InMemoryFileSystem()
 
         for pair in [(ToolsVersion.v5_2, ToolsVersion.v5_2), (ToolsVersion.v5_6, ToolsVersion.v5_6), (ToolsVersion.v5_2, ToolsVersion.v5_6)] {
-            let sandbox = AbsolutePath("/tmp/ws/")
+            let sandbox = AbsolutePath(path: "/tmp/ws/")
             let workspace = try MockWorkspace(
                 sandbox: sandbox,
                 fileSystem: fs,
@@ -3602,7 +3602,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testResolvedFileStableCanonicalLocation() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -3795,7 +3795,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testPackageMirror() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let mirrors = DependencyMirrors()
@@ -3893,7 +3893,7 @@ final class WorkspaceTests: XCTestCase {
     // file for a transitive dependency whose URL is later changed to
     // something else, while keeping the same package identity.
     func testTransitiveDependencySwitchWithSameIdentity() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         // Use the same revision (hash) for "foo" to indicate they are the same
@@ -4031,7 +4031,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testForceResolveToResolvedVersions() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -4096,7 +4096,7 @@ final class WorkspaceTests: XCTestCase {
             let pinsStore = try ws.pinsStore.load()
             let fooPin = pinsStore.pins.first(where: { $0.packageRef.identity.description == "foo" })!
 
-            let fooRepo = workspace.repositoryProvider.specifierMap[RepositorySpecifier(path: AbsolutePath(fooPin.packageRef.locationString))]!
+            let fooRepo = workspace.repositoryProvider.specifierMap[RepositorySpecifier(path: try AbsolutePath(validating: fooPin.packageRef.locationString))]!
             let revision = try fooRepo.resolveRevision(tag: "1.0.0")
             let newState = PinsStore.PinState.version("1.0.0", revision: revision.identifier)
 
@@ -4147,7 +4147,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testForceResolveToResolvedVersionsDuplicateLocalDependency() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -4198,7 +4198,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testForceResolveWithNoResolvedFile() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -4249,7 +4249,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testForceResolveToResolvedVersionsLocalPackage() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -4341,7 +4341,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testRevisionDepOnLocal() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -4394,7 +4394,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testRootPackagesOverrideBasenameMismatch() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -4439,7 +4439,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testManagedDependenciesNotCaseSensitive() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -4527,7 +4527,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testUnsafeFlags() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -4601,7 +4601,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testEditDependencyHadOverridableConstraints() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -4702,7 +4702,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testTargetBasedDependency() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let barProducts: [MockProduct]
@@ -4806,7 +4806,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testLocalArchivedArtifactExtractionHappyPath() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         // create dummy xcframework and artifactbundle directories from the request archive
@@ -4909,17 +4909,17 @@ final class WorkspaceTests: XCTestCase {
         try fs.writeFileContents(bFrameworkArchivePath, bytes: ByteString([0xB0]))
 
         // Ensure that the artifacts do not exist yet
-        XCTAssertFalse(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/A/A1.xcframework")))
-        XCTAssertFalse(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/A/A2.artifactbundle")))
-        XCTAssertFalse(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/B/B.xcframework")))
+        XCTAssertFalse(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/A/A1.xcframework")))
+        XCTAssertFalse(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/A/A2.artifactbundle")))
+        XCTAssertFalse(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/B/B.xcframework")))
 
         try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
 
             // Ensure that the artifacts have been properly extracted
-            XCTAssertTrue(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/a/A1/A1.xcframework")))
-            XCTAssertTrue(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/a/A2/A2.artifactbundle")))
-            XCTAssertTrue(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/b/B/B.xcframework")))
+            XCTAssertTrue(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/a/A1/A1.xcframework")))
+            XCTAssertTrue(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/a/A2/A2.artifactbundle")))
+            XCTAssertTrue(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/b/B/B.xcframework")))
 
             // Ensure that the original archives have been untouched
             XCTAssertTrue(fs.exists(a1FrameworkArchivePath))
@@ -4928,15 +4928,15 @@ final class WorkspaceTests: XCTestCase {
 
             // Ensure that the temporary folders have been properly created
             XCTAssertEqual(archiver.extractions.map { $0.destinationPath.parentDirectory }.sorted(), [
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A1"),
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A2"),
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/b/B")
+                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A1"),
+                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A2"),
+                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/b/B")
             ])
 
             // Ensure that the temporary directories have been removed
-            XCTAssertTrue(try! fs.getDirectoryContents(AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A1")).isEmpty)
-            XCTAssertTrue(try! fs.getDirectoryContents(AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A2")).isEmpty)
-            XCTAssertTrue(try! fs.getDirectoryContents(AbsolutePath("/tmp/ws/.build/artifacts/extract/b/B")).isEmpty)
+            XCTAssertTrue(try! fs.getDirectoryContents(AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A1")).isEmpty)
+            XCTAssertTrue(try! fs.getDirectoryContents(AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A2")).isEmpty)
+            XCTAssertTrue(try! fs.getDirectoryContents(AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/b/B")).isEmpty)
         }
 
         workspace.checkManagedArtifacts { result in
@@ -4972,7 +4972,7 @@ final class WorkspaceTests: XCTestCase {
     // It ensures that all the appropriate clean-up operations are executed, and the workspace
     // contains the correct set of managed artifacts after the transition.
     func testLocalArchivedArtifactSourceTransitionPermutations() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let a1FrameworkName = "A1.xcframework"
@@ -5116,7 +5116,7 @@ final class WorkspaceTests: XCTestCase {
         try fs.writeFileContents(a4FrameworkArchivePath, bytes: ByteString([0xA4]))
 
         // Pin A to 1.0.0, Checkout B to 1.0.0
-        let aPath = workspace.pathToPackage(withName: "A")
+        let aPath = try workspace.pathToPackage(withName: "A")
         let aRef = PackageReference.localSourceControl(identity: PackageIdentity(path: aPath), path: aPath)
         let aRepo = workspace.repositoryProvider.specifierMap[RepositorySpecifier(path: aPath)]!
         let aRevision = try aRepo.resolveRevision(tag: "1.0.0")
@@ -5178,15 +5178,15 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertTrue(fs.exists(a4FrameworkArchivePath))
 
             // Ensure that the new artifacts have been properly extracted
-            XCTAssertTrue(fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/a/A1/\(a1FrameworkName)")))
-            XCTAssertTrue(fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/a/A3/\(a3FrameworkName)/local-archived")))
-            XCTAssertTrue(fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/a/A4/\(a4FrameworkName)/remote")))
+            XCTAssertTrue(fs.exists(try AbsolutePath(validating: "/tmp/ws/.build/artifacts/a/A1/\(a1FrameworkName)")))
+            XCTAssertTrue(fs.exists(try AbsolutePath(validating: "/tmp/ws/.build/artifacts/a/A3/\(a3FrameworkName)/local-archived")))
+            XCTAssertTrue(fs.exists(try AbsolutePath(validating: "/tmp/ws/.build/artifacts/a/A4/\(a4FrameworkName)/remote")))
 
             // Ensure that the old artifacts have been removed
-            XCTAssertFalse(fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/a/A2/\(a2FrameworkName)")))
-            XCTAssertFalse(fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/a/A3/\(a3FrameworkName)/remote")))
-            XCTAssertFalse(fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/a/A4/\(a4FrameworkName)/local-archived")))
-            XCTAssertFalse(fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/a/A5/\(a5FrameworkName)")))
+            XCTAssertFalse(fs.exists(try AbsolutePath(validating: "/tmp/ws/.build/artifacts/a/A2/\(a2FrameworkName)")))
+            XCTAssertFalse(fs.exists(try AbsolutePath(validating: "/tmp/ws/.build/artifacts/a/A3/\(a3FrameworkName)/remote")))
+            XCTAssertFalse(fs.exists(try AbsolutePath(validating: "/tmp/ws/.build/artifacts/a/A4/\(a4FrameworkName)/local-archived")))
+            XCTAssertFalse(fs.exists(try AbsolutePath(validating: "/tmp/ws/.build/artifacts/a/A5/\(a5FrameworkName)")))
         }
 
         workspace.checkManagedArtifacts { result in
@@ -5214,7 +5214,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testLocalArchivedArtifactNameDoesNotMatchTargetName() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         // create a dummy xcframework directory from the request archive
@@ -5254,7 +5254,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         // Create dummy zip files
-        let rootPath = workspace.pathToRoot(withName: "Root")
+        let rootPath = try workspace.pathToRoot(withName: "Root")
         let frameworksPath = rootPath.appending(component: "XCFrameworks")
         try fs.createDirectory(frameworksPath, recursive: true)
         try fs.writeFileContents(frameworksPath.appending(component: "archived-does-not-match-target-name.zip"), bytes: ByteString([0xA1]))
@@ -5265,7 +5265,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testLocalArchivedArtifactExtractionError() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let archiver = MockArchiver(handler: { _, _, destinationPath, completion in
@@ -5306,7 +5306,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testLocalArchiveDoesNotMatchTargetName() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         // create dummy xcframework and artifactbundle directories from the request archive
@@ -5351,7 +5351,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         // Create dummy zip files
-        let rootPath = workspace.pathToRoot(withName: "Root")
+        let rootPath = try workspace.pathToRoot(withName: "Root")
         let frameworksPath = rootPath.appending(component: "XCFrameworks")
         try fs.createDirectory(frameworksPath, recursive: true)
         try fs.writeFileContents(frameworksPath.appending(component: "A1.zip"), bytes: ByteString([0xA1]))
@@ -5379,7 +5379,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testLocalArchivedArtifactChecksumChange() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         // create dummy xcframework directories from the request archive
@@ -5425,7 +5425,7 @@ final class WorkspaceTests: XCTestCase {
             )
         )
 
-        let rootPath = workspace.pathToRoot(withName: "Root")
+        let rootPath = try workspace.pathToRoot(withName: "Root")
         let rootRef = PackageReference.root(identity: PackageIdentity(path: rootPath), path: rootPath)
 
         // Set an initial workspace state
@@ -5461,7 +5461,7 @@ final class WorkspaceTests: XCTestCase {
         try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             // Ensure that only the artifact archive with the changed checksum has been extracted
             XCTAssertEqual(archiver.extractions.map { $0.destinationPath.parentDirectory }.sorted(), [
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/root/A1")
+                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/A1")
             ])
         }
 
@@ -5480,7 +5480,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testLocalArchivedArtifactStripFirstComponent() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
 
@@ -5541,7 +5541,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         // create the mock archives
-        let rootPath = workspace.pathToRoot(withName: "Root")
+        let rootPath = try workspace.pathToRoot(withName: "Root")
         let archivesPath = rootPath.appending(components: "frameworks")
         try fs.createDirectory(archivesPath, recursive: true)
         try fs.writeFileContents(archivesPath.appending(component: "flat.zip"), bytes: ByteString([0x1]))
@@ -5549,17 +5549,17 @@ final class WorkspaceTests: XCTestCase {
         try fs.writeFileContents(archivesPath.appending(component: "nested2.zip"), bytes: ByteString([0x3]))
 
         // ensure that the artifacts do not exist yet
-        XCTAssertFalse(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/root/flat/flat.xcframework")))
-        XCTAssertFalse(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/root/nested/nested.artifactbundle")))
-        XCTAssertFalse(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/root/nested2/nested2.xcframework")))
+        XCTAssertFalse(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/root/flat/flat.xcframework")))
+        XCTAssertFalse(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/root/nested/nested.artifactbundle")))
+        XCTAssertFalse(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/root/nested2/nested2.xcframework")))
 
         try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/root")))
+            XCTAssert(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/root")))
             XCTAssertEqual(archiver.extractions.map { $0.destinationPath.parentDirectory }.sorted(), [
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/root/flat"),
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/root/nested"),
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/root/nested2"),
+                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/flat"),
+                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/nested"),
+                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/nested2"),
             ])
         }
 
@@ -5583,7 +5583,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testLocalArtifactHappyPath() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -5608,7 +5608,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        let rootPath = workspace.pathToRoot(withName: "Root")
+        let rootPath = try workspace.pathToRoot(withName: "Root")
 
         // make sure the directory exist in their destined location
         try createDummyXCFramework(fileSystem: fs, path: rootPath.appending(component: "XCFrameworks"), name: "A1")
@@ -5633,7 +5633,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testLocalArtifactDoesNotExist() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -5667,7 +5667,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testArtifactDownloadHappyPath() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
         let downloads = ThreadSafeKeyValueStore<URL, AbsolutePath>()
 
@@ -5790,8 +5790,8 @@ final class WorkspaceTests: XCTestCase {
 
         try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/a")))
-            XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/b")))
+            XCTAssert(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/a")))
+            XCTAssert(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/b")))
             XCTAssertEqual(downloads.map { $0.key.absoluteString }.sorted(), [
                 "https://a.com/a1.zip",
                 "https://a.com/a2.zip",
@@ -5803,9 +5803,9 @@ final class WorkspaceTests: XCTestCase {
                 ByteString([0xB0]).hexadecimalRepresentation,
             ])
             XCTAssertEqual(archiver.extractions.map { $0.destinationPath.parentDirectory }.sorted(), [
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A1"),
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A2"),
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/b/B")
+                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A1"),
+                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A2"),
+                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/b/B")
             ])
             XCTAssertEqual(
                 downloads.map { $0.value }.sorted(),
@@ -5849,7 +5849,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testArtifactDownloadWithPreviousState() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
         let downloads = ThreadSafeKeyValueStore<URL, AbsolutePath>()
 
@@ -6005,7 +6005,7 @@ final class WorkspaceTests: XCTestCase {
         try createDummyXCFramework(fileSystem: fs, path: a4FrameworkPath.parentDirectory, name: "A4")
 
         // Pin A to 1.0.0, Checkout B to 1.0.0
-        let aPath = workspace.pathToPackage(withName: "A")
+        let aPath = try workspace.pathToPackage(withName: "A")
         let aRef = PackageReference.localSourceControl(identity: PackageIdentity(path: aPath), path: aPath)
         let aRepo = workspace.repositoryProvider.specifierMap[RepositorySpecifier(path: aPath)]!
         let aRevision = try aRepo.resolveRevision(tag: "1.0.0")
@@ -6075,14 +6075,14 @@ final class WorkspaceTests: XCTestCase {
             testDiagnostics(diagnostics) { result in
                 result.check(diagnostic: "downloaded archive of binary target 'A3' from 'https://a.com/a3.zip' does not contain a binary artifact.", severity: .error)
             }
-            XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/b")))
-            XCTAssert(fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/a/A1/A1.xcframework")))
-            XCTAssert(fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/a/A2/A2.xcframework")))
-            XCTAssert(!fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/a/A3/A3.xcframework")))
-            XCTAssert(!fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/a/A4/A4.xcframework")))
-            XCTAssert(!fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/a/A5/A5.xcframework")))
-            XCTAssert(fs.exists(AbsolutePath("/tmp/ws/pkgs/a/XCFrameworks/A7.xcframework")))
-            XCTAssert(!fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/Foo")))
+            XCTAssert(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/b")))
+            XCTAssert(fs.exists(AbsolutePath(path: "/tmp/ws/.build/artifacts/a/A1/A1.xcframework")))
+            XCTAssert(fs.exists(AbsolutePath(path: "/tmp/ws/.build/artifacts/a/A2/A2.xcframework")))
+            XCTAssert(!fs.exists(AbsolutePath(path: "/tmp/ws/.build/artifacts/a/A3/A3.xcframework")))
+            XCTAssert(!fs.exists(AbsolutePath(path: "/tmp/ws/.build/artifacts/a/A4/A4.xcframework")))
+            XCTAssert(!fs.exists(AbsolutePath(path: "/tmp/ws/.build/artifacts/a/A5/A5.xcframework")))
+            XCTAssert(fs.exists(AbsolutePath(path: "/tmp/ws/pkgs/a/XCFrameworks/A7.xcframework")))
+            XCTAssert(!fs.exists(AbsolutePath(path: "/tmp/ws/.build/artifacts/Foo")))
             XCTAssertEqual(downloads.map { $0.key.absoluteString }.sorted(), [
                 "https://a.com/a2.zip",
                 "https://a.com/a3.zip",
@@ -6096,10 +6096,10 @@ final class WorkspaceTests: XCTestCase {
                 ByteString([0xB0]).hexadecimalRepresentation,
             ])
             XCTAssertEqual(archiver.extractions.map { $0.destinationPath.parentDirectory }.sorted(), [
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A2"),
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A3"),
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A7"),
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/b/B"),
+                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A2"),
+                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A3"),
+                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A7"),
+                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/b/B"),
             ])
             XCTAssertEqual(
                 downloads.map { $0.value }.sorted(),
@@ -6151,7 +6151,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testArtifactDownloadTwice() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
         let downloads = ThreadSafeArrayStore<(URL, AbsolutePath)>()
 
@@ -6229,7 +6229,7 @@ final class WorkspaceTests: XCTestCase {
 
         try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/root")))
+            XCTAssert(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/root")))
             XCTAssertEqual(workspace.checksumAlgorithm.hashes.map{ $0.hexadecimalRepresentation }.sorted(), [
                 ByteString([0xA1]).hexadecimalRepresentation,
             ])
@@ -6239,7 +6239,7 @@ final class WorkspaceTests: XCTestCase {
             "https://a.com/a1.zip",
         ])
         XCTAssertEqual(archiver.extractions.map { $0.destinationPath.parentDirectory }.sorted(), [
-            AbsolutePath("/tmp/ws/.build/artifacts/extract/root/A1"),
+            AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/A1"),
         ])
         XCTAssertEqual(
             downloads.map { $0.1 }.sorted(),
@@ -6254,7 +6254,7 @@ final class WorkspaceTests: XCTestCase {
 
         try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/root")))
+            XCTAssert(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/root")))
 
             XCTAssertEqual(workspace.checksumAlgorithm.hashes.map{ $0.hexadecimalRepresentation }.sorted(), [
                 ByteString([0xA1]).hexadecimalRepresentation, ByteString([0xA1]).hexadecimalRepresentation,
@@ -6265,8 +6265,8 @@ final class WorkspaceTests: XCTestCase {
             "https://a.com/a1.zip", "https://a.com/a1.zip",
         ])
         XCTAssertEqual(archiver.extractions.map { $0.destinationPath.parentDirectory }.sorted(), [
-            AbsolutePath("/tmp/ws/.build/artifacts/extract/root/A1"),
-            AbsolutePath("/tmp/ws/.build/artifacts/extract/root/A1"),
+            AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/A1"),
+            AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/A1"),
         ])
         XCTAssertEqual(
             downloads.map { $0.1 }.sorted(),
@@ -6276,7 +6276,7 @@ final class WorkspaceTests: XCTestCase {
 
     func testArtifactDownloadServerError() throws {
         let fs = InMemoryFileSystem()
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         try fs.createDirectory(sandbox, recursive: true)
 
         let httpClient = HTTPClient(handler: { request, _, completion in
@@ -6326,12 +6326,12 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // make sure artifact downloaded is deleted
-        XCTAssertTrue(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/root")))
-        XCTAssertFalse(fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/root/a.zip")))
+        XCTAssertTrue(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/root")))
+        XCTAssertFalse(fs.exists(AbsolutePath(path: "/tmp/ws/.build/artifacts/root/a.zip")))
     }
 
     func testArtifactDownloaderOrArchiverError() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         // returns a dummy zipfile for the requested artifact
@@ -6359,7 +6359,7 @@ final class WorkspaceTests: XCTestCase {
         })
 
         let archiver = MockArchiver(handler: { _, _, destinationPath, completion in
-            XCTAssertEqual(destinationPath.parentDirectory, AbsolutePath("/tmp/ws/.build/artifacts/extract/root/A2"))
+            XCTAssertEqual(destinationPath.parentDirectory, AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/A2"))
             completion(.failure(DummyError()))
         })
 
@@ -6407,7 +6407,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDownloadedArtifactNotAnArchiveError() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         // returns a dummy zipfile for the requested artifact
@@ -6507,7 +6507,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDownloadedArtifactInvalid() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         // returns a dummy zipfile for the requested artifact
@@ -6576,7 +6576,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDownloadedArtifactDoesNotMatchTargetName() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         // returns a dummy zipfile for the requested artifact
@@ -6654,7 +6654,7 @@ final class WorkspaceTests: XCTestCase {
 
     func testArtifactChecksum() throws {
         let fs = InMemoryFileSystem()
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         try fs.createDirectory(sandbox, recursive: true)
 
         let checksumAlgorithm = MockHashAlgorithm()
@@ -6705,7 +6705,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDownloadedArtifactChecksumChange() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let httpClient = HTTPClient(handler: { request, _, completion in
@@ -6728,7 +6728,7 @@ final class WorkspaceTests: XCTestCase {
             )
         )
 
-        let rootPath = workspace.pathToRoot(withName: "Root")
+        let rootPath = try workspace.pathToRoot(withName: "Root")
         let rootRef = PackageReference.root(identity: PackageIdentity(path: rootPath), path: rootPath)
 
         try workspace.set(
@@ -6754,7 +6754,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDownloadedArtifactChecksumChangeURLChange() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let httpClient = HTTPClient(handler: { request, _, completion in
@@ -6820,7 +6820,7 @@ final class WorkspaceTests: XCTestCase {
             )
         )
 
-        let rootPath = workspace.pathToRoot(withName: "Root")
+        let rootPath = try workspace.pathToRoot(withName: "Root")
         let rootRef = PackageReference.root(identity: PackageIdentity(path: rootPath), path: rootPath)
 
         try workspace.set(
@@ -6844,7 +6844,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testArtifactDownloadAddsAcceptHeader() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
         let downloads = ThreadSafeKeyValueStore<URL, AbsolutePath>()
         var acceptHeaders: [String] = []
@@ -6925,7 +6925,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDownloadedArtifactTransitive() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
         let downloads = ThreadSafeKeyValueStore<URL, AbsolutePath>()
 
@@ -7067,7 +7067,7 @@ final class WorkspaceTests: XCTestCase {
 
         try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/a")))
+            XCTAssert(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/a")))
             XCTAssertEqual(downloads.map { $0.key.absoluteString }.sorted(), [
                 "https://a.com/a.zip"
             ])
@@ -7075,7 +7075,7 @@ final class WorkspaceTests: XCTestCase {
                 ByteString([0xA]).hexadecimalRepresentation
             ])
             XCTAssertEqual(archiver.extractions.map { $0.destinationPath.parentDirectory }.sorted(), [
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A")
+                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A")
             ])
             XCTAssertEqual(
                 downloads.map { $0.value }.sorted(),
@@ -7097,7 +7097,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDownloadedArtifactArchiveExists() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
         // this relies on internal knowledge of the destination path construction
         let expectedDownloadDestination = sandbox.appending(components: ".build", "artifacts", "root", "binary", "binary.zip")
@@ -7204,7 +7204,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDownloadedArtifactConcurrency() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let maxConcurrentRequests = 2
@@ -7321,7 +7321,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDownloadedArtifactStripFirstComponent() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
         let downloads = ThreadSafeKeyValueStore<URL, AbsolutePath>()
 
@@ -7423,7 +7423,7 @@ final class WorkspaceTests: XCTestCase {
 
         try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/root")))
+            XCTAssert(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/root")))
             XCTAssertEqual(downloads.map { $0.key.absoluteString }.sorted(), [
                 "https://a.com/flat.zip",
                 "https://a.com/nested.zip",
@@ -7435,9 +7435,9 @@ final class WorkspaceTests: XCTestCase {
                 ByteString([0x03]).hexadecimalRepresentation,
             ])
             XCTAssertEqual(archiver.extractions.map { $0.destinationPath.parentDirectory }.sorted(), [
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/root/flat"),
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/root/nested"),
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/root/nested2"),
+                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/flat"),
+                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/nested"),
+                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/nested2"),
             ])
             XCTAssertEqual(
                 downloads.map { $0.value }.sorted(),
@@ -7474,7 +7474,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testArtifactMultipleExtensions() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
         let downloads = ThreadSafeKeyValueStore<URL, AbsolutePath>()
 
@@ -7568,8 +7568,8 @@ final class WorkspaceTests: XCTestCase {
                 ByteString([0xA2]).hexadecimalRepresentation,
             ])
             XCTAssertEqual(archiver.extractions.map { $0.destinationPath.parentDirectory }.sorted(), [
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/root/A1"),
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/root/A2"),
+                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/A1"),
+                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/A2"),
             ])
             XCTAssertEqual(
                 downloads.map { $0.value }.sorted(),
@@ -7598,7 +7598,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testLoadRootPackageWithBinaryDependencies() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
 
@@ -7646,7 +7646,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDownloadArchiveIndexFilesHappyPath() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
         let downloads = ThreadSafeKeyValueStore<URL, AbsolutePath>()
         let hostToolchain = try UserToolchain(destination: .hostDestination())
@@ -7817,8 +7817,8 @@ final class WorkspaceTests: XCTestCase {
 
         try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/a")))
-            XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/b")))
+            XCTAssert(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/a")))
+            XCTAssert(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/b")))
             XCTAssertEqual(downloads.map { $0.key.absoluteString }.sorted(), [
                 "https://a.com/a1.zip",
                 "https://a.com/a2/a2.zip",
@@ -7836,9 +7836,9 @@ final class WorkspaceTests: XCTestCase {
                 ).map{ $0.hexadecimalRepresentation }.sorted()
             )
             XCTAssertEqual(archiver.extractions.map { $0.destinationPath.parentDirectory }.sorted(), [
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A1"),
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A2"),
-                AbsolutePath("/tmp/ws/.build/artifacts/extract/b/B"),
+                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A1"),
+                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A2"),
+                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/b/B"),
             ])
             XCTAssertEqual(
                 downloads.map { $0.value }.sorted(),
@@ -7882,7 +7882,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDownloadArchiveIndexServerError() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         // returns a dummy files for the requested artifact
@@ -7914,7 +7914,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDownloadArchiveIndexFileBadChecksum() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
         let hostToolchain = try UserToolchain(destination: .hostDestination())
 
@@ -7973,7 +7973,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDownloadArchiveIndexFileChecksumChanges() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -7989,7 +7989,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        let rootPath = workspace.pathToRoot(withName: "Root")
+        let rootPath = try workspace.pathToRoot(withName: "Root")
         let rootRef = PackageReference.root(identity: PackageIdentity(path: rootPath), path: rootPath)
 
         try workspace.set(
@@ -8015,7 +8015,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDownloadArchiveIndexFileBadArchivesChecksum() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
         let hostToolchain = try UserToolchain(destination: .hostDestination())
 
@@ -8114,7 +8114,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDownloadArchiveIndexFileArchiveNotFound() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
         let hostToolchain = try UserToolchain(destination: .hostDestination())
 
@@ -8179,7 +8179,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDownloadArchiveIndexTripleNotFound() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let hostToolchain = try UserToolchain(destination: .hostDestination())
@@ -8241,7 +8241,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDuplicateDependencyIdentityWithNameAtRoot() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -8302,7 +8302,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDuplicateDependencyIdentityWithoutNameAtRoot() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -8363,7 +8363,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDuplicateExplicitDependencyName_AtRoot() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -8424,7 +8424,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDuplicateManifestNameAtRoot() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -8479,7 +8479,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDuplicateManifestName_ExplicitProductPackage_AtRoot() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -8534,7 +8534,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testManifestNameAndIdentityConflict_AtRoot_Pre52() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -8589,7 +8589,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testManifestNameAndIdentityConflict_AtRoot_Post52_Incorrect() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -8653,7 +8653,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testManifestNameAndIdentityConflict_AtRoot_Post52_Correct() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -8708,7 +8708,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testManifestNameAndIdentityConflict_ExplicitDependencyNames_AtRoot() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -8768,7 +8768,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testManifestNameAndIdentityConflict_ExplicitDependencyNames_ExplicitProductPackage_AtRoot() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -8828,7 +8828,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDuplicateTransitiveIdentityWithNames() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -8905,7 +8905,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDuplicateTransitiveIdentityWithoutNames() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -8990,7 +8990,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDuplicateTransitiveIdentitySimilarURLs1() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -9062,7 +9062,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDuplicateTransitiveIdentitySimilarURLs2() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -9134,7 +9134,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDuplicateTransitiveIdentityGitHubURLs1() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -9206,7 +9206,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDuplicateTransitiveIdentityGitHubURLs2() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -9278,7 +9278,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDuplicateTransitiveIdentityUnfamiliarURLs() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -9357,7 +9357,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDuplicateTransitiveIdentityWithSimilarURLs() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -9467,7 +9467,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDuplicateNestedTransitiveIdentityWithNames() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -9549,7 +9549,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDuplicateNestedTransitiveIdentityWithoutNames() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -9633,7 +9633,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testRootPathConflictsWithTransitiveIdentity() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -9700,7 +9700,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testResolutionBranchAndVersion() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -9791,7 +9791,7 @@ final class WorkspaceTests: XCTestCase {
                     """
             }
 
-            let manifestLoader = ManifestLoader(toolchain: UserToolchain.default)
+            let manifestLoader = try ManifestLoader(toolchain: UserToolchain.default)
             let sandbox = path.appending(component: "ws")
             let workspace = try Workspace(
                 fileSystem: fs,
@@ -9901,7 +9901,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testBasicResolutionFromSourceControl() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -9983,7 +9983,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testBasicTransitiveResolutionFromSourceControl() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -10095,7 +10095,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testBasicResolutionFromRegistry() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -10177,7 +10177,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testBasicTransitiveResolutionFromRegistry() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -10290,7 +10290,7 @@ final class WorkspaceTests: XCTestCase {
 
     // no dups
     func testResolutionMixedRegistryAndSourceControl1() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -10418,7 +10418,7 @@ final class WorkspaceTests: XCTestCase {
 
     // duplicate package at root level
     func testResolutionMixedRegistryAndSourceControl2() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -10528,7 +10528,7 @@ final class WorkspaceTests: XCTestCase {
     // mixed graph root --> dep1 scm
     //                  --> dep2 scm --> dep1 registry
     func testResolutionMixedRegistryAndSourceControl3() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -10697,7 +10697,7 @@ final class WorkspaceTests: XCTestCase {
     // mixed graph root --> dep1 scm
     //                  --> dep2 registry --> dep1 registry
     func testResolutionMixedRegistryAndSourceControl4() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -10841,7 +10841,7 @@ final class WorkspaceTests: XCTestCase {
     // mixed graph root --> dep1 scm
     //                  --> dep2 scm --> dep1 registry incompatible version
     func testResolutionMixedRegistryAndSourceControl5() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -10974,7 +10974,7 @@ final class WorkspaceTests: XCTestCase {
     // mixed graph root --> dep1 registry
     //                  --> dep2 registry --> dep1 scm
     func testResolutionMixedRegistryAndSourceControl6() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -11118,7 +11118,7 @@ final class WorkspaceTests: XCTestCase {
     // mixed graph root --> dep1 registry
     //                  --> dep2 registry --> dep1 scm incompatible version
     func testResolutionMixedRegistryAndSourceControl7() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -11251,7 +11251,7 @@ final class WorkspaceTests: XCTestCase {
     // mixed graph root --> dep1 registry --> dep3 scm
     //                  --> dep2 registry --> dep3 registry
     func testResolutionMixedRegistryAndSourceControl8() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -11416,7 +11416,7 @@ final class WorkspaceTests: XCTestCase {
     // mixed graph root --> dep1 registry --> dep3 scm
     //                  --> dep2 registry --> dep3 registry incompatible version
     func testResolutionMixedRegistryAndSourceControl9() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -11565,7 +11565,7 @@ final class WorkspaceTests: XCTestCase {
     // mixed graph root --> dep1 scm branch
     //                  --> dep2 registry --> dep1 registry
     func testResolutionMixedRegistryAndSourceControl10() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -11714,7 +11714,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testCustomPackageContainerProvider() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let customFS = InMemoryFileSystem()
@@ -11722,7 +11722,7 @@ final class WorkspaceTests: XCTestCase {
         try customFS.writeFileContents(.root.appending(component: Manifest.filename), bytes: "")
         try ToolsVersionSpecificationWriter.rewriteSpecification(manifestDirectory: .root, toolsVersion: .current, fileSystem: customFS)
         // write the sources
-        let sourcesDir = AbsolutePath("/Sources")
+        let sourcesDir = AbsolutePath(path: "/Sources")
         let targetDir = sourcesDir.appending(component: "Baz")
         try customFS.createDirectory(targetDir, recursive: true)
         try customFS.writeFileContents(targetDir.appending(component: "file.swift"), bytes: "")
@@ -11731,7 +11731,7 @@ final class WorkspaceTests: XCTestCase {
         let bazPackageReference = PackageReference(identity: PackageIdentity(url: bazURL), kind: .remoteSourceControl(bazURL))
         let bazContainer = MockPackageContainer(package: bazPackageReference, dependencies: ["1.0.0": []], fileSystem: customFS, customRetrievalPath: .root)
 
-        let fooPath = AbsolutePath("/tmp/ws/Foo")
+        let fooPath = AbsolutePath(path: "/tmp/ws/Foo")
         let fooPackageReference = PackageReference(identity: PackageIdentity(path: fooPath), kind: .root(fooPath))
         let fooContainer = MockPackageContainer(package: fooPackageReference)
 
@@ -11791,7 +11791,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testRegistryMissingConfigurationErrors() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let registryClient = try makeRegistryClient(
@@ -11843,7 +11843,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testRegistryReleasesServerErrors() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -11919,7 +11919,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testRegistryReleaseChecksumServerErrors() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -11995,7 +11995,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testRegistryManifestServerErrors() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -12071,7 +12071,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testRegistryDownloadServerErrors() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -12147,7 +12147,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testRegistryArchiveErrors() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -22,7 +22,7 @@ import XCBuildSupport
 import XCTest
 
 class PIFBuilderTests: XCTestCase {
-    let inputsDir = AbsolutePath(#file).parentDirectory.appending(components: "Inputs")
+    let inputsDir = AbsolutePath(path: #file).parentDirectory.appending(components: "Inputs")
 
     func testOrdering() throws {
         #if !os(macOS)
@@ -44,7 +44,7 @@ class PIFBuilderTests: XCTestCase {
                 manifests: [
                     Manifest.createLocalSourceControlManifest(
                         name: "B",
-                        path: .init("/B"),
+                        path: .init(path: "/B"),
                         toolsVersion: .v5_2,
                         products: [
                             .init(name: "bexe", type: .executable, targets: ["B1"]),
@@ -56,10 +56,10 @@ class PIFBuilderTests: XCTestCase {
                         ]),
                     Manifest.createRootManifest(
                         name: "A",
-                        path: .init("/A"),
+                        path: .init(path: "/A"),
                         toolsVersion: .v5_2,
                         dependencies: [
-                            .localSourceControl(path: .init("/B"), requirement: .branch("master")),
+                            .localSourceControl(path: .init(path: "/B"), requirement: .branch("master")),
                         ],
                         products: [
                             .init(name: "alib", type: .library(.static), targets: ["A2"]),
@@ -115,12 +115,12 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createManifest(
                     name: "Foo",
-                    path: .init("/Foo"),
-                    packageKind: .root(.init("/Foo")),
+                    path: .init(path: "/Foo"),
+                    packageKind: .root(.init(path: "/Foo")),
                     defaultLocalization: "fr",
                     toolsVersion: .v5_2,
                     dependencies: [
-                        .localSourceControl(path: .init("/Bar"), requirement: .branch("master")),
+                        .localSourceControl(path: .init(path: "/Bar"), requirement: .branch("master")),
                     ],
                     targets: [
                         .init(name: "foo", dependencies: [.product(name: "BarLib", package: "Bar")]),
@@ -128,7 +128,7 @@ class PIFBuilderTests: XCTestCase {
                     ]),
                 Manifest.createLocalSourceControlManifest(
                     name: "Bar",
-                    path: .init("/Bar"),
+                    path: .init(path: "/Bar"),
                     platforms: [
                         PlatformDescription(name: "macos", version: "10.14"),
                         PlatformDescription(name: "ios", version: "12"),
@@ -158,8 +158,8 @@ class PIFBuilderTests: XCTestCase {
 
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        PIFTester(pif) { workspace in
-            workspace.checkProject("PACKAGE:/Foo") { project in
+        try PIFTester(pif) { workspace in
+            try workspace.checkProject("PACKAGE:/Foo") { project in
                 XCTAssertEqual(project.path.pathString, "/Foo")
                 XCTAssertEqual(project.projectDirectory.pathString, "/Foo")
                 XCTAssertEqual(project.name, "Foo")
@@ -262,7 +262,7 @@ class PIFBuilderTests: XCTestCase {
                 }
             }
 
-            workspace.checkProject("PACKAGE:/Bar") { project in
+            try workspace.checkProject("PACKAGE:/Bar") { project in
                 XCTAssertEqual(project.path.pathString, "/Bar")
                 XCTAssertEqual(project.projectDirectory.pathString, "/Bar")
                 XCTAssertEqual(project.name, "Bar")
@@ -364,7 +364,7 @@ class PIFBuilderTests: XCTestCase {
                 }
             }
 
-            workspace.checkProject("AGGREGATE") { project in
+            try workspace.checkProject("AGGREGATE") { project in
                 project.checkAggregateTarget("ALL-EXCLUDING-TESTS") { target in
                     XCTAssertEqual(target.name, PIFBuilder.allExcludingTestsTargetName)
                     XCTAssertEqual(target.dependencies, ["PACKAGE-PRODUCT:foo"])
@@ -398,11 +398,11 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
-                    path: .init("/Foo"),
+                    path: .init(path: "/Foo"),
                     toolsVersion: .v5_2,
                     swiftLanguageVersions: [.v4_2, .v5],
                     dependencies: [
-                        .localSourceControl(path: .init("/Bar"), requirement: .branch("master")),
+                        .localSourceControl(path: .init(path: "/Bar"), requirement: .branch("master")),
                     ],
                     targets: [
                         .init(name: "foo", dependencies: [
@@ -420,7 +420,7 @@ class PIFBuilderTests: XCTestCase {
                     ]),
                 Manifest.createLocalSourceControlManifest(
                     name: "Bar",
-                    path: .init("/Bar"),
+                    path: .init(path: "/Bar"),
                     toolsVersion: .v4_2,
                     cLanguageStandard: "c11",
                     cxxLanguageStandard: "c++14",
@@ -440,7 +440,7 @@ class PIFBuilderTests: XCTestCase {
         )
 
         var pif: PIF.TopLevelObject!
-        try! withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
+        try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
             let builder = PIFBuilder(
                 graph: graph,
                 parameters: .mock(),
@@ -452,8 +452,8 @@ class PIFBuilderTests: XCTestCase {
 
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        PIFTester(pif) { workspace in
-            workspace.checkProject("PACKAGE:/Foo") { project in
+        try PIFTester(pif) { workspace in
+            try workspace.checkProject("PACKAGE:/Foo") { project in
 
                 // Root Swift executable target
 
@@ -590,7 +590,7 @@ class PIFBuilderTests: XCTestCase {
                 }
             }
 
-            workspace.checkProject("PACKAGE:/Bar") { project in
+            try workspace.checkProject("PACKAGE:/Bar") { project in
 
                 // Non-root Swift executable target
 
@@ -732,11 +732,11 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
-                    path: .init("/Foo"),
+                    path: .init(path: "/Foo"),
                     toolsVersion: .v5_2,
                     swiftLanguageVersions: [.v4_2, .v5],
                     dependencies: [
-                        .localSourceControl(path: .init("/Bar"), requirement: .branch("master")),
+                        .localSourceControl(path: .init(path: "/Bar"), requirement: .branch("master")),
                     ],
                     targets: [
                         .init(name: "FooTests", dependencies: [
@@ -754,7 +754,7 @@ class PIFBuilderTests: XCTestCase {
                     ]),
                 Manifest.createLocalSourceControlManifest(
                     name: "Bar",
-                    path: .init("/Bar"),
+                    path: .init(path: "/Bar"),
                     toolsVersion: .v4_2,
                     cLanguageStandard: "c11",
                     cxxLanguageStandard: "c++14",
@@ -775,7 +775,7 @@ class PIFBuilderTests: XCTestCase {
         )
 
         var pif: PIF.TopLevelObject!
-        try! withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
+        try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
             let builder = PIFBuilder(
                 graph: graph,
                 parameters: .mock(),
@@ -787,8 +787,8 @@ class PIFBuilderTests: XCTestCase {
 
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        PIFTester(pif) { workspace in
-            workspace.checkProject("PACKAGE:/Foo") { project in
+        try PIFTester(pif) { workspace in
+            try workspace.checkProject("PACKAGE:/Foo") { project in
                 project.checkTarget("PACKAGE-PRODUCT:FooTests") { target in
                     XCTAssertEqual(target.name, "FooTests_-5E24708DC81AF5C1_PackageProduct")
                     XCTAssertEqual(target.productType, .unitTest)
@@ -956,7 +956,7 @@ class PIFBuilderTests: XCTestCase {
                 }
             }
 
-            workspace.checkProject("PACKAGE:/Bar") { project in
+            try workspace.checkProject("PACKAGE:/Bar") { project in
                 project.checkNoTarget("PACKAGE-PRODUCT:BarTests")
                 project.checkNoTarget("PACKAGE-PRODUCT:CBarTests")
             }
@@ -980,11 +980,11 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
-                    path: .init("/Foo"),
+                    path: .init(path: "/Foo"),
                     toolsVersion: .v5_2,
                     swiftLanguageVersions: [.v4_2, .v5],
                     dependencies: [
-                        .localSourceControl(path: .init("/Bar"), requirement: .branch("master")),
+                        .localSourceControl(path: .init(path: "/Bar"), requirement: .branch("master")),
                     ],
                     products: [
                         .init(name: "FooLib1", type: .library(.static), targets: ["FooLib1"]),
@@ -999,7 +999,7 @@ class PIFBuilderTests: XCTestCase {
                     ]),
                 Manifest.createLocalSourceControlManifest(
                     name: "Bar",
-                    path: .init("/Bar"),
+                    path: .init(path: "/Bar"),
                     toolsVersion: .v4_2,
                     cLanguageStandard: "c11",
                     cxxLanguageStandard: "c++14",
@@ -1015,7 +1015,7 @@ class PIFBuilderTests: XCTestCase {
         )
 
         var pif: PIF.TopLevelObject!
-        try! withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
+        try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
             let builder = PIFBuilder(
                 graph: graph,
                 parameters: .mock(),
@@ -1027,8 +1027,8 @@ class PIFBuilderTests: XCTestCase {
 
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        PIFTester(pif) { workspace in
-            workspace.checkProject("PACKAGE:/Foo") { project in
+        try PIFTester(pif) { workspace in
+            try workspace.checkProject("PACKAGE:/Foo") { project in
                 project.checkTarget("PACKAGE-PRODUCT:FooLib1") { target in
                     XCTAssertEqual(target.name, "FooLib1_32B0F01AD0DD0FF3_PackageProduct")
                     XCTAssertEqual(target.productType, .packageProduct)
@@ -1102,7 +1102,7 @@ class PIFBuilderTests: XCTestCase {
                 }
             }
 
-            workspace.checkProject("PACKAGE:/Bar") { project in
+            try workspace.checkProject("PACKAGE:/Bar") { project in
                 project.checkTarget("PACKAGE-PRODUCT:BarLib") { target in
                     XCTAssertEqual(target.name, "BarLib_175D063FAE17B2_PackageProduct")
                     XCTAssertEqual(target.productType, .framework)
@@ -1182,12 +1182,12 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
-                    path: .init("/Foo"),
+                    path: .init(path: "/Foo"),
                     toolsVersion: .v5_2,
                     cxxLanguageStandard: "c++14",
                     swiftLanguageVersions: [.v4_2, .v5],
                     dependencies: [
-                        .localSourceControl(path: .init("/Bar"), requirement: .branch("master")),
+                        .localSourceControl(path: .init(path: "/Bar"), requirement: .branch("master")),
                     ],
                     targets: [
                         .init(name: "FooLib1", dependencies: ["SystemLib", "FooLib2"]),
@@ -1198,7 +1198,7 @@ class PIFBuilderTests: XCTestCase {
                     ]),
                 Manifest.createLocalSourceControlManifest(
                     name: "Bar",
-                    path: .init("/Bar"),
+                    path: .init(path: "/Bar"),
                     toolsVersion: .v4_2,
                     cLanguageStandard: "c11",
                     swiftLanguageVersions: [.v4_2],
@@ -1213,7 +1213,7 @@ class PIFBuilderTests: XCTestCase {
         )
 
         var pif: PIF.TopLevelObject!
-        try! withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
+        try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
             let builder = PIFBuilder(
                 graph: graph,
                 parameters: .mock(),
@@ -1225,8 +1225,8 @@ class PIFBuilderTests: XCTestCase {
 
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        PIFTester(pif) { workspace in
-            workspace.checkProject("PACKAGE:/Foo") { project in
+        try PIFTester(pif) { workspace in
+            try workspace.checkProject("PACKAGE:/Foo") { project in
                 project.checkTarget("PACKAGE-TARGET:FooLib1") { target in
                     XCTAssertEqual(target.name, "FooLib1")
                     XCTAssertEqual(target.productType, .objectFile)
@@ -1382,7 +1382,7 @@ class PIFBuilderTests: XCTestCase {
                 }
             }
 
-            workspace.checkProject("PACKAGE:/Bar") { project in
+            try workspace.checkProject("PACKAGE:/Bar") { project in
                 project.checkTarget("PACKAGE-TARGET:BarLib") { target in
                     XCTAssertEqual(target.name, "BarLib")
                     XCTAssertEqual(target.productType, .objectFile)
@@ -1480,9 +1480,9 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "App",
-                    path: .init("/App"),
+                    path: .init(path: "/App"),
                     dependencies: [
-                        .localSourceControl(path: .init("/Bar"), requirement: .branch("main")),
+                        .localSourceControl(path: .init(path: "/Bar"), requirement: .branch("main")),
                     ],
                     targets: [
                         .init(name: "App", dependencies: ["Logging", "Utils"], type: .executable),
@@ -1493,7 +1493,7 @@ class PIFBuilderTests: XCTestCase {
                     ]),
                 Manifest.createLocalSourceControlManifest(
                     name: "Bar",
-                    path: .init("/Bar"),
+                    path: .init(path: "/Bar"),
                     products: [
                         .init(name: "BarLib", type: .library(.dynamic), targets: ["Lib"]),
                     ],
@@ -1506,7 +1506,7 @@ class PIFBuilderTests: XCTestCase {
         )
 
         var pif: PIF.TopLevelObject!
-        try! withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
+        try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
             let builder = PIFBuilder(
                 graph: graph,
                 parameters: .mock(),
@@ -1518,8 +1518,8 @@ class PIFBuilderTests: XCTestCase {
 
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        PIFTester(pif) { workspace in
-            workspace.checkProject("PACKAGE:/App") { project in
+        try PIFTester(pif) { workspace in
+            try workspace.checkProject("PACKAGE:/App") { project in
                 project.checkTarget("PACKAGE-PRODUCT:App") { target in
                     XCTAssertEqual(target.name, "App_1DA2DD44_PackageProduct")
                     XCTAssertEqual(target.productType, .executable)
@@ -1601,7 +1601,7 @@ class PIFBuilderTests: XCTestCase {
                 }
             }
 
-            workspace.checkProject("PACKAGE:/Bar") { project in
+            try workspace.checkProject("PACKAGE:/Bar") { project in
                 project.checkTarget("PACKAGE-PRODUCT:BarLib") { target in
                     XCTAssertEqual(target.name, "BarLib_175D063FAE17B2_PackageProduct")
                     XCTAssertEqual(target.productType, .framework)
@@ -1703,7 +1703,7 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Bar",
-                    path: .init("/Bar"),
+                    path: .init(path: "/Bar"),
                     toolsVersion: .v4_2,
                     cLanguageStandard: "c11",
                     swiftLanguageVersions: [.v4_2],
@@ -1718,7 +1718,7 @@ class PIFBuilderTests: XCTestCase {
         )
 
         var pif: PIF.TopLevelObject!
-        try! withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
+        try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
             let builder = PIFBuilder(
                 graph: graph,
                 parameters: .mock(shouldCreateDylibForDynamicProducts: true),
@@ -1730,8 +1730,8 @@ class PIFBuilderTests: XCTestCase {
 
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        PIFTester(pif) { workspace in
-            workspace.checkProject("PACKAGE:/Bar") { project in
+        try PIFTester(pif) { workspace in
+            try workspace.checkProject("PACKAGE:/Bar") { project in
                 project.checkTarget("PACKAGE-PRODUCT:BarLib") { target in
                     XCTAssertEqual(target.name, "BarLib_175D063FAE17B2_PackageProduct")
                     XCTAssertEqual(target.productType, .dynamicLibrary)
@@ -1756,8 +1756,8 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createManifest(
                     name: "Bar",
-                    path: .init("/Bar"),
-                    packageKind: .root(.init("/Bar")),
+                    path: .init(path: "/Bar"),
+                    packageKind: .root(.init(path: "/Bar")),
                     toolsVersion: .v4_2,
                     cLanguageStandard: "c11",
                     swiftLanguageVersions: [.v4_2],
@@ -1772,7 +1772,7 @@ class PIFBuilderTests: XCTestCase {
         )
 
         var pif: PIF.TopLevelObject!
-        try! withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
+        try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
             let builder = PIFBuilder(
                 graph: graph,
                 parameters: .mock(shouldCreateDylibForDynamicProducts: true),
@@ -1784,8 +1784,8 @@ class PIFBuilderTests: XCTestCase {
 
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        PIFTester(pif) { workspace in
-            workspace.checkProject("PACKAGE:/Bar") { project in
+        try PIFTester(pif) { workspace in
+            try workspace.checkProject("PACKAGE:/Bar") { project in
                 project.checkTarget("PACKAGE-PRODUCT:BarLib") { target in
                     XCTAssertEqual(target.name, "BarLib_175D063FAE17B2_PackageProduct")
 
@@ -1814,7 +1814,7 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
-                    path: .init("/Foo"),
+                    path: .init(path: "/Foo"),
                     toolsVersion: .v5_2,
                     cxxLanguageStandard: "c++14",
                     swiftLanguageVersions: [.v4_2, .v5],
@@ -1827,7 +1827,7 @@ class PIFBuilderTests: XCTestCase {
         )
 
         var pif: PIF.TopLevelObject!
-        try! withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
+        try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
             let builder = PIFBuilder(
                 graph: graph,
                 parameters: .mock(),
@@ -1839,8 +1839,8 @@ class PIFBuilderTests: XCTestCase {
 
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        PIFTester(pif) { workspace in
-            workspace.checkProject("PACKAGE:/Foo") { project in
+        try PIFTester(pif) { workspace in
+            try workspace.checkProject("PACKAGE:/Foo") { project in
                 project.checkAggregateTarget("PACKAGE-TARGET:SystemLib1") { target in
                     XCTAssertEqual(target.name, "SystemLib1")
                     XCTAssertEqual(target.dependencies, [])
@@ -1933,7 +1933,7 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
-                    path: .init("/Foo"),
+                    path: .init(path: "/Foo"),
                     toolsVersion: .v5_3,
                     products: [
                         .init(name: "FooLib", type: .library(.automatic), targets: ["FooLib"]),
@@ -1947,7 +1947,7 @@ class PIFBuilderTests: XCTestCase {
             ],
             binaryArtifacts: [
                 .plain("foo"): [
-                    "BinaryLibrary": .init(kind: .xcframework, originURL: nil, path: AbsolutePath("/Foo/BinaryLibrary.xcframework"))
+                    "BinaryLibrary": .init(kind: .xcframework, originURL: nil, path: AbsolutePath(path: "/Foo/BinaryLibrary.xcframework"))
                 ]
             ],
             shouldCreateMultipleTestProducts: true,
@@ -1964,8 +1964,8 @@ class PIFBuilderTests: XCTestCase {
 
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        PIFTester(pif) { workspace in
-            workspace.checkProject("PACKAGE:/Foo") { project in
+        try PIFTester(pif) { workspace in
+            try workspace.checkProject("PACKAGE:/Foo") { project in
                 project.checkTarget("PACKAGE-PRODUCT:foo") { target in
                     XCTAssert(target.frameworks.contains("/Foo/BinaryLibrary.xcframework"))
                 }
@@ -2007,7 +2007,7 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
-                    path: .init("/Foo"),
+                    path: .init(path: "/Foo"),
                     toolsVersion: .v5_3,
                     products: [
                         .init(name: "FooLib", type: .library(.automatic), targets: ["FooLib"]),
@@ -2040,8 +2040,8 @@ class PIFBuilderTests: XCTestCase {
 
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        PIFTester(pif) { workspace in
-            workspace.checkProject("PACKAGE:/Foo") { project in
+        try PIFTester(pif) { workspace in
+            try workspace.checkProject("PACKAGE:/Foo") { project in
                 project.checkTarget("PACKAGE-PRODUCT:foo") { target in
                     XCTAssertEqual(target.dependencies, ["PACKAGE-RESOURCE:foo"])
                     XCTAssert(target.sources.contains("/Foo/Sources/foo/Resources/Database.xcdatamodel"))
@@ -2223,7 +2223,7 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
-                    path: .init("/Foo"),
+                    path: .init(path: "/Foo"),
                     toolsVersion: .v5,
                     products: [
                         .init(name: "FooLib", type: .library(.automatic), targets: ["FooLib"]),
@@ -2296,8 +2296,8 @@ class PIFBuilderTests: XCTestCase {
 
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        PIFTester(pif) { workspace in
-            workspace.checkProject("PACKAGE:/Foo") { project in
+        try PIFTester(pif) { workspace in
+            try workspace.checkProject("PACKAGE:/Foo") { project in
                 project.checkTarget("PACKAGE-PRODUCT:foo") { target in
                     target.checkBuildConfiguration("Debug") { configuration in
                         configuration.checkBuildSettings { settings in
@@ -2437,8 +2437,8 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createManifest(
                     name: "Foo",
-                    path: .init("/Foo"),
-                    packageKind: .root(.init("/Foo")),
+                    path: .init(path: "/Foo"),
+                    packageKind: .root(.init(path: "/Foo")),
                     toolsVersion: .v5_3,
                     targets: [
                         .init(name: "foo", dependencies: [
@@ -2468,8 +2468,8 @@ class PIFBuilderTests: XCTestCase {
             "PACKAGE-TARGET:FooLib2": PIF.PlatformFilter.iOSFilters,
         ]
 
-        PIFTester(pif) { workspace in
-            workspace.checkProject("PACKAGE:/Foo") { project in
+        try PIFTester(pif) { workspace in
+            try workspace.checkProject("PACKAGE:/Foo") { project in
                 project.checkTarget("PACKAGE-PRODUCT:foo") { target in
                     XCTAssertEqual(target.dependencies, ["PACKAGE-TARGET:FooLib1", "PACKAGE-TARGET:FooLib2"])
                     XCTAssertEqual(target.frameworks, ["PACKAGE-TARGET:FooLib1", "PACKAGE-TARGET:FooLib2"])
@@ -2506,7 +2506,7 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "Foo",
-                    path: .init("/Foo"),
+                    path: .init(path: "/Foo"),
                     platforms: [
                         PlatformDescription(name: "macos", version: "10.14", options: ["best"]),
                     ],
@@ -2529,8 +2529,8 @@ class PIFBuilderTests: XCTestCase {
 
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        PIFTester(pif) { workspace in
-            workspace.checkProject("PACKAGE:/Foo") { project in
+        try PIFTester(pif) { workspace in
+            try workspace.checkProject("PACKAGE:/Foo") { project in
                 project.checkBuildConfiguration("Debug") { configuration in
                     configuration.checkBuildSettings { settings in
                         XCTAssertEqual(settings[.SPECIALIZATION_SDK_OPTIONS, for: .macOS], ["best"])
@@ -2556,7 +2556,7 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     name: "MyLib",
-                    path: .init("/MyLib"),
+                    path: .init(path: "/MyLib"),
                     toolsVersion: .v5,
                     products: [
                         .init(name: "MyLib", type: .library(.automatic), targets: ["MyLib"]),
@@ -2584,8 +2584,8 @@ class PIFBuilderTests: XCTestCase {
 
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        PIFTester(pif) { workspace in
-            workspace.checkProject("PACKAGE:/MyLib") { project in
+        try PIFTester(pif) { workspace in
+            try workspace.checkProject("PACKAGE:/MyLib") { project in
                 project.checkTarget("PACKAGE-TARGET:MyLib") { target in
                     target.checkBuildConfiguration("Debug") { configuration in
                         configuration.checkBuildSettings { settings in
@@ -2614,7 +2614,7 @@ extension PIFBuilderParameters {
         PIFBuilderParameters(
             enableTestability: false,
             shouldCreateDylibForDynamicProducts: shouldCreateDylibForDynamicProducts,
-            toolchainLibDir: AbsolutePath("/toolchain/lib")
+            toolchainLibDir: AbsolutePath(path: "/toolchain/lib")
         )
     }
 }

--- a/Tests/XCBuildSupportTests/PIFTests.swift
+++ b/Tests/XCBuildSupportTests/PIFTests.swift
@@ -23,13 +23,13 @@ class PIFTests: XCTestCase {
         PIF.Workspace(
             guid: "workspace",
             name: "MyWorkspace",
-            path: AbsolutePath("/path/to/workspace"),
+            path: AbsolutePath(path: "/path/to/workspace"),
             projects: [
                 PIF.Project(
                     guid: "project",
                     name: "MyProject",
-                    path: AbsolutePath("/path/to/workspace/project"),
-                    projectDirectory: AbsolutePath("/path/to/workspace/project"),
+                    path: AbsolutePath(path: "/path/to/workspace/project"),
+                    projectDirectory: AbsolutePath(path: "/path/to/workspace/project"),
                     developmentRegion: "fr",
                     buildConfigurations: [
                         PIF.BuildConfiguration(
@@ -263,14 +263,14 @@ class PIFTests: XCTestCase {
 
         XCTAssertEqual(workspace["type"]?.string, "workspace")
         XCTAssertEqual(workspaceContents["guid"]?.string, "workspace@11")
-        XCTAssertEqual(workspaceContents["path"]?.string, AbsolutePath("/path/to/workspace").pathString)
+        XCTAssertEqual(workspaceContents["path"]?.string, AbsolutePath(path: "/path/to/workspace").pathString)
         XCTAssertEqual(workspaceContents["name"]?.string, "MyWorkspace")
         XCTAssertEqual(workspaceContents["projects"]?.array, [project["signature"]!])
 
         XCTAssertEqual(project["type"]?.string, "project")
         XCTAssertEqual(projectContents["guid"]?.string, "project@11")
-        XCTAssertEqual(projectContents["path"]?.string, AbsolutePath("/path/to/workspace/project").pathString)
-        XCTAssertEqual(projectContents["projectDirectory"]?.string, AbsolutePath("/path/to/workspace/project").pathString)
+        XCTAssertEqual(projectContents["path"]?.string, AbsolutePath(path: "/path/to/workspace/project").pathString)
+        XCTAssertEqual(projectContents["projectDirectory"]?.string, AbsolutePath(path: "/path/to/workspace/project").pathString)
         XCTAssertEqual(projectContents["projectName"]?.string, "MyProject")
         XCTAssertEqual(projectContents["projectIsPackage"]?.string, "true")
         XCTAssertEqual(projectContents["developmentRegion"]?.string, "fr")


### PR DESCRIPTION
Since it comes up regularly as a perceived user facing crash, we should reduce our use of the plain `AbsolutePath` initializer. I actually don't think it makes sense to even provide a non-throwing initializer that takes anything but a `StaticString` and even that's debatable.

This doesn't resolve all possible uses and specifically excludes uses in tests, but does fix several user facing issues, e.g.

```
❯ export SWIFTPM_TESTS_MODULECACHE=blah
❯ swift test
zsh: illegal hardware instruction  swift test
```
