### PR TITLE
Introduce `extraCXXFlags`, deprecate `extraCPPFlags`

### DIFF
--- a/Sources/PackageModel/Destination.swift
+++ b/Sources/PackageModel/Destination.swift
@@ -64,10 +64,34 @@ public struct Destination: Encodable, Equatable {
 
     /// Additional flags to be passed to the Swift compiler.
     public let extraSwiftCFlags: [String]
+    
+    /// Additional flags to be passed to the C++ compiler.
+    @available(*, deprecated, message: "use `extraCXXFlags` instead")
+    public var extraCPPFlags: [String] {
+        extraCXXFlags
+    }
+    
+    /// Additional flags to be passed to the C++ compiler.
+    public var extraCXXFlags: [String]
 
-    /// Additional flags to be passed when compiling with C++.
-    public let extraCPPFlags: [String]
-
+    /// Creates a compilation destination with the specified properties.
+    @available(*, deprecated, message: "use `init(target:sdk:binDir:extraCCFlags:extraSwiftCFlags:extraCXXFlags)` instead")
+    public init(
+        target: Triple? = nil,
+        sdk: AbsolutePath?,
+        binDir: AbsolutePath,
+        extraCCFlags: [String] = [],
+        extraSwiftCFlags: [String] = [],
+        extraCPPFlags: [String]
+    ) {
+        self.target = target
+        self.sdk = sdk
+        self.binDir = binDir
+        self.extraCCFlags = extraCCFlags
+        self.extraSwiftCFlags = extraSwiftCFlags
+        self.extraCXXFlags = extraCPPFlags
+    }
+    
     /// Creates a compilation destination with the specified properties.
     public init(
         target: Triple? = nil,
@@ -75,14 +99,14 @@ public struct Destination: Encodable, Equatable {
         binDir: AbsolutePath,
         extraCCFlags: [String] = [],
         extraSwiftCFlags: [String] = [],
-        extraCPPFlags: [String] = []
+        extraCXXFlags: [String] = []
     ) {
         self.target = target
         self.sdk = sdk
         self.binDir = binDir
         self.extraCCFlags = extraCCFlags
         self.extraSwiftCFlags = extraSwiftCFlags
-        self.extraCPPFlags = extraCPPFlags
+        self.extraCXXFlags = extraCXXFlags
     }
 
     /// Returns the bin directory for the host.
@@ -156,8 +180,7 @@ public struct Destination: Encodable, Equatable {
             sdk: sdkPath,
             binDir: binDir,
             extraCCFlags: extraCCFlags,
-            extraSwiftCFlags: extraSwiftCFlags,
-            extraCPPFlags: []
+            extraSwiftCFlags: extraSwiftCFlags
         )
     }
 
@@ -197,10 +220,7 @@ public struct Destination: Encodable, Equatable {
             return Destination(
                 target: triple,
                 sdk: wasiSysroot,
-                binDir: host.binDir,
-                extraCCFlags: [],
-                extraSwiftCFlags: [],
-                extraCPPFlags: []
+                binDir: host.binDir
             )
         }
         return nil
@@ -223,7 +243,8 @@ extension Destination {
             binDir: destination.binDir,
             extraCCFlags: destination.extraCCFlags,
             extraSwiftCFlags: destination.extraSwiftCFlags,
-            extraCPPFlags: destination.extraCPPFlags
+            // maintaining `destination.extraCPPFlags` naming inconsistency for compatibility.
+            extraCXXFlags: destination.extraCPPFlags
         )
     }
 }

--- a/Sources/PackageModel/Toolchain.swift
+++ b/Sources/PackageModel/Toolchain.swift
@@ -36,8 +36,12 @@ public protocol Toolchain {
     /// Additional flags to be passed to the Swift compiler.
     var extraSwiftCFlags: [String] { get }
 
-    /// Additional flags to be passed when compiling with C++.
+    /// Additional flags to be passed to the C++ compiler.
+    @available(*, deprecated, message: "use extraCXXFlags instead")
     var extraCPPFlags: [String] { get }
+    
+    /// Additional flags to be passed to the C++ compiler.
+    var extraCXXFlags: [String] { get }
 }
 
 extension Toolchain {
@@ -52,5 +56,9 @@ extension Toolchain {
     public var toolchainLibDir: AbsolutePath {
         // FIXME: Not sure if it's better to base this off of Swift compiler or our own binary.
         return AbsolutePath("../../lib", relativeTo: resolveSymlinks(swiftCompilerPath))
+    }
+    
+    public var extraCPPFlags: [String] {
+        extraCXXFlags
     }
 }

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -37,8 +37,15 @@ public final class UserToolchain: Toolchain {
     public var extraCCFlags: [String]
 
     public let extraSwiftCFlags: [String]
-
-    public var extraCPPFlags: [String]
+    
+    /// Additional flags to be passed to the C++ compiler.
+    @available(*, deprecated, message: "use extraCXXFlags instead")
+    public var extraCPPFlags: [String] {
+        extraCXXFlags
+    }
+    
+    /// Additional flags to be passed to the C++ compiler.
+    public var extraCXXFlags: [String]
 
     /// Path of the `swift` interpreter.
     public var swiftInterpreterPath: AbsolutePath {
@@ -397,10 +404,10 @@ public final class UserToolchain: Toolchain {
                 triple.isDarwin() ? "-isysroot" : "--sysroot", sdk.pathString
             ] + destination.extraCCFlags
 
-            self.extraCPPFlags = destination.extraCPPFlags
+            self.extraCXXFlags = destination.extraCXXFlags
         } else {
             self.extraCCFlags = destination.extraCCFlags
-            self.extraCPPFlags = destination.extraCPPFlags
+            self.extraCXXFlags = destination.extraCXXFlags
         }
 
         if triple.isWindows() {

--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -393,7 +393,8 @@ private struct _Toolchain: Encodable {
         try container.encode(toolchain.getClangCompiler(), forKey: .clangCompiler)
 
         try container.encode(toolchain.extraCCFlags, forKey: .extraCCFlags)
-        try container.encode(toolchain.extraCPPFlags, forKey: .extraCPPFlags)
+        // Maintaining `extraCPPFlags` key for compatibility with older encoding.
+        try container.encode(toolchain.extraCXXFlags, forKey: .extraCPPFlags)
         try container.encode(toolchain.extraSwiftCFlags, forKey: .extraSwiftCFlags)
         try container.encode(toolchain.swiftCompilerPath, forKey: .swiftCompiler)
     }

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -183,7 +183,7 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
         ).joined(separator: " ")
         settings["OTHER_CPLUSPLUSFLAGS"] = (
             ["$(inherited)"]
-            + buildParameters.toolchain.extraCPPFlags
+            + buildParameters.toolchain.extraCXXFlags
             + buildParameters.flags.cxxCompilerFlags.map { $0.spm_shellEscaped() }
         ).joined(separator: " ")
         settings["OTHER_SWIFT_FLAGS"] = (

--- a/Tests/BuildTests/MockBuildTestHelper.swift
+++ b/Tests/BuildTests/MockBuildTestHelper.swift
@@ -20,9 +20,9 @@ struct MockToolchain: PackageModel.Toolchain {
     let extraCCFlags: [String] = []
     let extraSwiftCFlags: [String] = []
     #if os(macOS)
-    let extraCPPFlags: [String] = ["-lc++"]
+    let extraCXXFlags: [String] = ["-lc++"]
     #else
-    let extraCPPFlags: [String] = ["-lstdc++"]
+    let extraCXXFlags: [String] = ["-lstdc++"]
     #endif
     func getClangCompiler() throws -> AbsolutePath {
         return AbsolutePath("/fake/path/to/clang")


### PR DESCRIPTION
### Motivation:

Usually, CPP is used as an abbreviation for the C preprocessor, while CXX more commonly refers to the C++ compiler. We also use `cxxSettings` in `Package.swift` manifest: https://developer.apple.com/documentation/packagedescription/target/cxxsettings.

### Modifications:

For this wider consistency, `extraCXXFlags` is introduced as a replacement for `extraCPPFlags`. The latter is then deprecated and is made a computed property that just returns the value of `extraCXXFlags`.

### Result:

Users who are coming from C++ background can be more familiar with the codebase. In the next schema version of `destination.json` (introduced in a future PR) we can use the new naming as well. 
