### PR TITLE
[Issue #5923] Fix resource-related build failure for package containing Objective-C and C sources

### DIFF
--- a/Fixtures/Resources/Simple/Package.swift
+++ b/Fixtures/Resources/Simple/Package.swift
@@ -24,5 +24,12 @@ let package = Package(
                 .copy("foo.txt"),
             ]
         ),
+
+        .target(
+            name: "MixedClangResource",
+            resources: [
+                .copy("foo.txt"),
+            ]
+        ),
     ]
 )

--- a/Fixtures/Resources/Simple/Sources/MixedClangResource/Foo.m
+++ b/Fixtures/Resources/Simple/Sources/MixedClangResource/Foo.m
@@ -1,0 +1,6 @@
+#import <Foundation/Foundation.h>
+
+#import "Foo.h"
+
+@implementation Foo
+@end

--- a/Fixtures/Resources/Simple/Sources/MixedClangResource/bar.c
+++ b/Fixtures/Resources/Simple/Sources/MixedClangResource/bar.c
@@ -1,0 +1,1 @@
+#include "bar.h"

--- a/Fixtures/Resources/Simple/Sources/MixedClangResource/bar.h
+++ b/Fixtures/Resources/Simple/Sources/MixedClangResource/bar.h
@@ -1,0 +1,6 @@
+#ifndef foo_h
+#define foo_h
+
+#include <stdio.h>
+
+#endif /* foo_h */

--- a/Fixtures/Resources/Simple/Sources/MixedClangResource/include/Foo.h
+++ b/Fixtures/Resources/Simple/Sources/MixedClangResource/include/Foo.h
@@ -1,0 +1,4 @@
+#import <Foundation/Foundation.h>
+
+@interface Foo : NSObject
+@end

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -356,7 +356,10 @@ public final class ClangTargetBuildDescription {
 
     /// Builds up basic compilation arguments for a source file in this target; these arguments may be different for C++ vs non-C++.
     /// NOTE: The parameter to specify whether to get C++ semantics is currently optional, but this is only for revlock avoidance with clients. Callers should always specify what they want based either the user's indication or on a default value (possibly based on the filename suffix).
-    public func basicArguments(isCXX isCXXOverride: Bool? = .none) throws -> [String] {
+    public func basicArguments(
+        isCXX isCXXOverride: Bool? = .none,
+        isC isCOverride: Bool = false
+    ) throws -> [String] {
         // For now fall back on the hold semantics if the C++ nature isn't specified. This is temporary until clients have been updated.
         let isCXX = isCXXOverride ?? clangTarget.isCXX
 
@@ -419,7 +422,10 @@ public final class ClangTargetBuildDescription {
         // Add arguments from declared build settings.
         args += try self.buildSettingsFlags()
 
-        if let resourceAccessorHeaderFile = self.resourceAccessorHeaderFile {
+        // Include the path to the resource header unless the arguments are
+        // being evaluated for a C file. A C file cannot depend on the resource
+        // accessor header due to it exporting a Foundation type (`NSBundle`).
+        if let resourceAccessorHeaderFile = self.resourceAccessorHeaderFile, !isCOverride {
             args += ["-include", resourceAccessorHeaderFile.pathString]
         }
 

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -358,7 +358,7 @@ public final class ClangTargetBuildDescription {
     /// NOTE: The parameter to specify whether to get C++ semantics is currently optional, but this is only for revlock avoidance with clients. Callers should always specify what they want based either the user's indication or on a default value (possibly based on the filename suffix).
     public func basicArguments(
         isCXX isCXXOverride: Bool? = .none,
-        isC isCOverride: Bool = false
+        isC: Bool = false
     ) throws -> [String] {
         // For now fall back on the hold semantics if the C++ nature isn't specified. This is temporary until clients have been updated.
         let isCXX = isCXXOverride ?? clangTarget.isCXX
@@ -425,7 +425,7 @@ public final class ClangTargetBuildDescription {
         // Include the path to the resource header unless the arguments are
         // being evaluated for a C file. A C file cannot depend on the resource
         // accessor header due to it exporting a Foundation type (`NSBundle`).
-        if let resourceAccessorHeaderFile = self.resourceAccessorHeaderFile, !isCOverride {
+        if let resourceAccessorHeaderFile = self.resourceAccessorHeaderFile, !isC {
             args += ["-include", resourceAccessorHeaderFile.pathString]
         }
 

--- a/Sources/Build/LLBuildManifestBuilder.swift
+++ b/Sources/Build/LLBuildManifestBuilder.swift
@@ -769,7 +769,9 @@ extension LLBuildManifestBuilder {
 
         for path in try target.compilePaths() {
             let isCXX = path.source.extension.map{ SupportedLanguageExtension.cppExtensions.contains($0) } ?? false
-            var args = try target.basicArguments(isCXX: isCXX)
+            let isC = path.source.extension.map { $0 == SupportedLanguageExtension.c.rawValue } ?? false
+
+            var args = try target.basicArguments(isCXX: isCXX, isC: isC)
 
             args += ["-MD", "-MT", "dependencies", "-MF", path.deps.pathString]
 

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -4000,9 +4000,9 @@ final class BuildPlanTests: XCTestCase {
 
         let fooTarget = try result.target(for: "Foo").clangTarget()
         XCTAssertEqual(try fooTarget.objects.map(\.pathString), [
-            buildPath.appending(components: "Foo.build", "resource_bundle_accessor.m.o").pathString,
             buildPath.appending(components: "Foo.build", "Foo.m.o").pathString,
-            buildPath.appending(components: "Foo.build", "bar.c.o").pathString
+            buildPath.appending(components: "Foo.build", "bar.c.o").pathString,
+            buildPath.appending(components: "Foo.build", "resource_bundle_accessor.m.o").pathString
         ])
 
         let resourceAccessorDirectory = buildPath.appending(components:

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -3999,11 +3999,11 @@ final class BuildPlanTests: XCTestCase {
         let buildPath: AbsolutePath = result.plan.buildParameters.dataPath.appending(component: "debug")
 
         let fooTarget = try result.target(for: "Foo").clangTarget()
-        XCTAssertEqual(try fooTarget.objects.map(\.pathString), [
+        XCTAssertEqual(try fooTarget.objects.map(\.pathString).sorted(), [
             buildPath.appending(components: "Foo.build", "Foo.m.o").pathString,
             buildPath.appending(components: "Foo.build", "bar.c.o").pathString,
             buildPath.appending(components: "Foo.build", "resource_bundle_accessor.m.o").pathString
-        ])
+        ].sorted())
 
         let resourceAccessorDirectory = buildPath.appending(components:
             "Foo.build",

--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -266,6 +266,19 @@ final class TestToolTests: CommandsTestCase {
         }
     }
 
+    // TODO: This test should be moved into `ResourceTests.swift` in the
+    // `FunctionalTests` scheme when the `FunctionalTests` scheme is re-enabled.
+    func testResourcesInMixedClangPackage() throws {
+        #if !os(macOS)
+        // Running swift-test fixtures on linux is not yet possible.
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
+
+        try fixture(name: "Resources/Simple") { fixturePath in
+            XCTAssertBuilds(fixturePath, extraArgs: ["--target", "MixedClangResource"])
+        }
+    }
+
     func testList() throws {
         try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
             let (stdout, stderr) = try SwiftPMProduct.SwiftTest.execute(["list"], packagePath: fixturePath)

--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -266,19 +266,6 @@ final class TestToolTests: CommandsTestCase {
         }
     }
 
-    // TODO: This test should be moved into `ResourceTests.swift` in the
-    // `FunctionalTests` scheme when the `FunctionalTests` scheme is re-enabled.
-    func testResourcesInMixedClangPackage() throws {
-        #if !os(macOS)
-        // Running swift-test fixtures on linux is not yet possible.
-        try XCTSkipIf(true, "test is only supported on macOS")
-        #endif
-
-        try fixture(name: "Resources/Simple") { fixturePath in
-            XCTAssertBuilds(fixturePath, extraArgs: ["--target", "MixedClangResource"])
-        }
-    }
-
     func testList() throws {
         try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
             let (stdout, stderr) = try SwiftPMProduct.SwiftTest.execute(["list"], packagePath: fixturePath)

--- a/Tests/FunctionalTests/ResourcesTests.swift
+++ b/Tests/FunctionalTests/ResourcesTests.swift
@@ -49,6 +49,17 @@ class ResourcesTests: XCTestCase {
         }
     }
 
+    func testResourcesInMixedClangPackage() throws {
+        #if !os(macOS)
+        // Running swift-test fixtures on linux is not yet possible.
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
+
+        try fixture(name: "Resources/Simple") { fixturePath in
+            XCTAssertBuilds(fixturePath, extraArgs: ["--target", "MixedClangResource"])
+        }
+    }
+
     func testMovedBinaryResources() throws {
         try fixture(name: "Resources/Moved") { fixturePath in
             var executables = ["SwiftyResource"]


### PR DESCRIPTION
Fix issue where adding a resource to a package containing Objective-C and C sources causes a build failure. **Note:** This only occurs when using `swift build` via the package manager CLI.

### Motivation:

Please see https://github.com/apple/swift-package-manager/issues/5923 for the context regarding the issue. The package manager will add the `resource_bundle_accessor.h` as an input when compiling C sources. This causes a build failure because of the Foundation import in `resource_bundle_accessor.h`.

This PR fixes this issue.

### Modifications:
- Modify build instructions for Clang targets to _not_ include the `-include /path/to/resource_bundle_accessor.h` compile argument when compiling a C source.
- Add unit test `testClangBundleAccessor` in `BuildPlanTests.swift`. I wrote this with intention of testing the fix but it doesn't actually test anything because those tests don't actually build anything. I was going to delete it, but noticed that resource bundle generation in Clang targets hasn't been tested so maybe it's a good test to keep?
- Add unit test `testResourcesInMixedClangPackage` in `TestToolTests.swift` to test this fix and potential regressions.
- Add corresponding fixture target for unit testing this fix.

### Result:

This fix enables packages to contain mixed Clang sources (e.g. Objective-C and C) _and_ resources.

Fixes #5923.