### PR TITLE
Add missing dependency to `DriverSupport`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -315,6 +315,7 @@ let package = Package(
         .target(
             name: "DriverSupport",
             dependencies: [
+		"Basics",
                 .product(name: "SwiftDriver", package: "swift-driver"),
             ],
             exclude: ["CMakeLists.txt"]


### PR DESCRIPTION
It depends on `Basics`, so we should declare that dependency.
