### PR TITLE
update submodules tests to set GIT_ALLOW_PROTOCOL = file

### DIFF
--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -20,6 +20,16 @@ import SPMTestSupport
 import enum TSCUtility.Git
 
 class GitRepositoryTests: XCTestCase {
+
+    override func setUp() {
+        // needed for submodule tests
+        Git.environment = ["GIT_ALLOW_PROTOCOL": "file"]
+    }
+
+    override func tearDown() {
+        Git.environment = ProcessInfo.processInfo.environment
+    }
+
     /// Test the basic provider functions.
     func testRepositorySpecifier() {
         do {
@@ -184,7 +194,9 @@ class GitRepositoryTests: XCTestCase {
             initGitRepo(repoPath)
 
             try Process.checkNonZeroExit(
-                args: Git.tool, "-C", repoPath.pathString, "submodule", "add", testRepoPath.pathString)
+                args: Git.tool, "-C", repoPath.pathString, "submodule", "add", testRepoPath.pathString,
+                environment: Git.environment
+            )
             let repo = GitRepository(path: repoPath)
             try repo.stageEverything()
             try repo.commit()
@@ -571,7 +583,11 @@ class GitRepositoryTests: XCTestCase {
 
             // Add submodule to foo and tag it as 1.0.1
             try foo.checkout(newBranch: "submodule")
-            try systemQuietly([Git.tool, "-C", fooPath.pathString, "submodule", "add", barPath.pathString, "bar"])
+            try Process.checkNonZeroExit(
+                args: Git.tool, "-C", fooPath.pathString, "submodule", "add", barPath.pathString, "bar",
+                environment: Git.environment
+            )
+
             try foo.stageEverything()
             try foo.commit()
             try foo.tag(name: "1.0.1")
@@ -589,7 +605,11 @@ class GitRepositoryTests: XCTestCase {
             // Add something to bar.
             try localFileSystem.writeFileContents(barPath.appending(component: "bar.txt"), bytes: "hello")
             // Add a submodule too to check for recursive submodules.
-            try systemQuietly([Git.tool, "-C", barPath.pathString, "submodule", "add", bazPath.pathString, "baz"])
+            try Process.checkNonZeroExit(
+                args: Git.tool, "-C", barPath.pathString, "submodule", "add", bazPath.pathString, "baz",
+                environment: Git.environment
+            )
+
             try bar.stageEverything()
             try bar.commit()
 


### PR DESCRIPTION
motivation: Recent versions of git made a security fix to disallow the file transport by default. The GitRepository submodule test cases fail with these recent versions, because they use local submodules which rely on the file transport.

changes: The GitRepositoryTests submodule tests set the environment variable GIT_ALLOW_PROTOCOL=file to tell git to allow use of the file protocol only for these tests where it's required.

credit for this change to @dtweston

