### PR TITLE
Fix `package describe` support for local zip binary artifacts

### DIFF
--- a/Sources/Workspace/Workspace+BinaryArtifacts.swift
+++ b/Sources/Workspace/Workspace+BinaryArtifacts.swift
@@ -515,6 +515,10 @@ extension Workspace.BinaryArtifactsManager {
     }
 
     private static func deriveBinaryArtifactKind(fileSystem: FileSystem, path: AbsolutePath, observabilityScope: ObservabilityScope) throws -> BinaryTarget.Kind? {
+        if path.suffix == ".zip" {
+            return .unknown
+        }
+
         let files = try fileSystem.getDirectoryContents(path)
             .map{ path.appending(component: $0) }
             .filter { fileSystem.isFile($0) }


### PR DESCRIPTION
swift package describe should work for targets that have binary zip dependencies.

### Motivation:

#4387. Several projects including swift package index and others want to use the output of `swift package describe`. This extends changes made in #3810 cc @tomerd 

### Modifications:
This patch updates,  `BinaryArtifactsManager.deriveBinaryArtifactKind` to return `BinaryTarget.Kind.unknown` if the path suffix is `.zip`.

This seemed like the minimal change to handle zip binary artifacts in `package describe`. 

Alternatively it might better to extend BinaryTarget.Kind to be explicitly aware of local zips.

Let me know if there is an alternative way you'd prefer this was implemented. 

### Result:

Projects should be able to run `swift package describe` and get correct output.
