### PR TITLE
Update cross-compilation SDK script for Swift 5.7

### DIFF
--- a/Utilities/build_ubuntu_cross_compilation_toolchain
+++ b/Utilities/build_ubuntu_cross_compilation_toolchain
@@ -13,8 +13,8 @@
 
 set -eu
 
-export PATH="/bin:/usr/bin"
-VERSION=${VERSION:-4.1-RELEASE}
+export PATH="/bin:/usr/bin:$(brew --prefix)/bin"
+VERSION=${VERSION:-5.7-RELEASE}
 if [[ -z "${VERSION##*RELEASE*}" ]]; then
   branch=swift-${VERSION%%RELEASE}release
 elif [[ -z "${VERSION##DEVELOPMENT-SNAPSHOT*}" ]]; then
@@ -26,21 +26,20 @@ fi
 function usage() {
     echo >&2 "Usage: $0 TMP-DIR SWIFT-FOR-MACOS.pkg SWIFT-FOR-LINUX.tar.gz"
     echo >&2
-    echo >&2 "Example: $0 /tmp/ ~/Downloads/swift-${VERSION}-osx.pkg ~/Downloads/swift-${VERSION}-ubuntu16.04.tar.gz"
+    echo >&2 "Example: $0 /tmp/ ~/Downloads/swift-${VERSION}-osx.pkg ~/Downloads/swift-${VERSION}-ubuntu22.04.tar.gz"
     echo >&2
     echo >&2 "Complete example:"
     echo >&2 "  # Download the Swift binaries for Ubuntu and macOS"
-    echo >&2 "  curl -o ~/Downloads/swift-${VERSION}-ubuntu16.04.tar.gz https://swift.org/builds/${branch}/ubuntu1604/swift-${VERSION}/swift-${VERSION}-ubuntu16.04.tar.gz"
+    echo >&2 "  curl -o ~/Downloads/swift-${VERSION}-ubuntu22.04.tar.gz https://swift.org/builds/${branch}/ubuntu2204/swift-${VERSION}/swift-${VERSION}-ubuntu22.04.tar.gz"
     echo >&2 "  curl -o ~/Downloads/swift-${VERSION}-osx.pkg https://swift.org/builds/${branch}/xcode/swift-${VERSION}/swift-${VERSION}-osx.pkg"
     echo >&2 "  # Compile the SDK and toolchain from that"
-    echo >&2 "  $0 /tmp/ ~/Downloads/swift-${VERSION}-osx.pkg ~/Downloads/swift-${VERSION}-ubuntu16.04.tar.gz"
+    echo >&2 "  $0 /tmp/ ~/Downloads/swift-${VERSION}-osx.pkg ~/Downloads/swift-${VERSION}-ubuntu22.04.tar.gz"
     echo >&2 "  # Create a test application"
     echo >&2 "  mkdir my-test-app"
     echo >&2 "  cd my-test-app"
     echo >&2 "  swift package init --type=executable"
     echo >&2 "  # Build it for Ubuntu"
-    echo >&2 "  swift build --destination /tmp/cross-toolchain/ubuntu-xenial-destination.json"
-
+    echo >&2 "  swift build --destination /tmp/cross-toolchain/ubuntu-jammy-destination.json"
 }
 
 if [[ $# -ne 3 ]]; then
@@ -112,12 +111,12 @@ test -f "$linux_swift_pkg"
 # config
 blocks_h_url="https://raw.githubusercontent.com/apple/swift-corelibs-libdispatch/main/src/BlocksRuntime/Block.h"
 xc_tc_name="swift.xctoolchain"
-linux_sdk_name="ubuntu-xenial.sdk"
+linux_sdk_name="ubuntu-jammy.sdk"
 cross_tc_basename="cross-toolchain"
-clang_package_url="https://releases.llvm.org/6.0.0/clang+llvm-6.0.0-x86_64-apple-darwin.tar.xz"
+clang_package_url="https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/clang+llvm-13.0.1-x86_64-apple-darwin.tar.xz"
 ubuntu_mirror="http://gb.archive.ubuntu.com/ubuntu"
-packages_file="$ubuntu_mirror/dists/xenial/main/binary-amd64/Packages.gz"
-pkg_names=( libc6-dev linux-libc-dev libicu55 libgcc-5-dev libicu-dev libc6 libgcc1 libstdc++-5-dev libstdc++6 zlib1g-dev )
+packages_file="$ubuntu_mirror/dists/jammy/main/binary-amd64/Packages.gz"
+pkg_names=( libc6-dev linux-libc-dev libicu70 libgcc-12-dev libicu-dev libc6 libgcc-s1 libstdc++-12-dev libstdc++6 zlib1g-dev )
 pkgs=()
 
 # url
@@ -131,7 +130,8 @@ function download_with_cache() {
     local out
     out="$dest/cache/$2"
     if [[ ! -f "$out" ]]; then
-        curl --fail -s -o "$out" "$1"
+        # Download with curl, also follow redirects.
+        curl -L --fail -s -o "$out" "$1"
     fi
     echo "$out"
 }
@@ -221,7 +221,7 @@ find "$linux_sdk_name" -type l | while read -r line; do
         ln -s "${fixedlink#./}" "${line#./}"
     fi
 done
-ln -s 5 "$linux_sdk_name/usr/lib/gcc/x86_64-linux-gnu/5.4.0"
+ln -s 5 "$linux_sdk_name/usr/lib/gcc/x86_64-linux-gnu/9"
 
 tmp=$(mktemp -d "$dest/tmp_pkgs_XXXXXX")
 unpack "$tmp" "$macos_swift_pkg"
@@ -244,17 +244,19 @@ fi
 # fix up glibc modulemap
 fix_glibc_modulemap "$cross_tc_basename/$xc_tc_name/usr/lib/swift/linux/x86_64/glibc.modulemap"
 
-cat > "$cross_tc_basename/ubuntu-xenial-destination.json" <<EOF
+cat > "$cross_tc_basename/ubuntu-jammy-destination.json" <<EOF
 {
     "version": 1,
     "sdk": "$(pwd)/$cross_tc_basename/$linux_sdk_name",
     "toolchain-bin-dir": "$(pwd)/$cross_tc_basename/$xc_tc_name/usr/bin",
-    "target": "x86_64-unknown-linux",
+    "target": "x86_64-unknown-linux-gnu",
     "extra-cc-flags": [
         "-fPIC"
     ],
     "extra-swiftc-flags": [
-        "-use-ld=lld", "-tools-directory", "$(pwd)/$cross_tc_basename/$xc_tc_name/usr/bin"
+        "-use-ld=lld",
+        "-tools-directory", "$(pwd)/$cross_tc_basename/$xc_tc_name/usr/bin",
+        "-sdk", "$(pwd)/$cross_tc_basename/$linux_sdk_name",
     ],
     "extra-cpp-flags": [
         "-lstdc++"
@@ -263,7 +265,7 @@ cat > "$cross_tc_basename/ubuntu-xenial-destination.json" <<EOF
 EOF
 
 echo
-echo "OK, your cross compilation toolchain for Ubuntu Xenial is now ready to be used"
+echo "OK, your cross compilation toolchain for Ubuntu Jammy is now ready to be used"
 echo " - SDK: $(pwd)/$cross_tc_basename/$linux_sdk_name"
 echo " - toolchain: $(pwd)/$cross_tc_basename/$xc_tc_name"
-echo " - SwiftPM destination.json: $(pwd)/$cross_tc_basename/ubuntu-xenial-destination.json"
+echo " - SwiftPM destination.json: $(pwd)/$cross_tc_basename/ubuntu-jammy-destination.json"


### PR DESCRIPTION
### Motivation:

`Utilities/build_ubuntu_cross_compilation_toolchain` is currently outdated.

### Modifications:

Updated the script to use Swift 5.7, Ubuntu 22.04 (Jammy), and LLVM/clang 13.0.1.

### Result:

Cross-compilation SDK script is working for latest versions of Swift and Ubuntu.
