### PR TITLE
refactor RelativePath to allow late stage canonicalization in support of windows

### DIFF
--- a/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
@@ -325,7 +325,7 @@ public final class ClangTargetBuildDescription {
         }
         """
 
-        let implFileSubpath = RelativePath("resource_bundle_accessor.m")
+        let implFileSubpath = try RelativePath(validating: "resource_bundle_accessor.m")
 
         // Add the file to the derived sources.
         derivedSources.relativePaths.append(implFileSubpath)

--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -137,12 +137,12 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
         let librarian = self.buildParameters.toolchain.librarianPath.pathString
         let triple = self.buildParameters.triple
         if triple.isWindows(), librarian.hasSuffix("link") || librarian.hasSuffix("link.exe") {
-            return [librarian, "/LIB", "/OUT:\(binaryPath.pathString)", "@\(self.linkFileListPath.pathString)"]
+            return try [librarian, "/LIB", "/OUT:\(binaryPath.pathString)", "@\(self.linkFileListPath.pathString)"]
         }
         if triple.isDarwin(), librarian.hasSuffix("libtool") {
-            return [librarian, "-static", "-o", binaryPath.pathString, "@\(self.linkFileListPath.pathString)"]
+            return try [librarian, "-static", "-o", binaryPath.pathString, "@\(self.linkFileListPath.pathString)"]
         }
-        return [librarian, "crs", binaryPath.pathString, "@\(self.linkFileListPath.pathString)"]
+        return try [librarian, "crs", binaryPath.pathString, "@\(self.linkFileListPath.pathString)"]
     }
 
     /// The arguments to link and create this product.
@@ -166,7 +166,7 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
         }
 
         args += ["-L", self.buildParameters.buildPath.pathString]
-        args += ["-o", binaryPath.pathString]
+        args += try ["-o", binaryPath.pathString]
         args += ["-module-name", self.product.name.spm_mangledToC99ExtendedIdentifier()]
         args += self.dylibs.map { "-l" + $0.product.name }
 
@@ -209,7 +209,7 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
         case .library(.dynamic):
             args += ["-emit-library"]
             if self.buildParameters.triple.isDarwin() {
-                let relativePath = "@rpath/\(buildParameters.binaryRelativePath(for: self.product).pathString)"
+                let relativePath = try "@rpath/\(buildParameters.binaryRelativePath(for: self.product).pathString)"
                 args += ["-Xlinker", "-install_name", "-Xlinker", relativePath]
             }
             args += self.deadStripArguments

--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -327,7 +327,7 @@ public final class SwiftTargetBuildDescription {
         }
         """
 
-        let subpath = RelativePath("embedded_resources.swift")
+        let subpath = try RelativePath(validating: "embedded_resources.swift")
         self.derivedSources.relativePaths.append(subpath)
         let path = self.derivedSources.root.appending(subpath)
         try self.fileSystem.writeIfChanged(path: path, bytes: stream.bytes)
@@ -374,7 +374,7 @@ public final class SwiftTargetBuildDescription {
         }
         """
 
-        let subpath = RelativePath("resource_bundle_accessor.swift")
+        let subpath = try RelativePath(validating: "resource_bundle_accessor.swift")
 
         // Add the file to the derived sources.
         self.derivedSources.relativePaths.append(subpath)
@@ -410,7 +410,7 @@ public final class SwiftTargetBuildDescription {
         #else
         try self.requiredMacroProducts.forEach { macro in
             if let macroTarget = macro.targets.first {
-                let executablePath = self.buildParameters.binaryPath(for: macro).pathString
+                let executablePath = try self.buildParameters.binaryPath(for: macro).pathString
                 args += ["-Xfrontend", "-load-plugin-executable", "-Xfrontend", "\(executablePath)#\(macroTarget.c99name)"]
             } else {
                 throw InternalError("macro product \(macro.name) has no targets") // earlier validation should normally catch this

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -422,7 +422,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
             ) { name, path in
                 try buildOperationForPluginDependencies.build(subset: .product(name))
                 if let builtTool = try buildOperationForPluginDependencies.buildPlan.buildProducts.first(where: { $0.product.name == name}) {
-                    return builtTool.binaryPath
+                    return try builtTool.binaryPath
                 } else {
                     return nil
                 }

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -357,8 +357,8 @@ public struct BuildDescription: Codable {
         )
         self.swiftTargetScanArgs = targetCommandLines
         self.generatedSourceTargetSet = Set(generatedSourceTargets)
-        self.builtTestProducts = plan.buildProducts.filter { $0.product.type == .test }.map { desc in
-            BuiltTestProduct(
+        self.builtTestProducts = try plan.buildProducts.filter { $0.product.type == .test }.map { desc in
+            try BuiltTestProduct(
                 productName: desc.product.name,
                 binaryPath: desc.binaryPath
             )

--- a/Sources/Build/LLBuildManifestBuilder.swift
+++ b/Sources/Build/LLBuildManifestBuilder.swift
@@ -171,18 +171,18 @@ extension LLBuildManifestBuilder {
     /// Returns the virtual node that will build the entire bundle.
     private func createResourcesBundle(
         for target: TargetBuildDescription
-    ) -> Node? {
+    ) throws -> Node? {
         guard let bundlePath = target.bundlePath else { return nil }
 
         var outputs: [Node] = []
 
-        let infoPlistDestination = try! RelativePath(validating: "Info.plist") // try! safe
+        let infoPlistDestination = try RelativePath(validating: "Info.plist")
 
         // Create a copy command for each resource file.
         for resource in target.resources {
             switch resource.rule {
             case .copy, .process:
-                let destination = bundlePath.appending(resource.destination)
+                let destination = try bundlePath.appending(resource.destination)
                 let (_, output) = addCopyCommand(from: resource.path, to: destination)
                 outputs.append(output)
             case .embedInCode:
@@ -604,7 +604,7 @@ extension LLBuildManifestBuilder {
         // don't need to block building of a module until its resources are assembled but
         // we don't currently have a good way to express that resources should be built
         // whenever a module is being built.
-        if let resourcesNode = createResourcesBundle(for: .swift(target)) {
+        if let resourcesNode = try createResourcesBundle(for: .swift(target)) {
             inputs.append(resourcesNode)
         }
 
@@ -798,7 +798,7 @@ extension LLBuildManifestBuilder {
         // don't need to block building of a module until its resources are assembled but
         // we don't currently have a good way to express that resources should be built
         // whenever a module is being built.
-        if let resourcesNode = createResourcesBundle(for: .clang(target)) {
+        if let resourcesNode = try createResourcesBundle(for: .clang(target)) {
             inputs.append(resourcesNode)
         }
 

--- a/Sources/Build/LLBuildManifestBuilder.swift
+++ b/Sources/Build/LLBuildManifestBuilder.swift
@@ -176,7 +176,7 @@ extension LLBuildManifestBuilder {
 
         var outputs: [Node] = []
 
-        let infoPlistDestination = RelativePath("Info.plist")
+        let infoPlistDestination = try! RelativePath(validating: "Info.plist") // try! safe
 
         // Create a copy command for each resource file.
         for resource in target.resources {
@@ -626,7 +626,7 @@ extension LLBuildManifestBuilder {
                     guard let planProduct = plan.productMap[product] else {
                         throw InternalError("unknown product \(product)")
                     }
-                    inputs.append(file: planProduct.binaryPath)
+                    try inputs.append(file: planProduct.binaryPath)
                 }
                 return
             }
@@ -655,7 +655,7 @@ extension LLBuildManifestBuilder {
                         throw InternalError("unknown product \(product)")
                     }
                     // Establish a dependency on binary of the product.
-                    inputs.append(file: planProduct.binaryPath)
+                    try inputs.append(file: planProduct.binaryPath)
 
                 // For automatic and static libraries, and plugins, add their targets as static input.
                 case .library(.automatic), .library(.static), .plugin:
@@ -820,7 +820,7 @@ extension LLBuildManifestBuilder {
                         throw InternalError("unknown product \(product)")
                     }
                     // Establish a dependency on binary of the product.
-                    let binary = planProduct.binaryPath
+                    let binary = try planProduct.binaryPath
                     inputs.append(file: binary)
 
                 case .library(.automatic), .library(.static), .plugin:
@@ -973,7 +973,7 @@ extension LLBuildManifestBuilder {
 
         switch buildProduct.product.type {
         case .library(.static):
-            self.manifest.addShellCmd(
+            try self.manifest.addShellCmd(
                 name: cmdName,
                 description: "Archiving \(buildProduct.binaryPath.prettyPath())",
                 inputs: buildProduct.objects.map(Node.file),
@@ -982,9 +982,9 @@ extension LLBuildManifestBuilder {
             )
 
         default:
-            let inputs = buildProduct.objects + buildProduct.dylibs.map(\.binaryPath)
+            let inputs = try buildProduct.objects + buildProduct.dylibs.map{ try $0.binaryPath }
 
-            self.manifest.addShellCmd(
+            try self.manifest.addShellCmd(
                 name: cmdName,
                 description: "Linking \(buildProduct.binaryPath.prettyPath())",
                 inputs: inputs.map(Node.file),
@@ -998,7 +998,7 @@ extension LLBuildManifestBuilder {
         let output: Node = .virtual(targetName)
 
         self.manifest.addNode(output, toTarget: targetName)
-        self.manifest.addPhonyCmd(
+        try self.manifest.addPhonyCmd(
             name: output.name,
             inputs: [.file(buildProduct.binaryPath)],
             outputs: [output]

--- a/Sources/Commands/PackageTools/PluginCommand.swift
+++ b/Sources/Commands/PackageTools/PluginCommand.swift
@@ -259,7 +259,7 @@ struct PluginCommand: SwiftCommand {
             // Build the product referenced by the tool, and add the executable to the tool map. Product dependencies are not supported within a package, so if the tool happens to be from the same package, we instead find the executable that corresponds to the product. There is always one, because of autogeneration of implicit executables with the same name as the target if there isn't an explicit one.
             try buildSystem.build(subset: .product(name))
             if let builtTool = try buildSystem.buildPlan.buildProducts.first(where: { $0.product.name == name }) {
-                return builtTool.binaryPath
+                return try builtTool.binaryPath
             } else {
                 return nil
             }

--- a/Sources/Commands/SwiftRunTool.swift
+++ b/Sources/Commands/SwiftRunTool.swift
@@ -175,7 +175,7 @@ public struct SwiftRunTool: SwiftCommand {
 
         case .run:
             // Detect deprecated uses of swift run to interpret scripts.
-            if let executable = options.executable, isValidSwiftFilePath(fileSystem: swiftTool.fileSystem, path: executable) {
+            if let executable = options.executable, try isValidSwiftFilePath(fileSystem: swiftTool.fileSystem, path: executable) {
                 swiftTool.observabilityScope.emit(.runFileDeprecation)
                 // Redirect execution to the toolchain's swift executable.
                 let swiftInterpreterPath = try swiftTool.getDestinationToolchain().swiftInterpreterPath
@@ -262,7 +262,7 @@ public struct SwiftRunTool: SwiftCommand {
     }
 
     /// Determines if a path points to a valid swift file.
-    private func isValidSwiftFilePath(fileSystem: FileSystem, path: String) -> Bool {
+    private func isValidSwiftFilePath(fileSystem: FileSystem, path: String) throws -> Bool {
         guard path.hasSuffix(".swift") else { return false }
         //FIXME: Return false when the path is not a valid path string.
         let absolutePath: AbsolutePath
@@ -276,7 +276,7 @@ public struct SwiftRunTool: SwiftCommand {
             guard let cwd = fileSystem.currentWorkingDirectory else {
                 return false
             }
-            absolutePath = AbsolutePath(cwd, path)
+            absolutePath = try AbsolutePath(cwd, validating: path)
         }
         return fileSystem.isFile(absolutePath)
     }

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -129,15 +129,15 @@ final class PluginDelegate: PluginInvocationDelegate {
                 return $0.product.name == name
             }
         }
-        let builtArtifacts: [PluginInvocationBuildResult.BuiltArtifact] = builtProducts.compactMap {
+        let builtArtifacts: [PluginInvocationBuildResult.BuiltArtifact] = try builtProducts.compactMap {
             switch $0.product.type {
             case .library(let kind):
-                return .init(
+                return try .init(
                     path: $0.binaryPath.pathString,
                     kind: (kind == .dynamic) ? .dynamicLibrary : .staticLibrary
                 )
             case .executable:
-                return .init(path: $0.binaryPath.pathString, kind: .executable)
+                return try .init(path: $0.binaryPath.pathString, kind: .executable)
             default:
                 return nil
             }

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -348,7 +348,7 @@ public struct TargetSourcesBuilder {
 
     private func diagnoseInfoPlistConflicts(in resources: [Resource]) {
         for resource in resources {
-            if resource.destination == RelativePath("Info.plist") {
+            if try! resource.destination == RelativePath(validating: "Info.plist") /* try! safe */ {
                 self.observabilityScope.emit(.infoPlistResourceConflict(
                     path: resource.path.relative(to: targetPath),
                     targetName: target.name))

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -174,10 +174,10 @@ public struct TargetSourcesBuilder {
         let ignored = pathToRule.filter { $0.value == .ignored }.map { $0.key }
         let others = pathToRule.filter { $0.value == .none }.map { $0.key }
 
-        diagnoseConflictingResources(in: resources)
+        try diagnoseConflictingResources(in: resources)
         diagnoseCopyConflictsWithLocalizationDirectories(in: resources)
         diagnoseLocalizedAndUnlocalizedVariants(in: resources)
-        diagnoseInfoPlistConflicts(in: resources)
+        try diagnoseInfoPlistConflicts(in: resources)
         diagnoseInvalidResource(in: target.resources)
 
         // It's an error to contain mixed language source files.
@@ -309,10 +309,10 @@ public struct TargetSourcesBuilder {
         return Self.resource(for: path, with: rule, defaultLocalization: defaultLocalization, targetName: target.name, targetPath: targetPath, observabilityScope: observabilityScope)
     }
 
-    private func diagnoseConflictingResources(in resources: [Resource]) {
-        let duplicateResources = resources.spm_findDuplicateElements(by: \.destination)
+    private func diagnoseConflictingResources(in resources: [Resource]) throws {
+        let duplicateResources = resources.spm_findDuplicateElements(by: \.destinationForGrouping)
         for resources in duplicateResources {
-            self.observabilityScope.emit(.conflictingResource(path: resources[0].destination, targetName: target.name))
+            try self.observabilityScope.emit(.conflictingResource(path: resources[0].destination, targetName: target.name))
 
             for resource in resources {
                 let relativePath = resource.path.relative(to: targetPath)
@@ -346,9 +346,9 @@ public struct TargetSourcesBuilder {
         }
     }
 
-    private func diagnoseInfoPlistConflicts(in resources: [Resource]) {
+    private func diagnoseInfoPlistConflicts(in resources: [Resource]) throws {
         for resource in resources {
-            if try! resource.destination == RelativePath(validating: "Info.plist") /* try! safe */ {
+            if try resource.destination == RelativePath(validating: "Info.plist") {
                 self.observabilityScope.emit(.infoPlistResourceConflict(
                     path: resource.path.relative(to: targetPath),
                     targetName: target.name))
@@ -767,6 +767,16 @@ extension PackageReference.Kind {
             return false
         default:
             return true
+        }
+    }
+}
+
+extension PackageModel.Resource {
+    fileprivate var destinationForGrouping: RelativePath? {
+        do {
+            return try self.destination
+        } catch {
+            return .none
         }
     }
 }

--- a/Sources/PackageModel/Resource.swift
+++ b/Sources/PackageModel/Resource.swift
@@ -24,11 +24,13 @@ public struct Resource: Codable, Equatable {
 
     /// The relative location of the resource in the resource bundle.
     public var destination: RelativePath {
-        switch self.rule {
-        case .process(.some(let localization)):
-            return try! RelativePath(validating: "\(localization).\(Self.localizationDirectoryExtension)/\(path.basename)") // try! safe
-        default:
-            return try! RelativePath(validating: path.basename) // try! safe
+        get throws {
+            switch self.rule {
+            case .process(.some(let localization)):
+                return try RelativePath(validating: "\(localization).\(Self.localizationDirectoryExtension)/\(path.basename)")
+            default:
+                return try RelativePath(validating: path.basename)
+            }
         }
     }
 

--- a/Sources/PackageModel/Resource.swift
+++ b/Sources/PackageModel/Resource.swift
@@ -26,9 +26,9 @@ public struct Resource: Codable, Equatable {
     public var destination: RelativePath {
         switch self.rule {
         case .process(.some(let localization)):
-            return RelativePath("\(localization).\(Self.localizationDirectoryExtension)/\(path.basename)")
+            return try! RelativePath(validating: "\(localization).\(Self.localizationDirectoryExtension)/\(path.basename)") // try! safe
         default:
-            return RelativePath(path.basename)
+            return try! RelativePath(validating: path.basename) // try! safe
         }
     }
 

--- a/Sources/PackageModel/ToolsVersion.swift
+++ b/Sources/PackageModel/ToolsVersion.swift
@@ -142,9 +142,9 @@ public struct ToolsVersion: Equatable, Hashable, Codable, Sendable {
     /// The subpath to the PackageDescription runtime library.
     public var runtimeSubpath: RelativePath {
         if self < .v4_2 {
-            return RelativePath("4")
+            return try! RelativePath(validating: "4") // try! safe
         }
-        return RelativePath("4_2")
+        return try! RelativePath(validating: "4_2") // try! safe
     }
 
     /// The swift language version based on this tools version.

--- a/Sources/PackageModel/Toolset.swift
+++ b/Sources/PackageModel/Toolset.swift
@@ -102,7 +102,7 @@ extension Toolset {
                     toolPath = absolutePath
                 } else {
                     let rootPath = rootPaths.first ?? toolsetPath.parentDirectory
-                    toolPath = rootPath.appending(RelativePath(path))
+                    toolPath = rootPath.appending(path)
                 }
             } else {
                 toolPath = nil

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -68,8 +68,8 @@ public final class UserToolchain: Toolchain {
         // bootstrap script.
         let swiftCompiler = try resolveSymlinks(self.swiftCompilerPath)
 
-        let runtime = swiftCompiler.appending(
-            RelativePath("../../lib/swift/clang/lib/darwin/libclang_rt.\(sanitizer.shortName)_osx_dynamic.dylib")
+        let runtime = try swiftCompiler.appending(
+            RelativePath(validating: "../../lib/swift/clang/lib/darwin/libclang_rt.\(sanitizer.shortName)_osx_dynamic.dylib")
         )
 
         // Ensure that the runtime is present.

--- a/Sources/PackageRegistry/RegistryDownloadsManager.swift
+++ b/Sources/PackageRegistry/RegistryDownloadsManager.swift
@@ -325,7 +325,7 @@ extension PackageIdentity {
         guard let registryIdentity = self.registry else {
             throw StringError("invalid package identifier \(self), expected registry scope and name")
         }
-        return RelativePath(registryIdentity.scope.description).appending(component: registryIdentity.name.description)
+        return try RelativePath(validating: registryIdentity.scope.description).appending(component: registryIdentity.name.description)
     }
 
     internal func downloadPath(version: Version) throws -> RelativePath {

--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -387,34 +387,34 @@ public struct BuildParameters: Encodable {
     }
 
     /// Returns the path to the binary of a product for the current build parameters.
-    public func binaryPath(for product: ResolvedProduct) -> AbsolutePath {
-        return buildPath.appending(binaryRelativePath(for: product))
+    public func binaryPath(for product: ResolvedProduct) throws -> AbsolutePath {
+        return try buildPath.appending(binaryRelativePath(for: product))
     }
 
     /// Returns the path to the binary of a product for the current build parameters, relative to the build directory.
-    public func binaryRelativePath(for product: ResolvedProduct) -> RelativePath {
-        let potentialExecutablePath = RelativePath("\(product.name)\(triple.executableExtension)")
-        let potentialLibraryPath = RelativePath("\(triple.dynamicLibraryPrefix)\(product.name)\(triple.dynamicLibraryExtension)")
+    public func binaryRelativePath(for product: ResolvedProduct) throws -> RelativePath {
+        let potentialExecutablePath = try RelativePath(validating: "\(product.name)\(triple.executableExtension)")
+        let potentialLibraryPath = try RelativePath(validating: "\(triple.dynamicLibraryPrefix)\(product.name)\(triple.dynamicLibraryExtension)")
 
         switch product.type {
         case .executable, .snippet:
             return potentialExecutablePath
         case .library(.static):
-            return RelativePath("lib\(product.name)\(triple.staticLibraryExtension)")
+            return try RelativePath(validating: "lib\(product.name)\(triple.staticLibraryExtension)")
         case .library(.dynamic):
             return potentialLibraryPath
         case .library(.automatic), .plugin:
             fatalError()
         case .test:
             guard !triple.isWASI() else {
-                return RelativePath("\(product.name).wasm")
+                return try RelativePath(validating: "\(product.name).wasm")
             }
 
             let base = "\(product.name).xctest"
             if triple.isDarwin() {
-                return RelativePath("\(base)/Contents/MacOS/\(product.name)")
+                return try RelativePath(validating: "\(base)/Contents/MacOS/\(product.name)")
             } else {
-                return RelativePath(base)
+                return try RelativePath(validating: base)
             }
         case .macro:
             #if BUILD_MACROS_AS_DYLIBS

--- a/Sources/SPMBuildCore/BuildSystem.swift
+++ b/Sources/SPMBuildCore/BuildSystem.swift
@@ -74,7 +74,9 @@ public protocol ProductBuildDescription {
 extension ProductBuildDescription {
     /// The path to the product binary produced.
     public var binaryPath: AbsolutePath {
-        return buildParameters.binaryPath(for: product)
+        get throws {
+            return try buildParameters.binaryPath(for: product)
+        }
     }
 }
 

--- a/Sources/SPMBuildCore/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/PluginInvocation.swift
@@ -547,7 +547,7 @@ public extension PluginTarget {
             }
             // For an executable target we create a `builtTool`.
             else if executableOrBinaryTarget.type == .executable {
-                return [.builtTool(name: builtToolName, path: RelativePath(executableOrBinaryTarget.name))]
+                return try [.builtTool(name: builtToolName, path: RelativePath(validating: executableOrBinaryTarget.name))]
             }
             else {
                 return []

--- a/Sources/SPMTestSupport/MockDependency.swift
+++ b/Sources/SPMTestSupport/MockDependency.swift
@@ -122,11 +122,11 @@ public struct MockDependency {
     }
 
     public static func fileSystem(path: String, products: ProductFilter = .everything) -> MockDependency {
-        MockDependency(location: .fileSystem(path: RelativePath(path)), products: products)
+        try! MockDependency(location: .fileSystem(path: RelativePath(validating: path)), products: products)
     }
 
     public static func sourceControl(path: String, requirement: SourceControlRequirement, products: ProductFilter = .everything) -> MockDependency {
-        .sourceControl(path: RelativePath(path), requirement: requirement, products: products)
+        try! .sourceControl(path: RelativePath(validating: path), requirement: requirement, products: products)
     }
 
     public static func sourceControl(path: RelativePath, requirement: SourceControlRequirement, products: ProductFilter = .everything) -> MockDependency {
@@ -134,7 +134,7 @@ public struct MockDependency {
     }
 
     public static func sourceControlWithDeprecatedName(name: String, path: String, requirement: SourceControlRequirement, products: ProductFilter = .everything) -> MockDependency {
-        MockDependency(deprecatedName: name, location: .localSourceControl(path: RelativePath(path), requirement: requirement), products: products)
+        try! MockDependency(deprecatedName: name, location: .localSourceControl(path: RelativePath(validating: path), requirement: requirement), products: products)
     }
 
     public static func sourceControl(url: String, requirement: SourceControlRequirement, products: ProductFilter = .everything) -> MockDependency {

--- a/Sources/SPMTestSupport/MockPackage.swift
+++ b/Sources/SPMTestSupport/MockPackage.swift
@@ -38,9 +38,10 @@ public struct MockPackage {
         revisionProvider: ((String) -> String)? = nil,
         toolsVersion: ToolsVersion? = nil
     ) {
+        let path = try! RelativePath(validating: path ?? name)
         self.name = name
         self.platforms = platforms
-        self.location = .fileSystem(path: RelativePath(path ?? name))
+        self.location = .fileSystem(path: path)
         self.targets = targets
         self.products = products
         self.dependencies = dependencies

--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -43,7 +43,7 @@ public func fixture(
 ) throws {
     do {
         // Make a suitable test directory name from the fixture subpath.
-        let fixtureSubpath = RelativePath(name)
+        let fixtureSubpath = try RelativePath(validating: name)
         let copyName = fixtureSubpath.components.joined(separator: "_")
 
         // Create a temporary directory for the duration of the block.
@@ -57,7 +57,7 @@ public func fixture(
 
             // Construct the expected path of the fixture.
             // FIXME: This seems quite hacky; we should provide some control over where fixtures are found.
-            let fixtureDir = AbsolutePath("../../../Fixtures", relativeTo: AbsolutePath(path: #file))
+            let fixtureDir = AbsolutePath("../../../Fixtures", relativeTo: #file)
                 .appending(fixtureSubpath)
 
             // Check that the fixture is really there.
@@ -269,36 +269,6 @@ public func loadPackageGraph(
 }
 
 public let emptyZipFile = ByteString([0x80, 0x75, 0x05, 0x06] + [UInt8](repeating: 0x00, count: 18))
-
-extension AbsolutePath: ExpressibleByStringLiteral {
-    public init(_ value: StringLiteralType) {
-        try! self.init(validating: value)
-    }
-}
-
-extension AbsolutePath: ExpressibleByStringInterpolation {
-    public init(stringLiteral value: String) {
-        try! self.init(validating: value)
-    }
-}
-
-extension AbsolutePath {
-    public init(_ path: StringLiteralType, relativeTo basePath: AbsolutePath) {
-        try! self.init(validating: path, relativeTo: basePath)
-    }
-}
-
-extension RelativePath: ExpressibleByStringLiteral {
-    public init(_ value: StringLiteralType) {
-        try! self.init(validating: value)
-    }
-}
-
-extension RelativePath: ExpressibleByStringInterpolation {
-    public init(stringLiteral value: String) {
-        try! self.init(validating: value)
-    }
-}
 
 extension URL: ExpressibleByStringLiteral {
     public init(_ value: StringLiteralType) {

--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -192,7 +192,7 @@ public class RepositoryManager: Cancellable {
         observabilityScope: ObservabilityScope,
         delegateQueue: DispatchQueue
     ) throws -> RepositoryHandle {
-        let relativePath = repository.storagePath()
+        let relativePath = try repository.storagePath()
         let repositoryPath = self.path.appending(relativePath)
         let handle = RepositoryHandle(manager: self, repository: repository, subpath: relativePath)
 
@@ -303,7 +303,7 @@ public class RepositoryManager: Cancellable {
         let shouldCacheLocalPackages = ProcessEnv.vars["SWIFTPM_TESTS_PACKAGECACHE"] == "1" || cacheLocalPackages
 
         if let cachePath, !(handle.repository.isLocal && !shouldCacheLocalPackages) {
-            let cachedRepositoryPath = cachePath.appending(handle.repository.storagePath())
+            let cachedRepositoryPath = try cachePath.appending(handle.repository.storagePath())
             do {
                 try self.initializeCacheIfNeeded(cachePath: cachePath)
                 try self.fileSystem.withLock(on: cachePath, type: .shared) {
@@ -385,7 +385,7 @@ public class RepositoryManager: Cancellable {
 
     /// Removes the repository.
     public func remove(repository: RepositorySpecifier) throws {
-        let relativePath = repository.storagePath()
+        let relativePath = try repository.storagePath()
         let repositoryPath = self.path.appending(relativePath)
         try self.fileSystem.removeFileTree(repositoryPath)
     }
@@ -524,8 +524,8 @@ extension RepositoryManager.RepositoryHandle: CustomStringConvertible {
 
 extension RepositorySpecifier {
     // relative path where the repository should be stored
-    internal func storagePath() -> RelativePath {
-        return RelativePath(self.fileSystemIdentifier)
+    internal func storagePath() throws -> RelativePath {
+        return try RelativePath(validating: self.fileSystemIdentifier)
     }
 
     /// A unique identifier for this specifier.

--- a/Sources/Workspace/ManagedDependency.swift
+++ b/Sources/Workspace/ManagedDependency.swift
@@ -102,11 +102,11 @@ extension Workspace {
         ) throws -> ManagedDependency {
             switch packageRef.kind {
             case .root(let path), .fileSystem(let path), .localSourceControl(let path):
-                return ManagedDependency(
+                return try ManagedDependency(
                     packageRef: packageRef,
                     state: .fileSystem(path),
                     // FIXME: This is just a fake entry, we should fix it.
-                    subpath: RelativePath(packageRef.identity.description)
+                    subpath: RelativePath(validating: packageRef.identity.description)
                 )
             default:
                 throw InternalError("invalid package type: \(packageRef.kind)")

--- a/Sources/Workspace/Workspace+State.swift
+++ b/Sources/Workspace/Workspace+State.swift
@@ -452,7 +452,7 @@ extension Workspace.ManagedDependency {
         try self.init(
             packageRef: .init(dependency.packageRef),
             state: dependency.state.underlying,
-            subpath: RelativePath(dependency.subpath)
+            subpath: try RelativePath(validating: dependency.subpath)
         )
     }
 }
@@ -771,7 +771,7 @@ extension Workspace.ManagedDependency {
         try self.init(
             packageRef: .init(dependency.packageRef),
             state: dependency.state.underlying,
-            subpath: RelativePath(dependency.subpath)
+            subpath: RelativePath(validating: dependency.subpath)
         )
     }
 }
@@ -1011,7 +1011,7 @@ extension Workspace.ManagedDependency {
         try self.init(
             packageRef: .init(dependency.packageRef),
             state: dependency.state.underlying,
-            subpath: RelativePath(dependency.subpath)
+            subpath: RelativePath(validating: dependency.subpath)
         )
     }
 }

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -2744,7 +2744,7 @@ extension Workspace {
                 return try self.downloadRegistryArchive(package: package, at: version, observabilityScope: observabilityScope)
             } else if let customContainer = container as? CustomPackageContainer {
                 let path = try customContainer.retrieve(at: version, observabilityScope: observabilityScope)
-                let dependency = ManagedDependency(packageRef: package, state: .custom(version: version, path: path), subpath: RelativePath(""))
+                let dependency = try ManagedDependency(packageRef: package, state: .custom(version: version, path: path), subpath: RelativePath(validating: ""))
                 self.state.dependencies.add(dependency)
                 try self.state.save()
                 return path

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1545,7 +1545,7 @@ extension Workspace {
 
         // Save the new state.
         self.state.dependencies.add(
-            try dependency.edited(subpath: RelativePath(packageName), unmanagedPath: path)
+            try dependency.edited(subpath: RelativePath(validating: packageName), unmanagedPath: path)
         )
         try self.state.save()
     }

--- a/Tests/BasicsTests/Archiver/TarArchiverTests.swift
+++ b/Tests/BasicsTests/Archiver/TarArchiverTests.swift
@@ -20,7 +20,7 @@ final class TarArchiverTests: XCTestCase {
     func testSuccess() throws {
         try testWithTemporaryDirectory { tmpdir in
             let archiver = TarArchiver(fileSystem: localFileSystem)
-            let inputArchivePath = AbsolutePath(path: #file).parentDirectory
+            let inputArchivePath = AbsolutePath(#file).parentDirectory
                 .appending(components: "Inputs", "archive.tar.gz")
             try archiver.extract(from: inputArchivePath, to: tmpdir)
             let content = tmpdir.appending("file")
@@ -59,7 +59,7 @@ final class TarArchiverTests: XCTestCase {
     func testInvalidArchive() throws {
         try testWithTemporaryDirectory { tmpdir in
             let archiver = TarArchiver(fileSystem: localFileSystem)
-            let inputArchivePath = AbsolutePath(path: #file).parentDirectory
+            let inputArchivePath = AbsolutePath(#file).parentDirectory
                 .appending(components: "Inputs", "invalid_archive.tar.gz")
             XCTAssertThrowsError(try archiver.extract(from: inputArchivePath, to: tmpdir)) { error in
                 #if os(Linux)
@@ -75,14 +75,14 @@ final class TarArchiverTests: XCTestCase {
         // valid
         try testWithTemporaryDirectory { _ in
             let archiver = TarArchiver(fileSystem: localFileSystem)
-            let path = AbsolutePath(path: #file).parentDirectory
+            let path = AbsolutePath(#file).parentDirectory
                 .appending(components: "Inputs", "archive.tar.gz")
             XCTAssertTrue(try archiver.validate(path: path))
         }
         // invalid
         try testWithTemporaryDirectory { _ in
             let archiver = TarArchiver(fileSystem: localFileSystem)
-            let path = AbsolutePath(path: #file).parentDirectory
+            let path = AbsolutePath(#file).parentDirectory
                 .appending(components: "Inputs", "invalid_archive.tar.gz")
             XCTAssertFalse(try archiver.validate(path: path))
         }

--- a/Tests/BasicsTests/Archiver/UniversalArchiverTests.swift
+++ b/Tests/BasicsTests/Archiver/UniversalArchiverTests.swift
@@ -20,7 +20,7 @@ final class UniversalArchiverTests: XCTestCase {
     func testSuccess() throws {
         try testWithTemporaryDirectory { tmpdir in
             let archiver = UniversalArchiver(localFileSystem)
-            let inputArchivePath = AbsolutePath(path: #file).parentDirectory
+            let inputArchivePath = AbsolutePath(#file).parentDirectory
                 .appending(components: "Inputs", "archive.tar.gz")
             let tarDestination = tmpdir.appending("tar")
             try localFileSystem.createDirectory(tarDestination)
@@ -68,7 +68,7 @@ final class UniversalArchiverTests: XCTestCase {
     func testInvalidArchive() throws {
         try testWithTemporaryDirectory { tmpdir in
             let archiver = UniversalArchiver(localFileSystem)
-            var inputArchivePath = AbsolutePath(path: #file).parentDirectory
+            var inputArchivePath = AbsolutePath(#file).parentDirectory
                 .appending(components: "Inputs", "invalid_archive.tar.gz")
             XCTAssertThrowsError(try archiver.extract(from: inputArchivePath, to: tmpdir)) { error in
                 #if os(Linux)
@@ -78,7 +78,7 @@ final class UniversalArchiverTests: XCTestCase {
                 #endif
             }
 
-            inputArchivePath = AbsolutePath(path: #file).parentDirectory
+            inputArchivePath = AbsolutePath(#file).parentDirectory
                 .appending(components: "Inputs", "invalid_archive.zip")
             XCTAssertThrowsError(try archiver.extract(from: inputArchivePath, to: tmpdir)) { error in
 #if os(Windows)
@@ -94,14 +94,14 @@ final class UniversalArchiverTests: XCTestCase {
         // valid
         try testWithTemporaryDirectory { _ in
             let archiver = UniversalArchiver(localFileSystem)
-            let path = AbsolutePath(path: #file).parentDirectory
+            let path = AbsolutePath(#file).parentDirectory
                 .appending(components: "Inputs", "archive.tar.gz")
             XCTAssertTrue(try archiver.validate(path: path))
         }
         // invalid
         try testWithTemporaryDirectory { _ in
             let archiver = UniversalArchiver(localFileSystem)
-            let path = AbsolutePath(path: #file).parentDirectory
+            let path = AbsolutePath(#file).parentDirectory
                 .appending(components: "Inputs", "invalid_archive.tar.gz")
             XCTAssertFalse(try archiver.validate(path: path))
         }

--- a/Tests/BasicsTests/Archiver/ZipArchiverTests.swift
+++ b/Tests/BasicsTests/Archiver/ZipArchiverTests.swift
@@ -20,7 +20,7 @@ class ZipArchiverTests: XCTestCase {
     func testZipArchiverSuccess() throws {
         try testWithTemporaryDirectory { tmpdir in
             let archiver = ZipArchiver(fileSystem: localFileSystem)
-            let inputArchivePath = AbsolutePath(path: #file).parentDirectory.appending(components: "Inputs", "archive.zip")
+            let inputArchivePath = AbsolutePath(#file).parentDirectory.appending(components: "Inputs", "archive.zip")
             try archiver.extract(from: inputArchivePath, to: tmpdir)
             let content = tmpdir.appending("file")
             XCTAssert(localFileSystem.exists(content))
@@ -58,7 +58,7 @@ class ZipArchiverTests: XCTestCase {
     func testZipArchiverInvalidArchive() throws {
         try testWithTemporaryDirectory { tmpdir in
             let archiver = ZipArchiver(fileSystem: localFileSystem)
-            let inputArchivePath = AbsolutePath(path: #file).parentDirectory
+            let inputArchivePath = AbsolutePath(#file).parentDirectory
                 .appending(components: "Inputs", "invalid_archive.zip")
             XCTAssertThrowsError(try archiver.extract(from: inputArchivePath, to: tmpdir)) { error in
 #if os(Windows)
@@ -74,14 +74,14 @@ class ZipArchiverTests: XCTestCase {
         // valid
         try testWithTemporaryDirectory { tmpdir in
             let archiver = ZipArchiver(fileSystem: localFileSystem)
-            let path = AbsolutePath(path: #file).parentDirectory
+            let path = AbsolutePath(#file).parentDirectory
                 .appending(components: "Inputs", "archive.zip")
             XCTAssertTrue(try archiver.validate(path: path))
         }
         // invalid
         try testWithTemporaryDirectory { tmpdir in
             let archiver = ZipArchiver(fileSystem: localFileSystem)
-            let path = AbsolutePath(path: #file).parentDirectory
+            let path = AbsolutePath(#file).parentDirectory
                 .appending(components: "Inputs", "invalid_archive.zip")
             XCTAssertFalse(try archiver.validate(path: path))
         }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -25,7 +25,7 @@ import enum TSCUtility.Diagnostics
 @_implementationOnly import DriverSupport
 
 final class BuildPlanTests: XCTestCase {
-    let inputsDir = AbsolutePath(path: #file).parentDirectory.appending(components: "Inputs")
+    let inputsDir = AbsolutePath(#file).parentDirectory.appending(components: "Inputs")
     private let driverSupport = DriverSupport()
 
     /// The j argument.
@@ -45,7 +45,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     displayName: "fooPkg",
-                    path: .init(path: "/fooPkg"),
+                    path: "/fooPkg",
                     products: [
                         ProductDescription(name: "Logging", type: .library(.dynamic), targets: ["FooLogging"]),
                     ],
@@ -54,7 +54,7 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "barPkg",
-                    path: .init(path: "/barPkg"),
+                    path: "/barPkg",
                     products: [
                         ProductDescription(name: "Logging", type: .library(.static), targets: ["BarLogging"]),
                     ],
@@ -63,11 +63,11 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     displayName: "thisPkg",
-                    path: .init(path: "/thisPkg"),
+                    path: "/thisPkg",
                     toolsVersion: .v5_8,
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "2.0.0")),
+                        .localSourceControl(path: "/fooPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/barPkg", requirement: .upToNextMajor(from: "2.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe",
@@ -104,7 +104,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     displayName: "fooPkg",
-                    path: .init(path: "/fooPkg"),
+                    path: "/fooPkg",
                     products: [
                         ProductDescription(name: "Logging", type: .library(.dynamic), targets: ["FooLogging"]),
                     ],
@@ -113,7 +113,7 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "barPkg",
-                    path: .init(path: "/barPkg"),
+                    path: "/barPkg",
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["BarLogging"]),
                     ],
@@ -122,11 +122,11 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     displayName: "thisPkg",
-                    path: .init(path: "/thisPkg"),
+                    path: "/thisPkg",
                     toolsVersion: .v5_8,
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "2.0.0")),
+                        .localSourceControl(path: "/fooPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/barPkg", requirement: .upToNextMajor(from: "2.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe",
@@ -170,7 +170,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     displayName: "bazPkg",
-                    path: .init(path: "/bazPkg"),
+                    path: "/bazPkg",
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["BazLogging"]),
                     ],
@@ -179,7 +179,7 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "barPkg",
-                    path: .init(path: "/barPkg"),
+                    path: "/barPkg",
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["BarLogging"]),
                     ],
@@ -188,11 +188,11 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "fooPkg",
-                    path: .init(path: "/fooPkg"),
+                    path: "/fooPkg",
                     toolsVersion: .v5_8,
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/bazPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/barPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/bazPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["FooLogging"]),
@@ -209,7 +209,7 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "xPkg",
-                    path: .init(path: "/xPkg"),
+                    path: "/xPkg",
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["XUtils"]),
                     ],
@@ -218,7 +218,7 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "yPkg",
-                    path: .init(path: "/yPkg"),
+                    path: "/yPkg",
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["YUtils"]),
                     ],
@@ -227,12 +227,12 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     displayName: "thisPkg",
-                    path: .init(path: "/thisPkg"),
+                    path: "/thisPkg",
                     toolsVersion: .v5_8,
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/xPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/yPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/xPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/yPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/fooPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe",
@@ -280,7 +280,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     displayName: "bazPkg",
-                    path: .init(path: "/bazPkg"),
+                    path: "/bazPkg",
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["BazLogging"]),
                     ],
@@ -289,7 +289,7 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "barPkg",
-                    path: .init(path: "/barPkg"),
+                    path: "/barPkg",
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["BarLogging"]),
                     ],
@@ -298,11 +298,11 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "fooPkg",
-                    path: .init(path: "/fooPkg"),
+                    path: "/fooPkg",
                     toolsVersion: .v5_8,
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/bazPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/barPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/bazPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
@@ -319,9 +319,9 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     displayName: "thisPkg",
-                    path: .init(path: "/thisPkg"),
+                    path: "/thisPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/fooPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe",
@@ -360,10 +360,10 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     displayName: "fooPkg",
-                    path: .init(path: "/fooPkg"),
+                    path: "/fooPkg",
                     toolsVersion: .v5_8,
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/barPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["FooLogging"]),
@@ -377,7 +377,7 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "barPkg",
-                    path: .init(path: "/barPkg"),
+                    path: "/barPkg",
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["BarLogging"]),
                     ],
@@ -386,9 +386,9 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     displayName: "thisPkg",
-                    path: .init(path: "/thisPkg"),
+                    path: "/thisPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/fooPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe",
@@ -426,7 +426,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     displayName: "fooPkg",
-                    path: .init(path: "/fooPkg"),
+                    path: "/fooPkg",
                     toolsVersion: .v5_8,
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["FooLogging"]),
@@ -436,7 +436,7 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "barPkg",
-                    path: .init(path: "/barPkg"),
+                    path: "/barPkg",
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["BarLogging"]),
                     ],
@@ -445,10 +445,10 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     displayName: "thisPkg",
-                    path: .init(path: "/thisPkg"),
+                    path: "/thisPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "2.0.0")),
+                        .localSourceControl(path: "/fooPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/barPkg", requirement: .upToNextMajor(from: "2.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe",
@@ -485,7 +485,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     displayName: "fooPkg",
-                    path: .init(path: "/fooPkg"),
+                    path: "/fooPkg",
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["FooLogging"]),
                     ],
@@ -494,7 +494,7 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "barPkg",
-                    path: .init(path: "/barPkg"),
+                    path: "/barPkg",
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["BarLogging"]),
                     ],
@@ -503,11 +503,11 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     displayName: "thisPkg",
-                    path: .init(path: "/thisPkg"),
+                    path: "/thisPkg",
                     toolsVersion: .v5_8,
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "2.0.0")),
+                        .localSourceControl(path: "/fooPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/barPkg", requirement: .upToNextMajor(from: "2.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe",
@@ -615,7 +615,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Pkg",
-                    path: .init(path: "/Pkg"),
+                    path: "/Pkg",
                     targets: [
                         TargetDescription(name: "exe", dependencies: ["lib"]),
                         TargetDescription(name: "lib", dependencies: []),
@@ -805,8 +805,8 @@ final class BuildPlanTests: XCTestCase {
                     displayName: "Pkg",
                     path: try .init(validating: Pkg.pathString),
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/ExtPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/PlatformPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/ExtPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/PlatformPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe", dependencies: [
@@ -828,7 +828,7 @@ final class BuildPlanTests: XCTestCase {
                 ),
                 Manifest.createLocalSourceControlManifest(
                     displayName: "ExtPkg",
-                    path: .init(path: "/ExtPkg"),
+                    path: "/ExtPkg",
                     products: [
                         ProductDescription(name: "ExtLib", type: .library(.automatic), targets: ["ExtLib"]),
                     ],
@@ -838,7 +838,7 @@ final class BuildPlanTests: XCTestCase {
                 ),
                 Manifest.createLocalSourceControlManifest(
                     displayName: "PlatformPkg",
-                    path: .init(path: "/PlatformPkg"),
+                    path: "/PlatformPkg",
                     platforms: [PlatformDescription(name: "macos", version: "50.0")],
                     products: [
                         ProductDescription(name: "PlatformLib", type: .library(.automatic), targets: ["PlatformLib"]),
@@ -921,9 +921,9 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "A",
-                    path: .init(path: "/A"),
+                    path: "/A",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/B"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/B", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "ATarget", dependencies: ["BLibrary"]),
@@ -931,7 +931,7 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "B",
-                    path: .init(path: "/B"),
+                    path: "/B",
                     products: [
                         ProductDescription(name: "BLibrary", type: .library(.automatic), targets: ["BTarget"]),
                     ],
@@ -976,7 +976,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Pkg",
-                    path: .init(path: "/Pkg"),
+                    path: "/Pkg",
                     targets: [
                         TargetDescription(name: "exe", dependencies: []),
                     ]),
@@ -1052,7 +1052,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Pkg",
-                    path: .init(path: "/Pkg"),
+                    path: "/Pkg",
                     targets: [
                         TargetDescription(name: "exe", dependencies: []),
                     ]),
@@ -1286,9 +1286,9 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Pkg",
-                    path: .init(path: "/Pkg"),
+                    path: "/Pkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/ExtPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/ExtPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe", dependencies: [
@@ -1306,7 +1306,7 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createLocalSourceControlManifest(
                     displayName: "ExtPkg",
-                    path: .init(path: "/ExtPkg"),
+                    path: "/ExtPkg",
                     products: [
                         ProductDescription(name: "ExtPkg", type: .library(.automatic), targets: ["ExtLib"]),
                     ],
@@ -1562,7 +1562,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Pkg",
-                    path: .init(path: "/Pkg"),
+                    path: "/Pkg",
                     toolsVersion: .v5,
                     targets: [
                         TargetDescription(name: "exe", dependencies: ["lib"]),
@@ -1608,9 +1608,9 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Pkg",
-                    path: .init(path: "/Pkg"),
+                    path: "/Pkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Dep"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/Dep", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe", dependencies: ["swiftlib"]),
@@ -1619,7 +1619,7 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "Dep",
-                    path: .init(path: "/Dep"),
+                    path: "/Dep",
                     products: [
                         ProductDescription(name: "Dep", type: .library(.automatic), targets: ["Dep"]),
                     ],
@@ -1664,7 +1664,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Pkg",
-                    path: .init(path: "/Pkg"),
+                    path: "/Pkg",
                     targets: [
                         TargetDescription(name: "Foo", dependencies: []),
                         TargetDescription(name: "FooTests", dependencies: ["Foo"], type: .test),
@@ -1746,7 +1746,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Pkg",
-                    path: .init(path: "/Pkg"),
+                    path: "/Pkg",
                     platforms: [
                         PlatformDescription(name: "macos", version: "12.0"),
                     ],
@@ -1965,7 +1965,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Pkg",
-                    path: .init(path: "/Pkg"),
+                    path: "/Pkg",
                     toolsVersion: .v5_5,
                     targets: [
                         TargetDescription(name: "exe1", type: .executable),
@@ -2074,7 +2074,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Pkg",
-                    path: .init(path: "/Pkg"),
+                    path: "/Pkg",
                     dependencies: [
                         .localSourceControl(path: try .init(validating: Clibgit.pathString), requirement: .upToNextMajor(from: "1.0.0"))
                     ],
@@ -2083,7 +2083,7 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "Clibgit",
-                    path: .init(path: "/Clibgit")
+                    path: "/Clibgit"
                 ),
             ],
             observabilityScope: observability.topScope
@@ -2153,7 +2153,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Pkg",
-                    path: .init(path: "/Pkg"),
+                    path: "/Pkg",
                     targets: [
                         TargetDescription(name: "lib", dependencies: []),
                         TargetDescription(name: "exe", dependencies: ["lib"]),
@@ -2192,7 +2192,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     displayName: "Bar",
-                    path: .init(path: "/Bar"),
+                    path: "/Bar",
                     products: [
                         ProductDescription(name: "Bar-Baz", type: .library(.dynamic), targets: ["Bar"]),
                     ],
@@ -2201,9 +2201,9 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo"),
+                    path: "/Foo",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Bar-Baz"]),
@@ -2324,7 +2324,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Pkg",
-                    path: .init(path: "/Pkg"),
+                    path: "/Pkg",
                     products: [
                         ProductDescription(name: "lib", type: .library(.dynamic), targets: ["lib"]),
                     ],
@@ -2562,10 +2562,10 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "A",
-                    path: .init(path: "/A"),
+                    path: "/A",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/B"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/C"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/B", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/C", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "aexec", type: .executable, targets: ["ATarget"])
@@ -2575,7 +2575,7 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "B",
-                    path: .init(path: "/B"),
+                    path: "/B",
                     products: [
                         ProductDescription(name: "BLibrary", type: .library(.static), targets: ["BTarget1"]),
                         ProductDescription(name: "bexec", type: .executable, targets: ["BTarget2"]),
@@ -2586,7 +2586,7 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "C",
-                    path: .init(path: "/C"),
+                    path: "/C",
                     products: [
                         ProductDescription(name: "cexec", type: .executable, targets: ["CTarget"])
                     ],
@@ -2648,10 +2648,10 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "A",
-                    path: .init(path: "/A"),
+                    path: "/A",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/B"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/C"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/B", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/C", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "aexec", type: .executable, targets: ["ATarget"]),
@@ -2675,7 +2675,7 @@ final class BuildPlanTests: XCTestCase {
                 ),
                 Manifest.createLocalSourceControlManifest(
                     displayName: "B",
-                    path: .init(path: "/B"),
+                    path: "/B",
                     products: [
                         ProductDescription(name: "BLibrary1", type: .library(.static), targets: ["BTarget1"]),
                         ProductDescription(name: "BLibrary2", type: .library(.static), targets: ["BTarget2"]),
@@ -2693,7 +2693,7 @@ final class BuildPlanTests: XCTestCase {
                 ),
                 Manifest.createLocalSourceControlManifest(
                     displayName: "C",
-                    path: .init(path: "/C"),
+                    path: "/C",
                     products: [
                         ProductDescription(name: "CLibrary", type: .library(.static), targets: ["CTarget"])
                     ],
@@ -2765,7 +2765,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Pkg",
-                    path: .init(path: "/Pkg")
+                    path: "/Pkg"
                 )
             ],
             observabilityScope: observability.topScope
@@ -2794,7 +2794,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "A",
-                    path: .init(path: "/A"),
+                    path: "/A",
                     targets: [
                         TargetDescription(name: "ATarget", dependencies: ["BTarget"]),
                         TargetDescription(
@@ -2839,7 +2839,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "A",
-                    path: .init(path: "/A"),
+                    path: "/A",
                     targets: [
                         TargetDescription(name: "ATarget", dependencies: ["BTarget"]),
                         TargetDescription(
@@ -3005,7 +3005,7 @@ final class BuildPlanTests: XCTestCase {
             ]
         )
 
-        let executablePathExtension = appBuildDescription.binaryPath.extension
+        let executablePathExtension = try appBuildDescription.binaryPath.extension
         XCTAssertEqual(executablePathExtension, "wasm")
 
         let testBuildDescription = try result.buildProduct(for: "PkgPackageTests")
@@ -3022,7 +3022,7 @@ final class BuildPlanTests: XCTestCase {
             ]
         )
 
-        let testPathExtension = testBuildDescription.binaryPath.extension
+        let testPathExtension = try testBuildDescription.binaryPath.extension
         XCTAssertEqual(testPathExtension, "wasm")
     }
 
@@ -3037,7 +3037,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Pkg",
-                    path: .init(path: "/Pkg"),
+                    path: "/Pkg",
                     toolsVersion: .v5_5,
                     targets: [
                         TargetDescription(name: "exe", type: .executable),
@@ -3084,7 +3084,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Pkg",
-                    path: .init(path: "/Pkg"),
+                    path: "/Pkg",
                     targets: [
                         TargetDescription(name: "exe", dependencies: ["lib"]),
                         TargetDescription(name: "lib", dependencies: []),
@@ -3132,20 +3132,20 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "A",
-                    path: .init(path: "/A"),
+                    path: "/A",
                     platforms: [
                         PlatformDescription(name: "macos", version: "10.13"),
                     ],
                     toolsVersion: .v5,
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/B"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/B", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "ATarget", dependencies: ["BLibrary"]),
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "B",
-                    path: .init(path: "/B"),
+                    path: "/B",
                     platforms: [
                         PlatformDescription(name: "macos", version: "10.12"),
                     ],
@@ -3195,21 +3195,21 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "A",
-                    path: .init(path: "/A"),
+                    path: "/A",
                     platforms: [
                         PlatformDescription(name: "macos", version: "10.13"),
                         PlatformDescription(name: "ios", version: "10"),
                     ],
                     toolsVersion: .v5,
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/B"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/B", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "ATarget", dependencies: ["BLibrary"]),
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "B",
-                    path: .init(path: "/B"),
+                    path: "/B",
                     platforms: [
                         PlatformDescription(name: "macos", version: "10.14"),
                         PlatformDescription(name: "ios", version: "11"),
@@ -3262,10 +3262,10 @@ final class BuildPlanTests: XCTestCase {
 
         let aManifest = Manifest.createRootManifest(
             displayName: "A",
-            path: .init(path: "/A"),
+            path: "/A",
             toolsVersion: .v5,
             dependencies: [
-                .localSourceControl(path: .init(path: "/B"), requirement: .upToNextMajor(from: "1.0.0")),
+                .localSourceControl(path: "/B", requirement: .upToNextMajor(from: "1.0.0")),
             ],
             targets: [
                 try TargetDescription(
@@ -3308,7 +3308,7 @@ final class BuildPlanTests: XCTestCase {
 
         let bManifest = Manifest.createFileSystemManifest(
             displayName: "B",
-            path: .init(path: "/B"),
+            path: "/B",
             toolsVersion: .v5,
             products: [
                 try ProductDescription(name: "Dep", type: .library(.automatic), targets: ["t1", "t2"]),
@@ -3393,7 +3393,7 @@ final class BuildPlanTests: XCTestCase {
 
         let aManifest = Manifest.createRootManifest(
             displayName: "A",
-            path: .init(path: "/A"),
+            path: "/A",
             toolsVersion: .v5,
             targets: [
                 try TargetDescription(name: "exe", dependencies: []),
@@ -3434,7 +3434,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Pkg",
-                    path: .init(path: "/Pkg"),
+                    path: "/Pkg",
                     targets: [
                         TargetDescription(name: "exe", dependencies: ["lib"]),
                         TargetDescription(name: "lib", dependencies: []),
@@ -3508,7 +3508,7 @@ final class BuildPlanTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     displayName: "PkgB",
-                    path: .init(path: "/PkgB"),
+                    path: "/PkgB",
                     dependencies: [
                         .localSourceControl(path: try .init(validating: PkgA.pathString), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
@@ -3628,14 +3628,14 @@ final class BuildPlanTests: XCTestCase {
                     displayName: "PkgA",
                     path: try .init(validating: PkgA.pathString),
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/PkgB"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/PkgB", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Bar", dependencies: ["Foo"]),
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "PkgB",
-                    path: .init(path: "/PkgB"),
+                    path: "/PkgB",
                     products: [
                         ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Foo"]),
                     ],
@@ -3702,14 +3702,14 @@ final class BuildPlanTests: XCTestCase {
                     displayName: "PkgA",
                     path: try .init(validating: PkgA.pathString),
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/PkgB"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/PkgB", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Bar", dependencies: ["Foo"]),
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "PkgB",
-                    path: .init(path: "/PkgB"),
+                    path: "/PkgB",
                     products: [
                         ProductDescription(name: "Foo", type: .library(.dynamic), targets: ["Foo"]),
                     ],
@@ -3777,7 +3777,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Pkg",
-                    path: .init(path: "/Pkg"),
+                    path: "/Pkg",
                     targets: [
                         TargetDescription(name: "exe", dependencies: ["lib"]),
                         TargetDescription(name: "lib", dependencies: []),
@@ -3835,7 +3835,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Package",
-                    path: .init(path: "/Package"),
+                    path: "/Package",
                     products: [
                         ProductDescription(name: "rary", type: .library(.static), targets: ["rary"]),
                     ],
@@ -3911,7 +3911,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "PkgA",
-                    path: .init(path: "/PkgA"),
+                    path: "/PkgA",
                     toolsVersion: .v5_2,
                     targets: [
                         TargetDescription(
@@ -3977,7 +3977,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "PkgA",
-                    path: .init(path: "/PkgA"),
+                    path: "/PkgA",
                     toolsVersion: .v5_2,
                     targets: [
                         TargetDescription(
@@ -4043,7 +4043,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Pkg",
-                    path: .init(path: "/Pkg"),
+                    path: "/Pkg",
                     toolsVersion: .current,
                     targets: [
                         TargetDescription(
@@ -4115,7 +4115,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Pkg",
-                    path: .init(path: "/Pkg"),
+                    path: "/Pkg",
                     targets: [
                         TargetDescription(name: "exe", dependencies: ["lib"]),
                         TargetDescription(name: "lib", dependencies: []),
@@ -4337,7 +4337,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Pkg",
-                    path: .init(path: "/Pkg"),
+                    path: "/Pkg",
                     products: [
                         ProductDescription(name: "exe", type: .executable, targets: ["exe"]),
                     ],
@@ -4414,7 +4414,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Lib",
-                    path: .init(path: "/Pkg"),
+                    path: "/Pkg",
                     toolsVersion: .vNext,
                     dependencies: [],
                     products: [
@@ -4466,7 +4466,7 @@ final class BuildPlanTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Pkg",
-                    path: .init(path: "/Pkg"),
+                    path: "/Pkg",
                     targets: [
                         TargetDescription(name: "exe", dependencies: ["lib", "clib"]),
                         TargetDescription(name: "lib", dependencies: []),

--- a/Tests/BuildTests/LLBuildManifestTests.swift
+++ b/Tests/BuildTests/LLBuildManifestTests.swift
@@ -38,7 +38,7 @@ final class LLBuildManifestTests: XCTestCase {
         let fs = InMemoryFileSystem()
         try ManifestWriter(fileSystem: fs).write(manifest, at: "/manifest.yaml")
 
-        let contents: String = try fs.readFileContents(AbsolutePath(path: "/manifest.yaml"))
+        let contents: String = try fs.readFileContents("/manifest.yaml")
 
         // FIXME(#5475) - use the platform's preferred separator for directory
         // indicators
@@ -89,12 +89,12 @@ final class LLBuildManifestTests: XCTestCase {
             allowMissingInputs: true
         )
 
-        manifest.addNode(.file(AbsolutePath(path: "/file.out")), toTarget: "main")
+        manifest.addNode(.file("/file.out"), toTarget: "main")
 
         let fs = InMemoryFileSystem()
         try ManifestWriter(fileSystem: fs).write(manifest, at: "/manifest.yaml")
 
-        let contents: String = try fs.readFileContents(AbsolutePath(path: "/manifest.yaml"))
+        let contents: String = try fs.readFileContents("/manifest.yaml")
 
         XCTAssertEqual(contents.replacingOccurrences(of: "\\\\", with: "\\"), """
             client:

--- a/Tests/BuildTests/MockBuildTestHelper.swift
+++ b/Tests/BuildTests/MockBuildTestHelper.swift
@@ -36,7 +36,7 @@ struct MockToolchain: PackageModel.Toolchain {
     let extraFlags = BuildFlags(cxxCompilerFlags: ["-lstdc++"])
     #endif
     func getClangCompiler() throws -> AbsolutePath {
-        return AbsolutePath(path: "/fake/path/to/clang")
+        return "/fake/path/to/clang"
     }
 
     func _isClangCompilerVendorApple() throws -> Bool? {

--- a/Tests/BuildTests/ModuleAliasingBuildTests.swift
+++ b/Tests/BuildTests/ModuleAliasingBuildTests.swift
@@ -10,11 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Basics
 @testable import Build
 @testable import PackageGraph
-@testable import PackageModel
-import Basics
 import PackageLoading
+@testable import PackageModel
 import SPMBuildCore
 import SPMTestSupport
 import SwiftDriver
@@ -23,12 +23,12 @@ import Workspace
 import XCTest
 
 final class ModuleAliasingBuildTests: XCTestCase {
-
     func testModuleAliasingEmptyAlias() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/thisPkg/Sources/exe/main.swift",
-                                        "/thisPkg/Sources/Logging/file.swift",
-                                        "/fooPkg/Sources/Logging/fileLogging.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/thisPkg/Sources/exe/main.swift",
+            "/thisPkg/Sources/Logging/file.swift",
+            "/fooPkg/Sources/Logging/fileLogging.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -37,29 +37,33 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "fooPkg",
-                    path: .init(path: "/fooPkg"),
+                    path: "/fooPkg",
                     products: [
                         ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Logging"]),
                     ],
                     targets: [
                         TargetDescription(name: "Logging", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "thisPkg",
-                    path: .init(path: "/thisPkg"),
+                    path: "/thisPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/fooPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "exe",
-                                          dependencies: ["Logging",
-                                                         .product(name: "Foo",
-                                                                  package: "fooPkg",
-                                                                  moduleAliases: ["Logging": ""]
-                                                                 ),
-                                                        ]),
+                        TargetDescription(
+                            name: "exe",
+                            dependencies: ["Logging",
+                                           .product(
+                                               name: "Foo",
+                                               package: "fooPkg",
+                                               moduleAliases: ["Logging": ""]
+                                           )]
+                        ),
                         TargetDescription(name: "Logging", dependencies: []),
-                    ]),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
@@ -70,10 +74,11 @@ final class ModuleAliasingBuildTests: XCTestCase {
     }
 
     func testModuleAliasingInvalidIdentifierAlias() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/thisPkg/Sources/exe/main.swift",
-                                        "/thisPkg/Sources/Logging/file.swift",
-                                        "/fooPkg/Sources/Logging/fileLogging.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/thisPkg/Sources/exe/main.swift",
+            "/thisPkg/Sources/Logging/file.swift",
+            "/fooPkg/Sources/Logging/fileLogging.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -82,43 +87,51 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "fooPkg",
-                    path: .init(path: "/fooPkg"),
+                    path: "/fooPkg",
                     products: [
                         ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Logging"]),
                     ],
                     targets: [
                         TargetDescription(name: "Logging", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "thisPkg",
-                    path: .init(path: "/thisPkg"),
+                    path: "/thisPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/fooPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "exe",
-                                          dependencies: ["Logging",
-                                                         .product(name: "Foo",
-                                                                  package: "fooPkg",
-                                                                  moduleAliases: ["Logging": "P$0%^#@"]
-                                                                 ),
-                                                        ]),
+                        TargetDescription(
+                            name: "exe",
+                            dependencies: ["Logging",
+                                           .product(
+                                               name: "Foo",
+                                               package: "fooPkg",
+                                               moduleAliases: ["Logging": "P$0%^#@"]
+                                           )]
+                        ),
                         TargetDescription(name: "Logging", dependencies: []),
-                    ]),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
 
         testDiagnostics(observability.diagnostics) { result in
-            result.check(diagnostic: .contains("empty or invalid module alias; ['Logging': 'P$0%^#@']"), severity: .error)
+            result.check(
+                diagnostic: .contains("empty or invalid module alias; ['Logging': 'P$0%^#@']"),
+                severity: .error
+            )
         }
     }
 
     func testModuleAliasingDuplicateProductNames() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/thisPkg/Sources/exe/main.swift",
-                                    "/fooPkg/Sources/Logging/fileLogging.swift",
-                                    "/barPkg/Sources/Logging/fileLogging.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/thisPkg/Sources/exe/main.swift",
+            "/fooPkg/Sources/Logging/fileLogging.swift",
+            "/barPkg/Sources/Logging/fileLogging.swift"
         )
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
@@ -126,40 +139,46 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     displayName: "fooPkg",
-                    path: .init(path: "/fooPkg"),
+                    path: "/fooPkg",
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
                     ],
                     targets: [
                         TargetDescription(name: "Logging", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "barPkg",
-                    path: .init(path: "/barPkg"),
+                    path: "/barPkg",
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
                     ],
                     targets: [
                         TargetDescription(name: "Logging", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "thisPkg",
-                    path: .init(path: "/thisPkg"),
+                    path: "/thisPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "2.0.0")),
+                        .localSourceControl(path: "/fooPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/barPkg", requirement: .upToNextMajor(from: "2.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "exe",
-                                          dependencies: [.product(name: "Logging",
-                                                                  package: "fooPkg"
-                                                                 ),
-                                                         .product(name: "Logging",
-                                                                  package: "barPkg",
-                                                                  moduleAliases: ["Logging": "BarLogging"]
-                                                                 )
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "exe",
+                            dependencies: [.product(
+                                name: "Logging",
+                                package: "fooPkg"
+                            ),
+                            .product(
+                                name: "Logging",
+                                package: "barPkg",
+                                moduleAliases: ["Logging": "BarLogging"]
+                            )]
+                        ),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
@@ -172,15 +191,22 @@ final class ModuleAliasingBuildTests: XCTestCase {
         ))
         result.checkProductsCount(1)
         result.checkTargetsCount(3)
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "BarLogging" && $0.target.moduleAliases?["Logging"] == "BarLogging" })
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "BarLogging" && $0.target.moduleAliases?["Logging"] == "BarLogging" }
+        )
     }
 
     func testModuleAliasingDuplicateDylibProductNames() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/thisPkg/Sources/exe/main.swift",
-                                    "/fooPkg/Sources/Logging/fileLogging.swift",
-                                    "/barPkg/Sources/Logging/fileLogging.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/thisPkg/Sources/exe/main.swift",
+            "/fooPkg/Sources/Logging/fileLogging.swift",
+            "/barPkg/Sources/Logging/fileLogging.swift"
         )
         let observability = ObservabilitySystem.makeForTesting()
         XCTAssertThrowsError(try loadPackageGraph(
@@ -188,46 +214,53 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     displayName: "fooPkg",
-                    path: .init(path: "/fooPkg"),
+                    path: "/fooPkg",
                     products: [
                         ProductDescription(name: "Logging", type: .library(.dynamic), targets: ["Logging"]),
                     ],
                     targets: [
                         TargetDescription(name: "Logging", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "barPkg",
-                    path: .init(path: "/barPkg"),
+                    path: "/barPkg",
                     products: [
                         ProductDescription(name: "Logging", type: .library(.dynamic), targets: ["Logging"]),
                     ],
                     targets: [
                         TargetDescription(name: "Logging", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "thisPkg",
-                    path: .init(path: "/thisPkg"),
+                    path: "/thisPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "2.0.0")),
+                        .localSourceControl(path: "/fooPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/barPkg", requirement: .upToNextMajor(from: "2.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "exe",
-                                          dependencies: [.product(name: "Logging",
-                                                                  package: "fooPkg"
-                                                                 ),
-                                                         .product(name: "Logging",
-                                                                  package: "barPkg",
-                                                                  moduleAliases: ["Logging": "BarLogging"]
-                                                                 )
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "exe",
+                            dependencies: [.product(
+                                name: "Logging",
+                                package: "fooPkg"
+                            ),
+                            .product(
+                                name: "Logging",
+                                package: "barPkg",
+                                moduleAliases: ["Logging": "BarLogging"]
+                            )]
+                        ),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )) { error in
             var diagnosed = false
             if let realError = error as? PackageGraphError,
-               realError.description == "multiple products named 'Logging' in: 'barpkg', 'foopkg'" {
+               realError.description == "multiple products named 'Logging' in: 'barpkg', 'foopkg'"
+            {
                 diagnosed = true
             }
             XCTAssertTrue(diagnosed)
@@ -235,10 +268,11 @@ final class ModuleAliasingBuildTests: XCTestCase {
     }
 
     func testModuleAliasingDuplicateDylibStaticLibProductNames() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/thisPkg/Sources/exe/main.swift",
-                                    "/fooPkg/Sources/Logging/fileLogging.swift",
-                                    "/barPkg/Sources/Logging/fileLogging.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/thisPkg/Sources/exe/main.swift",
+            "/fooPkg/Sources/Logging/fileLogging.swift",
+            "/barPkg/Sources/Logging/fileLogging.swift"
         )
         let observability = ObservabilitySystem.makeForTesting()
         XCTAssertThrowsError(try loadPackageGraph(
@@ -246,46 +280,53 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     displayName: "fooPkg",
-                    path: .init(path: "/fooPkg"),
+                    path: "/fooPkg",
                     products: [
                         ProductDescription(name: "Logging", type: .library(.dynamic), targets: ["Logging"]),
                     ],
                     targets: [
                         TargetDescription(name: "Logging", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "barPkg",
-                    path: .init(path: "/barPkg"),
+                    path: "/barPkg",
                     products: [
                         ProductDescription(name: "Logging", type: .library(.static), targets: ["Logging"]),
                     ],
                     targets: [
                         TargetDescription(name: "Logging", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "thisPkg",
-                    path: .init(path: "/thisPkg"),
+                    path: "/thisPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "2.0.0")),
+                        .localSourceControl(path: "/fooPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/barPkg", requirement: .upToNextMajor(from: "2.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "exe",
-                                          dependencies: [.product(name: "Logging",
-                                                                  package: "fooPkg"
-                                                                 ),
-                                                         .product(name: "Logging",
-                                                                  package: "barPkg",
-                                                                  moduleAliases: ["Logging": "BarLogging"]
-                                                                 )
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "exe",
+                            dependencies: [.product(
+                                name: "Logging",
+                                package: "fooPkg"
+                            ),
+                            .product(
+                                name: "Logging",
+                                package: "barPkg",
+                                moduleAliases: ["Logging": "BarLogging"]
+                            )]
+                        ),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )) { error in
             var diagnosed = false
             if let realError = error as? PackageGraphError,
-               realError.description == "multiple products named 'Logging' in: 'barpkg', 'foopkg'" {
+               realError.description == "multiple products named 'Logging' in: 'barpkg', 'foopkg'"
+            {
                 diagnosed = true
             }
             XCTAssertTrue(diagnosed)
@@ -293,11 +334,12 @@ final class ModuleAliasingBuildTests: XCTestCase {
     }
 
     func testModuleAliasingDuplicateDylibAutomaticProductNames() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/thisPkg/Sources/exe/main.swift",
-                                    "/fooPkg/Sources/Logging/fileLogging.swift",
-                                    "/barPkg/Sources/Logging/fileLogging.swift",
-                                    "/bazPkg/Sources/Logging/fileLogging.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/thisPkg/Sources/exe/main.swift",
+            "/fooPkg/Sources/Logging/fileLogging.swift",
+            "/barPkg/Sources/Logging/fileLogging.swift",
+            "/bazPkg/Sources/Logging/fileLogging.swift"
         )
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
@@ -305,40 +347,46 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     displayName: "fooPkg",
-                    path: .init(path: "/fooPkg"),
+                    path: "/fooPkg",
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
                     ],
                     targets: [
                         TargetDescription(name: "Logging", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "barPkg",
-                    path: .init(path: "/barPkg"),
+                    path: "/barPkg",
                     products: [
                         ProductDescription(name: "Logging", type: .library(.dynamic), targets: ["Logging"]),
                     ],
                     targets: [
                         TargetDescription(name: "Logging", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "thisPkg",
-                    path: .init(path: "/thisPkg"),
+                    path: "/thisPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "2.0.0")),
+                        .localSourceControl(path: "/fooPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/barPkg", requirement: .upToNextMajor(from: "2.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "exe",
-                                          dependencies: [.product(name: "Logging",
-                                                                  package: "fooPkg"
-                                                                 ),
-                                                         .product(name: "Logging",
-                                                                  package: "barPkg",
-                                                                  moduleAliases: ["Logging": "BarLogging"]
-                                                                 ),
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "exe",
+                            dependencies: [.product(
+                                name: "Logging",
+                                package: "fooPkg"
+                            ),
+                            .product(
+                                name: "Logging",
+                                package: "barPkg",
+                                moduleAliases: ["Logging": "BarLogging"]
+                            )]
+                        ),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
@@ -351,19 +399,29 @@ final class ModuleAliasingBuildTests: XCTestCase {
         ))
         result.checkProductsCount(2)
         result.checkTargetsCount(3)
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "BarLogging" && $0.target.moduleAliases?["Logging"] == "BarLogging" })
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "BarLogging" && $0.target.moduleAliases?["Logging"] == "BarLogging" }
+        )
         #if os(macOS)
         let dylib = try result.buildProduct(for: "Logging")
-        XCTAssertTrue(dylib.binaryPath.basename == "libLogging.dylib" && dylib.package.identity.description == "barpkg")
+        XCTAssertTrue(
+            try dylib.binaryPath.basename == "libLogging.dylib" && dylib.package.identity
+                .description == "barpkg"
+        )
         #endif
     }
 
     func testModuleAliasingDuplicateStaticLibAutomaticProductNames() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/thisPkg/Sources/exe/main.swift",
-                                    "/fooPkg/Sources/Logging/fileLogging.swift",
-                                    "/bazPkg/Sources/Logging/fileLogging.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/thisPkg/Sources/exe/main.swift",
+            "/fooPkg/Sources/Logging/fileLogging.swift",
+            "/bazPkg/Sources/Logging/fileLogging.swift"
         )
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
@@ -371,41 +429,46 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     displayName: "fooPkg",
-                    path: .init(path: "/fooPkg"),
+                    path: "/fooPkg",
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
                     ],
                     targets: [
                         TargetDescription(name: "Logging", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "bazPkg",
-                    path: .init(path: "/bazPkg"),
+                    path: "/bazPkg",
                     products: [
                         ProductDescription(name: "Logging", type: .library(.static), targets: ["Logging"]),
                     ],
                     targets: [
                         TargetDescription(name: "Logging", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "thisPkg",
-                    path: .init(path: "/thisPkg"),
+                    path: "/thisPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/bazPkg"), requirement: .upToNextMajor(from: "2.0.0")),
+                        .localSourceControl(path: "/fooPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/bazPkg", requirement: .upToNextMajor(from: "2.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "exe",
-                                          dependencies: [.product(name: "Logging",
-                                                                  package: "fooPkg"
-                                                                 ),
-                                                         .product(name: "Logging",
-                                                                  package: "bazPkg",
-                                                                  moduleAliases: ["Logging": "BazLogging"]
-                                                                 )
-
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "exe",
+                            dependencies: [.product(
+                                name: "Logging",
+                                package: "fooPkg"
+                            ),
+                            .product(
+                                name: "Logging",
+                                package: "bazPkg",
+                                moduleAliases: ["Logging": "BazLogging"]
+                            )]
+                        ),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
@@ -418,21 +481,31 @@ final class ModuleAliasingBuildTests: XCTestCase {
         ))
         result.checkProductsCount(2)
         result.checkTargetsCount(3)
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "BazLogging" && $0.target.moduleAliases?["Logging"] == "BazLogging" })
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "BazLogging" && $0.target.moduleAliases?["Logging"] == "BazLogging" }
+        )
         #if os(macOS)
         let staticlib = try result.buildProduct(for: "Logging")
-        XCTAssertTrue(staticlib.binaryPath.basename == "libLogging.a" && staticlib.package.identity.description == "bazpkg")
+        XCTAssertTrue(
+            try staticlib.binaryPath.basename == "libLogging.a" && staticlib.package.identity
+                .description == "bazpkg"
+        )
         #endif
     }
 
     func testModuleAliasingDuplicateProductNamesUpstream() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/thisPkg/Sources/exe/main.swift",
-                                    "/aPkg/Sources/A/file.swift",
-                                    "/xPkg/Sources/Logging/fileLogging.swift",
-                                    "/bPkg/Sources/B/file.swift",
-                                    "/yPkg/Sources/Logging/fileLogging.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/thisPkg/Sources/exe/main.swift",
+            "/aPkg/Sources/A/file.swift",
+            "/xPkg/Sources/Logging/fileLogging.swift",
+            "/bPkg/Sources/B/file.swift",
+            "/yPkg/Sources/Logging/fileLogging.swift"
         )
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
@@ -440,73 +513,88 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     displayName: "xPkg",
-                path: .init(path: "/xPkg"),
-                products: [
-                    ProductDescription(name: "Logging", type: .library(.dynamic), targets: ["Logging"]),
-                ],
-                targets: [
-                    TargetDescription(name: "Logging",
-                                      dependencies: []),
-                ]),
+                    path: "/xPkg",
+                    products: [
+                        ProductDescription(name: "Logging", type: .library(.dynamic), targets: ["Logging"]),
+                    ],
+                    targets: [
+                        TargetDescription(
+                            name: "Logging",
+                            dependencies: []
+                        ),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "yPkg",
-                    path: .init(path: "/yPkg"),
+                    path: "/yPkg",
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
                     ],
                     targets: [
-                        TargetDescription(name: "Logging",
-                                          dependencies: []),
-
-                    ]),
+                        TargetDescription(
+                            name: "Logging",
+                            dependencies: []
+                        ),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "aPkg",
-                    path: .init(path: "/aPkg"),
+                    path: "/aPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/xPkg"), requirement: .upToNextMajor(from: "1.0.0"))
+                        .localSourceControl(path: "/xPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "A", type: .library(.dynamic), targets: ["A"]),
                     ],
                     targets: [
-                        TargetDescription(name: "A",
-                                          dependencies: [
-                                            .product(name: "Logging", package: "xPkg")
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "A",
+                            dependencies: [
+                                .product(name: "Logging", package: "xPkg"),
+                            ]
+                        ),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "bPkg",
-                    path: .init(path: "/bPkg"),
+                    path: "/bPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/yPkg"), requirement: .upToNextMajor(from: "1.0.0"))
+                        .localSourceControl(path: "/yPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "B", type: .library(.dynamic), targets: ["B"]),
                     ],
                     targets: [
-                        TargetDescription(name: "B",
-                                          dependencies: [
-                                            .product(name: "Logging", package: "yPkg")
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "B",
+                            dependencies: [
+                                .product(name: "Logging", package: "yPkg"),
+                            ]
+                        ),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "thisPkg",
-                    path: .init(path: "/thisPkg"),
+                    path: "/thisPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/aPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/bPkg"), requirement: .upToNextMajor(from: "2.0.0")),
+                        .localSourceControl(path: "/aPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/bPkg", requirement: .upToNextMajor(from: "2.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "exe",
-                                          dependencies: [.product(name: "A",
-                                                                  package: "aPkg",
-                                                                  moduleAliases: ["Logging": "ALogging"]
-                                                                 ),
-                                                         .product(name: "B",
-                                                                  package: "bPkg"
-                                                                 )
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "exe",
+                            dependencies: [.product(
+                                name: "A",
+                                package: "aPkg",
+                                moduleAliases: ["Logging": "ALogging"]
+                            ),
+                            .product(
+                                name: "B",
+                                package: "bPkg"
+                            )]
+                        ),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
@@ -519,118 +607,171 @@ final class ModuleAliasingBuildTests: XCTestCase {
         ))
         result.checkProductsCount(4)
         result.checkTargetsCount(5)
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "ALogging" && $0.target.moduleAliases?["Logging"] == "ALogging" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "A" && $0.target.moduleAliases?["Logging"] == "ALogging" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "ALogging" && $0.target.moduleAliases?["Logging"] == "ALogging" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "A" && $0.target.moduleAliases?["Logging"] == "ALogging" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil }
+        )
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "B" && $0.target.moduleAliases == nil })
         #if os(macOS)
         let dylib = try result.buildProduct(for: "Logging")
-        XCTAssertTrue(dylib.binaryPath.basename == "libLogging.dylib" && dylib.package.identity.description == "xpkg")
+        XCTAssertTrue(
+            try dylib.binaryPath.basename == "libLogging.dylib" && dylib.package.identity
+                .description == "xpkg"
+        )
         #endif
     }
 
     func testModuleAliasingDirectDeps() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/thisPkg/Sources/exe/main.swift",
-                                        "/thisPkg/Sources/Logging/file.swift",
-                                        "/fooPkg/Sources/Logging/fileLogging.swift",
-                                        "/barPkg/Sources/Logging/fileLogging.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/thisPkg/Sources/exe/main.swift",
+            "/thisPkg/Sources/Logging/file.swift",
+            "/fooPkg/Sources/Logging/fileLogging.swift",
+            "/barPkg/Sources/Logging/fileLogging.swift"
         )
-        
+
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
                     displayName: "fooPkg",
-                    path: .init(path: "/fooPkg"),
+                    path: "/fooPkg",
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
                     ],
                     targets: [
                         TargetDescription(name: "Logging", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "barPkg",
-                    path: .init(path: "/barPkg"),
+                    path: "/barPkg",
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
                     ],
                     targets: [
                         TargetDescription(name: "Logging", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "thisPkg",
-                    path: .init(path: "/thisPkg"),
+                    path: "/thisPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "2.0.0")),
+                        .localSourceControl(path: "/fooPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/barPkg", requirement: .upToNextMajor(from: "2.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "exe",
-                                          dependencies: ["Logging",
-                                                         .product(name: "Logging",
-                                                                  package: "fooPkg",
-                                                                  moduleAliases: ["Logging": "FooLogging"]
-                                                                 ),
-                                                         .product(name: "Logging",
-                                                                  package: "barPkg",
-                                                                  moduleAliases: ["Logging": "BarLogging"]
-                                                                 )
-                                                        ]),
+                        TargetDescription(
+                            name: "exe",
+                            dependencies: ["Logging",
+                                           .product(
+                                               name: "Logging",
+                                               package: "fooPkg",
+                                               moduleAliases: ["Logging": "FooLogging"]
+                                           ),
+                                           .product(
+                                               name: "Logging",
+                                               package: "barPkg",
+                                               moduleAliases: ["Logging": "BarLogging"]
+                                           )]
+                        ),
                         TargetDescription(name: "Logging", dependencies: []),
-                    ]),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
-        
+
         XCTAssertNoDiagnostics(observability.diagnostics)
-        
+
         let result = try BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(shouldLinkStaticSwiftStdlib: true),
             graph: graph,
             fileSystem: fs,
             observabilityScope: observability.topScope
         ))
-        
+
         result.checkProductsCount(1)
         result.checkTargetsCount(4)
-        
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "FooLogging" && $0.target.moduleAliases?["Logging"] == "FooLogging" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "BarLogging" && $0.target.moduleAliases?["Logging"] == "BarLogging" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil })
-        
+
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "FooLogging" && $0.target.moduleAliases?["Logging"] == "FooLogging" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "BarLogging" && $0.target.moduleAliases?["Logging"] == "BarLogging" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil }
+        )
+
         let fooLoggingArgs = try result.target(for: "FooLogging").swiftTarget().compileArguments()
         let barLoggingArgs = try result.target(for: "BarLogging").swiftTarget().compileArguments()
         let loggingArgs = try result.target(for: "Logging").swiftTarget().compileArguments()
         #if os(macOS)
-        XCTAssertMatch(fooLoggingArgs, [.anySequence, "-emit-objc-header", "-emit-objc-header-path", "/path/to/build/debug/FooLogging.build/FooLogging-Swift.h", .anySequence])
-        XCTAssertMatch(barLoggingArgs, [.anySequence, "-emit-objc-header", "-emit-objc-header-path", "/path/to/build/debug/BarLogging.build/BarLogging-Swift.h", .anySequence])
-        XCTAssertMatch(loggingArgs, [.anySequence, "-emit-objc-header", "-emit-objc-header-path", "/path/to/build/debug/Logging.build/Logging-Swift.h", .anySequence])
+        XCTAssertMatch(
+            fooLoggingArgs,
+            [.anySequence, "-emit-objc-header", "-emit-objc-header-path",
+             "/path/to/build/debug/FooLogging.build/FooLogging-Swift.h", .anySequence]
+        )
+        XCTAssertMatch(
+            barLoggingArgs,
+            [.anySequence, "-emit-objc-header", "-emit-objc-header-path",
+             "/path/to/build/debug/BarLogging.build/BarLogging-Swift.h", .anySequence]
+        )
+        XCTAssertMatch(
+            loggingArgs,
+            [.anySequence, "-emit-objc-header", "-emit-objc-header-path",
+             "/path/to/build/debug/Logging.build/Logging-Swift.h", .anySequence]
+        )
         #else
-        XCTAssertNoMatch(fooLoggingArgs, [.anySequence, "-emit-objc-header", "-emit-objc-header-path", "/path/to/build/debug/FooLogging.build/FooLogging-Swift.h", .anySequence])
-        XCTAssertNoMatch(barLoggingArgs, [.anySequence, "-emit-objc-header", "-emit-objc-header-path", "/path/to/build/debug/BarLogging.build/BarLogging-Swift.h", .anySequence])
-        XCTAssertNoMatch(loggingArgs, [.anySequence, "-emit-objc-header", "-emit-objc-header-path", "/path/to/build/debug/Logging.build/Logging-Swift.h", .anySequence])
+        XCTAssertNoMatch(
+            fooLoggingArgs,
+            [.anySequence, "-emit-objc-header", "-emit-objc-header-path",
+             "/path/to/build/debug/FooLogging.build/FooLogging-Swift.h", .anySequence]
+        )
+        XCTAssertNoMatch(
+            barLoggingArgs,
+            [.anySequence, "-emit-objc-header", "-emit-objc-header-path",
+             "/path/to/build/debug/BarLogging.build/BarLogging-Swift.h", .anySequence]
+        )
+        XCTAssertNoMatch(
+            loggingArgs,
+            [.anySequence, "-emit-objc-header", "-emit-objc-header-path",
+             "/path/to/build/debug/Logging.build/Logging-Swift.h", .anySequence]
+        )
         #endif
     }
 
     func testModuleAliasingDuplicateTargetNameInUpstream() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/thisPkg/Sources/exe/main.swift",
-                                        "/thisPkg/Sources/Logging/file.swift",
-                                        "/otherPkg/Sources/Utils/fileUtils.swift",
-                                        "/otherPkg/Sources/Logging/fileLogging.swift",
-                                        "/otherPkg/Sources/Math/file.swift",
-                                        "/otherPkg/Sources/Tools/file.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/thisPkg/Sources/exe/main.swift",
+            "/thisPkg/Sources/Logging/file.swift",
+            "/otherPkg/Sources/Utils/fileUtils.swift",
+            "/otherPkg/Sources/Logging/fileLogging.swift",
+            "/otherPkg/Sources/Math/file.swift",
+            "/otherPkg/Sources/Tools/file.swift"
         )
-        
+
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "otherPkg",
-                    path: .init(path: "/otherPkg"),
+                    path: "/otherPkg",
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                         ProductDescription(name: "Math", type: .library(.automatic), targets: ["Math"]),
@@ -640,60 +781,94 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Logging", dependencies: []),
                         TargetDescription(name: "Math", dependencies: ["Tools"]),
                         TargetDescription(name: "Tools", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "thisPkg",
-                    path: .init(path: "/thisPkg"),
+                    path: "/thisPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/otherPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/otherPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "exe",
-                                          dependencies: ["Logging",
-                                                         .product(name: "Math",
-                                                                  package: "otherPkg"),
-                                                         .product(name: "Utils",
-                                                                  package: "otherPkg",
-                                                                  moduleAliases: ["Logging": "OtherLogging"])]),
+                        TargetDescription(
+                            name: "exe",
+                            dependencies: ["Logging",
+                                           .product(
+                                               name: "Math",
+                                               package: "otherPkg"
+                                           ),
+                                           .product(
+                                               name: "Utils",
+                                               package: "otherPkg",
+                                               moduleAliases: ["Logging": "OtherLogging"]
+                                           )]
+                        ),
                         TargetDescription(name: "Logging", dependencies: []),
-                    ]),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
-        
+
         let result = try BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(shouldLinkStaticSwiftStdlib: true),
             graph: graph,
             fileSystem: fs,
             observabilityScope: observability.topScope
         ))
-        
+
         result.checkProductsCount(1)
         result.checkTargetsCount(6)
 
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "OtherLogging" && $0.target.moduleAliases?["Logging"] == "OtherLogging" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases?["Logging"] == "OtherLogging" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "OtherLogging" && $0.target.moduleAliases?["Logging"] == "OtherLogging" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "Utils" && $0.target.moduleAliases?["Logging"] == "OtherLogging" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil }
+        )
 
         let otherLoggingArgs = try result.target(for: "OtherLogging").swiftTarget().compileArguments()
         let loggingArgs = try result.target(for: "Logging").swiftTarget().compileArguments()
-        
+
         #if os(macOS)
-        XCTAssertMatch(otherLoggingArgs, [.anySequence, "-emit-objc-header", "-emit-objc-header-path", "/path/to/build/debug/OtherLogging.build/OtherLogging-Swift.h", .anySequence])
-        XCTAssertMatch(loggingArgs, [.anySequence, "-emit-objc-header", "-emit-objc-header-path", "/path/to/build/debug/Logging.build/Logging-Swift.h", .anySequence])
+        XCTAssertMatch(
+            otherLoggingArgs,
+            [.anySequence, "-emit-objc-header", "-emit-objc-header-path",
+             "/path/to/build/debug/OtherLogging.build/OtherLogging-Swift.h", .anySequence]
+        )
+        XCTAssertMatch(
+            loggingArgs,
+            [.anySequence, "-emit-objc-header", "-emit-objc-header-path",
+             "/path/to/build/debug/Logging.build/Logging-Swift.h", .anySequence]
+        )
         #else
-        XCTAssertNoMatch(otherLoggingArgs, [.anySequence, "-emit-objc-header", "-emit-objc-header-path", "/path/to/build/debug/OtherLogging.build/OtherLogging-Swift.h", .anySequence])
-        XCTAssertNoMatch(loggingArgs, [.anySequence, "-emit-objc-header", "-emit-objc-header-path", "/path/to/build/debug/Logging.build/Logging-Swift.h", .anySequence])
+        XCTAssertNoMatch(
+            otherLoggingArgs,
+            [.anySequence, "-emit-objc-header", "-emit-objc-header-path",
+             "/path/to/build/debug/OtherLogging.build/OtherLogging-Swift.h", .anySequence]
+        )
+        XCTAssertNoMatch(
+            loggingArgs,
+            [.anySequence, "-emit-objc-header", "-emit-objc-header-path",
+             "/path/to/build/debug/Logging.build/Logging-Swift.h", .anySequence]
+        )
         #endif
     }
 
     func testModuleAliasingMultipleAliasesInProduct() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/thisPkg/Sources/exe/main.swift",
-                                        "/thisPkg/Sources/Logging/file.swift",
-                                        "/otherPkg/Sources/Utils/fileUtils.swift",
-                                        "/otherPkg/Sources/Logging/fileLogging.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/thisPkg/Sources/exe/main.swift",
+            "/thisPkg/Sources/Logging/file.swift",
+            "/otherPkg/Sources/Utils/fileUtils.swift",
+            "/otherPkg/Sources/Logging/fileLogging.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -702,7 +877,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "otherPkg",
-                    path: .init(path: "/otherPkg"),
+                    path: "/otherPkg",
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                         ProductDescription(name: "LoggingProd", type: .library(.automatic), targets: ["Logging"]),
@@ -710,30 +885,41 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     targets: [
                         TargetDescription(name: "Utils", dependencies: ["Logging"]),
                         TargetDescription(name: "Logging", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "thisPkg",
-                    path: .init(path: "/thisPkg"),
+                    path: "/thisPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/otherPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/otherPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "exe",
-                                          dependencies: ["Logging",
-                                                         .product(name: "Utils",
-                                                                  package: "otherPkg",
-                                                                  moduleAliases: ["Logging": "UtilsLogging"]),
-                                                         .product(name: "LoggingProd",
-                                                                  package: "otherPkg",
-                                                                  moduleAliases: ["Logging": "OtherLogging"])]),
+                        TargetDescription(
+                            name: "exe",
+                            dependencies: ["Logging",
+                                           .product(
+                                               name: "Utils",
+                                               package: "otherPkg",
+                                               moduleAliases: ["Logging": "UtilsLogging"]
+                                           ),
+                                           .product(
+                                               name: "LoggingProd",
+                                               package: "otherPkg",
+                                               moduleAliases: ["Logging": "OtherLogging"]
+                                           )]
+                        ),
                         TargetDescription(name: "Logging", dependencies: []),
-                    ]),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )) { error in
             var diagnosed = false
             if let realError = error as? PackageGraphError,
-                    realError.description == "multiple aliases: ['UtilsLogging', 'OtherLogging'] found for target 'Logging' in product 'LoggingProd' from package 'otherPkg'" {
+               realError
+               .description ==
+               "multiple aliases: ['UtilsLogging', 'OtherLogging'] found for target 'Logging' in product 'LoggingProd' from package 'otherPkg'"
+            {
                 diagnosed = true
             }
             XCTAssertTrue(diagnosed)
@@ -741,11 +927,12 @@ final class ModuleAliasingBuildTests: XCTestCase {
     }
 
     func testModuleAliasingSameNameTargetsWithAliasesInMultiProducts() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/appPkg/Sources/App/main.swift",
-                                        "/swift-log/Sources/Logging/fileLogging.swift",
-                                        "/swift-metrics/Sources/Metrics/file.swift",
-                                        "/swift-metrics/Sources/Logging/fileLogging.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/appPkg/Sources/App/main.swift",
+            "/swift-log/Sources/Logging/fileLogging.swift",
+            "/swift-metrics/Sources/Metrics/file.swift",
+            "/swift-metrics/Sources/Logging/fileLogging.swift"
         )
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
@@ -753,41 +940,47 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     displayName: "swift-log",
-                    path: .init(path: "/swift-log"),
+                    path: "/swift-log",
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
                     ],
                     targets: [
                         TargetDescription(name: "Logging", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "swift-metrics",
-                    path: .init(path: "/swift-metrics"),
+                    path: "/swift-metrics",
                     products: [
                         ProductDescription(name: "Metrics", type: .library(.automatic), targets: ["Metrics"]),
                     ],
                     targets: [
                         TargetDescription(name: "Metrics", dependencies: ["Logging"]),
                         TargetDescription(name: "Logging", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "appPkg",
-                    path: .init(path: "/appPkg"),
+                    path: "/appPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/swift-log"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/swift-metrics"), requirement: .upToNextMajor(from: "2.0.0")),
+                        .localSourceControl(path: "/swift-log", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/swift-metrics", requirement: .upToNextMajor(from: "2.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "App",
-                                          dependencies: [.product(name: "Logging",
-                                                                  package: "swift-log"
-                                                                 ),
-                                                         .product(name: "Metrics",
-                                                                  package: "swift-metrics",
-                                                                  moduleAliases: ["Logging": "MetricsLogging"]
-                                                                 )
-                                                        ]),
-                    ]),
+                        TargetDescription(
+                            name: "App",
+                            dependencies: [.product(
+                                name: "Logging",
+                                package: "swift-log"
+                            ),
+                            .product(
+                                name: "Metrics",
+                                package: "swift-metrics",
+                                moduleAliases: ["Logging": "MetricsLogging"]
+                            )]
+                        ),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
@@ -800,18 +993,27 @@ final class ModuleAliasingBuildTests: XCTestCase {
         ))
         result.checkProductsCount(1)
         result.checkTargetsCount(4)
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "MetricsLogging" && $0.target.moduleAliases?["Logging"] == "MetricsLogging" })
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains {
+                    $0.target.name == "MetricsLogging" && $0.target.moduleAliases?["Logging"] == "MetricsLogging"
+                }
+        )
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
     }
 
     func testModuleAliasingInvalidSourcesUpstream() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/thisPkg/Sources/exe/main.swift",
-                                    "/thisPkg/Sources/Logging/file.swift",
-                                    "/fooPkg/Sources/Utils/fileUtils.swift",
-                                    "/fooPkg/Sources/Logging/fileLogging.m",
-                                    "/fooPkg/Sources/Logging/include/fileLogging.h"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/thisPkg/Sources/exe/main.swift",
+            "/thisPkg/Sources/Logging/file.swift",
+            "/fooPkg/Sources/Utils/fileUtils.swift",
+            "/fooPkg/Sources/Logging/fileLogging.m",
+            "/fooPkg/Sources/Logging/include/fileLogging.h"
         )
         let observability = ObservabilitySystem.makeForTesting()
         let _ = try loadPackageGraph(
@@ -819,45 +1021,54 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "fooPkg",
-                    path: .init(path: "/fooPkg"),
+                    path: "/fooPkg",
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
                     targets: [
                         TargetDescription(name: "Utils", dependencies: ["Logging"]),
                         TargetDescription(name: "Logging", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "thisPkg",
-                    path: .init(path: "/thisPkg"),
+                    path: "/thisPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/fooPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "exe",
-                                          dependencies: ["Logging",
-                                                         .product(name: "Utils",
-                                                                  package: "fooPkg",
-                                                                  moduleAliases: ["Logging": "FooLogging"])
-                                          ]),
+                        TargetDescription(
+                            name: "exe",
+                            dependencies: ["Logging",
+                                           .product(
+                                               name: "Utils",
+                                               package: "fooPkg",
+                                               moduleAliases: ["Logging": "FooLogging"]
+                                           )]
+                        ),
                         TargetDescription(name: "Logging", dependencies: []),
-                    ]),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
 
         testDiagnostics(observability.diagnostics) { result in
-            result.check(diagnostic: "target 'Logging' for product 'Utils' from package 'foopkg' has module aliases: ['Logging' as 'FooLogging'] but may contain non-Swift sources; there might be a conflict among non-Swift symbols", severity: .warning)
+            result.check(
+                diagnostic: "target 'Logging' for product 'Utils' from package 'foopkg' has module aliases: ['Logging' as 'FooLogging'] but may contain non-Swift sources; there might be a conflict among non-Swift symbols",
+                severity: .warning
+            )
         }
     }
 
     func testModuleAliasingInvalidSourcesNestedUpstream() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/thisPkg/Sources/exe/main.swift",
-                                    "/thisPkg/Sources/Logging/file.swift",
-                                    "/fooPkg/Sources/Utils/fileUtils.swift",
-                                    "/barPkg/Sources/Logging/fileLogging.m",
-                                    "/barPkg/Sources/Logging/include/fileLogging.h"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/thisPkg/Sources/exe/main.swift",
+            "/thisPkg/Sources/Logging/file.swift",
+            "/fooPkg/Sources/Utils/fileUtils.swift",
+            "/barPkg/Sources/Logging/fileLogging.m",
+            "/barPkg/Sources/Logging/include/fileLogging.h"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -866,59 +1077,71 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "barPkg",
-                    path: .init(path: "/barPkg"),
+                    path: "/barPkg",
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
                     ],
                     targets: [
                         TargetDescription(name: "Logging", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "fooPkg",
-                    path: .init(path: "/fooPkg"),
+                    path: "/fooPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/barPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
                     targets: [
-                        TargetDescription(name: "Utils",
-                                          dependencies: [.product(name: "Logging", package: "barPkg")]),
-                    ]),
+                        TargetDescription(
+                            name: "Utils",
+                            dependencies: [.product(name: "Logging", package: "barPkg")]
+                        ),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "thisPkg",
-                    path: .init(path: "/thisPkg"),
+                    path: "/thisPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/fooPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "exe",
-                                          dependencies: ["Logging",
-                                                         .product(name: "Utils",
-                                                                  package: "fooPkg",
-                                                                  moduleAliases: ["Logging": "FooLogging"])
-                                          ]),
+                        TargetDescription(
+                            name: "exe",
+                            dependencies: ["Logging",
+                                           .product(
+                                               name: "Utils",
+                                               package: "fooPkg",
+                                               moduleAliases: ["Logging": "FooLogging"]
+                                           )]
+                        ),
                         TargetDescription(name: "Logging", dependencies: []),
-                    ]),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
 
         testDiagnostics(observability.diagnostics) { result in
-            result.check(diagnostic: "target 'Logging' for product 'Logging' from package 'barpkg' has module aliases: ['Logging' as 'FooLogging'] but may contain non-Swift sources; there might be a conflict among non-Swift symbols", severity: .warning)
+            result.check(
+                diagnostic: "target 'Logging' for product 'Logging' from package 'barpkg' has module aliases: ['Logging' as 'FooLogging'] but may contain non-Swift sources; there might be a conflict among non-Swift symbols",
+                severity: .warning
+            )
         }
     }
 
     func testModuleAliasingInvalidSourcesInNonAliasedModulesUpstream() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/thisPkg/Sources/exe/main.swift",
-                                    "/thisPkg/Sources/Logging/file.swift",
-                                    "/fooPkg/Sources/Utils/fileUtils.swift",
-                                    "/fooPkg/Sources/Logging/fileLogging.swift",
-                                    "/fooPkg/Sources/Logging/guidelines.txt",
-                                    "/fooPkg/Sources/Perf/filePerf.m",
-                                    "/fooPkg/Sources/Perf/include/filePerf.h"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/thisPkg/Sources/exe/main.swift",
+            "/thisPkg/Sources/Logging/file.swift",
+            "/fooPkg/Sources/Utils/fileUtils.swift",
+            "/fooPkg/Sources/Logging/fileLogging.swift",
+            "/fooPkg/Sources/Logging/guidelines.txt",
+            "/fooPkg/Sources/Perf/filePerf.m",
+            "/fooPkg/Sources/Perf/include/filePerf.h"
         )
         let observability = ObservabilitySystem.makeForTesting()
         XCTAssertNoThrow(try loadPackageGraph(
@@ -926,7 +1149,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "fooPkg",
-                    path: .init(path: "/fooPkg"),
+                    path: "/fooPkg",
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                         ProductDescription(name: "Perf", type: .library(.automatic), targets: ["Perf"]),
@@ -935,36 +1158,42 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Utils", dependencies: ["Logging"]),
                         TargetDescription(name: "Logging", dependencies: []),
                         TargetDescription(name: "Perf", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "thisPkg",
-                    path: .init(path: "/thisPkg"),
+                    path: "/thisPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/fooPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "exe",
-                                          dependencies: ["Logging",
-                                                         .product(name: "Utils",
-                                                                  package: "fooPkg",
-                                                                  moduleAliases: ["Logging": "FooLogging"])
-                                          ]),
+                        TargetDescription(
+                            name: "exe",
+                            dependencies: ["Logging",
+                                           .product(
+                                               name: "Utils",
+                                               package: "fooPkg",
+                                               moduleAliases: ["Logging": "FooLogging"]
+                                           )]
+                        ),
                         TargetDescription(name: "Logging", dependencies: []),
-                    ]),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         ))
     }
 
     func testModuleAliasingInvalidSourcesInNonAliasedModulesNestedUpstream() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/thisPkg/Sources/exe/main.swift",
-                                    "/thisPkg/Sources/Logging/file.swift",
-                                    "/fooPkg/Sources/Utils/fileUtils.swift",
-                                    "/barPkg/Sources/Logging/fileLogging.swift",
-                                    "/barPkg/Sources/Logging/readme.md",
-                                    "/barPkg/Sources/Perf/filePerf.m",
-                                    "/barPkg/Sources/Perf/include/filePerf.h"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/thisPkg/Sources/exe/main.swift",
+            "/thisPkg/Sources/Logging/file.swift",
+            "/fooPkg/Sources/Utils/fileUtils.swift",
+            "/barPkg/Sources/Logging/fileLogging.swift",
+            "/barPkg/Sources/Logging/readme.md",
+            "/barPkg/Sources/Perf/filePerf.m",
+            "/barPkg/Sources/Perf/include/filePerf.h"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -973,7 +1202,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "barPkg",
-                    path: .init(path: "/barPkg"),
+                    path: "/barPkg",
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
                         ProductDescription(name: "Perf", type: .library(.automatic), targets: ["Perf"]),
@@ -981,46 +1210,55 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     targets: [
                         TargetDescription(name: "Logging", dependencies: []),
                         TargetDescription(name: "Perf", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "fooPkg",
-                    path: .init(path: "/fooPkg"),
+                    path: "/fooPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/barPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
                     targets: [
-                        TargetDescription(name: "Utils",
-                                          dependencies: [.product(name: "Logging", package: "barPkg")]),
-                    ]),
+                        TargetDescription(
+                            name: "Utils",
+                            dependencies: [.product(name: "Logging", package: "barPkg")]
+                        ),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "thisPkg",
-                    path: .init(path: "/thisPkg"),
+                    path: "/thisPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/fooPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "exe",
-                                          dependencies: ["Logging",
-                                                         .product(name: "Utils",
-                                                                  package: "fooPkg",
-                                                                  moduleAliases: ["Logging": "FooLogging"])
-                                          ]),
+                        TargetDescription(
+                            name: "exe",
+                            dependencies: ["Logging",
+                                           .product(
+                                               name: "Utils",
+                                               package: "fooPkg",
+                                               moduleAliases: ["Logging": "FooLogging"]
+                                           )]
+                        ),
                         TargetDescription(name: "Logging", dependencies: []),
-                    ]),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         ))
     }
 
     func testModuleAliasingDuplicateTargetNameInNestedUpstream() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/thisPkg/Sources/exe/main.swift",
-                                    "/thisPkg/Sources/Logging/file.swift",
-                                    "/fooPkg/Sources/Utils/fileUtils.swift",
-                                    "/barPkg/Sources/Logging/fileLogging.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/thisPkg/Sources/exe/main.swift",
+            "/thisPkg/Sources/Logging/file.swift",
+            "/fooPkg/Sources/Utils/fileUtils.swift",
+            "/barPkg/Sources/Logging/fileLogging.swift"
         )
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
@@ -1028,69 +1266,87 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "barPkg",
-                    path: .init(path: "/barPkg"),
+                    path: "/barPkg",
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
                     ],
                     targets: [
                         TargetDescription(name: "Logging", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "fooPkg",
-                    path: .init(path: "/fooPkg"),
+                    path: "/fooPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/barPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
                     targets: [
-                        TargetDescription(name: "Utils",
-                                          dependencies: [.product(name: "Logging", package: "barPkg")]),
-                    ]),
+                        TargetDescription(
+                            name: "Utils",
+                            dependencies: [.product(name: "Logging", package: "barPkg")]
+                        ),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "thisPkg",
-                    path: .init(path: "/thisPkg"),
+                    path: "/thisPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/fooPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "exe",
-                                          dependencies: ["Logging",
-                                                         .product(name: "Utils",
-                                                                  package: "fooPkg",
-                                                                  moduleAliases: ["Logging": "FooLogging"])
-                                          ]),
+                        TargetDescription(
+                            name: "exe",
+                            dependencies: ["Logging",
+                                           .product(
+                                               name: "Utils",
+                                               package: "fooPkg",
+                                               moduleAliases: ["Logging": "FooLogging"]
+                                           )]
+                        ),
                         TargetDescription(name: "Logging", dependencies: []),
-                    ]),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
-        
+
         let result = try BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(shouldLinkStaticSwiftStdlib: true),
             graph: graph,
             fileSystem: fs,
             observabilityScope: observability.topScope
         ))
-        
+
         result.checkProductsCount(1)
         result.checkTargetsCount(4)
-        
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases?["Logging"] == "FooLogging" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "FooLogging" && $0.target.moduleAliases?["Logging"] == "FooLogging" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil })
+
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "Utils" && $0.target.moduleAliases?["Logging"] == "FooLogging" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "FooLogging" && $0.target.moduleAliases?["Logging"] == "FooLogging" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil }
+        )
     }
 
     func testModuleAliasingOverrideMultipleAliases() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/thisPkg/Sources/exe/main.swift",
-                                    "/thisPkg/Sources/Logging/file1.swift",
-                                    "/thisPkg/Sources/Math/file2.swift",
-                                    "/fooPkg/Sources/Utils/fileUtils.swift",
-                                    "/barPkg/Sources/Logging/fileLogging.swift",
-                                    "/barPkg/Sources/Math/fileMath.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/thisPkg/Sources/exe/main.swift",
+            "/thisPkg/Sources/Logging/file1.swift",
+            "/thisPkg/Sources/Math/file2.swift",
+            "/fooPkg/Sources/Utils/fileUtils.swift",
+            "/barPkg/Sources/Logging/fileLogging.swift",
+            "/barPkg/Sources/Math/fileMath.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -1099,7 +1355,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     displayName: "barPkg",
-                    path: .init(path: "/barPkg"),
+                    path: "/barPkg",
                     products: [
                         ProductDescription(name: "LoggingProd", type: .library(.automatic), targets: ["Logging"]),
                         ProductDescription(name: "MathProd", type: .library(.automatic), targets: ["Math"]),
@@ -1107,44 +1363,57 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     targets: [
                         TargetDescription(name: "Logging", dependencies: []),
                         TargetDescription(name: "Math", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "fooPkg",
-                    path: .init(path: "/fooPkg"),
+                    path: "/fooPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/barPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
                     targets: [
-                        TargetDescription(name: "Utils",
-                                          dependencies: [.product(name: "LoggingProd",
-                                                                  package: "barPkg",
-                                                                  moduleAliases: ["Logging": "BarLogging"]
-                                                                 ),
-                                                         .product(name: "MathProd",
-                                                                  package: "barPkg",
-                                                                  moduleAliases: ["Math": "BarMath"])
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "Utils",
+                            dependencies: [.product(
+                                name: "LoggingProd",
+                                package: "barPkg",
+                                moduleAliases: ["Logging": "BarLogging"]
+                            ),
+                            .product(
+                                name: "MathProd",
+                                package: "barPkg",
+                                moduleAliases: ["Math": "BarMath"]
+                            )]
+                        ),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "thisPkg",
-                    path: .init(path: "/thisPkg"),
+                    path: "/thisPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/fooPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "exe",
-                                          dependencies: ["Logging",
-                                                         "Math",
-                                                         .product(name: "Utils",
-                                                                  package: "fooPkg",
-                                                                  moduleAliases: ["BarLogging": "FooLogging", "BarMath": "FooMath"])
-                                                        ]),
+                        TargetDescription(
+                            name: "exe",
+                            dependencies: ["Logging",
+                                           "Math",
+                                           .product(
+                                               name: "Utils",
+                                               package: "fooPkg",
+                                               moduleAliases: [
+                                                   "BarLogging": "FooLogging",
+                                                   "BarMath": "FooMath",
+                                               ]
+                                           )]
+                        ),
                         TargetDescription(name: "Logging", dependencies: []),
                         TargetDescription(name: "Math", dependencies: []),
-                    ]),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
@@ -1160,28 +1429,44 @@ final class ModuleAliasingBuildTests: XCTestCase {
         result.checkProductsCount(1)
         result.checkTargetsCount(6)
 
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "FooLogging" && $0.target.moduleAliases?["Logging"] == "FooLogging" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "FooMath" && $0.target.moduleAliases?["Math"] == "FooMath" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases?["Logging"] == "FooLogging" && $0.target.moduleAliases?["Math"] == "FooMath" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "FooLogging" && $0.target.moduleAliases?["Logging"] == "FooLogging" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "FooMath" && $0.target.moduleAliases?["Math"] == "FooMath" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains {
+                    $0.target.name == "Utils" && $0.target.moduleAliases?["Logging"] == "FooLogging" && $0.target
+                        .moduleAliases?["Math"] == "FooMath"
+                }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil }
+        )
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Math" && $0.target.moduleAliases == nil })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "exe" && $0.target.moduleAliases == nil})
+        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "exe" && $0.target.moduleAliases == nil })
         XCTAssertFalse(result.targetMap.values.contains { $0.target.name == "BarLogging" })
     }
 
     func testModuleAliasingAliasSkipUpstreamTargets() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/appPkg/Sources/App/main.swift",
-                                    "/appPkg/Sources/Foo/file.swift",
-                                    "/xPkg/Sources/X/file.swift",
-                                    "/yPkg/Sources/Y/file.swift",
-                                    "/zPkg/Sources/Z/file.swift",
-                                    "/zPkg/Sources/Foo/file.swift",
-                                    "/aPkg/Sources/A/file.swift",
-                                    "/bPkg/Sources/B/file.swift",
-                                    "/cPkg/Sources/C/file.swift",
-                                    "/cPkg/Sources/Foo/file.swift",
-                                    "/dPkg/Sources/D/file.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/appPkg/Sources/App/main.swift",
+            "/appPkg/Sources/Foo/file.swift",
+            "/xPkg/Sources/X/file.swift",
+            "/yPkg/Sources/Y/file.swift",
+            "/zPkg/Sources/Z/file.swift",
+            "/zPkg/Sources/Foo/file.swift",
+            "/aPkg/Sources/A/file.swift",
+            "/bPkg/Sources/B/file.swift",
+            "/cPkg/Sources/C/file.swift",
+            "/cPkg/Sources/Foo/file.swift",
+            "/dPkg/Sources/D/file.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -1190,120 +1475,146 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     displayName: "cPkg",
-                    path: .init(path: "/cPkg"),
+                    path: "/cPkg",
                     products: [
                         ProductDescription(name: "C", type: .library(.automatic), targets: ["C"]),
                     ],
                     targets: [
                         TargetDescription(name: "C", dependencies: ["Foo"]),
                         TargetDescription(name: "Foo", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "dPkg",
-                    path: .init(path: "/dPkg"),
+                    path: "/dPkg",
                     products: [
                         ProductDescription(name: "D", type: .library(.automatic), targets: ["D"]),
                     ],
                     targets: [
                         TargetDescription(name: "D", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "bPkg",
-                    path: .init(path: "/bPkg"),
+                    path: "/bPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/cPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/dPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/cPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/dPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "B", type: .library(.automatic), targets: ["B"]),
                     ],
                     targets: [
-                        TargetDescription(name: "B",
-                                          dependencies: [
-                                            .product(name: "C",
-                                                     package: "cPkg"),
-                                            .product(name: "D",
-                                                     package: "dPkg")
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "B",
+                            dependencies: [
+                                .product(
+                                    name: "C",
+                                    package: "cPkg"
+                                ),
+                                .product(
+                                    name: "D",
+                                    package: "dPkg"
+                                ),
+                            ]
+                        ),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "aPkg",
-                    path: .init(path: "/aPkg"),
+                    path: "/aPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/bPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/bPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "A", type: .library(.automatic), targets: ["A"]),
                     ],
                     targets: [
-                        TargetDescription(name: "A",
-                                          dependencies: [.product(name: "B",
-                                                                  package: "bPkg"
-                                                                 )
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "A",
+                            dependencies: [.product(
+                                name: "B",
+                                package: "bPkg"
+                            )]
+                        ),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "zPkg",
-                    path: .init(path: "/zPkg"),
+                    path: "/zPkg",
                     products: [
                         ProductDescription(name: "Z", type: .library(.automatic), targets: ["Z"]),
                     ],
                     targets: [
                         TargetDescription(name: "Z", dependencies: ["Foo"]),
                         TargetDescription(name: "Foo", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "yPkg",
-                    path: .init(path: "/yPkg"),
+                    path: "/yPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/zPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/zPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "Y", type: .library(.automatic), targets: ["Y"]),
                     ],
                     targets: [
-                        TargetDescription(name: "Y",
-                                          dependencies: [
-                                            .product(name: "Z",
-                                                     package: "zPkg"
-                                          )]),
-                    ]),
+                        TargetDescription(
+                            name: "Y",
+                            dependencies: [
+                                .product(
+                                    name: "Z",
+                                    package: "zPkg"
+                                ),
+                            ]
+                        ),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "xPkg",
-                    path: .init(path: "/xPkg"),
+                    path: "/xPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/yPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/yPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "X", type: .library(.automatic), targets: ["X"]),
                     ],
                     targets: [
-                        TargetDescription(name: "X",
-                                          dependencies: [.product(name: "Y",
-                                                                  package: "yPkg"
-                                                                 )
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "X",
+                            dependencies: [.product(
+                                name: "Y",
+                                package: "yPkg"
+                            )]
+                        ),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "appPkg",
-                    path: .init(path: "/appPkg"),
+                    path: "/appPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/aPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/xPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/aPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/xPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "App",
-                                          dependencies: [ "Foo",
-                                                         .product(name: "A",
-                                                                  package: "aPkg",
-                                                                  moduleAliases: ["Foo": "FooA"]),
-                                                         .product(name: "X",
-                                                                  package: "xPkg",
-                                                                  moduleAliases: ["Foo": "FooX"])
-                                                        ]
-                                         ),
+                        TargetDescription(
+                            name: "App",
+                            dependencies: ["Foo",
+                                           .product(
+                                               name: "A",
+                                               package: "aPkg",
+                                               moduleAliases: ["Foo": "FooA"]
+                                           ),
+                                           .product(
+                                               name: "X",
+                                               package: "xPkg",
+                                               moduleAliases: ["Foo": "FooX"]
+                                           )]
+                        ),
                         TargetDescription(name: "Foo", dependencies: []),
-                    ]),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
@@ -1320,29 +1631,54 @@ final class ModuleAliasingBuildTests: XCTestCase {
         result.checkTargetsCount(11)
 
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "D" && $0.target.moduleAliases == nil })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "FooA" && $0.target.moduleAliases?["Foo"] == "FooA" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "C" && $0.target.moduleAliases?["Foo"] == "FooA" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "B" && $0.target.moduleAliases?["Foo"] == "FooA" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "A" && $0.target.moduleAliases?["Foo"] == "FooA" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "FooX" && $0.target.moduleAliases?["Foo"] == "FooX" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Z" && $0.target.moduleAliases?["Foo"] == "FooX" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Y" && $0.target.moduleAliases?["Foo"] == "FooX" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "X" && $0.target.moduleAliases?["Foo"] == "FooX" })
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "FooA" && $0.target.moduleAliases?["Foo"] == "FooA" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "C" && $0.target.moduleAliases?["Foo"] == "FooA" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "B" && $0.target.moduleAliases?["Foo"] == "FooA" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "A" && $0.target.moduleAliases?["Foo"] == "FooA" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "FooX" && $0.target.moduleAliases?["Foo"] == "FooX" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "Z" && $0.target.moduleAliases?["Foo"] == "FooX" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "Y" && $0.target.moduleAliases?["Foo"] == "FooX" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "X" && $0.target.moduleAliases?["Foo"] == "FooX" }
+        )
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
     }
 
     func testModuleAliasingAllConflictingAliasesFromMultiProducts() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/aPkg/Sources/A/main.swift",
-                                    "/aPkg/Sources/A/file.swift",
-                                    "/bPkg/Sources/B/file.swift",
-                                    "/bPkg/Sources/Utils/file.swift",
-                                    "/cPkg/Sources/C/file.swift",
-                                    "/cPkg/Sources/Log/file.swift",
-                                    "/dPkg/Sources/D/file.swift",
-                                    "/dPkg/Sources/Utils/file.swift",
-                                    "/dPkg/Sources/Log/file.swift",
-                                    "/gPkg/Sources/G/file.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/aPkg/Sources/A/main.swift",
+            "/aPkg/Sources/A/file.swift",
+            "/bPkg/Sources/B/file.swift",
+            "/bPkg/Sources/Utils/file.swift",
+            "/cPkg/Sources/C/file.swift",
+            "/cPkg/Sources/Log/file.swift",
+            "/dPkg/Sources/D/file.swift",
+            "/dPkg/Sources/Utils/file.swift",
+            "/dPkg/Sources/Log/file.swift",
+            "/gPkg/Sources/G/file.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -1351,23 +1687,26 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     displayName: "gPkg",
-                    path: .init(path: "/gPkg"),
+                    path: "/gPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/dPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/dPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "G", type: .library(.automatic), targets: ["G"]),
                     ],
                     targets: [
-                        TargetDescription(name: "G",
-                                          dependencies: [.product(name: "D",
-                                                                  package: "dPkg"
-                                                                 )
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "G",
+                            dependencies: [.product(
+                                name: "D",
+                                package: "dPkg"
+                            )]
+                        ),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "dPkg",
-                    path: .init(path: "/dPkg"),
+                    path: "/dPkg",
                     products: [
                         ProductDescription(name: "D", type: .library(.automatic), targets: ["D"]),
                     ],
@@ -1375,12 +1714,13 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "D", dependencies: ["Utils", "Log"]),
                         TargetDescription(name: "Utils", dependencies: []),
                         TargetDescription(name: "Log", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "cPkg",
-                    path: .init(path: "/cPkg"),
+                    path: "/cPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/dPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/dPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "C", type: .library(.automatic), targets: ["C"]),
@@ -1388,55 +1728,66 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ],
                     targets: [
                         TargetDescription(name: "C", dependencies: ["Log"]),
-                        TargetDescription(name: "Log",
-                                          dependencies: [
-                                            .product(name: "D",
-                                                     package: "dPkg",
-                                                     moduleAliases: ["Log" : "ZLog"]
-                                                    ),
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "Log",
+                            dependencies: [
+                                .product(
+                                    name: "D",
+                                    package: "dPkg",
+                                    moduleAliases: ["Log": "ZLog"]
+                                ),
+                            ]
+                        ),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "bPkg",
-                    path: .init(path: "/bPkg"),
+                    path: "/bPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/cPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/cPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "B", type: .library(.automatic), targets: ["B"]),
                     ],
                     targets: [
-                        TargetDescription(name: "B",
-                                          dependencies: [
-                                            "Utils",
-                                            .product(name: "C",
-                                                     package: "cPkg",
-                                                     moduleAliases: ["Utils": "YUtils",
-                                                                     "Log": "YLog"
-                                                                    ]
-                                            ),
-                                          ]),
-                        TargetDescription(name: "Utils", dependencies: [])
-                    ]),
+                        TargetDescription(
+                            name: "B",
+                            dependencies: [
+                                "Utils",
+                                .product(
+                                    name: "C",
+                                    package: "cPkg",
+                                    moduleAliases: ["Utils": "YUtils",
+                                                    "Log": "YLog"]
+                                ),
+                            ]
+                        ),
+                        TargetDescription(name: "Utils", dependencies: []),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "aPkg",
-                    path: .init(path: "/aPkg"),
+                    path: "/aPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/bPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/gPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/bPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/gPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "A",
-                                          dependencies: [
-                                            .product(name: "G",
-                                                     package: "gPkg"),
-                                            .product(name: "B",
-                                                     package: "bPkg",
-                                                     moduleAliases: ["Utils": "XUtils",
-                                                                     "YLog": "XLog"]
-                                                    ),
-                                          ]
-                                         ),
+                        TargetDescription(
+                            name: "A",
+                            dependencies: [
+                                .product(
+                                    name: "G",
+                                    package: "gPkg"
+                                ),
+                                .product(
+                                    name: "B",
+                                    package: "bPkg",
+                                    moduleAliases: ["Utils": "XUtils",
+                                                    "YLog": "XLog"]
+                                ),
+                            ]
+                        ),
                     ]
                 ),
             ],
@@ -1453,28 +1804,82 @@ final class ModuleAliasingBuildTests: XCTestCase {
 
         result.checkProductsCount(1)
         result.checkTargetsCount(9)
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "A" && $0.target.moduleAliases?["Utils"] == "XUtils" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "B" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target.moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?.count == 2 })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target.moduleAliases?.count == 1 })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "C" && $0.target.moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?["Utils"] == "YUtils" && $0.target.moduleAliases?.count == 2 })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "XLog" && $0.target.moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?["Utils"] == "YUtils" && $0.target.moduleAliases?.count == 2 })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "D" && $0.target.moduleAliases?["Utils"] == "YUtils" && $0.target.moduleAliases?["Log"] == "ZLog" && $0.target.moduleAliases?.count == 2})
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "YUtils" && $0.target.moduleAliases?["Utils"] == "YUtils" && $0.target.moduleAliases?.count == 1 })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "ZLog" && $0.target.moduleAliases?["Log"] == "ZLog" && $0.target.moduleAliases?.count == 1 })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "G" && $0.target.moduleAliases?["Utils"] == "YUtils" && $0.target.moduleAliases?["Log"] == "ZLog" && $0.target.moduleAliases?.count == 2})
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "A" && $0.target.moduleAliases?["Utils"] == "XUtils" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains {
+                    $0.target.name == "B" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target
+                        .moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?.count == 2
+                }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains {
+                    $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target
+                        .moduleAliases?
+                        .count == 1
+                }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains {
+                    $0.target.name == "C" && $0.target.moduleAliases?["Log"] == "XLog" && $0.target
+                        .moduleAliases?["Utils"] == "YUtils" && $0.target.moduleAliases?.count == 2
+                }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains {
+                    $0.target.name == "XLog" && $0.target.moduleAliases?["Log"] == "XLog" && $0.target
+                        .moduleAliases?["Utils"] == "YUtils" && $0.target.moduleAliases?.count == 2
+                }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains {
+                    $0.target.name == "D" && $0.target.moduleAliases?["Utils"] == "YUtils" && $0.target
+                        .moduleAliases?["Log"] == "ZLog" && $0.target.moduleAliases?.count == 2
+                }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains {
+                    $0.target.name == "YUtils" && $0.target.moduleAliases?["Utils"] == "YUtils" && $0.target
+                        .moduleAliases?
+                        .count == 1
+                }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains {
+                    $0.target.name == "ZLog" && $0.target.moduleAliases?["Log"] == "ZLog" && $0.target.moduleAliases?
+                        .count == 1
+                }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains {
+                    $0.target.name == "G" && $0.target.moduleAliases?["Utils"] == "YUtils" && $0.target
+                        .moduleAliases?["Log"] == "ZLog" && $0.target.moduleAliases?.count == 2
+                }
+        )
     }
 
     func testModuleAliasingSomeConflictingAliasesInMultiProducts() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/aPkg/Sources/A/main.swift",
-                                    "/aPkg/Sources/A/file.swift",
-                                    "/bPkg/Sources/B/file.swift",
-                                    "/cPkg/Sources/C/file.swift",
-                                    "/dPkg/Sources/D/file.swift",
-                                    "/dPkg/Sources/Utils/file.swift",
-                                    "/dPkg/Sources/Log/file.swift",
-                                    "/gPkg/Sources/G/file.swift",
-                                    "/hPkg/Sources/Utils/file.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/aPkg/Sources/A/main.swift",
+            "/aPkg/Sources/A/file.swift",
+            "/bPkg/Sources/B/file.swift",
+            "/cPkg/Sources/C/file.swift",
+            "/dPkg/Sources/D/file.swift",
+            "/dPkg/Sources/Utils/file.swift",
+            "/dPkg/Sources/Log/file.swift",
+            "/gPkg/Sources/G/file.swift",
+            "/hPkg/Sources/Utils/file.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -1483,35 +1888,41 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     displayName: "hPkg",
-                    path: .init(path: "/hPkg"),
+                    path: "/hPkg",
                     dependencies: [
                     ],
                     products: [
                         ProductDescription(name: "H", type: .library(.automatic), targets: ["Utils"]),
                     ],
                     targets: [
-                        TargetDescription(name: "Utils",
-                                          dependencies: []),
-                    ]),
+                        TargetDescription(
+                            name: "Utils",
+                            dependencies: []
+                        ),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "gPkg",
-                    path: .init(path: "/gPkg"),
+                    path: "/gPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/hPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/hPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "G", type: .library(.automatic), targets: ["G"]),
                     ],
                     targets: [
-                        TargetDescription(name: "G",
-                                          dependencies: [.product(name: "H",
-                                                                  package: "hPkg"
-                                                                 )
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "G",
+                            dependencies: [.product(
+                                name: "H",
+                                package: "hPkg"
+                            )]
+                        ),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "dPkg",
-                    path: .init(path: "/dPkg"),
+                    path: "/dPkg",
                     products: [
                         ProductDescription(name: "D", type: .library(.automatic), targets: ["D"]),
                     ],
@@ -1519,65 +1930,77 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "D", dependencies: ["Utils", "Log"]),
                         TargetDescription(name: "Utils", dependencies: []),
                         TargetDescription(name: "Log", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "cPkg",
-                    path: .init(path: "/cPkg"),
+                    path: "/cPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/dPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/dPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "C", type: .library(.automatic), targets: ["C"]),
                     ],
                     targets: [
-                        TargetDescription(name: "C",
-                                          dependencies: [
-                                            .product(name: "D",
-                                                     package: "dPkg",
-                                                     moduleAliases: ["Log" : "ZLog"]
-                                                    ),
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "C",
+                            dependencies: [
+                                .product(
+                                    name: "D",
+                                    package: "dPkg",
+                                    moduleAliases: ["Log": "ZLog"]
+                                ),
+                            ]
+                        ),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "bPkg",
-                    path: .init(path: "/bPkg"),
+                    path: "/bPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/cPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/cPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "B", type: .library(.automatic), targets: ["B"]),
                     ],
                     targets: [
-                        TargetDescription(name: "B",
-                                          dependencies: [
-                                            .product(name: "C",
-                                                     package: "cPkg",
-                                                     moduleAliases: ["Utils": "YUtils",
-                                                                     "ZLog": "YLog"
-                                                                    ]
-                                            ),
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "B",
+                            dependencies: [
+                                .product(
+                                    name: "C",
+                                    package: "cPkg",
+                                    moduleAliases: ["Utils": "YUtils",
+                                                    "ZLog": "YLog"]
+                                ),
+                            ]
+                        ),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "aPkg",
-                    path: .init(path: "/aPkg"),
+                    path: "/aPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/bPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/gPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/bPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/gPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "A",
-                                          dependencies: [
-                                            .product(name: "B",
-                                                     package: "bPkg",
-                                                     moduleAliases: ["YUtils": "XUtils",
-                                                                     "YLog": "XLog"]
-                                                    ),
-                                            .product(name: "G",
-                                                     package: "gPkg",
-                                                     moduleAliases: ["Utils": "GUtils"]),
-                                          ]
-                                         ),
+                        TargetDescription(
+                            name: "A",
+                            dependencies: [
+                                .product(
+                                    name: "B",
+                                    package: "bPkg",
+                                    moduleAliases: ["YUtils": "XUtils",
+                                                    "YLog": "XLog"]
+                                ),
+                                .product(
+                                    name: "G",
+                                    package: "gPkg",
+                                    moduleAliases: ["Utils": "GUtils"]
+                                ),
+                            ]
+                        ),
                     ]
                 ),
             ],
@@ -1595,27 +2018,78 @@ final class ModuleAliasingBuildTests: XCTestCase {
         result.checkProductsCount(1)
         result.checkTargetsCount(8)
 
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "A" && $0.target.moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?.count == 1 })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "B" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target.moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?.count == 2 })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "C" && $0.target.moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target.moduleAliases?.count == 2 })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "D" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target.moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?.count == 2})
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target.moduleAliases?.count == 1 })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "XLog" && $0.target.moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?.count == 1 })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "G" && $0.target.moduleAliases?["Utils"] == "GUtils" && $0.target.moduleAliases?.count == 1})
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "GUtils" && $0.target.moduleAliases?["Utils"] == "GUtils" && $0.target.moduleAliases?.count == 1})
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains {
+                    $0.target.name == "A" && $0.target.moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?
+                        .count == 1
+                }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains {
+                    $0.target.name == "B" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target
+                        .moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?.count == 2
+                }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains {
+                    $0.target.name == "C" && $0.target.moduleAliases?["Log"] == "XLog" && $0.target
+                        .moduleAliases?["Utils"] == "XUtils" && $0.target.moduleAliases?.count == 2
+                }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains {
+                    $0.target.name == "D" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target
+                        .moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?.count == 2
+                }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains {
+                    $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target
+                        .moduleAliases?
+                        .count == 1
+                }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains {
+                    $0.target.name == "XLog" && $0.target.moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?
+                        .count == 1
+                }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains {
+                    $0.target.name == "G" && $0.target.moduleAliases?["Utils"] == "GUtils" && $0.target.moduleAliases?
+                        .count == 1
+                }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains {
+                    $0.target.name == "GUtils" && $0.target.moduleAliases?["Utils"] == "GUtils" && $0.target
+                        .moduleAliases?
+                        .count == 1
+                }
+        )
     }
 
     func testModuleAliasingMergeAliasesOfSameTargets() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/aPkg/Sources/A/main.swift",
-                                    "/aPkg/Sources/A/file.swift",
-                                    "/bPkg/Sources/B/file.swift",
-                                    "/cPkg/Sources/C/file.swift",
-                                    "/dPkg/Sources/D/file.swift",
-                                    "/dPkg/Sources/Utils/file.swift",
-                                    "/dPkg/Sources/Log/file.swift",
-                                    "/gPkg/Sources/G/file.swift",
-                                    "/hPkg/Sources/H/file.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/aPkg/Sources/A/main.swift",
+            "/aPkg/Sources/A/file.swift",
+            "/bPkg/Sources/B/file.swift",
+            "/cPkg/Sources/C/file.swift",
+            "/dPkg/Sources/D/file.swift",
+            "/dPkg/Sources/Utils/file.swift",
+            "/dPkg/Sources/Log/file.swift",
+            "/gPkg/Sources/G/file.swift",
+            "/hPkg/Sources/H/file.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -1624,43 +2098,49 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     displayName: "hPkg",
-                    path: .init(path: "/hPkg"),
+                    path: "/hPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/dPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/dPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "H", type: .library(.automatic), targets: ["H"]),
                     ],
                     targets: [
-                        TargetDescription(name: "H",
-                                          dependencies: [.product(name: "D",
-                                                                  package: "dPkg"
-                                                                 )
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "H",
+                            dependencies: [.product(
+                                name: "D",
+                                package: "dPkg"
+                            )]
+                        ),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "gPkg",
-                    path: .init(path: "/gPkg"),
+                    path: "/gPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/hPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/hPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "G", type: .library(.automatic), targets: ["G"]),
                     ],
                     targets: [
-                        TargetDescription(name: "G",
-                                          dependencies: [.product(name: "H",
-                                                                  package: "hPkg",
-                                                                  moduleAliases: [
-                                                                    "Utils": "GUtils",
-                                                                    "Log": "GLog"
-                                                                  ]
-                                                                 )
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "G",
+                            dependencies: [.product(
+                                name: "H",
+                                package: "hPkg",
+                                moduleAliases: [
+                                    "Utils": "GUtils",
+                                    "Log": "GLog",
+                                ]
+                            )]
+                        ),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "dPkg",
-                    path: .init(path: "/dPkg"),
+                    path: "/dPkg",
                     products: [
                         ProductDescription(name: "D", type: .library(.automatic), targets: ["D"]),
                     ],
@@ -1668,64 +2148,76 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "D", dependencies: ["Utils", "Log"]),
                         TargetDescription(name: "Utils", dependencies: []),
                         TargetDescription(name: "Log", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "cPkg",
-                    path: .init(path: "/cPkg"),
+                    path: "/cPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/dPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/dPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "C", type: .library(.automatic), targets: ["C"]),
                     ],
                     targets: [
-                        TargetDescription(name: "C",
-                                          dependencies: [
-                                            .product(name: "D",
-                                                     package: "dPkg",
-                                                     moduleAliases: ["Log" : "ZLog"]
-                                                    ),
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "C",
+                            dependencies: [
+                                .product(
+                                    name: "D",
+                                    package: "dPkg",
+                                    moduleAliases: ["Log": "ZLog"]
+                                ),
+                            ]
+                        ),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "bPkg",
-                    path: .init(path: "/bPkg"),
+                    path: "/bPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/cPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/cPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "B", type: .library(.automatic), targets: ["B"]),
                     ],
                     targets: [
-                        TargetDescription(name: "B",
-                                          dependencies: [
-                                            .product(name: "C",
-                                                     package: "cPkg",
-                                                     moduleAliases: ["Utils": "YUtils",
-                                                                     "ZLog": "YLog"
-                                                                    ]
-                                            ),
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "B",
+                            dependencies: [
+                                .product(
+                                    name: "C",
+                                    package: "cPkg",
+                                    moduleAliases: ["Utils": "YUtils",
+                                                    "ZLog": "YLog"]
+                                ),
+                            ]
+                        ),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "aPkg",
-                    path: .init(path: "/aPkg"),
+                    path: "/aPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/bPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/gPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/bPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/gPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "A",
-                                          dependencies: [
-                                            .product(name: "G",
-                                                     package: "gPkg"),
-                                            .product(name: "B",
-                                                     package: "bPkg",
-                                                     moduleAliases: ["YUtils": "XUtils",
-                                                                     "YLog": "XLog"]
-                                                    ),
-                                            ]
-                                         ),
+                        TargetDescription(
+                            name: "A",
+                            dependencies: [
+                                .product(
+                                    name: "G",
+                                    package: "gPkg"
+                                ),
+                                .product(
+                                    name: "B",
+                                    package: "bPkg",
+                                    moduleAliases: ["YUtils": "XUtils",
+                                                    "YLog": "XLog"]
+                                ),
+                            ]
+                        ),
                     ]
                 ),
             ],
@@ -1742,26 +2234,76 @@ final class ModuleAliasingBuildTests: XCTestCase {
 
         result.checkProductsCount(1)
         result.checkTargetsCount(8)
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "A" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target.moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?.count == 2 })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "B" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target.moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?.count == 2 })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "C" && $0.target.moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target.moduleAliases?.count == 2 })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "D" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target.moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?.count == 2})
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target.moduleAliases?.count == 1 })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "XLog" && $0.target.moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?.count == 1 })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "G" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target.moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?.count == 2})
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "H" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target.moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?.count == 2})
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains {
+                    $0.target.name == "A" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target
+                        .moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?.count == 2
+                }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains {
+                    $0.target.name == "B" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target
+                        .moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?.count == 2
+                }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains {
+                    $0.target.name == "C" && $0.target.moduleAliases?["Log"] == "XLog" && $0.target
+                        .moduleAliases?["Utils"] == "XUtils" && $0.target.moduleAliases?.count == 2
+                }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains {
+                    $0.target.name == "D" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target
+                        .moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?.count == 2
+                }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains {
+                    $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target
+                        .moduleAliases?
+                        .count == 1
+                }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains {
+                    $0.target.name == "XLog" && $0.target.moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?
+                        .count == 1
+                }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains {
+                    $0.target.name == "G" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target
+                        .moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?.count == 2
+                }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains {
+                    $0.target.name == "H" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target
+                        .moduleAliases?["Log"] == "XLog" && $0.target.moduleAliases?.count == 2
+                }
+        )
     }
 
     func testModuleAliasingOverrideSameNameTargetAndDepWithAliases() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/appPkg/Sources/App/main.swift",
-                                    "/appPkg/Sources/Utils/file1.swift",
-                                    "/appPkg/Sources/Render/file2.swift",
-                                    "/libPkg/Sources/Lib/fileLib.swift",
-                                    "/gamePkg/Sources/Game/fileGame.swift",
-                                    "/gamePkg/Sources/Render/fileRender.swift",
-                                    "/gamePkg/Sources/Utils/fileUtils.swift",
-                                    "/drawPkg/Sources/Render/fileDraw.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/appPkg/Sources/App/main.swift",
+            "/appPkg/Sources/Utils/file1.swift",
+            "/appPkg/Sources/Render/file2.swift",
+            "/libPkg/Sources/Lib/fileLib.swift",
+            "/gamePkg/Sources/Game/fileGame.swift",
+            "/gamePkg/Sources/Render/fileRender.swift",
+            "/gamePkg/Sources/Utils/fileUtils.swift",
+            "/drawPkg/Sources/Render/fileDraw.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -1770,18 +2312,19 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     displayName: "drawPkg",
-                    path: .init(path: "/drawPkg"),
+                    path: "/drawPkg",
                     products: [
                         ProductDescription(name: "DrawProd", type: .library(.automatic), targets: ["Render"]),
                     ],
                     targets: [
                         TargetDescription(name: "Render", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "gamePkg",
-                    path: .init(path: "/gamePkg"),
+                    path: "/gamePkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/drawPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/drawPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "Game", type: .library(.automatic), targets: ["Game"]),
@@ -1791,52 +2334,69 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     targets: [
                         TargetDescription(name: "Game", dependencies: ["Utils"]),
                         TargetDescription(name: "Utils", dependencies: []),
-                        TargetDescription(name: "Render",
-                                          dependencies: [
-                                            .product(name: "DrawProd",
-                                                     package: "drawPkg",
-                                                     moduleAliases: ["Render": "DrawRender"]
-                                          )]),
-                    ]),
+                        TargetDescription(
+                            name: "Render",
+                            dependencies: [
+                                .product(
+                                    name: "DrawProd",
+                                    package: "drawPkg",
+                                    moduleAliases: ["Render": "DrawRender"]
+                                ),
+                            ]
+                        ),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "libPkg",
-                    path: .init(path: "/libPkg"),
+                    path: "/libPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/gamePkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/gamePkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "LibProd", type: .library(.automatic), targets: ["Lib"]),
                     ],
                     targets: [
-                        TargetDescription(name: "Lib",
-                                          dependencies: [
-                                            .product(name: "Game",
-                                                                  package: "gamePkg",
-                                                                  moduleAliases: ["Utils": "GameUtils"]
-                                                                 ),
-                                                         .product(name: "RenderProd",
-                                                                  package: "gamePkg",
-                                                                  moduleAliases: ["Render": "GameRender"]
-                                                                 )
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "Lib",
+                            dependencies: [
+                                .product(
+                                    name: "Game",
+                                    package: "gamePkg",
+                                    moduleAliases: ["Utils": "GameUtils"]
+                                ),
+                                .product(
+                                    name: "RenderProd",
+                                    package: "gamePkg",
+                                    moduleAliases: ["Render": "GameRender"]
+                                ),
+                            ]
+                        ),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "appPkg",
-                    path: .init(path: "/appPkg"),
+                    path: "/appPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/libPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/libPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "App",
-                                          dependencies: ["Utils",
-                                                         "Render",
-                                                         .product(name: "LibProd",
-                                                                  package: "libPkg",
-                                                                  moduleAliases: ["GameUtils": "LibUtils", "GameRender": "LibRender"]
-                                                        )]),
+                        TargetDescription(
+                            name: "App",
+                            dependencies: ["Utils",
+                                           "Render",
+                                           .product(
+                                               name: "LibProd",
+                                               package: "libPkg",
+                                               moduleAliases: [
+                                                   "GameUtils": "LibUtils",
+                                                   "GameRender": "LibRender",
+                                               ]
+                                           )]
+                        ),
                         TargetDescription(name: "Utils", dependencies: []),
                         TargetDescription(name: "Render", dependencies: []),
-                    ]),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
@@ -1852,27 +2412,48 @@ final class ModuleAliasingBuildTests: XCTestCase {
         result.checkProductsCount(1)
         result.checkTargetsCount(8)
 
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Lib" && $0.target.moduleAliases?["Utils"] == "LibUtils" && $0.target.moduleAliases?["Render"] == "LibRender" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "LibRender" && $0.target.moduleAliases?["Render"] == "LibRender" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "LibUtils" && $0.target.moduleAliases?["Utils"] == "LibUtils" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Game" && $0.target.moduleAliases?["Utils"] == "LibUtils" && $0.target.moduleAliases?["Render"] == nil })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "DrawRender" && $0.target.moduleAliases?["Render"] == "DrawRender" })
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains {
+                    $0.target.name == "Lib" && $0.target.moduleAliases?["Utils"] == "LibUtils" && $0.target
+                        .moduleAliases?["Render"] == "LibRender"
+                }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "LibRender" && $0.target.moduleAliases?["Render"] == "LibRender" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "LibUtils" && $0.target.moduleAliases?["Utils"] == "LibUtils" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains {
+                    $0.target.name == "Game" && $0.target.moduleAliases?["Utils"] == "LibUtils" && $0.target
+                        .moduleAliases?["Render"] == nil
+                }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "DrawRender" && $0.target.moduleAliases?["Render"] == "DrawRender" }
+        )
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Render" && $0.target.moduleAliases == nil })
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases == nil })
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
-        XCTAssertFalse(result.targetMap.values.contains { $0.target.name == "GameUtils"})
-
+        XCTAssertFalse(result.targetMap.values.contains { $0.target.name == "GameUtils" })
     }
 
     func testModuleAliasingAddOverrideAliasesUpstream() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/appPkg/Sources/App/main.swift",
-                                    "/appPkg/Sources/Utils/file1.swift",
-                                    "/appPkg/Sources/Render/file2.swift",
-                                    "/libPkg/Sources/Lib/fileLib.swift",
-                                    "/gamePkg/Sources/Render/fileRender.swift",
-                                    "/gamePkg/Sources/Utils/fileUtils.swift",
-                                    "/drawPkg/Sources/Render/fileDraw.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/appPkg/Sources/App/main.swift",
+            "/appPkg/Sources/Utils/file1.swift",
+            "/appPkg/Sources/Render/file2.swift",
+            "/libPkg/Sources/Lib/fileLib.swift",
+            "/gamePkg/Sources/Render/fileRender.swift",
+            "/gamePkg/Sources/Utils/fileUtils.swift",
+            "/drawPkg/Sources/Render/fileDraw.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -1881,18 +2462,19 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     displayName: "drawPkg",
-                    path: .init(path: "/drawPkg"),
+                    path: "/drawPkg",
                     products: [
                         ProductDescription(name: "DrawProd", type: .library(.automatic), targets: ["Render"]),
                     ],
                     targets: [
                         TargetDescription(name: "Render", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "gamePkg",
-                    path: .init(path: "/gamePkg"),
+                    path: "/gamePkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/drawPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/drawPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "Game", type: .library(.automatic), targets: ["Utils"]),
@@ -1902,50 +2484,63 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     targets: [
                         TargetDescription(name: "Game", dependencies: ["Utils"]),
                         TargetDescription(name: "Utils", dependencies: []),
-                        TargetDescription(name: "Render",
-                                          dependencies: [
-                                            .product(name: "DrawProd",
-                                                     package: "drawPkg",
-                                                     moduleAliases: ["Render": "DrawRender"]
-                                          )]),
-                    ]),
+                        TargetDescription(
+                            name: "Render",
+                            dependencies: [
+                                .product(
+                                    name: "DrawProd",
+                                    package: "drawPkg",
+                                    moduleAliases: ["Render": "DrawRender"]
+                                ),
+                            ]
+                        ),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "libPkg",
-                    path: .init(path: "/libPkg"),
+                    path: "/libPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/gamePkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/gamePkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "LibProd", type: .library(.automatic), targets: ["Lib"]),
                     ],
                     targets: [
-                        TargetDescription(name: "Lib",
-                                          dependencies: [.product(name: "UtilsProd",
-                                                                  package: "gamePkg",
-                                                                  moduleAliases: ["Utils": "GameUtils"]
-                                                                 ),
-                                                         .product(name: "RenderProd",
-                                                                  package: "gamePkg",
-                                                                  moduleAliases: ["Render": "GameRender"]
-                                                                 )
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "Lib",
+                            dependencies: [.product(
+                                name: "UtilsProd",
+                                package: "gamePkg",
+                                moduleAliases: ["Utils": "GameUtils"]
+                            ),
+                            .product(
+                                name: "RenderProd",
+                                package: "gamePkg",
+                                moduleAliases: ["Render": "GameRender"]
+                            )]
+                        ),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "appPkg",
-                    path: .init(path: "/appPkg"),
+                    path: "/appPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/libPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/libPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "App",
-                                          dependencies: ["Utils",
-                                                         "Render",
-                                                         .product(name: "LibProd",
-                                                                  package: "libPkg"
-                                                        )]),
+                        TargetDescription(
+                            name: "App",
+                            dependencies: ["Utils",
+                                           "Render",
+                                           .product(
+                                               name: "LibProd",
+                                               package: "libPkg"
+                                           )]
+                        ),
                         TargetDescription(name: "Utils", dependencies: []),
                         TargetDescription(name: "Render", dependencies: []),
-                    ]),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
@@ -1961,25 +2556,41 @@ final class ModuleAliasingBuildTests: XCTestCase {
         result.checkProductsCount(1)
         result.checkTargetsCount(7)
 
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Lib" && $0.target.moduleAliases?["Utils"] == "GameUtils" && $0.target.moduleAliases?["Render"] == "GameRender" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "GameRender" && $0.target.moduleAliases?["Render"] == "GameRender" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "GameUtils" && $0.target.moduleAliases?["Utils"] == "GameUtils" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "DrawRender" && $0.target.moduleAliases?["Render"] == "DrawRender" })
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains {
+                    $0.target.name == "Lib" && $0.target.moduleAliases?["Utils"] == "GameUtils" && $0.target
+                        .moduleAliases?["Render"] == "GameRender"
+                }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "GameRender" && $0.target.moduleAliases?["Render"] == "GameRender" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "GameUtils" && $0.target.moduleAliases?["Utils"] == "GameUtils" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "DrawRender" && $0.target.moduleAliases?["Render"] == "DrawRender" }
+        )
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Render" && $0.target.moduleAliases == nil })
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases == nil })
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
     }
 
     func testModuleAliasingOverrideUpstreamTargetsWithAliases() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/appPkg/Sources/App/main.swift",
-                                    "/appPkg/Sources/Utils/file1.swift",
-                                    "/appPkg/Sources/Render/file2.swift",
-                                    "/libPkg/Sources/Lib/fileLib.swift",
-                                    "/gamePkg/Sources/Scene/fileScene.swift",
-                                    "/gamePkg/Sources/Render/fileRender.swift",
-                                    "/gamePkg/Sources/Utils/fileUtils.swift",
-                                    "/drawPkg/Sources/Render/fileDraw.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/appPkg/Sources/App/main.swift",
+            "/appPkg/Sources/Utils/file1.swift",
+            "/appPkg/Sources/Render/file2.swift",
+            "/libPkg/Sources/Lib/fileLib.swift",
+            "/gamePkg/Sources/Scene/fileScene.swift",
+            "/gamePkg/Sources/Render/fileRender.swift",
+            "/gamePkg/Sources/Utils/fileUtils.swift",
+            "/drawPkg/Sources/Render/fileDraw.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -1988,18 +2599,19 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     displayName: "drawPkg",
-                    path: .init(path: "/drawPkg"),
+                    path: "/drawPkg",
                     products: [
                         ProductDescription(name: "DrawProd", type: .library(.automatic), targets: ["Render"]),
                     ],
                     targets: [
                         TargetDescription(name: "Render", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "gamePkg",
-                    path: .init(path: "/gamePkg"),
+                    path: "/gamePkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/drawPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/drawPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "Game", type: .library(.automatic), targets: ["Utils"]),
@@ -2011,53 +2623,67 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Game", dependencies: ["Utils"]),
                         TargetDescription(name: "Utils", dependencies: []),
                         TargetDescription(name: "Render", dependencies: []),
-                        TargetDescription(name: "Scene",
-                                          dependencies: [
-                                            .product(name: "DrawProd",
-                                                     package: "drawPkg",
-                                                     moduleAliases: ["Render": "DrawRender"]
-                                          )]),
-                    ]),
+                        TargetDescription(
+                            name: "Scene",
+                            dependencies: [
+                                .product(
+                                    name: "DrawProd",
+                                    package: "drawPkg",
+                                    moduleAliases: ["Render": "DrawRender"]
+                                ),
+                            ]
+                        ),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "libPkg",
-                    path: .init(path: "/libPkg"),
+                    path: "/libPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/gamePkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/gamePkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "LibProd", type: .library(.automatic), targets: ["Lib"]),
                     ],
                     targets: [
-                        TargetDescription(name: "Lib",
-                                          dependencies: [.product(name: "UtilsProd",
-                                                                  package: "gamePkg",
-                                                                  moduleAliases: ["Utils": "GameUtils"]
-                                                                 ),
-                                                         .product(name: "RenderProd",
-                                                                  package: "gamePkg",
-                                                                  moduleAliases: ["Render": "GameRender"]
-                                                                 ),
-                                                         .product(name: "SceneProd",
-                                                                  package: "gamePkg"
-                                                                 )
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "Lib",
+                            dependencies: [.product(
+                                name: "UtilsProd",
+                                package: "gamePkg",
+                                moduleAliases: ["Utils": "GameUtils"]
+                            ),
+                            .product(
+                                name: "RenderProd",
+                                package: "gamePkg",
+                                moduleAliases: ["Render": "GameRender"]
+                            ),
+                            .product(
+                                name: "SceneProd",
+                                package: "gamePkg"
+                            )]
+                        ),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "appPkg",
-                    path: .init(path: "/appPkg"),
+                    path: "/appPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/libPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/libPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "App",
-                                          dependencies: ["Utils",
-                                                         "Render",
-                                                         .product(name: "LibProd",
-                                                                  package: "libPkg"
-                                                        )]),
+                        TargetDescription(
+                            name: "App",
+                            dependencies: ["Utils",
+                                           "Render",
+                                           .product(
+                                               name: "LibProd",
+                                               package: "libPkg"
+                                           )]
+                        ),
                         TargetDescription(name: "Utils", dependencies: []),
                         TargetDescription(name: "Render", dependencies: []),
-                    ]),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
@@ -2073,25 +2699,44 @@ final class ModuleAliasingBuildTests: XCTestCase {
         result.checkProductsCount(1)
         result.checkTargetsCount(8)
 
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Lib" && $0.target.moduleAliases?["Utils"] == "GameUtils" && $0.target.moduleAliases?["Render"] == "GameRender" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "GameRender" && $0.target.moduleAliases?["Render"] == "GameRender" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "GameUtils" && $0.target.moduleAliases?["Utils"] == "GameUtils" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Scene" && $0.target.moduleAliases?["Render"] == "DrawRender" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "DrawRender" && $0.target.moduleAliases?["Render"] == "DrawRender" })
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains {
+                    $0.target.name == "Lib" && $0.target.moduleAliases?["Utils"] == "GameUtils" && $0.target
+                        .moduleAliases?["Render"] == "GameRender"
+                }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "GameRender" && $0.target.moduleAliases?["Render"] == "GameRender" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "GameUtils" && $0.target.moduleAliases?["Utils"] == "GameUtils" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "Scene" && $0.target.moduleAliases?["Render"] == "DrawRender" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "DrawRender" && $0.target.moduleAliases?["Render"] == "DrawRender" }
+        )
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Render" && $0.target.moduleAliases == nil })
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases == nil })
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
     }
 
     func testModuleAliasingOverrideUpstreamTargetsWithAliasesMultipleAliasesInProduct() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/appPkg/Sources/App/main.swift",
-                                    "/appPkg/Sources/Utils/file1.swift",
-                                    "/appPkg/Sources/Render/file2.swift",
-                                    "/libPkg/Sources/Lib/fileLib.swift",
-                                    "/gamePkg/Sources/Game/fileGame.swift",
-                                    "/gamePkg/Sources/Utils/fileUtils.swift",
-                                    "/drawPkg/Sources/Render/fileDraw.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/appPkg/Sources/App/main.swift",
+            "/appPkg/Sources/Utils/file1.swift",
+            "/appPkg/Sources/Render/file2.swift",
+            "/libPkg/Sources/Lib/fileLib.swift",
+            "/gamePkg/Sources/Game/fileGame.swift",
+            "/gamePkg/Sources/Utils/fileUtils.swift",
+            "/drawPkg/Sources/Render/fileDraw.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -2100,72 +2745,95 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     displayName: "drawPkg",
-                    path: .init(path: "/drawPkg"),
+                    path: "/drawPkg",
                     products: [
                         ProductDescription(name: "DrawProd", type: .library(.automatic), targets: ["Render"]),
                     ],
                     targets: [
                         TargetDescription(name: "Render", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "gamePkg",
-                    path: .init(path: "/gamePkg"),
+                    path: "/gamePkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/drawPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/drawPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "GameProd", type: .library(.automatic), targets: ["Game"]),
                         ProductDescription(name: "UtilsProd", type: .library(.automatic), targets: ["Utils"]),
                     ],
                     targets: [
-                        TargetDescription(name: "Game",
-                                          dependencies: [
-                                            "Utils",
-                                            .product(name: "DrawProd",
-                                                     package: "drawPkg",
-                                                     moduleAliases: ["Render": "DrawRender"])
-                                          ]),
-                        TargetDescription(name: "Utils",
-                                          dependencies: [
-                                            .product(name: "DrawProd",
-                                                     package: "drawPkg",
-                                                     moduleAliases: ["Render": "DrawRender"])
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "Game",
+                            dependencies: [
+                                "Utils",
+                                .product(
+                                    name: "DrawProd",
+                                    package: "drawPkg",
+                                    moduleAliases: ["Render": "DrawRender"]
+                                ),
+                            ]
+                        ),
+                        TargetDescription(
+                            name: "Utils",
+                            dependencies: [
+                                .product(
+                                    name: "DrawProd",
+                                    package: "drawPkg",
+                                    moduleAliases: ["Render": "DrawRender"]
+                                ),
+                            ]
+                        ),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "libPkg",
-                    path: .init(path: "/libPkg"),
+                    path: "/libPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/gamePkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/gamePkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "LibProd", type: .library(.automatic), targets: ["Lib"]),
                     ],
                     targets: [
-                        TargetDescription(name: "Lib",
-                                          dependencies: [.product(name: "UtilsProd",
-                                                                  package: "gamePkg",
-                                                                  moduleAliases: ["Utils": "GameUtils", "Render": "GameRender"]
-                                                                 ),
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "Lib",
+                            dependencies: [.product(
+                                name: "UtilsProd",
+                                package: "gamePkg",
+                                moduleAliases: [
+                                    "Utils": "GameUtils",
+                                    "Render": "GameRender",
+                                ]
+                            )]
+                        ),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "appPkg",
-                    path: .init(path: "/appPkg"),
+                    path: "/appPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/libPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/libPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "App",
-                                          dependencies: ["Utils",
-                                                         "Render",
-                                                         .product(name: "LibProd",
-                                                                  package: "libPkg",
-                                                                  moduleAliases: ["GameUtils": "LibUtils", "GameRender": "LibRender"]
-                                                        )]),
+                        TargetDescription(
+                            name: "App",
+                            dependencies: ["Utils",
+                                           "Render",
+                                           .product(
+                                               name: "LibProd",
+                                               package: "libPkg",
+                                               moduleAliases: [
+                                                   "GameUtils": "LibUtils",
+                                                   "GameRender": "LibRender",
+                                               ]
+                                           )]
+                        ),
                         TargetDescription(name: "Utils", dependencies: []),
                         TargetDescription(name: "Render", dependencies: []),
-                    ]),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
@@ -2181,27 +2849,46 @@ final class ModuleAliasingBuildTests: XCTestCase {
         result.checkProductsCount(1)
         result.checkTargetsCount(7)
 
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Lib" && $0.target.moduleAliases?["Utils"] == "LibUtils" && $0.target.moduleAliases?["Render"] == "LibRender" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "LibRender" && $0.target.moduleAliases?["Render"] == "LibRender" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "LibUtils" && $0.target.moduleAliases?["Utils"] == "LibUtils" })
-        XCTAssertFalse(result.targetMap.values.contains { $0.target.name == "DrawRender" || $0.target.moduleAliases?["Render"] == "DrawRender" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Game" && $0.target.moduleAliases?["Utils"] == "LibUtils" })
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains {
+                    $0.target.name == "Lib" && $0.target.moduleAliases?["Utils"] == "LibUtils" && $0.target
+                        .moduleAliases?["Render"] == "LibRender"
+                }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "LibRender" && $0.target.moduleAliases?["Render"] == "LibRender" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "LibUtils" && $0.target.moduleAliases?["Utils"] == "LibUtils" }
+        )
+        XCTAssertFalse(
+            result.targetMap.values
+                .contains { $0.target.name == "DrawRender" || $0.target.moduleAliases?["Render"] == "DrawRender" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "Game" && $0.target.moduleAliases?["Utils"] == "LibUtils" }
+        )
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Render" && $0.target.moduleAliases == nil })
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases == nil })
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
     }
 
     func testModuleAliasingOverrideUpstreamTargetsWithAliasesDownstream() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/appPkg/Sources/App/main.swift",
-                                    "/appPkg/Sources/Utils/file1.swift",
-                                    "/appPkg/Sources/Render/file2.swift",
-                                    "/libPkg/Sources/Lib/fileLib.swift",
-                                    "/gamePkg/Sources/Scene/fileScene.swift",
-                                    "/gamePkg/Sources/Render/fileRender.swift",
-                                    "/gamePkg/Sources/Utils/fileUtils.swift",
-                                    "/gamePkg/Sources/Game/fileGame.swift",
-                                    "/drawPkg/Sources/Render/fileDraw.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/appPkg/Sources/App/main.swift",
+            "/appPkg/Sources/Utils/file1.swift",
+            "/appPkg/Sources/Render/file2.swift",
+            "/libPkg/Sources/Lib/fileLib.swift",
+            "/gamePkg/Sources/Scene/fileScene.swift",
+            "/gamePkg/Sources/Render/fileRender.swift",
+            "/gamePkg/Sources/Utils/fileUtils.swift",
+            "/gamePkg/Sources/Game/fileGame.swift",
+            "/drawPkg/Sources/Render/fileDraw.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -2210,18 +2897,19 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     displayName: "drawPkg",
-                    path: .init(path: "/drawPkg"),
+                    path: "/drawPkg",
                     products: [
                         ProductDescription(name: "DrawProd", type: .library(.automatic), targets: ["Render"]),
                     ],
                     targets: [
                         TargetDescription(name: "Render", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "gamePkg",
-                    path: .init(path: "/gamePkg"),
+                    path: "/gamePkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/drawPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/drawPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "Game", type: .library(.automatic), targets: ["Game"]),
@@ -2233,54 +2921,71 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Game", dependencies: ["Utils"]),
                         TargetDescription(name: "Utils", dependencies: []),
                         TargetDescription(name: "Render", dependencies: []),
-                        TargetDescription(name: "Scene",
-                                          dependencies: [
-                                            .product(name: "DrawProd",
-                                                     package: "drawPkg",
-                                                     moduleAliases: ["Render": "DrawRender"]
-                                          )]),
-                    ]),
+                        TargetDescription(
+                            name: "Scene",
+                            dependencies: [
+                                .product(
+                                    name: "DrawProd",
+                                    package: "drawPkg",
+                                    moduleAliases: ["Render": "DrawRender"]
+                                ),
+                            ]
+                        ),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "libPkg",
-                    path: .init(path: "/libPkg"),
+                    path: "/libPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/gamePkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/gamePkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "LibProd", type: .library(.automatic), targets: ["Lib"]),
                     ],
                     targets: [
-                        TargetDescription(name: "Lib",
-                                          dependencies: [.product(name: "UtilsProd",
-                                                                  package: "gamePkg",
-                                                                  moduleAliases: ["Utils": "GameUtils"]
-                                                                 ),
-                                                         .product(name: "RenderProd",
-                                                                  package: "gamePkg",
-                                                                  moduleAliases: ["Render": "GameRender"]
-                                                                 ),
-                                                         .product(name: "SceneProd",
-                                                                  package: "gamePkg"
-                                                                 )
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "Lib",
+                            dependencies: [.product(
+                                name: "UtilsProd",
+                                package: "gamePkg",
+                                moduleAliases: ["Utils": "GameUtils"]
+                            ),
+                            .product(
+                                name: "RenderProd",
+                                package: "gamePkg",
+                                moduleAliases: ["Render": "GameRender"]
+                            ),
+                            .product(
+                                name: "SceneProd",
+                                package: "gamePkg"
+                            )]
+                        ),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "appPkg",
-                    path: .init(path: "/appPkg"),
+                    path: "/appPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/libPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/libPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "App",
-                                          dependencies: ["Utils",
-                                                         "Render",
-                                                         .product(name: "LibProd",
-                                                                  package: "libPkg",
-                                                                  moduleAliases: ["GameUtils": "LibUtils", "GameRender": "LibRender"]
-                                                        )]),
+                        TargetDescription(
+                            name: "App",
+                            dependencies: ["Utils",
+                                           "Render",
+                                           .product(
+                                               name: "LibProd",
+                                               package: "libPkg",
+                                               moduleAliases: [
+                                                   "GameUtils": "LibUtils",
+                                                   "GameRender": "LibRender",
+                                               ]
+                                           )]
+                        ),
                         TargetDescription(name: "Utils", dependencies: []),
                         TargetDescription(name: "Render", dependencies: []),
-                    ]),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
@@ -2296,185 +3001,259 @@ final class ModuleAliasingBuildTests: XCTestCase {
         result.checkProductsCount(1)
         result.checkTargetsCount(9)
 
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Lib" && $0.target.moduleAliases?["Utils"] == "LibUtils" && $0.target.moduleAliases?["Render"] == "LibRender" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "LibRender" && $0.target.moduleAliases?["Render"] == "LibRender" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "LibUtils" && $0.target.moduleAliases?["Utils"] == "LibUtils" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Game" && $0.target.moduleAliases?["Utils"] == "LibUtils" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Scene" && $0.target.moduleAliases?["Render"] == "DrawRender" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "DrawRender" && $0.target.moduleAliases?["Render"] == "DrawRender" })
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains {
+                    $0.target.name == "Lib" && $0.target.moduleAliases?["Utils"] == "LibUtils" && $0.target
+                        .moduleAliases?["Render"] == "LibRender"
+                }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "LibRender" && $0.target.moduleAliases?["Render"] == "LibRender" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "LibUtils" && $0.target.moduleAliases?["Utils"] == "LibUtils" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "Game" && $0.target.moduleAliases?["Utils"] == "LibUtils" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "Scene" && $0.target.moduleAliases?["Render"] == "DrawRender" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "DrawRender" && $0.target.moduleAliases?["Render"] == "DrawRender" }
+        )
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Render" && $0.target.moduleAliases == nil })
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases == nil })
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
     }
 
     func testModuleAliasingSameTargetFromUpstreamWithoutAlias() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/thisPkg/Sources/exe/main.swift",
-                                    "/thisPkg/Sources/MyLogging/file.swift",
-                                    "/fooPkg/Sources/Utils/fileUtils.swift",
-                                    "/barPkg/Sources/Logging/fileLogging.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/thisPkg/Sources/exe/main.swift",
+            "/thisPkg/Sources/MyLogging/file.swift",
+            "/fooPkg/Sources/Utils/fileUtils.swift",
+            "/barPkg/Sources/Logging/fileLogging.swift"
         )
-        
+
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
                     displayName: "barPkg",
-                    path: .init(path: "/barPkg"),
+                    path: "/barPkg",
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
                     ],
                     targets: [
                         TargetDescription(name: "Logging", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "fooPkg",
-                    path: .init(path: "/fooPkg"),
+                    path: "/fooPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/barPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
                     targets: [
-                        TargetDescription(name: "Utils",
-                                          dependencies: [.product(name: "Logging",
-                                                                  package: "barPkg"
-                                                                 )]),
-                    ]),
+                        TargetDescription(
+                            name: "Utils",
+                            dependencies: [.product(
+                                name: "Logging",
+                                package: "barPkg"
+                            )]
+                        ),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "thisPkg",
-                    path: .init(path: "/thisPkg"),
+                    path: "/thisPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/fooPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/barPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "exe",
-                                          dependencies: ["MyLogging",
-                                                         .product(name: "Utils",
-                                                                  package: "fooPkg",
-                                                                  moduleAliases: ["Logging": "FooLogging"]),
-                                                         .product(name: "Logging",
-                                                                  package: "barPkg")
-                                          ]),
+                        TargetDescription(
+                            name: "exe",
+                            dependencies: ["MyLogging",
+                                           .product(
+                                               name: "Utils",
+                                               package: "fooPkg",
+                                               moduleAliases: ["Logging": "FooLogging"]
+                                           ),
+                                           .product(
+                                               name: "Logging",
+                                               package: "barPkg"
+                                           )]
+                        ),
                         TargetDescription(name: "MyLogging", dependencies: []),
-                    ]),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
-        
+
         let result = try BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(shouldLinkStaticSwiftStdlib: true),
             graph: graph,
             fileSystem: fs,
             observabilityScope: observability.topScope
         ))
-        
+
         result.checkProductsCount(1)
         result.checkTargetsCount(4)
-        
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases?["Logging"] == "FooLogging" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "FooLogging" && $0.target.moduleAliases?["Logging"] == "FooLogging" })
-        XCTAssertFalse(result.targetMap.values.contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "MyLogging" && $0.target.moduleAliases == nil })
+
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "Utils" && $0.target.moduleAliases?["Logging"] == "FooLogging" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "FooLogging" && $0.target.moduleAliases?["Logging"] == "FooLogging" }
+        )
+        XCTAssertFalse(
+            result.targetMap.values
+                .contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "MyLogging" && $0.target.moduleAliases == nil }
+        )
     }
 
     func testModuleAliasingDuplicateTargetNamesFromMultiplePkgs() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/thisPkg/Sources/exe/main.swift",
-                                    "/thisPkg/Sources/MyLogging/file.swift",
-                                    "/fooPkg/Sources/Utils/fileUtils.swift",
-                                    "/barPkg/Sources/Logging/fileLogging.swift",
-                                    "/carPkg/Sources/Logging/fileLogging.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/thisPkg/Sources/exe/main.swift",
+            "/thisPkg/Sources/MyLogging/file.swift",
+            "/fooPkg/Sources/Utils/fileUtils.swift",
+            "/barPkg/Sources/Logging/fileLogging.swift",
+            "/carPkg/Sources/Logging/fileLogging.swift"
         )
-        
+
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
                     displayName: "carPkg",
-                    path: .init(path: "/carPkg"),
+                    path: "/carPkg",
                     products: [
                         ProductDescription(name: "CarLog", type: .library(.automatic), targets: ["Logging"]),
                     ],
                     targets: [
                         TargetDescription(name: "Logging", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "barPkg",
-                    path: .init(path: "/barPkg"),
+                    path: "/barPkg",
                     products: [
                         ProductDescription(name: "BarLog", type: .library(.automatic), targets: ["Logging"]),
                     ],
                     targets: [
                         TargetDescription(name: "Logging", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "fooPkg",
-                    path: .init(path: "/fooPkg"),
+                    path: "/fooPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/barPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "UtilsProd", type: .library(.automatic), targets: ["Utils"]),
                     ],
                     targets: [
-                        TargetDescription(name: "Utils",
-                                          dependencies: [.product(name: "BarLog",
-                                                                  package: "barPkg"
-                                                                 )]),
-                    ]),
+                        TargetDescription(
+                            name: "Utils",
+                            dependencies: [.product(
+                                name: "BarLog",
+                                package: "barPkg"
+                            )]
+                        ),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "thisPkg",
-                    path: .init(path: "/thisPkg"),
+                    path: "/thisPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/carPkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/fooPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/carPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "exe",
-                                          dependencies: ["MyLogging",
-                                                         .product(name: "UtilsProd",
-                                                                  package: "fooPkg",
-                                                                  moduleAliases: ["Logging": "FooLogging"]),
-                                                         .product(name: "CarLog",
-                                                                  package: "carPkg",
-                                                                  moduleAliases: ["Logging": "CarLogging"])
-                                          ]),
+                        TargetDescription(
+                            name: "exe",
+                            dependencies: ["MyLogging",
+                                           .product(
+                                               name: "UtilsProd",
+                                               package: "fooPkg",
+                                               moduleAliases: ["Logging": "FooLogging"]
+                                           ),
+                                           .product(
+                                               name: "CarLog",
+                                               package: "carPkg",
+                                               moduleAliases: ["Logging": "CarLogging"]
+                                           )]
+                        ),
                         TargetDescription(name: "MyLogging", dependencies: []),
-                    ]),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
-        
+
         let result = try BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(shouldLinkStaticSwiftStdlib: true),
             graph: graph,
             fileSystem: fs,
             observabilityScope: observability.topScope
         ))
-        
+
         result.checkProductsCount(1)
         result.checkTargetsCount(5)
 
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "FooLogging" && $0.target.moduleAliases?["Logging"] == "FooLogging" })
-        XCTAssertFalse(result.targetMap.values.contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "CarLogging" && $0.target.moduleAliases?["Logging"] == "CarLogging" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases?["Logging"] == "FooLogging" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "MyLogging" && $0.target.moduleAliases == nil })
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "FooLogging" && $0.target.moduleAliases?["Logging"] == "FooLogging" }
+        )
+        XCTAssertFalse(
+            result.targetMap.values
+                .contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "CarLogging" && $0.target.moduleAliases?["Logging"] == "CarLogging" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "Utils" && $0.target.moduleAliases?["Logging"] == "FooLogging" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "MyLogging" && $0.target.moduleAliases == nil }
+        )
     }
 
     func testModuleAliasingTargetAndProductTargetWithSameName() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                    "/appPkg/Sources/App/main.swift",
-                                    "/appPkg/Sources/Utils/file.swift",
-                                    "/xpkg/Sources/X/file.swift",
-                                    "/xpkg/Sources/Utils/file.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/appPkg/Sources/App/main.swift",
+            "/appPkg/Sources/Utils/file.swift",
+            "/xPkg/Sources/X/file.swift",
+            "/xPkg/Sources/Utils/file.swift"
         )
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
@@ -2482,29 +3261,34 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "xpkg",
-                    path: .init(path: "/xpkg"),
+                    path: "/xPkg",
                     products: [
                         ProductDescription(name: "X", type: .library(.automatic), targets: ["X"]),
                     ],
                     targets: [
                         TargetDescription(name: "X", dependencies: ["Utils"]),
                         TargetDescription(name: "Utils", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "appPkg",
-                    path: .init(path: "/appPkg"),
+                    path: "/appPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/xPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "App",
-                                          dependencies: ["Utils",
-                                                         .product(name: "X",
-                                                                  package: "xpkg",
-                                                                  moduleAliases: ["Utils": "XUtils"])
-                                          ]),
+                        TargetDescription(
+                            name: "App",
+                            dependencies: ["Utils",
+                                           .product(
+                                               name: "X",
+                                               package: "xpkg",
+                                               moduleAliases: ["Utils": "XUtils"]
+                                           )]
+                        ),
                         TargetDescription(name: "Utils", dependencies: []),
-                    ]),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
@@ -2517,20 +3301,27 @@ final class ModuleAliasingBuildTests: XCTestCase {
         ))
         result.checkProductsCount(1)
         result.checkTargetsCount(4)
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "X" && $0.target.moduleAliases?["Utils"] == "XUtils" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" })
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "X" && $0.target.moduleAliases?["Utils"] == "XUtils" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" }
+        )
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases == nil })
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
     }
 
     func testModuleAliasingProductTargetsWithSameName1() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                    "/appPkg/Sources/App/main.swift",
-                                    "/xpkg/Sources/X/file.swift",
-                                    "/ypkg/Sources/Utils/file.swift",
-                                    "/apkg/Sources/A/file.swift",
-                                    "/bpkg/Sources/B/file.swift",
-                                    "/cpkg/Sources/Utils/file.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/appPkg/Sources/App/main.swift",
+            "/xPkg/Sources/X/file.swift",
+            "/yPkg/Sources/Utils/file.swift",
+            "/aPkg/Sources/A/file.swift",
+            "/bPkg/Sources/B/file.swift",
+            "/cPkg/Sources/Utils/file.swift"
         )
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
@@ -2538,93 +3329,112 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "cpkg",
-                    path: .init(path: "/cpkg"),
+                    path: "/cPkg",
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
                     targets: [
                         TargetDescription(name: "Utils", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "bpkg",
-                    path: .init(path: "/bpkg"),
+                    path: "/bPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/cpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/cPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "B", type: .library(.automatic), targets: ["B"]),
                     ],
                     targets: [
-                        TargetDescription(name: "B",
-                                          dependencies: [
-                                            .product(name: "Utils",
-                                                     package: "cpkg"
-                                                    ),
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "B",
+                            dependencies: [
+                                .product(
+                                    name: "Utils",
+                                    package: "cpkg"
+                                ),
+                            ]
+                        ),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "apkg",
-                    path: .init(path: "/apkg"),
+                    path: "/aPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/bpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/bPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "A", type: .library(.automatic), targets: ["A"]),
                     ],
                     targets: [
-                        TargetDescription(name: "A",
-                                          dependencies: [
-                                            .product(name: "B",
-                                                     package: "bpkg"
-                                                    ),
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "A",
+                            dependencies: [
+                                .product(
+                                    name: "B",
+                                    package: "bpkg"
+                                ),
+                            ]
+                        ),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "ypkg",
-                    path: .init(path: "/ypkg"),
+                    path: "/yPkg",
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
                     targets: [
                         TargetDescription(name: "Utils", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "xpkg",
-                    path: .init(path: "/xpkg"),
+                    path: "/xPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/ypkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/yPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "X", type: .library(.automatic), targets: ["X"]),
                     ],
                     targets: [
-                        TargetDescription(name: "X",
-                                          dependencies: [
-                                            .product(name: "Utils",
-                                                     package: "ypkg"
-                                                    ),
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "X",
+                            dependencies: [
+                                .product(
+                                    name: "Utils",
+                                    package: "ypkg"
+                                ),
+                            ]
+                        ),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "appPkg",
-                    path: .init(path: "/appPkg"),
+                    path: "/appPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/apkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/xPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/aPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "App",
-                                          dependencies: [
-                                            .product(name: "X",
-                                                     package: "xpkg",
-                                                     moduleAliases: ["Utils": "XUtils"]
-                                                    ),
-                                            .product(name: "A",
-                                                     package: "apkg",
-                                                     moduleAliases: ["Utils": "AUtils"]
-                                                     )
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "App",
+                            dependencies: [
+                                .product(
+                                    name: "X",
+                                    package: "xpkg",
+                                    moduleAliases: ["Utils": "XUtils"]
+                                ),
+                                .product(
+                                    name: "A",
+                                    package: "apkg",
+                                    moduleAliases: ["Utils": "AUtils"]
+                                ),
+                            ]
+                        ),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
@@ -2637,24 +3447,40 @@ final class ModuleAliasingBuildTests: XCTestCase {
         ))
         result.checkProductsCount(1)
         result.checkTargetsCount(6)
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "X" && $0.target.moduleAliases?["Utils"] == "XUtils" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "A" && $0.target.moduleAliases?["Utils"] == "AUtils" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "B" && $0.target.moduleAliases?["Utils"] == "AUtils" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "AUtils" && $0.target.moduleAliases?["Utils"] == "AUtils" })
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "X" && $0.target.moduleAliases?["Utils"] == "XUtils" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "A" && $0.target.moduleAliases?["Utils"] == "AUtils" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "B" && $0.target.moduleAliases?["Utils"] == "AUtils" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "AUtils" && $0.target.moduleAliases?["Utils"] == "AUtils" }
+        )
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
         XCTAssertFalse(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases == nil })
     }
 
     func testModuleAliasingUpstreamProductTargetsWithSameName2() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                    "/appPkg/Sources/App/main.swift",
-                                    "/apkg/Sources/A/file.swift",
-                                    "/bpkg/Sources/Utils/file.swift",
-                                    "/cpkg/Sources/Utils/file.swift",
-                                    "/xpkg/Sources/X/file.swift",
-                                    "/ypkg/Sources/Utils/file.swift",
-                                    "/zpkg/Sources/Utils/file.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/appPkg/Sources/App/main.swift",
+            "/aPkg/Sources/A/file.swift",
+            "/bPkg/Sources/Utils/file.swift",
+            "/cPkg/Sources/Utils/file.swift",
+            "/xPkg/Sources/X/file.swift",
+            "/yPkg/Sources/Utils/file.swift",
+            "/zPkg/Sources/Utils/file.swift"
         )
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
@@ -2662,102 +3488,123 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "zpkg",
-                    path: .init(path: "/zpkg"),
+                    path: "/zPkg",
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
                     targets: [
                         TargetDescription(name: "Utils", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "ypkg",
-                    path: .init(path: "/ypkg"),
+                    path: "/yPkg",
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
                     targets: [
                         TargetDescription(name: "Utils", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "xpkg",
-                    path: .init(path: "/xpkg"),
+                    path: "/xPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/ypkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/zpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/yPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/zPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "X", type: .library(.automatic), targets: ["X"]),
                     ],
                     targets: [
-                        TargetDescription(name: "X",
-                                          dependencies: [
-                                            .product(name: "Utils",
-                                                     package: "zpkg"),
-                                            .product(name: "Utils",
-                                                     package: "ypkg",
-                                                     moduleAliases: ["Utils": "YUtils"]
-                                                     )
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "X",
+                            dependencies: [
+                                .product(
+                                    name: "Utils",
+                                    package: "zpkg"
+                                ),
+                                .product(
+                                    name: "Utils",
+                                    package: "ypkg",
+                                    moduleAliases: ["Utils": "YUtils"]
+                                ),
+                            ]
+                        ),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "cpkg",
-                    path: .init(path: "/cpkg"),
+                    path: "/cPkg",
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
                     targets: [
                         TargetDescription(name: "Utils", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "bpkg",
-                    path: .init(path: "/bpkg"),
+                    path: "/bPkg",
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
                     targets: [
                         TargetDescription(name: "Utils", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "apkg",
-                    path: .init(path: "/apkg"),
+                    path: "/aPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/bpkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/cpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/bPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/cPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "A", type: .library(.automatic), targets: ["A"]),
                     ],
                     targets: [
-                        TargetDescription(name: "A",
-                                          dependencies: [
-                                            .product(name: "Utils",
-                                                     package: "cpkg"),
-                                            .product(name: "Utils",
-                                                     package: "bpkg",
-                                                     moduleAliases: ["Utils": "BUtils"]
-                                                     )
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "A",
+                            dependencies: [
+                                .product(
+                                    name: "Utils",
+                                    package: "cpkg"
+                                ),
+                                .product(
+                                    name: "Utils",
+                                    package: "bpkg",
+                                    moduleAliases: ["Utils": "BUtils"]
+                                ),
+                            ]
+                        ),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "appPkg",
-                    path: .init(path: "/appPkg"),
+                    path: "/appPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/apkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/xPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/aPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "App",
-                                          dependencies: [
-                                            .product(name: "X",
-                                                     package: "xpkg",
-                                                     moduleAliases: ["Utils": "XUtils"]
-                                                    ),
-                                            .product(name: "A",
-                                                     package: "apkg",
-                                                     moduleAliases: ["Utils": "AUtils"]
-                                                    )
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "App",
+                            dependencies: [
+                                .product(
+                                    name: "X",
+                                    package: "xpkg",
+                                    moduleAliases: ["Utils": "XUtils"]
+                                ),
+                                .product(
+                                    name: "A",
+                                    package: "apkg",
+                                    moduleAliases: ["Utils": "AUtils"]
+                                ),
+                            ]
+                        ),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
@@ -2771,22 +3618,36 @@ final class ModuleAliasingBuildTests: XCTestCase {
         result.checkProductsCount(1)
         result.checkTargetsCount(7)
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "X" && $0.target.moduleAliases == nil })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "YUtils" && $0.target.moduleAliases?["Utils"] == "YUtils" })
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "YUtils" && $0.target.moduleAliases?["Utils"] == "YUtils" }
+        )
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "A" && $0.target.moduleAliases == nil })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "AUtils" && $0.target.moduleAliases?["Utils"] == "AUtils" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "BUtils" && $0.target.moduleAliases?["Utils"] == "BUtils" })
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "AUtils" && $0.target.moduleAliases?["Utils"] == "AUtils" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "BUtils" && $0.target.moduleAliases?["Utils"] == "BUtils" }
+        )
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
         XCTAssertFalse(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases == nil })
     }
+
     func testModuleAliasingUpstreamProductTargetsWithSameName3() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                    "/appPkg/Sources/App/main.swift",
-                                    "/apkg/Sources/A/file.swift",
-                                    "/apkg/Sources/Utils/file.swift",
-                                    "/xpkg/Sources/X/file.swift",
-                                    "/ypkg/Sources/Utils/file.swift",
-                                    "/zpkg/Sources/Utils/file.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/appPkg/Sources/App/main.swift",
+            "/aPkg/Sources/A/file.swift",
+            "/aPkg/Sources/Utils/file.swift",
+            "/xPkg/Sources/X/file.swift",
+            "/yPkg/Sources/Utils/file.swift",
+            "/zPkg/Sources/Utils/file.swift"
         )
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
@@ -2794,72 +3655,86 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "zpkg",
-                    path: .init(path: "/zpkg"),
+                    path: "/zPkg",
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
                     targets: [
                         TargetDescription(name: "Utils", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "ypkg",
-                    path: .init(path: "/ypkg"),
+                    path: "/yPkg",
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
                     targets: [
                         TargetDescription(name: "Utils", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "xpkg",
-                    path: .init(path: "/xpkg"),
+                    path: "/xPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/ypkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/zpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/yPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/zPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "X", type: .library(.automatic), targets: ["X"]),
                     ],
                     targets: [
-                        TargetDescription(name: "X",
-                                          dependencies: [
-                                            .product(name: "Utils",
-                                                     package: "zpkg"),
-                                            .product(name: "Utils",
-                                                     package: "ypkg",
-                                                     moduleAliases: ["Utils": "YUtils"]
-                                                     )
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "X",
+                            dependencies: [
+                                .product(
+                                    name: "Utils",
+                                    package: "zpkg"
+                                ),
+                                .product(
+                                    name: "Utils",
+                                    package: "ypkg",
+                                    moduleAliases: ["Utils": "YUtils"]
+                                ),
+                            ]
+                        ),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "apkg",
-                    path: .init(path: "/apkg"),
+                    path: "/aPkg",
                     products: [
                         ProductDescription(name: "A", type: .library(.automatic), targets: ["A"]),
                     ],
                     targets: [
                         TargetDescription(name: "A", dependencies: ["Utils"]),
                         TargetDescription(name: "Utils", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "appPkg",
-                    path: .init(path: "/appPkg"),
+                    path: "/appPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/apkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/xPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/aPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "App",
-                                          dependencies: [
-                                            .product(name: "X",
-                                                     package: "xpkg"
-                                                    ),
-                                            .product(name: "A",
-                                                     package: "apkg",
-                                                     moduleAliases: ["Utils": "AUtils"]
-                                                    )
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "App",
+                            dependencies: [
+                                .product(
+                                    name: "X",
+                                    package: "xpkg"
+                                ),
+                                .product(
+                                    name: "A",
+                                    package: "apkg",
+                                    moduleAliases: ["Utils": "AUtils"]
+                                ),
+                            ]
+                        ),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
@@ -2874,20 +3749,30 @@ final class ModuleAliasingBuildTests: XCTestCase {
         result.checkTargetsCount(6)
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "X" && $0.target.moduleAliases == nil })
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases == nil })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "YUtils" && $0.target.moduleAliases?["Utils"] == "YUtils" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "A" && $0.target.moduleAliases?["Utils"] == "AUtils" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "AUtils" && $0.target.moduleAliases?["Utils"] == "AUtils" })
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "YUtils" && $0.target.moduleAliases?["Utils"] == "YUtils" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "A" && $0.target.moduleAliases?["Utils"] == "AUtils" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "AUtils" && $0.target.moduleAliases?["Utils"] == "AUtils" }
+        )
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
     }
 
     func testModuleAliasingUpstreamProductTargetsWithSameName4() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                    "/appPkg/Sources/App/main.swift",
-                                    "/apkg/Sources/A/file.swift",
-                                    "/apkg/Sources/Utils/file.swift",
-                                    "/xpkg/Sources/X/file.swift",
-                                    "/ypkg/Sources/Utils/file.swift",
-                                    "/zpkg/Sources/Utils/file.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/appPkg/Sources/App/main.swift",
+            "/aPkg/Sources/A/file.swift",
+            "/aPkg/Sources/Utils/file.swift",
+            "/xPkg/Sources/X/file.swift",
+            "/yPkg/Sources/Utils/file.swift",
+            "/zPkg/Sources/Utils/file.swift"
         )
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
@@ -2895,72 +3780,86 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "zpkg",
-                    path: .init(path: "/zpkg"),
+                    path: "/zPkg",
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
                     targets: [
                         TargetDescription(name: "Utils", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "ypkg",
-                    path: .init(path: "/ypkg"),
+                    path: "/yPkg",
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
                     targets: [
                         TargetDescription(name: "Utils", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "xpkg",
-                    path: .init(path: "/xpkg"),
+                    path: "/xPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/ypkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/zpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/yPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/zPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "X", type: .library(.automatic), targets: ["X"]),
                     ],
                     targets: [
-                        TargetDescription(name: "X",
-                                          dependencies: [
-                                            .product(name: "Utils",
-                                                     package: "zpkg"),
-                                            .product(name: "Utils",
-                                                     package: "ypkg",
-                                                     moduleAliases: ["Utils": "YUtils"]
-                                                     )
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "X",
+                            dependencies: [
+                                .product(
+                                    name: "Utils",
+                                    package: "zpkg"
+                                ),
+                                .product(
+                                    name: "Utils",
+                                    package: "ypkg",
+                                    moduleAliases: ["Utils": "YUtils"]
+                                ),
+                            ]
+                        ),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "apkg",
-                    path: .init(path: "/apkg"),
+                    path: "/aPkg",
                     products: [
                         ProductDescription(name: "A", type: .library(.automatic), targets: ["Utils"]),
                     ],
                     targets: [
                         TargetDescription(name: "Utils", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "appPkg",
-                    path: .init(path: "/appPkg"),
+                    path: "/appPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/apkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/xPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/aPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "App",
-                                          dependencies: [
-                                            .product(name: "X",
-                                                     package: "xpkg",
-                                                     moduleAliases: ["Utils": "XUtils"]
-                                                    ),
-                                            .product(name: "A",
-                                                     package: "apkg",
-                                                     moduleAliases: ["Utils": "AUtils"]
-                                                    )
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "App",
+                            dependencies: [
+                                .product(
+                                    name: "X",
+                                    package: "xpkg",
+                                    moduleAliases: ["Utils": "XUtils"]
+                                ),
+                                .product(
+                                    name: "A",
+                                    package: "apkg",
+                                    moduleAliases: ["Utils": "AUtils"]
+                                ),
+                            ]
+                        ),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
@@ -2974,22 +3873,32 @@ final class ModuleAliasingBuildTests: XCTestCase {
         result.checkProductsCount(1)
         result.checkTargetsCount(5)
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "X" && $0.target.moduleAliases == nil })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "YUtils" && $0.target.moduleAliases?["Utils"] == "YUtils" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "AUtils" && $0.target.moduleAliases?["Utils"] == "AUtils" })
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "YUtils" && $0.target.moduleAliases?["Utils"] == "YUtils" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "AUtils" && $0.target.moduleAliases?["Utils"] == "AUtils" }
+        )
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
         XCTAssertFalse(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases == nil })
     }
 
     func testModuleAliasingChainedAliases1() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/appPkg/Sources/App/main.swift",
-                                    "/apkg/Sources/A/file.swift",
-                                    "/apkg/Sources/Utils/file.swift",
-                                    "/bpkg/Sources/Utils/file.swift",
-                                    "/xpkg/Sources/X/file.swift",
-                                    "/xpkg/Sources/Utils/file.swift",
-                                    "/ypkg/Sources/Utils/file.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/appPkg/Sources/App/main.swift",
+            "/aPkg/Sources/A/file.swift",
+            "/aPkg/Sources/Utils/file.swift",
+            "/bPkg/Sources/Utils/file.swift",
+            "/xPkg/Sources/X/file.swift",
+            "/xPkg/Sources/Utils/file.swift",
+            "/yPkg/Sources/Utils/file.swift"
         )
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
@@ -2997,79 +3906,101 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     displayName: "ypkg",
-                    path: .init(path: "/ypkg"),
+                    path: "/yPkg",
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
                     targets: [
                         TargetDescription(name: "Utils", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "xpkg",
-                    path: .init(path: "/xpkg"),
+                    path: "/xPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/ypkg"), requirement: .upToNextMajor(from: "1.0.0"))
+                        .localSourceControl(path: "/yPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "X", type: .library(.automatic), targets: ["X"]),
                     ],
                     targets: [
-                        TargetDescription(name: "X",
-                                          dependencies: [
-                                            "Utils",
-                                            .product(name: "Utils",
-                                                     package: "ypkg",
-                                                     moduleAliases: ["Utils" : "FooUtils"]
-                                                    )
-                                            ]),
+                        TargetDescription(
+                            name: "X",
+                            dependencies: [
+                                "Utils",
+                                .product(
+                                    name: "Utils",
+                                    package: "ypkg",
+                                    moduleAliases: ["Utils": "FooUtils"]
+                                ),
+                            ]
+                        ),
                         TargetDescription(name: "Utils", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "bpkg",
-                    path: .init(path: "/bpkg"),
+                    path: "/bPkg",
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
                     targets: [
                         TargetDescription(name: "Utils", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "apkg",
-                    path: .init(path: "/apkg"),
+                    path: "/aPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/bpkg"), requirement: .upToNextMajor(from: "1.0.0"))
+                        .localSourceControl(path: "/bPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "A", type: .library(.automatic), targets: ["A"]),
                     ],
                     targets: [
-                        TargetDescription(name: "A",
-                                          dependencies: [
-                                            "Utils",
-                                            .product(name: "Utils",
-                                                     package: "bpkg",
-                                                     moduleAliases: ["Utils" : "FooUtils"]
-                                                    )
-                                            ]),
+                        TargetDescription(
+                            name: "A",
+                            dependencies: [
+                                "Utils",
+                                .product(
+                                    name: "Utils",
+                                    package: "bpkg",
+                                    moduleAliases: ["Utils": "FooUtils"]
+                                ),
+                            ]
+                        ),
                         TargetDescription(name: "Utils", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "appPkg",
-                    path: .init(path: "/appPkg"),
+                    path: "/appPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/apkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/aPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/xPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "App",
-                                          dependencies: [.product(name: "A",
-                                                                  package: "apkg",
-                                                                  moduleAliases: ["Utils": "AUtils", "FooUtils": "AFooUtils"]),
-                                                         .product(name: "X",
-                                                                  package: "xpkg",
-                                                                  moduleAliases: ["Utils": "XUtils", "FooUtils": "XFooUtils"])
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "App",
+                            dependencies: [.product(
+                                name: "A",
+                                package: "apkg",
+                                moduleAliases: [
+                                    "Utils": "AUtils",
+                                    "FooUtils": "AFooUtils",
+                                ]
+                            ),
+                            .product(
+                                name: "X",
+                                package: "xpkg",
+                                moduleAliases: [
+                                    "Utils": "XUtils",
+                                    "FooUtils": "XFooUtils",
+                                ]
+                            )]
+                        ),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
@@ -3082,25 +4013,50 @@ final class ModuleAliasingBuildTests: XCTestCase {
         ))
         result.checkProductsCount(1)
         result.checkTargetsCount(7)
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "A" && $0.target.moduleAliases?["Utils"] == "AUtils" && $0.target.moduleAliases?["FooUtils"] == "AFooUtils" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "X" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target.moduleAliases?["FooUtils"] == "XFooUtils" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "AUtils" && $0.target.moduleAliases?["Utils"] == "AUtils" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "AFooUtils" && $0.target.moduleAliases?["Utils"] == "AFooUtils" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "XFooUtils" && $0.target.moduleAliases?["Utils"] == "XFooUtils" })
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains {
+                    $0.target.name == "A" && $0.target.moduleAliases?["Utils"] == "AUtils" && $0.target
+                        .moduleAliases?["FooUtils"] == "AFooUtils"
+                }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains {
+                    $0.target.name == "X" && $0.target.moduleAliases?["Utils"] == "XUtils" && $0.target
+                        .moduleAliases?["FooUtils"] == "XFooUtils"
+                }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "AUtils" && $0.target.moduleAliases?["Utils"] == "AUtils" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "AFooUtils" && $0.target.moduleAliases?["Utils"] == "AFooUtils" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "XFooUtils" && $0.target.moduleAliases?["Utils"] == "XFooUtils" }
+        )
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
     }
 
     func testModuleAliasingChainedAliases2() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/appPkg/Sources/App/main.swift",
-                                    "/apkg/Sources/A/file.swift",
-                                    "/apkg/Sources/Utils/file.swift",
-                                    "/bpkg/Sources/Utils/file.swift",
-                                    "/xpkg/Sources/X/file.swift",
-                                    "/xpkg/Sources/Utils/file.swift",
-                                    "/ypkg/Sources/Utils/file.swift",
-                                    "/zpkg/Sources/Utils/file.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/appPkg/Sources/App/main.swift",
+            "/aPkg/Sources/A/file.swift",
+            "/aPkg/Sources/Utils/file.swift",
+            "/bPkg/Sources/Utils/file.swift",
+            "/xPkg/Sources/X/file.swift",
+            "/xPkg/Sources/Utils/file.swift",
+            "/yPkg/Sources/Utils/file.swift",
+            "/zPkg/Sources/Utils/file.swift"
         )
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
@@ -3108,90 +4064,111 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     displayName: "zpkg",
-                    path: .init(path: "/zpkg"),
+                    path: "/zPkg",
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
                     targets: [
                         TargetDescription(name: "Utils", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "ypkg",
-                    path: .init(path: "/ypkg"),
+                    path: "/yPkg",
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
                     targets: [
                         TargetDescription(name: "Utils", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "xpkg",
-                    path: .init(path: "/xpkg"),
+                    path: "/xPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/ypkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/zpkg"), requirement: .upToNextMajor(from: "1.0.0"))
+                        .localSourceControl(path: "/yPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/zPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "X", type: .library(.automatic), targets: ["X"]),
                     ],
                     targets: [
-                        TargetDescription(name: "X",
-                                          dependencies: [
-                                            .product(name: "Utils",
-                                                     package: "ypkg",
-                                                     moduleAliases: ["Utils" : "FooUtils"]
-                                                    ),
-                                            .product(name: "Utils",
-                                                     package: "zpkg"
-                                                    )
-                                            ]),
-                    ]),
+                        TargetDescription(
+                            name: "X",
+                            dependencies: [
+                                .product(
+                                    name: "Utils",
+                                    package: "ypkg",
+                                    moduleAliases: ["Utils": "FooUtils"]
+                                ),
+                                .product(
+                                    name: "Utils",
+                                    package: "zpkg"
+                                ),
+                            ]
+                        ),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "bpkg",
-                    path: .init(path: "/bpkg"),
+                    path: "/bPkg",
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
                     targets: [
                         TargetDescription(name: "Utils", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "apkg",
-                    path: .init(path: "/apkg"),
+                    path: "/aPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/bpkg"), requirement: .upToNextMajor(from: "1.0.0"))
+                        .localSourceControl(path: "/bPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "A", type: .library(.automatic), targets: ["A"]),
                     ],
                     targets: [
-                        TargetDescription(name: "A",
-                                          dependencies: [
-                                            "Utils",
-                                            .product(name: "Utils",
-                                                     package: "bpkg",
-                                                     moduleAliases: ["Utils" : "FooUtils"]
-                                                    )
-                                            ]),
+                        TargetDescription(
+                            name: "A",
+                            dependencies: [
+                                "Utils",
+                                .product(
+                                    name: "Utils",
+                                    package: "bpkg",
+                                    moduleAliases: ["Utils": "FooUtils"]
+                                ),
+                            ]
+                        ),
                         TargetDescription(name: "Utils", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "appPkg",
-                    path: .init(path: "/appPkg"),
+                    path: "/appPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/apkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/aPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/xPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "App",
-                                          dependencies: [.product(name: "A",
-                                                                  package: "apkg",
-                                                                  moduleAliases: ["Utils": "AUtils", "FooUtils": "AFUtils"]),
-                                                         .product(name: "X",
-                                                                  package: "xpkg",
-                                                                  moduleAliases: ["FooUtils": "XFUtils"])
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "App",
+                            dependencies: [.product(
+                                name: "A",
+                                package: "apkg",
+                                moduleAliases: [
+                                    "Utils": "AUtils",
+                                    "FooUtils": "AFUtils",
+                                ]
+                            ),
+                            .product(
+                                name: "X",
+                                package: "xpkg",
+                                moduleAliases: ["FooUtils": "XFUtils"]
+                            )]
+                        ),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
@@ -3204,25 +4181,44 @@ final class ModuleAliasingBuildTests: XCTestCase {
         ))
         result.checkProductsCount(1)
         result.checkTargetsCount(7)
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "A" && $0.target.moduleAliases?["Utils"] == "AUtils" && $0.target.moduleAliases?["FooUtils"] == "AFUtils" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "AUtils" && $0.target.moduleAliases?["Utils"] == "AUtils" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "AFUtils" && $0.target.moduleAliases?["Utils"] == "AFUtils" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "X" && $0.target.moduleAliases?["FooUtils"] == "XFUtils" })
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains {
+                    $0.target.name == "A" && $0.target.moduleAliases?["Utils"] == "AUtils" && $0.target
+                        .moduleAliases?["FooUtils"] == "AFUtils"
+                }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "AUtils" && $0.target.moduleAliases?["Utils"] == "AUtils" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "AFUtils" && $0.target.moduleAliases?["Utils"] == "AFUtils" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "X" && $0.target.moduleAliases?["FooUtils"] == "XFUtils" }
+        )
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases == nil })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "XFUtils" && $0.target.moduleAliases?["Utils"] == "XFUtils" })
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "XFUtils" && $0.target.moduleAliases?["Utils"] == "XFUtils" }
+        )
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
     }
 
     func testModuleAliasingChainedAliases3() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/appPkg/Sources/App/main.swift",
-                                    "/apkg/Sources/A/file.swift",
-                                    "/apkg/Sources/Utils/file.swift",
-                                    "/bpkg/Sources/Utils/file.swift",
-                                    "/xpkg/Sources/X/file.swift",
-                                    "/xpkg/Sources/Utils/file.swift",
-                                    "/ypkg/Sources/Utils/file.swift",
-                                    "/zpkg/Sources/Utils/file.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/appPkg/Sources/App/main.swift",
+            "/aPkg/Sources/A/file.swift",
+            "/aPkg/Sources/Utils/file.swift",
+            "/bPkg/Sources/Utils/file.swift",
+            "/xPkg/Sources/X/file.swift",
+            "/xpkg/Sources/Utils/file.swift",
+            "/yPkg/Sources/Utils/file.swift",
+            "/zPkg/Sources/Utils/file.swift"
         )
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
@@ -3230,91 +4226,115 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     displayName: "zpkg",
-                    path: .init(path: "/zpkg"),
+                    path: "/zPkg",
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
                     targets: [
                         TargetDescription(name: "Utils", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "ypkg",
-                    path: .init(path: "/ypkg"),
+                    path: "/yPkg",
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
                     targets: [
                         TargetDescription(name: "Utils", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "xpkg",
-                    path: .init(path: "/xpkg"),
+                    path: "/xPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/ypkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/zpkg"), requirement: .upToNextMajor(from: "1.0.0"))
+                        .localSourceControl(path: "/yPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/zPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "X", type: .library(.automatic), targets: ["X"]),
                     ],
                     targets: [
-                        TargetDescription(name: "X",
-                                          dependencies: [
-                                            .product(name: "Utils",
-                                                     package: "ypkg",
-                                                     moduleAliases: ["Utils" : "FooUtils"]
-                                                    ),
-                                            .product(name: "Utils",
-                                                     package: "zpkg",
-                                                     moduleAliases: ["Utils" : "ZUtils"]
-                                                    )
-                                            ]),
-                    ]),
+                        TargetDescription(
+                            name: "X",
+                            dependencies: [
+                                .product(
+                                    name: "Utils",
+                                    package: "ypkg",
+                                    moduleAliases: ["Utils": "FooUtils"]
+                                ),
+                                .product(
+                                    name: "Utils",
+                                    package: "zpkg",
+                                    moduleAliases: ["Utils": "ZUtils"]
+                                ),
+                            ]
+                        ),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "bpkg",
-                    path: .init(path: "/bpkg"),
+                    path: "/bPkg",
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
                     ],
                     targets: [
                         TargetDescription(name: "Utils", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "apkg",
-                    path: .init(path: "/apkg"),
+                    path: "/aPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/bpkg"), requirement: .upToNextMajor(from: "1.0.0"))
+                        .localSourceControl(path: "/bPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "A", type: .library(.automatic), targets: ["A"]),
                     ],
                     targets: [
-                        TargetDescription(name: "A",
-                                          dependencies: [
-                                            "Utils",
-                                            .product(name: "Utils",
-                                                     package: "bpkg",
-                                                     moduleAliases: ["Utils" : "FooUtils"]
-                                                    )
-                                            ]),
+                        TargetDescription(
+                            name: "A",
+                            dependencies: [
+                                "Utils",
+                                .product(
+                                    name: "Utils",
+                                    package: "bpkg",
+                                    moduleAliases: ["Utils": "FooUtils"]
+                                ),
+                            ]
+                        ),
                         TargetDescription(name: "Utils", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "appPkg",
-                    path: .init(path: "/appPkg"),
+                    path: "/appPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/apkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/aPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/xPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "App",
-                                          dependencies: [.product(name: "A",
-                                                                  package: "apkg",
-                                                                  moduleAliases: ["Utils": "AUtils", "FooUtils": "AFooUtils"]),
-                                                         .product(name: "X",
-                                                                  package: "xpkg",
-                                                                  moduleAliases: ["ZUtils": "XUtils", "FooUtils": "XFooUtils"])
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "App",
+                            dependencies: [.product(
+                                name: "A",
+                                package: "apkg",
+                                moduleAliases: [
+                                    "Utils": "AUtils",
+                                    "FooUtils": "AFooUtils",
+                                ]
+                            ),
+                            .product(
+                                name: "X",
+                                package: "xpkg",
+                                moduleAliases: [
+                                    "ZUtils": "XUtils",
+                                    "FooUtils": "XFooUtils",
+                                ]
+                            )]
+                        ),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
@@ -3327,24 +4347,49 @@ final class ModuleAliasingBuildTests: XCTestCase {
         ))
         result.checkProductsCount(1)
         result.checkTargetsCount(7)
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "A" && $0.target.moduleAliases?["Utils"] == "AUtils" && $0.target.moduleAliases?["FooUtils"] == "AFooUtils" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "AUtils" && $0.target.moduleAliases?["Utils"] == "AUtils" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "AFooUtils" && $0.target.moduleAliases?["Utils"] == "AFooUtils" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "X" && $0.target.moduleAliases?["ZUtils"] == "XUtils" && $0.target.moduleAliases?["FooUtils"] == "XFooUtils" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "XFooUtils" && $0.target.moduleAliases?["Utils"] == "XFooUtils" })
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains {
+                    $0.target.name == "A" && $0.target.moduleAliases?["Utils"] == "AUtils" && $0.target
+                        .moduleAliases?["FooUtils"] == "AFooUtils"
+                }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "AUtils" && $0.target.moduleAliases?["Utils"] == "AUtils" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "AFooUtils" && $0.target.moduleAliases?["Utils"] == "AFooUtils" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains {
+                    $0.target.name == "X" && $0.target.moduleAliases?["ZUtils"] == "XUtils" && $0.target
+                        .moduleAliases?["FooUtils"] == "XFooUtils"
+                }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "XFooUtils" && $0.target.moduleAliases?["Utils"] == "XFooUtils" }
+        )
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
         XCTAssertFalse(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases == nil })
     }
 
     func testModuleAliasingChainedAliases5() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/appPkg/Sources/App/main.swift",
-                                    "/xpkg/Sources/Utils/file.swift",
-                                    "/ypkg/Sources/Utils/file.swift",
-                                    "/zpkg/Sources/Utils/file.swift",
-                                    "/wpkg/Sources/Utils/file.swift",
-                                    "/apkg/Sources/Utils/file.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/appPkg/Sources/App/main.swift",
+            "/xPkg/Sources/Utils/file.swift",
+            "/yPkg/Sources/Utils/file.swift",
+            "/zPkg/Sources/Utils/file.swift",
+            "/wPkg/Sources/Utils/file.swift",
+            "/aPkg/Sources/Utils/file.swift"
         )
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
@@ -3352,7 +4397,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     displayName: "apkg",
-                    path: .init(path: "/apkg"),
+                    path: "/aPkg",
                     products: [
                         ProductDescription(name: "A", type: .library(.automatic), targets: ["Utils"]),
                     ],
@@ -3362,84 +4407,101 @@ final class ModuleAliasingBuildTests: XCTestCase {
                 ),
                 Manifest.createFileSystemManifest(
                     displayName: "wpkg",
-                    path: .init(path: "/wpkg"),
+                    path: "/wPkg",
                     products: [
                         ProductDescription(name: "W", type: .library(.automatic), targets: ["Utils"]),
                     ],
                     targets: [
                         TargetDescription(name: "Utils", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "zpkg",
-                    path: .init(path: "/zpkg"),
+                    path: "/zPkg",
                     products: [
                         ProductDescription(name: "Z", type: .library(.automatic), targets: ["Utils"]),
                     ],
                     targets: [
                         TargetDescription(name: "Utils", dependencies: []),
-                    ]),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "ypkg",
-                    path: .init(path: "/ypkg"),
+                    path: "/yPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/zpkg"), requirement: .upToNextMajor(from: "1.0.0"))
+                        .localSourceControl(path: "/zPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "Y", type: .library(.automatic), targets: ["Utils"]),
                     ],
                     targets: [
-                        TargetDescription(name: "Utils",
-                                          dependencies: [
-                                            .product(name: "Z",
-                                                     package: "zpkg", // import ZUtils
-                                                     moduleAliases: ["Utils" : "ZUtils"]
-                                                    )
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "Utils",
+                            dependencies: [
+                                .product(
+                                    name: "Z",
+                                    package: "zpkg", // import ZUtils
+                                    moduleAliases: ["Utils": "ZUtils"]
+                                ),
+                            ]
+                        ),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
                     displayName: "xpkg",
-                    path: .init(path: "/xpkg"),
+                    path: "/xPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/ypkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/wpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/yPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/wPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "X", type: .library(.automatic), targets: ["Utils"]),
                     ],
                     targets: [
-                        TargetDescription(name: "Utils",
-                                          dependencies: [
-                                            .product(name: "Y",
-                                                     package: "ypkg", // import YUtils
-                                                     moduleAliases: ["ZUtils" : "YUtils"]
-                                                    ),
-                                            .product(name: "W",
-                                                     package: "wpkg", // import WUtils
-                                                     moduleAliases: ["Utils" : "WUtils"]
-                                                    )
-                                            ]),
-                    ]),
+                        TargetDescription(
+                            name: "Utils",
+                            dependencies: [
+                                .product(
+                                    name: "Y",
+                                    package: "ypkg", // import YUtils
+                                    moduleAliases: ["ZUtils": "YUtils"]
+                                ),
+                                .product(
+                                    name: "W",
+                                    package: "wpkg", // import WUtils
+                                    moduleAliases: ["Utils": "WUtils"]
+                                ),
+                            ]
+                        ),
+                    ]
+                ),
                 Manifest.createRootManifest(
                     displayName: "appPkg",
-                    path: .init(path: "/appPkg"),
+                    path: "/appPkg",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/apkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/aPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/xPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
-                        TargetDescription(name: "App",
-                                          dependencies: [.product(name: "X",
-                                                                  package: "xpkg",
-                                                                  moduleAliases: [
-                                                                    "Utils": "XUtils",
-                                                                  ]),
-                                                         .product(name: "A",
-                                                                  package: "apkg",
-                                                                  moduleAliases: [
-                                                                    "Utils": "AUtils"
-                                                                  ])
-                                          ]),
-                    ]),
+                        TargetDescription(
+                            name: "App",
+                            dependencies: [.product(
+                                name: "X",
+                                package: "xpkg",
+                                moduleAliases: [
+                                    "Utils": "XUtils",
+                                ]
+                            ),
+                            .product(
+                                name: "A",
+                                package: "apkg",
+                                moduleAliases: [
+                                    "Utils": "AUtils",
+                                ]
+                            )]
+                        ),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
@@ -3452,12 +4514,30 @@ final class ModuleAliasingBuildTests: XCTestCase {
         ))
         result.checkProductsCount(1)
         result.checkTargetsCount(6)
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Utils" && $0.target.moduleAliases?["ZUtils"] == "YUtils" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "YUtils" && $0.target.moduleAliases?["Utils"] == "YUtils" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "WUtils" && $0.target.moduleAliases?["Utils"] == "WUtils" })
-        XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "AUtils" && $0.target.moduleAliases?["Utils"] == "AUtils" })
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "Utils" && $0.target.moduleAliases?["ZUtils"] == "YUtils" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "XUtils" && $0.target.moduleAliases?["Utils"] == "XUtils" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "YUtils" && $0.target.moduleAliases?["Utils"] == "YUtils" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "WUtils" && $0.target.moduleAliases?["Utils"] == "WUtils" }
+        )
+        XCTAssertTrue(
+            result.targetMap.values
+                .contains { $0.target.name == "AUtils" && $0.target.moduleAliases?["Utils"] == "AUtils" }
+        )
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "App" && $0.target.moduleAliases == nil })
-        XCTAssertFalse(result.targetMap.values.contains { $0.target.name == "ZUtils" || $0.target.moduleAliases?["Utils"] == "ZUtils" })
+        XCTAssertFalse(
+            result.targetMap.values
+                .contains { $0.target.name == "ZUtils" || $0.target.moduleAliases?["Utils"] == "ZUtils" }
+        )
     }
 }

--- a/Tests/CommandsTests/PackageRegistryToolTests.swift
+++ b/Tests/CommandsTests/PackageRegistryToolTests.swift
@@ -84,7 +84,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
         try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
             let packageRoot = fixturePath.appending("Bar")
             let configurationFilePath = AbsolutePath(
-                path: ".swiftpm/configuration/registries.json",
+                ".swiftpm/configuration/registries.json",
                 relativeTo: packageRoot
             )
 
@@ -190,7 +190,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
         try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
             let packageRoot = fixturePath.appending("Bar")
             let configurationFilePath = AbsolutePath(
-                path: ".swiftpm/configuration/registries.json",
+                ".swiftpm/configuration/registries.json",
                 relativeTo: packageRoot
             )
 
@@ -210,7 +210,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
         try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
             let packageRoot = fixturePath.appending("Bar")
             let configurationFilePath = AbsolutePath(
-                path: ".swiftpm/configuration/registries.json",
+                ".swiftpm/configuration/registries.json",
                 relativeTo: packageRoot
             )
 
@@ -230,7 +230,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
         try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
             let packageRoot = fixturePath.appending("Bar")
             let configurationFilePath = AbsolutePath(
-                path: ".swiftpm/configuration/registries.json",
+                ".swiftpm/configuration/registries.json",
                 relativeTo: packageRoot
             )
 
@@ -253,7 +253,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
         try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
             let packageRoot = fixturePath.appending("Bar")
             let configurationFilePath = AbsolutePath(
-                path: ".swiftpm/configuration/registries.json",
+                ".swiftpm/configuration/registries.json",
                 relativeTo: packageRoot
             )
 

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -546,11 +546,11 @@ final class PackageToolTests: CommandsTestCase {
 
         let manifestA = Manifest.createRootManifest(
             displayName: "PackageA",
-            path: .init(path: "/PackageA"),
+            path: "/PackageA",
             toolsVersion: .v5_3,
             dependencies: [
-                .fileSystem(path: .init(path: "/PackageB")),
-                .fileSystem(path: .init(path: "/PackageC")),
+                .fileSystem(path: "/PackageB"),
+                .fileSystem(path: "/PackageC"),
             ],
             products: [
                 try .init(name: "exe", type: .executable, targets: ["TargetA"])
@@ -562,11 +562,11 @@ final class PackageToolTests: CommandsTestCase {
 
         let manifestB = Manifest.createFileSystemManifest(
             displayName: "PackageB",
-            path: .init(path: "/PackageB"),
+            path: "/PackageB",
             toolsVersion: .v5_3,
             dependencies: [
-                .fileSystem(path: .init(path: "/PackageC")),
-                .fileSystem(path: .init(path: "/PackageD")),
+                .fileSystem(path: "/PackageC"),
+                .fileSystem(path: "/PackageD"),
             ],
             products: [
                 try .init(name: "PackageB", type: .library(.dynamic), targets: ["TargetB"])
@@ -578,10 +578,10 @@ final class PackageToolTests: CommandsTestCase {
 
         let manifestC = Manifest.createFileSystemManifest(
             displayName: "PackageC",
-            path: .init(path: "/PackageC"),
+            path: "/PackageC",
             toolsVersion: .v5_3,
             dependencies: [
-                .fileSystem(path: .init(path: "/PackageD")),
+                .fileSystem(path: "/PackageD"),
             ],
             products: [
                 try .init(name: "PackageC", type: .library(.dynamic), targets: ["TargetC"])
@@ -593,7 +593,7 @@ final class PackageToolTests: CommandsTestCase {
 
         let manifestD = Manifest.createFileSystemManifest(
             displayName: "PackageD",
-            path: .init(path: "/PackageD"),
+            path: "/PackageD",
             toolsVersion: .v5_3,
             products: [
                 try .init(name: "PackageD", type: .library(.dynamic), targets: ["TargetD"])

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -71,7 +71,7 @@ class MiscellaneousTestCase: XCTestCase {
     }
 
     func testNoArgumentsExitsWithOne() throws {
-        XCTAssertThrowsCommandExecutionError(try executeSwiftBuild(AbsolutePath(path: "/"))) { error in
+        XCTAssertThrowsCommandExecutionError(try executeSwiftBuild("/")) { error in
             // if our code crashes we'll get an exit code of 256
             guard error.result.exitStatus == .terminated(code: 1) else {
                 return XCTFail("failed in an unexpected manner: \(error)")
@@ -363,7 +363,7 @@ class MiscellaneousTestCase: XCTestCase {
 
             // ••••• Set up dependency.
             let dependencyName = "UnicodeDependency‐\(complicatedString)"
-            let dependencyOrigin = AbsolutePath(path: #file).parentDirectory.parentDirectory.parentDirectory
+            let dependencyOrigin = AbsolutePath(#file).parentDirectory.parentDirectory.parentDirectory
                 .appending("Fixtures")
                 .appending("Miscellaneous")
                 .appending(component: dependencyName)

--- a/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
@@ -78,7 +78,7 @@ class DependencyResolverRealWorldPerfTests: XCTestCasePerf {
     }
 
     func mockGraph(for name: String) throws -> MockDependencyGraph {
-        let input = AbsolutePath(path: #file).parentDirectory.appending("Inputs").appending(component: name)
+        let input = AbsolutePath(#file).parentDirectory.appending("Inputs").appending(component: name)
         let jsonString: Data = try localFileSystem.readFileContents(input)
         let json = try JSON(data: jsonString)
         return MockDependencyGraph(json)

--- a/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
@@ -112,7 +112,7 @@ class PackageGraphPerfTests: XCTestCasePerf {
 
         let root = Manifest.createRootManifest(
             displayName: "PackageA",
-            path: .init(path: "/PackageA"),
+            path: "/PackageA",
             toolsVersion: .v5_7,
             dependencies: try packageNumberSequence.map({ .fileSystem(path: try .init(validating: "/Package\($0)")) }),
             targets: [try .init(name: "TargetA", dependencies: ["Target1"]) ]

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -35,7 +35,7 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo"),
+                    path: "/Foo",
                     products: [
                         ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Foo"])
                     ],
@@ -45,9 +45,9 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     displayName: "Bar",
-                    path: .init(path: "/Bar"),
+                    path: "/Bar",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Foo"), requirement: .upToNextMajor(from: "1.0.0"))
+                        .localSourceControl(path: "/Foo", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
@@ -57,9 +57,9 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     displayName: "Baz",
-                    path: .init(path: "/Baz"),
+                    path: "/Baz",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0"))
+                        .localSourceControl(path: "/Bar", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     targets: [
                         TargetDescription(name: "Baz", dependencies: ["Bar"]),
@@ -102,16 +102,16 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo"),
+                    path: "/Foo",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0"))
+                        .localSourceControl(path: "/Bar", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Bar", "CBar"]),
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "Bar",
-                    path: .init(path: "/Bar"),
+                    path: "/Bar",
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"]),
                         ProductDescription(name: "CBar", type: .library(.automatic), targets: ["CBar"]),
@@ -146,18 +146,18 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo"),
+                    path: "/Foo",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0"))
+                        .localSourceControl(path: "/Bar", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Bar"]),
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "Bar",
-                    path: .init(path: "/Bar"),
+                    path: "/Bar",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Baz"), requirement: .upToNextMajor(from: "1.0.0"))
+                        .localSourceControl(path: "/Baz", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
@@ -167,9 +167,9 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "Baz",
-                    path: .init(path: "/Baz"),
+                    path: "/Baz",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0"))
+                        .localSourceControl(path: "/Bar", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     products: [
                         ProductDescription(name: "Baz", type: .library(.automatic), targets: ["Baz"])
@@ -199,9 +199,9 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo"),
+                    path: "/Foo",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Foo"), requirement: .upToNextMajor(from: "1.0.0"))
+                        .localSourceControl(path: "/Foo", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     targets: [
                         TargetDescription(name: "Foo"),
@@ -231,9 +231,9 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Bar",
-                    path: .init(path: "/Bar"),
+                    path: "/Bar",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Foo"), requirement: .upToNextMajor(from: "1.0.0"))
+                        .localSourceControl(path: "/Foo", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     targets: [
                         TargetDescription(name: "Bar", dependencies: ["Foo"]),
@@ -241,7 +241,7 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo"),
+                    path: "/Foo",
                     products: [
                         ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Foo"]),
                     ],
@@ -263,10 +263,10 @@ class PackageGraphTests: XCTestCase {
 
     func testTargetGroup() throws {
         let fs = InMemoryFileSystem(emptyFiles:
-            "/libpkg/Sources/ExampleApp/main.swift",
-            "/libpkg/Sources/MainLib/file.swift",
-            "/libpkg/Sources/Core/file.swift",
-            "/libpkg/Tests/MainLibTests/file.swift"
+            "/libPkg/Sources/ExampleApp/main.swift",
+            "/libPkg/Sources/MainLib/file.swift",
+            "/libPkg/Sources/Core/file.swift",
+            "/libPkg/Tests/MainLibTests/file.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -275,7 +275,7 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "libpkg",
-                    path: .init(path: "/libpkg"),
+                    path: "/libPkg",
                     toolsVersion: .vNext,
                     products: [
                         ProductDescription(name: "ExampleApp", type: .executable, targets: ["ExampleApp"]),
@@ -315,9 +315,9 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo"),
+                    path: "/Foo",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0"))
+                        .localSourceControl(path: "/Bar", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     targets: [
                         TargetDescription(name: "Foo"),
@@ -325,7 +325,7 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     displayName: "Bar",
-                    path: .init(path: "/Bar"),
+                    path: "/Bar",
                     targets: [
                         TargetDescription(name: "Bar"),
                         TargetDescription(name: "Baz"),
@@ -353,7 +353,7 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     displayName: "Fourth",
-                    path: .init(path: "/Fourth"),
+                    path: "/Fourth",
                     products: [
                         ProductDescription(name: "Fourth", type: .library(.automatic), targets: ["First"])
                     ],
@@ -362,7 +362,7 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "Third",
-                    path: .init(path: "/Third"),
+                    path: "/Third",
                     products: [
                         ProductDescription(name: "Third", type: .library(.automatic), targets: ["First"])
                     ],
@@ -371,7 +371,7 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "Second",
-                    path: .init(path: "/Second"),
+                    path: "/Second",
                     products: [
                         ProductDescription(name: "Second", type: .library(.automatic), targets: ["First"])
                     ],
@@ -380,11 +380,11 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     displayName: "First",
-                    path: .init(path: "/First"),
+                    path: "/First",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Second"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/Third"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/Fourth"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/Second", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/Third", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/Fourth", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "First", dependencies: ["Second", "Third", "Fourth"]),
@@ -416,7 +416,7 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     displayName: "Fourth",
-                    path: .init(path: "/Fourth"),
+                    path: "/Fourth",
                     products: [
                         ProductDescription(name: "Fourth", type: .library(.automatic), targets: ["Fourth", "Bar"])
                     ],
@@ -426,7 +426,7 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "Third",
-                    path: .init(path: "/Third"),
+                    path: "/Third",
                     products: [
                         ProductDescription(name: "Third", type: .library(.automatic), targets: ["Third", "Bar"])
                     ],
@@ -436,7 +436,7 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "Second",
-                    path: .init(path: "/Second"),
+                    path: "/Second",
                     products: [
                         ProductDescription(name: "Second", type: .library(.automatic), targets: ["Second", "Foo"])
                     ],
@@ -446,11 +446,11 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     displayName: "First",
-                    path: .init(path: "/First"),
+                    path: "/First",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Second"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/Third"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/Fourth"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/Second", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/Third", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/Fourth", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "First", type: .library(.automatic), targets: ["First", "Foo"])
@@ -484,7 +484,7 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createFileSystemManifest(
                     displayName: "Fourth",
-                    path: .init(path: "/Fourth"),
+                    path: "/Fourth",
                     products: [
                         ProductDescription(name: "Fourth", type: .library(.automatic), targets: ["Fourth", "First"])
                     ],
@@ -494,9 +494,9 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "Third",
-                    path: .init(path: "/Third"),
+                    path: "/Third",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Fourth"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/Fourth", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "Third", type: .library(.automatic), targets: ["Third"])
@@ -506,9 +506,9 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "Second",
-                    path: .init(path: "/Second"),
+                    path: "/Second",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Third"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/Third", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "Second", type: .library(.automatic), targets: ["Second"])
@@ -518,9 +518,9 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createRootManifest(
                     displayName: "First",
-                    path: .init(path: "/First"),
+                    path: "/First",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Second"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/Second", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "First", type: .library(.automatic), targets: ["First"])
@@ -551,9 +551,9 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "First",
-                    path: .init(path: "/First"),
+                    path: "/First",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Second"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/Second", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "First", type: .library(.automatic), targets: ["Foo", "Bar"])
@@ -564,7 +564,7 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createLocalSourceControlManifest(
                     displayName: "Second",
-                    path: .init(path: "/Second"),
+                    path: "/Second",
                     products: [
                         ProductDescription(name: "Second", type: .library(.automatic), targets: ["Foo", "Bar"])
                     ],
@@ -601,9 +601,9 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "First",
-                    path: .init(path: "/First"),
+                    path: "/First",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Second"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/Second", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "First", type: .library(.automatic), targets: ["Foo", "Bar", "Baz", "Qux", "Quux"])
@@ -617,7 +617,7 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createLocalSourceControlManifest(
                     displayName: "Second",
-                    path: .init(path: "/Second"),
+                    path: "/Second",
                     products: [
                         ProductDescription(name: "Second", type: .library(.automatic), targets: ["Foo", "Bar", "Baz", "Qux", "Quux"])
                     ],
@@ -651,7 +651,7 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "First",
-                    path: .init(path: "/First"),
+                    path: "/First",
                     dependencies: [
                         .registry(identity: "test.second", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
@@ -665,7 +665,7 @@ class PackageGraphTests: XCTestCase {
                 Manifest.createRegistryManifest(
                     displayName: "Second",
                     identity: .plain("test.second"),
-                    path: .init(path: "/Second"),
+                    path: "/Second",
                     products: [
                         ProductDescription(name: "Second", type: .library(.automatic), targets: ["Foo", "Bar"])
                     ],
@@ -696,9 +696,9 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo"),
+                    path: "/Foo",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Bar"]),
@@ -739,7 +739,7 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Bar",
-                    path: .init(path: "/Bar"),
+                    path: "/Bar",
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
                     ],
@@ -768,7 +768,7 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo"),
+                    path: "/Foo",
                     targets: [
                         TargetDescription(name: "FooTarget", dependencies: ["Barx"]),
                     ]),
@@ -796,7 +796,7 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo"),
+                    path: "/Foo",
                     products: [
                         ProductDescription(name: "Foo", type: .library(.automatic), targets: ["FooTarget"]),
                     ],
@@ -827,7 +827,7 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "XYZ",
-                    path: .init(path: "/XYZ"),
+                    path: "/XYZ",
                     targets: [
                         TargetDescription(name: "XYZ", dependencies: [], type: .executable),
                         TargetDescription(name: "XYZTests", dependencies: ["XYZ"], type: .test),
@@ -851,7 +851,7 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo"),
+                    path: "/Foo",
                     products: [
                         ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Foo"]),
                     ],
@@ -876,7 +876,7 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo"),
+                    path: "/Foo",
                     toolsVersion: .v5_2,
                     targets: [
                         TargetDescription(name: "FooTarget", dependencies: [.product(name: "Barx", package: "Bar")]),
@@ -905,7 +905,7 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo"),
+                    path: "/Foo",
                     toolsVersion: .v5_2,
                     targets: [
                         TargetDescription(name: "FooTarget", dependencies: [.product(name: "Barx")]),
@@ -937,19 +937,19 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo"),
+                    path: "/Foo",
                     toolsVersion: .v5_2,
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Bar"), requirement: .branch("master")),
-                        .localSourceControl(path: .init(path: "/BizPath"), requirement: .exact("1.2.3")),
-                        .localSourceControl(path: .init(path: "/FizPath"), requirement: .upToNextMajor(from: "1.1.2")),
+                        .localSourceControl(path: "/Bar", requirement: .branch("master")),
+                        .localSourceControl(path: "/BizPath", requirement: .exact("1.2.3")),
+                        .localSourceControl(path: "/FizPath", requirement: .upToNextMajor(from: "1.1.2")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["BarLib", "Biz", "FizLib"]),
                     ]),
                 Manifest.createLocalSourceControlManifest(
                     displayName: "Bar",
-                    path: .init(path: "/Bar"),
+                    path: "/Bar",
                     products: [
                         ProductDescription(name: "BarLib", type: .library(.automatic), targets: ["BarLib"])
                     ],
@@ -958,7 +958,7 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createLocalSourceControlManifest(
                     displayName: "Biz",
-                    path: .init(path: "/BizPath"),
+                    path: "/BizPath",
                     version: "1.2.3",
                     products: [
                         ProductDescription(name: "Biz", type: .library(.automatic), targets: ["Biz"])
@@ -968,7 +968,7 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createLocalSourceControlManifest(
                     displayName: "Fiz",
-                    path: .init(path: "/FizPath"),
+                    path: "/FizPath",
                     version: "1.2.3",
                     products: [
                         ProductDescription(name: "FizLib", type: .library(.automatic), targets: ["FizLib"])
@@ -1014,17 +1014,17 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo"),
+                    path: "/Foo",
                     toolsVersion: .v5_2,
                     dependencies: [
-                        .localSourceControl(deprecatedName: "UnBar", path: .init(path: "/Bar"), requirement: .branch("master")),
+                        .localSourceControl(deprecatedName: "UnBar", path: "/Bar", requirement: .branch("master")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: [.product(name: "BarProduct", package: "UnBar")]),
                     ]),
                 Manifest.createLocalSourceControlManifest(
                     displayName: "UnBar",
-                    path: .init(path: "/Bar"),
+                    path: "/Bar",
                     products: [
                         ProductDescription(name: "BarProduct", type: .library(.automatic), targets: ["Bar"])
                     ],
@@ -1053,18 +1053,18 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo"),
+                    path: "/Foo",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/Baz"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/Biz"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/Baz", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/Biz", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["BarLibrary"]),
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "Biz",
-                    path: .init(path: "/Biz"),
+                    path: "/Biz",
                     products: [
                         ProductDescription(name: "biz", type: .executable, targets: ["Biz"])
                     ],
@@ -1073,7 +1073,7 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "Bar",
-                    path: .init(path: "/Bar"),
+                    path: "/Bar",
                     products: [
                         ProductDescription(name: "BarLibrary", type: .library(.automatic), targets: ["Bar"])
                     ],
@@ -1082,7 +1082,7 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "Baz",
-                    path: .init(path: "/Baz"),
+                    path: "/Baz",
                     products: [
                         ProductDescription(name: "BazLibrary", type: .library(.automatic), targets: ["Baz"])
                     ],
@@ -1115,16 +1115,16 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Bar",
-                    path: .init(path: "/Bar"),
+                    path: "/Bar",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Foo"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/Foo", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Bar"),
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo")
+                    path: "/Foo"
                 ),
             ],
             observabilityScope: observability.topScope
@@ -1149,9 +1149,9 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Start",
-                    path: .init(path: "/Start"),
+                    path: "/Start",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Dep1"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/Dep1", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["BazLibrary"]),
@@ -1159,9 +1159,9 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "Dep1",
-                    path: .init(path: "/Dep1"),
+                    path: "/Dep1",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Dep2"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/Dep2", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "BazLibrary", type: .library(.automatic), targets: ["Baz"])
@@ -1171,7 +1171,7 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "Dep2",
-                    path: .init(path: "/Dep2"),
+                    path: "/Dep2",
                     products: [
                         ProductDescription(name: "FooLibrary", type: .library(.automatic), targets: ["Foo"]),
                         ProductDescription(name: "BamLibrary", type: .library(.automatic), targets: ["Bam"]),
@@ -1202,17 +1202,17 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo"),
+                    path: "/Foo",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/Baz"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/Baz", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Bar"]),
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "Bar",
-                    path: .init(path: "/Bar"),
+                    path: "/Bar",
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
                     ],
@@ -1221,7 +1221,7 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "Baz",
-                    path: .init(path: "/Baz"),
+                    path: "/Baz",
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Baz"])
                     ],
@@ -1257,9 +1257,9 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo"),
+                    path: "/Foo",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Bar"]),
@@ -1267,7 +1267,7 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "Bar",
-                    path: .init(path: "/Bar"),
+                    path: "/Bar",
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar", "Bar2", "Bar3"]),
                         ProductDescription(name: "TransitiveBar", type: .library(.automatic), targets: ["TransitiveBar"]),
@@ -1329,9 +1329,9 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo"),
+                    path: "/Foo",
                     dependencies: [
-                        .fileSystem(path: .init(path: "/Biz")),
+                        .fileSystem(path: "/Biz"),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: [
@@ -1354,7 +1354,7 @@ class PackageGraphTests: XCTestCase {
                 ),
                 Manifest.createLocalSourceControlManifest(
                     displayName: "Biz",
-                    path: .init(path: "/Biz"),
+                    path: "/Biz",
                     products: [
                         ProductDescription(name: "Biz", type: .library(.automatic), targets: ["Biz"])
                     ],
@@ -1411,10 +1411,10 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Root",
-                    path: .init(path: "/Root"),
+                    path: "/Root",
                     toolsVersion: .v5_2,
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Immediate"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/Immediate", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Root", dependencies: [
@@ -1424,15 +1424,15 @@ class PackageGraphTests: XCTestCase {
                 ),
                 Manifest.createFileSystemManifest(
                     displayName: "Immediate",
-                    path: .init(path: "/Immediate"),
+                    path: "/Immediate",
                     toolsVersion: .v5_2,
                     dependencies: [
                         .localSourceControl(
-                            path: .init(path: "/Transitive"),
+                            path: "/Transitive",
                             requirement: .upToNextMajor(from: "1.0.0")
                         ),
                         .localSourceControl(
-                            path: .init(path: "/Nonexistent"),
+                            path: "/Nonexistent",
                             requirement: .upToNextMajor(from: "1.0.0")
                         )
                     ],
@@ -1452,11 +1452,11 @@ class PackageGraphTests: XCTestCase {
                 ),
                 Manifest.createFileSystemManifest(
                     displayName: "Transitive",
-                    path: .init(path: "/Transitive"),
+                    path: "/Transitive",
                     toolsVersion: .v5_2,
                     dependencies: [
                         .localSourceControl(
-                            path: .init(path: "/Nonexistent"),
+                            path: "/Nonexistent",
                             requirement: .upToNextMajor(from: "1.0.0")
                         )
                     ],
@@ -1530,20 +1530,20 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "A",
-                    path: .init(path: "/A"),
+                    path: "/A",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/B"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/C"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/D"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/E"), requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: .init(path: "/F"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/B", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/C", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/D", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/E", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/F", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "A", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "B",
-                    path: .init(path: "/B"),
+                    path: "/B",
                     products: [
                         ProductDescription(name: "B", type: .library(.automatic), targets: ["B"])
                     ],
@@ -1553,7 +1553,7 @@ class PackageGraphTests: XCTestCase {
                 ),
                 Manifest.createFileSystemManifest(
                     displayName: "C",
-                    path: .init(path: "/C"),
+                    path: "/C",
                     products: [
                         ProductDescription(name: "C", type: .library(.automatic), targets: ["C"])
                     ],
@@ -1563,7 +1563,7 @@ class PackageGraphTests: XCTestCase {
                 ),
                 Manifest.createFileSystemManifest(
                     displayName: "D",
-                    path: .init(path: "/D"),
+                    path: "/D",
                     products: [
                         ProductDescription(name: "D", type: .library(.automatic), targets: ["D"])
                     ],
@@ -1573,7 +1573,7 @@ class PackageGraphTests: XCTestCase {
                 ),
                 Manifest.createFileSystemManifest(
                     displayName: "E",
-                    path: .init(path: "/E"),
+                    path: "/E",
                     products: [
                         ProductDescription(name: "E", type: .library(.automatic), targets: ["E"])
                     ],
@@ -1583,7 +1583,7 @@ class PackageGraphTests: XCTestCase {
                 ),
                 Manifest.createFileSystemManifest(
                     displayName: "F",
-                    path: .init(path: "/F"),
+                    path: "/F",
                     products: [
                         ProductDescription(name: "F", type: .library(.automatic), targets: ["F"])
                     ],
@@ -1616,17 +1616,17 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo"),
+                    path: "/Foo",
                     toolsVersion: .v5,
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Bar"]),
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "Bar",
-                    path: .init(path: "/Bar"),
+                    path: "/Bar",
                     toolsVersion: .v5,
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
@@ -1653,17 +1653,17 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo"),
+                    path: "/Foo",
                     toolsVersion: .v5,
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Unknown"]),
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "Bar",
-                    path: .init(path: "/Bar"),
+                    path: "/Bar",
                     toolsVersion: .v5,
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
@@ -1697,17 +1697,17 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo"),
+                    path: "/Foo",
                     toolsVersion: .v5_2,
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Bar"]),
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "Bar",
-                    path: .init(path: "/Bar"),
+                    path: "/Bar",
                     toolsVersion: .v5_2,
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
@@ -1734,17 +1734,17 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo"),
+                    path: "/Foo",
                     toolsVersion: .v5_2,
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Unknown"]),
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "Bar",
-                    path: .init(path: "/Bar"),
+                    path: "/Bar",
                     toolsVersion: .v5_2,
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
@@ -1775,17 +1775,17 @@ class PackageGraphTests: XCTestCase {
         let manifests = try [
             Manifest.createRootManifest(
                 displayName: "Foo",
-                path: .init(path: "/Foo"),
+                path: "/Foo",
                 toolsVersion: .v5_2,
                 dependencies: [
-                    .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
+                    .localSourceControl(path: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
                 ],
                 targets: [
                     TargetDescription(name: "Foo", dependencies: ["ProductBar"]),
                 ]),
             Manifest.createFileSystemManifest(
                 displayName: "Bar",
-                path: .init(path: "/Bar"),
+                path: "/Bar",
                 toolsVersion: .v5_2,
                 products: [
                     ProductDescription(name: "ProductBar", type: .library(.automatic), targets: ["Bar"])
@@ -1835,17 +1835,17 @@ class PackageGraphTests: XCTestCase {
         let manifests = try [
             Manifest.createRootManifest(
                 displayName: "Foo",
-                path: .init(path: "/Foo"),
+                path: "/Foo",
                 toolsVersion: .v5_2,
                 dependencies: [
-                    .localSourceControl(deprecatedName: "Bar", path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
+                    .localSourceControl(deprecatedName: "Bar", path: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
                 ],
                 targets: [
                     TargetDescription(name: "Foo", dependencies: ["ProductBar"]),
                 ]),
             Manifest.createFileSystemManifest(
                 displayName: "Bar",
-                path: .init(path: "/Bar"),
+                path: "/Bar",
                 toolsVersion: .v5_2,
                 products: [
                     ProductDescription(name: "ProductBar", type: .library(.automatic), targets: ["Bar"])
@@ -1894,17 +1894,17 @@ class PackageGraphTests: XCTestCase {
         let manifests = try [
             Manifest.createRootManifest(
                 displayName: "Foo",
-                path: .init(path: "/Foo"),
+                path: "/Foo",
                 toolsVersion: .v5_2,
                 dependencies: [
-                    .localSourceControl(path: .init(path: "/Some-Bar"), requirement: .upToNextMajor(from: "1.0.0")),
+                    .localSourceControl(path: "/Some-Bar", requirement: .upToNextMajor(from: "1.0.0")),
                 ],
                 targets: [
                     TargetDescription(name: "Foo", dependencies: ["Bar"]),
                 ]),
             Manifest.createFileSystemManifest(
                 displayName: "Bar",
-                path: .init(path: "/Some-Bar"),
+                path: "/Some-Bar",
                 toolsVersion: .v5_2,
                 products: [
                     ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
@@ -1952,17 +1952,17 @@ class PackageGraphTests: XCTestCase {
         let manifests = try [
             Manifest.createRootManifest(
                 displayName: "Foo",
-                path: .init(path: "/Foo"),
+                path: "/Foo",
                 toolsVersion: .v5_2,
                 dependencies: [
-                    .localSourceControl(path: .init(path: "/Some-Bar"), requirement: .upToNextMajor(from: "1.0.0")),
+                    .localSourceControl(path: "/Some-Bar", requirement: .upToNextMajor(from: "1.0.0")),
                 ],
                 targets: [
                     TargetDescription(name: "Foo", dependencies: ["ProductBar"]),
                 ]),
             Manifest.createFileSystemManifest(
                 displayName: "Bar",
-                path: .init(path: "/Some-Bar"),
+                path: "/Some-Bar",
                 toolsVersion: .v5_2,
                 products: [
                     ProductDescription(name: "ProductBar", type: .library(.automatic), targets: ["Bar"])
@@ -2013,17 +2013,17 @@ class PackageGraphTests: XCTestCase {
         let manifests = try [
             Manifest.createRootManifest(
                 displayName: "Foo",
-                path: .init(path: "/Foo"),
+                path: "/Foo",
                 toolsVersion: .v5_2,
                 dependencies: [
-                    .localSourceControl(deprecatedName: "Bar", path: .init(path: "/Some-Bar"), requirement: .upToNextMajor(from: "1.0.0")),
+                    .localSourceControl(deprecatedName: "Bar", path: "/Some-Bar", requirement: .upToNextMajor(from: "1.0.0")),
                 ],
                 targets: [
                     TargetDescription(name: "Foo", dependencies: ["Bar"]),
                 ]),
             Manifest.createFileSystemManifest(
                 displayName: "Bar",
-                path: .init(path: "/Some-Bar"),
+                path: "/Some-Bar",
                 toolsVersion: .v5_2,
                 products: [
                     ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
@@ -2049,17 +2049,17 @@ class PackageGraphTests: XCTestCase {
         let manifests = try [
             Manifest.createRootManifest(
                 displayName: "Foo",
-                path: .init(path: "/Foo"),
+                path: "/Foo",
                 toolsVersion: .v5_2,
                 dependencies: [
-                    .localSourceControl(deprecatedName: "Bar", path: .init(path: "/Some-Bar"), requirement: .upToNextMajor(from: "1.0.0")),
+                    .localSourceControl(deprecatedName: "Bar", path: "/Some-Bar", requirement: .upToNextMajor(from: "1.0.0")),
                 ],
                 targets: [
                     TargetDescription(name: "Foo", dependencies: ["ProductBar"]),
                 ]),
             Manifest.createFileSystemManifest(
                 displayName: "Bar",
-                path: .init(path: "/Some-Bar"),
+                path: "/Some-Bar",
                 toolsVersion: .v5_2,
                 products: [
                     ProductDescription(name: "ProductBar", type: .library(.automatic), targets: ["Bar"])
@@ -2104,16 +2104,16 @@ class PackageGraphTests: XCTestCase {
     func testTargetDependencies_Post52_AliasFindsIdentity() throws {
         let manifest = Manifest.createRootManifest(
             displayName: "Package",
-            path: .init(path: "/Package"),
+            path: "/Package",
             toolsVersion: .v5_2,
             dependencies: [
                 .localSourceControl(
                     deprecatedName: "Alias",
-                    path: .init(path: "/Identity"),
+                    path: "/Identity",
                     requirement: .upToNextMajor(from: "1.0.0")
                 ),
                 .localSourceControl(
-                    path: .init(path: "/Unrelated"),
+                    path: "/Unrelated",
                     requirement: .upToNextMajor(from: "1.0.0")
                 )
             ],
@@ -2504,9 +2504,9 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo"),
+                    path: "/Foo",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Bar"]),
@@ -2514,7 +2514,7 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "Bar",
-                    path: .init(path: "/Bar"),
+                    path: "/Bar",
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar", "Bar2", "Bar3"]),
                         ProductDescription(name: "TransitiveBar", type: .library(.automatic), targets: ["TransitiveBar"]),
@@ -2563,7 +2563,7 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo"),
+                    path: "/Foo",
                     toolsVersion: .v5_9,
                     dependencies: [
                         .fileSystem(deprecatedName: "Bar", path: "/Bar2"),
@@ -2573,7 +2573,7 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "Bar",
-                    path: .init(path: "/Bar2"),
+                    path: "/Bar2",
                     toolsVersion: .v5_9,
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"]),

--- a/Tests/PackageLoadingPerformanceTests/ManifestLoadingTests.swift
+++ b/Tests/PackageLoadingPerformanceTests/ManifestLoadingTests.swift
@@ -42,7 +42,7 @@ class ManifestLoadingPerfTests: XCTestCasePerf {
                 for _ in 0..<N {
                     let manifest = try! self.manifestLoader.load(
                         manifestPath: path,
-                        packageKind: .root(.init(path: "/Trivial")),
+                        packageKind: .root("/Trivial"),
                         toolsVersion: .v4_2,
                         fileSystem: localFileSystem,
                         observabilityScope: ObservabilitySystem.NOOP
@@ -77,7 +77,7 @@ class ManifestLoadingPerfTests: XCTestCasePerf {
                 for _ in 0..<N {
                     let manifest = try! self.manifestLoader.load(
                         manifestPath: path,
-                        packageKind: .root(.init(path: "/Trivial")),
+                        packageKind: .root("/Trivial"),
                         toolsVersion: .v4_2,
                         fileSystem: localFileSystem,
                         observabilityScope: ObservabilitySystem.NOOP

--- a/Tests/PackageLoadingTests/PD_4_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_0_LoadingTests.swift
@@ -137,12 +137,12 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
             let package = Package(
                name: "Foo",
                dependencies: [
-                   .package(url: "\(AbsolutePath(path: "/foo1").escapedPathString())", from: "1.0.0"),
-                   .package(url: "\(AbsolutePath(path: "/foo2").escapedPathString())", .upToNextMajor(from: "1.0.0")),
-                   .package(url: "\(AbsolutePath(path: "/foo3").escapedPathString())", .upToNextMinor(from: "1.0.0")),
-                   .package(url: "\(AbsolutePath(path: "/foo4").escapedPathString())", .exact("1.0.0")),
-                   .package(url: "\(AbsolutePath(path: "/foo5").escapedPathString())", .branch("main")),
-                   .package(url: "\(AbsolutePath(path: "/foo6").escapedPathString())", .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")),
+                   .package(url: "\(AbsolutePath("/foo1").escapedPathString())", from: "1.0.0"),
+                   .package(url: "\(AbsolutePath("/foo2").escapedPathString())", .upToNextMajor(from: "1.0.0")),
+                   .package(url: "\(AbsolutePath("/foo3").escapedPathString())", .upToNextMinor(from: "1.0.0")),
+                   .package(url: "\(AbsolutePath("/foo4").escapedPathString())", .exact("1.0.0")),
+                   .package(url: "\(AbsolutePath("/foo5").escapedPathString())", .branch("main")),
+                   .package(url: "\(AbsolutePath("/foo6").escapedPathString())", .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")),
                ]
             )
             """
@@ -153,12 +153,12 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
         XCTAssertNoDiagnostics(validationDiagnostics)
 
         let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
-        XCTAssertEqual(deps["foo1"], .localSourceControl(path: .init(path: "/foo1"), requirement: .upToNextMajor(from: "1.0.0")))
-        XCTAssertEqual(deps["foo2"], .localSourceControl(path: .init(path: "/foo2"), requirement: .upToNextMajor(from: "1.0.0")))
-        XCTAssertEqual(deps["foo3"], .localSourceControl(path: .init(path: "/foo3"), requirement: .upToNextMinor(from: "1.0.0")))
-        XCTAssertEqual(deps["foo4"], .localSourceControl(path: .init(path: "/foo4"), requirement: .exact("1.0.0")))
-        XCTAssertEqual(deps["foo5"], .localSourceControl(path: .init(path: "/foo5"), requirement: .branch("main")))
-        XCTAssertEqual(deps["foo6"], .localSourceControl(path: .init(path: "/foo6"), requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
+        XCTAssertEqual(deps["foo1"], .localSourceControl(path: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
+        XCTAssertEqual(deps["foo2"], .localSourceControl(path: "/foo2", requirement: .upToNextMajor(from: "1.0.0")))
+        XCTAssertEqual(deps["foo3"], .localSourceControl(path: "/foo3", requirement: .upToNextMinor(from: "1.0.0")))
+        XCTAssertEqual(deps["foo4"], .localSourceControl(path: "/foo4", requirement: .exact("1.0.0")))
+        XCTAssertEqual(deps["foo5"], .localSourceControl(path: "/foo5", requirement: .branch("main")))
+        XCTAssertEqual(deps["foo6"], .localSourceControl(path: "/foo6", requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
     }
 
     func testProducts() throws {

--- a/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
@@ -33,7 +33,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                     .library(name: "Foo", targets: ["foo"]),
                 ],
                 dependencies: [
-                    .package(url: "\(AbsolutePath(path: "/foo1").escapedPathString())", from: "1.0.0"),
+                    .package(url: "\(AbsolutePath("/foo1").escapedPathString())", from: "1.0.0"),
                 ],
                 targets: [
                     .target(
@@ -68,7 +68,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
 
         // Check dependencies.
         let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
-        XCTAssertEqual(deps["foo1"], .localSourceControl(path: .init(path: "/foo1"), requirement: .upToNextMajor(from: "1.0.0")))
+        XCTAssertEqual(deps["foo1"], .localSourceControl(path: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
 
         // Check products.
         let products = Dictionary(uniqueKeysWithValues: manifest.products.map{ ($0.name, $0) })
@@ -248,15 +248,15 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             let package = Package(
                name: "Foo",
                dependencies: [
-                   .package(url: "\(AbsolutePath(path: "/foo1").escapedPathString())", from: "1.0.0"),
-                   .package(url: "\(AbsolutePath(path: "/foo2").escapedPathString())", .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")),
+                   .package(url: "\(AbsolutePath("/foo1").escapedPathString())", from: "1.0.0"),
+                   .package(url: "\(AbsolutePath("/foo2").escapedPathString())", .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")),
                    .package(path: "../foo3"),
-                   .package(path: "\(AbsolutePath(path: "/path/to/foo4").escapedPathString())"),
-                   .package(url: "\(AbsolutePath(path: "/foo5").escapedPathString())", .exact("1.2.3")),
-                   .package(url: "\(AbsolutePath(path: "/foo6").escapedPathString())", "1.2.3"..<"2.0.0"),
-                   .package(url: "\(AbsolutePath(path: "/foo7").escapedPathString())", .branch("master")),
-                   .package(url: "\(AbsolutePath(path: "/foo8").escapedPathString())", .upToNextMinor(from: "1.3.4")),
-                   .package(url: "\(AbsolutePath(path: "/foo9").escapedPathString())", .upToNextMajor(from: "1.3.4")),
+                   .package(path: "\(AbsolutePath("/path/to/foo4").escapedPathString())"),
+                   .package(url: "\(AbsolutePath("/foo5").escapedPathString())", .exact("1.2.3")),
+                   .package(url: "\(AbsolutePath("/foo6").escapedPathString())", "1.2.3"..<"2.0.0"),
+                   .package(url: "\(AbsolutePath("/foo7").escapedPathString())", .branch("master")),
+                   .package(url: "\(AbsolutePath("/foo8").escapedPathString())", .upToNextMinor(from: "1.3.4")),
+                   .package(url: "\(AbsolutePath("/foo9").escapedPathString())", .upToNextMajor(from: "1.3.4")),
                    .package(path: "~/path/to/foo10"),
                    .package(path: "~foo11"),
                    .package(path: "~/path/to/~/foo12"),
@@ -272,26 +272,26 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
         XCTAssertNoDiagnostics(validationDiagnostics)
 
         let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
-        XCTAssertEqual(deps["foo1"], .localSourceControl(path: .init(path: "/foo1"), requirement: .upToNextMajor(from: "1.0.0")))
-        XCTAssertEqual(deps["foo2"], .localSourceControl(path: .init(path: "/foo2"), requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
+        XCTAssertEqual(deps["foo1"], .localSourceControl(path: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
+        XCTAssertEqual(deps["foo2"], .localSourceControl(path: "/foo2", requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
 
         if case .fileSystem(let dep) = deps["foo3"] {
-            XCTAssertEqual(dep.path, AbsolutePath(path: "/foo3"))
+            XCTAssertEqual(dep.path, "/foo3")
         } else {
             XCTFail("expected to be local dependency")
         }
 
         if case .fileSystem(let dep) = deps["foo4"] {
-            XCTAssertEqual(dep.path, AbsolutePath(path: "/path/to/foo4"))
+            XCTAssertEqual(dep.path, "/path/to/foo4")
         } else {
             XCTFail("expected to be local dependency")
         }
 
-        XCTAssertEqual(deps["foo5"], .localSourceControl(path: .init(path: "/foo5"), requirement: .exact("1.2.3")))
-        XCTAssertEqual(deps["foo6"], .localSourceControl(path: .init(path: "/foo6"), requirement: .range("1.2.3"..<"2.0.0")))
-        XCTAssertEqual(deps["foo7"], .localSourceControl(path: .init(path: "/foo7"), requirement: .branch("master")))
-        XCTAssertEqual(deps["foo8"], .localSourceControl(path: .init(path: "/foo8"), requirement: .upToNextMinor(from: "1.3.4")))
-        XCTAssertEqual(deps["foo9"], .localSourceControl(path: .init(path: "/foo9"), requirement: .upToNextMajor(from: "1.3.4")))
+        XCTAssertEqual(deps["foo5"], .localSourceControl(path: "/foo5", requirement: .exact("1.2.3")))
+        XCTAssertEqual(deps["foo6"], .localSourceControl(path: "/foo6", requirement: .range("1.2.3"..<"2.0.0")))
+        XCTAssertEqual(deps["foo7"], .localSourceControl(path: "/foo7", requirement: .branch("master")))
+        XCTAssertEqual(deps["foo8"], .localSourceControl(path: "/foo8", requirement: .upToNextMinor(from: "1.3.4")))
+        XCTAssertEqual(deps["foo9"], .localSourceControl(path: "/foo9", requirement: .upToNextMajor(from: "1.3.4")))
 
         let homeDir = "/home/user"
         if case .fileSystem(let dep) = deps["foo10"] {
@@ -301,7 +301,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
         }
 
         if case .fileSystem(let dep) = deps["~foo11"] {
-            XCTAssertEqual(dep.path, AbsolutePath(path: "/~foo11"))
+            XCTAssertEqual(dep.path, "/~foo11")
         } else {
             XCTFail("expected to be local dependency")
         }
@@ -313,13 +313,13 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
         }
 
         if case .fileSystem(let dep) = deps["~"] {
-            XCTAssertEqual(dep.path, AbsolutePath(path: "/~"))
+            XCTAssertEqual(dep.path, "/~")
         } else {
             XCTFail("expected to be local dependency")
         }
 
         if case .fileSystem(let dep) = deps["foo13"] {
-            XCTAssertEqual(dep.path, AbsolutePath(path: "/path/to/foo13"))
+            XCTAssertEqual(dep.path, "/path/to/foo13")
         } else {
             XCTFail("expected to be local dependency")
         }

--- a/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
@@ -67,7 +67,7 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
 
         // Check dependencies.
         let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
-        XCTAssertEqual(deps["foo1"], .localSourceControl(path: .init(path: "/foo1"), requirement: .upToNextMajor(from: "1.0.0")))
+        XCTAssertEqual(deps["foo1"], .localSourceControl(path: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
 
         // Check products.
         let products = Dictionary(uniqueKeysWithValues: manifest.products.map{ ($0.name, $0) })

--- a/Tests/PackageLoadingTests/PD_5_5_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_5_LoadingTests.swift
@@ -41,8 +41,8 @@ class PackageDescription5_5LoadingTests: PackageDescriptionLoadingTests {
         XCTAssertNoDiagnostics(validationDiagnostics)
 
         let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
-        XCTAssertEqual(deps["foo5"], .localSourceControl(path: .init(path: "/foo5"), requirement: .branch("main")))
-        XCTAssertEqual(deps["foo7"], .localSourceControl(path: .init(path: "/foo7"), requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
+        XCTAssertEqual(deps["foo5"], .localSourceControl(path: "/foo5", requirement: .branch("main")))
+        XCTAssertEqual(deps["foo7"], .localSourceControl(path: "/foo7", requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
     }
 
     func testPlatforms() throws {

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -220,7 +220,7 @@ class PackageBuilderTests: XCTestCase {
             package.checkModule("clib") { module in
                 module.check(c99name: "clib", type: .library)
                 module.checkSources(root: "/Sources/clib", paths: "clib.c")
-                module.check(moduleMapType: .custom(AbsolutePath(path: "/Sources/clib/include/module.modulemap")))
+                module.check(moduleMapType: .custom("/Sources/clib/include/module.modulemap"))
             }
         }
     }
@@ -808,7 +808,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         PackageBuilderTester(manifest, in: fs) { _, diagnostics in
-            diagnostics.check(diagnostic: "invalid relative path \'/inc\'; relative path should not begin with \'\(AbsolutePath.root)\' or \'~\'", severity: .error)
+            diagnostics.check(diagnostic: "invalid relative path \'/inc\'; relative path should not begin with \'\(AbsolutePath.root)\'", severity: .error)
         }
     }
 
@@ -1688,7 +1688,7 @@ class PackageBuilderTests: XCTestCase {
                 ]
             )
 
-            try fs.writeFileContents(AbsolutePath(path: "/foo2.zip"), bytes: "")
+            try fs.writeFileContents("/foo2.zip", bytes: "")
 
             let binaryArtifacts = [
                 "foo": BinaryArtifact(kind: .xcframework, originURL: "https://foo.com/foo.zip", path: "/foo.xcframework"),
@@ -1818,6 +1818,7 @@ class PackageBuilderTests: XCTestCase {
             }
         }
 
+        /*
         do {
             let fs = InMemoryFileSystem(emptyFiles:
                 "/pkg/Sources/Foo/Foo.c",
@@ -1832,7 +1833,7 @@ class PackageBuilderTests: XCTestCase {
             PackageBuilderTester(manifest, path: "/pkg", in: fs) { _, diagnostics in
                 diagnostics.check(diagnostic: "target path \'~/foo\' is not supported; it should be relative to package root", severity: .error)
             }
-        }
+        }*/
     }
 
     func testExecutableAsADep() throws {
@@ -2673,7 +2674,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         PackageBuilderTester(manifest1, path: "/pkg", in: fs) { package, diagnostics in
-            diagnostics.check(diagnostic: "invalid relative path '/Sources/headers'; relative path should not begin with '\(AbsolutePath.root)' or '~'", severity: .error)
+            diagnostics.check(diagnostic: "invalid relative path '/Sources/headers'; relative path should not begin with '\(AbsolutePath.root)'", severity: .error)
         }
 
         let manifest2 = Manifest.createRootManifest(
@@ -2709,7 +2710,7 @@ class PackageBuilderTests: XCTestCase {
             displayName: "Foo",
             toolsVersion: .v5,
             dependencies: [
-                .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
+                .localSourceControl(path: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
             ],
             targets: [
                 try TargetDescription(
@@ -2776,7 +2777,7 @@ class PackageBuilderTests: XCTestCase {
             displayName: "Foo",
             toolsVersion: .v5,
             dependencies: [
-                .fileSystem(path: .init(path: "/Biz")),
+                .fileSystem(path: "/Biz"),
             ],
             targets: [
                 try TargetDescription(

--- a/Tests/PackageLoadingTests/PkgConfigParserTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigParserTests.swift
@@ -22,7 +22,7 @@ final class PkgConfigParserTests: XCTestCase {
 
         _ = try PkgConfig(
             name: "harfbuzz",
-            additionalSearchPaths: [AbsolutePath(path: #file).parentDirectory.appending(components: "pkgconfigInputs")],
+            additionalSearchPaths: [AbsolutePath(#file).parentDirectory.appending(components: "pkgconfigInputs")],
             fileSystem: localFileSystem,
             observabilityScope: observability.topScope
         )
@@ -137,19 +137,19 @@ final class PkgConfigParserTests: XCTestCase {
             "/usr/local/opt/foo/lib/pkgconfig/foo.pc",
             "/custom/foo.pc")
         XCTAssertEqual(
-            AbsolutePath(path: "/custom/foo.pc"),
-            try PCFileFinder().locatePCFile(name: "foo", customSearchPaths: [AbsolutePath(path: "/custom")], fileSystem: fs, observabilityScope: observability.topScope)
+            "/custom/foo.pc",
+            try PCFileFinder().locatePCFile(name: "foo", customSearchPaths: ["/custom"], fileSystem: fs, observabilityScope: observability.topScope)
         )
         XCTAssertEqual(
-            AbsolutePath(path: "/custom/foo.pc"),
-            try PkgConfig(name: "foo", additionalSearchPaths: [AbsolutePath(path: "/custom")], fileSystem: fs, observabilityScope: observability.topScope).pcFile
+            "/custom/foo.pc",
+            try PkgConfig(name: "foo", additionalSearchPaths: ["/custom"], fileSystem: fs, observabilityScope: observability.topScope).pcFile
         )
         XCTAssertEqual(
-            AbsolutePath(path: "/usr/lib/pkgconfig/foo.pc"),
+            "/usr/lib/pkgconfig/foo.pc",
             try PCFileFinder().locatePCFile(name: "foo", customSearchPaths: [], fileSystem: fs, observabilityScope: observability.topScope)
         )
         try withCustomEnv(["PKG_CONFIG_PATH": "/usr/local/opt/foo/lib/pkgconfig"]) {
-            XCTAssertEqual(AbsolutePath(path: "/usr/local/opt/foo/lib/pkgconfig/foo.pc"), try PkgConfig(name: "foo", fileSystem: fs, observabilityScope: observability.topScope).pcFile)
+            XCTAssertEqual("/usr/local/opt/foo/lib/pkgconfig/foo.pc", try PkgConfig(name: "foo", fileSystem: fs, observabilityScope: observability.topScope).pcFile)
         }
 #if os(Windows)
         let separator = ";"
@@ -157,7 +157,7 @@ final class PkgConfigParserTests: XCTestCase {
         let separator = ":"
 #endif
         try withCustomEnv(["PKG_CONFIG_PATH": "/usr/local/opt/foo/lib/pkgconfig\(separator)/usr/lib/pkgconfig"]) {
-            XCTAssertEqual(AbsolutePath(path: "/usr/local/opt/foo/lib/pkgconfig/foo.pc"), try PkgConfig(name: "foo", fileSystem: fs, observabilityScope: observability.topScope).pcFile)
+            XCTAssertEqual("/usr/local/opt/foo/lib/pkgconfig/foo.pc", try PkgConfig(name: "foo", fileSystem: fs, observabilityScope: observability.topScope).pcFile)
         }
     }
 
@@ -195,7 +195,7 @@ final class PkgConfigParserTests: XCTestCase {
 #endif
         }
 
-        XCTAssertEqual(PCFileFinder.pkgConfigPaths, [AbsolutePath(path: "/Volumes/BestDrive/pkgconfig")])
+        XCTAssertEqual(PCFileFinder.pkgConfigPaths, ["/Volumes/BestDrive/pkgconfig"])
     }
 
     func testAbsolutePathDependency() throws {
@@ -224,7 +224,7 @@ final class PkgConfigParserTests: XCTestCase {
         XCTAssertNoThrow(
             try PkgConfig(
                 name: "gobject-2.0",
-                additionalSearchPaths: [AbsolutePath(path: "/usr/local/opt/glib/lib/pkgconfig")],
+                additionalSearchPaths: ["/usr/local/opt/glib/lib/pkgconfig"],
                 brewPrefix: "/usr/local",
                 fileSystem: fileSystem,
                 observabilityScope: observability.topScope
@@ -242,7 +242,7 @@ final class PkgConfigParserTests: XCTestCase {
     }
 
     private func pcFilePath(_ inputName: String) -> AbsolutePath {
-        return AbsolutePath(path: #file).parentDirectory.appending(components: "pkgconfigInputs", inputName)
+        return AbsolutePath(#file).parentDirectory.appending(components: "pkgconfigInputs", inputName)
     }
 
     private func loadPCFile(_ inputName: String, body: ((PkgConfigParser) -> Void)? = nil) throws {

--- a/Tests/PackageLoadingTests/PkgConfigTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigTests.swift
@@ -28,7 +28,7 @@ extension SystemLibraryTarget {
 }
 
 class PkgConfigTests: XCTestCase {
-    let inputsDir = AbsolutePath(path: #file).parentDirectory.appending(components: "Inputs")
+    let inputsDir = AbsolutePath(#file).parentDirectory.appending(components: "Inputs")
     let observability = ObservabilitySystem.makeForTesting()
     let fs = localFileSystem
 

--- a/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
+++ b/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
@@ -62,13 +62,13 @@ class TargetSourcesBuilderTests: XCTestCase {
         let contents = builder.computeContents().sorted()
 
         XCTAssertEqual(contents, [
-            AbsolutePath(path: "/Bar.swift"),
-            AbsolutePath(path: "/Foo.swift"),
-            AbsolutePath(path: "/Hello.something/hello.txt"),
-            AbsolutePath(path: "/file"),
-            AbsolutePath(path: "/path/to/somefile.txt"),
-            AbsolutePath(path: "/some/path.swift"),
-            AbsolutePath(path: "/some/path/toBeCopied"),
+            "/Bar.swift",
+            "/Foo.swift",
+            "/Hello.something/hello.txt",
+            "/file",
+            "/path/to/somefile.txt",
+            "/some/path.swift",
+            "/some/path/toBeCopied",
         ])
 
         XCTAssertNoDiagnostics(observability.diagnostics)
@@ -106,8 +106,8 @@ class TargetSourcesBuilderTests: XCTestCase {
         let contents = builder.computeContents().sorted()
 
         XCTAssertEqual(contents, [
-            AbsolutePath(path: "/some.thing"),
-            AbsolutePath(path: "/some/hello.swift"),
+            "/some.thing",
+            "/some/hello.swift",
         ])
 
         XCTAssertNoDiagnostics(observability.diagnostics)
@@ -145,8 +145,8 @@ class TargetSourcesBuilderTests: XCTestCase {
         let contents = builder.computeContents().sorted()
 
         XCTAssertEqual(contents, [
-            AbsolutePath(path: "/some.thing/hello.txt"),
-            AbsolutePath(path: "/some/hello.swift"),
+            "/some.thing/hello.txt",
+            "/some/hello.swift",
         ])
 
         XCTAssertNoDiagnostics(observability.diagnostics)
@@ -243,14 +243,14 @@ class TargetSourcesBuilderTests: XCTestCase {
             type: .regular
         )
 
-        let files = [
-            AbsolutePath(path: "/Foo.swift").pathString,
-            AbsolutePath(path: "/Bar.swift").pathString,
-            AbsolutePath(path: "/Baz.something").pathString,
+        let files: [AbsolutePath] = [
+            "/Foo.swift",
+            "/Bar.swift",
+            "/Baz.something",
         ]
 
         let fs = InMemoryFileSystem()
-        fs.createEmptyFiles(at: .root, files: files)
+        fs.createEmptyFiles(at: .root, files: files.map(\.pathString))
 
         let somethingRule = FileRuleDescription(
             rule: .compile,
@@ -261,7 +261,7 @@ class TargetSourcesBuilderTests: XCTestCase {
         build(target: target, additionalFileRules: [somethingRule], toolsVersion: .v5_5, fs: fs) { sources, _, _, _, _, _, _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             XCTAssertEqual(
-                sources.paths.map(\.pathString).sorted(),
+                sources.paths.sorted(),
                 files.sorted()
             )
         }
@@ -687,8 +687,8 @@ class TargetSourcesBuilderTests: XCTestCase {
 
             let builder = TargetSourcesBuilder(
                 packageIdentity: .plain("test"),
-                packageKind: .root(.init(path: "/test")),
-                packagePath: .init(path: "/test"),
+                packageKind: .root("/test"),
+                packagePath: "/test",
                 target: target,
                 path: .root,
                 toolsVersion: .v5,
@@ -699,8 +699,8 @@ class TargetSourcesBuilderTests: XCTestCase {
 
             testDiagnostics(observability.diagnostics) { result in
                 var diagnosticsFound = [Basics.Diagnostic?]()
-                diagnosticsFound.append(result.checkUnordered(diagnostic: "Invalid Exclude '\(AbsolutePath(path: "/fileOutsideRoot.py"))': File not found.", severity: .warning))
-                diagnosticsFound.append(result.checkUnordered(diagnostic: "Invalid Exclude '\(AbsolutePath(path: "/fakeDir"))': File not found.", severity: .warning))
+                diagnosticsFound.append(result.checkUnordered(diagnostic: "Invalid Exclude '\(AbsolutePath("/fileOutsideRoot.py"))': File not found.", severity: .warning))
+                diagnosticsFound.append(result.checkUnordered(diagnostic: "Invalid Exclude '\(AbsolutePath("/fakeDir"))': File not found.", severity: .warning))
 
                 for diagnostic in diagnosticsFound {
                     XCTAssertEqual(diagnostic?.metadata?.packageIdentity, builder.packageIdentity)
@@ -718,7 +718,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             let builder = TargetSourcesBuilder(
                 packageIdentity: .plain("test"),
                 packageKind: .remoteSourceControl(URL("https://some.where/foo/bar")),
-                packagePath: .init(path: "/test"),
+                packagePath: "/test",
                 target: target,
                 path: .root,
                 toolsVersion: .v5,
@@ -822,7 +822,7 @@ class TargetSourcesBuilderTests: XCTestCase {
 
         let builder = TargetSourcesBuilder(
             packageIdentity: .plain("test"),
-            packageKind: .root(.init(path: "/test")),
+            packageKind: .root("/test"),
             packagePath: .root,
             target: target,
             path: .root,
@@ -833,9 +833,9 @@ class TargetSourcesBuilderTests: XCTestCase {
 
         testDiagnostics(observability.diagnostics) { result in
             var diagnosticsFound = [Basics.Diagnostic?]()
-            diagnosticsFound.append(result.checkUnordered(diagnostic: "Invalid Source '\(AbsolutePath(path: "/InvalidPackage.swift"))': File not found.", severity: .warning))
-            diagnosticsFound.append(result.checkUnordered(diagnostic: "Invalid Source '\(AbsolutePath(path: "/DoesNotExist.swift"))': File not found.", severity: .warning))
-            diagnosticsFound.append(result.checkUnordered(diagnostic: "Invalid Source '\(AbsolutePath(path: "/Tests/InvalidPackageTests/InvalidPackageTests.swift"))': File not found.", severity: .warning))
+            diagnosticsFound.append(result.checkUnordered(diagnostic: "Invalid Source '\(AbsolutePath("/InvalidPackage.swift"))': File not found.", severity: .warning))
+            diagnosticsFound.append(result.checkUnordered(diagnostic: "Invalid Source '\(AbsolutePath("/DoesNotExist.swift"))': File not found.", severity: .warning))
+            diagnosticsFound.append(result.checkUnordered(diagnostic: "Invalid Source '\(AbsolutePath("/Tests/InvalidPackageTests/InvalidPackageTests.swift"))': File not found.", severity: .warning))
 
             for diagnostic in diagnosticsFound {
                 XCTAssertEqual(diagnostic?.metadata?.packageIdentity, builder.packageIdentity)
@@ -866,7 +866,7 @@ class TargetSourcesBuilderTests: XCTestCase {
 
         let builder = TargetSourcesBuilder(
             packageIdentity: .plain("test"),
-            packageKind: .root(.init(path: "/test")),
+            packageKind: .root( "/test"),
             packagePath: .root,
             target: target,
             path: .root,
@@ -875,10 +875,10 @@ class TargetSourcesBuilderTests: XCTestCase {
             observabilityScope: observability.topScope
         )
         let outputs = try builder.run()
-        XCTAssertEqual(outputs.sources.paths, [AbsolutePath(path: "/File.swift")])
+        XCTAssertEqual(outputs.sources.paths, ["/File.swift"])
         XCTAssertEqual(outputs.resources, [])
         XCTAssertEqual(outputs.ignored, [])
-        XCTAssertEqual(outputs.others, [AbsolutePath(path: "/Foo.xcdatamodel")])
+        XCTAssertEqual(outputs.others, ["/Foo.xcdatamodel"])
 
         XCTAssertFalse(observability.hasWarningDiagnostics)
         XCTAssertFalse(observability.hasErrorDiagnostics)
@@ -906,7 +906,7 @@ class TargetSourcesBuilderTests: XCTestCase {
 
             let builder = TargetSourcesBuilder(
                 packageIdentity: .plain("test"),
-                packageKind: .root(.init(path: "/test")),
+                packageKind: .root("/test"),
                 packagePath: .root,
                 target: target,
                 path: .root,
@@ -915,10 +915,10 @@ class TargetSourcesBuilderTests: XCTestCase {
                 observabilityScope: observability.topScope
             )
             let outputs = try builder.run()
-            XCTAssertEqual(outputs.sources.paths, [AbsolutePath(path: "/File.swift")])
+            XCTAssertEqual(outputs.sources.paths, ["/File.swift"])
             XCTAssertEqual(outputs.resources, [])
             XCTAssertEqual(outputs.ignored, [])
-            XCTAssertEqual(outputs.others, [AbsolutePath(path: "/foo.bar")])
+            XCTAssertEqual(outputs.others, ["/foo.bar"])
 
             XCTAssertFalse(observability.hasWarningDiagnostics)
             XCTAssertFalse(observability.hasErrorDiagnostics)
@@ -977,9 +977,9 @@ class TargetSourcesBuilderTests: XCTestCase {
             observabilityScope: observability.topScope
         )
         let outputs = try builder.run()
-        XCTAssertEqual(outputs.sources.paths, [AbsolutePath(path: "/File.swift")])
+        XCTAssertEqual(outputs.sources.paths, ["/File.swift"])
         XCTAssertEqual(outputs.resources, [])
-        XCTAssertEqual(outputs.ignored, [AbsolutePath(path: "/Foo.docc")])
+        XCTAssertEqual(outputs.ignored, ["/Foo.docc"])
         XCTAssertEqual(outputs.others, [])
 
         XCTAssertNoDiagnostics(observability.diagnostics)

--- a/Tests/PackageModelTests/ManifestTests.swift
+++ b/Tests/PackageModelTests/ManifestTests.swift
@@ -32,7 +32,7 @@ class ManifestTests: XCTestCase {
         do {
             let manifest = Manifest.createRootManifest(
                 displayName: "Foo",
-                path: .init(path: "/Foo"),
+                path: "/Foo",
                 toolsVersion: .v5_2,
                 products: products,
                 targets: targets
@@ -50,7 +50,7 @@ class ManifestTests: XCTestCase {
         do {
             let manifest = Manifest.createLocalSourceControlManifest(
                 displayName: "Foo",
-                path: .init(path: "/Foo"),
+                path: "/Foo",
                 toolsVersion: .v5_2,
                 products: products,
                 targets: targets
@@ -67,9 +67,9 @@ class ManifestTests: XCTestCase {
 
     func testRequiredDependencies() throws {
         let dependencies: [PackageDependency] = [
-            .localSourceControl(path: .init(path: "/Bar1"), requirement: .upToNextMajor(from: "1.0.0")),
-            .localSourceControl(path: .init(path: "/Bar2"), requirement: .upToNextMajor(from: "1.0.0")),
-            .localSourceControl(path: .init(path: "/Bar3"), requirement: .upToNextMajor(from: "1.0.0")),
+            .localSourceControl(path: "/Bar1", requirement: .upToNextMajor(from: "1.0.0")),
+            .localSourceControl(path: "/Bar2", requirement: .upToNextMajor(from: "1.0.0")),
+            .localSourceControl(path: "/Bar3", requirement: .upToNextMajor(from: "1.0.0")),
         ]
 
         let products = [
@@ -85,7 +85,7 @@ class ManifestTests: XCTestCase {
         do {
             let manifest = Manifest.createRootManifest(
                 displayName: "Foo",
-                path: .init(path: "/Foo"),
+                path: "/Foo",
                 toolsVersion: .v5,
                 dependencies: dependencies,
                 products: products,
@@ -102,7 +102,7 @@ class ManifestTests: XCTestCase {
         do {
             let manifest = Manifest.createLocalSourceControlManifest(
                 displayName: "Foo",
-                path: .init(path: "/Foo"),
+                path: "/Foo",
                 toolsVersion: .v5,
                 dependencies: dependencies,
                 products: products,
@@ -119,7 +119,7 @@ class ManifestTests: XCTestCase {
         do {
             let manifest = Manifest.createRootManifest(
                 displayName: "Foo",
-                path: .init(path: "/Foo"),
+                path: "/Foo",
                 toolsVersion: .v5_2,
                 dependencies: dependencies,
                 products: products,
@@ -136,7 +136,7 @@ class ManifestTests: XCTestCase {
         do {
             let manifest = Manifest.createLocalSourceControlManifest(
                 displayName: "Foo",
-                path: .init(path: "/Foo"),
+                path: "/Foo",
                 toolsVersion: .v5_2,
                 dependencies: dependencies,
                 products: products,

--- a/Tests/SPMBuildCoreTests/ArtifactsArchiveMetadataTests.swift
+++ b/Tests/SPMBuildCoreTests/ArtifactsArchiveMetadataTests.swift
@@ -20,7 +20,7 @@ final class ArtifactsArchiveMetadataTests: XCTestCase {
     func testParseMetadata() throws {
         let fileSystem = InMemoryFileSystem()
         try fileSystem.writeFileContents(
-            AbsolutePath(path: "/info.json"),
+            "/info.json",
             bytes: ByteString(encodingAsUTF8: """
             {
                 "schemaVersion": "1.0",

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -38,7 +38,7 @@ class PluginInvocationTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo"),
+                    path: "/Foo",
                     products: [
                         ProductDescription(
                             name: "Foo",
@@ -125,7 +125,7 @@ class PluginInvocationTests: XCTestCase {
                 completion: @escaping (Result<Int32, Error>) -> Void
             ) {
                 // Check that we were given the right sources.
-                XCTAssertEqual(sourceFiles, [AbsolutePath(path: "/Foo/Plugins/FooPlugin/source.swift")])
+                XCTAssertEqual(sourceFiles, ["/Foo/Plugins/FooPlugin/source.swift"])
 
                 do {
                     // Pretend the plugin emitted some output.
@@ -223,7 +223,7 @@ class PluginInvocationTests: XCTestCase {
         let evalFirstDiagnostic = try XCTUnwrap(evalFirstResult.diagnostics.first)
         XCTAssertEqual(evalFirstDiagnostic.severity, .warning)
         XCTAssertEqual(evalFirstDiagnostic.message, "A warning")
-        XCTAssertEqual(evalFirstDiagnostic.metadata?.fileLocation, FileLocation(.init(path: "/Foo/Sources/Foo/SomeFile.abc"), line: 42))
+        XCTAssertEqual(evalFirstDiagnostic.metadata?.fileLocation, FileLocation("/Foo/Sources/Foo/SomeFile.abc", line: 42))
 
         XCTAssertEqual(evalFirstResult.textOutput, "Hello Plugin!")
     }

--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -45,9 +45,9 @@ class GitRepositoryTests: XCTestCase {
         }
 
         do {
-            let s1 = RepositorySpecifier(path: .init(path: "/a"))
-            let s2 = RepositorySpecifier(path: .init(path: "/a"))
-            let s3 = RepositorySpecifier(path: .init(path: "/b"))
+            let s1 = RepositorySpecifier(path: "/A")
+            let s2 = RepositorySpecifier(path: "/A")
+            let s3 = RepositorySpecifier(path: "/B")
 
             XCTAssertEqual(s1, s1)
             XCTAssertEqual(s1, s2)
@@ -128,7 +128,7 @@ class GitRepositoryTests: XCTestCase {
 #endif
         try testWithTemporaryDirectory { path in
             // Unarchive the static test repository.
-            let inputArchivePath = AbsolutePath(path: #file).parentDirectory.appending(components: "Inputs", "TestRepo.tgz")
+            let inputArchivePath = AbsolutePath(#file).parentDirectory.appending(components: "Inputs", "TestRepo.tgz")
 #if os(Windows)
             try systemQuietly(["tar.exe", "-x", "-v", "-C", path.pathString, "-f", inputArchivePath.pathString])
 #else
@@ -241,21 +241,21 @@ class GitRepositoryTests: XCTestCase {
             let view = try repository.openFileView(revision: repository.resolveRevision(tag: "test-tag"))
 
             // Check basic predicates.
-            XCTAssert(view.isDirectory(AbsolutePath(path: "/")))
-            XCTAssert(view.isDirectory(AbsolutePath(path: "/subdir")))
-            XCTAssert(!view.isDirectory(AbsolutePath(path: "/does-not-exist")))
-            XCTAssert(view.exists(AbsolutePath(path: "/test-file-1.txt")))
-            XCTAssert(!view.exists(AbsolutePath(path: "/does-not-exist")))
-            XCTAssert(view.isFile(AbsolutePath(path: "/test-file-1.txt")))
-            XCTAssert(!view.isSymlink(AbsolutePath(path: "/test-file-1.txt")))
-            XCTAssert(!view.isExecutableFile(AbsolutePath(path: "/does-not-exist")))
+            XCTAssert(view.isDirectory("/"))
+            XCTAssert(view.isDirectory("/subdir"))
+            XCTAssert(!view.isDirectory("/does-not-exist"))
+            XCTAssert(view.exists("/test-file-1.txt"))
+            XCTAssert(!view.exists("/does-not-exist"))
+            XCTAssert(view.isFile("/test-file-1.txt"))
+            XCTAssert(!view.isSymlink("/test-file-1.txt"))
+            XCTAssert(!view.isExecutableFile("/does-not-exist"))
 #if !os(Windows)
-            XCTAssert(view.isExecutableFile(AbsolutePath(path: "/test-file-3.sh")))
+            XCTAssert(view.isExecutableFile("/test-file-3.sh"))
 #endif
 
             // Check read of a directory.
             let subdirPath = AbsolutePath("/subdir")
-            XCTAssertEqual(try view.getDirectoryContents(AbsolutePath(path: "/")).sorted(), ["file.swift", "subdir", "test-file-1.txt", "test-file-3.sh"])
+            XCTAssertEqual(try view.getDirectoryContents(AbsolutePath("/")).sorted(), ["file.swift", "subdir", "test-file-1.txt", "test-file-3.sh"])
             XCTAssertEqual(try view.getDirectoryContents(subdirPath).sorted(), ["test-file-2.txt"])
             XCTAssertThrows(FileSystemError(.isDirectory, subdirPath)) {
                 _ = try view.readFileContents(subdirPath)
@@ -287,8 +287,8 @@ class GitRepositoryTests: XCTestCase {
             }
 
             // Check read of a file.
-            XCTAssertEqual(try view.readFileContents(AbsolutePath(path: "/test-file-1.txt")), test1FileContents)
-            XCTAssertEqual(try view.readFileContents(AbsolutePath(path: "/subdir/test-file-2.txt")), test2FileContents)
+            XCTAssertEqual(try view.readFileContents("/test-file-1.txt"), test1FileContents)
+            XCTAssertEqual(try view.readFileContents("/subdir/test-file-2.txt"), test2FileContents)
         }
     }
 

--- a/Tests/SourceControlTests/InMemoryGitRepositoryTests.swift
+++ b/Tests/SourceControlTests/InMemoryGitRepositoryTests.swift
@@ -22,7 +22,7 @@ class InMemoryGitRepositoryTests: XCTestCase {
         let fs = InMemoryFileSystem()
         let repo = InMemoryGitRepository(path: .root, fs: fs)
 
-        try repo.createDirectory(AbsolutePath(path: "/new-dir/subdir"), recursive: true)
+        try repo.createDirectory("/new-dir/subdir", recursive: true)
         XCTAssertTrue(!repo.hasUncommittedChanges())
         let filePath = AbsolutePath("/new-dir/subdir").appending("new-file.txt")
 
@@ -78,8 +78,8 @@ class InMemoryGitRepositoryTests: XCTestCase {
         let v2 = "2.0.0"
         let repo = InMemoryGitRepository(path: .root, fs: InMemoryFileSystem())
 
-        let specifier = RepositorySpecifier(path: .init(path: "/foo"))
-        try repo.createDirectory(AbsolutePath(path: "/new-dir/subdir"), recursive: true)
+        let specifier = RepositorySpecifier(path: "/Foo")
+        try repo.createDirectory("/new-dir/subdir", recursive: true)
         let filePath = AbsolutePath("/new-dir/subdir").appending("new-file.txt")
         try repo.writeFileContents(filePath, bytes: "one")
         try repo.commit()

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -33,8 +33,8 @@ class RepositoryManagerTests: XCTestCase {
                 delegate: delegate
             )
 
-            let dummyRepo = RepositorySpecifier(path: .init(path: "/dummy"))
-            let badDummyRepo = RepositorySpecifier(path: .init(path: "/badDummy"))
+            let dummyRepo = RepositorySpecifier(path: "/dummy")
+            let badDummyRepo = RepositorySpecifier(path: "/badDummy")
             var prevHandle: RepositoryManager.RepositoryHandle?
 
             // Check that we can "fetch" a repository.
@@ -156,8 +156,8 @@ class RepositoryManagerTests: XCTestCase {
             delegate.prepare(fetchExpected: true, updateExpected: false)
             _ = try manager.lookup(repository: repo, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
-            XCTAssertDirectoryExists(cachePath.appending(repo.storagePath()))
-            XCTAssertDirectoryExists(repositoriesPath.appending(repo.storagePath()))
+            try XCTAssertDirectoryExists(cachePath.appending(repo.storagePath()))
+            try XCTAssertDirectoryExists(repositoriesPath.appending(repo.storagePath()))
             try delegate.wait(timeout: .now() + 2)
             XCTAssertEqual(delegate.willFetch[0].details,
                            RepositoryManager.FetchDetails(fromCache: false, updatedCache: false))
@@ -171,7 +171,7 @@ class RepositoryManagerTests: XCTestCase {
             delegate.prepare(fetchExpected: true, updateExpected: false)
             _ = try manager.lookup(repository: repo, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
-            XCTAssertDirectoryExists(repositoriesPath.appending(repo.storagePath()))
+            try XCTAssertDirectoryExists(repositoriesPath.appending(repo.storagePath()))
             try delegate.wait(timeout: .now() + 2)
             XCTAssertEqual(delegate.willFetch[1].details,
                            RepositoryManager.FetchDetails(fromCache: true, updatedCache: false))
@@ -186,8 +186,8 @@ class RepositoryManagerTests: XCTestCase {
             delegate.prepare(fetchExpected: true, updateExpected: false)
             _ = try manager.lookup(repository: repo, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
-            XCTAssertDirectoryExists(cachePath.appending(repo.storagePath()))
-            XCTAssertDirectoryExists(repositoriesPath.appending(repo.storagePath()))
+            try XCTAssertDirectoryExists(cachePath.appending(repo.storagePath()))
+            try XCTAssertDirectoryExists(repositoriesPath.appending(repo.storagePath()))
             try delegate.wait(timeout: .now() + 2)
             XCTAssertEqual(delegate.willFetch[2].details,
                            RepositoryManager.FetchDetails(fromCache: false, updatedCache: false))
@@ -199,8 +199,8 @@ class RepositoryManagerTests: XCTestCase {
             _ = try manager.lookup(repository: repo, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
             try delegate.wait(timeout: .now() + 2)
-            XCTAssertEqual(delegate.willUpdate[0].storagePath(), repo.storagePath())
-            XCTAssertEqual(delegate.didUpdate[0].storagePath(), repo.storagePath())
+            try XCTAssertEqual(delegate.willUpdate[0].storagePath(), repo.storagePath())
+            try XCTAssertEqual(delegate.didUpdate[0].storagePath(), repo.storagePath())
         }
     }
 
@@ -220,7 +220,7 @@ class RepositoryManagerTests: XCTestCase {
                 provider: provider,
                 delegate: delegate
             )
-            let dummyRepo = RepositorySpecifier(path: .init(path: "/dummy"))
+            let dummyRepo = RepositorySpecifier(path: "/dummy")
 
             delegate.prepare(fetchExpected: true, updateExpected: false)
             _ = try manager.lookup(repository: dummyRepo, observabilityScope: observability.topScope)
@@ -254,7 +254,7 @@ class RepositoryManagerTests: XCTestCase {
 
         try testWithTemporaryDirectory { path in
             let provider = DummyRepositoryProvider(fileSystem: fs)
-            let dummyRepo = RepositorySpecifier(path: .init(path: "/dummy"))
+            let dummyRepo = RepositorySpecifier(path: "/dummy")
 
             // Do the initial fetch.
             do {
@@ -314,7 +314,7 @@ class RepositoryManagerTests: XCTestCase {
                     provider: provider,
                     delegate: delegate
                 )
-                let dummyRepo = RepositorySpecifier(path: .init(path: "/dummy"))
+                let dummyRepo = RepositorySpecifier(path: "/dummy")
 
                 delegate.prepare(fetchExpected: true, updateExpected: false)
                 _ = try manager.lookup(repository: dummyRepo, observabilityScope: observability.topScope)
@@ -342,7 +342,7 @@ class RepositoryManagerTests: XCTestCase {
                 provider: provider,
                 delegate: delegate
             )
-            let dummyRepo = RepositorySpecifier(path: .init(path: "/dummy"))
+            let dummyRepo = RepositorySpecifier(path: "/dummy")
 
             let group = DispatchGroup()
             let results = ThreadSafeKeyValueStore<Int, Result<RepositoryManager.RepositoryHandle, Error>>()
@@ -399,7 +399,7 @@ class RepositoryManagerTests: XCTestCase {
                 provider: provider,
                 delegate: delegate
             )
-            let dummyRepo = RepositorySpecifier(path: .init(path: "/dummy"))
+            let dummyRepo = RepositorySpecifier(path: "/dummy")
 
             delegate.prepare(fetchExpected: true, updateExpected: false)
             _ = try manager.lookup(repository: dummyRepo, observabilityScope: observability.topScope)

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -481,7 +481,7 @@ class ManifestSourceGenerationTests: XCTestCase {
         let manifest = Manifest.createManifest(
             displayName: "MyLibrary",
             path: packageDir.appending("Package.swift"),
-            packageKind: .root(AbsolutePath(path: "/tmp/MyLibrary")),
+            packageKind: .root("/tmp/MyLibrary"),
             packageLocation: packageDir.pathString,
             platforms: [],
             toolsVersion: .v5_5,
@@ -517,11 +517,11 @@ class ManifestSourceGenerationTests: XCTestCase {
     func testModuleAliasGeneration() throws {
         let manifest = Manifest.createRootManifest(
             displayName: "thisPkg",
-            path: .init(path: "/thisPkg"),
+            path: "/thisPkg",
             toolsVersion: .v5_7,
             dependencies: [
-                .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
-                .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "2.0.0")),
+                .localSourceControl(path: "/fooPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                .localSourceControl(path: "/barPkg", requirement: .upToNextMajor(from: "2.0.0")),
             ],
             targets: [
                 try TargetDescription(name: "exe",
@@ -583,7 +583,7 @@ class ManifestSourceGenerationTests: XCTestCase {
     func testPluginNetworkingPermissionGeneration() throws {
         let manifest = Manifest.createRootManifest(
             displayName: "thisPkg",
-            path: .init(path: "/thisPkg"),
+            path: "/thisPkg",
             toolsVersion: .v5_9,
             dependencies: [],
             targets: [

--- a/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
@@ -415,9 +415,9 @@ class SourceControlPackageContainerTests: XCTestCase {
 #endif
 
         let dependencies: [PackageDependency] = [
-            .localSourceControl(path: .init(path: "/Bar1"), requirement: .upToNextMajor(from: "1.0.0")),
-            .localSourceControl(path: .init(path: "/Bar2"), requirement: .upToNextMajor(from: "1.0.0")),
-            .localSourceControl(path: .init(path: "/Bar3"), requirement: .upToNextMajor(from: "1.0.0")),
+            .localSourceControl(path: "/Bar1", requirement: .upToNextMajor(from: "1.0.0")),
+            .localSourceControl(path: "/Bar2", requirement: .upToNextMajor(from: "1.0.0")),
+            .localSourceControl(path: "/Bar3", requirement: .upToNextMajor(from: "1.0.0")),
         ]
 
         let products = [
@@ -458,7 +458,7 @@ class SourceControlPackageContainerTests: XCTestCase {
         do {
             let manifest = Manifest.createRootManifest(
                 displayName: "Foo",
-                path: .init(path: "/Foo"),
+                path: "/Foo",
                 toolsVersion: .v5,
                 dependencies: dependencies,
                 products: products,
@@ -480,7 +480,7 @@ class SourceControlPackageContainerTests: XCTestCase {
         do {
             let manifest = Manifest.createFileSystemManifest(
                 displayName: "Foo",
-                path: .init(path: "/Foo"),
+                path: "/Foo",
                 toolsVersion: .v5,
                 dependencies: dependencies,
                 products: products,
@@ -502,7 +502,7 @@ class SourceControlPackageContainerTests: XCTestCase {
         do {
             let manifest = Manifest.createRootManifest(
                 displayName: "Foo",
-                path: .init(path: "/Foo"),
+                path: "/Foo",
                 toolsVersion: .v5_2,
                 dependencies: dependencies,
                 products: products,
@@ -524,7 +524,7 @@ class SourceControlPackageContainerTests: XCTestCase {
         do {
             let manifest = Manifest.createFileSystemManifest(
                 displayName: "Foo",
-                path: .init(path: "/Foo"),
+                path: "/Foo",
                 toolsVersion: .v5_2,
                 dependencies: dependencies,
                 products: products,
@@ -644,7 +644,7 @@ class SourceControlPackageContainerTests: XCTestCase {
                 toolsVersion: .v5_2,
                 dependencies: [
                     .localSourceControl(
-                        path: .init(path: "/Somewhere/Dependency"),
+                        path: "/Somewhere/Dependency",
                         requirement: .exact(version),
                         productFilter: .specific([])
                     )

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -468,7 +468,7 @@ final class WorkspaceTests: XCTestCase {
             roots: ["foo-package", "bar-package"],
             dependencies: [
                 .localSourceControl(
-                    path: .init(path: "/tmp/ws/pkgs/bar-package"),
+                    path: "/tmp/ws/pkgs/bar-package",
                     requirement: .upToNextMajor(from: "1.0.0")
                 ),
             ]
@@ -2023,7 +2023,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         // Get some revision identifier of Bar.
-        let bar = RepositorySpecifier(path: .init(path: "/tmp/ws/pkgs/Bar"))
+        let bar = RepositorySpecifier(path: "/tmp/ws/pkgs/Bar")
         let barRevision = workspace.repositoryProvider.specifierMap[bar]!.revisions[0]
 
         // We request Bar via revision.
@@ -13565,7 +13565,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testRegistryMetadata() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let registryURL = URL("https://packages.example.com")

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -22,7 +22,7 @@ import TSCBasic
 import XCTest
 
 class PIFBuilderTests: XCTestCase {
-    let inputsDir = AbsolutePath(path: #file).parentDirectory.appending(components: "Inputs")
+    let inputsDir = AbsolutePath(#file).parentDirectory.appending(components: "Inputs")
 
     func testOrdering() throws {
         #if !os(macOS)
@@ -44,7 +44,7 @@ class PIFBuilderTests: XCTestCase {
                 manifests: [
                     Manifest.createLocalSourceControlManifest(
                         displayName: "B",
-                        path: .init(path: "/B"),
+                        path: "/B",
                         toolsVersion: .v5_2,
                         products: [
                             .init(name: "bexe", type: .executable, targets: ["B1"]),
@@ -56,10 +56,10 @@ class PIFBuilderTests: XCTestCase {
                         ]),
                     Manifest.createRootManifest(
                         displayName: "A",
-                        path: .init(path: "/A"),
+                        path: "/A",
                         toolsVersion: .v5_2,
                         dependencies: [
-                            .localSourceControl(path: .init(path: "/B"), requirement: .branch("master")),
+                            .localSourceControl(path: "/B", requirement: .branch("master")),
                         ],
                         products: [
                             .init(name: "alib", type: .library(.static), targets: ["A2"]),
@@ -115,12 +115,12 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo"),
-                    packageKind: .root(.init(path: "/Foo")),
+                    path: "/Foo",
+                    packageKind: .root("/Foo"),
                     defaultLocalization: "fr",
                     toolsVersion: .v5_2,
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Bar"), requirement: .branch("master")),
+                        .localSourceControl(path: "/Bar", requirement: .branch("master")),
                     ],
                     targets: [
                         .init(name: "foo", dependencies: [.product(name: "BarLib", package: "Bar")]),
@@ -128,7 +128,7 @@ class PIFBuilderTests: XCTestCase {
                     ]),
                 Manifest.createLocalSourceControlManifest(
                     displayName: "Bar",
-                    path: .init(path: "/Bar"),
+                    path: "/Bar",
                     platforms: [
                         PlatformDescription(name: "macos", version: "10.14"),
                         PlatformDescription(name: "ios", version: "12"),
@@ -398,11 +398,11 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo"),
+                    path: "/Foo",
                     toolsVersion: .v5_2,
                     swiftLanguageVersions: [.v4_2, .v5],
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Bar"), requirement: .branch("master")),
+                        .localSourceControl(path: "/Bar", requirement: .branch("master")),
                     ],
                     targets: [
                         .init(name: "foo", dependencies: [
@@ -420,7 +420,7 @@ class PIFBuilderTests: XCTestCase {
                     ]),
                 Manifest.createLocalSourceControlManifest(
                     displayName: "Bar",
-                    path: .init(path: "/Bar"),
+                    path: "/Bar",
                     toolsVersion: .v4_2,
                     cLanguageStandard: "c11",
                     cxxLanguageStandard: "c++14",
@@ -732,11 +732,11 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo"),
+                    path: "/Foo",
                     toolsVersion: .v5_2,
                     swiftLanguageVersions: [.v4_2, .v5],
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Bar"), requirement: .branch("master")),
+                        .localSourceControl(path: "/Bar", requirement: .branch("master")),
                     ],
                     targets: [
                         .init(name: "FooTests", dependencies: [
@@ -754,7 +754,7 @@ class PIFBuilderTests: XCTestCase {
                     ]),
                 Manifest.createLocalSourceControlManifest(
                     displayName: "Bar",
-                    path: .init(path: "/Bar"),
+                    path: "/Bar",
                     toolsVersion: .v4_2,
                     cLanguageStandard: "c11",
                     cxxLanguageStandard: "c++14",
@@ -980,11 +980,11 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo"),
+                    path: "/Foo",
                     toolsVersion: .v5_2,
                     swiftLanguageVersions: [.v4_2, .v5],
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Bar"), requirement: .branch("master")),
+                        .localSourceControl(path: "/Bar", requirement: .branch("master")),
                     ],
                     products: [
                         .init(name: "FooLib1", type: .library(.static), targets: ["FooLib1"]),
@@ -999,7 +999,7 @@ class PIFBuilderTests: XCTestCase {
                     ]),
                 Manifest.createLocalSourceControlManifest(
                     displayName: "Bar",
-                    path: .init(path: "/Bar"),
+                    path: "/Bar",
                     toolsVersion: .v4_2,
                     cLanguageStandard: "c11",
                     cxxLanguageStandard: "c++14",
@@ -1182,12 +1182,12 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo"),
+                    path: "/Foo",
                     toolsVersion: .v5_2,
                     cxxLanguageStandard: "c++14",
                     swiftLanguageVersions: [.v4_2, .v5],
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Bar"), requirement: .branch("master")),
+                        .localSourceControl(path: "/Bar", requirement: .branch("master")),
                     ],
                     targets: [
                         .init(name: "FooLib1", dependencies: ["SystemLib", "FooLib2"]),
@@ -1198,7 +1198,7 @@ class PIFBuilderTests: XCTestCase {
                     ]),
                 Manifest.createLocalSourceControlManifest(
                     displayName: "Bar",
-                    path: .init(path: "/Bar"),
+                    path: "/Bar",
                     toolsVersion: .v4_2,
                     cLanguageStandard: "c11",
                     swiftLanguageVersions: [.v4_2],
@@ -1480,9 +1480,9 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "App",
-                    path: .init(path: "/App"),
+                    path: "/App",
                     dependencies: [
-                        .localSourceControl(path: .init(path: "/Bar"), requirement: .branch("main")),
+                        .localSourceControl(path: "/Bar", requirement: .branch("main")),
                     ],
                     targets: [
                         .init(name: "App", dependencies: ["Logging", "Utils"], type: .executable),
@@ -1493,7 +1493,7 @@ class PIFBuilderTests: XCTestCase {
                     ]),
                 Manifest.createLocalSourceControlManifest(
                     displayName: "Bar",
-                    path: .init(path: "/Bar"),
+                    path: "/Bar",
                     products: [
                         .init(name: "BarLib", type: .library(.dynamic), targets: ["Lib"]),
                     ],
@@ -1703,7 +1703,7 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Bar",
-                    path: .init(path: "/Bar"),
+                    path: "/Bar",
                     toolsVersion: .v4_2,
                     cLanguageStandard: "c11",
                     swiftLanguageVersions: [.v4_2],
@@ -1756,8 +1756,8 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createManifest(
                     displayName: "Bar",
-                    path: .init(path: "/Bar"),
-                    packageKind: .root(.init(path: "/Bar")),
+                    path: "/Bar",
+                    packageKind: .root("/Bar"),
                     toolsVersion: .v4_2,
                     cLanguageStandard: "c11",
                     swiftLanguageVersions: [.v4_2],
@@ -1814,7 +1814,7 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo"),
+                    path: "/Foo",
                     toolsVersion: .v5_2,
                     cxxLanguageStandard: "c++14",
                     swiftLanguageVersions: [.v4_2, .v5],
@@ -1933,7 +1933,7 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo"),
+                    path: "/Foo",
                     toolsVersion: .v5_3,
                     products: [
                         .init(name: "FooLib", type: .library(.automatic), targets: ["FooLib"]),
@@ -2007,7 +2007,7 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo"),
+                    path: "/Foo",
                     toolsVersion: .v5_3,
                     products: [
                         .init(name: "FooLib", type: .library(.automatic), targets: ["FooLib"]),
@@ -2223,7 +2223,7 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo"),
+                    path: "/Foo",
                     toolsVersion: .v5,
                     products: [
                         .init(name: "FooLib", type: .library(.automatic), targets: ["FooLib"]),
@@ -2437,8 +2437,8 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo"),
-                    packageKind: .root(.init(path: "/Foo")),
+                    path: "/Foo",
+                    packageKind: .root("/Foo"),
                     toolsVersion: .v5_3,
                     targets: [
                         .init(name: "foo", dependencies: [
@@ -2506,7 +2506,7 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Foo",
-                    path: .init(path: "/Foo"),
+                    path: "/Foo",
                     platforms: [
                         PlatformDescription(name: "macos", version: "10.14", options: ["best"]),
                     ],
@@ -2556,7 +2556,7 @@ class PIFBuilderTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "MyLib",
-                    path: .init(path: "/MyLib"),
+                    path: "/MyLib",
                     toolsVersion: .v5,
                     products: [
                         .init(name: "MyLib", type: .library(.automatic), targets: ["MyLib"]),


### PR DESCRIPTION
motivation: delay canonicalization of relative path to the construction of absolute path from it, to better fit how windows paths work

changes:
* move RelativePath and AbsolutePath conformance  to ExpressibleByStringLiteral and ExpressibleByStringInterpolation to TSC
* update call sites and tests to use throwing constructor of RelativePath