### PR TITLE
Rename `getToolchain()` to `getDestinationToolchain()`

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -398,7 +398,7 @@ extension SwiftPackageTool {
         var regenerateBaseline: Bool = false
 
         func run(_ swiftTool: SwiftTool) throws {
-            let apiDigesterPath = try swiftTool.getToolchain().getSwiftAPIDigester()
+            let apiDigesterPath = try swiftTool.getDestinationToolchain().getSwiftAPIDigester()
             let apiDigesterTool = SwiftAPIDigester(fileSystem: swiftTool.fileSystem, tool: apiDigesterPath)
 
             let packageRoot = try globalOptions.locations.packageDirectory ?? swiftTool.getPackageRoot()
@@ -600,7 +600,7 @@ extension SwiftPackageTool {
             // Configure the symbol graph extractor.
             let symbolGraphExtractor = try SymbolGraphExtract(
                 fileSystem: swiftTool.fileSystem,
-                tool: swiftTool.getToolchain().getSymbolGraphExtract(),
+                tool: swiftTool.getDestinationToolchain().getSymbolGraphExtract(),
                 skipSynthesizedMembers: skipSynthesizedMembers,
                 minimumAccessLevel: minimumAccessLevel,
                 skipInheritedDocs: skipInheritedDocs,
@@ -1075,7 +1075,7 @@ extension SwiftPackageTool {
             let readOnlyDirectories = writableDirectories.contains{ package.path.isDescendantOfOrEqual(to: $0) } ? [] : [package.path]
 
             // Use the directory containing the compiler as an additional search directory, and add the $PATH.
-            let toolSearchDirs = [try swiftTool.getToolchain().swiftCompilerPath.parentDirectory]
+            let toolSearchDirs = [try swiftTool.getDestinationToolchain().swiftCompilerPath.parentDirectory]
                 + getEnvSearchPaths(pathString: ProcessEnv.path, currentWorkingDirectory: .none)
             
             // Build or bring up-to-date any executable host-side tools on which this plugin depends. Add them and any binary dependencies to the tool-names-to-path map.
@@ -1282,7 +1282,7 @@ final class PluginDelegate: PluginInvocationDelegate {
     
     func performTestsForPlugin(subset: PluginInvocationTestSubset, parameters: PluginInvocationTestParameters) throws -> PluginInvocationTestResult {
         // Build the tests. Ideally we should only build those that match the subset, but we don't have a way to know which ones they are until we've built them and can examine the binaries.
-        let toolchain = try swiftTool.getToolchain()
+        let toolchain = try swiftTool.getDestinationToolchain()
         var buildParameters = try swiftTool.buildParameters()
         buildParameters.enableTestability = true
         buildParameters.enableCodeCoverage = parameters.enableCodeCoverage
@@ -1428,7 +1428,7 @@ final class PluginDelegate: PluginInvocationDelegate {
         // Configure the symbol graph extractor.
         var symbolGraphExtractor = try SymbolGraphExtract(
             fileSystem: swiftTool.fileSystem,
-            tool: swiftTool.getToolchain().getSymbolGraphExtract()
+            tool: swiftTool.getDestinationToolchain().getSymbolGraphExtract()
         )
         symbolGraphExtractor.skipSynthesizedMembers = !options.includeSynthesized
         switch options.minimumAccessLevel {

--- a/Sources/Commands/SwiftRunTool.swift
+++ b/Sources/Commands/SwiftRunTool.swift
@@ -140,7 +140,7 @@ public struct SwiftRunTool: SwiftCommand {
             print("Launching Swift REPL with arguments: \(arguments.joined(separator: " "))")
             try self.run(
                 fileSystem: swiftTool.fileSystem,
-                executablePath: swiftTool.getToolchain().swiftInterpreterPath,
+                executablePath: swiftTool.getDestinationToolchain().swiftInterpreterPath,
                 originalWorkingDirectory: swiftTool.originalWorkingDirectory,
                 arguments: arguments
             )
@@ -164,7 +164,7 @@ public struct SwiftRunTool: SwiftCommand {
                 }
 
                 let pathRelativeToWorkingDirectory = executablePath.relative(to: swiftTool.originalWorkingDirectory)
-                let lldbPath = try swiftTool.getToolchain().getLLDB()
+                let lldbPath = try swiftTool.getDestinationToolchain().getLLDB()
                 try exec(path: lldbPath.pathString, args: ["--", pathRelativeToWorkingDirectory.pathString] + options.arguments)
             } catch let error as RunError {
                 swiftTool.observabilityScope.emit(error)
@@ -176,7 +176,7 @@ public struct SwiftRunTool: SwiftCommand {
             if let executable = options.executable, isValidSwiftFilePath(fileSystem: swiftTool.fileSystem, path: executable) {
                 swiftTool.observabilityScope.emit(.runFileDeprecation)
                 // Redirect execution to the toolchain's swift executable.
-                let swiftInterpreterPath = try swiftTool.getToolchain().swiftInterpreterPath
+                let swiftInterpreterPath = try swiftTool.getDestinationToolchain().swiftInterpreterPath
                 // Prepend the script to interpret to the arguments.
                 let arguments = [executable] + options.arguments
                 try self.run(

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -165,7 +165,7 @@ public struct SwiftTestTool: SwiftCommand {
             try self.validateArguments(observabilityScope: swiftTool.observabilityScope)
 
             // validate XCTest available on darwin based systems
-            let toolchain = try swiftTool.getToolchain()
+            let toolchain = try swiftTool.getDestinationToolchain()
             if toolchain.triple.isDarwin() && toolchain.xctestPath == nil {
                 throw TestError.xctestNotAvailable
             }
@@ -183,7 +183,7 @@ public struct SwiftTestTool: SwiftCommand {
             let command = try GenerateLinuxMain.parse()
             try command.run(swiftTool)
         } else if !self.options.shouldRunInParallel {
-            let toolchain = try swiftTool.getToolchain()
+            let toolchain = try swiftTool.getDestinationToolchain()
             let testProducts = try buildTestsIfNeeded(swiftTool: swiftTool)
             let buildParameters = try swiftTool.buildParametersForTest(options: self.options)
 
@@ -259,7 +259,7 @@ public struct SwiftTestTool: SwiftCommand {
             }
 
         } else {
-            let toolchain = try swiftTool.getToolchain()
+            let toolchain = try swiftTool.getDestinationToolchain()
             let testProducts = try buildTestsIfNeeded(swiftTool: swiftTool)
             let testSuites = try TestingSupport.getTestSuites(
                 in: testProducts,
@@ -351,7 +351,7 @@ public struct SwiftTestTool: SwiftCommand {
     /// Merges all profraw profiles in codecoverage directory into default.profdata file.
     private func mergeCodeCovRawDataFiles(swiftTool: SwiftTool) throws {
         // Get the llvm-prof tool.
-        let llvmProf = try swiftTool.getToolchain().getLLVMProf()
+        let llvmProf = try swiftTool.getDestinationToolchain().getLLVMProf()
 
         // Get the profraw files.
         let buildParameters = try swiftTool.buildParametersForTest(options: self.options)
@@ -373,7 +373,7 @@ public struct SwiftTestTool: SwiftCommand {
     /// Exports profdata as a JSON file.
     private func exportCodeCovAsJSON(to path: AbsolutePath, testBinary: AbsolutePath, swiftTool: SwiftTool) throws {
         // Export using the llvm-cov tool.
-        let llvmCov = try swiftTool.getToolchain().getLLVMCov()
+        let llvmCov = try swiftTool.getDestinationToolchain().getLLVMCov()
         let buildParameters = try swiftTool.buildParametersForTest(options: self.options)
         let args = [
             llvmCov.pathString,

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -666,7 +666,7 @@ public class SwiftTool {
     }
 
     /// Returns the user toolchain to compile the actual product.
-    func getToolchain() throws -> UserToolchain {
+    func getDestinationToolchain() throws -> UserToolchain {
         return try _destinationToolchain.get()
     }
 
@@ -787,7 +787,7 @@ public class SwiftTool {
 
     private lazy var _buildParameters: Result<BuildParameters, Swift.Error> = {
         return Result(catching: {
-            let toolchain = try self.getToolchain()
+            let toolchain = try self.getDestinationToolchain()
             let triple = toolchain.triple
 
             // Use "apple" as the subdirectory because in theory Xcode build system

--- a/Sources/Commands/Utilities/TestingSupport.swift
+++ b/Sources/Commands/Utilities/TestingSupport.swift
@@ -75,7 +75,7 @@ enum TestingSupport {
         let data: String = try withTemporaryFile { tempFile in
             let args = [try Self.xctestHelperPath(swiftTool: swiftTool).pathString, path.pathString, tempFile.path.pathString]
             var env = try Self.constructTestEnvironment(
-                toolchain: try swiftTool.getToolchain(),
+                toolchain: try swiftTool.getDestinationToolchain(),
                 buildParameters: swiftTool.buildParametersForTest(
                     enableCodeCoverage: enableCodeCoverage
                 ),
@@ -94,7 +94,7 @@ enum TestingSupport {
         }
         #else
         let env = try Self.constructTestEnvironment(
-            toolchain: try swiftTool.getToolchain(),
+            toolchain: try swiftTool.getDestinationToolchain(),
             buildParameters: swiftTool.buildParametersForTest(
                 enableCodeCoverage: enableCodeCoverage
             ),

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -480,7 +480,7 @@ final class PackageToolTests: CommandsTestCase {
     // Returns symbol graph with or without pretty printing.
     private func symbolGraph(atPath path: AbsolutePath, withPrettyPrinting: Bool, file: StaticString = #file, line: UInt = #line) throws -> Data? {
         let tool = try SwiftTool(options: GlobalOptions.parse(["--package-path", path.pathString]))
-        let symbolGraphExtractorPath = try tool.getToolchain().getSymbolGraphExtract()
+        let symbolGraphExtractorPath = try tool.getDestinationToolchain().getSymbolGraphExtract()
 
         let arguments = withPrettyPrinting ? ["dump-symbol-graph", "--pretty-print"] : ["dump-symbol-graph"]
 


### PR DESCRIPTION
Simple rename for clarity since we `getHostToolchain()`.
