### PR TITLE
Update testBuildCompleteMessage to be more tolerant to cache changes

### DIFF
--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -289,7 +289,12 @@ final class BuildToolTests: CommandsTestCase {
             }
 
             do {
-                // test second time, to make sure message is presented even when nothing to build (cached)
+                // test second time, to stabilize the cache
+                let _ = try execute([], packagePath: fixturePath)
+            }
+
+            do {
+                // test third time, to make sure message is presented even when nothing to build (cached)
                 let result = try execute([], packagePath: fixturePath)
                 XCTAssertNoMatch(result.stdout, .regex("\\[[1-9][0-9]*\\/[1-9][0-9]*\\] Compiling"))
                 let lines = result.stdout.split(separator: "\n")


### PR DESCRIPTION
The test testBuildCompleteMessage appears to be sensitive to changes in the cache when built against the C++ driver. Let's make it a bit more tolerant by adding a build just to stabilize the cache before checking for the build messages.