### PR TITLE
PackageModel: add `struct BuildFlags`, reduce reliance on TSC

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -423,7 +423,7 @@ public final class ClangTargetBuildDescription {
             args += ["-include", resourceAccessorHeaderFile.pathString]
         }
 
-        args += buildParameters.toolchain.extraCCFlags
+        args += buildParameters.toolchain.extraFlags.cCompilerFlags
         // User arguments (from -Xcc and -Xcxx below) should follow generated arguments to allow user overrides
         args += buildParameters.flags.cCompilerFlags
 
@@ -944,7 +944,7 @@ public final class SwiftTargetBuildDescription {
             args += ["-emit-module-interface-path", parseableModuleInterfaceOutputPath.pathString]
         }
 
-        args += buildParameters.toolchain.extraSwiftCFlags
+        args += buildParameters.toolchain.extraFlags.swiftCompilerFlags
         // User arguments (from -Xswiftc) should follow generated arguments to allow user overrides
         args += buildParameters.swiftCompilerFlags
 
@@ -1014,7 +1014,7 @@ public final class SwiftTargetBuildDescription {
         result.append("-emit-module")
         result.append("-emit-module-path")
         result.append(moduleOutputPath.pathString)
-        result += buildParameters.toolchain.extraSwiftCFlags
+        result += buildParameters.toolchain.extraFlags.swiftCompilerFlags
 
         result.append("-Xfrontend")
         result.append("-experimental-skip-non-inlinable-function-bodies")
@@ -1090,7 +1090,7 @@ public final class SwiftTargetBuildDescription {
         result += buildParameters.sanitizers.compileSwiftFlags()
         result += ["-parseable-output"]
         result += try self.buildSettingsFlags()
-        result += buildParameters.toolchain.extraSwiftCFlags
+        result += buildParameters.toolchain.extraFlags.swiftCompilerFlags
         result += buildParameters.swiftCompilerFlags
         return result
     }
@@ -1537,7 +1537,7 @@ public final class ProductBuildDescription {
         // building for Darwin in debug configuration.
         args += swiftASTs.flatMap{ ["-Xlinker", "-add_ast_path", "-Xlinker", $0.pathString] }
 
-        args += buildParameters.toolchain.extraSwiftCFlags
+        args += buildParameters.toolchain.extraFlags.swiftCompilerFlags
         // User arguments (from -Xlinker and -Xswiftc) should follow generated arguments to allow user overrides
         args += buildParameters.linkerFlags
         args += stripInvalidArguments(buildParameters.swiftCompilerFlags)
@@ -2341,7 +2341,7 @@ public class BuildPlan {
         let buildPath = buildParameters.buildPath.pathString
         var arguments = ["-I", buildPath]
 
-        var extraSwiftCFlags = buildParameters.toolchain.extraSwiftCFlags
+        var extraSwiftCFlags = buildParameters.toolchain.extraFlags.swiftCompilerFlags
         if !includeLibrarySearchPaths {
             for index in extraSwiftCFlags.indices.dropLast().reversed() {
                 if extraSwiftCFlags[index] == "-L" {

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -17,7 +17,6 @@ import PackageModel
 import SPMBuildCore
 import Build
 
-import struct TSCUtility.BuildFlags
 import struct TSCUtility.Triple
 
 struct GlobalOptions: ParsableArguments {
@@ -279,10 +278,11 @@ struct BuildOptions: ParsableArguments {
 
     var buildFlags: BuildFlags {
         BuildFlags(
-            xcc: cCompilerFlags,
-            xcxx: cxxCompilerFlags,
-            xswiftc: swiftCompilerFlags,
-            xlinker: linkerFlags)
+            cCompilerFlags: cCompilerFlags,
+            cxxCompilerFlags: cxxCompilerFlags,
+            swiftCompilerFlags: swiftCompilerFlags,
+            linkerFlags: linkerFlags
+        )
     }
 
     /// The compilation destination’s target triple.

--- a/Sources/PackageModel/BuildFlags.swift
+++ b/Sources/PackageModel/BuildFlags.swift
@@ -1,0 +1,37 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+/// Build-tool independent flags.
+public struct BuildFlags: Equatable, Encodable {
+
+    /// Flags to pass to the C compiler.
+    public var cCompilerFlags: [String]
+
+    /// Flags to pass to the C++ compiler.
+    public var cxxCompilerFlags: [String]
+    
+    /// Flags to pass to the Swift compiler.
+    public var swiftCompilerFlags: [String]
+
+    /// Flags to pass to the linker.
+    public var linkerFlags: [String]
+
+    public init(
+        cCompilerFlags: [String]? = nil,
+        cxxCompilerFlags: [String]? = nil,
+        swiftCompilerFlags: [String]? = nil,
+        linkerFlags: [String]? = nil
+    ) {
+        self.cCompilerFlags = cCompilerFlags ?? []
+        self.cxxCompilerFlags = cxxCompilerFlags ?? []
+        self.swiftCompilerFlags = swiftCompilerFlags ?? []
+        self.linkerFlags = linkerFlags ?? []
+    }
+}

--- a/Sources/PackageModel/CMakeLists.txt
+++ b/Sources/PackageModel/CMakeLists.txt
@@ -9,6 +9,7 @@
 add_library(PackageModel
   BuildConfiguration.swift
   BuildEnvironment.swift
+  BuildFlags.swift
   BuildSettings.swift
   Destination.swift
   Diagnostics.swift

--- a/Sources/PackageModel/Destination.swift
+++ b/Sources/PackageModel/Destination.swift
@@ -60,22 +60,28 @@ public struct Destination: Encodable, Equatable {
     public var binDir: AbsolutePath
 
     /// Additional flags to be passed to the C compiler.
-    public let extraCCFlags: [String]
+    @available(*, deprecated, message: "use `extraFlags.cCompilerFlags` instead")
+    public var extraCCFlags: [String] {
+        extraFlags.cCompilerFlags
+    }
 
     /// Additional flags to be passed to the Swift compiler.
-    public let extraSwiftCFlags: [String]
-    
-    /// Additional flags to be passed to the C++ compiler.
-    @available(*, deprecated, message: "use `extraCXXFlags` instead")
-    public var extraCPPFlags: [String] {
-        extraCXXFlags
+    @available(*, deprecated, message: "use `extraFlags.swiftCompilerFlags` instead")
+    public var extraSwiftCFlags: [String] {
+        extraFlags.swiftCompilerFlags
     }
     
     /// Additional flags to be passed to the C++ compiler.
-    public var extraCXXFlags: [String]
+    @available(*, deprecated, message: "use `extraFlags.cxxCompilerFlags` instead")
+    public var extraCPPFlags: [String] {
+        extraFlags.cxxCompilerFlags
+    }
+    
+    /// Additional flags to be passed to the build tools.
+    public let extraFlags: BuildFlags
 
     /// Creates a compilation destination with the specified properties.
-    @available(*, deprecated, message: "use `init(target:sdk:binDir:extraCCFlags:extraSwiftCFlags:extraCXXFlags)` instead")
+    @available(*, deprecated, message: "use `init(target:sdk:binDir:extraFlags)` instead")
     public init(
         target: Triple? = nil,
         sdk: AbsolutePath?,
@@ -87,9 +93,11 @@ public struct Destination: Encodable, Equatable {
         self.target = target
         self.sdk = sdk
         self.binDir = binDir
-        self.extraCCFlags = extraCCFlags
-        self.extraSwiftCFlags = extraSwiftCFlags
-        self.extraCXXFlags = extraCPPFlags
+        self.extraFlags = BuildFlags(
+            cCompilerFlags: extraCCFlags,
+            cxxCompilerFlags: extraCPPFlags,
+            swiftCompilerFlags: extraSwiftCFlags
+        )
     }
     
     /// Creates a compilation destination with the specified properties.
@@ -97,16 +105,12 @@ public struct Destination: Encodable, Equatable {
         target: Triple? = nil,
         sdk: AbsolutePath?,
         binDir: AbsolutePath,
-        extraCCFlags: [String] = [],
-        extraSwiftCFlags: [String] = [],
-        extraCXXFlags: [String] = []
+        extraFlags: BuildFlags = BuildFlags()
     ) {
         self.target = target
         self.sdk = sdk
         self.binDir = binDir
-        self.extraCCFlags = extraCCFlags
-        self.extraSwiftCFlags = extraSwiftCFlags
-        self.extraCXXFlags = extraCXXFlags
+        self.extraFlags = extraFlags
     }
 
     /// Returns the bin directory for the host.
@@ -179,8 +183,7 @@ public struct Destination: Encodable, Equatable {
             target: nil,
             sdk: sdkPath,
             binDir: binDir,
-            extraCCFlags: extraCCFlags,
-            extraSwiftCFlags: extraSwiftCFlags
+            extraFlags: BuildFlags(cCompilerFlags: extraCCFlags, swiftCompilerFlags: extraSwiftCFlags)
         )
     }
 
@@ -241,10 +244,12 @@ extension Destination {
             target: destination.target.map{ try Triple($0) },
             sdk: destination.sdk,
             binDir: destination.binDir,
-            extraCCFlags: destination.extraCCFlags,
-            extraSwiftCFlags: destination.extraSwiftCFlags,
-            // maintaining `destination.extraCPPFlags` naming inconsistency for compatibility.
-            extraCXXFlags: destination.extraCPPFlags
+            extraFlags: BuildFlags(
+                cCompilerFlags: destination.extraCCFlags,
+                // maintaining `destination.extraCPPFlags` naming inconsistency for compatibility.
+                cxxCompilerFlags: destination.extraCPPFlags,
+                swiftCompilerFlags: destination.extraSwiftCFlags
+            )
         )
     }
 }

--- a/Sources/PackageModel/Toolchain.swift
+++ b/Sources/PackageModel/Toolchain.swift
@@ -29,19 +29,21 @@ public protocol Toolchain {
     // the OSS clang compiler. This API should not used for any other purpose.
     /// Returns true if clang compiler's vendor is Apple and nil if unknown.
     func _isClangCompilerVendorApple() throws -> Bool?
+    
+    /// Additional flags to be passed to the build tools.
+    var extraFlags: BuildFlags { get }
 
     /// Additional flags to be passed to the C compiler.
+    @available(*, deprecated, message: "use extraFlags.cCompilerFlags instead")
     var extraCCFlags: [String] { get }
 
     /// Additional flags to be passed to the Swift compiler.
+    @available(*, deprecated, message: "use extraFlags.swiftCompilerFlags instead")
     var extraSwiftCFlags: [String] { get }
 
     /// Additional flags to be passed to the C++ compiler.
-    @available(*, deprecated, message: "use extraCXXFlags instead")
+    @available(*, deprecated, message: "use extraFlags.cxxCompilerFlags instead")
     var extraCPPFlags: [String] { get }
-    
-    /// Additional flags to be passed to the C++ compiler.
-    var extraCXXFlags: [String] { get }
 }
 
 extension Toolchain {
@@ -62,7 +64,15 @@ extension Toolchain {
         }
     }
     
+    public var extraCCFlags: [String] {
+        extraFlags.cCompilerFlags
+    }
+    
     public var extraCPPFlags: [String] {
-        extraCXXFlags
+        extraFlags.cxxCompilerFlags
+    }
+    
+    public var extraSwiftCFlags: [String] {
+        extraFlags.swiftCompilerFlags
     }
 }

--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -16,7 +16,6 @@ import TSCBasic
 import PackageModel
 import PackageGraph
 
-import struct TSCUtility.BuildFlags
 import struct TSCUtility.Triple
 
 public struct BuildParameters: Encodable {
@@ -392,10 +391,10 @@ private struct _Toolchain: Encodable {
         try container.encode(toolchain.swiftCompilerPath, forKey: .swiftCompiler)
         try container.encode(toolchain.getClangCompiler(), forKey: .clangCompiler)
 
-        try container.encode(toolchain.extraCCFlags, forKey: .extraCCFlags)
+        try container.encode(toolchain.extraFlags.cCompilerFlags, forKey: .extraCCFlags)
         // Maintaining `extraCPPFlags` key for compatibility with older encoding.
-        try container.encode(toolchain.extraCXXFlags, forKey: .extraCPPFlags)
-        try container.encode(toolchain.extraSwiftCFlags, forKey: .extraSwiftCFlags)
+        try container.encode(toolchain.extraFlags.cxxCompilerFlags, forKey: .extraCPPFlags)
+        try container.encode(toolchain.extraFlags.swiftCompilerFlags, forKey: .extraSwiftCFlags)
         try container.encode(toolchain.swiftCompilerPath, forKey: .swiftCompiler)
     }
 }

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -178,17 +178,17 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
         settings["LIBRARY_SEARCH_PATHS"] = "$(inherited) \(try buildParameters.toolchain.toolchainLibDir.pathString)"
         settings["OTHER_CFLAGS"] = (
             ["$(inherited)"]
-            + buildParameters.toolchain.extraCCFlags
+            + buildParameters.toolchain.extraFlags.cCompilerFlags
             + buildParameters.flags.cCompilerFlags.map { $0.spm_shellEscaped() }
         ).joined(separator: " ")
         settings["OTHER_CPLUSPLUSFLAGS"] = (
             ["$(inherited)"]
-            + buildParameters.toolchain.extraCXXFlags
+            + buildParameters.toolchain.extraFlags.cxxCompilerFlags
             + buildParameters.flags.cxxCompilerFlags.map { $0.spm_shellEscaped() }
         ).joined(separator: " ")
         settings["OTHER_SWIFT_FLAGS"] = (
             ["$(inherited)"]
-            + buildParameters.toolchain.extraSwiftCFlags
+            + buildParameters.toolchain.extraFlags.swiftCompilerFlags
             + buildParameters.flags.swiftCompilerFlags.map { $0.spm_shellEscaped() }
         ).joined(separator: " ")
         settings["OTHER_LDFLAGS"] = (

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -21,7 +21,6 @@ import SwiftDriver
 import TSCBasic
 import Workspace
 import XCTest
-import struct TSCUtility.BuildFlags
 import enum TSCUtility.Diagnostics
 import struct TSCUtility.Triple
 
@@ -3372,13 +3371,17 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let userDestination = Destination(sdk: AbsolutePath(path: "/fake/sdk"),
+        let userDestination = Destination(
+            sdk: AbsolutePath(path: "/fake/sdk"),
             binDir: try UserToolchain.default.destination.binDir,
-            extraCCFlags: ["-I/fake/sdk/sysroot", "-clang-flag-from-json"],
-            extraSwiftCFlags: ["-swift-flag-from-json"])
+            extraFlags: BuildFlags(
+                cCompilerFlags: ["-I/fake/sdk/sysroot", "-clang-flag-from-json"],
+                swiftCompilerFlags: ["-swift-flag-from-json"]
+            )
+        )
         let mockToolchain = try UserToolchain(destination: userDestination)
         let extraBuildParameters = mockBuildParameters(toolchain: mockToolchain,
-            flags: BuildFlags(xcc: ["-clang-command-line-flag"], xswiftc: ["-swift-command-line-flag"]))
+            flags: BuildFlags(cCompilerFlags: ["-clang-command-line-flag"], swiftCompilerFlags: ["-swift-command-line-flag"]))
         let result = try BuildPlanResult(plan: BuildPlan(
             buildParameters: extraBuildParameters,
             graph: graph,

--- a/Tests/BuildTests/MockBuildTestHelper.swift
+++ b/Tests/BuildTests/MockBuildTestHelper.swift
@@ -17,12 +17,11 @@ struct MockToolchain: PackageModel.Toolchain {
     let librarianPath = AbsolutePath(path: "/fake/path/to/ar")
 #endif
     let swiftCompilerPath = AbsolutePath(path: "/fake/path/to/swiftc")
-    let extraCCFlags: [String] = []
-    let extraSwiftCFlags: [String] = []
+    
     #if os(macOS)
-    let extraCXXFlags: [String] = ["-lc++"]
+    let extraFlags = BuildFlags(cxxCompilerFlags: ["-lc++"])
     #else
-    let extraCXXFlags: [String] = ["-lstdc++"]
+    let extraFlags = BuildFlags(cxxCompilerFlags: ["-lstdc++"])
     #endif
     func getClangCompiler() throws -> AbsolutePath {
         return AbsolutePath(path: "/fake/path/to/clang")
@@ -63,7 +62,7 @@ func mockBuildParameters(
     buildPath: AbsolutePath = AbsolutePath(path: "/path/to/build"),
     config: BuildConfiguration = .debug,
     toolchain: PackageModel.Toolchain = MockToolchain(),
-    flags: BuildFlags = BuildFlags(),
+    flags: PackageModel.BuildFlags = PackageModel.BuildFlags(),
     shouldLinkStaticSwiftStdlib: Bool = false,
     canRenameEntrypointFunctionName: Bool = false,
     destinationTriple: TSCUtility.Triple = hostTriple,


### PR DESCRIPTION
### Motivation:

We're relying on `BuildFlags` from TSC for passing flags in some places, but there are also cases where flags are passed as separate properties, such as `extraCFlags`, `extraCXXFlags` etc.  `BuildFlags` is quite useful, as it allows grouping of these properties instead of passing them around separately. In most if not all cases they need to be passed all at once anyway. This apparently already let to issues, where `Destination` didn't have its own linker flags property, also see https://github.com/apple/swift-package-manager/pull/5793. We also had issues with inconsistent naming of these properties. Unifying everything under `BuildFlags` could prevent such issues from happening.

### Modifications:

Adding `BuildFlags` to `PackageModel`, mostly a copy of the declaration in TSC, but with a cleaned up initializer arguments naming. Modified uses of build tools flags to use this new struct instead of passing arounds properties separately.

### Result:

Reduced reliance on TSC, unified use of `BuildFlags` across the codebase.
