### PR TITLE
Fix ShellCheck warning in CC SDK script for Ubuntu

### DIFF
--- a/Utilities/build_ubuntu_cross_compilation_toolchain
+++ b/Utilities/build_ubuntu_cross_compilation_toolchain
@@ -13,7 +13,8 @@
 
 set -eu
 
-export PATH="/bin:/usr/bin:$(brew --prefix)/bin"
+PATH="/bin:/usr/bin:$(brew --prefix)/bin"
+export PATH
 VERSION=${VERSION:-5.7-RELEASE}
 if [[ -z "${VERSION##*RELEASE*}" ]]; then
   branch=swift-${VERSION%%RELEASE}release


### PR DESCRIPTION
[ShellCheck](https://www.shellcheck.net) (a linter for shell scripts) discovered [a warning](https://www.shellcheck.net/wiki/SC2155) in our cross-compilation SDK script.

### Motivation:

We'd like our shell scripts to be maintainable, readable, and debuggable, and not having linter warnings in them helps us achieve that.

In the original code, the return value of `brew` is ignored, and export will instead always return true. This may prevent conditionals, `set -e` and traps from working correctly.

### Modifications:

`PATH` environment variable is declared and assigned separately to avoid masking return value of `brew`.

### Result:

When `brew` is not installed on user's machine when the script is executed, they'll see a clear error messaging related to this, instead of resurfacing this as a different confusing error later in the script.
