### PR TITLE
Utilities/bootstrap: fix ignored `--clang-path` option

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -530,8 +530,8 @@ def build_llbuild(args):
     call(["touch", "codemodel-v2"], cwd=api_dir, verbose=args.verbose)
 
     flags = [
-        "-DCMAKE_C_COMPILER:=clang",
-        "-DCMAKE_CXX_COMPILER:=clang++",
+        "-DCMAKE_C_COMPILER:=%s" % (args.clang_path),
+        "-DCMAKE_CXX_COMPILER:=%s" % (args.clang_path),
         "-DLLBUILD_SUPPORT_BINDINGS:=Swift",
     ]
 

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -619,6 +619,7 @@ def build_swiftpm_with_swiftpm(args, integrated_swift_driver):
     swiftpm_args = [
         "SWIFT_EXEC=" + args.swiftc_path,
         "SWIFT_DRIVER_SWIFT_EXEC=" + args.swiftc_path,
+        "CC=" + args.clang_path
     ]
 
     if args.bootstrap:

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -500,6 +500,7 @@ def build_with_cmake(args, cmake_args, ninja_args, source_path, build_dir):
             "-DCMAKE_BUILD_TYPE:=Debug",
             "-DCMAKE_Swift_FLAGS='%s'" % swift_flags,
             "-DCMAKE_Swift_COMPILER:=%s" % (args.swiftc_path),
+            "-DCMAKE_C_COMPILER:=%s" % (args.clang_path),
         ] + cmake_args + [source_path]
 
         if args.verbose:


### PR DESCRIPTION
### Motivation:

`Utilities/bootstrap` has `--clang-path`, which currently is parsed, but not propagated anywhere. Ignoring this option caused issues on certain Linux distributions, where the process of bringing up clang is convoluted and `bootstrap` ended up using GCC, which caused build failures.

### Modifications:

`args.clang_path` value is now passed to CMake as `-DCMAKE_C_COMPILER`.

### Result:

Build failures on Linux in certain configurations are fixed.
