### PR TITLE
enable scm to regsitry substitution

### DIFF
--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -186,7 +186,7 @@ public struct ResolverOptions: ParsableArguments {
 
 
     @Flag(help: "Define automatic transformation of source control based dependencies to registry based ones")
-    public var sourceControlToRegistryDependencyTransformation: SourceControlToRegistryDependencyTransformation = .disabled
+    public var sourceControlToRegistryDependencyTransformation: SourceControlToRegistryDependencyTransformation = .swizzle
 
     public enum SourceControlToRegistryDependencyTransformation: EnumerableFlag {
         case disabled


### PR DESCRIPTION
motivation: support registry based depedendencies

changes: enabe the "swizzle" mode by default, which would replace a dependency that comes from source control with one that comes frmo the regsitry when the identity mapping is known
