### PR TITLE
Fix `disableSandboxForPluginCommands`

### DIFF
--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -102,7 +102,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         additionalFileRules: [FileRuleDescription],
         pluginScriptRunner: PluginScriptRunner,
         pluginWorkDirectory: AbsolutePath,
-        disableSandboxForPluginCommands: Bool = false,
+        disableSandboxForPluginCommands: Bool,
         outputStream: OutputByteStream,
         logLevel: Basics.Diagnostic.Severity,
         fileSystem: TSCBasic.FileSystem,

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -263,6 +263,7 @@ extension SwiftCommand {
                     additionalFileRules: FileRuleDescription.swiftpmFileTypes,
                     pluginScriptRunner: swiftTool.getPluginScriptRunner(),
                     pluginWorkDirectory: try swiftTool.getActiveWorkspace().location.pluginWorkingDirectory,
+                    disableSandboxForPluginCommands: swiftTool.options.security.shouldDisableSandbox,
                     outputStream: customOutputStream ?? swiftTool.outputStream,
                     logLevel: customLogLevel ?? swiftTool.logLevel,
                     fileSystem: swiftTool.fileSystem,


### PR DESCRIPTION
This was broken in #5846 which accidentally used the default value instead of passing along the global option.

rdar://101681661