### PR TITLE
Basics: add missing `@Sendable` to `withTemporaryDirectory`

### DIFF
--- a/Sources/Basics/TemporaryFile.swift
+++ b/Sources/Basics/TemporaryFile.swift
@@ -39,7 +39,7 @@ public func withTemporaryDirectory<Result>(
     fileSystem: FileSystem = localFileSystem,
     dir: AbsolutePath? = nil,
     prefix: String = "TemporaryDirectory",
-    _ body: @escaping (AbsolutePath, @escaping (AbsolutePath) -> Void) async throws -> Result
+    _ body: @Sendable @escaping (AbsolutePath, @escaping (AbsolutePath) -> Void) async throws -> Result
 ) throws -> Task<Result, Error> {
     let temporaryDirectory = try createTemporaryDirectory(fileSystem: fileSystem, dir: dir, prefix: prefix)
     


### PR DESCRIPTION
### Motivation:

This fixes `Capture of 'body' with non-sendable type '(AbsolutePath, @escaping (AbsolutePath) -> Void) async throws -> Result' in a @Sendable closure` warning.

### Modifications:

Added `@Sendable` attribute to the `body` argument of `withTemporaryDirectory`.

### Result:

Less concurrency-related warnings when `Sendable`-related checks are enabled.
