### PR TITLE
Default target platform to current host version if unspecified

### DIFF
--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import Foundation
 import OrderedCollections
 import PackageLoading
 import PackageModel
@@ -624,13 +625,18 @@ private func computePlatforms(
             minimumSupportedVersion = platform.oldestSupportedVersion
         }
 
-        let oldestSupportedVersion: PlatformVersion
+        var oldestSupportedVersion = minimumSupportedVersion
         if platform == .macCatalyst, let iOS = derivedPlatforms.first(where: { $0.platform == .iOS }) {
             // If there was no deployment target specified for Mac Catalyst, fall back to the iOS deployment target.
             oldestSupportedVersion = max(minimumSupportedVersion, iOS.version)
-        } else {
-            oldestSupportedVersion = minimumSupportedVersion
         }
+
+        #if os(macOS)
+        if platform == .macOS {
+            let version = ProcessInfo.processInfo.operatingSystemVersion
+            oldestSupportedVersion = PlatformVersion("\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)")
+        }
+        #endif
 
         let supportedPlatform = SupportedPlatform(
             platform: platform,


### PR DESCRIPTION
Previously if you created a new basic Swift package and added a dependency, such as swift-syntax, that requires a minimum version greater than macOS 10.13, you would have to set the platform version to something above that in the Package.swift. With this change if the supported platform version is unspecified, the current host version is used instead. This makes it easier to test out projects where the minimum version isn't important. The user can still get a hermetic minimum version by setting whatever value they need.

https://github.com/apple/swift-syntax/blob/ef4605bc20a17f73939623fef9cec75fa89928b1/Package.swift#L28