### PR TITLE
Restore --build-path

### DIFF
--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -67,7 +67,14 @@ public struct LocationOptions: ParsableArguments {
 
     /// The custom .build directory, if provided.
     @Option(name: .customLong("scratch-path"), help: "Specify a custom scratch directory path (default .build)", completion: .directory)
-    public var scratchDirectory: AbsolutePath?
+    var _scratchDirectory: AbsolutePath?
+
+    @Option(name: .customLong("build-path"), help: .hidden)
+    var _deprecated_buildPath: AbsolutePath?
+
+    var scratchDirectory: AbsolutePath? {
+        self._scratchDirectory ?? self._deprecated_buildPath
+    }
 
     /// The path to the file containing multiroot package data. This is currently Xcode's workspace file.
     @Option(name: .customLong("multiroot-data-file"), help: .hidden, completion: .directory)


### PR DESCRIPTION
This was removed in https://github.com/apple/swift-package-manager/pull/5807 before projects had time to migrate. Restore this option until they do.

rdar://101841334