### PR TITLE
Fix duplicated category method issue

### DIFF
--- a/Tests/PackageCollectionsSigningTests/CertificatePolicyTests.swift
+++ b/Tests/PackageCollectionsSigningTests/CertificatePolicyTests.swift
@@ -20,7 +20,7 @@ import XCTest
 
 class CertificatePolicyTests: XCTestCase {
     func test_RSA_validate_happyCase() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsSigningTests_skipIfUnsupportedPlatform()
 
         try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let certPath = fixturePath.appending(components: "Signing", "Test_rsa.cer")
@@ -40,7 +40,7 @@ class CertificatePolicyTests: XCTestCase {
     }
 
     func test_EC_validate_happyCase() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsSigningTests_skipIfUnsupportedPlatform()
 
         try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let certPath = fixturePath.appending(components: "Signing", "Test_ec.cer")
@@ -60,7 +60,7 @@ class CertificatePolicyTests: XCTestCase {
     }
 
     func test_validate_untrustedRoot() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsSigningTests_skipIfUnsupportedPlatform()
 
         try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let certPath = fixturePath.appending(components: "Signing", "Test_rsa.cer")
@@ -91,7 +91,7 @@ class CertificatePolicyTests: XCTestCase {
     }
 
     func test_validate_expiredCert() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsSigningTests_skipIfUnsupportedPlatform()
 
         try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let certPath = fixturePath.appending(components: "Signing", "Test_rsa.cer")
@@ -121,7 +121,7 @@ class CertificatePolicyTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
 
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsSigningTests_skipIfUnsupportedPlatform()
 
         try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let certPath = fixturePath.appending(components: "Signing", "development-revoked.cer")
@@ -168,7 +168,7 @@ class CertificatePolicyTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
 
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsSigningTests_skipIfUnsupportedPlatform()
 
         try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let certPath = fixturePath.appending(components: "Signing", "development.cer")
@@ -236,7 +236,7 @@ class CertificatePolicyTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
 
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsSigningTests_skipIfUnsupportedPlatform()
 
         try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             // This must be an Apple Swift Package Collection cert
@@ -305,7 +305,7 @@ class CertificatePolicyTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
 
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsSigningTests_skipIfUnsupportedPlatform()
 
         try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             // This must be an Apple Distribution cert
@@ -374,7 +374,7 @@ class CertificatePolicyTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
 
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsSigningTests_skipIfUnsupportedPlatform()
 
         try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let certPath = fixturePath.appending(components: "Signing", "development.cer")
@@ -449,7 +449,7 @@ class CertificatePolicyTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
 
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsSigningTests_skipIfUnsupportedPlatform()
 
         try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             // This must be an Apple Swift Package Collection cert
@@ -527,7 +527,7 @@ class CertificatePolicyTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
 
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsSigningTests_skipIfUnsupportedPlatform()
 
         try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             // This must be an Apple Distribution cert

--- a/Tests/PackageCollectionsSigningTests/CertificateTests.swift
+++ b/Tests/PackageCollectionsSigningTests/CertificateTests.swift
@@ -19,7 +19,7 @@ import TSCBasic
 
 class CertificateTests: XCTestCase {
     func test_withRSAKey_fromDER() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsSigningTests_skipIfUnsupportedPlatform()
 
         try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let path = fixturePath.appending(components: "Signing", "Test_rsa.cer")
@@ -42,7 +42,7 @@ class CertificateTests: XCTestCase {
     }
 
     func test_withECKey_fromDER() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsSigningTests_skipIfUnsupportedPlatform()
 
         try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let path = fixturePath.appending(components: "Signing", "Test_ec.cer")

--- a/Tests/PackageCollectionsSigningTests/KeyTests+EC.swift
+++ b/Tests/PackageCollectionsSigningTests/KeyTests+EC.swift
@@ -19,7 +19,7 @@ import TSCBasic
 
 class ECKeyTests: XCTestCase {
     func testPublicKeyFromCertificate() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsSigningTests_skipIfUnsupportedPlatform()
 
         try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let path = fixturePath.appending(components: "Signing", "Test_ec.cer")
@@ -31,13 +31,13 @@ class ECKeyTests: XCTestCase {
     }
 
     func testPublicKeyFromPEM() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsSigningTests_skipIfUnsupportedPlatform()
 
         XCTAssertNoThrow(try ECPublicKey(pem: ecPublicKey.bytes))
     }
 
     func testPrivateKeyFromPEM() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsSigningTests_skipIfUnsupportedPlatform()
 
         XCTAssertNoThrow(try ECPrivateKey(pem: ecPrivateKey.bytes))
     }

--- a/Tests/PackageCollectionsSigningTests/KeyTests+RSA.swift
+++ b/Tests/PackageCollectionsSigningTests/KeyTests+RSA.swift
@@ -19,7 +19,7 @@ import TSCBasic
 
 class RSAKeyTests: XCTestCase {
     func testPublicKeyFromCertificate() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsSigningTests_skipIfUnsupportedPlatform()
 
         try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let path = fixturePath.appending(components: "Signing", "Test_rsa.cer")
@@ -31,13 +31,13 @@ class RSAKeyTests: XCTestCase {
     }
 
     func testPublicKeyFromPEM() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsSigningTests_skipIfUnsupportedPlatform()
 
         XCTAssertNoThrow(try RSAPublicKey(pem: rsaPublicKey.bytes))
     }
 
     func testPrivateKeyFromPEM() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsSigningTests_skipIfUnsupportedPlatform()
 
         XCTAssertNoThrow(try RSAPrivateKey(pem: rsaPrivateKey.bytes))
     }

--- a/Tests/PackageCollectionsSigningTests/PackageCollectionSigningTest.swift
+++ b/Tests/PackageCollectionsSigningTests/PackageCollectionSigningTest.swift
@@ -21,7 +21,7 @@ import XCTest
 
 class PackageCollectionSigningTests: XCTestCase {
     func test_RSA_signAndValidate_happyCase() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsSigningTests_skipIfUnsupportedPlatform()
 
         try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let jsonDecoder = JSONDecoder.makeWithDefaults()
@@ -53,7 +53,7 @@ class PackageCollectionSigningTests: XCTestCase {
     }
 
     func test_RSA_signAndValidate_collectionMismatch() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsSigningTests_skipIfUnsupportedPlatform()
 
         try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let collection1 = PackageCollectionModel.V1.Collection(
@@ -109,7 +109,7 @@ class PackageCollectionSigningTests: XCTestCase {
     }
 
     func test_EC_signAndValidate_happyCase() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsSigningTests_skipIfUnsupportedPlatform()
 
         try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let jsonDecoder = JSONDecoder.makeWithDefaults()
@@ -141,7 +141,7 @@ class PackageCollectionSigningTests: XCTestCase {
     }
 
     func test_EC_signAndValidate_collectionMismatch() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsSigningTests_skipIfUnsupportedPlatform()
 
         try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let collection1 = PackageCollectionModel.V1.Collection(
@@ -202,7 +202,7 @@ class PackageCollectionSigningTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
 
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsSigningTests_skipIfUnsupportedPlatform()
 
         try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let jsonDecoder = JSONDecoder.makeWithDefaults()
@@ -311,7 +311,7 @@ class PackageCollectionSigningTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
 
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsSigningTests_skipIfUnsupportedPlatform()
 
         try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let jsonDecoder = JSONDecoder.makeWithDefaults()
@@ -405,7 +405,7 @@ class PackageCollectionSigningTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
 
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsSigningTests_skipIfUnsupportedPlatform()
 
         try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let jsonDecoder = JSONDecoder.makeWithDefaults()
@@ -499,7 +499,7 @@ class PackageCollectionSigningTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
 
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsSigningTests_skipIfUnsupportedPlatform()
 
         try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let jsonDecoder = JSONDecoder.makeWithDefaults()
@@ -553,7 +553,7 @@ class PackageCollectionSigningTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
 
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsSigningTests_skipIfUnsupportedPlatform()
 
         try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let jsonDecoder = JSONDecoder.makeWithDefaults()
@@ -618,7 +618,7 @@ class PackageCollectionSigningTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
 
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsSigningTests_skipIfUnsupportedPlatform()
 
         try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let jsonDecoder = JSONDecoder.makeWithDefaults()

--- a/Tests/PackageCollectionsSigningTests/SignatureTests.swift
+++ b/Tests/PackageCollectionsSigningTests/SignatureTests.swift
@@ -19,7 +19,7 @@ import TSCBasic
 
 class SignatureTests: XCTestCase {
     func test_RS256_generateAndValidate_happyCase() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsSigningTests_skipIfUnsupportedPlatform()
 
         try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let jsonEncoder = JSONEncoder()
@@ -45,7 +45,7 @@ class SignatureTests: XCTestCase {
     }
 
     func test_RS256_generateAndValidate_keyMismatch() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsSigningTests_skipIfUnsupportedPlatform()
 
         try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let jsonEncoder = JSONEncoder()
@@ -74,7 +74,7 @@ class SignatureTests: XCTestCase {
     }
 
     func test_ES256_generateAndValidate_happyCase() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsSigningTests_skipIfUnsupportedPlatform()
 
         try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let jsonEncoder = JSONEncoder()
@@ -100,7 +100,7 @@ class SignatureTests: XCTestCase {
     }
 
     func test_ES256_generateAndValidate_keyMismatch() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsSigningTests_skipIfUnsupportedPlatform()
 
         try fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let jsonEncoder = JSONEncoder()

--- a/Tests/PackageCollectionsSigningTests/SigningTests+ECKey.swift
+++ b/Tests/PackageCollectionsSigningTests/SigningTests+ECKey.swift
@@ -17,7 +17,7 @@ import XCTest
 
 class ECKeySigningTests: XCTestCase {
     func test_signAndValidate_happyCase() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsSigningTests_skipIfUnsupportedPlatform()
 
         let privateKey = try ECPrivateKey(pem: ecPrivateKey.bytes)
         let publicKey = try ECPublicKey(pem: ecPublicKey.bytes)
@@ -28,7 +28,7 @@ class ECKeySigningTests: XCTestCase {
     }
 
     func test_signAndValidate_mismatch() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsSigningTests_skipIfUnsupportedPlatform()
 
         let privateKey = try ECPrivateKey(pem: ecPrivateKey.bytes)
         let publicKey = try ECPublicKey(pem: ecPublicKey.bytes)

--- a/Tests/PackageCollectionsSigningTests/SigningTests+RSAKey.swift
+++ b/Tests/PackageCollectionsSigningTests/SigningTests+RSAKey.swift
@@ -17,7 +17,7 @@ import XCTest
 
 class RSAKeySigningTests: XCTestCase {
     func test_signAndValidate_happyCase() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsSigningTests_skipIfUnsupportedPlatform()
 
         let privateKey = try RSAPrivateKey(pem: rsaPrivateKey.bytes)
         let publicKey = try RSAPublicKey(pem: rsaPublicKey.bytes)
@@ -28,7 +28,7 @@ class RSAKeySigningTests: XCTestCase {
     }
 
     func test_signAndValidate_mismatch() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsSigningTests_skipIfUnsupportedPlatform()
 
         let privateKey = try RSAPrivateKey(pem: rsaPrivateKey.bytes)
         let publicKey = try RSAPublicKey(pem: rsaPublicKey.bytes)

--- a/Tests/PackageCollectionsSigningTests/Utilities.swift
+++ b/Tests/PackageCollectionsSigningTests/Utilities.swift
@@ -179,7 +179,7 @@ extension String {
 }
 
 extension XCTestCase {
-    func skipIfUnsupportedPlatform() throws {
+    func PackageCollectionsSigningTests_skipIfUnsupportedPlatform() throws {
         #if os(macOS) || os(Linux) || os(Windows) || os(Android)
         #else
         throw XCTSkip("Skipping test on unsupported platform")

--- a/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
@@ -56,7 +56,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testBasicRegistration() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -83,7 +83,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testAddDuplicates() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -111,7 +111,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testAddUnsigned() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -154,7 +154,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testInvalidCollectionNotAdded() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         // This test doesn't use search at all and finishes quickly so disable target trie to prevent race
@@ -192,7 +192,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testCollectionPendingTrustConfirmIsKeptOnAdd() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         // This test doesn't use search at all and finishes quickly so disable target trie to prevent race
@@ -230,7 +230,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testCollectionWithInvalidSignatureNotAdded() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         // This test doesn't use search at all and finishes quickly so disable target trie to prevent race
@@ -268,7 +268,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testDelete() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -319,7 +319,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testDeleteFromBothStorages() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -354,7 +354,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testOrdering() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -425,7 +425,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testReorder() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -527,7 +527,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testUpdateTrust() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -578,7 +578,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testList() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -600,7 +600,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testListSubset() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -628,7 +628,7 @@ final class PackageCollectionsTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
 
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -658,7 +658,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testPackageSearch() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -795,7 +795,7 @@ final class PackageCollectionsTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
 
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -825,7 +825,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testTargetsSearch() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -929,7 +929,7 @@ final class PackageCollectionsTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
 
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -959,7 +959,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testHappyRefresh() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -981,7 +981,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testBrokenRefresh() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         struct BrokenProvider: PackageCollectionProvider {
             let brokenSources: [PackageCollectionsModel.CollectionSource]
@@ -1055,7 +1055,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testRefreshOne() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -1077,7 +1077,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testRefreshOneTrustedUnsigned() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -1097,7 +1097,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testRefreshOneNotFound() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -1115,7 +1115,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testListTargets() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -1153,7 +1153,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testFetchMetadataHappy() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -1191,7 +1191,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testFetchMetadataInOrder() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -1229,7 +1229,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testFetchMetadataInCollections() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -1266,7 +1266,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testMergedPackageMetadata() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let packageId = UUID().uuidString
 
@@ -1355,7 +1355,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testFetchMetadataNotFoundInCollections() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -1378,7 +1378,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testFetchMetadataNotFoundByProvider() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -1416,7 +1416,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testFetchMetadataProviderError() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         struct BrokenMetadataProvider: PackageMetadataProvider {
             var name: String = "BrokenMetadataProvider"
@@ -1470,7 +1470,7 @@ final class PackageCollectionsTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
 
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -1500,7 +1500,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testListPackages() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -1617,7 +1617,7 @@ private extension PackageCollections {
 }
 
 extension XCTestCase {
-    func skipIfUnsupportedPlatform() throws {
+    func PackageCollectionsTests_skipIfUnsupportedPlatform() throws {
         if !PackageCollections.isSupportedPlatform {
             throw XCTSkip("Skipping test on unsupported platform")
         }

--- a/Tests/PackageCollectionsTests/PackageIndexAndCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageIndexAndCollectionsTests.swift
@@ -20,7 +20,7 @@ import XCTest
 
 class PackageIndexAndCollectionsTests: XCTestCase {
     func testCollectionAddRemoveGetList() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
         
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
@@ -57,7 +57,7 @@ class PackageIndexAndCollectionsTests: XCTestCase {
     }
     
     func testRefreshCollections() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
@@ -79,7 +79,7 @@ class PackageIndexAndCollectionsTests: XCTestCase {
     }
     
     func testRefreshCollection() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
@@ -101,7 +101,7 @@ class PackageIndexAndCollectionsTests: XCTestCase {
     }
     
     func testListPackages() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
@@ -200,7 +200,7 @@ class PackageIndexAndCollectionsTests: XCTestCase {
     }
     
     func testListTargets() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
@@ -238,7 +238,7 @@ class PackageIndexAndCollectionsTests: XCTestCase {
     }
     
     func testFindTargets() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
@@ -354,7 +354,7 @@ class PackageIndexAndCollectionsTests: XCTestCase {
     }
     
     func testGetPackageMetadata() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
         
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
@@ -393,7 +393,7 @@ class PackageIndexAndCollectionsTests: XCTestCase {
     }
     
     func testGetPackageMetadata_brokenIndex() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
         
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
@@ -433,7 +433,7 @@ class PackageIndexAndCollectionsTests: XCTestCase {
     }
     
     func testGetPackageMetadata_indexAndCollectionError() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
         
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
@@ -454,7 +454,7 @@ class PackageIndexAndCollectionsTests: XCTestCase {
     }
     
     func testFindPackages() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
         
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
@@ -555,7 +555,7 @@ class PackageIndexAndCollectionsTests: XCTestCase {
     }
     
     func testFindPackages_brokenIndex() throws {
-        try skipIfUnsupportedPlatform()
+        try PackageCollectionsTests_skipIfUnsupportedPlatform()
         
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }


### PR DESCRIPTION
Currently, we get this linker warning:

```
ld: warning: method '-skipIfUnsupportedPlatformAndReturnError:' in category from /Users/neonacho/Projects/public/swift-package-manager/.build/arm64-apple-macosx/debug/PackageCollectionsTests.build/PackageCollectionsTests.swift.o conflicts with same method from another category
```

since we have two test modules defining the same category methods on `XCTestCase`. To avoid this, we can add a prefix to both implementations.
