### PR TITLE
[5.7] Avoid redundant checks in cycle detection

### DIFF
--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -872,6 +872,8 @@ fileprivate func findCycle(
 ) rethrows -> (path: [Manifest], cycle: [Manifest])? {
     // Ordered set to hold the current traversed path.
     var path = OrderedCollections.OrderedSet<Manifest>()
+    
+    var fullyVisitedManifests = Set<Manifest>()
 
     // Function to visit nodes recursively.
     // FIXME: Convert to stack.
@@ -879,6 +881,12 @@ fileprivate func findCycle(
       _ node: GraphLoadingNode,
       _ successors: (GraphLoadingNode) throws -> [GraphLoadingNode]
     ) rethrows -> (path: [Manifest], cycle: [Manifest])? {
+        // Once all successors have been visited, this node cannot participate
+        // in a cycle.
+        if fullyVisitedManifests.contains(node.manifest) {
+            return nil
+        }
+        
         // If this node is already in the current path then we have found a cycle.
         if !path.append(node.manifest).inserted {
             let index = path.firstIndex(of: node.manifest)! // forced unwrap safe
@@ -893,6 +901,8 @@ fileprivate func findCycle(
         // No cycle found for this node, remove it from the path.
         let item = path.removeLast()
         assert(item == node.manifest)
+        // Track fully visited nodes
+        fullyVisitedManifests.insert(node.manifest)
         return nil
     }
 

--- a/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
@@ -94,7 +94,7 @@ class PackageGraphPerfTests: XCTestCasePerf {
 
         let fs = InMemoryFileSystem(emptyFiles: packageNumberSequence.map({ "/Package\($0)/Sources/Target\($0)/s.swift" }) + ["/PackageA/Sources/TargetA/s.swift"])
 
-        let packageSequence = try packageNumberSequence.map { sequenceNumber in
+        let packageSequence: [Manifest] = try packageNumberSequence.map { (sequenceNumber: Int) -> Manifest in
             let dependencySequence = sequenceNumber < lastPackageNumber ? Array((sequenceNumber + 1)...lastPackageNumber) : []
             return Manifest.createFileSystemManifest(
                 name: "Package\(sequenceNumber)",

--- a/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
@@ -112,7 +112,7 @@ class PackageGraphPerfTests: XCTestCasePerf {
 
         let root = Manifest.createRootManifest(
             name: "PackageA",
-            path: .init(path: "/PackageA"),
+            path: .init("/PackageA"),
             toolsVersion: .v5_7,
             dependencies: try packageNumberSequence.map({ .fileSystem(path: try .init(validating: "/Package\($0)")) }),
             targets: [try .init(name: "TargetA", dependencies: ["Target1"]) ]

--- a/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
@@ -87,4 +87,48 @@ class PackageGraphPerfTests: XCTestCasePerf {
             XCTAssertNoDiagnostics(observability.diagnostics)
         }
     }
+
+    func testEfficientCycleDetection() throws {
+        let lastPackageNumber = 20
+        let packageNumberSequence = (1...lastPackageNumber)
+
+        let fs = InMemoryFileSystem(emptyFiles: packageNumberSequence.map({ "/Package\($0)/Sources/Target\($0)/s.swift" }) + ["/PackageA/Sources/TargetA/s.swift"])
+
+        let packageSequence = try packageNumberSequence.map { sequenceNumber in
+            let dependencySequence = sequenceNumber < lastPackageNumber ? Array((sequenceNumber + 1)...lastPackageNumber) : []
+            return Manifest.createFileSystemManifest(
+                name: "Package\(sequenceNumber)",
+                path: try .init(validating: "/Package\(sequenceNumber)"),
+                toolsVersion: .v5_7,
+                dependencies: try dependencySequence.map({ .fileSystem(path: try .init(validating: "/Package\($0)")) }),
+                products: [
+                    try .init(name: "Package\(sequenceNumber)", type: .library(.dynamic), targets: ["Target\(sequenceNumber)"])
+                ],
+                targets: [
+                    try .init(name: "Target\(sequenceNumber)", dependencies: dependencySequence.map { .product(name: "Target\($0)", package: "Package\($0)") })
+                ]
+            )
+        }
+
+        let root = Manifest.createRootManifest(
+            name: "PackageA",
+            path: .init(path: "/PackageA"),
+            toolsVersion: .v5_7,
+            dependencies: try packageNumberSequence.map({ .fileSystem(path: try .init(validating: "/Package\($0)")) }),
+            targets: [try .init(name: "TargetA", dependencies: ["Target1"]) ]
+        )
+
+        let observability = ObservabilitySystem.makeForTesting()
+
+        let N = 1
+        measure {
+            do {
+                for _ in 0..<N {
+                    _ = try loadPackageGraph(fileSystem: fs, manifests: [root] + packageSequence, observabilityScope: observability.topScope)
+                }
+            } catch {
+                XCTFail("Loading package graph is not expected to fail in this test.")
+            }
+        }
+    }
 }


### PR DESCRIPTION
Dramatically improve speed of cycle detection for large or well-connected manifest graphs.

### Motivation:

Loading a project with a large or well-connected package graph in Xcode can be very slow. 

Xcode uses `Workspace.loadPackageGraph(rootPath:...)`, which calls into
calls into [`findCycle()`](https://github.com/apple/swift-package-manager/blob/25c671ef3ef2bd7a245403f9848cb3be3321c790/Sources/PackageGraph/PackageGraph%2BLoading.swift#L866). `findCycle` has a bug leading to slower than linear cycle detection.

### Modifications:

There is a note to convert to use an algorithm tracking traversal with a stack, which would allow for linear time cycle detection. But given the output of `findCycle` is the path to first the cycle, and the cycle itself, not all the elements in a strongly connected subgraph, it's enough to memoize fully explored nodes.

Once all of a Manifests outbound edges have been traversed for cycles, it's not possible for it to participate in a cycle. So if a fully-explored Manifest is encountered again in a cycle check, exit early.

Without such an early exit, cycle detection is slower than linear. This change makes it linear.

### Result:

I made a tool to generate and profile the loading of package graphs through the same path as Xcode [here](https://github.com/fcanas/manifest-cycle-bug).

These are the results of profiling package loading a small range of number of packages.

| Number of packages | apple/spm | memoized |
|--------------------|-----------|----------|
| 22                 | 17.9s     | 0.2s     |
| 23                 | 35.8s     | 0.2s     |
| 24                 | 88.1s     | 0.2s     |
| 25                 | 160.5s    | 0.2s     |
| 26                 | 323.4s    | 0.2s     |
