### PR TITLE
Fix preconcurrency-related warnings

### DIFF
--- a/Examples/package-info/Sources/package-info/example.swift
+++ b/Examples/package-info/Sources/package-info/example.swift
@@ -1,10 +1,9 @@
 #if swift(>=5.7)
 @preconcurrency import Basics
-@preconcurrency import TSCBasic
 #else
 import Basics
-import TSCBasic
 #endif
+import TSCBasic
 import Workspace
 
 @main

--- a/Tests/BasicsTests/TemporaryFileTests.swift
+++ b/Tests/BasicsTests/TemporaryFileTests.swift
@@ -9,11 +9,7 @@
  */
 
 import XCTest
-#if swift(>=5.7)
-@preconcurrency import TSCBasic
-#else
 import TSCBasic
-#endif
 
 import Basics
 


### PR DESCRIPTION
Since we merged https://github.com/apple/swift-tools-support-core/pull/367
