### PR TITLE
Remove most deprecated APIs

### DIFF
--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -270,11 +270,6 @@ private final class InProcessTool: Tool {
         self.type = type
     }
 
-    @available(*, deprecated, message: "Use the overload that returns an Optional")
-    func createCommand(_ name: String) -> ExternalCommand {
-        return type.init(self.context)
-    }
-
     func createCommand(_ name: String) -> ExternalCommand? {
         return type.init(self.context)
     }

--- a/Sources/Build/SPMSwiftDriverExecutor.swift
+++ b/Sources/Build/SPMSwiftDriverExecutor.swift
@@ -44,7 +44,7 @@ final class SPMSwiftDriverExecutor: DriverExecutor {
                  forceResponseFiles: Bool,
                  recordedInputModificationDates: [TypedVirtualPath : TimePoint]) throws -> ProcessResult {
         let arguments: [String] = try resolver.resolveArgumentList(for: job,
-                                                                   forceResponseFiles: forceResponseFiles)
+                                                                   useResponseFiles: forceResponseFiles ? .forced : .heuristic)
         
         try job.verifyInputsNotModified(since: recordedInputModificationDates,
                                         fileSystem: fileSystem)
@@ -74,7 +74,7 @@ final class SPMSwiftDriverExecutor: DriverExecutor {
     func description(of job: Job, forceResponseFiles: Bool) throws -> String {
         // FIXME: This is duplicated from SwiftDriver, maybe it shouldn't be a protocol requirement.
         let (args, usedResponseFile) = try resolver.resolveArgumentList(for: job,
-                                                                        forceResponseFiles: forceResponseFiles)
+                                                                        useResponseFiles: forceResponseFiles ? .forced : .heuristic)
         var result = args.joined(separator: " ")
         
         if usedResponseFile {

--- a/Sources/PackageCollections/API.swift
+++ b/Sources/PackageCollections/API.swift
@@ -106,41 +106,6 @@ public protocol PackageCollectionsProtocol {
         callback: @escaping (Result<PackageCollectionsModel.Collection, Error>) -> Void
     )
 
-    // MARK: - Package APIs
-
-    /// Returns metadata for the package identified by the given `PackageReference`, along with the
-    /// identifiers of `PackageCollection`s where the package is found.
-    ///
-    /// A failure is returned if the package is not found.
-    ///
-    /// - Parameters:
-    ///   - reference: The package reference
-    ///   - callback: The closure to invoke when result becomes available
-    // deprecated 9/21
-    @available(*, deprecated, message: "use getPackageMetadata(identity:) instead")
-    func getPackageMetadata(
-        _ reference: PackageReference,
-        callback: @escaping (Result<PackageCollectionsModel.PackageMetadata, Error>) -> Void
-    )
-
-    /// Returns metadata for the package identified by the given `PackageReference`, along with the
-    /// identifiers of `PackageCollection`s where the package is found.
-    ///
-    /// A failure is returned if the package is not found.
-    ///
-    /// - Parameters:
-    ///   - reference: The package reference
-    ///   - collections: Optional. If specified, only look for package in these collections. Data from the most recently
-    ///                  processed collection will be used.
-    ///   - callback: The closure to invoke when result becomes available
-    // deprecated 9/21
-    @available(*, deprecated, message: "use getPackageMetadata(identity:) instead")
-    func getPackageMetadata(
-        _ reference: PackageReference,
-        collections: Set<PackageCollectionsModel.CollectionIdentifier>?,
-        callback: @escaping (Result<PackageCollectionsModel.PackageMetadata, Error>) -> Void
-    )
-
     /// Returns metadata for the package identified by the given `PackageIdentity`, along with the
     /// identifiers of `PackageCollection`s where the package is found.
     ///

--- a/Sources/PackageCollections/Model/PackageTypes.swift
+++ b/Sources/PackageCollections/Model/PackageTypes.swift
@@ -85,24 +85,6 @@ extension PackageCollectionsModel {
         /// The package's programming languages
         public let languages: Set<String>?
 
-        // deprecated 9/21
-        @available(*, deprecated, message: "use identity and location instead")
-        public var reference: PackageReference {
-            guard let url = URL(string: self.location) else {
-                fatalError("invalid url \(self.location)")
-            }
-            return .init(identity: self.identity, kind: .remoteSourceControl(url), name: nil)
-        }
-
-        // deprecated 9/21
-        @available(*, deprecated, message: "use identity and location instead")
-        public var repository: RepositorySpecifier {
-            guard let url = URL(string: self.location) else {
-                fatalError("invalid url \(self.location)")
-            }
-            return .init(url: url)
-        }
-
         /// Initializes a `Package`
         init(
             identity: PackageIdentity,
@@ -159,27 +141,6 @@ extension PackageCollectionsModel.Package {
 
         /// When the package version was created
         public let createdAt: Date?
-        
-        @available(*, deprecated, message: "use manifests instead")
-        public var packageName: String { self.defaultManifest!.packageName }
-
-        @available(*, deprecated, message: "use manifests instead")
-        public var targets: [Target] { self.defaultManifest!.targets }
-
-        @available(*, deprecated, message: "use manifests instead")
-        public var products: [Product] { self.defaultManifest!.products }
-
-        @available(*, deprecated, message: "use manifests instead")
-        public var toolsVersion: ToolsVersion { self.defaultManifest!.toolsVersion }
-
-        @available(*, deprecated, message: "use manifests instead")
-        public var minimumPlatformVersions: [SupportedPlatform]? { nil }
-
-        @available(*, deprecated, message: "use verifiedCompatibility instead")
-        public var verifiedPlatforms: [PackageModel.Platform]? { nil }
-
-        @available(*, deprecated, message: "use verifiedCompatibility instead")
-        public var verifiedSwiftVersions: [SwiftLanguageVersion]? { nil }
 
         public struct Manifest: Equatable, Codable {
             /// The Swift tools version specified in `Package.swift`.

--- a/Sources/PackageCollections/Model/TargetListResult.swift
+++ b/Sources/PackageCollections/Model/TargetListResult.swift
@@ -48,15 +48,6 @@ extension PackageCollectionsModel.TargetListResult {
 
         /// Package collections that contain this package and at least one of the `versions`
         public let collections: [PackageCollectionsModel.CollectionIdentifier]
-
-        // deprecated 9/2021
-        @available(*, deprecated, message: "use identity and location instead")
-        public var repository: RepositorySpecifier {
-            guard let url = URL(string: self.location) else {
-                fatalError("invalid url \(self.location)")
-            }
-            return .init(url: url)
-        }
     }
 }
 

--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -393,21 +393,6 @@ public struct PackageCollections: PackageCollectionsProtocol, Closable {
 
     // MARK: - Package Metadata
 
-    // deprecated 9/21
-    @available(*, deprecated, message: "user identity based API instead")
-    public func getPackageMetadata(_ reference: PackageReference,
-                                   callback: @escaping (Result<PackageCollectionsModel.PackageMetadata, Error>) -> Void) {
-        self.getPackageMetadata(reference, collections: nil, callback: callback)
-    }
-
-    // deprecated 9/21
-    @available(*, deprecated, message: "user identity based API instead")
-    public func getPackageMetadata(_ reference: PackageReference,
-                                   collections: Set<PackageCollectionsModel.CollectionIdentifier>?,
-                                   callback: @escaping (Result<PackageCollectionsModel.PackageMetadata, Error>) -> Void) {
-        self.getPackageMetadata(identity: reference.identity, location: reference.locationString, collections: .none, callback: callback)
-    }
-
     public func getPackageMetadata(identity: PackageIdentity,
                                    location: String? = .none,
                                    callback: @escaping (Result<PackageCollectionsModel.PackageMetadata, Error>) -> Void) {

--- a/Sources/PackageGraph/DependencyMirrors.swift
+++ b/Sources/PackageGraph/DependencyMirrors.swift
@@ -36,11 +36,6 @@ public final class DependencyMirrors: Equatable {
         self.visited = .init()
     }
 
-    @available(*, deprecated)
-    private convenience init(_ mirrors: [Mirror]) {
-        self.init(Dictionary(mirrors.map({ ($0.original, $0.mirror) }), uniquingKeysWith: { first, _ in first }))
-    }
-
     public static func == (lhs: DependencyMirrors, rhs: DependencyMirrors) -> Bool {
         return lhs.mapping == rhs.mapping
     }
@@ -187,47 +182,5 @@ extension DependencyMirrors: Collection {
 extension DependencyMirrors: ExpressibleByDictionaryLiteral {
     public convenience init(dictionaryLiteral elements: (String, String)...) {
         self.init(Dictionary(elements, uniquingKeysWith: { first, _ in first }))
-    }
-}
-
-@available(*, deprecated)
-extension DependencyMirrors: JSONMappable, JSONSerializable {
-    public convenience init(json: JSON) throws {
-        self.init(try [Mirror](json: json))
-    }
-
-    public func toJSON() -> JSON {
-        let mirrors = self.index.map { Mirror(original: $0.key, mirror: $0.value) }
-        return .array(mirrors.sorted(by: { $0.original < $1.mirror }).map { $0.toJSON() })
-    }
-}
-
-/// An individual repository mirror.
-@available(*, deprecated)
-private struct Mirror {
-    /// The original repository path.
-    let original: String
-
-    /// The mirrored repository path.
-    let mirror: String
-
-    init(original: String, mirror: String) {
-        self.original = original
-        self.mirror = mirror
-    }
-}
-
-@available(*, deprecated)
-extension Mirror: JSONMappable, JSONSerializable {
-    init(json: JSON) throws {
-        self.original = try json.get("original")
-        self.mirror = try json.get("mirror")
-    }
-
-    func toJSON() -> JSON {
-        .init([
-            "original": original,
-            "mirror": mirror
-        ])
     }
 }

--- a/Sources/PackageGraph/DependencyResolver.swift
+++ b/Sources/PackageGraph/DependencyResolver.swift
@@ -46,63 +46,6 @@ public protocol DependencyResolverDelegate {
     func solved(result: [DependencyResolver.Binding])
 }
 
-@available(*, deprecated, message: "user verbosity flags instead")
-public struct TracingDependencyResolverDelegate: DependencyResolverDelegate {
-    private let stream: OutputByteStream
-
-    public init (path: AbsolutePath) throws {
-        self.stream = try LocalFileOutputByteStream(path, closeOnDeinit: true, buffered: false)
-    }
-
-    public init (stream: OutputByteStream) {
-        self.stream = stream
-    }
-
-    public func willResolve(term: Term) {
-        self.log("resolving: \(term.node.package.identity)")
-    }
-
-    public func didResolve(term: Term, version: Version, duration: DispatchTimeInterval) {
-        self.log("resolved: \(term.node.package.identity) @ \(version)")
-    }
-
-    public func derived(term: Term) {
-        self.log("derived: \(term.node.package.identity)")
-    }
-
-    public func conflict(conflict: Incompatibility) {
-        self.log("conflict: \(conflict)")
-    }
-
-    public func failedToResolve(incompatibility: Incompatibility) {
-        self.log("failed to resolve: \(incompatibility)")
-    }
-
-    public func satisfied(term: Term, by assignment: Assignment, incompatibility: Incompatibility) {
-        log("CR: \(term) is satisfied by \(assignment)")
-        log("CR: which is caused by \(assignment.cause?.description ?? "")")
-        log("CR: new incompatibility \(incompatibility)")
-    }
-
-    public func partiallySatisfied(term: Term, by assignment: Assignment, incompatibility: Incompatibility, difference: Term) {
-        log("CR: \(term) is partially satisfied by \(assignment)")
-        log("CR: which is caused by \(assignment.cause?.description ?? "")")
-        log("CR: new incompatibility \(incompatibility)")
-    }
-
-    public func solved(result: [DependencyResolver.Binding]) {
-        self.log("solved:")
-        for (package, binding, _) in result {
-            self.log("\(package) \(binding)")
-        }
-    }
-
-    private func log(_ message: String) {
-        self.stream <<< message <<< "\n"
-        self.stream.flush()
-    }
-}
-
 public struct ObservabilityDependencyResolverDelegate: DependencyResolverDelegate {
     private let observabilityScope: ObservabilityScope
 

--- a/Sources/PackageLoading/IdentityResolver.swift
+++ b/Sources/PackageLoading/IdentityResolver.swift
@@ -16,9 +16,6 @@ import TSCBasic
 
 // TODO: refactor this when adding registry support
 public protocol IdentityResolver {
-    // deprecated 9/21
-    @available(*, deprecated, message: "use resolveIdentity for url or path instead")
-    func resolveIdentity(for location: String) -> PackageIdentity
     func resolveIdentity(for packageKind: PackageReference.Kind) throws -> PackageIdentity
     func resolveIdentity(for url: URL) throws -> PackageIdentity
     func resolveIdentity(for path: AbsolutePath) throws -> PackageIdentity
@@ -30,13 +27,6 @@ public struct DefaultIdentityResolver: IdentityResolver {
 
     public init(locationMapper: @escaping (String) -> String = { $0 }) {
         self.locationMapper = locationMapper
-    }
-
-    // deprecated 9/21
-    @available(*, deprecated, message: "use resolveIdentity for url or path instead")
-    public func resolveIdentity(for location: String) -> PackageIdentity {
-        let location = self.mappedLocation(for: location)
-        return PackageIdentity(urlString: location)
     }
 
     public func resolveIdentity(for packageKind: PackageReference.Kind) throws -> PackageIdentity {

--- a/Sources/PackageLoading/ToolsVersionParser.swift
+++ b/Sources/PackageLoading/ToolsVersionParser.swift
@@ -16,54 +16,6 @@ import PackageModel
 import TSCBasic
 
 /// Protocol for the manifest loader interface.
-// deprecated 3/22, remove when clients stop using
-@available(*, deprecated, message: "use ToolsVersionParser instead")
-public protocol ToolsVersionLoaderProtocol {
-
-    /// Load the tools version at the give package path.
-    ///
-    /// - Parameters:
-    ///   - path: The path to the package.
-    ///   - fileSystem: The file system to use to read the file which contains tools version.
-    /// - Returns: The tools version.
-    /// - Throws: ToolsVersion.Error
-    func load(at path: AbsolutePath, fileSystem: FileSystem) throws -> ToolsVersion
-}
-
-
-// deprecated 3/22, remove when clients stop using
-@available(*, deprecated, message: "use ToolsVersionParser instead")
-public struct ToolsVersionLoader: ToolsVersionLoaderProtocol {
-    // FIXME: Remove this property and the initializer?
-    // Arbitrary tools versions are used only in `ToolsVersionLoaderTests.testVersionSpecificManifestFallbacks()`.
-    // Relevant discussion: https://github.com/apple/swift-package-manager/pull/2937#discussion_r512239726
-    /// The Swift toolchain version used by the instance of `ToolsVersionLoader`.
-    ///
-    /// If the value differs from `ToolsVersion.currentToolsVersion`, then the `ToolsVersionLoader` instance is simulating that it's run on a Swift version different from the version used by libSwiftPM.
-    let currentToolsVersion: ToolsVersion
-
-    /// Creates a manifest loader with the given Swift toolchain version.
-    /// - Parameter currentToolsVersion: The Swift toolchain version to simulate the manifest loading strategy for. By default, this parameter is the current version used by libSwiftPM. A non-default version is only used for providing testability.
-    public init(currentToolsVersion: ToolsVersion = .current) {
-        self.currentToolsVersion = currentToolsVersion
-    }
-
-    public func load(at packagePath: AbsolutePath, fileSystem: FileSystem) throws -> ToolsVersion {
-        // The file which contains the tools version.
-        let manifestPath = try ManifestLoader.findManifest(packagePath: packagePath, fileSystem: fileSystem, currentToolsVersion: self.currentToolsVersion)
-        guard fileSystem.isFile(manifestPath) else {
-            // FIXME: We should return an error from here but Workspace tests rely on this in order to work.
-            // This doesn't really cause issues (yet) in practice though.
-            return ToolsVersion.current
-        }
-        return try ToolsVersionParser.parse(manifestPath: manifestPath, fileSystem: fileSystem)
-    }
-
-    public func load(utf8String: String) throws -> ToolsVersion {
-        try ToolsVersionParser.parse(utf8String: utf8String)
-    }
-}
-
 public struct ToolsVersionParser {
     // designed to be used as a static utility
     private init() {}

--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -25,12 +25,6 @@ public final class Manifest {
     public static let basename = "Package"
 
     /// The name of the package as it appears in the manifest
-    @available(*, deprecated, message: "use displayName instead, and only for display purposes")
-    public var name: String {
-        return self.displayName
-    }
-
-    /// The name of the package as it appears in the manifest
     /// FIXME: deprecate this, there is no value in this once we have real package identifiers
     public let displayName: String
 
@@ -52,14 +46,6 @@ public final class Manifest {
     /// The canonical repository URL the manifest was loaded from.
     public var canonicalPackageLocation: CanonicalPackageLocation {
         CanonicalPackageLocation(self.packageLocation)
-    }
-
-    // FIXME: deprecated 2/2021, remove once clients migrate
-    @available(*, deprecated, message: "use packageLocation instead")
-    public var url: String {
-        get {
-            self.packageLocation
-        }
     }
 
     /// Whether kind of package this manifest is from.

--- a/Sources/PackageModel/PackageModel.swift
+++ b/Sources/PackageModel/PackageModel.swift
@@ -98,13 +98,6 @@ public final class Package: Encodable {
 }
 
 extension Package {
-    @available(*, deprecated, message: "use DiagnosticsContext instead")
-    public var diagnosticLocation: DiagnosticLocation {
-        return PackageLocation.Local(name: self.manifest.name, packagePath: self.path)
-    }
-}
-
-extension Package {
     public var diagnosticsMetadata: ObservabilityMetadata {
         return .packageMetadata(identity: self.identity, kind: self.manifest.packageKind)
     }

--- a/Sources/PackageModel/PackageReference.swift
+++ b/Sources/PackageModel/PackageReference.swift
@@ -87,11 +87,6 @@ public struct PackageReference {
     /// The identity of the package.
     public let identity: PackageIdentity
 
-    @available(*, deprecated)
-    public var name: String {
-        return self.deprecatedName
-    }
-
     /// The name of the package, if available.
     // soft deprecated 11/21
     public private(set) var deprecatedName: String

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -454,68 +454,6 @@ public class Workspace {
         )
     }
 
-    // deprecate 12/21
-    @_disfavoredOverload
-    @available(*, deprecated, message: "use alternative initializer")
-    public convenience init(
-        fileSystem: FileSystem,
-        location: Location,
-        mirrors: DependencyMirrors? = .none,
-        registries: RegistryConfiguration? = .none,
-        authorizationProvider: AuthorizationProvider? = .none,
-        customToolsVersion: ToolsVersion? = .none,
-        customManifestLoader: ManifestLoaderProtocol? = .none,
-        customPackageContainerProvider: PackageContainerProvider? = .none,
-        customRepositoryManager: RepositoryManager? = .none,
-        customRepositoryProvider: RepositoryProvider? = .none,
-        customRegistryClient: RegistryClient? = .none,
-        customIdentityResolver: IdentityResolver? = .none,
-        customHTTPClient: HTTPClient? = .none,
-        customArchiver: Archiver? = .none,
-        customChecksumAlgorithm: HashAlgorithm? = .none,
-        customFingerprintStorage: PackageFingerprintStorage? = .none,
-        additionalFileRules: [FileRuleDescription]? = .none,
-        resolverUpdateEnabled: Bool? = .none,
-        resolverPrefetchingEnabled: Bool? = .none,
-        resolverFingerprintCheckingMode: FingerprintCheckingMode = .strict,
-        sharedRepositoriesCacheEnabled: Bool? = .none,
-        delegate: Delegate? = .none
-    ) throws {
-        let configuration = WorkspaceConfiguration(
-            skipDependenciesUpdates: !(resolverUpdateEnabled ?? !WorkspaceConfiguration.default.skipDependenciesUpdates),
-            prefetchBasedOnResolvedFile: resolverPrefetchingEnabled ?? WorkspaceConfiguration.default.prefetchBasedOnResolvedFile,
-            additionalFileRules: additionalFileRules ?? WorkspaceConfiguration.default.additionalFileRules,
-            sharedDependenciesCacheEnabled: sharedRepositoriesCacheEnabled ?? WorkspaceConfiguration.default.sharedDependenciesCacheEnabled,
-            fingerprintCheckingMode: resolverFingerprintCheckingMode,
-            sourceControlToRegistryDependencyTransformation: WorkspaceConfiguration.default.sourceControlToRegistryDependencyTransformation
-        )
-        try self.init(
-            fileSystem: fileSystem,
-            location: location,
-            authorizationProvider: authorizationProvider,
-            configuration: configuration,
-            cancellator: .none,
-            initializationWarningHandler: .none,
-            customRegistriesConfiguration: registries,
-            customFingerprints: customFingerprintStorage,
-            customMirrors: mirrors,
-            customToolsVersion: customToolsVersion,
-            customHostToolchain: .none,
-            customManifestLoader: customManifestLoader,
-            customPackageContainerProvider: customPackageContainerProvider,
-            customRepositoryManager: customRepositoryManager,
-            customRepositoryProvider: customRepositoryProvider,
-            customRegistryClient: customRegistryClient,
-            customBinaryArtifactsManager: .init(
-                httpClient: customHTTPClient,
-                archiver: customArchiver
-            ),
-            customIdentityResolver: customIdentityResolver,
-            customChecksumAlgorithm: customChecksumAlgorithm,
-            delegate: delegate
-        )
-    }
-
     /// Initializer for testing purposes only. Use non underscored initializers instead.
     // this initializer is only public because of cross module visibility (eg MockWorkspace)
     // as such it is by design an exact mirror of the private initializer below
@@ -721,12 +659,6 @@ public class Workspace {
 
 extension Workspace {
 
-    // deprecated 10/2021
-    @available(*, deprecated, message: "use observability system APIs instead")
-    public func edit(packageName: String, path: AbsolutePath? = nil, revision: Revision? = nil, checkoutBranch: String? = nil, diagnostics: DiagnosticsEngine) {
-        self.edit(packageName: packageName, path: path, revision: revision, checkoutBranch: checkoutBranch, observabilityScope: ObservabilitySystem(diagnosticEngine: diagnostics).topScope)
-    }
-
     /// Puts a dependency in edit mode creating a checkout in editables directory.
     ///
     /// - Parameters:
@@ -757,12 +689,6 @@ extension Workspace {
         }
     }
 
-    // deprecated 10/2021
-    @available(*, deprecated, message: "use observability system APIs instead")
-    public func unedit(packageName: String, forceRemove: Bool, root: PackageGraphRootInput, diagnostics: DiagnosticsEngine) throws {
-        try self.unedit(packageName: packageName, forceRemove: forceRemove, root: root, observabilityScope: ObservabilitySystem(diagnosticEngine: diagnostics).topScope)
-    }
-
     /// Ends the edit mode of an edited dependency.
     ///
     /// This will re-resolve the dependencies after ending edit as the original
@@ -786,12 +712,6 @@ extension Workspace {
         }
 
         try self.unedit(dependency: dependency, forceRemove: forceRemove, root: root, observabilityScope: observabilityScope)
-    }
-
-    // deprecated 10/2021
-    @available(*, deprecated, message: "use observability system APIs instead")
-    public func resolve(packageName: String, root: PackageGraphRootInput, version: Version? = nil, branch: String? = nil, revision: String? = nil, diagnostics: DiagnosticsEngine) throws {
-        try self.resolve(packageName: packageName, root: root, version: version, branch: branch, revision: revision, observabilityScope: ObservabilitySystem(diagnosticEngine: diagnostics).topScope)
     }
 
     /// Resolve a package at the given state.
@@ -856,13 +776,6 @@ extension Workspace {
         )
     }
 
-
-    // deprecated 10/2021
-    @available(*, deprecated, message: "use observability system APIs instead")
-    public func clean(with diagnostics: DiagnosticsEngine) {
-        self.clean(observabilityScope: ObservabilitySystem(diagnosticEngine: diagnostics).topScope)
-    }
-
     /// Cleans the build artifacts from workspace data.
     ///
     /// - Parameters:
@@ -896,13 +809,6 @@ extension Workspace {
         }
     }
 
-
-    // deprecated 10/2021
-    @available(*, deprecated, message: "use observability system APIs instead")
-    public func purgeCache(with diagnostics: DiagnosticsEngine) {
-        self.purgeCache(observabilityScope: ObservabilitySystem(diagnosticEngine: diagnostics).topScope)
-    }
-
     /// Cleans the build artifacts from workspace data.
     ///
     /// - Parameters:
@@ -913,13 +819,6 @@ extension Workspace {
             try self.registryDownloadsManager.purgeCache()
             try self.manifestLoader.purgeCache()
         }
-    }
-
-
-    // deprecated 10/2021
-    @available(*, deprecated, message: "use observability system APIs instead")
-    public func reset(with diagnostics: DiagnosticsEngine) {
-        self.reset(observabilityScope: ObservabilitySystem(diagnosticEngine: diagnostics).topScope)
     }
 
     /// Resets the entire workspace by removing the data directory.
@@ -949,13 +848,6 @@ extension Workspace {
     /// Cancel the active dependency resolution operation.
     public func cancelActiveResolverOperation() {
         // FIXME: Need to add cancel support.
-    }
-
-    // deprecated 10/2021
-    @available(*, deprecated, message: "use observability system APIs instead")
-    @discardableResult
-    public func updateDependencies(root: PackageGraphRootInput, packages: [String] = [], diagnostics: DiagnosticsEngine, dryRun: Bool = false) throws -> [(PackageReference, Workspace.PackageStateChange)]? {
-        try self.updateDependencies(root: root, packages: packages, dryRun: dryRun, observabilityScope: ObservabilitySystem(diagnosticEngine: diagnostics).topScope)
     }
 
     /// Updates the current dependencies.
@@ -1116,20 +1008,6 @@ extension Workspace {
         )
     }
 
-    @available(*, deprecated, message: "use observabilityScope variant instead")
-    @discardableResult
-    public func loadPackageGraph(
-        rootPath: AbsolutePath,
-        explicitProduct: String? = nil,
-        diagnostics: DiagnosticsEngine
-    ) throws -> PackageGraph {
-        try self.loadPackageGraph(
-            rootPath: rootPath,
-            explicitProduct: explicitProduct,
-            observabilityScope: ObservabilitySystem(diagnosticEngine: diagnostics).topScope
-        )
-    }
-
     @discardableResult
     public func loadPackageGraph(
         rootPath: AbsolutePath,
@@ -1242,25 +1120,6 @@ extension Workspace {
                 return manifest
             })
         }
-    }
-
-
-    @available(*, deprecated, message: "use observability system APIs instead")
-    public func loadRootManifest(at path: AbsolutePath, diagnostics: DiagnosticsEngine, completion: @escaping(Result<Manifest, Error>) -> Void) {
-        self.loadRootManifest(at: path, observabilityScope: ObservabilitySystem(diagnosticEngine: diagnostics).topScope, completion: completion)
-    }
-
-    @available(*, deprecated, message: "use observabilityScope variant instead")
-    public func loadRootPackage(
-        at path: AbsolutePath,
-        diagnostics: DiagnosticsEngine,
-        completion: @escaping(Result<Package, Error>) -> Void
-    ) {
-        self.loadRootPackage(
-            at: path,
-            observabilityScope: ObservabilitySystem(diagnosticEngine: diagnostics).topScope,
-            completion: completion
-        )
     }
 
     /// Loads root package

--- a/Tests/BasicsTests/ObservabilitySystemTests.swift
+++ b/Tests/BasicsTests/ObservabilitySystemTests.swift
@@ -268,48 +268,6 @@ final class ObservabilitySystemTest: XCTestCase {
         }
     }
 
-    @available(*, deprecated, message: "temporary for transition DiagnosticsEngine -> DiagnosticsEmitter")
-    func testBridging() throws {
-        do {
-            let collector = Collector()
-            let observabilitySystem = ObservabilitySystem(collector)
-            let diagnosticsEngine = observabilitySystem.topScope.makeDiagnosticsEngine()
-
-            let data = TestData()
-            let location = TestLocation()
-
-            diagnosticsEngine.emit(.error(data), location: location)
-
-            XCTAssertEqual(collector.diagnostics.count, 1)
-            XCTAssertEqual(collector.diagnostics.first!.metadata?.legacyDiagnosticLocation?.description, location.description)
-            XCTAssertEqual(collector.diagnostics.first!.metadata?.legacyDiagnosticData?.underlying.description, data.description)
-        }
-
-        do {
-            let diagnosticsEngine1 = DiagnosticsEngine()
-            let observabilitySystem = ObservabilitySystem(diagnosticEngine: diagnosticsEngine1)
-            let diagnosticsEngine2 = observabilitySystem.topScope.makeDiagnosticsEngine()
-
-            let data = TestData()
-            let location = TestLocation()
-
-            diagnosticsEngine2.emit(.error(data), location: location)
-
-            XCTAssertEqual(diagnosticsEngine1.diagnostics.count, 1)
-            XCTAssertEqual(diagnosticsEngine1.diagnostics.first!.message.data as? TestData, data)
-            XCTAssertEqual(diagnosticsEngine1.diagnostics.first!.location as? TestLocation, location)
-        }
-
-        struct TestData: DiagnosticData, Equatable {
-            var description: String = UUID().uuidString
-        }
-
-        struct TestLocation: DiagnosticLocation, Equatable {
-            var description: String = UUID().uuidString
-
-        }
-    }
-
     struct Collector: ObservabilityHandlerProvider, DiagnosticsHandler {
         private let _diagnostics = ThreadSafeArrayStore<Diagnostic>()
 


### PR DESCRIPTION
Bring back this change after fixing SourceKit-LSP's use of deprecated API. I had accidentally merged this in #5756 without merging https://github.com/apple/sourcekit-lsp/pull/643 first. Since that has now landed, we can bring this back.