### PR TITLE
Improve `diagnose-api-breaking-changes` error reporting

### DIFF
--- a/Fixtures/Miscellaneous/APIDiff/BrokenPkg/Package.swift
+++ b/Fixtures/Miscellaneous/APIDiff/BrokenPkg/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version: 5.7
+
+import PackageDescription
+
+let package = Package(
+    name: "BrokenPkg",
+    products: [
+        .library(name: "BrokenPkg", targets: ["BrokenPkg", "Swift2"]),
+    ],
+    targets: [
+        .target(name: "BrokenPkg", publicHeadersPath: "bestHeaders", cSettings: [ .define("FLAG"), ]),
+        .target(name: "Swift2", dependencies: ["BrokenPkg"], cSettings: [ .define("FLAG"), ]),
+    ]
+)

--- a/Fixtures/Miscellaneous/APIDiff/BrokenPkg/Sources/BrokenPkg/bestHeaders/header.h
+++ b/Fixtures/Miscellaneous/APIDiff/BrokenPkg/Sources/BrokenPkg/bestHeaders/header.h
@@ -1,0 +1,3 @@
+#ifndef FLAG
+#error "fail"
+#endif

--- a/Fixtures/Miscellaneous/APIDiff/BrokenPkg/Sources/BrokenPkg/code.m
+++ b/Fixtures/Miscellaneous/APIDiff/BrokenPkg/Sources/BrokenPkg/code.m
@@ -1,0 +1,1 @@
+#import "header.h"

--- a/Fixtures/Miscellaneous/APIDiff/BrokenPkg/Sources/Swift2/file.swift
+++ b/Fixtures/Miscellaneous/APIDiff/BrokenPkg/Sources/Swift2/file.swift
@@ -1,0 +1,1 @@
+import BrokenPkg

--- a/Sources/Commands/Utilities/APIDigester.swift
+++ b/Sources/Commands/Utilities/APIDigester.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Dispatch
+import Foundation
 
 import TSCBasic
 
@@ -188,15 +189,28 @@ public struct SwiftAPIDigester {
         for module: String,
         buildPlan: SPMBuildCore.BuildPlan
     ) throws {
-        var args = ["-dump-sdk"]
+        var args = ["-dump-sdk", "-compiler-style-diags"]
         args += try buildPlan.createAPIToolCommonArgs(includeLibrarySearchPaths: false)
         args += ["-module", module, "-o", outputPath.pathString]
 
-        try runTool(args)
+        let result = try runTool(args)
 
         if !self.fileSystem.exists(outputPath) {
-            throw Error.failedToGenerateBaseline(module)
+            throw Error.failedToGenerateBaseline(module: module)
         }
+
+        try self.fileSystem.readFileContents(outputPath).withData { data in
+            if let jsonObject = try JSONSerialization.jsonObject(with: data, options: []) as? [String:Any] {
+                guard let abiRoot = jsonObject["ABIRoot"] as? [String:Any] else {
+                    throw Error.failedToValidateBaseline(module: module)
+                }
+
+                guard let symbols = abiRoot["children"] as? NSArray, symbols.count > 0 else {
+                    throw Error.noSymbolsInBaseline(module: module, toolOutput: try result.utf8Output())
+                }
+            }
+        }
+
     }
 
     /// Compare the current package API to a provided baseline file.
@@ -233,25 +247,31 @@ public struct SwiftAPIDigester {
         }
     }
 
-    private func runTool(_ args: [String]) throws {
+    @discardableResult private func runTool(_ args: [String]) throws -> ProcessResult {
         let arguments = [tool.pathString] + args
         let process = TSCBasic.Process(
             arguments: arguments,
-            outputRedirection: .collect
+            outputRedirection: .collect(redirectStderr: true)
         )
         try process.launch()
-        try process.waitUntilExit()
+        return try process.waitUntilExit()
     }
 }
 
 extension SwiftAPIDigester {
     public enum Error: Swift.Error, CustomStringConvertible {
-        case failedToGenerateBaseline(String)
+        case failedToGenerateBaseline(module: String)
+        case failedToValidateBaseline(module: String)
+        case noSymbolsInBaseline(module: String, toolOutput: String)
 
         public var description: String {
             switch self {
             case .failedToGenerateBaseline(let module):
                 return "failed to generate baseline for \(module)"
+            case .failedToValidateBaseline(let module):
+                return "failed to validate baseline for \(module)"
+            case .noSymbolsInBaseline(let module, let toolOutput):
+                return "baseline for \(module) contains no symbols, swift-api-digester output: \(toolOutput)"
             }
         }
     }

--- a/Tests/CommandsTests/APIDiffTests.swift
+++ b/Tests/CommandsTests/APIDiffTests.swift
@@ -412,4 +412,14 @@ final class APIDiffTests: CommandsTestCase {
             XCTAssertMatch(error.stdout, .contains("`swift package experimental-api-diff` has been renamed to `swift package diagnose-api-breaking-changes`"))
         }
     }
+
+    func testBrokenAPIDiff() throws {
+        try skipIfApiDigesterUnsupportedOrUnset()
+        try fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
+            let packageRoot = fixturePath.appending(component: "BrokenPkg")
+            XCTAssertThrowsCommandExecutionError(try execute(["diagnose-api-breaking-changes", "1.2.3"], packagePath: packageRoot)) { error in
+                XCTAssertMatch(error.stderr, .contains("baseline for Swift2 contains no symbols, swift-api-digester output"))
+            }
+        }
+    }
 }


### PR DESCRIPTION
It looks like `swift-api-digester` is always returning 0, so failures to parse modules can turn into false negative breakage reports. Do a minimal sniff test of the produced JSON to see if it contains symbols and if it does not, we'll emit the full output of `swift-api-digester` which will hopefully contain any errors encountered.
