### PR TITLE
Verify that the pinned version is still available

### DIFF
--- a/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
+++ b/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
@@ -1115,12 +1115,16 @@ internal final class PubGrubPackageContainer {
     /// Returns the best available version for a given term.
     func getBestAvailableVersion(for term: Term) throws -> Version? {
         assert(term.isPositive, "Expected term to be positive")
-        var versionSet = term.requirement
+        let versionSet = term.requirement
 
         // Restrict the selection to the pinned version if is allowed by the current requirements.
         if let pinnedVersion = self.pinnedVersion {
             if versionSet.contains(pinnedVersion) {
-                versionSet = .exact(pinnedVersion)
+                // Make sure the pinned version is still available
+                let version = try self.underlying.versionsDescending().first { pinnedVersion == $0 }
+                if version != nil {
+                    return version
+                }
             }
         }
 


### PR DESCRIPTION
Before committing to the pinned version, the resolver should make sure that it's still available. This change fixes #5873.

### Motivation:

If the resolver decides to honor a pin that is no longer available, the error message produced is `Dependencies could not be resolved because no versions of 'package' match the requirement 1.0.0..<2.0.0 and root depends on 'package' 1.0.0..<2.0.0`. However, that error message is confusing, because the requirement specified in the error message was replaced by the stricter version requirement that was pinned for the project. 

Since pinned versions are discarded if they no longer meet the requirements, it seemed reasonable to do the same if the pinned version is no longer available.

### Modifications:

The resolver first checks to see if the pinned version of the package is still available before using it as a requirement.

### Result:

After this change, the package resolution will no longer fail if a pinned version of a package is no longer available. Instead, the pinned version will be ignored, and the resolver will choose the most recent package version that meets the constraints.