### PR TITLE
PackageModel: rename "CC SDKs" to "destinations"

### DIFF
--- a/Sources/Basics/FileSystem+Extensions.swift
+++ b/Sources/Basics/FileSystem+Extensions.swift
@@ -226,23 +226,23 @@ extension FileSystem {
 
 // MARK: - cross-compilation SDKs
 
-private let sdksDirectoryName = "sdks"
+private let crossCompilationDestinationsDirectoryName = "destinations"
 
 extension FileSystem {
-    /// SwiftPM cross-compilation SDKs directory (if exists)
-    public var swiftPMCrossCompilationSDKsDirectory: AbsolutePath {
+    /// SwiftPM cross-compilation destinations directory (if exists)
+    public var swiftPMCrossCompilationDestinationsDirectory: AbsolutePath {
         get throws {
             if let path = try self.idiomaticSwiftPMDirectory {
-                return path.appending(component: sdksDirectoryName)
+                return path.appending(component: crossCompilationDestinationsDirectoryName)
             } else {
-                return try self.dotSwiftPMCrossCompilationSDKsDirectory
+                return try self.dotSwiftPMCrossCompilationDestinationsDirectory
             }
         }
     }
 
-    fileprivate var dotSwiftPMCrossCompilationSDKsDirectory: AbsolutePath {
+    fileprivate var dotSwiftPMCrossCompilationDestinationsDirectory: AbsolutePath {
         get throws {
-            return try self.dotSwiftPM.appending(component: sdksDirectoryName)
+            return try self.dotSwiftPM.appending(component: crossCompilationDestinationsDirectoryName)
         }
     }
 }

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -85,7 +85,7 @@ public struct LocationOptions: ParsableArguments {
     public var customCompileDestination: AbsolutePath?
 
     @Option(name: .customLong("experimental-destinations-path"), help: .hidden, completion: .directory)
-    var destinationsDirectory: AbsolutePath?
+    var crossCompilationDestinationsDirectory: AbsolutePath?
 }
 
 public struct CachingOptions: ParsableArguments {

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -84,8 +84,8 @@ public struct LocationOptions: ParsableArguments {
     @Option(name: .customLong("destination"), help: .hidden, completion: .directory)
     public var customCompileDestination: AbsolutePath?
 
-    @Option(name: .customLong("experimental-cross-compilation-sdks-path"), help: .hidden, completion: .directory)
-    var ccSDKsDirectory: AbsolutePath?
+    @Option(name: .customLong("experimental-destinations-path"), help: .hidden, completion: .directory)
+    var destinationsDirectory: AbsolutePath?
 }
 
 public struct CachingOptions: ParsableArguments {

--- a/Sources/CoreCommands/SwiftTool.swift
+++ b/Sources/CoreCommands/SwiftTool.swift
@@ -162,7 +162,7 @@ public final class SwiftTool {
     public let sharedConfigurationDirectory: AbsolutePath?
 
     /// Path to the cross-compilation SDK directory.
-    let sharedDestinationsDirectory: AbsolutePath?
+    public let sharedCrossCompilationDestinationsDirectory: AbsolutePath?
 
     /// Cancellator to handle cancellation of outstanding work when handling SIGINT
     public let cancellator: Cancellator
@@ -310,7 +310,7 @@ public final class SwiftTool {
         self.sharedSecurityDirectory = try getSharedSecurityDirectory(options: self.options, fileSystem: fileSystem)
         self.sharedConfigurationDirectory = try getSharedConfigurationDirectory(options: self.options, fileSystem: fileSystem)
         self.sharedCacheDirectory = try getSharedCacheDirectory(options: self.options, fileSystem: fileSystem)
-        self.sharedDestinationsDirectory = try getSharedDestinationsDirectory(options: self.options, fileSystem: fileSystem)
+        self.sharedCrossCompilationDestinationsDirectory = try getSharedCrossCompilationDestinationsDirectory(options: self.options, fileSystem: fileSystem)
 
         // set global process logging handler
         Process.loggingHandler = { self.observabilityScope.emit(debug: $0) }
@@ -781,18 +781,18 @@ private func getSharedCacheDirectory(options: GlobalOptions, fileSystem: FileSys
     }
 }
 
-private func getSharedDestinationsDirectory(
+private func getSharedCrossCompilationDestinationsDirectory(
     options: GlobalOptions,
     fileSystem: FileSystem
 ) throws -> AbsolutePath? {
-    if let explicitDestinationsDirectory = options.locations.destinationsDirectory {
+    if let explicitDestinationsDirectory = options.locations.crossCompilationDestinationsDirectory {
         // Create the explicit destinations path if necessary
         if !fileSystem.exists(explicitDestinationsDirectory) {
             try fileSystem.createDirectory(explicitDestinationsDirectory, recursive: true)
         }
         return explicitDestinationsDirectory
     } else {
-        return try fileSystem.swiftPMCrossCompilationSDKsDirectory
+        return try fileSystem.swiftPMCrossCompilationDestinationsDirectory
     }
 }
 

--- a/Sources/CoreCommands/SwiftTool.swift
+++ b/Sources/CoreCommands/SwiftTool.swift
@@ -162,7 +162,7 @@ public final class SwiftTool {
     public let sharedConfigurationDirectory: AbsolutePath?
 
     /// Path to the cross-compilation SDK directory.
-    let sharedCCSDKDirectory: AbsolutePath?
+    let sharedDestinationsDirectory: AbsolutePath?
 
     /// Cancellator to handle cancellation of outstanding work when handling SIGINT
     public let cancellator: Cancellator
@@ -310,7 +310,7 @@ public final class SwiftTool {
         self.sharedSecurityDirectory = try getSharedSecurityDirectory(options: self.options, fileSystem: fileSystem)
         self.sharedConfigurationDirectory = try getSharedConfigurationDirectory(options: self.options, fileSystem: fileSystem)
         self.sharedCacheDirectory = try getSharedCacheDirectory(options: self.options, fileSystem: fileSystem)
-        self.sharedCCSDKDirectory = try getSharedCCSDKsDirectory(options: self.options, fileSystem: fileSystem)
+        self.sharedDestinationsDirectory = try getSharedDestinationsDirectory(options: self.options, fileSystem: fileSystem)
 
         // set global process logging handler
         Process.loggingHandler = { self.observabilityScope.emit(debug: $0) }
@@ -644,7 +644,7 @@ public final class SwiftTool {
         }
         // Apply any manual overrides.
         if let triple = self.options.build.customCompileTriple {
-            destination.destinationTriple = triple
+            destination.targetTriple = triple
         }
         if let binDir = self.options.build.customCompileToolchain {
             destination.toolchainBinDir = binDir.appending(components: "usr", "bin")
@@ -781,16 +781,16 @@ private func getSharedCacheDirectory(options: GlobalOptions, fileSystem: FileSys
     }
 }
 
-private func getSharedCCSDKsDirectory(
+private func getSharedDestinationsDirectory(
     options: GlobalOptions,
     fileSystem: FileSystem
 ) throws -> AbsolutePath? {
-    if let explicitCCSDKsDirectory = options.locations.ccSDKsDirectory {
-        // Create the explicit SDKs path if necessary
-        if !fileSystem.exists(explicitCCSDKsDirectory) {
-            try fileSystem.createDirectory(explicitCCSDKsDirectory, recursive: true)
+    if let explicitDestinationsDirectory = options.locations.destinationsDirectory {
+        // Create the explicit destinations path if necessary
+        if !fileSystem.exists(explicitDestinationsDirectory) {
+            try fileSystem.createDirectory(explicitDestinationsDirectory, recursive: true)
         }
-        return explicitCCSDKsDirectory
+        return explicitDestinationsDirectory
     } else {
         return try fileSystem.swiftPMCrossCompilationSDKsDirectory
     }

--- a/Sources/PackageModel/Destination.swift
+++ b/Sources/PackageModel/Destination.swift
@@ -38,7 +38,7 @@ extension DestinationError: CustomStringConvertible {
 /// The compilation destination, has information about everything that's required for a certain destination.
 public struct Destination: Encodable, Equatable {
 
-    /// The clang/LLVM triple describing the destination's target OS and architecture.
+    /// The clang/LLVM triple describing the target OS and architecture.
     ///
     /// The triple has the general format <arch><sub>-<vendor>-<sys>-<abi>, where:
     ///  - arch = x86_64, i386, arm, thumb, mips, etc.
@@ -48,7 +48,7 @@ public struct Destination: Encodable, Equatable {
     ///  - abi = eabi, gnu, android, macho, elf, etc.
     ///
     /// for more information see //https://clang.llvm.org/docs/CrossCompilation.html
-    public var destinationTriple: Triple?
+    public var targetTriple: Triple?
 
     /// The clang/LLVM triple describing the host platform that supports this destination.
     public let hostTriple: Triple?
@@ -106,7 +106,7 @@ public struct Destination: Encodable, Equatable {
     public let extraFlags: BuildFlags
 
     /// Creates a compilation destination with the specified properties.
-    @available(*, deprecated, message: "use `init(destinationTriple:sdkRootDir:toolchainBinDir:extraFlags)` instead")
+    @available(*, deprecated, message: "use `init(targetTriple:sdkRootDir:toolchainBinDir:extraFlags)` instead")
     public init(
         target: Triple? = nil,
         sdk: AbsolutePath?,
@@ -116,7 +116,7 @@ public struct Destination: Encodable, Equatable {
         extraCPPFlags: [String]
     ) {
         self.hostTriple = nil
-        self.destinationTriple = target
+        self.targetTriple = target
         self.sdkRootDir = sdk
         self.toolchainBinDir = binDir
         self.extraFlags = BuildFlags(
@@ -129,13 +129,13 @@ public struct Destination: Encodable, Equatable {
     /// Creates a compilation destination with the specified properties.
     public init(
         hostTriple: Triple? = nil,
-        destinationTriple: Triple? = nil,
+        targetTriple: Triple? = nil,
         sdkRootDir: AbsolutePath?,
         toolchainBinDir: AbsolutePath,
         extraFlags: BuildFlags = BuildFlags()
     ) {
         self.hostTriple = hostTriple
-        self.destinationTriple = destinationTriple
+        self.targetTriple = targetTriple
         self.sdkRootDir = sdkRootDir
         self.toolchainBinDir = toolchainBinDir
         self.extraFlags = extraFlags
@@ -249,7 +249,7 @@ public struct Destination: Encodable, Equatable {
                 .parentDirectory // usr
                 .appending(components: "share", "wasi-sysroot")
             return Destination(
-                destinationTriple: triple,
+                targetTriple: triple,
                 sdkRootDir: wasiSysroot,
                 toolchainBinDir: host.toolchainBinDir
             )
@@ -269,7 +269,7 @@ extension Destination {
         case 1:
             let destination = try decoder.decode(path: path, fileSystem: fileSystem, as: DestinationInfoV1.self)
             try self.init(
-                destinationTriple: destination.target.map{ try Triple($0) },
+                targetTriple: destination.target.map{ try Triple($0) },
                 sdkRootDir: destination.sdk,
                 toolchainBinDir: destination.binDir,
                 extraFlags: .init(
@@ -285,7 +285,7 @@ extension Destination {
             // TODO support multiple host and destination triple.
             try self.init(
                 hostTriple: destination.hostTriples.map(Triple.init).first,
-                destinationTriple: destination.destinationTriples.map(Triple.init).first,
+                targetTriple: destination.targetTriples.map(Triple.init).first,
                 sdkRootDir: AbsolutePath(validating: destination.sdkRootDir, relativeTo: destinationDirectory),
                 toolchainBinDir: AbsolutePath(validating: destination.toolchainBinDir, relativeTo: destinationDirectory),
                 extraFlags: .init(
@@ -330,7 +330,7 @@ fileprivate struct DestinationInfoV2: Codable {
     let sdkRootDir: String
     let toolchainBinDir: String
     let hostTriples: [String]
-    let destinationTriples: [String]
+    let targetTriples: [String]
     let extraCCFlags: [String]
     let extraSwiftCFlags: [String]
     let extraCXXFlags: [String]

--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -180,14 +180,14 @@ public final class Manifest {
         }
 
         var requiredDependencies: Set<PackageIdentity> = []
-        for destinationTriple in self.targetsRequired(for: products) {
-            for targetDependency in destinationTriple.dependencies {
+        for targetTriple in self.targetsRequired(for: products) {
+            for targetDependency in targetTriple.dependencies {
                 if let dependency = self.packageDependency(referencedBy: targetDependency) {
                     requiredDependencies.insert(dependency.identity)
                 }
             }
 
-            destinationTriple.pluginUsages?.forEach {
+            targetTriple.pluginUsages?.forEach {
                 if let dependency = self.packageDependency(referencedBy: $0) {
                     requiredDependencies.insert(dependency.identity)
                 }

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -373,7 +373,7 @@ public final class UserToolchain: Toolchain {
         self.archs = destination.archs
 
         // Use the triple from destination or compute the host triple using swiftc.
-        var triple = destination.destinationTriple ?? Triple.getHostTriple(usingSwiftCompiler: swiftCompilers.compile)
+        var triple = destination.targetTriple ?? Triple.getHostTriple(usingSwiftCompiler: swiftCompilers.compile)
 
         self.librarianPath = try UserToolchain.determineLibrarian(triple: triple, binDir: binDir, useXcrun: useXcrun, environment: environment, searchPaths: envSearchPaths)
 

--- a/Tests/PackageModelTests/DestinationTests.swift
+++ b/Tests/PackageModelTests/DestinationTests.swift
@@ -20,7 +20,7 @@ private let bundleRootPath = try! AbsolutePath(validating: "/tmp/cross-toolchain
 private let toolchainBinDir = RelativePath("swift.xctoolchain/usr/bin")
 private let sdkRootDir = RelativePath("ubuntu-jammy.sdk")
 private let hostTriple = "arm64-apple-darwin22.1.0"
-private let destinationTriple = "x86_64-unknown-linux-gnu"
+private let targetTriple = "x86_64-unknown-linux-gnu"
 private let extraFlags = BuildFlags(
     cCompilerFlags: ["-fintegrated-as"],
     cxxCompilerFlags: ["-fno-exceptions"],
@@ -34,7 +34,7 @@ private let destinationV1JSON =
         "version": 1,
         "sdk": "\#(bundleRootPath.appending(sdkRootDir))",
         "toolchain-bin-dir": "\#(bundleRootPath.appending(toolchainBinDir))",
-        "target": "\#(destinationTriple)",
+        "target": "\#(targetTriple)",
         "extra-cc-flags": \#(extraFlags.cCompilerFlags),
         "extra-swiftc-flags": \#(extraFlags.swiftCompilerFlags),
         "extra-cpp-flags": \#(extraFlags.cxxCompilerFlags)
@@ -48,7 +48,7 @@ private let destinationV2JSON =
         "sdkRootDir": "\#(sdkRootDir)",
         "toolchainBinDir": "\#(toolchainBinDir)",
         "hostTriples": ["\#(hostTriple)"],
-        "destinationTriples": ["\#(destinationTriple)"],
+        "targetTriples": ["\#(targetTriple)"],
         "extraCCFlags": \#(extraFlags.cCompilerFlags),
         "extraSwiftCFlags": \#(extraFlags.swiftCompilerFlags),
         "extraCXXFlags": \#(extraFlags.cxxCompilerFlags),
@@ -74,7 +74,7 @@ final class DestinationTests: XCTestCase {
         XCTAssertEqual(
             destinationV1,
             Destination(
-                destinationTriple: try Triple(destinationTriple),
+                targetTriple: try Triple(targetTriple),
                 sdkRootDir: sdkRootAbsolutePath,
                 toolchainBinDir: toolchainBinAbsolutePath,
                 extraFlags: flagsWithoutLinkerFlags
@@ -87,7 +87,7 @@ final class DestinationTests: XCTestCase {
             destinationV2,
             Destination(
                 hostTriple: try Triple(hostTriple),
-                destinationTriple: try Triple(destinationTriple),
+                targetTriple: try Triple(targetTriple),
                 sdkRootDir: sdkRootAbsolutePath,
                 toolchainBinDir: toolchainBinAbsolutePath,
                 extraFlags: extraFlags

--- a/Tests/PackageModelTests/PackageModelTests.swift
+++ b/Tests/PackageModelTests/PackageModelTests.swift
@@ -61,7 +61,7 @@ class PackageModelTests: XCTestCase {
         let toolchainPath = AbsolutePath(path: "/some/path/to/a/toolchain.xctoolchain")
 
         let destination = Destination(
-            destinationTriple: triple,
+            targetTriple: triple,
             sdkRootDir: sdkDir,
             toolchainBinDir: toolchainPath.appending(components: "usr", "bin")
         )


### PR DESCRIPTION
### Motivation:

"Cross-compilation SDK" is a bit of a mouthful to say, and we've previously denoted this as a "destination". After some consideration, I think calling "cross-compilation SDKs" as "destinations" simplifies a lot of things. Additionally, "target triple" and "target platform" are terms of art after all. Renaming them to "destination triple" and "destination platform" arguably was a mistake. Since we had no tagged releases in the meantime, let's clean up the naming before it's too late.

### Modifications:

`--experimental-cross-compilation-sdks-path` is renamed to `--experimental-destinations-path`, `sharedCCSDKDirectory` to `sharedDestinationsDirectory`. `destinationTriple` is renamed to `targetTriple`.

### Result:

More clear, widely consistent naming. 
