### PR TITLE
Add diags for non-existing binary used by prebuild plugin

### DIFF
--- a/Sources/SPMBuildCore/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/PluginInvocation.swift
@@ -189,7 +189,7 @@ extension PluginTarget {
                     
                 case .definePrebuildCommand(let config, let outputFilesDir):
                     let execPath = try AbsolutePath(validating: config.executable)
-                    if !FileManager.default.fileExists(atPath: execPath.pathString) {
+                    if !localFileSystem.exists(execPath) {
                         observabilityScope.emit(error: "exectuable target '\(execPath.basename)' is not pre-built; a plugin running a prebuild command should only rely on a pre-built binary; as a workaround, build '\(execPath.basename)' first and then run the plugin")
                     }
                     self.invocationDelegate.pluginDefinedPrebuildCommand(

--- a/Sources/SPMBuildCore/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/PluginInvocation.swift
@@ -380,18 +380,18 @@ extension PackageGraph {
                 // Set up a delegate to handle callbacks from the build tool plugin. We'll capture free-form text output as well as defined commands and diagnostics.
                 let delegateQueue = DispatchQueue(label: "plugin-invocation")
                 class PluginDelegate: PluginInvocationDelegate {
+                    let fileSystem: FileSystem
                     let delegateQueue: DispatchQueue
                     let toolPaths: [AbsolutePath]
-                    let fileSystem: FileSystem
                     var outputData = Data()
                     var diagnostics = [Basics.Diagnostic]()
                     var buildCommands = [BuildToolPluginInvocationResult.BuildCommand]()
                     var prebuildCommands = [BuildToolPluginInvocationResult.PrebuildCommand]()
                     
-                    init(delegateQueue: DispatchQueue, toolPaths: [AbsolutePath], fileSystem: FileSystem) {
+                    init(fileSystem: FileSystem, delegateQueue: DispatchQueue, toolPaths: [AbsolutePath]) {
+                        self.fileSystem = fileSystem
                         self.delegateQueue = delegateQueue
                         self.toolPaths = toolPaths
-                        self.fileSystem = fileSystem
                     }
                     
                     func pluginCompilationStarted(commandLine: [String], environment: EnvironmentVariables) {
@@ -443,7 +443,7 @@ extension PackageGraph {
                             outputFilesDirectory: outputFilesDirectory))
                     }
                 }
-                let delegate = PluginDelegate(delegateQueue: delegateQueue, toolPaths: toolPaths, fileSystem: fileSystem)
+                let delegate = PluginDelegate(fileSystem: fileSystem, delegateQueue: delegateQueue, toolPaths: toolPaths)
 
                 // Invoke the build tool plugin with the input parameters and the delegate that will collect outputs.
                 let startTime = DispatchTime.now()

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -586,7 +586,7 @@ class PluginInvocationTests: XCTestCase {
             let packageDir = tmpPath.appending(components: "mypkg")
             try localFileSystem.createDirectory(packageDir, recursive: true)
             try localFileSystem.writeFileContents(packageDir.appending(component: "Package.swift"), string: """
-                // swift-tools-version:5.6
+                // swift-tools-version:5.7
 
                 import PackageDescription
 
@@ -629,12 +629,12 @@ class PluginInvocationTests: XCTestCase {
             let depTargetDir = packageDir.appending(components: "Sources", "Y")
             try localFileSystem.createDirectory(depTargetDir, recursive: true)
             try localFileSystem.writeFileContents(depTargetDir.appending(component: "main.swift"), string: """
-            struct Y {
-                func run() {
-                    print("You passed us two arguments, argumentOne, and argumentTwo")
+                struct Y {
+                    func run() {
+                        print("You passed us two arguments, argumentOne, and argumentTwo")
+                    }
                 }
-            }
-            Y.main()
+                Y.main()
             """)
 
             let pluginTargetDir = packageDir.appending(components: "Plugins", "X")
@@ -645,7 +645,7 @@ class PluginInvocationTests: XCTestCase {
                       func createBuildCommands(context: PluginContext, target: Target) async throws -> [Command] {
                           [
                               Command.prebuildCommand(
-                                  displayName: "X: Running SomeCommand before the build...",
+                                  displayName: "X: Running Y before the build...",
                                   executable: try context.tool(named: "Y").path,
                                   arguments: [ "ARGUMENT_ONE", "ARGUMENT_TWO" ],
                                   outputFilesDirectory: context.pluginWorkDirectory.appending("OUTPUT_FILES_DIRECTORY")
@@ -694,29 +694,8 @@ class PluginInvocationTests: XCTestCase {
                 toolchain: try UserToolchain.default
             )
 
-            // Define a plugin compilation delegate that just captures the passed information.
-            class Delegate: PluginScriptCompilerDelegate {
-                var commandLine: [String]?
-                var environment: EnvironmentVariables?
-                var compiledResult: PluginCompilationResult?
-                var cachedResult: PluginCompilationResult?
-                init() {
-                }
-                func willCompilePlugin(commandLine: [String], environment: EnvironmentVariables) {
-                    self.commandLine = commandLine
-                    self.environment = environment
-                }
-                func didCompilePlugin(result: PluginCompilationResult) {
-                    self.compiledResult = result
-                }
-                func skippedCompilingPlugin(cachedResult: PluginCompilationResult) {
-                    self.cachedResult = cachedResult
-                }
-            }
-
-            // Try to compile the plugin script.
+            // Invoke build tool plugin
             do {
-                // Invoke build tool plugin
                 let outputDir = packageDir.appending(component: ".build")
                 let builtToolsDir = outputDir.appending(component: "debug")
                 let _ = try packageGraph.invokeBuildToolPlugins(
@@ -734,7 +713,6 @@ class PluginInvocationTests: XCTestCase {
                     result.check(diagnostic: .contains(msg), severity: .error)
                 }
             }
-
         }
     }
 }


### PR DESCRIPTION
Add diags for non-existing binary used by prebuild plugin.
Add a test to verify a package with a plugin target no longer requires a non-plugin target.
Resolves rdar://90442392, rdar://86787091