### PR TITLE
Tests: correct expectations for WorkspaceTests

### DIFF
--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -5660,8 +5660,8 @@ final class WorkspaceTests: XCTestCase {
 
         workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
-                result.checkUnordered(diagnostic: .contains("local binary target 'A1' at '\(AbsolutePath("/tmp/ws/roots/Root/XCFrameworks/incorrect.xcframework"))' does not contain a binary artifact.") , severity: .error)
-                result.checkUnordered(diagnostic: .contains("local binary target 'A2' at '\(AbsolutePath("/tmp/ws/roots/Root/ArtifactBundles/incorrect.artifactbundle"))' does not contain a binary artifact.") , severity: .error)
+                result.checkUnordered(diagnostic: .contains("local binary target 'A1' at '\(AbsolutePath(path: "/tmp/ws/roots/Root/XCFrameworks/incorrect.xcframework"))' does not contain a binary artifact.") , severity: .error)
+                result.checkUnordered(diagnostic: .contains("local binary target 'A2' at '\(AbsolutePath(path: "/tmp/ws/roots/Root/ArtifactBundles/incorrect.artifactbundle"))' does not contain a binary artifact.") , severity: .error)
             }
         }
     }

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -5660,8 +5660,8 @@ final class WorkspaceTests: XCTestCase {
 
         workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
-                result.checkUnordered(diagnostic: .contains("local binary target 'A1' at '/tmp/ws/roots/Root/XCFrameworks/incorrect.xcframework' does not contain a binary artifact.") , severity: .error)
-                result.checkUnordered(diagnostic: .contains("local binary target 'A2' at '/tmp/ws/roots/Root/ArtifactBundles/incorrect.artifactbundle' does not contain a binary artifact.") , severity: .error)
+                result.checkUnordered(diagnostic: .contains("local binary target 'A1' at '\(AbsolutePath("/tmp/ws/roots/Root/XCFrameworks/incorrect.xcframework"))' does not contain a binary artifact.") , severity: .error)
+                result.checkUnordered(diagnostic: .contains("local binary target 'A2' at '\(AbsolutePath("/tmp/ws/roots/Root/ArtifactBundles/incorrect.artifactbundle"))' does not contain a binary artifact.") , severity: .error)
             }
         }
     }


### PR DESCRIPTION
The path representation is always platform dependent and cannot be written as a literal.  Use `AbsolutePath` to ensure that we get the correct spelling for the path separator.
