### PR TITLE
Error on empty product names

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -181,6 +181,7 @@ extension Target.Error.ModuleNameProblem: CustomStringConvertible {
 extension Product {
     /// An error in a product definition.
     enum Error: Swift.Error {
+        case emptyName
         case moduleEmpty(product: String, target: String)
     }
 }
@@ -188,6 +189,8 @@ extension Product {
 extension Product.Error: CustomStringConvertible {
     var description: String {
         switch self {
+        case .emptyName:
+            return "product names can not be empty"
         case .moduleEmpty(let product, let target):
             return "target '\(target)' referenced in product '\(product)' is empty"
         }
@@ -1147,6 +1150,10 @@ public final class PackageBuilder {
             filteredProducts = self.manifest.products.filter { set.contains($0.name) }
         }
         for product in filteredProducts {
+            if product.name.isEmpty {
+                throw Product.Error.emptyName
+            }
+
             let targets = try modulesFrom(targetNames: product.targets, product: product.name)
             // Perform special validations if this product is exporting
             // a system library target.

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -577,6 +577,24 @@ class PackageBuilderTests: XCTestCase {
         }
     }
 
+    func testEmptyProductNameError() throws {
+        let fs = InMemoryFileSystem(emptyFiles: "/Sources/best/best.swift")
+
+        let manifest = Manifest.createRootManifest(
+            name: "pkg",
+            products: [
+                try ProductDescription(name: "", type: .library(.automatic), targets: ["best"]),
+            ],
+            targets: [
+                try TargetDescription(name: "best"),
+            ]
+        )
+
+        PackageBuilderTester(manifest, in: fs) { package, diagnostics in
+            diagnostics.check(diagnostic: "product names can not be empty", severity: .error)
+        }
+    }
+
     func testMultipleTestEntryPointsError() throws {
         let name = SwiftTarget.defaultTestEntryPointName
         let swift: AbsolutePath = AbsolutePath("/swift")


### PR DESCRIPTION
This seems like an oversight in `PackageBuilder` validation so I don't think it needs to be guarded by tools-version.

rdar://94661861
