### PR TITLE
PackageModel: clean up naming of `Destination` properties

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -842,13 +842,13 @@ public class SwiftTool {
         }
         // Apply any manual overrides.
         if let triple = self.options.build.customCompileTriple {
-            destination.target = triple
+            destination.destinationTriple = triple
         }
         if let binDir = self.options.build.customCompileToolchain {
-            destination.binDir = binDir.appending(components: "usr", "bin")
+            destination.toolchainBinDir = binDir.appending(components: "usr", "bin")
         }
         if let sdk = self.options.build.customCompileSDK {
-            destination.sdk = sdk
+            destination.sdkRootDir = sdk
         }
         destination.archs = options.build.archs
 

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -3372,8 +3372,8 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         let userDestination = Destination(
-            sdk: AbsolutePath(path: "/fake/sdk"),
-            binDir: try UserToolchain.default.destination.binDir,
+            sdkRootDir: AbsolutePath(path: "/fake/sdk"),
+            toolchainBinDir: try UserToolchain.default.destination.toolchainBinDir,
             extraFlags: BuildFlags(
                 cCompilerFlags: ["-I/fake/sdk/sysroot", "-clang-flag-from-json"],
                 swiftCompilerFlags: ["-swift-flag-from-json"]
@@ -3400,7 +3400,7 @@ final class BuildPlanTests: XCTestCase {
       #else
         args += ["--sysroot"]
       #endif
-        args += ["\(userDestination.sdk!)", "-I/fake/sdk/sysroot", "-clang-flag-from-json", .anySequence, "-clang-command-line-flag"]
+        args += ["\(userDestination.sdkRootDir!)", "-I/fake/sdk/sysroot", "-clang-flag-from-json", .anySequence, "-clang-command-line-flag"]
         XCTAssertMatch(try lib.basicArguments(isCXX: false), args)
 
         let exe = try result.target(for: "exe").swiftTarget().compileArguments()

--- a/Tests/PackageModelTests/PackageModelTests.swift
+++ b/Tests/PackageModelTests/PackageModelTests.swift
@@ -56,17 +56,17 @@ class PackageModelTests: XCTestCase {
     }
 
     func testAndroidCompilerFlags() throws {
-        let target = try Triple("x86_64-unknown-linux-android")
+        let triple = try Triple("x86_64-unknown-linux-android")
         let sdk = AbsolutePath(path: "/some/path/to/an/SDK.sdk")
         let toolchainPath = AbsolutePath(path: "/some/path/to/a/toolchain.xctoolchain")
 
         let destination = Destination(
-            target: target,
-            sdk: sdk,
-            binDir: toolchainPath.appending(components: "usr", "bin")
+            destinationTriple: triple,
+            sdkRootDir: sdk,
+            toolchainBinDir: toolchainPath.appending(components: "usr", "bin")
         )
 
-        XCTAssertEqual(try UserToolchain.deriveSwiftCFlags(triple: target, destination: destination, environment: .process()), [
+        XCTAssertEqual(try UserToolchain.deriveSwiftCFlags(triple: triple, destination: destination, environment: .process()), [
             // Needed when cross‐compiling for Android. 2020‐03‐01
             "-sdk", sdk.pathString,
         ])


### PR DESCRIPTION
### Motivation:

`Destination` type has some properties with pretty short names based entirely on abbreviations or knowledge of context. It also can't store the triple of the host that supports this destination. Making names of properties consistent makes it more maintainable and readable.

### Modifications:

Introduced `sdkRootDir` replacing `sdk`, `toolchainBinDir` replacing `binDir`, and `destinationTriple` replacing `target` old names are marked as deprecated. Also added the new `hostTriple` property.

### Result:

Makes property names in the codebase more consistent, also incorporates some preparatory work I'm doing for #5812.
