### PR TITLE
Skip two failing tests

### DIFF
--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -280,6 +280,8 @@ final class BuildToolTests: CommandsTestCase {
     }
 
     func testBuildCompleteMessage() throws {
+        throw XCTSkip("This test fails to match the 'Compiling' regex; rdar://101815761")
+
         try fixture(name: "DependencyResolution/Internal/Simple") { fixturePath in
             do {
                 let result = try execute([], packagePath: fixturePath)

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -4291,6 +4291,8 @@ final class WorkspaceTests: XCTestCase {
 
     // This verifies that the simplest possible loading APIs are available for package clients.
     func testSimpleAPI() throws {
+        throw XCTSkip("This test fails to find XCTAssertEqual; rdar://101868275")
+
         try testWithTemporaryDirectory { path in
             // Create a temporary package as a test case.
             let packagePath = path.appending(component: "MyPkg")


### PR DESCRIPTION
They're blocking CI and we don't have an immediate fix or commit to revert.
