### PR TITLE
Support vending products that are backed by binaryTargets

### DIFF
--- a/Fixtures/Miscellaneous/Plugins/BinaryToolProductPlugin/Dependency/Binaries/MyVendedSourceGenBuildTool.artifactbundle/info.json
+++ b/Fixtures/Miscellaneous/Plugins/BinaryToolProductPlugin/Dependency/Binaries/MyVendedSourceGenBuildTool.artifactbundle/info.json
@@ -1,0 +1,19 @@
+{
+    "schemaVersion": "1.0",
+    "artifacts": {
+        "mytool": {
+            "type": "executable",
+            "version": "1.2.3",
+            "variants": [
+                {
+                    "path": "mytool-macos/mytool",
+                    "supportedTriples": ["x86_64-apple-macosx", "arm64-apple-macosx"]
+                },
+                {
+                    "path": "mytool-linux/mytool",
+                    "supportedTriples": ["x86_64-unknown-linux-gnu"]
+                }
+            ]
+        }
+    }
+}

--- a/Fixtures/Miscellaneous/Plugins/BinaryToolProductPlugin/Dependency/Binaries/MyVendedSourceGenBuildTool.artifactbundle/mytool-linux/mytool
+++ b/Fixtures/Miscellaneous/Plugins/BinaryToolProductPlugin/Dependency/Binaries/MyVendedSourceGenBuildTool.artifactbundle/mytool-linux/mytool
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+print_usage() {
+    echo "usage: ${0##*/} [--verbose] <in> <out>"
+}
+
+# Parse arguments until we find '--' or an argument that isn't an option.
+until [ $# -eq 0 ]
+do
+    case "$1" in
+        --verbose) verbose=1; shift;;
+        --) shift; break;;
+        -*) echo "unknown option: ${1}"; print_usage; exit 1; shift;;
+        *) break;;
+    esac
+done
+
+# Print usage and leave if we don't have exactly two arguments.
+if [ $# -ne 2 ]; then
+    print_usage
+    exit 1
+fi
+
+# For our sample tool we just copy from one to the other.
+if [ $verbose != 0 ]; then
+    echo "[${0##*/}-linux] '$1' '$2'"
+fi
+
+cp "$1" "$2"

--- a/Fixtures/Miscellaneous/Plugins/BinaryToolProductPlugin/Dependency/Binaries/MyVendedSourceGenBuildTool.artifactbundle/mytool-macos/mytool
+++ b/Fixtures/Miscellaneous/Plugins/BinaryToolProductPlugin/Dependency/Binaries/MyVendedSourceGenBuildTool.artifactbundle/mytool-macos/mytool
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+print_usage() {
+    echo "usage: ${0##*/} [--verbose] <in> <out>"
+}
+
+# Parse arguments until we find '--' or an argument that isn't an option.
+until [ $# -eq 0 ]
+do
+    case "$1" in
+        --verbose) verbose=1; shift;;
+        --) shift; break;;
+        -*) echo "unknown option: ${1}"; print_usage; exit 1; shift;;
+        *) break;;
+    esac
+done
+
+# Print usage and leave if we don't have exactly two arguments.
+if [ $# -ne 2 ]; then
+    print_usage
+    exit 1
+fi
+
+# For our sample tool we just copy from one to the other.
+if [ $verbose != 0 ]; then
+    echo "[${0##*/}-macosx] '$1' '$2'"
+fi
+
+cp "$1" "$2"

--- a/Fixtures/Miscellaneous/Plugins/BinaryToolProductPlugin/Dependency/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/BinaryToolProductPlugin/Dependency/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version: 5.6
+import PackageDescription
+
+let package = Package(
+    name: "MyBinaryProduct",
+    products: [
+        .executable(
+            name: "MyVendedSourceGenBuildTool",
+            targets: ["MyVendedSourceGenBuildTool"]
+        ),    
+    ],
+    targets: [
+        .binaryTarget(
+            name: "MyVendedSourceGenBuildTool",
+            path: "Binaries/MyVendedSourceGenBuildTool.artifactbundle"
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/Plugins/BinaryToolProductPlugin/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/BinaryToolProductPlugin/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version: 5.6
+import PackageDescription
+
+let package = Package(
+    name: "MyBinaryToolPlugin",
+    dependencies: [
+        .package(path: "Dependency"),
+    ],
+    targets: [
+        // A local tool that uses a build tool plugin.
+        .executableTarget(
+            name: "MyLocalTool",
+            plugins: [
+                "MySourceGenBuildToolPlugin",
+            ]
+        ),
+        // The plugin that generates build tool commands to invoke MySourceGenBuildTool.
+        .plugin(
+            name: "MySourceGenBuildToolPlugin",
+            capability: .buildTool(),
+            dependencies: [
+                .product(name: "MyVendedSourceGenBuildTool", package: "Dependency"),
+            ]
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/Plugins/BinaryToolProductPlugin/Plugins/MySourceGenBuildToolPlugin/plugin.swift
+++ b/Fixtures/Miscellaneous/Plugins/BinaryToolProductPlugin/Plugins/MySourceGenBuildToolPlugin/plugin.swift
@@ -1,0 +1,34 @@
+import PackagePlugin
+
+@main
+struct MyPlugin: BuildToolPlugin {
+    
+    func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
+        print("Hello from the Build Tool Plugin!")
+        guard let target = target as? SourceModuleTarget else { return [] }
+        let inputFiles = target.sourceFiles.filter({ $0.path.extension == "dat" })
+        return try inputFiles.map {
+            let inputFile = $0
+            let inputPath = inputFile.path
+            let outputName = inputPath.stem + ".swift"
+            let outputPath = context.pluginWorkDirectory.appending(outputName)
+            return .buildCommand(
+                displayName:
+                    "Generating \(outputName) from \(inputPath.lastComponent)",
+                executable:
+                    try context.tool(named: "mytool").path,
+                arguments: [
+                    "--verbose",
+                    "\(inputPath)",
+                    "\(outputPath)"
+                ],
+                inputFiles: [
+                    inputPath,
+                ],
+                outputFiles: [
+                    outputPath
+                ]
+            )
+        }
+    }
+}

--- a/Fixtures/Miscellaneous/Plugins/BinaryToolProductPlugin/Sources/MyLocalTool/foo.dat
+++ b/Fixtures/Miscellaneous/Plugins/BinaryToolProductPlugin/Sources/MyLocalTool/foo.dat
@@ -1,0 +1,1 @@
+let foo = "I am Foo!"

--- a/Fixtures/Miscellaneous/Plugins/BinaryToolProductPlugin/Sources/MyLocalTool/main.swift
+++ b/Fixtures/Miscellaneous/Plugins/BinaryToolProductPlugin/Sources/MyLocalTool/main.swift
@@ -1,0 +1,1 @@
+print("Generated string Foo: '\(foo)'")

--- a/Sources/Build/LLBuildManifestBuilder.swift
+++ b/Sources/Build/LLBuildManifestBuilder.swift
@@ -553,7 +553,7 @@ extension LLBuildManifestBuilder {
             if target.type == .executable {
                 // FIXME: Optimize.
                 let _product = try plan.graph.allProducts.first {
-                    try $0.type == .executable && $0.executableTarget() == target
+                    try $0.type == .executable && $0.executableTarget == target
                 }
                 if let product = _product {
                     guard let planProduct = plan.productMap[product] else {

--- a/Sources/PackageGraph/ResolvedProduct.swift
+++ b/Sources/PackageGraph/ResolvedProduct.swift
@@ -43,11 +43,16 @@ public final class ResolvedProduct {
     /// The main executable target of product.
     ///
     /// Note: This property is only valid for executable products.
-    public func executableTarget() throws -> ResolvedTarget {
-        guard type == .executable || type == .snippet else {
-            throw InternalError("firstExecutableModule should only be called for executable targets")
+    public var executableTarget: ResolvedTarget {
+        get throws {
+            guard type == .executable || type == .snippet else {
+                throw InternalError("`executableTarget` should only be called for executable targets")
+            }
+            guard let underlyingExecutableTarget = targets.map({ $0.underlyingTarget }).executables.first, let executableTarget = targets.first(where: { $0.underlyingTarget == underlyingExecutableTarget }) else {
+                throw InternalError("could not determine executable target")
+            }
+            return executableTarget
         }
-        return targets.first(where: { $0.type == .executable || $0.type == .snippet })!
     }
 
     public init(product: Product, targets: [ResolvedTarget]) {

--- a/Sources/PackageLoading/ManifestLoader+Validation.swift
+++ b/Sources/PackageLoading/ManifestLoader+Validation.swift
@@ -78,10 +78,14 @@ public struct ManifestValidator {
                 }
             }
 
-            // Check that products that reference only binary targets don't define a type.
-            let areTargetsBinary = product.targets.allSatisfy { self.manifest.targetMap[$0]?.type == .binary }
-            if areTargetsBinary && product.type != .library(.automatic) {
-                diagnostics.append(.invalidBinaryProductType(productName: product.name))
+            // Check that products that reference only binary targets don't define an explicit library type.
+            if product.targets.allSatisfy({ self.manifest.targetMap[$0]?.type == .binary }) {
+                switch product.type {
+                case .library(.automatic), .executable:
+                    break
+                default:
+                    diagnostics.append(.invalidBinaryProductType(productName: product.name))
+                }
             }
         }
 
@@ -262,7 +266,7 @@ extension Basics.Diagnostic {
     }
 
     static func invalidBinaryProductType(productName: String) -> Self {
-        .error("invalid type for binary product '\(productName)'; products referencing only binary targets must have a type of 'library'")
+        .error("invalid type for binary product '\(productName)'; products referencing only binary targets must be executable or automatic library products")
     }
 
     /*static func duplicateDependency(dependencyIdentity: PackageIdentity) -> Self {

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -1290,7 +1290,7 @@ public final class PackageBuilder {
     }
 
     private func validateExecutableProduct(_ product: ProductDescription, with targets: [Target]) -> Bool {
-        let executableTargetCount = targets.filter { $0.type == .executable }.count
+        let executableTargetCount = targets.executables.count
         guard executableTargetCount == 1 else {
             if executableTargetCount == 0 {
                 if let target = targets.spm_only {

--- a/Sources/PackageModel/Product.swift
+++ b/Sources/PackageModel/Product.swift
@@ -43,7 +43,7 @@ public class Product: Codable {
             throw InternalError("Targets cannot be empty")
         }
         if type == .executable {
-            guard targets.filter({ $0.type == .executable }).count == 1 else {
+            guard targets.executables.count == 1 else {
                 throw InternalError("Executable products should have exactly one executable target.")
             }
         }

--- a/Sources/PackageModel/Target.swift
+++ b/Sources/PackageModel/Target.swift
@@ -638,6 +638,11 @@ public final class BinaryTarget: Target {
         }
     }
 
+    public var containsExecutable: Bool {
+        // FIXME: needs to be revisited once libraries are supported in artifact bundles
+        return self.kind == .artifactsArchive
+    }
+
     public enum Origin: Equatable, Codable {
 
         /// Represents an artifact that was downloaded from a remote URL.
@@ -796,6 +801,21 @@ public enum PluginPermission: Hashable, Codable {
         switch desc {
         case .writeToPackageDirectory(let reason):
             self = .writeToPackageDirectory(reason: reason)
+        }
+    }
+}
+
+public extension Sequence where Iterator.Element == Target {
+    var executables: [Target] {
+        return filter {
+            switch $0.type {
+            case .binary:
+                return ($0 as? BinaryTarget)?.containsExecutable == true
+            case .executable:
+                return true
+            default:
+                return false
+            }
         }
     }
 }

--- a/Sources/SPMBuildCore/PluginContextSerializer.swift
+++ b/Sources/SPMBuildCore/PluginContextSerializer.swift
@@ -184,9 +184,7 @@ internal struct PluginContextSerializer {
         switch product.type {
             
         case .executable:
-            guard let mainExecTarget = product.targets.first(where: { $0.type == .executable }) else {
-                throw InternalError("could not determine main executable target for product \(product)")
-            }
+            let mainExecTarget = try product.executableTarget
             guard let mainExecTargetId = try serialize(target: mainExecTarget) else {
                 throw InternalError("unable to serialize main executable target \(mainExecTarget) for product \(product)")
             }

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -155,6 +155,19 @@ class PluginTests: XCTestCase {
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
     }
+
+    func testUseOfBinaryToolVendedAsProduct() throws {
+        #if !os(macOS)
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
+        // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
+        try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+        try fixture(name: "Miscellaneous/Plugins") { fixturePath in
+            let (stdout, _) = try executeSwiftBuild(fixturePath.appending(component: "BinaryToolProductPlugin"), configuration: .Debug, extraArgs: ["--product", "MyLocalTool"])
+            XCTAssert(stdout.contains("Linking MyLocalTool"), "stdout:\n\(stdout)")
+            XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
+        }
+    }
     
     func testCommandPluginInvocation() throws {
         // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).

--- a/Tests/PackageLoadingTests/PD_5_3_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_3_LoadingTests.swift
@@ -177,29 +177,7 @@ class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
             let (_, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
             testDiagnostics(validationDiagnostics) { result in
-                result.check(diagnostic: "invalid type for binary product 'FooLibrary'; products referencing only binary targets must have a type of 'library'", severity: .error)
-            }
-        }
-
-        do {
-            let content = """
-                import PackageDescription
-                let package = Package(
-                    name: "Foo",
-                    products: [
-                        .executable(name: "FooLibrary", targets: ["Foo"]),
-                    ],
-                    targets: [
-                        .binaryTarget(name: "Foo", path: "Foo.xcframework"),
-                    ]
-                )
-                """
-
-            let observability = ObservabilitySystem.makeForTesting()
-            let (_, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
-            XCTAssertNoDiagnostics(observability.diagnostics)
-            testDiagnostics(validationDiagnostics) { result in
-                result.check(diagnostic: "invalid type for binary product 'FooLibrary'; products referencing only binary targets must have a type of 'library'", severity: .error)
+                result.check(diagnostic: "invalid type for binary product 'FooLibrary'; products referencing only binary targets must be executable or automatic library products", severity: .error)
             }
         }
 


### PR DESCRIPTION
This adds support for vending an executable product that consists solely of a binary target that is backed by an artifact bundle. This allows vending binary executables as their own separate package, independently of the plugins that are using them.

rdar://101096803