### PR TITLE
Make the code that deals with the remaining data in the NSFileHandle readabilityHandler be more robust

### DIFF
--- a/Sources/Workspace/DefaultPluginScriptRunner.swift
+++ b/Sources/Workspace/DefaultPluginScriptRunner.swift
@@ -516,7 +516,10 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
             }
 
             // Read and pass on any remaining messages from the plugin.
-            stdoutPipe.fileHandleForReading.readabilityHandler?(stdoutPipe.fileHandleForReading)
+            let handle = stdoutPipe.fileHandleForReading
+            if let handler = handle.readabilityHandler {
+                handler(handle)
+            }
 
             // Call the completion block with a result that depends on how the process ended.
             callbackQueue.async {


### PR DESCRIPTION
There were cases in which this code in DefaultPluginScriptRunner could crash.  This change introduces local variables that keep both the handle and handler alive long enough to not crash rather than doing it all in one expression.  Note that this isn't a race condition — the handler does the correct locking.  But the object lifetime was a bit ambiguous with the existing line of code, and the new one removes the ambiguity.

No new unit tests — 21 of the existing unit tests cover this, and that's how the ambiguity was found.

rdar://101229820
