### PR TITLE
Add diagnostics for unsupported plugin dependency

### DIFF
--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -792,8 +792,10 @@ private final class ResolvedTargetBuilder: ResolvedBuilder<ResolvedTarget> {
         let dependencies = try self.dependencies.map { dependency -> ResolvedTarget.Dependency in
             switch dependency {
             case .target(let targetBuilder, let conditions):
+                try self.target.validateDependency(target: targetBuilder.target)
                 return .target(try targetBuilder.construct(), conditions: conditions)
             case .product(let productBuilder, let conditions):
+                try self.target.validateDependency(product: productBuilder.product, productPackage: productBuilder.packageBuilder.package.identity)
                 let product = try productBuilder.construct()
                 if !productBuilder.packageBuilder.isAllowedToVendUnsafeProducts {
                     try self.diagnoseInvalidUseOfUnsafeFlags(product)
@@ -811,6 +813,19 @@ private final class ResolvedTargetBuilder: ResolvedBuilder<ResolvedTarget> {
     }
 }
 
+extension Target {
+
+  func validateDependency(target: Target) throws {
+    if self.type == .plugin && target.type == .library {
+      throw PackageGraphError.unsupported(targetName: self.name, targetType: self.type.rawValue, dependencyName: target.name, dependencyType: target.type.rawValue, dependencyPackage: nil)
+    }
+  }
+  func validateDependency(product: Product, productPackage: PackageIdentity) throws {
+    if self.type == .plugin && product.type.isLibrary {
+      throw PackageGraphError.unsupported(targetName: self.name, targetType: self.type.rawValue, dependencyName: product.name, dependencyType: product.type.description, dependencyPackage: productPackage.description)
+    }
+  }
+}
 /// Builder for resolved package.
 private final class ResolvedPackageBuilder: ResolvedBuilder<ResolvedPackage> {
 

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -817,12 +817,12 @@ extension Target {
 
   func validateDependency(target: Target) throws {
     if self.type == .plugin && target.type == .library {
-      throw PackageGraphError.unsupported(targetName: self.name, targetType: self.type.rawValue, dependencyName: target.name, dependencyType: target.type.rawValue, dependencyPackage: nil)
+      throw PackageGraphError.unsupportedPluginDependency(targetName: self.name, dependencyName: target.name, dependencyType: target.type.rawValue, dependencyPackage: nil)
     }
   }
   func validateDependency(product: Product, productPackage: PackageIdentity) throws {
     if self.type == .plugin && product.type.isLibrary {
-      throw PackageGraphError.unsupported(targetName: self.name, targetType: self.type.rawValue, dependencyName: product.name, dependencyType: product.type.description, dependencyPackage: productPackage.description)
+      throw PackageGraphError.unsupportedPluginDependency(targetName: self.name, dependencyName: product.name, dependencyType: product.type.description, dependencyPackage: productPackage.description)
     }
   }
 }

--- a/Sources/PackageGraph/PackageGraph.swift
+++ b/Sources/PackageGraph/PackageGraph.swift
@@ -36,8 +36,8 @@ enum PackageGraphError: Swift.Error {
         targetName: String,
         packageIdentifier: String
     )
-    /// Dependency between a given target of its type and a dependent target/product of its type is unsupported
-    case unsupported(targetName: String, targetType: String, dependencyName: String, dependencyType: String,  dependencyPackage: String?)
+    /// Dependency between a plugin and a dependent target/product of a given type is unsupported
+    case unsupportedPluginDependency(targetName: String, dependencyName: String, dependencyType: String, dependencyPackage: String?)
     /// A product was found in multiple packages.
     case duplicateProduct(product: String, packages: [String])
 
@@ -255,12 +255,12 @@ extension PackageGraphError: CustomStringConvertible {
             return "multiple aliases: ['\(aliases.joined(separator: "', '"))'] found for target '\(target)' in product '\(product)' from package '\(package)'"
         case .invalidSourcesForModuleAliasing(let target, let product, let package):
             return "module aliasing can only be used for Swift based targets; non-Swift sources found in target '\(target)' for product '\(product)' from package '\(package)'"
-        case .unsupported(let targetName, let targetType, let dependencyName, let dependencyType,  let dependencyPackage):
+        case .unsupportedPluginDependency(let targetName, let dependencyName, let dependencyType,  let dependencyPackage):
             var trailingMsg = ""
             if let depPkg = dependencyPackage {
               trailingMsg = " from package '\(depPkg)'"
             }
-            return "target '\(targetName)' of type '\(targetType)' cannot depend on '\(dependencyName)' of type '\(dependencyType)'\(trailingMsg); this dependency is unsupported"
+            return "plugin '\(targetName)' cannot depend on '\(dependencyName)' of type '\(dependencyType)'\(trailingMsg); this dependency is unsupported"
         }
     }
 }

--- a/Sources/PackageGraph/PackageGraph.swift
+++ b/Sources/PackageGraph/PackageGraph.swift
@@ -36,7 +36,8 @@ enum PackageGraphError: Swift.Error {
         targetName: String,
         packageIdentifier: String
     )
-
+    /// Dependency between a given target of its type and a dependent target/product of its type is unsupported
+    case unsupported(targetName: String, targetType: String, dependencyName: String, dependencyType: String,  dependencyPackage: String?)
     /// A product was found in multiple packages.
     case duplicateProduct(product: String, packages: [String])
 
@@ -254,6 +255,12 @@ extension PackageGraphError: CustomStringConvertible {
             return "multiple aliases: ['\(aliases.joined(separator: "', '"))'] found for target '\(target)' in product '\(product)' from package '\(package)'"
         case .invalidSourcesForModuleAliasing(let target, let product, let package):
             return "module aliasing can only be used for Swift based targets; non-Swift sources found in target '\(target)' for product '\(product)' from package '\(package)'"
+        case .unsupported(let targetName, let targetType, let dependencyName, let dependencyType,  let dependencyPackage):
+            var trailingMsg = ""
+            if let depPkg = dependencyPackage {
+              trailingMsg = " from package '\(depPkg)'"
+            }
+            return "target '\(targetName)' of type '\(targetType)' cannot depend on '\(dependencyName)' of type '\(dependencyType)'\(trailingMsg); this dependency is unsupported"
         }
     }
 }

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -585,6 +585,9 @@ class PluginInvocationTests: XCTestCase {
     }
 
     func testUnsupportedDependencyProduct() throws {
+        // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
+        try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+
         try testWithTemporaryDirectory { tmpPath in
             // Create a sample package with a library product and a plugin.
             let packageDir = tmpPath.appending(components: "MyPackage")
@@ -680,6 +683,9 @@ class PluginInvocationTests: XCTestCase {
     }
 
     func testUnsupportedDependencyTarget() throws {
+        // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
+        try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+
         try testWithTemporaryDirectory { tmpPath in
             // Create a sample package with a library target and a plugin.
             let packageDir = tmpPath.appending(components: "MyPackage")

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
-import PackageGraph
+@testable import PackageGraph
 import PackageLoading
 import PackageModel
 @testable import SPMBuildCore
@@ -584,6 +584,177 @@ class PluginInvocationTests: XCTestCase {
         }
     }
 
+    func testUnsupportedDependencyProduct() throws {
+        try testWithTemporaryDirectory { tmpPath in
+            // Create a sample package with a library product and a plugin.
+            let packageDir = tmpPath.appending(components: "MyPackage")
+            try localFileSystem.createDirectory(packageDir, recursive: true)
+            try localFileSystem.writeFileContents(packageDir.appending(component: "Package.swift"), string: """
+            // swift-tools-version: 5.7
+            import PackageDescription
+            let package = Package(
+                name: "MyPackage",
+                dependencies: [
+                  .package(path: "../FooPackage"),
+                ],
+                targets: [
+                    .plugin(
+                        name: "MyPlugin",
+                        capability: .buildTool(),
+                        dependencies: [
+                            .product(name: "FooLib", package: "FooPackage"),
+                        ]
+                    ),
+                ]
+            )
+            """)
+
+            let myPluginTargetDir = packageDir.appending(components: "Plugins", "MyPlugin")
+            try localFileSystem.createDirectory(myPluginTargetDir, recursive: true)
+            try localFileSystem.writeFileContents(myPluginTargetDir.appending(component: "plugin.swift"), string: """
+                  import PackagePlugin
+                  import Foo
+                  @main struct MyBuildToolPlugin: BuildToolPlugin {
+                      func createBuildCommands(
+                          context: PluginContext,
+                          target: Target
+                      ) throws -> [Command] { }
+                  }
+                  """)
+
+            let fooPkgDir = tmpPath.appending(components: "FooPackage")
+            try localFileSystem.createDirectory(fooPkgDir, recursive: true)
+            try localFileSystem.writeFileContents(fooPkgDir.appending(component: "Package.swift"), string: """
+                // swift-tools-version: 5.7
+                import PackageDescription
+                let package = Package(
+                    name: "FooPackage",
+                    products: [
+                        .library(name: "FooLib",
+                                 targets: ["Foo"]),
+                    ],
+                    targets: [
+                        .target(
+                            name: "Foo",
+                            dependencies: []
+                        ),
+                    ]
+                )
+                """)
+            let fooTargetDir = fooPkgDir.appending(components: "Sources", "Foo")
+            try localFileSystem.createDirectory(fooTargetDir, recursive: true)
+            try localFileSystem.writeFileContents(fooTargetDir.appending(component: "file.swift"), string: """
+                  public func foo() { }
+                  """)
+
+            // Load a workspace from the package.
+            let observability = ObservabilitySystem.makeForTesting()
+            let workspace = try Workspace(
+                fileSystem: localFileSystem,
+                forRootPackage: packageDir,
+                customManifestLoader: ManifestLoader(toolchain: UserToolchain.default),
+                delegate: MockWorkspaceDelegate()
+            )
+
+            // Load the root manifest.
+            let rootInput = PackageGraphRootInput(packages: [packageDir], dependencies: [])
+            let rootManifests = try tsc_await {
+                workspace.loadRootManifests(
+                    packages: rootInput.packages,
+                    observabilityScope: observability.topScope,
+                    completion: $0
+                )
+            }
+            XCTAssert(rootManifests.count == 1, "\(rootManifests)")
+
+            // Load the package graph.
+            XCTAssertThrowsError(try workspace.loadPackageGraph(rootInput: rootInput, observabilityScope: observability.topScope)) { error in
+                var diagnosed = false
+                if let realError = error as? PackageGraphError,
+                   realError.description == "plugin 'MyPlugin' cannot depend on 'FooLib' of type 'library' from package 'foopackage'; this dependency is unsupported" {
+                    diagnosed = true
+                }
+                XCTAssertTrue(diagnosed)
+            }
+        }
+    }
+
+    func testUnsupportedDependencyTarget() throws {
+        try testWithTemporaryDirectory { tmpPath in
+            // Create a sample package with a library target and a plugin.
+            let packageDir = tmpPath.appending(components: "MyPackage")
+            try localFileSystem.createDirectory(packageDir, recursive: true)
+            try localFileSystem.writeFileContents(packageDir.appending(component: "Package.swift"), string: """
+                // swift-tools-version: 5.7
+                import PackageDescription
+                let package = Package(
+                    name: "MyPackage",
+                    targets: [
+                        .target(
+                            name: "MyLibrary",
+                            dependencies: []
+                        ),
+                        .plugin(
+                            name: "MyPlugin",
+                            capability: .buildTool(),
+                            dependencies: [
+                                "MyLibrary"
+                            ]
+                        ),
+                    ]
+                )
+                """)
+
+            let myLibraryTargetDir = packageDir.appending(components: "Sources", "MyLibrary")
+            try localFileSystem.createDirectory(myLibraryTargetDir, recursive: true)
+            try localFileSystem.writeFileContents(myLibraryTargetDir.appending(component: "library.swift"), string: """
+                    public func hello() { }
+                    """)
+            let myPluginTargetDir = packageDir.appending(components: "Plugins", "MyPlugin")
+            try localFileSystem.createDirectory(myPluginTargetDir, recursive: true)
+            try localFileSystem.writeFileContents(myPluginTargetDir.appending(component: "plugin.swift"), string: """
+                  import PackagePlugin
+                  import MyLibrary
+                  @main struct MyBuildToolPlugin: BuildToolPlugin {
+                      func createBuildCommands(
+                          context: PluginContext,
+                          target: Target
+                      ) throws -> [Command] { }
+                  }
+                  """)
+
+            // Load a workspace from the package.
+            let observability = ObservabilitySystem.makeForTesting()
+            let workspace = try Workspace(
+                fileSystem: localFileSystem,
+                forRootPackage: packageDir,
+                customManifestLoader: ManifestLoader(toolchain: UserToolchain.default),
+                delegate: MockWorkspaceDelegate()
+            )
+
+            // Load the root manifest.
+            let rootInput = PackageGraphRootInput(packages: [packageDir], dependencies: [])
+            let rootManifests = try tsc_await {
+                workspace.loadRootManifests(
+                    packages: rootInput.packages,
+                    observabilityScope: observability.topScope,
+                    completion: $0
+                )
+            }
+            XCTAssert(rootManifests.count == 1, "\(rootManifests)")
+
+            // Load the package graph.
+            XCTAssertThrowsError(try workspace.loadPackageGraph(rootInput: rootInput, observabilityScope: observability.topScope)) { error in
+                var diagnosed = false
+                if let realError = error as? PackageGraphError,
+                   realError.description == "plugin 'MyPlugin' cannot depend on 'MyLibrary' of type 'library'; this dependency is unsupported" {
+                    diagnosed = true
+                }
+                XCTAssertTrue(diagnosed)
+            }
+        }
+    }
+
     func testPrebuildPluginShouldNotUseExecTarget() throws {
         try testWithTemporaryDirectory { tmpPath in
             // Create a sample package with a library target and a plugin.
@@ -656,7 +827,6 @@ class PluginInvocationTests: XCTestCase {
                               )
                           ]
                       }
-
                   }
                   """)
 


### PR DESCRIPTION
A plugin target currently cannot depend on a library target or product; this PR adds a check to validate it and throws an error
Resolves rdar://95117424

