### PR TITLE
build: enforce shared library for PackagePlugin

### DIFF
--- a/Sources/PackagePlugin/CMakeLists.txt
+++ b/Sources/PackagePlugin/CMakeLists.txt
@@ -6,7 +6,7 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
-add_library(PackagePlugin
+add_library(PackagePlugin SHARED
   ArgumentExtractor.swift
   Command.swift
   Context.swift


### PR DESCRIPTION
Synchronise the Package.swift and CMakeLists.txt to build this as a shared library.  Previously we were reliant on `-DBUILD_SHARED_LIBS=YES` being passed to properly construct this artifact.