### PR TITLE
Bring back the implementation of SE-0301

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -330,6 +330,17 @@ let package = Package(
             ],
             exclude: ["CMakeLists.txt"]
         ),
+        .target(
+            /** Perform mechanical edits to the package manifest */
+            name: "PackageSyntax",
+            dependencies: [
+                "PackageGraph",
+                "PackageModel",
+                "Workspace",
+                "Basics",
+                .product(name: "SwiftParser", package: "swift-syntax"),
+            ]
+        ),
 
         // MARK: Commands
 
@@ -384,6 +395,12 @@ let package = Package(
             name: "swift-package-registry",
             dependencies: ["Commands"],
             exclude: ["CMakeLists.txt"]
+        ),
+        .executableTarget(
+            /** Perform mechanical edits to the package manifest */
+            name: "swift-package-editor",
+            dependencies: ["PackageSyntax",
+                           .product(name: "ArgumentParser", package: "swift-argument-parser")]
         ),
         .executableTarget(
             /** Shim tool to find test names on OS X */
@@ -537,6 +554,10 @@ let package = Package(
             dependencies: ["XCBuildSupport", "SPMTestSupport"],
             exclude: ["Inputs/Foo.pc"]
         ),
+        .testTarget(
+            name: "PackageSyntaxTests",
+            dependencies: ["PackageSyntax"]
+        ),
 
         // Examples (These are built to ensure they stay up to date with the API.)
         .executableTarget(
@@ -586,6 +607,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: minimumCryptoVersion)),
         .package(url: "https://github.com/apple/swift-system.git", .upToNextMinor(from: "1.1.1")),
         .package(url: "https://github.com/apple/swift-collections.git", .upToNextMinor(from: "1.0.1")),
+        .package(url: "https://github.com/apple/swift-syntax.git", .branch(relatedDependenciesBranch)),
     ]
 } else {
     package.dependencies += [
@@ -595,5 +617,6 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(path: "../swift-crypto"),
         .package(path: "../swift-system"),
         .package(path: "../swift-collections"),
+        .package(path: "../swift-syntax"),
     ]
 }

--- a/Sources/PackageSyntax/Formatting.swift
+++ b/Sources/PackageSyntax/Formatting.swift
@@ -1,0 +1,210 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import SwiftSyntax
+
+extension ArrayExprSyntax {
+    public func withAdditionalElementExpr(_ expr: ExprSyntax) -> ArrayExprSyntax {
+        if self.elements.count >= 2 {
+            // If the array expression has >=2 elements, use the trivia between
+            // the last and second-to-last elements to determine how we insert
+            // the new one.
+            let lastElement = self.elements.last!
+            let secondToLastElement = self.elements[self.elements.index(self.elements.endIndex, offsetBy: -2)]
+
+            let newElements = self.elements
+                .removingLast()
+                .appending(
+                    lastElement.withTrailingComma(
+                        TokenSyntax.commaToken(
+                            trailingTrivia: (lastElement.trailingTrivia ?? []) +
+                                rightSquare.leadingTrivia.droppingPiecesAfterLastComment() +
+                                (secondToLastElement.trailingTrivia ?? [])
+                        )
+                    )
+                )
+                .appending(
+                    ArrayElementSyntax(
+                        expression: expr,
+                        trailingComma: TokenSyntax.commaToken()
+                    ).withLeadingTrivia(lastElement.leadingTrivia?.droppingPiecesUpToAndIncludingLastComment() ?? [])
+                )
+
+            return self.withElements(newElements)
+                .withRightSquare(
+                    self.rightSquare.withLeadingTrivia(
+                        self.rightSquare.leadingTrivia.droppingPiecesUpToAndIncludingLastComment()
+                    )
+                )
+        } else {
+            // For empty and single-element array exprs, we determine the indent
+            // of the line the opening square bracket appears on, and then use
+            // that to indent the added element and closing brace onto newlines.
+            let (indentTrivia, unitIndent) = self.leftSquare.determineIndentOfStartingLine()
+            var newElements: [ArrayElementSyntax] = []
+            if !self.elements.isEmpty {
+                let existingElement = self.elements.first!
+                newElements.append(
+                    ArrayElementSyntax(expression: existingElement.expression,
+                                                   trailingComma: TokenSyntax.commaToken())
+                        .withLeadingTrivia(indentTrivia + unitIndent)
+                        .withTrailingTrivia((existingElement.trailingTrivia ?? []) + .newlines(1))
+                )
+            }
+
+            newElements.append(
+                ArrayElementSyntax(expression: expr, trailingComma: TokenSyntax.commaToken())
+                    .withLeadingTrivia(indentTrivia + unitIndent)
+            )
+
+            return self.withLeftSquare(self.leftSquare.withTrailingTrivia(.newlines(1)))
+                .withElements(ArrayElementListSyntax(newElements))
+                .withRightSquare(self.rightSquare.withLeadingTrivia(.newlines(1) + indentTrivia))
+        }
+    }
+}
+
+extension ArrayExprSyntax {
+    func reindentingLastCallExprElement() -> ArrayExprSyntax {
+        let lastElement = elements.last!
+        let (indent, unitIndent) = lastElement.determineIndentOfStartingLine()
+        let formattingVisitor = MultilineArgumentListRewriter(indent: indent, unitIndent: unitIndent)
+        let formattedLastElement = formattingVisitor.visit(lastElement).as(ArrayElementSyntax.self)!
+        return self.withElements(elements.replacing(childAt: elements.count - 1, with: formattedLastElement))
+    }
+}
+
+fileprivate extension TriviaPiece {
+    var isComment: Bool {
+        switch self {
+        case .spaces, .tabs, .verticalTabs, .formfeeds, .newlines,
+                .carriageReturns, .carriageReturnLineFeeds, .unexpectedText, .shebang:
+            return false
+        case .lineComment, .blockComment, .docLineComment, .docBlockComment:
+            return true
+        }
+    }
+
+    var isHorizontalWhitespace: Bool {
+        switch self {
+        case .spaces, .tabs:
+            return true
+        default:
+            return false
+        }
+    }
+
+    var isSpaces: Bool {
+        guard case .spaces = self else { return false }
+        return true
+    }
+
+    var isTabs: Bool {
+        guard case .tabs = self else { return false }
+        return true
+    }
+}
+
+fileprivate extension Trivia {
+    func droppingPiecesAfterLastComment() -> Trivia {
+        Trivia(pieces: .init(self.lazy.reversed().drop(while: { !$0.isComment }).reversed()))
+    }
+
+    func droppingPiecesUpToAndIncludingLastComment() -> Trivia {
+        Trivia(pieces: .init(self.lazy.reversed().prefix(while: { !$0.isComment }).reversed()))
+    }
+}
+
+extension SyntaxProtocol {
+    func determineIndentOfStartingLine() -> (indent: Trivia, unitIndent: Trivia) {
+        let sourceLocationConverter = SourceLocationConverter(file: "", tree: self.root.as(SourceFileSyntax.self)!)
+        let line = startLocation(converter: sourceLocationConverter).line ?? 0
+        let visitor = DetermineLineIndentVisitor(lineNumber: line, sourceLocationConverter: sourceLocationConverter)
+        visitor.walk(self.root)
+        return (indent: visitor.lineIndent, unitIndent: visitor.lineUnitIndent)
+    }
+}
+
+public final class DetermineLineIndentVisitor: SyntaxVisitor {
+
+    let lineNumber: Int
+    let locationConverter: SourceLocationConverter
+    private var bestMatch: TokenSyntax?
+
+    public var lineIndent: Trivia {
+        guard let pieces = bestMatch?.leadingTrivia
+                .lazy
+                .reversed()
+                .prefix(while: \.isHorizontalWhitespace)
+                .reversed() else { return .spaces(4) }
+        return Trivia(pieces: Array(pieces))
+    }
+
+    public var lineUnitIndent: Trivia {
+        if lineIndent.allSatisfy(\.isSpaces) {
+            let addedSpaces = lineIndent.reduce(0, {
+                guard case .spaces(let count) = $1 else { fatalError() }
+                return $0 + count
+            }) % 4 == 0 ? 4 : 2
+            return .spaces(addedSpaces)
+        } else if lineIndent.allSatisfy(\.isTabs) {
+            return .tabs(1)
+        } else {
+            // If we can't determine the indent, default to 4 spaces.
+            return .spaces(4)
+        }
+    }
+
+    public init(lineNumber: Int, sourceLocationConverter: SourceLocationConverter) {
+        self.lineNumber = lineNumber
+        self.locationConverter = sourceLocationConverter
+        super.init(viewMode: .sourceAccurate)
+    }
+
+    public override func visit(_ tokenSyntax: TokenSyntax) -> SyntaxVisitorContinueKind {
+        let range = tokenSyntax.sourceRange(converter: locationConverter,
+                                               afterLeadingTrivia: false,
+                                               afterTrailingTrivia: true)
+        guard let startLine = range.start.line,
+              let endLine = range.end.line,
+              let startColumn = range.start.column,
+              let endColumn = range.end.column else {
+            return .skipChildren
+        }
+
+        if (startLine, startColumn) <= (lineNumber, 1),
+           (lineNumber, 1) <= (endLine, endColumn) {
+            bestMatch = tokenSyntax
+            return .visitChildren
+        } else {
+            return .skipChildren
+        }
+    }
+}
+
+/// Moves each argument to a function call expression onto a new line and indents them appropriately.
+final class MultilineArgumentListRewriter: SyntaxRewriter {
+    let indent: Trivia
+    let unitIndent: Trivia
+
+    init(indent: Trivia, unitIndent: Trivia) {
+        self.indent = indent
+        self.unitIndent = unitIndent
+    }
+
+    override func visit(_ token: TokenSyntax) -> Syntax {
+        guard token.tokenKind == .rightParen else { return Syntax(token) }
+        return Syntax(token.withLeadingTrivia(.newlines(1) + indent))
+    }
+
+    override func visit(_ node: TupleExprElementSyntax) -> Syntax {
+        return Syntax(node.withLeadingTrivia(.newlines(1) + indent + unitIndent))
+    }
+}

--- a/Sources/PackageSyntax/ManifestRewriter.swift
+++ b/Sources/PackageSyntax/ManifestRewriter.swift
@@ -1,0 +1,822 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import SwiftParser
+import SwiftSyntax
+import TSCBasic
+import TSCUtility
+import PackageModel
+import Foundation
+import PackageGraph
+
+/// A package manifest rewriter.
+///
+/// This class provides functionality for rewriting the
+/// Swift package manifest using the SwiftSyntax library.
+///
+/// Similar to SwiftSyntax, this class only deals with the
+/// syntax and has no functionality for semantics of the manifest.
+public final class ManifestRewriter {
+
+    /// The contents of the original manifest.
+    public let originalManifest: String
+
+    /// The contents of the edited manifest.
+    public var editedManifest: String {
+        return editedSource.description
+    }
+
+    /// The edited manifest syntax.
+    private var editedSource: SourceFileSyntax
+
+    /// Engine used to report manifest rewrite failures.
+    private let diagnosticsEngine: DiagnosticsEngine
+
+    /// Create a new manfiest editor with the given contents.
+    public init(_ manifest: String, diagnosticsEngine: DiagnosticsEngine) throws {
+        self.originalManifest = manifest
+        self.diagnosticsEngine = diagnosticsEngine
+        self.editedSource = try Parser.parse(source: manifest)
+    }
+
+    /// Add a package dependency.
+    public func addPackageDependency(
+        name: String?,
+        url: String,
+        requirement: PackageDependencyRequirement,
+        branchAndRevisionConvenienceMethodsSupported: Bool
+    ) throws {
+        let initFnExpr = try findPackageInit()
+
+        // Find dependencies section in the argument list of Package(...).
+        let packageDependenciesFinder = ArrayExprArgumentFinder(expectedLabel: "dependencies")
+        packageDependenciesFinder.walk(initFnExpr.argumentList)
+
+        let packageDependencies: ArrayExprSyntax
+        switch packageDependenciesFinder.result {
+        case .found(let existingPackageDependencies):
+            packageDependencies = existingPackageDependencies
+        case .missing:
+            // We didn't find a dependencies section, so insert one.
+            let argListWithDependencies = EmptyArrayArgumentWriter(argumentLabel: "dependencies",
+                                                                   followingArgumentLabels:
+                                                                   "targets",
+                                                                   "swiftLanguageVersions",
+                                                                   "cLanguageStandard",
+                                                                   "cxxLanguageStandard")
+                .visit(initFnExpr.argumentList)
+
+            // Find the inserted section.
+            let packageDependenciesFinder = ArrayExprArgumentFinder(expectedLabel: "dependencies")
+            packageDependenciesFinder.walk(argListWithDependencies)
+            guard case .found(let newPackageDependencies) = packageDependenciesFinder.result else {
+                fatalError("Could not find just inserted dependencies array")
+            }
+            packageDependencies = newPackageDependencies
+        case .incompatibleExpr:
+            diagnosticsEngine.emit(.incompatibleArgument(name: "targets"))
+            throw Diagnostics.fatalError
+        }
+
+        // Add the the package dependency entry.
+        let newManifest = PackageDependencyWriter(
+            name: name,
+            url: url,
+            requirement: requirement,
+            branchAndRevisionConvenienceMethodsSupported: branchAndRevisionConvenienceMethodsSupported
+        ).visit(packageDependencies).root
+
+        self.editedSource = newManifest.as(SourceFileSyntax.self)!
+    }
+
+    /// Add a target dependency.
+    public func addByNameTargetDependency(
+        target: String,
+        dependency: String
+    ) throws {
+        let targetDependencies = try findTargetDependenciesArrayExpr(target: target)
+
+        // Add the target dependency entry.
+        let newManifest = targetDependencies.withAdditionalElementExpr(ExprSyntax(
+            StringLiteralExprSyntax(dependency)
+        )).root
+
+        self.editedSource = newManifest.as(SourceFileSyntax.self)!
+    }
+
+    public func addProductTargetDependency(
+        target: String,
+        product: String,
+        package: TextualPackageReference
+    ) throws {
+        let targetDependencies = try findTargetDependenciesArrayExpr(target: target)
+
+        let dotProductExpr = MemberAccessExprSyntax(base: nil,
+                                                                dot: TokenSyntax.periodToken(),
+                                                                name: TokenSyntax.identifier("product"),
+                                                                declNameArguments: nil)
+
+        let argumentList = TupleExprElementListSyntax([
+            TupleExprElementSyntax(label: TokenSyntax.identifier("name"),
+                                               colon: TokenSyntax.colonToken(trailingTrivia: .spaces(1)),
+                                               expression: ExprSyntax(StringLiteralExprSyntax(product)),
+                                               trailingComma: TokenSyntax.commaToken(trailingTrivia: .spaces(1))),
+            TupleExprElementSyntax(label: TokenSyntax.identifier("package"),
+                                               colon: TokenSyntax.colonToken(trailingTrivia: .spaces(1)),
+                                   expression: ExprSyntax(StringLiteralExprSyntax(package.displayName)),
+                                               trailingComma: nil)
+        ])
+
+        let callExpr = FunctionCallExprSyntax(calledExpression: ExprSyntax(dotProductExpr),
+                                                          leftParen: TokenSyntax.leftParenToken(),
+                                                          argumentList: argumentList,
+                                                          rightParen: TokenSyntax.rightParenToken(),
+                                                          trailingClosure: nil,
+                                                          additionalTrailingClosures: nil)
+
+        // Add the target dependency entry.
+        let newManifest = targetDependencies.withAdditionalElementExpr(ExprSyntax(callExpr)).root
+        self.editedSource = newManifest.as(SourceFileSyntax.self)!
+    }
+
+    private func findTargetDependenciesArrayExpr(target: String) throws -> ArrayExprSyntax {
+        let initFnExpr = try findPackageInit()
+
+        // Find the `targets: []` array.
+        let targetsArrayFinder = ArrayExprArgumentFinder(expectedLabel: "targets")
+        targetsArrayFinder.walk(initFnExpr.argumentList)
+        guard case .found(let targetsArrayExpr) = targetsArrayFinder.result else {
+            diagnosticsEngine.emit(.missingPackageInitArgument(name: "targets"))
+            throw Diagnostics.fatalError
+        }
+
+        // Find the target node.
+        let targetFinder = NamedEntityArgumentListFinder(name: target)
+        targetFinder.walk(targetsArrayExpr)
+        guard let targetNode = targetFinder.foundEntity else {
+            diagnosticsEngine.emit(.missingTarget(name: target))
+            throw Diagnostics.fatalError
+        }
+
+        let targetDependencyFinder = ArrayExprArgumentFinder(expectedLabel: "dependencies")
+        targetDependencyFinder.walk(targetNode)
+
+        guard case .found(let targetDependencies) = targetDependencyFinder.result else {
+            diagnosticsEngine.emit(.missingArgument(name: "dependencies", parent: "target '\(target)'"))
+            throw Diagnostics.fatalError
+        }
+        return targetDependencies
+    }
+
+    /// Add a new target.
+    public func addTarget(
+        targetName: String,
+        factoryMethodName: String
+    ) throws {
+        let initFnExpr = try findPackageInit()
+        let targetsNode = try findOrCreateTargetsList(in: initFnExpr)
+
+        let dotTargetExpr = MemberAccessExprSyntax(
+            base: nil,
+            dot: TokenSyntax.periodToken(),
+            name: TokenSyntax.identifier(factoryMethodName),
+            declNameArguments: nil
+        )
+
+        let nameArg = TupleExprElementSyntax(
+            label: TokenSyntax.identifier("name"),
+            colon: TokenSyntax.colonToken(trailingTrivia: .spaces(1)),
+            expression: ExprSyntax(StringLiteralExprSyntax(targetName)),
+            trailingComma: TokenSyntax.commaToken()
+        )
+
+        let emptyArray = ArrayExprSyntax(leftSquare: TokenSyntax.leftSquareBracketToken(), elements: ArrayElementListSyntax([]), rightSquare: TokenSyntax.rightSquareBracketToken())
+        let depenenciesArg = TupleExprElementSyntax(
+            label: TokenSyntax.identifier("dependencies"),
+            colon: TokenSyntax.colonToken(trailingTrivia: .spaces(1)),
+            expression: ExprSyntax(emptyArray),
+            trailingComma: nil
+        )
+
+        let expr = FunctionCallExprSyntax(
+            calledExpression: ExprSyntax(dotTargetExpr),
+            leftParen: TokenSyntax.leftParenToken(),
+            argumentList: TupleExprElementListSyntax([
+                nameArg, depenenciesArg,
+            ]),
+            rightParen: TokenSyntax.rightParenToken(),
+            trailingClosure: nil,
+            additionalTrailingClosures: nil
+        )
+
+        let newManifest = targetsNode
+            .withAdditionalElementExpr(ExprSyntax(expr))
+            .reindentingLastCallExprElement()
+            .root
+
+        self.editedSource = newManifest.as(SourceFileSyntax.self)!
+    }
+
+    public func addBinaryTarget(targetName: String,
+                                urlOrPath: String,
+                                checksum: String?) throws {
+        let initFnExpr = try findPackageInit()
+        let targetsNode = try findOrCreateTargetsList(in: initFnExpr)
+
+        let dotTargetExpr = MemberAccessExprSyntax(
+            base: nil,
+            dot: TokenSyntax.periodToken(),
+            name: TokenSyntax.identifier("binaryTarget"),
+            declNameArguments: nil
+        )
+
+        var args: [TupleExprElementSyntax] = []
+
+        let nameArg = TupleExprElementSyntax(
+            label: TokenSyntax.identifier("name"),
+            colon: TokenSyntax.colonToken(trailingTrivia: .spaces(1)),
+            expression: ExprSyntax(StringLiteralExprSyntax(targetName)),
+            trailingComma: TokenSyntax.commaToken()
+        )
+        args.append(nameArg)
+
+        if Foundation.URL(string: urlOrPath)?.scheme == nil {
+            guard checksum == nil else {
+                diagnosticsEngine.emit(.unexpectedChecksumForBinaryTarget(path: urlOrPath))
+                throw Diagnostics.fatalError
+            }
+
+            let pathArg = TupleExprElementSyntax(
+                label: TokenSyntax.identifier("path"),
+                colon: TokenSyntax.colonToken(trailingTrivia: .spaces(1)),
+                expression: ExprSyntax(StringLiteralExprSyntax(urlOrPath)),
+                trailingComma: nil
+            )
+            args.append(pathArg)
+        } else {
+            guard let checksum = checksum else {
+                diagnosticsEngine.emit(.missingChecksumForBinaryTarget(url: urlOrPath))
+                throw Diagnostics.fatalError
+            }
+
+            let urlArg = TupleExprElementSyntax(
+                label: TokenSyntax.identifier("url"),
+                colon: TokenSyntax.colonToken(trailingTrivia: .spaces(1)),
+                expression: ExprSyntax(StringLiteralExprSyntax(urlOrPath)),
+                trailingComma: TokenSyntax.commaToken()
+            )
+            args.append(urlArg)
+
+            let checksumArg = TupleExprElementSyntax(
+                label: TokenSyntax.identifier("checksum"),
+                colon: TokenSyntax.colonToken(trailingTrivia: .spaces(1)),
+                expression: ExprSyntax(StringLiteralExprSyntax(checksum)),
+                trailingComma: nil
+            )
+            args.append(checksumArg)
+        }
+
+        let expr = FunctionCallExprSyntax(
+            calledExpression: ExprSyntax(dotTargetExpr),
+            leftParen: TokenSyntax.leftParenToken(),
+            argumentList: TupleExprElementListSyntax(args),
+            rightParen: TokenSyntax.rightParenToken(),
+          trailingClosure: nil,
+          additionalTrailingClosures: nil
+        )
+
+        let newManifest = targetsNode
+            .withAdditionalElementExpr(ExprSyntax(expr))
+            .reindentingLastCallExprElement()
+            .root
+
+        self.editedSource = newManifest.as(SourceFileSyntax.self)!
+    }
+
+    // Add a new product.
+    public func addProduct(name: String, type: ProductType) throws {
+        let initFnExpr = try findPackageInit()
+
+        let productsFinder = ArrayExprArgumentFinder(expectedLabel: "products")
+        productsFinder.walk(initFnExpr.argumentList)
+        let productsNode: ArrayExprSyntax
+
+        switch productsFinder.result {
+        case .found(let existingProducts):
+            productsNode = existingProducts
+        case .missing:
+            // We didn't find a products section, so insert one.
+            let argListWithProducts = EmptyArrayArgumentWriter(argumentLabel: "products",
+                                                               followingArgumentLabels:
+                                                               "dependencies",
+                                                               "targets",
+                                                               "swiftLanguageVersions",
+                                                               "cLanguageStandard",
+                                                               "cxxLanguageStandard")
+                .visit(initFnExpr.argumentList)
+
+            // Find the inserted section.
+            let productsFinder = ArrayExprArgumentFinder(expectedLabel: "products")
+            productsFinder.walk(argListWithProducts)
+            guard case .found(let newProducts) = productsFinder.result else {
+                fatalError("Could not find just inserted products array")
+            }
+            productsNode = newProducts
+        case .incompatibleExpr:
+            diagnosticsEngine.emit(.incompatibleArgument(name: "products"))
+            throw Diagnostics.fatalError
+        }
+
+        let newManifest = NewProductWriter(
+            name: name, type: type
+        ).visit(productsNode).root
+
+        self.editedSource = newManifest.as(SourceFileSyntax.self)!
+    }
+
+    // Add a target to a product.
+    public func addProductTarget(product: String, target: String) throws {
+        let initFnExpr = try findPackageInit()
+
+        // Find the `products: []` array.
+        let productsArrayFinder = ArrayExprArgumentFinder(expectedLabel: "products")
+        productsArrayFinder.walk(initFnExpr.argumentList)
+        guard case .found(let productsArrayExpr) = productsArrayFinder.result else {
+            diagnosticsEngine.emit(.missingPackageInitArgument(name: "products"))
+            throw Diagnostics.fatalError
+        }
+
+        // Find the product node.
+        let productFinder = NamedEntityArgumentListFinder(name: product)
+        productFinder.walk(productsArrayExpr)
+        guard let productNode = productFinder.foundEntity else {
+            diagnosticsEngine.emit(.missingProduct(name: product))
+            throw Diagnostics.fatalError
+        }
+
+        let productTargetsFinder = ArrayExprArgumentFinder(expectedLabel: "targets")
+        productTargetsFinder.walk(productNode)
+
+        guard case .found(let productTargets) = productTargetsFinder.result else {
+            diagnosticsEngine.emit(.missingArgument(name: "targets", parent: "product '\(product)'"))
+            throw Diagnostics.fatalError
+        }
+
+        let newManifest = productTargets.withAdditionalElementExpr(ExprSyntax(
+            StringLiteralExprSyntax(target)
+        )).root
+
+        self.editedSource = newManifest.as(SourceFileSyntax.self)!
+    }
+
+    private func findOrCreateTargetsList(in packageInitExpr: FunctionCallExprSyntax) throws -> ArrayExprSyntax {
+        let targetsFinder = ArrayExprArgumentFinder(expectedLabel: "targets")
+        targetsFinder.walk(packageInitExpr.argumentList)
+
+        let targetsNode: ArrayExprSyntax
+        switch targetsFinder.result {
+        case .found(let existingTargets):
+            targetsNode = existingTargets
+        case .missing:
+            // We didn't find a targets section, so insert one.
+            let argListWithTargets = EmptyArrayArgumentWriter(argumentLabel: "targets",
+                                                              followingArgumentLabels:
+                                                              "swiftLanguageVersions",
+                                                              "cLanguageStandard",
+                                                              "cxxLanguageStandard")
+                .visit(packageInitExpr.argumentList)
+
+            // Find the inserted section.
+            let targetsFinder = ArrayExprArgumentFinder(expectedLabel: "targets")
+            targetsFinder.walk(argListWithTargets)
+            guard case .found(let newTargets) = targetsFinder.result else {
+                fatalError("Could not find just-inserted targets array")
+            }
+            targetsNode = newTargets
+        case .incompatibleExpr:
+            diagnosticsEngine.emit(.incompatibleArgument(name: "targets"))
+            throw Diagnostics.fatalError
+        }
+
+        return targetsNode
+    }
+
+    private func findPackageInit() throws -> FunctionCallExprSyntax {
+        // Find Package initializer.
+        let packageFinder = PackageInitFinder()
+        packageFinder.walk(editedSource)
+        switch packageFinder.result {
+        case .found(let initFnExpr):
+            return initFnExpr
+        case .foundMultiple:
+            diagnosticsEngine.emit(.multiplePackageInits)
+            throw Diagnostics.fatalError
+        case .missing:
+            diagnosticsEngine.emit(.missingPackageInit)
+            throw Diagnostics.fatalError
+        }
+    }
+}
+
+// MARK: - Syntax Visitors
+
+/// Package init finder.
+final class PackageInitFinder: SyntaxVisitor {
+
+    enum Result {
+        case found(FunctionCallExprSyntax)
+        case foundMultiple
+        case missing
+    }
+
+    /// Reference to the function call of the package initializer.
+    private(set) var result: Result = .missing
+
+    override func visit(_ node: InitializerClauseSyntax) -> SyntaxVisitorContinueKind {
+        if let fnCall = FunctionCallExprSyntax(Syntax(node.value)),
+            let identifier = fnCall.calledExpression.firstToken,
+            identifier.text == "Package" {
+            if case .missing = result {
+                result = .found(fnCall)
+            } else {
+                result = .foundMultiple
+            }
+        }
+        return .skipChildren
+    }
+
+    init() {
+        super.init(viewMode: .sourceAccurate)
+    }
+}
+
+/// Finder for an array expression used as or as part of a labeled argument.
+final class ArrayExprArgumentFinder: SyntaxVisitor {
+
+    enum Result {
+        case found(ArrayExprSyntax)
+        case missing
+        case incompatibleExpr
+    }
+
+    private(set) var result: Result
+    private let expectedLabel: String
+
+    init(expectedLabel: String) {
+        self.expectedLabel = expectedLabel
+        self.result = .missing
+        super.init(viewMode: .sourceAccurate)
+    }
+
+    override func visit(_ node: TupleExprElementSyntax) -> SyntaxVisitorContinueKind {
+        guard node.label?.text == expectedLabel else {
+            return .skipChildren
+        }
+
+        // We have custom code like foo + bar + [] (hopefully there is an array expr here).
+        if let seq = node.expression.as(SequenceExprSyntax.self),
+           let arrayExpr = seq.elements.first(where: { $0.is(ArrayExprSyntax.self) })?.as(ArrayExprSyntax.self) {
+            result = .found(arrayExpr)
+        } else if let arrayExpr = node.expression.as(ArrayExprSyntax.self) {
+            result = .found(arrayExpr)
+        } else {
+            result = .incompatibleExpr
+        }
+
+        return .skipChildren
+    }
+}
+
+/// Given an Array expression of call expressions, find the argument list of the call
+/// expression with the specified `name` argument.
+final class NamedEntityArgumentListFinder: SyntaxVisitor {
+
+    let entityToFind: String
+    private(set) var foundEntity: TupleExprElementListSyntax?
+
+    init(name: String) {
+        self.entityToFind = name
+        super.init(viewMode: .sourceAccurate)
+    }
+
+    override func visit(_ node: TupleExprElementSyntax) -> SyntaxVisitorContinueKind {
+        guard case .identifier(let label)? = node.label?.tokenKind else {
+            return .skipChildren
+        }
+        guard label == "name", let targetNameExpr = node.expression.as(StringLiteralExprSyntax.self),
+              targetNameExpr.segments.count == 1, let segment = targetNameExpr.segments.first?.as(StringSegmentSyntax.self) else {
+            return .skipChildren
+        }
+
+        guard case .stringSegment(let name) = segment.content.tokenKind else {
+            return .skipChildren
+        }
+
+        if name == self.entityToFind {
+            self.foundEntity = node.parent?.as(TupleExprElementListSyntax.self)
+            return .skipChildren
+        }
+
+        return .skipChildren
+    }
+}
+
+// MARK: - Syntax Rewriters
+
+/// Writer for an empty array argument.
+final class EmptyArrayArgumentWriter: SyntaxRewriter {
+    let argumentLabel: String
+    let followingArgumentLabels: Set<String>
+
+    init(argumentLabel: String, followingArgumentLabels: String...) {
+        self.argumentLabel = argumentLabel
+        self.followingArgumentLabels = .init(followingArgumentLabels)
+    }
+
+    override func visit(_ node: TupleExprElementListSyntax) -> Syntax {
+        let leadingTrivia = node.firstToken?.leadingTrivia ?? .zero
+
+        let existingLabels = node.map(\.label?.text)
+        let insertionIndex = existingLabels.firstIndex {
+            followingArgumentLabels.contains($0 ?? "")
+        } ?? existingLabels.endIndex
+
+        let dependenciesArg = TupleExprElementSyntax(
+            label: TokenSyntax.identifier(argumentLabel, leadingTrivia: leadingTrivia),
+            colon: TokenSyntax.colonToken(trailingTrivia: .spaces(1)),
+            expression: ExprSyntax(ArrayExprSyntax(
+                                    leftSquare: TokenSyntax.leftSquareBracketToken(),
+                                    elements: ArrayElementListSyntax([]),
+                                    rightSquare: TokenSyntax.rightSquareBracketToken())),
+            trailingComma: insertionIndex != existingLabels.endIndex ? TokenSyntax.commaToken() : nil
+        )
+
+        var newNode = node
+        if let lastArgument = newNode.last,
+           insertionIndex == existingLabels.endIndex,
+           node.lastToken?.tokenKind != .comma {
+            // If the new argument is being added at the end of the list, the argument before it needs a comma.
+            newNode = newNode.replacing(childAt: newNode.count-1,
+                                        with: lastArgument.withTrailingComma(TokenSyntax.commaToken()))
+        }
+        
+        return Syntax(newNode.inserting(dependenciesArg, at: insertionIndex))
+    }
+}
+
+/// Package dependency writer.
+final class PackageDependencyWriter: SyntaxRewriter {
+
+    /// The dependency name to write.
+    let name: String?
+
+    /// The dependency url to write.
+    let url: String
+
+    /// The dependency requirement.
+    let requirement: PackageDependencyRequirement
+
+    /// Whether convenience methods for branch and revision dependencies are supported.
+    let branchAndRevisionConvenienceMethodsSupported: Bool
+
+    init(name: String?,
+         url: String,
+         requirement: PackageDependencyRequirement,
+         branchAndRevisionConvenienceMethodsSupported: Bool) {
+        self.name = name
+        self.url = url
+        self.requirement = requirement
+        self.branchAndRevisionConvenienceMethodsSupported = branchAndRevisionConvenienceMethodsSupported
+    }
+
+    override func visit(_ node: ArrayExprSyntax) -> ExprSyntax {
+
+        let dotPackageExpr = MemberAccessExprSyntax(
+            base: nil,
+            dot: TokenSyntax.periodToken(),
+            name: TokenSyntax.identifier("package"),
+            declNameArguments: nil
+        )
+
+        var args: [TupleExprElementSyntax] = []
+
+        if let name = self.name {
+            let nameArg = TupleExprElementSyntax(
+                label: TokenSyntax.identifier("name"),
+                colon: TokenSyntax.colonToken(trailingTrivia: .spaces(1)),
+                expression: ExprSyntax(StringLiteralExprSyntax(name)),
+                trailingComma: TokenSyntax.commaToken(trailingTrivia: .spaces(1))
+            )
+            args.append(nameArg)
+        }
+
+        let locationArgLabel = requirement == .localPackage ? "path" : "url"
+        let locationArg = TupleExprElementSyntax(
+            label: TokenSyntax.identifier(locationArgLabel),
+            colon: TokenSyntax.colonToken(trailingTrivia: .spaces(1)),
+            expression: ExprSyntax(StringLiteralExprSyntax(self.url)),
+            trailingComma: requirement == .localPackage ? nil : TokenSyntax.commaToken(trailingTrivia: .spaces(1))
+        )
+        args.append(locationArg)
+
+        let addUnlabeledImplicitMemberCallWithStringArg = { (baseName: String, argumentLabel: String?, argumentString: String) in
+            let memberExpr = MemberAccessExprSyntax(base: nil,
+                                                                dot: TokenSyntax.periodToken(),
+                                                                name: TokenSyntax.identifier(baseName),
+                                                                declNameArguments: nil)
+            let argList = TupleExprElementListSyntax([
+                TupleExprElementSyntax(label: argumentLabel.map { TokenSyntax.identifier($0) },
+                                                   colon: argumentLabel.map { _ in TokenSyntax.colonToken(trailingTrivia: .spaces(1)) },
+                                                   expression: ExprSyntax(StringLiteralExprSyntax(argumentString)),
+                                                   trailingComma: nil)
+            ])
+            let exactExpr = FunctionCallExprSyntax(calledExpression: ExprSyntax(memberExpr),
+                                                               leftParen: TokenSyntax.leftParenToken(),
+                                                               argumentList: argList,
+                                                               rightParen: TokenSyntax.rightParenToken(),
+                                                               trailingClosure: nil,
+                                                               additionalTrailingClosures: nil)
+            let exactArg = TupleExprElementSyntax(label: nil,
+                                                              colon: nil,
+                                                              expression: ExprSyntax(exactExpr),
+                                                              trailingComma: nil)
+            args.append(exactArg)
+        }
+
+        let addUnlabeledRangeArg = { (start: String, end: String, rangeOperator: String) in
+            let rangeExpr = SequenceExprSyntax(elements: ExprListSyntax([
+                ExprSyntax(StringLiteralExprSyntax(start)),
+                ExprSyntax(BinaryOperatorExprSyntax(
+                            operatorToken: TokenSyntax.unspacedBinaryOperator(rangeOperator))
+                ),
+                ExprSyntax(StringLiteralExprSyntax(end))
+            ]))
+            let arg = TupleExprElementSyntax(label: nil,
+                                                         colon: nil,
+                                                         expression: ExprSyntax(rangeExpr),
+                                                         trailingComma: nil)
+            args.append(arg)
+        }
+
+        let addLabeledStringArg = { (label: String, literalString: String) in
+            let arg = TupleExprElementSyntax(label: TokenSyntax.identifier(label),
+                                                         colon: TokenSyntax.colonToken(trailingTrivia: .spaces(1)),
+                                                         expression: ExprSyntax(StringLiteralExprSyntax(literalString)),
+                                                         trailingComma: nil)
+            args.append(arg)
+        }
+
+        switch requirement {
+        case .exact(let version):
+            addUnlabeledImplicitMemberCallWithStringArg("exact", nil, version)
+        case .revision(let revision):
+            if branchAndRevisionConvenienceMethodsSupported {
+                addLabeledStringArg("revision", revision)
+            } else {
+                addUnlabeledImplicitMemberCallWithStringArg("revision", nil, revision)
+            }
+        case .branch(let branch):
+            if branchAndRevisionConvenienceMethodsSupported {
+                addLabeledStringArg("branch", branch)
+            } else {
+                addUnlabeledImplicitMemberCallWithStringArg("branch", nil, branch)
+            }
+        case .upToNextMajor(let version):
+            addUnlabeledImplicitMemberCallWithStringArg("upToNextMajor", "from", version)
+        case .upToNextMinor(let version):
+            addUnlabeledImplicitMemberCallWithStringArg("upToNextMinor", "from", version)
+        case .range(let start, let end):
+            addUnlabeledRangeArg(start, end, "..<")
+        case .closedRange(let start, let end):
+            addUnlabeledRangeArg(start, end, "...")
+        case .localPackage:
+            break
+        }
+
+        let expr = FunctionCallExprSyntax(
+            calledExpression: ExprSyntax(dotPackageExpr),
+            leftParen: TokenSyntax.leftParenToken(),
+            argumentList: TupleExprElementListSyntax(args),
+            rightParen: TokenSyntax.rightParenToken(),
+          trailingClosure: nil,
+          additionalTrailingClosures: nil
+        )
+
+        return ExprSyntax(node.withAdditionalElementExpr(ExprSyntax(expr)))
+    }
+}
+
+/// Writer for inserting a new product in a products array.
+final class NewProductWriter: SyntaxRewriter {
+
+    let name: String
+    let type: ProductType
+
+    init(name: String, type: ProductType) {
+        self.name = name
+        self.type = type
+    }
+
+    override func visit(_ node: ArrayExprSyntax) -> ExprSyntax {
+        let dotExpr = MemberAccessExprSyntax(
+            base: nil,
+            dot: TokenSyntax.periodToken(),
+            name: TokenSyntax.identifier(type == .executable ? "executable" : "library"),
+            declNameArguments: nil
+        )
+
+        var args: [TupleExprElementSyntax] = []
+
+        let nameArg = TupleExprElementSyntax(
+            label: TokenSyntax.identifier("name"),
+            colon: TokenSyntax.colonToken(trailingTrivia: .spaces(1)),
+            expression: ExprSyntax(StringLiteralExprSyntax(name)),
+            trailingComma: TokenSyntax.commaToken()
+        )
+        args.append(nameArg)
+
+        if case .library(let kind) = type, kind != .automatic {
+            let typeExpr = MemberAccessExprSyntax(base: nil,
+                                                              dot: TokenSyntax.periodToken(),
+                                                              name: TokenSyntax.identifier(kind == .dynamic ? "dynamic" : "static"),
+                                                              declNameArguments: nil)
+            let typeArg = TupleExprElementSyntax(
+                label: TokenSyntax.identifier("type"),
+                colon: TokenSyntax.colonToken(trailingTrivia: .spaces(1)),
+                expression: ExprSyntax(typeExpr),
+                trailingComma: TokenSyntax.commaToken()
+            )
+            args.append(typeArg)
+        }
+
+        let emptyArray = ArrayExprSyntax(leftSquare: TokenSyntax.leftSquareBracketToken(),
+                                                     elements: ArrayElementListSyntax([]),
+                                                     rightSquare: TokenSyntax.rightSquareBracketToken())
+        let targetsArg = TupleExprElementSyntax(
+            label: TokenSyntax.identifier("targets"),
+            colon: TokenSyntax.colonToken(trailingTrivia: .spaces(1)),
+            expression: ExprSyntax(emptyArray),
+            trailingComma: nil
+        )
+        args.append(targetsArg)
+
+        let expr = FunctionCallExprSyntax(
+            calledExpression: ExprSyntax(dotExpr),
+            leftParen: TokenSyntax.leftParenToken(),
+            argumentList: TupleExprElementListSyntax(args),
+            rightParen: TokenSyntax.rightParenToken(),
+          trailingClosure: nil,
+          additionalTrailingClosures: nil
+        )
+
+        return ExprSyntax(node
+                            .withAdditionalElementExpr(ExprSyntax(expr))
+                            .reindentingLastCallExprElement())
+    }
+}
+
+private extension TSCBasic.Diagnostic.Message {
+    static var missingPackageInit: Self =
+        .error("couldn't find Package initializer")
+    static var multiplePackageInits: Self =
+        .error("found multiple Package initializers")
+    static func missingPackageInitArgument(name: String) -> Self {
+        .error("couldn't find '\(name)' argument in Package initializer")
+    }
+    static func missingArgument(name: String, parent: String) -> Self {
+        .error("couldn't find '\(name)' argument of \(parent)")
+    }
+    static func incompatibleArgument(name: String) -> Self {
+        .error("'\(name)' argument is not an array literal or concatenation of array literals")
+    }
+    static func missingProduct(name: String) -> Self {
+        .error("couldn't find product '\(name)'")
+    }
+    static func missingTarget(name: String) -> Self {
+        .error("couldn't find target '\(name)'")
+    }
+    static func unexpectedChecksumForBinaryTarget(path: String) -> Self {
+        .error("'\(path)' is a local path, but a checksum was specified for the binary target")
+    }
+    static func missingChecksumForBinaryTarget(url: String) -> Self {
+        .error("'\(url)' is a remote URL, but no checksum was specified for the binary target")
+    }
+}
+
+public extension StringLiteralExprSyntax {
+    init(_ stringLiteral: String) {
+        self.init(openDelimiter: nil,
+                  openQuote: .stringQuoteToken(),
+                  segments: StringLiteralSegmentsSyntax([Syntax(StringSegmentSyntax(content: .stringSegment(stringLiteral)))]),
+                  closeQuote: .stringQuoteToken(),
+                  closeDelimiter: nil
+        )
+    }
+}

--- a/Sources/PackageSyntax/PackageEditor.swift
+++ b/Sources/PackageSyntax/PackageEditor.swift
@@ -1,0 +1,469 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import TSCUtility
+import TSCBasic
+import SourceControl
+import PackageLoading
+import PackageModel
+import Workspace
+import Foundation
+import class Basics.ObservabilitySystem
+import PackageGraph
+
+/// Wrapper type for name and idenity which can be used to refer to external packages depending on tools-version.
+public struct TextualPackageReference {
+    public let displayName: String
+    public let identity: PackageIdentity
+
+    public init(_ package: ResolvedPackage) {
+        // This is needed to support older tools-versions
+        self.displayName = package.manifest.displayName
+        self.identity = package.identity
+    }
+
+    public init(displayName: String, identity: PackageIdentity) {
+        self.displayName = displayName
+        self.identity = identity
+    }
+}
+
+/// An editor for Swift packages.
+///
+/// This class provides high-level functionality for performing
+/// editing operations a package.
+public final class PackageEditor {
+
+    /// Reference to the package editor context.
+    let context: PackageEditorContext
+
+    /// Create a package editor instance.
+    public convenience init(manifestPath: AbsolutePath,
+                            repositoryManager: RepositoryManager,
+                            toolchain: UserToolchain,
+                            diagnosticsEngine: DiagnosticsEngine) throws {
+        self.init(context: try PackageEditorContext(manifestPath: manifestPath,
+                                                    repositoryManager: repositoryManager,
+                                                    toolchain: toolchain,
+                                                    diagnosticsEngine: diagnosticsEngine))
+    }
+
+    /// Create a package editor instance.
+    public init(context: PackageEditorContext) {
+        self.context = context
+    }
+
+    /// The file system to perform disk operations on.
+    var fs: FileSystem {
+        return context.fs
+    }
+
+    /// Add a package dependency.
+    public func addPackageDependency(url: String, requirement: PackageDependencyRequirement?) throws {
+        var requirement = requirement
+        let manifestPath = context.manifestPath
+        // Validate that the package doesn't already contain this dependency.
+        let loadedManifest = try context.loadManifest(at: context.manifestPath.parentDirectory)
+
+        try diagnoseUnsupportedToolsVersions(manifest: loadedManifest)
+
+        let containsDependency = loadedManifest.dependencies.contains {
+            return PackageIdentity(url: URL(string: url)!) == $0.identity
+        }
+        guard !containsDependency else {
+            context.diagnosticsEngine.emit(.packageDependencyAlreadyExists(url: url,
+                                                                           packageName: loadedManifest.displayName))
+            throw Diagnostics.fatalError
+        }
+
+        // If the input URL is a path, force the requirement to be a local package.
+        if URL(string: url)?.scheme == nil {
+            guard requirement == nil || requirement == .localPackage else {
+                context.diagnosticsEngine.emit(.nonLocalRequirementSpecifiedForLocalPath(path: url))
+                throw Diagnostics.fatalError
+            }
+            requirement = .localPackage
+        }
+
+        // Load the dependency manifest depending on the inputs.
+        let dependencyManifest: Manifest
+        if requirement == .localPackage {
+            let path = AbsolutePath(url, relativeTo: fs.currentWorkingDirectory!)
+            dependencyManifest = try context.loadManifest(at: path)
+            requirement = .localPackage
+        } else {
+            // Otherwise, first lookup the dependency.
+            let id = PackageIdentity(url: URL(string: url)!)
+            let spec = RepositorySpecifier(url: URL(string: url)!)
+            let handle = try tsc_await{
+                let observability = ObservabilitySystem { _, _ in }
+                context.repositoryManager.lookup(package: id, repository: spec, skipUpdate: true, observabilityScope: observability.topScope, delegateQueue: .global(qos: .userInitiated), callbackQueue: .global(qos: .userInitiated), completion: $0)
+            }
+            let repo = try handle.open()
+
+            // Compute the requirement.
+            if let inputRequirement = requirement {
+                requirement = inputRequirement
+            } else {
+                // Use the latest version or the main/master branch.
+                let versions = try repo.getTags().compactMap{ Version($0) }
+                let latestVersion = versions.filter({ $0.prereleaseIdentifiers.isEmpty }).max() ?? versions.max()
+                let mainExists = (try? repo.resolveRevision(identifier: "main")) != nil
+                requirement = latestVersion.map{ PackageDependencyRequirement.upToNextMajor($0.description) } ??
+                    (mainExists ? PackageDependencyRequirement.branch("main") : PackageDependencyRequirement.branch("master"))
+            }
+
+            // Load the manifest.
+            let revision = try repo.resolveRevision(identifier: requirement!.ref!)
+            let repoFS = try repo.openFileView(revision: revision)
+            dependencyManifest = try context.loadManifest(at: .root, fs: repoFS)
+        }
+
+        // Add the package dependency.
+        let manifestContents = try fs.readFileContents(manifestPath).cString
+        let editor = try ManifestRewriter(manifestContents, diagnosticsEngine: context.diagnosticsEngine)
+
+        // Only tools-version 5.2, 5.3, & 5.4 should specify a package name.
+        // At this point, we've already diagnosed tools-versions less than 5.2 as unsupported
+        if loadedManifest.toolsVersion < .v5_5 {
+            // Using `displayName` here for non-display purposes in support of older manifest formats.
+            try editor.addPackageDependency(name: dependencyManifest.displayName,
+                                            url: url,
+                                            requirement: requirement!,
+                                            branchAndRevisionConvenienceMethodsSupported: false)
+        } else {
+            try editor.addPackageDependency(name: nil,
+                                            url: url,
+                                            requirement: requirement!,
+                                            branchAndRevisionConvenienceMethodsSupported: true)
+        }
+
+        try context.verifyEditedManifest(contents: editor.editedManifest)
+        try fs.writeFileContents(manifestPath, bytes: ByteString(encodingAsUTF8: editor.editedManifest))
+    }
+
+    /// Add a new target.
+    public func addTarget(_ newTarget: NewTarget, productPackageNameMapping: [String: TextualPackageReference]) throws {
+        let manifestPath = context.manifestPath
+
+        // Validate that the package doesn't already contain a target with the same name.
+        let loadedManifest = try context.loadManifest(at: manifestPath.parentDirectory)
+
+        try diagnoseUnsupportedToolsVersions(manifest: loadedManifest)
+
+        if loadedManifest.targets.contains(where: { $0.name == newTarget.name }) {
+            context.diagnosticsEngine.emit(.targetAlreadyExists(name: newTarget.name,
+                                                                packageName: loadedManifest.displayName))
+            throw Diagnostics.fatalError
+        }
+
+        let manifestContents = try fs.readFileContents(manifestPath).cString
+        let editor = try ManifestRewriter(manifestContents, diagnosticsEngine: context.diagnosticsEngine)
+
+        switch newTarget {
+        case .library(name: let name, includeTestTarget: _, dependencyNames: let dependencyNames),
+             .executable(name: let name, dependencyNames: let dependencyNames),
+             .test(name: let name, dependencyNames: let dependencyNames):
+            try editor.addTarget(targetName: newTarget.name,
+                                 factoryMethodName: newTarget.factoryMethodName(for: loadedManifest.toolsVersion))
+
+            for dependency in dependencyNames {
+                if loadedManifest.targets.map(\.name).contains(dependency) {
+                    try editor.addByNameTargetDependency(target: name, dependency: dependency)
+                } else if let productPackage = productPackageNameMapping[dependency] {
+                    if productPackage.displayName == dependency {
+                        try editor.addByNameTargetDependency(target: name, dependency: dependency)
+                    } else {
+                        try editor.addProductTargetDependency(target: name, product: dependency, package: productPackage)
+                    }
+                } else {
+                    context.diagnosticsEngine.emit(.missingProductOrTarget(name: dependency))
+                    throw Diagnostics.fatalError
+                }
+            }
+        case .binary(name: let name, urlOrPath: let urlOrPath, checksum: let checksum):
+            guard loadedManifest.toolsVersion >= .v5_3 else {
+                context.diagnosticsEngine.emit(.unsupportedToolsVersionForBinaryTargets)
+                throw Diagnostics.fatalError
+            }
+            try editor.addBinaryTarget(targetName: name, urlOrPath: urlOrPath, checksum: checksum)
+        }
+
+        try context.verifyEditedManifest(contents: editor.editedManifest)
+        try fs.writeFileContents(manifestPath, bytes: ByteString(encodingAsUTF8: editor.editedManifest))
+
+        // Write template files.
+        try writeTemplateFilesForTarget(newTarget)
+
+        if case .library(name: let name, includeTestTarget: true, dependencyNames: _) = newTarget {
+            try self.addTarget(.test(name: "\(name)Tests", dependencyNames: [name]),
+                               productPackageNameMapping: productPackageNameMapping)
+        }
+    }
+
+    private func diagnoseUnsupportedToolsVersions(manifest: Manifest) throws {
+        guard manifest.toolsVersion >= .v5_2 else {
+            context.diagnosticsEngine.emit(.unsupportedToolsVersionForEditing)
+            throw Diagnostics.fatalError
+        }
+    }
+
+    private func writeTemplateFilesForTarget(_ newTarget: NewTarget) throws {
+        switch newTarget {
+        case .library:
+            let targetPath = context.manifestPath.parentDirectory.appending(components: "Sources", newTarget.name)
+            if !localFileSystem.exists(targetPath) {
+                let file = targetPath.appending(component: "\(newTarget.name).swift")
+                try fs.createDirectory(targetPath, recursive: true)
+                try fs.writeFileContents(file, bytes: "")
+            }
+        case .executable:
+            let targetPath = context.manifestPath.parentDirectory.appending(components: "Sources", newTarget.name)
+            if !localFileSystem.exists(targetPath) {
+                let file = targetPath.appending(component: "main.swift")
+                try fs.createDirectory(targetPath, recursive: true)
+                try fs.writeFileContents(file, bytes: "")
+            }
+        case .test:
+            let testTargetPath = context.manifestPath.parentDirectory.appending(components: "Tests", newTarget.name)
+            if !fs.exists(testTargetPath) {
+                let file = testTargetPath.appending(components: newTarget.name + ".swift")
+                try fs.createDirectory(testTargetPath, recursive: true)
+                try fs.writeFileContents(file) {
+                    $0 <<< """
+                    import XCTest
+                    @testable import <#Module#>
+
+                    final class <#TestCase#>: XCTestCase {
+                        func testExample() {
+
+                        }
+                    }
+                    """
+                }
+            }
+        case .binary:
+            break
+        }
+    }
+
+    public func addProduct(name: String, type: ProductType, targets: [String]) throws {
+        let manifestPath = context.manifestPath
+
+        // Validate that the package doesn't already contain a product with the same name.
+        let loadedManifest = try context.loadManifest(at: manifestPath.parentDirectory)
+
+        try diagnoseUnsupportedToolsVersions(manifest: loadedManifest)
+
+        guard !loadedManifest.products.contains(where: { $0.name == name }) else {
+            context.diagnosticsEngine.emit(.productAlreadyExists(name: name,
+                                                                 packageName: loadedManifest.displayName))
+            throw Diagnostics.fatalError
+        }
+
+        let manifestContents = try fs.readFileContents(manifestPath).cString
+        let editor = try ManifestRewriter(manifestContents, diagnosticsEngine: context.diagnosticsEngine)
+        try editor.addProduct(name: name, type: type)
+
+
+        for target in targets {
+            guard loadedManifest.targets.map(\.name).contains(target) else {
+                context.diagnosticsEngine.emit(.noTarget(name: target, packageName: loadedManifest.displayName))
+                throw Diagnostics.fatalError
+            }
+            try editor.addProductTarget(product: name, target: target)
+        }
+
+        try context.verifyEditedManifest(contents: editor.editedManifest)
+        try fs.writeFileContents(manifestPath, bytes: ByteString(encodingAsUTF8: editor.editedManifest))
+    }
+}
+
+extension Array where Element == TargetDescription.Dependency {
+    func containsDependency(_ other: String) -> Bool {
+        return self.contains {
+            switch $0 {
+            case .target(name: let name, condition: _),
+                 .product(name: let name, package: _, moduleAliases: _, condition: _),
+                 .byName(name: let name, condition: _):
+                return name == other
+            }
+        }
+    }
+}
+
+/// The types of target.
+public enum NewTarget {
+    case library(name: String, includeTestTarget: Bool, dependencyNames: [String])
+    case executable(name: String, dependencyNames: [String])
+    case test(name: String, dependencyNames: [String])
+    case binary(name: String, urlOrPath: String, checksum: String?)
+
+    /// The name of the factory method for a target type.
+    func factoryMethodName(for toolsVersion: ToolsVersion) -> String {
+        switch self {
+        case .executable:
+          if toolsVersion >= .v5_4 {
+            return "executableTarget"
+          } else {
+            return "target"
+          }
+        case .library: return "target"
+        case .test: return "testTarget"
+        case .binary: return "binaryTarget"
+        }
+    }
+
+    /// The name of the new target.
+    var name: String {
+        switch self {
+        case .library(name: let name, includeTestTarget: _, dependencyNames: _),
+             .executable(name: let name, dependencyNames: _),
+             .test(name: let name, dependencyNames: _),
+             .binary(name: let name, urlOrPath: _, checksum: _):
+            return name
+        }
+    }
+}
+
+public enum PackageDependencyRequirement: Equatable {
+    case exact(String)
+    case revision(String)
+    case branch(String)
+    case upToNextMajor(String)
+    case upToNextMinor(String)
+    case range(String, String)
+    case closedRange(String, String)
+    case localPackage
+
+    var ref: String? {
+        switch self {
+        case .exact(let ref): return ref
+        case .revision(let ref): return ref
+        case .branch(let ref): return ref
+        case .upToNextMajor(let ref): return ref
+        case .upToNextMinor(let ref): return ref
+        case .range(let start, _): return start
+        case .closedRange(let start, _): return start
+        case .localPackage: return nil
+        }
+    }
+}
+
+extension ProductType {
+    var isLibrary: Bool {
+        switch self {
+        case .library:
+            return true
+        case .executable, .test, .plugin, .snippet:
+            return false
+        }
+    }
+}
+
+/// The global context for package editor.
+public final class PackageEditorContext {
+    /// Path to the package manifest.
+    let manifestPath: AbsolutePath
+
+    /// The manifest loader.
+    let manifestLoader: ManifestLoaderProtocol
+
+    /// The repository manager.
+    let repositoryManager: RepositoryManager
+
+    /// The file system in use.
+    let fs: FileSystem
+
+    /// The diagnostics engine used to report errors.
+    let diagnosticsEngine: DiagnosticsEngine
+
+    public init(manifestPath: AbsolutePath,
+                repositoryManager: RepositoryManager,
+                toolchain: UserToolchain,
+                diagnosticsEngine: DiagnosticsEngine,
+                fs: FileSystem = localFileSystem) throws {
+        self.manifestPath = manifestPath
+        self.repositoryManager = repositoryManager
+        self.diagnosticsEngine = diagnosticsEngine
+        self.fs = fs
+
+        self.manifestLoader = ManifestLoader(toolchain: toolchain)
+    }
+
+    func verifyEditedManifest(contents: String) throws {
+        do {
+            try withTemporaryDirectory {
+                let path = $0
+                try localFileSystem.writeFileContents(path.appending(component: "Package.swift"),
+                                                      bytes: ByteString(encodingAsUTF8: contents))
+                _ = try loadManifest(at: path, fs: localFileSystem)
+            }
+        } catch {
+            diagnosticsEngine.emit(.failedToLoadEditedManifest(error: error))
+            throw Diagnostics.fatalError
+        }
+    }
+
+    /// Load the manifest at the given path.
+    func loadManifest(
+        at path: AbsolutePath,
+        fs: FileSystem? = nil
+    ) throws -> Manifest {
+        let fs = fs ?? self.fs
+
+        let manifestPath = try ManifestLoader.findManifest(packagePath: path, fileSystem: fs, currentToolsVersion: .current)
+        let toolsVersion = try ToolsVersionParser.parse(manifestPath: manifestPath, fileSystem: fs)
+        return try tsc_await {
+            manifestLoader.load(
+                packagePath: path,
+                packageIdentity: .plain("<synthesized-root>"),
+                packageKind: .fileSystem(path),
+                packageLocation: path.pathString,
+                packageVersion: nil,
+                currentToolsVersion: toolsVersion,
+                identityResolver: DefaultIdentityResolver(),
+                fileSystem: fs,
+                observabilityScope: ObservabilitySystem { _, _ in }.topScope,
+                delegateQueue: .global(),
+                callbackQueue: .global(),
+                completion: $0
+            )
+        }
+    }
+}
+
+private extension Diagnostic.Message {
+    static func failedToLoadEditedManifest(error: Error) -> Diagnostic.Message {
+        .error("discarding changes because the edited manifest could not be loaded: \(error)")
+    }
+    static var unsupportedToolsVersionForEditing: Diagnostic.Message =
+        .error("command line editing of manifests is only supported for packages with a swift-tools-version of 5.2 and later")
+    static var unsupportedToolsVersionForBinaryTargets: Diagnostic.Message =
+        .error("binary targets are only supported in packages with a swift-tools-version of 5.3 and later")
+    static func productAlreadyExists(name: String, packageName: String) -> Diagnostic.Message {
+        .error("a product named '\(name)' already exists in '\(packageName)'")
+    }
+    static func packageDependencyAlreadyExists(url: String, packageName: String) -> Diagnostic.Message {
+        .error("'\(packageName)' already has a dependency on '\(url)'")
+    }
+    static func noTarget(name: String, packageName: String) -> Diagnostic.Message {
+        .error("no target named '\(name)' in '\(packageName)'")
+    }
+    static func targetAlreadyExists(name: String, packageName: String) -> Diagnostic.Message {
+        .error("a target named '\(name)' already exists in '\(packageName)'")
+    }
+    static func nonLocalRequirementSpecifiedForLocalPath(path: String) -> Diagnostic.Message {
+        .error("'\(path)' is a local package, but a non-local requirement was specified")
+    }
+    static func missingProductOrTarget(name: String) -> Diagnostic.Message {
+        .error("could not find a product or target named '\(name)'")
+    }
+}

--- a/Sources/swift-package-editor/SwiftPackageEditorTool.swift
+++ b/Sources/swift-package-editor/SwiftPackageEditorTool.swift
@@ -1,0 +1,345 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import ArgumentParser
+import Basics
+import TSCBasic
+import PackageModel
+import PackageGraph
+import SourceControl
+import Workspace
+import Foundation
+import PackageSyntax
+import PackageLoading
+import TSCUtility
+
+@main
+public struct SwiftPackageEditorTool: ParsableCommand {
+    public static var configuration = CommandConfiguration(
+        commandName: "package-editor",
+        _superCommandName: "swift",
+        abstract: "Edit Package.swift files",
+        version: SwiftVersion.current.completeDisplayString,
+        subcommands: [AddDependency.self, AddTarget.self, AddProduct.self],
+        helpNames: [.short, .long, .customLong("help", withSingleDash: true)])
+    public init() {}
+}
+
+final class EditorTool {
+    let diagnostics: DiagnosticsEngine
+    let packageRoot: AbsolutePath
+    let toolchain: UserToolchain
+    let packageEditor: PackageEditor
+    private var cachedPackageGraph: PackageGraph?
+
+    init() throws {
+        diagnostics = DiagnosticsEngine(handlers: [print(diagnostic:)])
+
+        guard let cwd = localFileSystem.currentWorkingDirectory else {
+            diagnostics.emit(.error("could not determine current working directory"))
+            throw ExitCode.failure
+        }
+
+        var root = cwd
+        while !localFileSystem.isFile(root.appending(component: Manifest.filename)) {
+            root = root.parentDirectory
+            guard !root.isRoot else {
+                diagnostics.emit(.error("could not find package manifest"))
+                throw ExitCode.failure
+            }
+        }
+        packageRoot = root
+
+        toolchain = try UserToolchain(destination: Destination.hostDestination(originalWorkingDirectory: cwd))
+
+        let manifestPath = try ManifestLoader.findManifest(packagePath: packageRoot,
+                                                           fileSystem: localFileSystem,
+                                                           currentToolsVersion: ToolsVersion.current)
+        let repositoryManager = RepositoryManager(fileSystem: localFileSystem,
+                                                  path: packageRoot.appending(component: ".build"),
+                                                  provider: GitRepositoryProvider(),
+                                                  initializationWarningHandler: { _ in })
+        packageEditor = try PackageEditor(manifestPath: manifestPath,
+                                          repositoryManager: repositoryManager,
+                                          toolchain: toolchain,
+                                          diagnosticsEngine: diagnostics)
+    }
+
+    func loadPackageGraph() throws -> PackageGraph {
+        if let cachedPackageGraph = cachedPackageGraph {
+            return cachedPackageGraph
+        }
+        let workspace = try Workspace.init(forRootPackage: packageRoot, customManifestLoader: nil)
+        let observability = ObservabilitySystem { _, _ in }
+        let graph = try workspace.loadPackageGraph(rootPath: packageRoot, observabilityScope: observability.topScope)
+        guard !diagnostics.hasErrors else {
+            throw ExitCode.failure
+        }
+        cachedPackageGraph = graph
+        return graph
+    }
+}
+
+protocol EditorCommand: ParsableCommand {
+    func run(_ editorTool: EditorTool) throws
+}
+
+extension EditorCommand {
+    public func run() throws {
+        let editorTool = try EditorTool()
+        try self.run(editorTool)
+        if editorTool.diagnostics.hasErrors {
+            throw ExitCode.failure
+        }
+    }
+}
+
+struct AddDependency: EditorCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Add a dependency to the current package.")
+
+    @Argument(help: "The URL of a remote package, or the path to a local package")
+    var dependencyURL: String
+
+    @Option(help: "Specifies an exact package version requirement")
+    var exact: Version?
+
+    @Option(help: "Specifies a package revision requirement")
+    var revision: String?
+
+    @Option(help: "Specifies a package branch requirement")
+    var branch: String?
+
+    @Option(help: "Specifies a package version requirement from the specified version up to the next major version")
+    var from: Version?
+
+    @Option(help: "Specifies a package version requirement from the specified version up to the next minor version")
+    var upToNextMinorFrom: Version?
+
+    @Option(help: "Specifies the upper bound of a range-based package version requirement")
+    var to: Version?
+
+    @Option(help: "Specifies the upper bound of a closed range-based package version requirement")
+    var through: Version?
+
+    func run(_ editorTool: EditorTool) throws {
+        var requirements: [PackageDependencyRequirement] = []
+        if let exactVersion = exact {
+            requirements.append(.exact(exactVersion.description))
+        }
+        if let revision = revision {
+            requirements.append(.revision(revision))
+        }
+        if let branch = branch {
+            requirements.append(.branch(branch))
+        }
+        if let version = from {
+            requirements.append(.upToNextMajor(version.description))
+        }
+        if let version = upToNextMinorFrom {
+            requirements.append(.upToNextMinor(version.description))
+        }
+
+        guard requirements.count <= 1 else {
+            editorTool.diagnostics.emit(.error("only one requirement is allowed when specifiying a dependency"))
+            throw ExitCode.failure
+        }
+
+        var requirement = requirements.first
+
+        if case .upToNextMajor(let rangeStart) = requirement {
+            guard to == nil || through == nil else {
+                editorTool.diagnostics.emit(.error("'--to' and '--through' may not be used in the same requirement"))
+                throw ExitCode.failure
+            }
+            if let rangeEnd = to {
+                requirement = .range(rangeStart.description, rangeEnd.description)
+            } else if let closedRangeEnd = through {
+                requirement = .closedRange(rangeStart.description, closedRangeEnd.description)
+            }
+        } else {
+            guard to == nil, through == nil else {
+                editorTool.diagnostics.emit(.error("'--to' and '--through' may only be used with '--from' to specify a range requirement"))
+                throw ExitCode.failure
+            }
+        }
+
+        do {
+            try editorTool.packageEditor.addPackageDependency(url: dependencyURL, requirement: requirement)
+        } catch Diagnostics.fatalError {
+            throw ExitCode.failure
+        }
+    }
+}
+
+struct AddTarget: EditorCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Add a target to the current package.")
+
+    @Argument(help: "The name of the new target")
+    var name: String
+
+    @Option(help: "The type of the new target (library, executable, test, or binary)")
+    var type: String = "library"
+
+    @Flag(help: "If present, no corresponding test target will be created for a new library target")
+    var noTestTarget: Bool = false
+
+    @Option(parsing: .upToNextOption,
+            help: "A list of target dependency names (targets and/or dependency products)")
+    var dependencies: [String] = []
+
+    @Option(help: "The URL for a remote binary target")
+    var url: String?
+
+    @Option(help: "The checksum for a remote binary target")
+    var checksum: String?
+
+    @Option(help: "The path for a local binary target")
+    var path: String?
+
+    func run(_ editorTool: EditorTool) throws {
+        let newTarget: NewTarget
+        switch type {
+        case "library":
+            try verifyNoTargetBinaryOptionsPassed(diagnostics: editorTool.diagnostics)
+            newTarget = .library(name: name,
+                                 includeTestTarget: !noTestTarget,
+                                 dependencyNames: dependencies)
+        case "executable":
+            try verifyNoTargetBinaryOptionsPassed(diagnostics: editorTool.diagnostics)
+            newTarget = .executable(name: name,
+                                    dependencyNames: dependencies)
+        case "test":
+            try verifyNoTargetBinaryOptionsPassed(diagnostics: editorTool.diagnostics)
+            newTarget = .test(name: name,
+                              dependencyNames: dependencies)
+        case "binary":
+            guard dependencies.isEmpty else {
+                editorTool.diagnostics.emit(.error("option '--dependencies' is not supported for binary targets"))
+                throw ExitCode.failure
+            }
+            // This check is somewhat forgiving, and does the right thing if
+            // the user passes a url with --path or a path with --url.
+            guard let urlOrPath = url ?? path, url == nil || path == nil else {
+                editorTool.diagnostics.emit(.error("binary targets must specify either a path or both a URL and a checksum"))
+                throw ExitCode.failure
+            }
+            newTarget = .binary(name: name,
+                                urlOrPath: urlOrPath,
+                                checksum: checksum)
+        default:
+            editorTool.diagnostics.emit(.error("unsupported target type '\(type)'; supported types are library, executable, test, and binary"))
+            throw ExitCode.failure
+        }
+
+        do {
+            let mapping = try createProductPackageNameMapping(packageGraph: editorTool.loadPackageGraph())
+            try editorTool.packageEditor.addTarget(newTarget, productPackageNameMapping: mapping)
+        } catch Diagnostics.fatalError {
+            throw ExitCode.failure
+        }
+    }
+
+    private func createProductPackageNameMapping(packageGraph: PackageGraph) throws -> [String: TextualPackageReference] {
+        var productPackageNameMapping: [String: TextualPackageReference] = [:]
+        for dependencyPackage in packageGraph.rootPackages.flatMap(\.dependencies) {
+            for product in dependencyPackage.products {
+                productPackageNameMapping[product.name] = TextualPackageReference(dependencyPackage)
+            }
+        }
+        return productPackageNameMapping
+    }
+
+    private func verifyNoTargetBinaryOptionsPassed(diagnostics: DiagnosticsEngine) throws {
+        guard url == nil else {
+            diagnostics.emit(.error("option '--url' is only supported for binary targets"))
+            throw ExitCode.failure
+        }
+        guard path == nil else {
+            diagnostics.emit(.error("option '--path' is only supported for binary targets"))
+            throw ExitCode.failure
+        }
+        guard checksum == nil else {
+            diagnostics.emit(.error("option '--checksum' is only supported for binary targets"))
+            throw ExitCode.failure
+        }
+    }
+}
+
+struct AddProduct: EditorCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Add a product to the current package.")
+
+    @Argument(help: "The name of the new product")
+    var name: String
+
+    @Option(help: "The type of the new product (library, static-library, dynamic-library, or executable)")
+    var type: ProductType?
+
+    @Option(parsing: .upToNextOption,
+            help: "A list of target names to add to the new product")
+    var targets: [String]
+
+    func run(_ editorTool: EditorTool) throws {
+        do {
+            try editorTool.packageEditor.addProduct(name: name, type: type ?? .library(.automatic), targets: targets)
+        } catch Diagnostics.fatalError {
+            throw ExitCode.failure
+        }
+    }
+}
+
+extension Version: ExpressibleByArgument {
+    public init?(argument: String) {
+        self.init(argument)
+    }
+}
+
+extension ProductType: ExpressibleByArgument {
+    public init?(argument: String) {
+        switch argument {
+        case "library":
+            self = .library(.automatic)
+        case "static-library":
+            self = .library(.static)
+        case "dynamic-library":
+            self = .library(.dynamic)
+        case "executable":
+            self = .executable
+        default:
+            return nil
+        }
+    }
+
+    public static var defaultCompletionKind: CompletionKind {
+        .list(["library", "static-library", "dynamic-library", "executable"])
+    }
+}
+
+func print(diagnostic: TSCBasic.Diagnostic) {
+    if !(diagnostic.location is UnknownLocation) {
+        stderrStream <<< diagnostic.location.description <<< ": "
+    }
+    switch diagnostic.message.behavior {
+    case .error:
+        stderrStream <<< "error: "
+    case .warning:
+        stderrStream <<< "warning: "
+    case .note:
+        stderrStream <<< "note"
+    case .remark:
+        stderrStream <<< "remark: "
+    case .ignored:
+        break
+    }
+    stderrStream <<< diagnostic.description <<< "\n"
+    stderrStream.flush()
+}

--- a/Tests/PackageSyntaxTests/AddPackageDependencyTests.swift
+++ b/Tests/PackageSyntaxTests/AddPackageDependencyTests.swift
@@ -1,0 +1,579 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+
+import PackageSyntax
+
+final class AddPackageDependencyTests: XCTestCase {
+    func testAddPackageDependency() throws {
+        let manifest = """
+            // swift-tools-version:5.2
+            import PackageDescription
+
+            let package = Package(
+                name: "exec",
+                dependencies: [
+                ],
+                targets: [
+                    .target(
+                        name: "exec",
+                        dependencies: []),
+                    .testTarget(
+                        name: "execTests",
+                        dependencies: ["exec"]),
+                ]
+            )
+            """
+        
+        
+        let editor = try ManifestRewriter(manifest, diagnosticsEngine: .init())
+        try editor.addPackageDependency(
+            name: "goo",
+            url: "https://github.com/foo/goo",
+            requirement: .upToNextMajor("1.0.1"),
+            branchAndRevisionConvenienceMethodsSupported: false
+        )
+        
+        XCTAssertEqual(editor.editedManifest, """
+            // swift-tools-version:5.2
+            import PackageDescription
+
+            let package = Package(
+                name: "exec",
+                dependencies: [
+                    .package(name: "goo", url: "https://github.com/foo/goo", .upToNextMajor(from: "1.0.1")),
+                ],
+                targets: [
+                    .target(
+                        name: "exec",
+                        dependencies: []),
+                    .testTarget(
+                        name: "execTests",
+                        dependencies: ["exec"]),
+                ]
+            )
+            """)
+    }
+
+    func testAddPackageDependency2() throws {
+        let manifest = """
+            let package = Package(
+                name: "exec",
+                dependencies: [],
+                targets: [
+                    .target(name: "exec"),
+                ]
+            )
+            """
+
+
+        let editor = try ManifestRewriter(manifest, diagnosticsEngine: .init())
+        try editor.addPackageDependency(
+            name: "goo",
+            url: "https://github.com/foo/goo",
+            requirement: .upToNextMajor("1.0.1"),
+            branchAndRevisionConvenienceMethodsSupported: false
+        )
+
+        XCTAssertEqual(editor.editedManifest, """
+            let package = Package(
+                name: "exec",
+                dependencies: [
+                    .package(name: "goo", url: "https://github.com/foo/goo", .upToNextMajor(from: "1.0.1")),
+                ],
+                targets: [
+                    .target(name: "exec"),
+                ]
+            )
+            """)
+    }
+
+    func testAddPackageDependency3() throws {
+        let manifest = """
+            let package = Package(
+                name: "exec",
+                dependencies: [
+                    // Here is a comment.
+                    .package(url: "https://github.com/foo/bar", .branch("master")),
+                ],
+                targets: [
+                    .target(name: "exec"),
+                ]
+            )
+            """
+
+
+        let editor = try ManifestRewriter(manifest, diagnosticsEngine: .init())
+        try editor.addPackageDependency(
+            name: "goo",
+            url: "https://github.com/foo/goo",
+            requirement: .upToNextMajor("1.0.1"),
+            branchAndRevisionConvenienceMethodsSupported: false
+        )
+
+        // FIXME: preserve comment
+        XCTAssertEqual(editor.editedManifest, """
+            let package = Package(
+                name: "exec",
+                dependencies: [
+                    .package(url: "https://github.com/foo/bar", .branch("master")),
+                    .package(name: "goo", url: "https://github.com/foo/goo", .upToNextMajor(from: "1.0.1")),
+                ],
+                targets: [
+                    .target(name: "exec"),
+                ]
+            )
+            """)
+    }
+
+    func testAddPackageDependency4() throws {
+        let manifest = """
+            let package = Package(
+                name: "exec",
+                targets: [
+                    .target(name: "exec"),
+                ]
+            )
+            """
+
+
+        let editor = try ManifestRewriter(manifest, diagnosticsEngine: .init())
+        try editor.addPackageDependency(
+            name: "goo",
+            url: "https://github.com/foo/goo",
+            requirement: .upToNextMajor("1.0.1"),
+            branchAndRevisionConvenienceMethodsSupported: false
+        )
+
+        XCTAssertEqual(editor.editedManifest, """
+            let package = Package(
+                name: "exec",
+                dependencies: [
+                    .package(name: "goo", url: "https://github.com/foo/goo", .upToNextMajor(from: "1.0.1")),
+                ],
+                targets: [
+                    .target(name: "exec"),
+                ]
+            )
+            """)
+    }
+
+    func testAddPackageDependency5() throws {
+        // FIXME: This is broken, we end up removing the comment.
+        let manifest = """
+            let package = Package(
+                name: "exec",
+                dependencies: [
+                    // Here is a comment.
+                ],
+                targets: [
+                    .target(name: "exec"),
+                ]
+            )
+            """
+
+
+        let editor = try ManifestRewriter(manifest, diagnosticsEngine: .init())
+        try editor.addPackageDependency(
+            name: "goo",
+            url: "https://github.com/foo/goo",
+            requirement: .upToNextMajor("1.0.1"),
+            branchAndRevisionConvenienceMethodsSupported: false
+        )
+
+        XCTAssertEqual(editor.editedManifest, """
+            let package = Package(
+                name: "exec",
+                dependencies: [
+                    .package(name: "goo", url: "https://github.com/foo/goo", .upToNextMajor(from: "1.0.1")),
+                ],
+                targets: [
+                    .target(name: "exec"),
+                ]
+            )
+            """)
+    }
+
+    func testAddPackageDependency6() throws {
+        let manifest = """
+            let myDeps = [
+                .package(url: "https://github.com/foo/foo", from: "1.0.2"),
+            ]
+
+            let package = Package(
+                name: "exec",
+                dependencies: myDeps + [
+                    .package(url: "https://github.com/foo/bar", from: "1.0.3"),
+                ],
+                targets: [
+                    .target(name: "exec"),
+                ]
+            )
+            """
+
+
+        let editor = try ManifestRewriter(manifest, diagnosticsEngine: .init())
+        try editor.addPackageDependency(
+            name: "goo",
+            url: "https://github.com/foo/goo",
+            requirement: .upToNextMajor("1.0.1"),
+            branchAndRevisionConvenienceMethodsSupported: false
+        )
+
+        XCTAssertEqual(editor.editedManifest, """
+            let myDeps = [
+                .package(url: "https://github.com/foo/foo", from: "1.0.2"),
+            ]
+
+            let package = Package(
+                name: "exec",
+                dependencies: myDeps + [
+                    .package(url: "https://github.com/foo/bar", from: "1.0.3"),
+                    .package(name: "goo", url: "https://github.com/foo/goo", .upToNextMajor(from: "1.0.1")),
+                ],
+                targets: [
+                    .target(name: "exec"),
+                ]
+            )
+            """)
+    }
+
+    func testAddPackageDependency7() throws {
+        let manifest = """
+            let package = Package(
+                name: "exec",
+                dependencies: [
+                    .package(url: "https://github.com/foo/bar", from: "1.0.3")
+                ],
+                targets: [
+                    .target(name: "exec")
+                ]
+            )
+            """
+
+
+        let editor = try ManifestRewriter(manifest, diagnosticsEngine: .init())
+        try editor.addPackageDependency(
+            name: "goo",
+            url: "https://github.com/foo/goo",
+            requirement: .upToNextMajor("1.0.1"),
+            branchAndRevisionConvenienceMethodsSupported: false
+        )
+
+        XCTAssertEqual(editor.editedManifest, """
+            let package = Package(
+                name: "exec",
+                dependencies: [
+                    .package(url: "https://github.com/foo/bar", from: "1.0.3"),
+                    .package(name: "goo", url: "https://github.com/foo/goo", .upToNextMajor(from: "1.0.1")),
+                ],
+                targets: [
+                    .target(name: "exec")
+                ]
+            )
+            """)
+    }
+
+    func testAddPackageDependency8() throws {
+        let manifest = """
+            let package = Package(
+                name: "exec",
+                platforms: [.iOS],
+                targets: [
+                    .target(name: "exec"),
+                ]
+            )
+            """
+
+
+        let editor = try ManifestRewriter(manifest, diagnosticsEngine: .init())
+        try editor.addPackageDependency(
+            name: "goo",
+            url: "https://github.com/foo/goo",
+            requirement: .upToNextMajor("1.0.1"),
+            branchAndRevisionConvenienceMethodsSupported: false
+        )
+
+        XCTAssertEqual(editor.editedManifest, """
+            let package = Package(
+                name: "exec",
+                platforms: [.iOS],
+                dependencies: [
+                    .package(name: "goo", url: "https://github.com/foo/goo", .upToNextMajor(from: "1.0.1")),
+                ],
+                targets: [
+                    .target(name: "exec"),
+                ]
+            )
+            """)
+    }
+
+    func testAddPackageDependency9() throws {
+        let manifest = """
+            let package = Package(
+                name: "exec",
+                platforms: [.iOS],
+                swiftLanguageVersions: []
+            )
+            """
+
+
+        let editor = try ManifestRewriter(manifest, diagnosticsEngine: .init())
+        try editor.addPackageDependency(
+            name: "goo",
+            url: "https://github.com/foo/goo",
+            requirement: .upToNextMajor("1.0.1"),
+            branchAndRevisionConvenienceMethodsSupported: false
+        )
+
+        XCTAssertEqual(editor.editedManifest, """
+            let package = Package(
+                name: "exec",
+                platforms: [.iOS],
+                dependencies: [
+                    .package(name: "goo", url: "https://github.com/foo/goo", .upToNextMajor(from: "1.0.1")),
+                ],
+                swiftLanguageVersions: []
+            )
+            """)
+    }
+
+    func testAddPackageDependency10() throws {
+        let manifest = """
+            let package = Package(
+                name: "exec",
+                platforms: [.iOS],
+            )
+            """
+
+
+        let editor = try ManifestRewriter(manifest, diagnosticsEngine: .init())
+        try editor.addPackageDependency(
+            name: "goo",
+            url: "https://github.com/foo/goo",
+            requirement: .upToNextMajor("1.0.1"),
+            branchAndRevisionConvenienceMethodsSupported: false
+        )
+
+        XCTAssertEqual(editor.editedManifest, """
+            let package = Package(
+                name: "exec",
+                platforms: [.iOS],
+                dependencies: [
+                    .package(name: "goo", url: "https://github.com/foo/goo", .upToNextMajor(from: "1.0.1")),
+                ]
+            )
+            """)
+    }
+
+    func testAddPackageDependencyWithExactRequirement() throws {
+        let manifest = """
+            let package = Package(
+                name: "exec",
+                platforms: [.iOS],
+            )
+            """
+
+
+        let editor = try ManifestRewriter(manifest, diagnosticsEngine: .init())
+        try editor.addPackageDependency(
+            name: "goo",
+            url: "https://github.com/foo/goo",
+            requirement: .exact("2.0.2"),
+            branchAndRevisionConvenienceMethodsSupported: false
+        )
+
+        XCTAssertEqual(editor.editedManifest, """
+            let package = Package(
+                name: "exec",
+                platforms: [.iOS],
+                dependencies: [
+                    .package(name: "goo", url: "https://github.com/foo/goo", .exact("2.0.2")),
+                ]
+            )
+            """)
+    }
+
+    func testAddPackageDependencyWithBranchRequirement() throws {
+        let manifest = """
+            let package = Package(
+                name: "exec",
+                platforms: [.iOS],
+            )
+            """
+
+
+        let editor = try ManifestRewriter(manifest, diagnosticsEngine: .init())
+        try editor.addPackageDependency(
+            name: "goo",
+            url: "https://github.com/foo/goo",
+            requirement: .branch("main"),
+            branchAndRevisionConvenienceMethodsSupported: false
+        )
+
+        XCTAssertEqual(editor.editedManifest, """
+            let package = Package(
+                name: "exec",
+                platforms: [.iOS],
+                dependencies: [
+                    .package(name: "goo", url: "https://github.com/foo/goo", .branch("main")),
+                ]
+            )
+            """)
+    }
+
+    func testAddPackageDependencyWithRevisionRequirement() throws {
+        let manifest = """
+            let package = Package(
+                name: "exec",
+                platforms: [.iOS],
+            )
+            """
+
+
+        let editor = try ManifestRewriter(manifest, diagnosticsEngine: .init())
+        try editor.addPackageDependency(
+            name: "goo",
+            url: "https://github.com/foo/goo",
+            requirement: .revision("abcde"),
+            branchAndRevisionConvenienceMethodsSupported: false
+        )
+
+        XCTAssertEqual(editor.editedManifest, """
+            let package = Package(
+                name: "exec",
+                platforms: [.iOS],
+                dependencies: [
+                    .package(name: "goo", url: "https://github.com/foo/goo", .revision("abcde")),
+                ]
+            )
+            """)
+    }
+
+    func testAddPackageDependencyWithBranchRequirementUsingConvenienceMethods() throws {
+        let manifest = """
+            let package = Package(
+                name: "exec",
+                platforms: [.iOS],
+            )
+            """
+
+
+        let editor = try ManifestRewriter(manifest, diagnosticsEngine: .init())
+        try editor.addPackageDependency(
+            name: "goo",
+            url: "https://github.com/foo/goo",
+            requirement: .branch("main"),
+            branchAndRevisionConvenienceMethodsSupported: true
+        )
+
+        XCTAssertEqual(editor.editedManifest, """
+            let package = Package(
+                name: "exec",
+                platforms: [.iOS],
+                dependencies: [
+                    .package(name: "goo", url: "https://github.com/foo/goo", branch: "main"),
+                ]
+            )
+            """)
+    }
+
+    func testAddPackageDependencyWithRevisionRequirementUsingConvenienceMethods() throws {
+        let manifest = """
+            let package = Package(
+                name: "exec",
+                platforms: [.iOS],
+            )
+            """
+
+
+        let editor = try ManifestRewriter(manifest, diagnosticsEngine: .init())
+        try editor.addPackageDependency(
+            name: "goo",
+            url: "https://github.com/foo/goo",
+            requirement: .revision("abcde"),
+            branchAndRevisionConvenienceMethodsSupported: true
+        )
+
+        XCTAssertEqual(editor.editedManifest, """
+            let package = Package(
+                name: "exec",
+                platforms: [.iOS],
+                dependencies: [
+                    .package(name: "goo", url: "https://github.com/foo/goo", revision: "abcde"),
+                ]
+            )
+            """)
+    }
+
+    func testAddPackageDependencyWithUpToNextMinorRequirement() throws {
+        let manifest = """
+            let package = Package(
+                name: "exec",
+                platforms: [.iOS],
+            )
+            """
+
+
+        let editor = try ManifestRewriter(manifest, diagnosticsEngine: .init())
+        try editor.addPackageDependency(
+            name: "goo",
+            url: "https://github.com/foo/goo",
+            requirement: .upToNextMinor("1.1.1"),
+            branchAndRevisionConvenienceMethodsSupported: false
+        )
+
+        XCTAssertEqual(editor.editedManifest, """
+            let package = Package(
+                name: "exec",
+                platforms: [.iOS],
+                dependencies: [
+                    .package(name: "goo", url: "https://github.com/foo/goo", .upToNextMinor(from: "1.1.1")),
+                ]
+            )
+            """)
+    }
+
+    func testAddPackageDependenciesWithRangeRequirements() throws {
+        let manifest = """
+            let package = Package(
+                name: "exec",
+                platforms: [.iOS],
+            )
+            """
+
+
+        let editor = try ManifestRewriter(manifest, diagnosticsEngine: .init())
+        try editor.addPackageDependency(
+            name: "goo",
+            url: "https://github.com/foo/goo",
+            requirement: .range("1.1.1", "2.2.2"),
+            branchAndRevisionConvenienceMethodsSupported: false
+        )
+        try editor.addPackageDependency(
+            name: "goo",
+            url: "https://github.com/foo/goo",
+            requirement: .closedRange("2.2.2", "3.3.3"),
+            branchAndRevisionConvenienceMethodsSupported: false
+        )
+
+        XCTAssertEqual(editor.editedManifest, """
+            let package = Package(
+                name: "exec",
+                platforms: [.iOS],
+                dependencies: [
+                    .package(name: "goo", url: "https://github.com/foo/goo", "1.1.1"..<"2.2.2"),
+                    .package(name: "goo", url: "https://github.com/foo/goo", "2.2.2"..."3.3.3"),
+                ]
+            )
+            """)
+    }
+}

--- a/Tests/PackageSyntaxTests/AddProductTests.swift
+++ b/Tests/PackageSyntaxTests/AddProductTests.swift
@@ -1,0 +1,198 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import XCTest
+
+import PackageSyntax
+
+final class AddProductTests: XCTestCase {
+    func testAddProduct() throws {
+        let manifest = """
+            // swift-tools-version:5.2
+            import PackageDescription
+
+            let package = Package(
+                name: "exec",
+                products: [
+                    .executable(name: "abc", targets: ["foo"]),
+                ]
+                targets: [
+                    .target(
+                        name: "foo",
+                        dependencies: []),
+                    .target(
+                        name: "bar",
+                        dependencies: []),
+                    .testTarget(
+                        name: "fooTests",
+                        dependencies: ["foo", "bar"]),
+                ]
+            )
+            """
+
+        let editor = try ManifestRewriter(manifest, diagnosticsEngine: .init())
+        try editor.addProduct(name: "exec", type: .executable)
+        try editor.addProduct(name: "lib", type: .library(.automatic))
+        try editor.addProduct(name: "staticLib", type: .library(.static))
+        try editor.addProduct(name: "dynamicLib", type: .library(.dynamic))
+
+        XCTAssertEqual(editor.editedManifest, """
+            // swift-tools-version:5.2
+            import PackageDescription
+
+            let package = Package(
+                name: "exec",
+                products: [
+                    .executable(name: "abc", targets: ["foo"]),
+                    .executable(
+                        name: "exec",
+                        targets: []
+                    ),
+                    .library(
+                        name: "lib",
+                        targets: []
+                    ),
+                    .library(
+                        name: "staticLib",
+                        type: .static,
+                        targets: []
+                    ),
+                    .library(
+                        name: "dynamicLib",
+                        type: .dynamic,
+                        targets: []
+                    ),
+                ]
+                targets: [
+                    .target(
+                        name: "foo",
+                        dependencies: []),
+                    .target(
+                        name: "bar",
+                        dependencies: []),
+                    .testTarget(
+                        name: "fooTests",
+                        dependencies: ["foo", "bar"]),
+                ]
+            )
+            """)
+    }
+
+    func testAddProduct2() throws {
+        let manifest = """
+            // swift-tools-version:5.2
+            import PackageDescription
+
+            let package = Package(
+                name: "exec",
+                targets: [
+                    .target(
+                        name: "foo",
+                        dependencies: []),
+                    .target(
+                        name: "bar",
+                        dependencies: []),
+                    .testTarget(
+                        name: "fooTests",
+                        dependencies: ["foo", "bar"]),
+                ]
+            )
+            """
+
+        let editor = try ManifestRewriter(manifest, diagnosticsEngine: .init())
+        try editor.addProduct(name: "exec", type: .executable)
+        try editor.addProduct(name: "lib", type: .library(.automatic))
+        try editor.addProduct(name: "staticLib", type: .library(.static))
+        try editor.addProduct(name: "dynamicLib", type: .library(.dynamic))
+
+        // FIXME: weird indentation
+        XCTAssertEqual(editor.editedManifest, """
+            // swift-tools-version:5.2
+            import PackageDescription
+
+            let package = Package(
+                name: "exec",
+                products: [
+                    .executable(
+                        name: "exec",
+                        targets: []
+                    ),
+                    .library(
+                        name: "lib",
+                        targets: []
+                    ),
+                    .library(
+                        name: "staticLib",
+                        type: .static,
+                        targets: []
+                    ),
+                    .library(
+                        name: "dynamicLib",
+                        type: .dynamic,
+                        targets: []
+                    ),
+                ],
+                targets: [
+                    .target(
+                        name: "foo",
+                        dependencies: []),
+                    .target(
+                        name: "bar",
+                        dependencies: []),
+                    .testTarget(
+                        name: "fooTests",
+                        dependencies: ["foo", "bar"]),
+                ]
+            )
+            """)
+    }
+
+    func testAddProduct3() throws {
+        let manifest = """
+            // swift-tools-version:5.2
+            import PackageDescription
+
+            let package = Package(
+            \tname: "exec",
+            \ttargets: [
+            \t\t.target(
+            \t\t\tname: "foo",
+            \t\t\tdependencies: []
+            \t\t),
+            \t]
+            )
+            """
+
+        let editor = try ManifestRewriter(manifest, diagnosticsEngine: .init())
+        try editor.addProduct(name: "exec", type: .executable)
+
+        // FIXME: weird indentation
+        XCTAssertEqual(editor.editedManifest, """
+            // swift-tools-version:5.2
+            import PackageDescription
+
+            let package = Package(
+            \tname: "exec",
+            \tproducts: [
+            \t\t.executable(
+            \t\t\tname: "exec",
+            \t\t\ttargets: []
+            \t\t),
+            \t],
+            \ttargets: [
+            \t\t.target(
+            \t\t\tname: "foo",
+            \t\t\tdependencies: []
+            \t\t),
+            \t]
+            )
+            """)
+    }
+}

--- a/Tests/PackageSyntaxTests/AddTargetDependencyTests.swift
+++ b/Tests/PackageSyntaxTests/AddTargetDependencyTests.swift
@@ -1,0 +1,156 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+
+import PackageSyntax
+
+final class AddTargetDependencyTests: XCTestCase {
+    func testAddTargetDependency() throws {
+        let manifest = """
+            // swift-tools-version:5.2
+            import PackageDescription
+
+            let package = Package(
+                name: "exec",
+                dependencies: [
+                    .package(url: "https://github.com/foo/goo", from: "1.0.1"),
+                ],
+                targets: [
+                    .target(
+                        name: "a",
+                        dependencies: []),
+                    .target(
+                        name: "exec",
+                        dependencies: []),
+                    .target(
+                        name: "c",
+                        dependencies: []),
+                    .testTarget(
+                        name: "execTests",
+                        dependencies: ["exec"]),
+                ]
+            )
+            """
+        
+        let editor = try ManifestRewriter(manifest, diagnosticsEngine: .init())
+        try editor.addByNameTargetDependency(
+            target: "exec", dependency: "foo")
+        try editor.addByNameTargetDependency(
+            target: "exec", dependency: "bar")
+        try editor.addByNameTargetDependency(
+            target: "execTests", dependency: "foo")
+
+        XCTAssertEqual(editor.editedManifest, """
+            // swift-tools-version:5.2
+            import PackageDescription
+
+            let package = Package(
+                name: "exec",
+                dependencies: [
+                    .package(url: "https://github.com/foo/goo", from: "1.0.1"),
+                ],
+                targets: [
+                    .target(
+                        name: "a",
+                        dependencies: []),
+                    .target(
+                        name: "exec",
+                        dependencies: [
+                            "foo",
+                            "bar",
+                        ]),
+                    .target(
+                        name: "c",
+                        dependencies: []),
+                    .testTarget(
+                        name: "execTests",
+                        dependencies: [
+                            "exec",
+                            "foo",
+                        ]),
+                ]
+            )
+            """)
+    }
+
+    func testAddTargetDependency2() throws {
+        let manifest = """
+            let package = Package(
+                name: "exec",
+                targets: [
+                    .target(
+                        name: "foo",
+                        dependencies: ["bar"]),
+                    .target(
+                        name: "foo1",
+                        dependencies: ["bar",]),
+                    .target(
+                        name: "foo2",
+                        dependencies: []),
+                    .target(
+                        name: "foo3",
+                        dependencies: ["foo", "bar"]),
+                    .target(
+                        name: "foo4",
+                        dependencies: [
+                            "foo", "bar"
+                        ]),
+                ]
+            )
+            """
+
+        let editor = try ManifestRewriter(manifest, diagnosticsEngine: .init())
+        try editor.addByNameTargetDependency(
+            target: "foo", dependency: "dep")
+        try editor.addByNameTargetDependency(
+            target: "foo1", dependency: "dep")
+        try editor.addByNameTargetDependency(
+            target: "foo2", dependency: "dep")
+        try editor.addByNameTargetDependency(
+            target: "foo3", dependency: "dep")
+        try editor.addByNameTargetDependency(
+            target: "foo4", dependency: "dep")
+
+        XCTAssertEqual(editor.editedManifest, """
+            let package = Package(
+                name: "exec",
+                targets: [
+                    .target(
+                        name: "foo",
+                        dependencies: [
+                            "bar",
+                            "dep",
+                        ]),
+                    .target(
+                        name: "foo1",
+                        dependencies: [
+                            "bar",
+                            "dep",
+                        ]),
+                    .target(
+                        name: "foo2",
+                        dependencies: [
+                            "dep",
+                        ]),
+                    .target(
+                        name: "foo3",
+                        dependencies: ["foo", "bar", "dep",]),
+                    .target(
+                        name: "foo4",
+                        dependencies: [
+                            "foo", "bar", "dep",
+                        ]),
+                ]
+            )
+            """)
+    }
+
+}

--- a/Tests/PackageSyntaxTests/AddTargetTests.swift
+++ b/Tests/PackageSyntaxTests/AddTargetTests.swift
@@ -1,0 +1,148 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import XCTest
+
+import PackageSyntax
+
+final class AddTargetTests: XCTestCase {
+    func testAddTarget() throws {
+        let manifest = """
+            // swift-tools-version:5.2
+            import PackageDescription
+
+            let package = Package(
+                name: "exec",
+                dependencies: [
+                    .package(url: "https://github.com/foo/goo", from: "1.0.1"),
+                ],
+                targets: [
+                    .target(
+                        name: "foo",
+                        dependencies: []),
+                    .target(
+                        name: "bar",
+                        dependencies: []),
+                    .testTarget(
+                        name: "fooTests",
+                        dependencies: ["foo", "bar"]),
+                ]
+            )
+            """
+        
+        let editor = try ManifestRewriter(manifest, diagnosticsEngine: .init())
+        try editor.addTarget(targetName: "NewTarget", factoryMethodName: "target")
+        try editor.addTarget(targetName: "NewTargetTests", factoryMethodName: "testTarget")
+        try editor.addByNameTargetDependency(target: "NewTargetTests", dependency: "NewTarget")
+
+        XCTAssertEqual(editor.editedManifest, """
+            // swift-tools-version:5.2
+            import PackageDescription
+
+            let package = Package(
+                name: "exec",
+                dependencies: [
+                    .package(url: "https://github.com/foo/goo", from: "1.0.1"),
+                ],
+                targets: [
+                    .target(
+                        name: "foo",
+                        dependencies: []),
+                    .target(
+                        name: "bar",
+                        dependencies: []),
+                    .testTarget(
+                        name: "fooTests",
+                        dependencies: ["foo", "bar"]),
+                    .target(
+                        name: "NewTarget",
+                        dependencies: []
+                    ),
+                    .testTarget(
+                        name: "NewTargetTests",
+                        dependencies: [
+                            "NewTarget",
+                        ]
+                    ),
+                ]
+            )
+            """)
+    }
+
+    func testAddTarget2() throws {
+        let manifest = """
+                // swift-tools-version:5.2
+                import PackageDescription
+
+                let package = Package(
+                    name: "exec",
+                    dependencies: [
+                        .package(url: "https://github.com/foo/goo", from: "1.0.1"),
+                    ]
+                )
+                """
+
+        let editor = try ManifestRewriter(manifest, diagnosticsEngine: .init())
+        try editor.addTarget(targetName: "NewTarget", factoryMethodName: "target")
+
+        XCTAssertEqual(editor.editedManifest, """
+                // swift-tools-version:5.2
+                import PackageDescription
+
+                let package = Package(
+                    name: "exec",
+                    dependencies: [
+                        .package(url: "https://github.com/foo/goo", from: "1.0.1"),
+                    ],
+                    targets: [
+                        .target(
+                            name: "NewTarget",
+                            dependencies: []
+                        ),
+                    ]
+                )
+                """)
+    }
+
+    func testAddTarget3() throws {
+        let manifest = """
+                // swift-tools-version:5.2
+                import PackageDescription
+
+                let package = Package(
+                \tname: "exec",
+                \tdependencies: [
+                \t\t.package(url: "https://github.com/foo/goo", from: "1.0.1"),
+                \t]
+                )
+                """
+
+        let editor = try ManifestRewriter(manifest, diagnosticsEngine: .init())
+        try editor.addTarget(targetName: "NewTarget", factoryMethodName: "target")
+
+        XCTAssertEqual(editor.editedManifest, """
+                // swift-tools-version:5.2
+                import PackageDescription
+
+                let package = Package(
+                \tname: "exec",
+                \tdependencies: [
+                \t\t.package(url: "https://github.com/foo/goo", from: "1.0.1"),
+                \t],
+                \ttargets: [
+                \t\t.target(
+                \t\t\tname: "NewTarget",
+                \t\t\tdependencies: []
+                \t\t),
+                \t]
+                )
+                """)
+    }
+}

--- a/Tests/PackageSyntaxTests/ArrayFormattingTests.swift
+++ b/Tests/PackageSyntaxTests/ArrayFormattingTests.swift
@@ -1,0 +1,470 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import XCTest
+import PackageSyntax
+import SwiftSyntax
+import SwiftParser
+
+final class ArrayFormattingTests: XCTestCase {
+    func assertAdding(string: String, to arrayLiteralCode: String, produces result: String) {
+        let sourceFileSyntax = try! Parser.parse(source: arrayLiteralCode)
+        let arrayExpr = sourceFileSyntax.statements.first?.item.as(ArrayExprSyntax.self)!
+        let outputSyntax = arrayExpr?.withAdditionalElementExpr(ExprSyntax(StringLiteralExprSyntax(string)))
+        XCTAssertEqual(outputSyntax!.description, result)
+    }
+
+    func assertAdding(string: String, toFunctionCallArg functionCallCode: String, produces result: String) {
+        let sourceFileSyntax = try! Parser.parse(source: functionCallCode)
+        let funcExpr = sourceFileSyntax.statements.first!.item.as(FunctionCallExprSyntax.self)!
+        let arg = funcExpr.argumentList.first!
+        let arrayExpr = arg.expression.as(ArrayExprSyntax.self)!
+        let newExpr = arrayExpr.withAdditionalElementExpr(ExprSyntax(StringLiteralExprSyntax(string)))
+        let outputSyntax = funcExpr.withArgumentList(
+            funcExpr.argumentList.replacing(childAt: 0,
+                                            with: arg.withExpression(ExprSyntax(newExpr)))
+        )
+        XCTAssertEqual(outputSyntax.description, result)
+    }
+
+    func testInsertingIntoArrayExprWith2PlusElements() throws {
+        assertAdding(string: "c", to: #"["a", "b"]"#, produces: #"["a", "b", "c",]"#)
+        assertAdding(string: "c", to: #"["a", "b",]"#, produces: #"["a", "b", "c",]"#)
+        assertAdding(string: "c", to: #"["a","b"]"#, produces: #"["a","b","c",]"#)
+        assertAdding(string: "c",
+                     to: #"["a", /*hello*/"b"/*world!*/]"#,
+                     produces: #"["a", /*hello*/"b",/*world!*/ "c",]"#)
+        assertAdding(string: "c", to: """
+            [
+                "a",
+                "b"
+            ]
+        """, produces: """
+            [
+                "a",
+                "b",
+                "c",
+            ]
+        """)
+        assertAdding(string: "c", to: """
+            [
+                "a",
+                "b",
+            ]
+        """, produces: """
+            [
+                "a",
+                "b",
+                "c",
+            ]
+        """)
+        assertAdding(string: "c", to: """
+            [
+                "a", "b"
+            ]
+        """, produces: """
+            [
+                "a", "b", "c",
+            ]
+        """)
+        assertAdding(string: "e", to: """
+            [
+                "a", "b",
+                "c", "d",
+            ]
+        """, produces: """
+            [
+                "a", "b",
+                "c", "d", "e",
+            ]
+        """)
+        assertAdding(string: "e", to: """
+            ["a", "b",
+             "c", "d"]
+        """, produces: """
+            ["a", "b",
+             "c", "d", "e",]
+        """)
+        assertAdding(string: "c", to: """
+        \t[
+        \t\t"a",
+        \t\t"b",
+        \t]
+        """, produces: """
+        \t[
+        \t\t"a",
+        \t\t"b",
+        \t\t"c",
+        \t]
+        """)
+        assertAdding(string: "c", to: """
+            [
+                "a", // Comment about a
+                "b",
+            ]
+        """, produces: """
+            [
+                "a", // Comment about a
+                "b", 
+                "c",
+            ]
+        """)
+        assertAdding(string: "c", to: """
+            [
+                "a",
+                "b", // Comment about b
+            ]
+        """, produces: """
+            [
+                "a",
+                "b", // Comment about b
+                "c",
+            ]
+        """)
+        assertAdding(string: "c", to: """
+            [
+                "a",
+                "b",
+                /*comment*/
+            ]
+        """, produces: """
+            [
+                "a",
+                "b",
+                /*comment*/
+                "c",
+            ]
+        """)
+        assertAdding(string: "c", to: """
+            [
+                /*
+                1
+                */
+                "a",
+                /*
+                2
+                */
+                "b",
+                /*
+                3
+                */
+            ]
+        """, produces: """
+            [
+                /*
+                1
+                */
+                "a",
+                /*
+                2
+                */
+                "b",
+                /*
+                3
+                */
+                "c",
+            ]
+        """)
+        assertAdding(string: "c", to: """
+            [
+                /// Comment
+
+                "a",
+
+
+                "b",
+            ]
+        """, produces: """
+            [
+                /// Comment
+
+                "a",
+
+
+                "b",
+
+        
+                "c",
+            ]
+        """)
+        assertAdding(string: "3", toFunctionCallArg: """
+        foo(someArg: ["1", "2"])
+        """, produces: """
+        foo(someArg: ["1", "2", "3",])
+        """)
+        assertAdding(string: "3", toFunctionCallArg: """
+            foo(someArg: ["1",
+                          "2"])
+        """, produces: """
+            foo(someArg: ["1",
+                          "2",
+                          "3",])
+        """)
+        assertAdding(string: "3", toFunctionCallArg: """
+                    foo(
+                        arg1: ["1", "2"], arg2: []
+                    )
+        """, produces: """
+                    foo(
+                        arg1: ["1", "2", "3",], arg2: []
+                    )
+        """)
+        assertAdding(string: "3", toFunctionCallArg: """
+        foo(someArg: [
+            "1",
+            "2",
+        ])
+        """, produces: """
+        foo(someArg: [
+            "1",
+            "2",
+            "3",
+        ])
+        """)
+        assertAdding(string: "3", toFunctionCallArg: """
+                    foo(
+                        arg1: [
+                            "1",
+                            "2",
+                        ], arg2: []
+                    )
+        """, produces: """
+                    foo(
+                        arg1: [
+                            "1",
+                            "2",
+                            "3",
+                        ], arg2: []
+                    )
+        """)
+    }
+
+    func testInsertingIntoEmptyArrayExpr() {
+        assertAdding(string: "1", to: #"[]"#, produces: """
+        [
+            "1",
+        ]
+        """)
+        assertAdding(string: "1", to: """
+        [
+
+        ]
+        """, produces: """
+        [
+            "1",
+        ]
+        """)
+        assertAdding(string: "1", to: """
+        [
+        ]
+        """, produces: """
+        [
+            "1",
+        ]
+        """)
+        assertAdding(string: "1", to: """
+            [
+
+            ]
+        """, produces: """
+            [
+                "1",
+            ]
+        """)
+        assertAdding(string: "1", to: """
+        \t[
+
+        \t]
+        """, produces: """
+        \t[
+        \t\t"1",
+        \t]
+        """)
+        assertAdding(string: "1", toFunctionCallArg: """
+        foo(someArg: [])
+        """, produces: """
+        foo(someArg: [
+            "1",
+        ])
+        """)
+        assertAdding(string: "1", toFunctionCallArg: """
+            foo(someArg: [])
+        """, produces: """
+            foo(someArg: [
+                "1",
+            ])
+        """)
+        assertAdding(string: "1", toFunctionCallArg: """
+                    foo(
+                        arg1: [], arg2: []
+                    )
+        """, produces: """
+                    foo(
+                        arg1: [
+                            "1",
+                        ], arg2: []
+                    )
+        """)
+        assertAdding(string: "1", toFunctionCallArg: """
+        \tfoo(someArg: [])
+        """, produces: """
+        \tfoo(someArg: [
+        \t\t"1",
+        \t])
+        """)
+    }
+
+    func testInsertingIntoSingleElementArrayExpr() {
+        assertAdding(string: "b", to: """
+        ["a"]
+        """, produces: """
+        [
+            "a",
+            "b",
+        ]
+        """)
+        assertAdding(string: "b", to: """
+        [
+            "a"
+        ]
+        """, produces: """
+        [
+            "a",
+            "b",
+        ]
+        """)
+        assertAdding(string: "b", to: """
+        ["a",]
+        """, produces: """
+        [
+            "a",
+            "b",
+        ]
+        """)
+        assertAdding(string: "b", to: """
+        [
+            "a",
+        ]
+        """, produces: """
+        [
+            "a",
+            "b",
+        ]
+        """)
+        assertAdding(string: "2", toFunctionCallArg: """
+        foo(someArg: ["1"])
+        """, produces: """
+        foo(someArg: [
+            "1",
+            "2",
+        ])
+        """)
+        assertAdding(string: "2", toFunctionCallArg: """
+            foo(someArg: ["1"])
+        """, produces: """
+            foo(someArg: [
+                "1",
+                "2",
+            ])
+        """)
+        assertAdding(string: "2", toFunctionCallArg: """
+                    foo(
+                        arg1: ["1"], arg2: []
+                    )
+        """, produces: """
+                    foo(
+                        arg1: [
+                            "1",
+                            "2",
+                        ], arg2: []
+                    )
+        """)
+        assertAdding(string: "2", toFunctionCallArg: """
+        foo(someArg: [
+            "1"
+        ])
+        """, produces: """
+        foo(someArg: [
+            "1",
+            "2",
+        ])
+        """)
+        assertAdding(string: "2", toFunctionCallArg: """
+            foo(someArg: [
+                "1"
+            ])
+        """, produces: """
+            foo(someArg: [
+                "1",
+                "2",
+            ])
+        """)
+        assertAdding(string: "2", toFunctionCallArg: """
+                    foo(
+                        arg1: [
+                            "1"
+                        ], arg2: []
+                    )
+        """, produces: """
+                    foo(
+                        arg1: [
+                            "1",
+                            "2",
+                        ], arg2: []
+                    )
+        """)
+    }
+
+    func assert(code: String, hasIndent indent: Trivia, forLine line: Int) {
+        let sourceFileSyntax = try! Parser.parse(source: code)
+        let converter = SourceLocationConverter(file: "test.swift", tree: sourceFileSyntax)
+        let visitor = DetermineLineIndentVisitor(lineNumber: line, sourceLocationConverter: converter)
+        visitor.walk(sourceFileSyntax)
+        XCTAssertEqual(visitor.lineIndent, indent)
+    }
+
+    func testIndentVisitor() throws {
+        assert(code: """
+        foo(
+            arg: []
+        )
+        """, hasIndent: [.spaces(4)], forLine: 2)
+        assert(code: """
+        foo(
+        \targ: []
+        )
+        """, hasIndent: [.tabs(1)], forLine: 2)
+        assert(code: """
+        foo(
+            arg1: [], arg2: []
+        )
+        """, hasIndent: [.spaces(4)], forLine: 2)
+        assert(code: """
+        foo(
+            bar(
+                arg1: [],
+                arg2: []
+            )
+        )
+        """, hasIndent: [.spaces(8)], forLine: 3)
+        assert(code: """
+        foo(
+            bar(arg1: [],
+                arg2: [])
+        )
+        """, hasIndent: [.spaces(4)], forLine: 2)
+        assert(code: """
+        foo(
+            bar(arg1: [],
+                arg2: [])
+        )
+        """, hasIndent: [.spaces(8)], forLine: 3)
+    }
+}

--- a/Tests/PackageSyntaxTests/InMemoryGitRepository.swift
+++ b/Tests/PackageSyntaxTests/InMemoryGitRepository.swift
@@ -1,0 +1,482 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+// FIXME: Share this with SwiftPM
+
+import Basics
+import TSCBasic
+import TSCUtility
+import SourceControl
+import Dispatch
+import class Foundation.NSUUID
+import struct Foundation.URL
+import class Foundation.NSLock
+
+/// The error encountered during in memory git repository operations.
+public enum InMemoryGitRepositoryError: Swift.Error {
+    case unknownRevision
+    case unknownTag
+    case tagAlreadyPresent
+}
+
+/// A class that implements basic git features on in-memory file system. It takes the path and file system reference
+/// where the repository should be created. The class itself is a file system pointing to current revision state
+/// i.e. HEAD. All mutations should be made on file system interface of this class and then they can be committed using
+/// commit() method. Calls to checkout related methods will checkout the HEAD on the passed file system at the
+/// repository path, as well as on the file system interface of this class.
+/// Note: This class is intended to be used as testing infrastructure only.
+/// Note: This class is not thread safe yet.
+public final class InMemoryGitRepository {
+    /// The revision identifier.
+    public typealias RevisionIdentifier = String
+
+    /// A struct representing a revision state. Minimally it contains a hash identifier for the revision
+    /// and the file system state.
+    fileprivate struct RevisionState {
+        /// The revision identifier hash. It should be unique amoung all the identifiers.
+        var hash: RevisionIdentifier
+
+        /// The filesystem state contained in this revision.
+        let fileSystem: InMemoryFileSystem
+
+        /// Creates copy of the state.
+        func copy() -> RevisionState {
+            return RevisionState(hash: self.hash, fileSystem: self.fileSystem.copy())
+        }
+    }
+
+    /// THe HEAD i.e. the current checked out state.
+    fileprivate var head: RevisionState
+
+    /// The history dictionary.
+    fileprivate var history: [RevisionIdentifier: RevisionState] = [:]
+
+    /// The map containing tag name to revision identifier values.
+    fileprivate var tagsMap: [String: RevisionIdentifier] = [:]
+
+    /// Indicates whether there are any uncommited changes in the repository.
+    fileprivate var isDirty = false
+
+    /// The path at which this repository is located.
+    fileprivate let path: AbsolutePath
+
+    /// The file system in which this repository should be installed.
+    private let fs: InMemoryFileSystem
+
+    private let lock = NSLock()
+
+    /// Create a new repository at the given path and filesystem.
+    public init(path: AbsolutePath, fs: InMemoryFileSystem) {
+        self.path = path
+        self.fs = fs
+        // Point head to a new revision state with empty hash to begin with.
+        self.head = RevisionState(hash: "", fileSystem: InMemoryFileSystem())
+    }
+
+    /// The array of current tags in the repository.
+    public func getTags() throws -> [String] {
+        self.lock.withLock {
+            Array(self.tagsMap.keys)
+        }
+    }
+
+    /// The list of revisions in the repository.
+    public var revisions: [RevisionIdentifier] {
+        self.lock.withLock {
+            Array(self.history.keys)
+        }
+    }
+
+    /// Copy/clone this repository.
+    fileprivate func copy(at newPath: AbsolutePath? = nil)  throws -> InMemoryGitRepository {
+        let path = newPath ?? self.path
+        try self.fs.createDirectory(path, recursive: true)
+        let repo = InMemoryGitRepository(path: path, fs: self.fs)
+        self.lock.withLock {
+            for (revision, state) in self.history {
+                repo.history[revision] = state.copy()
+            }
+            repo.tagsMap = self.tagsMap
+            repo.head = self.head.copy()
+        }
+        return repo
+    }
+
+    /// Commits the current state of the repository filesystem and returns the commit identifier.
+    @discardableResult
+    public func commit() throws -> String {
+        // Create a fake hash for thie commit.
+        let hash = String((NSUUID().uuidString + NSUUID().uuidString).prefix(40))
+        self.lock.withLock {
+            self.head.hash = hash
+            // Store the commit in history.
+            self.history[hash] = head.copy()
+            // We are not dirty anymore.
+            self.isDirty = false
+        }
+        // Install the current HEAD i.e. this commit to the filesystem that was passed.
+        try installHead()
+        return hash
+    }
+
+    /// Checks out the provided revision.
+    public func checkout(revision: RevisionIdentifier) throws {
+        guard let state = (self.lock.withLock { history[revision] }) else {
+            throw InMemoryGitRepositoryError.unknownRevision
+        }
+        // Point the head to the revision state.
+        self.lock.withLock {
+            self.head = state
+            self.isDirty = false
+        }
+        // Install this state on the passed filesystem.
+        try self.installHead()
+    }
+
+    /// Checks out a given tag.
+    public func checkout(tag: String) throws {
+        guard let hash = (self.lock.withLock { tagsMap[tag] }) else {
+            throw InMemoryGitRepositoryError.unknownTag
+        }
+        // Point the head to the revision state of the tag.
+        // It should be impossible that a tag exisits which doesnot have a state.
+        self.lock.withLock {
+            self.head = history[hash]!
+            self.isDirty = false
+        }
+        // Install this state on the passed filesystem.
+        try self.installHead()
+    }
+
+    /// Installs (or checks out) current head on the filesystem on which this repository exists.
+    fileprivate func installHead() throws {
+        // Remove the old state.
+        try self.fs.removeFileTree(self.path)
+        // Create the repository directory.
+        try self.fs.createDirectory(self.path, recursive: true)
+        // Get the file system state at the HEAD,
+        let headFs = self.lock.withLock { self.head.fileSystem }
+
+        /// Recursively copies the content at HEAD to fs.
+        func install(from sourcePath: AbsolutePath, to destinationPath: AbsolutePath) throws {
+            assert(headFs.isDirectory(sourcePath))
+            for entry in try headFs.getDirectoryContents(sourcePath) {
+                // The full path of the entry.
+                let sourceEntryPath = sourcePath.appending(component: entry)
+                let destinationEntryPath = destinationPath.appending(component: entry)
+                if headFs.isFile(sourceEntryPath) {
+                    // If we have a file just write the file.
+                    let bytes = try headFs.readFileContents(sourceEntryPath)
+                    try self.fs.writeFileContents(destinationEntryPath, bytes: bytes)
+                } else if headFs.isDirectory(sourceEntryPath) {
+                    // If we have a directory, create that directory and copy its contents.
+                    try self.fs.createDirectory(destinationEntryPath, recursive: false)
+                    try install(from: sourceEntryPath, to: destinationEntryPath)
+                }
+            }
+        }
+        // Install at the repository path.
+        try install(from: .root, to: path)
+    }
+
+    /// Tag the current HEAD with the given name.
+    public func tag(name: String) throws {
+        guard (self.lock.withLock { self.tagsMap[name] }) == nil else {
+            throw InMemoryGitRepositoryError.tagAlreadyPresent
+        }
+        self.lock.withLock {
+            self.tagsMap[name] = self.head.hash
+        }
+    }
+
+    public func hasUncommittedChanges() -> Bool {
+        self.lock.withLock {
+            isDirty
+        }
+    }
+
+    public func fetch() throws {
+        // TODO.
+    }
+}
+
+extension InMemoryGitRepository: FileSystem {
+    public func isReadable(_ path: TSCBasic.AbsolutePath) -> Bool {
+        self.lock.withLock {
+            self.head.fileSystem.isReadable(path)
+        }
+    }
+
+    public func isWritable(_ path: TSCBasic.AbsolutePath) -> Bool {
+        self.lock.withLock {
+            self.head.fileSystem.isWritable(path)
+        }
+    }
+
+    public var tempDirectory: TSCBasic.AbsolutePath {
+        self.lock.withLock {
+            self.head.fileSystem.tempDirectory
+        }
+    }
+
+    public func exists(_ path: AbsolutePath, followSymlink: Bool) -> Bool {
+        self.lock.withLock {
+            self.head.fileSystem.exists(path, followSymlink: followSymlink)
+        }
+    }
+
+    public func isDirectory(_ path: AbsolutePath) -> Bool {
+        self.lock.withLock {
+            self.head.fileSystem.isDirectory(path)
+        }
+    }
+
+    public func isFile(_ path: AbsolutePath) -> Bool {
+        self.lock.withLock {
+            self.head.fileSystem.isFile(path)
+        }
+    }
+
+    public func isSymlink(_ path: AbsolutePath) -> Bool {
+        self.lock.withLock {
+            self.head.fileSystem.isSymlink(path)
+        }
+    }
+
+    public func isExecutableFile(_ path: AbsolutePath) -> Bool {
+        self.lock.withLock {
+            self.head.fileSystem.isExecutableFile(path)
+        }
+    }
+
+    public var currentWorkingDirectory: AbsolutePath? {
+        return AbsolutePath("/")
+    }
+
+    public func changeCurrentWorkingDirectory(to path: AbsolutePath) throws {
+        throw FileSystemError(.unsupported, path)
+    }
+
+    public var homeDirectory: AbsolutePath {
+        fatalError("Unsupported")
+    }
+
+    public var cachesDirectory: AbsolutePath? {
+        fatalError("Unsupported")
+    }
+
+    public func getDirectoryContents(_ path: AbsolutePath) throws -> [String] {
+        try self.lock.withLock {
+            try self.head.fileSystem.getDirectoryContents(path)
+        }
+    }
+
+    public func createDirectory(_ path: AbsolutePath, recursive: Bool) throws {
+        try self.lock.withLock {
+            try self.head.fileSystem.createDirectory(path, recursive: recursive)
+        }
+    }
+    
+    public func createSymbolicLink(_ path: AbsolutePath, pointingAt destination: AbsolutePath, relative: Bool) throws {
+        throw FileSystemError(.unsupported, path)
+    }
+
+    public func readFileContents(_ path: AbsolutePath) throws -> ByteString {
+        try self.lock.withLock {
+            return try head.fileSystem.readFileContents(path)
+        }
+    }
+
+    public func writeFileContents(_ path: AbsolutePath, bytes: ByteString) throws {
+        try self.lock.withLock {
+            try self.head.fileSystem.writeFileContents(path, bytes: bytes)
+            self.isDirty = true
+        }
+    }
+
+    public func removeFileTree(_ path: AbsolutePath) throws {
+        try self.lock.withLock {
+            try self.head.fileSystem.removeFileTree(path)
+        }
+    }
+
+    public func chmod(_ mode: FileMode, path: AbsolutePath, options: Set<FileMode.Option>) throws {
+        try self.lock.withLock {
+            try self.head.fileSystem.chmod(mode, path: path, options: options)
+        }
+    }
+
+    public func copy(from sourcePath: AbsolutePath, to destinationPath: AbsolutePath) throws {
+        try self.lock.withLock {
+            try self.head.fileSystem.copy(from: sourcePath, to: destinationPath)
+        }
+    }
+
+    public func move(from sourcePath: AbsolutePath, to destinationPath: AbsolutePath) throws {
+        try self.lock.withLock {
+            try self.head.fileSystem.move(from: sourcePath, to: destinationPath)
+        }
+    }
+}
+
+extension InMemoryGitRepository: Repository {
+    public func resolveRevision(tag: String) throws -> Revision {
+        self.lock.withLock {
+            return Revision(identifier: self.tagsMap[tag]!)
+        }
+    }
+
+    public func resolveRevision(identifier: String) throws -> Revision {
+        self.lock.withLock {
+            return Revision(identifier: self.tagsMap[identifier] ?? identifier)
+        }
+    }
+
+    public func exists(revision: Revision) -> Bool {
+        self.lock.withLock {
+            return self.history[revision.identifier] != nil
+        }
+    }
+
+    public func openFileView(revision: Revision) throws -> FileSystem {
+        self.lock.withLock {
+            return self.history[revision.identifier]!.fileSystem
+        }
+    }
+
+    public func openFileView(tag: String) throws -> FileSystem {
+        let revision = try self.resolveRevision(tag: tag)
+        return try self.openFileView(revision: revision)
+    }
+}
+
+extension InMemoryGitRepository: WorkingCheckout {
+    public func getCurrentRevision() throws -> Revision {
+        self.lock.withLock {
+            return Revision(identifier: self.head.hash)
+        }
+    }
+
+    public func checkout(revision: Revision) throws {
+        // will lock
+        try checkout(revision: revision.identifier)
+    }
+
+    public func hasUnpushedCommits() throws -> Bool {
+        return false
+    }
+
+    public func checkout(newBranch: String) throws {
+        self.lock.withLock {
+            self.history[newBranch] = head
+        }
+    }
+
+    public func isAlternateObjectStoreValid() -> Bool {
+        return true
+    }
+
+    public func areIgnored(_ paths: [AbsolutePath]) throws -> [Bool] {
+        return [false]
+    }
+}
+
+/// This class implement provider for in memeory git repository.
+public final class InMemoryGitRepositoryProvider: RepositoryProvider {
+    /// Contains the repository added to this provider.
+    public var specifierMap = ThreadSafeKeyValueStore<RepositorySpecifier, InMemoryGitRepository>()
+
+    /// Contains the repositories which are fetched using this provider.
+    public var fetchedMap = ThreadSafeKeyValueStore<AbsolutePath, InMemoryGitRepository>()
+
+    /// Contains the repositories which are checked out using this provider.
+    public var checkoutsMap = ThreadSafeKeyValueStore<AbsolutePath, InMemoryGitRepository>()
+
+    /// Create a new provider.
+    public init() {
+    }
+
+    /// Add a repository to this provider. Only the repositories added with this interface can be operated on
+    /// with this provider.
+    public func add(specifier: RepositorySpecifier, repository: InMemoryGitRepository) {
+        // Save the repository in specifer map.
+        specifierMap[specifier] = repository
+    }
+
+    /// This method returns the stored reference to the git repository which was fetched or checked out.
+    public func openRepo(at path: AbsolutePath) -> InMemoryGitRepository {
+        return fetchedMap[path] ?? checkoutsMap[path]!
+    }
+
+    // MARK: - RepositoryProvider conformance
+    // Note: These methods use force unwrap (instead of throwing) to honor their preconditions.
+
+    public func fetch(repository: SourceControl.RepositorySpecifier, to path: TSCBasic.AbsolutePath, progressHandler: ((SourceControl.FetchProgress) -> Void)?) throws {
+        try self.fetch(repository: repository, to: path)
+    }
+
+    public func fetch(repository: RepositorySpecifier, to path: AbsolutePath) throws {
+        let urlString = repository.url.absoluteString
+        let url: Foundation.URL
+        // Strip `.git` suffix if present.
+        if urlString.hasSuffix(".git") {
+            url = URL(string: String(urlString.dropLast(4)))!
+        } else {
+            url = repository.url
+        }
+
+        let repo = specifierMap[RepositorySpecifier(url: url)]!
+        fetchedMap[path] = try repo.copy()
+        add(specifier: RepositorySpecifier(url: path.asURL), repository: repo)
+    }
+
+    public func copy(from sourcePath: AbsolutePath, to destinationPath: AbsolutePath) throws {
+        let repo = fetchedMap[sourcePath]!
+        fetchedMap[destinationPath] = try repo.copy()
+    }
+
+    public func open(repository: RepositorySpecifier, at path: AbsolutePath) throws -> Repository {
+        return fetchedMap[path]!
+    }
+
+    public func createWorkingCopy(
+        repository: RepositorySpecifier,
+        sourcePath: AbsolutePath,
+        at destinationPath: AbsolutePath,
+        editable: Bool
+    ) throws -> WorkingCheckout {
+        let checkout = try fetchedMap[sourcePath]!.copy(at: destinationPath)
+        checkoutsMap[destinationPath] = checkout
+        return checkout
+    }
+
+    public func workingCopyExists(at path: AbsolutePath) throws -> Bool {
+        return checkoutsMap.contains(path)
+    }
+
+    public func openWorkingCopy(at path: AbsolutePath) throws -> WorkingCheckout {
+        return checkoutsMap[path]!
+    }
+
+    public func repositoryExists(at path: TSCBasic.AbsolutePath) throws -> Bool {
+        return fetchedMap.contains(path)
+    }
+
+    public func isValidDirectory(_ directory: TSCBasic.AbsolutePath) -> Bool {
+        return true
+    }
+
+    public func isValidRefFormat(_ ref: String) -> Bool {
+        return true
+    }
+
+    public func cancel(deadline: DispatchTime) throws {
+    }
+}

--- a/Tests/PackageSyntaxTests/PackageEditorTests.swift
+++ b/Tests/PackageSyntaxTests/PackageEditorTests.swift
@@ -1,0 +1,876 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+import TSCBasic
+import TSCUtility
+import SourceControl
+import PackageModel
+
+import PackageSyntax
+
+final class PackageEditorTests: XCTestCase {
+
+    func testAddDependency5_2_to_5_4() throws {
+        for version in ["5.2", "5.3", "5.4"] {
+            let manifest = """
+                // swift-tools-version:\(version)
+                import PackageDescription
+
+                let package = Package(
+                    name: "exec",
+                    dependencies: [
+                        .package(url: "https://github.com/foo/goo", from: "1.0.1"),
+                    ],
+                    targets: [
+                        .target(
+                            name: "foo",
+                            dependencies: []),
+                        .target(
+                            name: "bar",
+                            dependencies: []),
+                        .testTarget(
+                            name: "fooTests",
+                            dependencies: ["foo", "bar"]),
+                    ]
+                )
+                """
+
+            let fs = InMemoryFileSystem(emptyFiles:
+                "/pkg/Package.swift",
+                "/pkg/Sources/foo/source.swift",
+                "/pkg/Sources/bar/source.swift",
+                "/pkg/Tests/fooTests/source.swift",
+                "end")
+
+            let manifestPath = AbsolutePath("/pkg/Package.swift")
+            try fs.writeFileContents(manifestPath) { $0 <<< manifest }
+            try fs.createDirectory(.init("/pkg/repositories"), recursive: false)
+            try fs.createDirectory(.init("/pkg/repo"), recursive: false)
+
+
+            let provider = InMemoryGitRepositoryProvider()
+            let repo = InMemoryGitRepository(path: .init("/pkg/repo"), fs: fs)
+            try repo.writeFileContents(.init("/Package.swift"), bytes: .init(encodingAsUTF8: """
+            // swift-tools-version:5.2
+            import PackageDescription
+
+            let package = Package(name: "repo")
+            """))
+            try repo.commit()
+            try repo.tag(name: "1.1.1")
+            let url = try XCTUnwrap(URL(string: "http://www.githost.com/repo"))
+            provider.add(specifier: .init(url: url), repository: repo)
+
+            let context = try PackageEditorContext(
+                manifestPath: AbsolutePath("/pkg/Package.swift"),
+                repositoryManager: RepositoryManager(fileSystem: fs, path: .init("/pkg/repositories"), provider: provider, initializationWarningHandler: { _ in }),
+                toolchain: Resources.default.toolchain,
+                diagnosticsEngine: .init(),
+                fs: fs
+            )
+            let editor = PackageEditor(context: context)
+
+            try editor.addPackageDependency(url: "http://www.githost.com/repo.git", requirement: PackageDependencyRequirement.exact("1.1.1"))
+
+            let newManifest = try fs.readFileContents(manifestPath).cString
+            XCTAssertEqual(newManifest, """
+                // swift-tools-version:\(version)
+                import PackageDescription
+
+                let package = Package(
+                    name: "exec",
+                    dependencies: [
+                        .package(url: "https://github.com/foo/goo", from: "1.0.1"),
+                        .package(name: "repo", url: "http://www.githost.com/repo.git", .exact("1.1.1")),
+                    ],
+                    targets: [
+                        .target(
+                            name: "foo",
+                            dependencies: []),
+                        .target(
+                            name: "bar",
+                            dependencies: []),
+                        .testTarget(
+                            name: "fooTests",
+                            dependencies: ["foo", "bar"]),
+                    ]
+                )
+                """)
+        }
+    }
+
+    func testAddDependency5_5() throws {
+        let manifest = """
+                // swift-tools-version:5.5
+                import PackageDescription
+
+                let package = Package(
+                    name: "exec",
+                    dependencies: [
+                        .package(url: "https://github.com/foo/goo", from: "1.0.1"),
+                    ],
+                    targets: [
+                        .target(
+                            name: "foo",
+                            dependencies: []),
+                        .target(
+                            name: "bar",
+                            dependencies: []),
+                        .testTarget(
+                            name: "fooTests",
+                            dependencies: ["foo", "bar"]),
+                    ]
+                )
+                """
+
+        let fs = InMemoryFileSystem(emptyFiles:
+                                        "/pkg/Package.swift",
+                                    "/pkg/Sources/foo/source.swift",
+                                    "/pkg/Sources/bar/source.swift",
+                                    "/pkg/Tests/fooTests/source.swift",
+                                    "end")
+
+        let manifestPath = AbsolutePath("/pkg/Package.swift")
+        try fs.writeFileContents(manifestPath) { $0 <<< manifest }
+        try fs.createDirectory(.init("/pkg/repositories"), recursive: false)
+        try fs.createDirectory(.init("/pkg/repo"), recursive: false)
+
+
+        let provider = InMemoryGitRepositoryProvider()
+        let repo = InMemoryGitRepository(path: .init("/pkg/repo"), fs: fs)
+        try repo.writeFileContents(.init("/Package.swift"), bytes: .init(encodingAsUTF8: """
+            // swift-tools-version:5.2
+            import PackageDescription
+
+            let package = Package(name: "repo")
+            """))
+        try repo.commit()
+        try repo.tag(name: "1.1.1")
+        let url = try XCTUnwrap(URL(string: "http://www.githost.com/repo"))
+        provider.add(specifier: .init(url: url), repository: repo)
+
+        let context = try PackageEditorContext(
+            manifestPath: AbsolutePath("/pkg/Package.swift"),
+            repositoryManager: RepositoryManager(fileSystem: fs, path: .init("/pkg/repositories"), provider: provider, initializationWarningHandler: { _ in }),
+            toolchain: Resources.default.toolchain,
+            diagnosticsEngine: .init(),
+            fs: fs
+        )
+        let editor = PackageEditor(context: context)
+
+        try editor.addPackageDependency(url: "http://www.githost.com/repo.git", requirement: PackageDependencyRequirement.exact("1.1.1"))
+
+        let newManifest = try fs.readFileContents(manifestPath).cString
+        XCTAssertEqual(newManifest, """
+                // swift-tools-version:5.5
+                import PackageDescription
+
+                let package = Package(
+                    name: "exec",
+                    dependencies: [
+                        .package(url: "https://github.com/foo/goo", from: "1.0.1"),
+                        .package(url: "http://www.githost.com/repo.git", .exact("1.1.1")),
+                    ],
+                    targets: [
+                        .target(
+                            name: "foo",
+                            dependencies: []),
+                        .target(
+                            name: "bar",
+                            dependencies: []),
+                        .testTarget(
+                            name: "fooTests",
+                            dependencies: ["foo", "bar"]),
+                    ]
+                )
+                """)
+    }
+
+    func testAddTarget5_2() throws {
+        let manifest = """
+                // swift-tools-version:5.2
+                import PackageDescription
+
+                let package = Package(
+                    name: "exec",
+                    dependencies: [
+                        .package(url: "https://github.com/foo/goo", from: "1.0.1"),
+                    ],
+                    targets: [
+                        .target(
+                            name: "foo",
+                            dependencies: []),
+                        .target(
+                            name: "bar",
+                            dependencies: []),
+                        .testTarget(
+                            name: "fooTests",
+                            dependencies: ["foo", "bar"]),
+                    ]
+                )
+                """
+
+        let fs = InMemoryFileSystem(emptyFiles:
+                                        "/pkg/Package.swift",
+                                    "/pkg/Sources/foo/source.swift",
+                                    "/pkg/Sources/bar/source.swift",
+                                    "/pkg/Tests/fooTests/source.swift",
+                                    "end")
+
+        let manifestPath = AbsolutePath("/pkg/Package.swift")
+        try fs.writeFileContents(manifestPath) { $0 <<< manifest }
+
+        let diags = DiagnosticsEngine()
+        let context = try PackageEditorContext(
+            manifestPath: AbsolutePath("/pkg/Package.swift"),
+            repositoryManager: RepositoryManager(fileSystem: fs, path: .init("/pkg/repositories"), provider: InMemoryGitRepositoryProvider(), initializationWarningHandler: { _ in }),
+            toolchain: Resources.default.toolchain,
+            diagnosticsEngine: diags,
+            fs: fs)
+        let editor = PackageEditor(context: context)
+
+        XCTAssertThrows(Diagnostics.fatalError) {
+            try editor.addTarget(.library(name: "foo", includeTestTarget: true, dependencyNames: []),
+                                 productPackageNameMapping: [:])
+        }
+        XCTAssertEqual(diags.diagnostics.map(\.message.text), ["a target named 'foo' already exists in 'exec'"])
+        XCTAssertThrows(Diagnostics.fatalError) {
+            try editor.addTarget(.library(name: "Error", includeTestTarget: true, dependencyNames: ["NotFound"]),
+                                 productPackageNameMapping: [:])
+        }
+        XCTAssertEqual(diags.diagnostics.map(\.message.text), ["a target named 'foo' already exists in 'exec'",
+                                                               "could not find a product or target named 'NotFound'"])
+
+        try editor.addTarget(.library(name: "baz", includeTestTarget: true, dependencyNames: []),
+                             productPackageNameMapping: [:])
+        try editor.addTarget(.executable(name: "qux", dependencyNames: ["foo", "baz"]),
+                             productPackageNameMapping: [:])
+        try editor.addTarget(.test(name: "IntegrationTests", dependencyNames: ["OtherProduct", "goo"]),
+                             productPackageNameMapping: ["goo": TextualPackageReference("goo"), "OtherProduct": TextualPackageReference("goo")])
+
+        let newManifest = try fs.readFileContents(manifestPath).cString
+        XCTAssertEqual(newManifest, """
+                // swift-tools-version:5.2
+                import PackageDescription
+
+                let package = Package(
+                    name: "exec",
+                    dependencies: [
+                        .package(url: "https://github.com/foo/goo", from: "1.0.1"),
+                    ],
+                    targets: [
+                        .target(
+                            name: "foo",
+                            dependencies: []),
+                        .target(
+                            name: "bar",
+                            dependencies: []),
+                        .testTarget(
+                            name: "fooTests",
+                            dependencies: ["foo", "bar"]),
+                        .target(
+                            name: "baz",
+                            dependencies: []
+                        ),
+                        .testTarget(
+                            name: "bazTests",
+                            dependencies: [
+                                "baz",
+                            ]
+                        ),
+                        .target(
+                            name: "qux",
+                            dependencies: [
+                                "foo",
+                                "baz",
+                            ]
+                        ),
+                        .testTarget(
+                            name: "IntegrationTests",
+                            dependencies: [
+                                .product(name: "OtherProduct", package: "goo"),
+                                "goo",
+                            ]
+                        ),
+                    ]
+                )
+                """)
+
+        XCTAssertTrue(fs.exists(AbsolutePath("/pkg/Sources/baz/baz.swift")))
+        XCTAssertTrue(fs.exists(AbsolutePath("/pkg/Tests/bazTests/bazTests.swift")))
+        XCTAssertTrue(fs.exists(AbsolutePath("/pkg/Sources/qux/main.swift")))
+        XCTAssertFalse(fs.exists(AbsolutePath("/pkg/Tests/quxTests")))
+        XCTAssertTrue(fs.exists(AbsolutePath("/pkg/Tests/IntegrationTests/IntegrationTests.swift")))
+    }
+
+
+    func testAddTarget5_3() throws {
+        let manifest = """
+                // swift-tools-version:5.3
+                import PackageDescription
+
+                let package = Package(
+                    name: "exec",
+                    dependencies: [
+                        .package(url: "https://github.com/foo/goo", from: "1.0.1"),
+                    ],
+                    targets: [
+                        .target(
+                            name: "foo",
+                            dependencies: []),
+                        .target(
+                            name: "bar",
+                            dependencies: []),
+                        .testTarget(
+                            name: "fooTests",
+                            dependencies: ["foo", "bar"]),
+                    ]
+                )
+                """
+
+        let fs = InMemoryFileSystem(emptyFiles:
+                                        "/pkg/Package.swift",
+                                    "/pkg/Sources/foo/source.swift",
+                                    "/pkg/Sources/bar/source.swift",
+                                    "/pkg/Tests/fooTests/source.swift",
+                                    "end")
+
+        let manifestPath = AbsolutePath("/pkg/Package.swift")
+        try fs.writeFileContents(manifestPath) { $0 <<< manifest }
+
+        let diags = DiagnosticsEngine()
+        let context = try PackageEditorContext(
+            manifestPath: AbsolutePath("/pkg/Package.swift"),
+            repositoryManager: RepositoryManager(fileSystem: fs, path: .init("/pkg/repositories"), provider: InMemoryGitRepositoryProvider(), initializationWarningHandler: { _ in }),
+            toolchain: Resources.default.toolchain,
+            diagnosticsEngine: diags,
+            fs: fs)
+        let editor = PackageEditor(context: context)
+
+        XCTAssertThrows(Diagnostics.fatalError) {
+            try editor.addTarget(.library(name: "foo", includeTestTarget: true, dependencyNames: []),
+                                 productPackageNameMapping: [:])
+        }
+        XCTAssertEqual(diags.diagnostics.map(\.message.text), ["a target named 'foo' already exists in 'exec'"])
+        XCTAssertThrows(Diagnostics.fatalError) {
+            try editor.addTarget(.library(name: "Error", includeTestTarget: true, dependencyNames: ["NotFound"]),
+                                 productPackageNameMapping: [:])
+        }
+        XCTAssertEqual(diags.diagnostics.map(\.message.text), ["a target named 'foo' already exists in 'exec'",
+                                                               "could not find a product or target named 'NotFound'"])
+
+        try editor.addTarget(.library(name: "baz", includeTestTarget: true, dependencyNames: []),
+                             productPackageNameMapping: [:])
+        try editor.addTarget(.executable(name: "qux", dependencyNames: ["foo", "baz"]),
+                             productPackageNameMapping: [:])
+        try editor.addTarget(.test(name: "IntegrationTests", dependencyNames: ["OtherProduct", "goo"]),
+                             productPackageNameMapping: ["goo": TextualPackageReference("goo"), "OtherProduct": TextualPackageReference("goo")])
+        try editor.addTarget(.binary(name: "LocalBinary",
+                                     urlOrPath: "/some/local/binary/target.xcframework",
+                                     checksum: nil),
+                             productPackageNameMapping: [:])
+        try editor.addTarget(.binary(name: "RemoteBinary",
+                                     urlOrPath: "https://mybinaries.com/RemoteBinary.zip",
+                                     checksum: "totallylegitchecksum"),
+                             productPackageNameMapping: [:])
+
+        let newManifest = try fs.readFileContents(manifestPath).cString
+        XCTAssertEqual(newManifest, """
+                // swift-tools-version:5.3
+                import PackageDescription
+
+                let package = Package(
+                    name: "exec",
+                    dependencies: [
+                        .package(url: "https://github.com/foo/goo", from: "1.0.1"),
+                    ],
+                    targets: [
+                        .target(
+                            name: "foo",
+                            dependencies: []),
+                        .target(
+                            name: "bar",
+                            dependencies: []),
+                        .testTarget(
+                            name: "fooTests",
+                            dependencies: ["foo", "bar"]),
+                        .target(
+                            name: "baz",
+                            dependencies: []
+                        ),
+                        .testTarget(
+                            name: "bazTests",
+                            dependencies: [
+                                "baz",
+                            ]
+                        ),
+                        .target(
+                            name: "qux",
+                            dependencies: [
+                                "foo",
+                                "baz",
+                            ]
+                        ),
+                        .testTarget(
+                            name: "IntegrationTests",
+                            dependencies: [
+                                .product(name: "OtherProduct", package: "goo"),
+                                "goo",
+                            ]
+                        ),
+                        .binaryTarget(
+                            name: "LocalBinary",
+                            path: "/some/local/binary/target.xcframework"
+                        ),
+                        .binaryTarget(
+                            name: "RemoteBinary",
+                            url: "https://mybinaries.com/RemoteBinary.zip",
+                            checksum: "totallylegitchecksum"
+                        ),
+                    ]
+                )
+                """)
+
+        XCTAssertTrue(fs.exists(AbsolutePath("/pkg/Sources/baz/baz.swift")))
+        XCTAssertTrue(fs.exists(AbsolutePath("/pkg/Tests/bazTests/bazTests.swift")))
+        XCTAssertTrue(fs.exists(AbsolutePath("/pkg/Sources/qux/main.swift")))
+        XCTAssertFalse(fs.exists(AbsolutePath("/pkg/Tests/quxTests")))
+        XCTAssertTrue(fs.exists(AbsolutePath("/pkg/Tests/IntegrationTests/IntegrationTests.swift")))
+    }
+
+    func testAddTarget5_4_to_5_5() throws {
+        for version in ["5.4", "5.5"] {
+            let manifest = """
+              // swift-tools-version:\(version)
+              import PackageDescription
+
+              let package = Package(
+                  name: "exec",
+                  dependencies: [
+                      .package(url: "https://github.com/foo/goo", from: "1.0.1"),
+                  ],
+                  targets: [
+                      .target(
+                          name: "foo",
+                          dependencies: []),
+                      .target(
+                          name: "bar",
+                          dependencies: []),
+                      .testTarget(
+                          name: "fooTests",
+                          dependencies: ["foo", "bar"]),
+                  ]
+              )
+              """
+
+            let fs = InMemoryFileSystem(emptyFiles:
+                                        "/pkg/Package.swift",
+                                        "/pkg/Sources/foo/source.swift",
+                                        "/pkg/Sources/bar/source.swift",
+                                        "/pkg/Tests/fooTests/source.swift",
+                                        "end")
+
+            let manifestPath = AbsolutePath("/pkg/Package.swift")
+            try fs.writeFileContents(manifestPath) { $0 <<< manifest }
+
+            let diags = DiagnosticsEngine()
+            let context = try PackageEditorContext(
+                manifestPath: AbsolutePath("/pkg/Package.swift"),
+                repositoryManager: RepositoryManager(fileSystem: fs, path: .init("/pkg/repositories"), provider: InMemoryGitRepositoryProvider(), initializationWarningHandler: { _ in }),
+                toolchain: Resources.default.toolchain,
+                diagnosticsEngine: diags,
+                fs: fs)
+            let editor = PackageEditor(context: context)
+
+            XCTAssertThrows(Diagnostics.fatalError) {
+                try editor.addTarget(.library(name: "foo", includeTestTarget: true, dependencyNames: []),
+                                     productPackageNameMapping: [:])
+            }
+            XCTAssertEqual(diags.diagnostics.map(\.message.text), ["a target named 'foo' already exists in 'exec'"])
+            XCTAssertThrows(Diagnostics.fatalError) {
+                try editor.addTarget(.library(name: "Error", includeTestTarget: true, dependencyNames: ["NotFound"]),
+                                     productPackageNameMapping: [:])
+            }
+            XCTAssertEqual(diags.diagnostics.map(\.message.text), ["a target named 'foo' already exists in 'exec'",
+                                                                   "could not find a product or target named 'NotFound'"])
+
+            try editor.addTarget(.library(name: "baz", includeTestTarget: true, dependencyNames: []),
+                                 productPackageNameMapping: [:])
+            try editor.addTarget(.executable(name: "qux", dependencyNames: ["foo", "baz"]),
+                                 productPackageNameMapping: [:])
+            try editor.addTarget(.test(name: "IntegrationTests", dependencyNames: ["OtherProduct", "goo"]),
+                                 productPackageNameMapping: ["goo": TextualPackageReference("goo"), "OtherProduct": TextualPackageReference("goo")])
+            try editor.addTarget(.binary(name: "LocalBinary",
+                                         urlOrPath: "/some/local/binary/target.xcframework",
+                                         checksum: nil),
+                                 productPackageNameMapping: [:])
+            try editor.addTarget(.binary(name: "RemoteBinary",
+                                         urlOrPath: "https://mybinaries.com/RemoteBinary.zip",
+                                         checksum: "totallylegitchecksum"),
+                                 productPackageNameMapping: [:])
+
+            let newManifest = try fs.readFileContents(manifestPath).cString
+            XCTAssertEqual(newManifest, """
+              // swift-tools-version:\(version)
+              import PackageDescription
+
+              let package = Package(
+                  name: "exec",
+                  dependencies: [
+                      .package(url: "https://github.com/foo/goo", from: "1.0.1"),
+                  ],
+                  targets: [
+                      .target(
+                          name: "foo",
+                          dependencies: []),
+                      .target(
+                          name: "bar",
+                          dependencies: []),
+                      .testTarget(
+                          name: "fooTests",
+                          dependencies: ["foo", "bar"]),
+                      .target(
+                          name: "baz",
+                          dependencies: []
+                      ),
+                      .testTarget(
+                          name: "bazTests",
+                          dependencies: [
+                              "baz",
+                          ]
+                      ),
+                      .executableTarget(
+                          name: "qux",
+                          dependencies: [
+                              "foo",
+                              "baz",
+                          ]
+                      ),
+                      .testTarget(
+                          name: "IntegrationTests",
+                          dependencies: [
+                              .product(name: "OtherProduct", package: "goo"),
+                              "goo",
+                          ]
+                      ),
+                      .binaryTarget(
+                          name: "LocalBinary",
+                          path: "/some/local/binary/target.xcframework"
+                      ),
+                      .binaryTarget(
+                          name: "RemoteBinary",
+                          url: "https://mybinaries.com/RemoteBinary.zip",
+                          checksum: "totallylegitchecksum"
+                      ),
+                  ]
+              )
+              """)
+
+            XCTAssertTrue(fs.exists(AbsolutePath("/pkg/Sources/baz/baz.swift")))
+            XCTAssertTrue(fs.exists(AbsolutePath("/pkg/Tests/bazTests/bazTests.swift")))
+            XCTAssertTrue(fs.exists(AbsolutePath("/pkg/Sources/qux/main.swift")))
+            XCTAssertFalse(fs.exists(AbsolutePath("/pkg/Tests/quxTests")))
+            XCTAssertTrue(fs.exists(AbsolutePath("/pkg/Tests/IntegrationTests/IntegrationTests.swift")))
+        }
+    }
+
+    func testAddProduct5_2_to_5_5() throws {
+        for version in ["5.2", "5.3", "5.4", "5.5"] {
+            let manifest = """
+                // swift-tools-version:\(version)
+                import PackageDescription
+
+                let package = Package(
+                    name: "exec",
+                    products: [
+                        .executable(name: "abc", targets: ["foo"]),
+                    ],
+                    dependencies: [
+                        .package(url: "https://github.com/foo/goo", from: "1.0.1"),
+                    ],
+                    targets: [
+                        .target(
+                            name: "foo",
+                            dependencies: []),
+                        .target(
+                            name: "bar",
+                            dependencies: []),
+                        .testTarget(
+                            name: "fooTests",
+                            dependencies: ["foo", "bar"]),
+                    ]
+                )
+                """
+
+            let fs = InMemoryFileSystem(emptyFiles:
+                "/pkg/Package.swift",
+                "/pkg/Sources/foo/source.swift",
+                "/pkg/Sources/bar/source.swift",
+                "/pkg/Tests/fooTests/source.swift",
+                "end")
+
+            let manifestPath = AbsolutePath("/pkg/Package.swift")
+            try fs.writeFileContents(manifestPath) { $0 <<< manifest }
+
+            let diags = DiagnosticsEngine()
+            let context = try PackageEditorContext(
+                manifestPath: AbsolutePath("/pkg/Package.swift"),
+                repositoryManager: RepositoryManager(fileSystem: fs, path: .init("/pkg/repositories"), provider: InMemoryGitRepositoryProvider(), initializationWarningHandler: { _ in }),
+                toolchain: Resources.default.toolchain,
+                diagnosticsEngine: diags,
+                fs: fs)
+            let editor = PackageEditor(context: context)
+
+            XCTAssertThrows(Diagnostics.fatalError) {
+                try editor.addProduct(name: "abc", type: .library(.automatic), targets: [])
+            }
+
+            XCTAssertThrows(Diagnostics.fatalError) {
+                try editor.addProduct(name: "SomeProduct", type: .library(.automatic), targets: ["nonexistent"])
+            }
+
+            XCTAssertEqual(diags.diagnostics.map(\.message.text), ["a product named 'abc' already exists in 'exec'",
+                                                                   "no target named 'nonexistent' in 'exec'"])
+
+            try editor.addProduct(name: "xyz", type: .executable, targets: ["bar"])
+            try editor.addProduct(name: "libxyz", type: .library(.dynamic), targets: ["foo", "bar"])
+
+            let newManifest = try fs.readFileContents(manifestPath).cString
+            XCTAssertEqual(newManifest, """
+                // swift-tools-version:\(version)
+                import PackageDescription
+
+                let package = Package(
+                    name: "exec",
+                    products: [
+                        .executable(name: "abc", targets: ["foo"]),
+                        .executable(
+                            name: "xyz",
+                            targets: [
+                                "bar",
+                            ]
+                        ),
+                        .library(
+                            name: "libxyz",
+                            type: .dynamic,
+                            targets: [
+                                "foo",
+                                "bar",
+                            ]
+                        ),
+                    ],
+                    dependencies: [
+                        .package(url: "https://github.com/foo/goo", from: "1.0.1"),
+                    ],
+                    targets: [
+                        .target(
+                            name: "foo",
+                            dependencies: []),
+                        .target(
+                            name: "bar",
+                            dependencies: []),
+                        .testTarget(
+                            name: "fooTests",
+                            dependencies: ["foo", "bar"]),
+                    ]
+                )
+                """)
+        }
+    }
+
+    func testToolsVersionTest() throws {
+        let manifest = """
+            // swift-tools-version:5.0
+            import PackageDescription
+
+            let package = Package(
+                name: "exec",
+                dependencies: [
+                    .package(url: "https://github.com/foo/goo", from: "1.0.1"),
+                ],
+                targets: [
+                    .target(
+                        name: "foo",
+                        dependencies: []),
+                ]
+            )
+            """
+
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/pkg/Package.swift",
+            "/pkg/Sources/foo/source.swift",
+            "end")
+
+        let manifestPath = AbsolutePath("/pkg/Package.swift")
+        try fs.writeFileContents(manifestPath) { $0 <<< manifest }
+
+        let diags = DiagnosticsEngine()
+        let context = try PackageEditorContext(
+            manifestPath: AbsolutePath("/pkg/Package.swift"),
+            repositoryManager: RepositoryManager(fileSystem: fs, path: .init("/pkg/repositories"), provider: InMemoryGitRepositoryProvider(), initializationWarningHandler: { _ in }),
+            toolchain: Resources.default.toolchain, diagnosticsEngine: diags, fs: fs)
+        let editor = PackageEditor(context: context)
+
+        XCTAssertThrows(Diagnostics.fatalError) {
+            try editor.addTarget(.library(name: "bar", includeTestTarget: true, dependencyNames: []),
+                                 productPackageNameMapping: [:])
+        }
+        XCTAssertEqual(diags.diagnostics.map(\.message.text),
+                       ["command line editing of manifests is only supported for packages with a swift-tools-version of 5.2 and later"])
+    }
+
+    func testEditingManifestsWithComplexArgumentExpressions() throws {
+        let manifest = """
+            // swift-tools-version:5.3
+            import PackageDescription
+
+            let flag = false
+            let extraDeps: [Package.Dependency] = []
+
+            let package = Package(
+                name: "exec",
+                products: [
+                    .library(name: "Library", targets: ["foo"])
+                ].filter { _ in true },
+                dependencies: extraDeps + [
+                    .package(url: "https://github.com/foo/goo", from: "1.0.1"),
+                ],
+                targets: flag ? [] : [
+                    .target(
+                        name: "foo",
+                        dependencies: []),
+                ]
+            )
+            """
+
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/pkg/Package.swift",
+            "/pkg/Sources/foo/source.swift",
+            "end")
+
+        let manifestPath = AbsolutePath("/pkg/Package.swift")
+        try fs.writeFileContents(manifestPath) { $0 <<< manifest }
+
+        try fs.createDirectory(.init("/pkg/repositories"), recursive: false)
+        try fs.createDirectory(.init("/pkg/repo"), recursive: false)
+
+
+        let provider = InMemoryGitRepositoryProvider()
+        let repo = InMemoryGitRepository(path: .init("/pkg/repo"), fs: fs)
+        try repo.writeFileContents(.init("/Package.swift"), bytes: .init(encodingAsUTF8: """
+        // swift-tools-version:5.2
+        import PackageDescription
+
+        let package = Package(name: "repo")
+        """))
+        try repo.commit()
+        try repo.tag(name: "1.1.1")
+        let url = try XCTUnwrap(URL(string: "http://www.githost.com/repo"))
+        provider.add(specifier: .init(url: url), repository: repo)
+
+        let diags = DiagnosticsEngine()
+        let context = try PackageEditorContext(
+            manifestPath: AbsolutePath("/pkg/Package.swift"),
+            repositoryManager: RepositoryManager(fileSystem: fs, path: .init("/pkg/repositories"),
+                                                 provider: provider, initializationWarningHandler: { _ in }),
+            toolchain: Resources.default.toolchain,
+            diagnosticsEngine: diags,
+            fs: fs)
+        let editor = PackageEditor(context: context)
+        try editor.addPackageDependency(url: "http://www.githost.com/repo.git", requirement: .exact("1.1.1"))
+        try editor.addTarget(.library(name: "Library", includeTestTarget: false, dependencyNames: []),
+                             productPackageNameMapping: [:])
+        XCTAssertEqual(diags.diagnostics.map(\.message.text), [])
+        XCTAssertThrows(Diagnostics.fatalError) {
+            try editor.addProduct(name: "Executable", type: .executable, targets: ["foo"])
+        }
+        XCTAssertEqual(diags.diagnostics.map(\.message.text),
+                       ["'products' argument is not an array literal or concatenation of array literals"])
+
+        let newManifest = try fs.readFileContents(manifestPath).cString
+        XCTAssertEqual(newManifest, """
+        // swift-tools-version:5.3
+        import PackageDescription
+
+        let flag = false
+        let extraDeps: [Package.Dependency] = []
+
+        let package = Package(
+            name: "exec",
+            products: [
+                .library(name: "Library", targets: ["foo"])
+            ].filter { _ in true },
+            dependencies: extraDeps + [
+                .package(url: "https://github.com/foo/goo", from: "1.0.1"),
+                .package(name: "repo", url: "http://www.githost.com/repo.git", .exact("1.1.1")),
+            ],
+            targets: flag ? [] : [
+                .target(
+                    name: "foo",
+                    dependencies: []),
+                .target(
+                    name: "Library",
+                    dependencies: []
+                ),
+            ]
+        )
+        """)
+    }
+
+    func testEditingConditionalPackageInit() throws {
+        let manifest = """
+            // swift-tools-version:5.3
+            import PackageDescription
+
+            #if os(macOS)
+            let package = Package(
+                name: "macOSPackage"
+            )
+            #else
+            let package = Package(
+                name: "otherPlatformsPackage"
+            )
+            #endif
+            """
+
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/pkg/Package.swift",
+            "/pkg/Sources/foo/source.swift",
+            "end")
+
+        let manifestPath = AbsolutePath("/pkg/Package.swift")
+        try fs.writeFileContents(manifestPath) { $0 <<< manifest }
+
+        try fs.createDirectory(.init("/pkg/repositories"), recursive: false)
+
+        let diags = DiagnosticsEngine()
+        let context = try PackageEditorContext(
+            manifestPath: AbsolutePath("/pkg/Package.swift"),
+            repositoryManager: RepositoryManager(fileSystem: fs, path: .init("/pkg/repositories"),
+                                                 provider: InMemoryGitRepositoryProvider(), initializationWarningHandler: { _ in }),
+            toolchain: Resources.default.toolchain,
+            diagnosticsEngine: diags,
+            fs: fs)
+        let editor = PackageEditor(context: context)
+        XCTAssertThrows(Diagnostics.fatalError) {
+            try editor.addTarget(.library(name: "Library", includeTestTarget: false, dependencyNames: []),
+                                 productPackageNameMapping: [:])
+        }
+        XCTAssertEqual(diags.diagnostics.map(\.message.text), ["found multiple Package initializers"])
+    }
+}
+
+fileprivate extension TextualPackageReference {
+    init(_ packageName: String) {
+        let identity = PackageIdentity(path: .root.appending(component: packageName))
+        self.init(displayName: packageName, identity: identity)
+    }
+}

--- a/Tests/PackageSyntaxTests/Resources.swift
+++ b/Tests/PackageSyntaxTests/Resources.swift
@@ -1,0 +1,67 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+// FIXME: Share with SwiftPM
+
+import TSCBasic
+import SPMBuildCore
+import Foundation
+import PackageLoading
+import Workspace
+import PackageModel
+
+#if os(macOS)
+private func bundleRoot() -> AbsolutePath {
+    for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
+        return AbsolutePath(bundle.bundlePath).parentDirectory
+    }
+    fatalError()
+}
+#endif
+
+public class Resources {
+
+    public var swiftCompiler: AbsolutePath {
+        return toolchain.swiftCompilerPath
+    }
+
+    public var libDir: AbsolutePath {
+        return toolchain.swiftPMLibrariesLocation.manifestLibraryPath
+    }
+
+    public var swiftCompilerFlags: [String] {
+        return []
+    }
+
+  #if os(macOS)
+    public var sdkPlatformFrameworksPath: AbsolutePath {
+        return Destination.sdkPlatformFrameworkPaths()!.fwk
+    }
+  #endif
+
+    public let toolchain: UserToolchain
+
+    public static let `default` = Resources()
+
+    private init() {
+        let binDir: AbsolutePath
+      #if os(macOS)
+        binDir = bundleRoot()
+      #else
+        binDir = AbsolutePath(CommandLine.arguments[0], relativeTo: localFileSystem.currentWorkingDirectory!).parentDirectory
+      #endif
+        toolchain = try! UserToolchain(destination: Destination.hostDestination(binDir))
+    }
+
+    /// True if SwiftPM has PackageDescription 4 runtime available.
+    public static var havePD4Runtime: Bool {
+        return true
+    }
+}

--- a/Tests/PackageSyntaxTests/TestSupport.swift
+++ b/Tests/PackageSyntaxTests/TestSupport.swift
@@ -1,0 +1,61 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+// FIXME: Find a way to share this with SwiftPM
+import TSCBasic
+import XCTest
+
+extension InMemoryFileSystem {
+  /// Create a new file system with an empty file at each provided path.
+  convenience init(emptyFiles files: String...) {
+      self.init(emptyFiles: files)
+  }
+
+  /// Create a new file system with an empty file at each provided path.
+  convenience init(emptyFiles files: [String]) {
+      self.init()
+      self.createEmptyFiles(at: .root, files: files)
+  }
+}
+
+extension FileSystem {
+    func createEmptyFiles(at root: AbsolutePath, files: String...) {
+        self.createEmptyFiles(at: root, files: files)
+    }
+
+    func createEmptyFiles(at root: AbsolutePath, files: [String]) {
+        do {
+            try createDirectory(root, recursive: true)
+            for path in files {
+                let path = root.appending(RelativePath(String(path.dropFirst())))
+                try createDirectory(path.parentDirectory, recursive: true)
+                try writeFileContents(path, bytes: "")
+            }
+        } catch {
+            fatalError("Failed to create empty files: \(error)")
+        }
+    }
+}
+
+func XCTAssertThrows<T: Swift.Error>(
+  _ expectedError: T,
+  file: StaticString = #file,
+  line: UInt = #line,
+  _ body: () throws -> Void
+) where T: Equatable {
+  do {
+    try body()
+    XCTFail("body completed successfully", file: file, line: line)
+  } catch let error as T {
+    XCTAssertEqual(error, expectedError, file: file, line: line)
+  } catch {
+    XCTFail("unexpected error thrown: \(error)", file: file, line: line)
+  }
+}


### PR DESCRIPTION
This is basically bringing back @owenv's work from https://github.com/owenv/swift-package-editor into SwiftPM itself. Previously, we didn't have a way to use swift-syntax from the toolchain, but with the new `SwiftParser` library, it has now become independent of the toolchain and that problem has been solved.

I talked to @owenv, updated his code/tests for the newer APIs in swift-syntax and SwiftPM. Right now, I have not brought over the integration tests, yet, only the unit tests. I will also have to do some updates to support newer manifests versions, e.g. by adding a way to use registry dependencies.

In contrast to the original proposal, I'm keeping this in a separate top-level command called `swift package-editor`. This is up for discussion, but I think it would be good to start moduralizing the CLI a bit more to avoid having to build every dependency and module in the first CMake stage. That would require taking aprt the `Commands` module eventually, for now I am just opting to not add more functionality into that since it just makes everything very monolithic.
