### PR TITLE
Disable `FunctionalTests` temporarily

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -458,7 +458,8 @@ let package = Package(
             name: "WorkspaceTests",
             dependencies: ["Workspace", "SPMTestSupport"]
         ),
-        .testTarget(
+        // rdar://101868275 "error: cannot find 'XCTAssertEqual' in scope" can affect almost any functional test, so we flat out disable them all until we know what is going on
+        /*.testTarget(
             name: "FunctionalTests",
             dependencies: [
                 "swift-build",
@@ -467,7 +468,7 @@ let package = Package(
                 "PackageModel",
                 "SPMTestSupport"
             ]
-        ),
+        ),*/
         .testTarget(
             name: "FunctionalPerformanceTests",
             dependencies: [


### PR DESCRIPTION
rdar://101868275 "error: cannot find 'XCTAssertEqual' in scope" can affect almost any functional test, so we flat out disable them all until we know what is going on