### PR TITLE
Make `configuration` optional in `BuildEnvironment`

### DIFF
--- a/Sources/PackageModel/BuildEnvironment.swift
+++ b/Sources/PackageModel/BuildEnvironment.swift
@@ -13,9 +13,9 @@
 /// A build environment with which to evaluation conditions.
 public struct BuildEnvironment: Codable {
     public let platform: Platform
-    public let configuration: BuildConfiguration
+    public let configuration: BuildConfiguration?
 
-    public init(platform: Platform, configuration: BuildConfiguration) {
+    public init(platform: Platform, configuration: BuildConfiguration? = nil) {
         self.platform = platform
         self.configuration = configuration
     }

--- a/Sources/PackageModel/Manifest/PackageConditionDescription.swift
+++ b/Sources/PackageModel/Manifest/PackageConditionDescription.swift
@@ -78,6 +78,10 @@ public struct ConfigurationCondition: PackageConditionProtocol {
     }
 
     public func satisfies(_ environment: BuildEnvironment) -> Bool {
-        configuration == environment.configuration
+        if environment.configuration == nil {
+            return true
+        } else {
+            return configuration == environment.configuration
+        }
     }
 }

--- a/Tests/BuildTests/MockBuildTestHelper.swift
+++ b/Tests/BuildTests/MockBuildTestHelper.swift
@@ -101,7 +101,7 @@ func mockBuildParameters(environment: BuildEnvironment) -> BuildParameters {
         fatalError("unsupported platform in tests")
     }
 
-    return mockBuildParameters(config: environment.configuration, destinationTriple: triple)
+    return mockBuildParameters(config: environment.configuration ?? .debug, destinationTriple: triple)
 }
 
 enum BuildError: Swift.Error {


### PR DESCRIPTION
This allows filtering dependencies solely based on whether they support a given platform which may be desirable if the build configuration is not yet known.
