### PR TITLE
Make sure we actually use swift-driver

### DIFF
--- a/Sources/SPMTestSupport/Toolchain.swift
+++ b/Sources/SPMTestSupport/Toolchain.swift
@@ -94,28 +94,4 @@ extension UserToolchain {
         return true
       #endif
     }
-
-    /// Helper function to determine whether serialized diagnostics work properly in the current environment.
-    public func supportsSerializedDiagnostics(otherSwiftFlags: [String] = []) -> Bool {
-        do {
-            try testWithTemporaryDirectory { tmpPath in
-                let inputPath = tmpPath.appending(component: "best.swift")
-                try localFileSystem.writeFileContents(inputPath, string: "func foo() -> Bool {\nvar unused: Int\nreturn true\n}\n")
-                let outputPath = tmpPath.appending(component: "foo")
-                let serializedDiagnosticsPath = tmpPath.appending(component: "out.dia")
-                let toolchainPath = self.swiftCompilerPath.parentDirectory.parentDirectory
-                try Process.checkNonZeroExit(arguments: ["/usr/bin/xcrun", "--toolchain", toolchainPath.pathString, "swiftc", inputPath.pathString, "-Xfrontend", "-serialize-diagnostics-path", "-Xfrontend", serializedDiagnosticsPath.pathString, "-g", "-o", outputPath.pathString] + otherSwiftFlags)
-                try Process.checkNonZeroExit(arguments: [outputPath.pathString])
-
-                let diaFileContents = try localFileSystem.readFileContents(serializedDiagnosticsPath)
-                let diagnosticsSet = try SerializedDiagnostics(bytes: diaFileContents)
-                if diagnosticsSet.diagnostics.isEmpty {
-                    throw StringError("does not support diagnostics")
-                }
-            }
-            return true
-        } catch {
-            return false
-        }
-    }
 }

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -412,14 +412,12 @@ class PluginInvocationTests: XCTestCase {
                 XCTAssertEqual(delegate.compiledResult, result)
                 XCTAssertNil(delegate.cachedResult)
 
-                if try UserToolchain.default.supportsSerializedDiagnostics() {
-                    // Check the serialized diagnostics. We should no longer have an error but now have a warning.
-                    let diaFileContents = try localFileSystem.readFileContents(result.diagnosticsFile)
-                    let diagnosticsSet = try SerializedDiagnostics(bytes: diaFileContents)
-                    XCTAssertEqual(diagnosticsSet.diagnostics.count, 1, "unexpected diagnostics count in \(diagnosticsSet.diagnostics) from \(result.diagnosticsFile.pathString)")
-                    let warningDiagnostic = try XCTUnwrap(diagnosticsSet.diagnostics.first)
-                    XCTAssertTrue(warningDiagnostic.text.hasPrefix("variable \'unused\' was never used"), "\(warningDiagnostic)")
-                }
+                // Check the serialized diagnostics. We should no longer have an error but now have a warning.
+                let diaFileContents = try localFileSystem.readFileContents(result.diagnosticsFile)
+                let diagnosticsSet = try SerializedDiagnostics(bytes: diaFileContents)
+                XCTAssertEqual(diagnosticsSet.diagnostics.count, 1, "unexpected diagnostics count in \(diagnosticsSet.diagnostics) from \(result.diagnosticsFile.pathString)")
+                let warningDiagnostic = try XCTUnwrap(diagnosticsSet.diagnostics.first)
+                XCTAssertTrue(warningDiagnostic.text.hasPrefix("variable \'unused\' was never used"), "\(warningDiagnostic)")
 
                 // Check that the executable file exists.
                 XCTAssertTrue(localFileSystem.exists(result.executableFile), "\(result.executableFile.pathString)")
@@ -457,14 +455,12 @@ class PluginInvocationTests: XCTestCase {
                 XCTAssertNil(delegate.compiledResult)
                 XCTAssertEqual(delegate.cachedResult, result)
 
-                if try UserToolchain.default.supportsSerializedDiagnostics() {
-                    // Check that the diagnostics still have the same warning as before.
-                    let diaFileContents = try localFileSystem.readFileContents(result.diagnosticsFile)
-                    let diagnosticsSet = try SerializedDiagnostics(bytes: diaFileContents)
-                    XCTAssertEqual(diagnosticsSet.diagnostics.count, 1)
-                    let warningDiagnostic = try XCTUnwrap(diagnosticsSet.diagnostics.first)
-                    XCTAssertTrue(warningDiagnostic.text.hasPrefix("variable \'unused\' was never used"), "\(warningDiagnostic)")
-                }
+                // Check that the diagnostics still have the same warning as before.
+                let diaFileContents = try localFileSystem.readFileContents(result.diagnosticsFile)
+                let diagnosticsSet = try SerializedDiagnostics(bytes: diaFileContents)
+                XCTAssertEqual(diagnosticsSet.diagnostics.count, 1)
+                let warningDiagnostic = try XCTUnwrap(diagnosticsSet.diagnostics.first)
+                XCTAssertTrue(warningDiagnostic.text.hasPrefix("variable \'unused\' was never used"), "\(warningDiagnostic)")
 
                 // Check that the executable file exists.
                 XCTAssertTrue(localFileSystem.exists(result.executableFile), "\(result.executableFile.pathString)")

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -649,6 +649,9 @@ def build_swiftpm_with_swiftpm(args, integrated_swift_driver):
     symlink_force(args.swiftc_path, os.path.join(args.target_dir, args.conf, "swift"))
     symlink_force(args.swiftc_path, os.path.join(args.target_dir, args.conf, "swift-autolink-extract"))
 
+    # Symlink swift-driver built by CMake into the "fake" toolchain
+    symlink_force(os.path.join(args.bootstrap_dir, "..", "swift-driver", "bin", "swift-driver"), os.path.join(args.target_dir, args.conf, "swift-driver"))
+
     lib_dir = os.path.join(args.target_dir, "lib", "swift")
 
     # Remove old cruft.


### PR DESCRIPTION
This tries to use the swift-driver built during the first-stage for the "fake" toolchain we're constructing for bootstrapping. Basically a variation on #5842.

Trying first whether it is sufficient to just have the symlink, if not we should be able to combine the approach from #5842 and this together.