### PR TITLE
[PackageLoading] Diagnose empty manifest separately from missing tools version specification

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -17,9 +17,11 @@ import TSCBasic
 import enum TSCUtility.Diagnostics
 
 public enum ManifestParseError: Swift.Error, Equatable {
+    /// The manifest is empty, or at least from SwiftPM's perspective it is.
+    case emptyManifest(path: AbsolutePath)
     /// The manifest contains invalid format.
     case invalidManifestFormat(String, diagnosticFile: AbsolutePath?)
-
+    // TODO: Test this error.
     /// The manifest was successfully loaded by swift interpreter but there were runtime issues.
     case runtimeManifestErrors([String])
 }
@@ -28,10 +30,12 @@ public enum ManifestParseError: Swift.Error, Equatable {
 extension ManifestParseError: CustomStringConvertible {
     public var description: String {
         switch self {
+        case .emptyManifest(let manifestPath):
+            return "'\(manifestPath)' is empty"
         case .invalidManifestFormat(let error, _):
-            return "Invalid manifest\n\(error)"
+            return "invalid manifest\n\(error)"
         case .runtimeManifestErrors(let errors):
-            return "Invalid manifest (evaluation failed)\n\(errors.joined(separator: "\n"))"
+            return "invalid manifest (evaluation failed)\n\(errors.joined(separator: "\n"))"
         }
     }
 }

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -215,7 +215,7 @@ final class WorkspaceTests: XCTestCase {
             XCTAssert(rootManifests.count == 0, "\(rootManifests)")
 
             testDiagnostics(observability.diagnostics) { result in
-                let diagnostic = result.check(diagnostic: .prefix("Invalid manifest\n\(path.appending(components: "MyPkg", "Package.swift")):3:8: error: An error in MyPkg"), severity: .error)
+                let diagnostic = result.check(diagnostic: .prefix("invalid manifest\n\(path.appending(components: "MyPkg", "Package.swift")):3:8: error: An error in MyPkg"), severity: .error)
                 XCTAssertEqual(diagnostic?.metadata?.packageIdentity, .init(path: pkgDir))
                 XCTAssertEqual(diagnostic?.metadata?.packageKind, .root(pkgDir))
             }


### PR DESCRIPTION
This change makes it clearer to the user what problem SwiftPM thinks their manifest has, avoiding some confusions in [cases like this](https://forums.swift.org/t/missing-swift-tools-version-specification-build-fail/61051).

In the future, for errors not specific to the tools version specification, we should move their diagnostics to before calling `ToolsVersionParser.parse`. This probably requires some restructuring of manifest parsing in general.

Some additional changes:

- Removed an incorrect FIXME, and added a TODO for testing `ManifestParseError.runtimeManifestErrors`.

- Decapitalised the description for the other `ManifestParseError` cases, in keeping with [Swift’s diagnostics style](https://github.com/apple/swift/blob/3a939255c8fc1f2825560cca3a5fa6b167c414c3/docs/Diagnostics.md).
