### PR TITLE
Only automatically link snippets to product libraries

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -543,8 +543,9 @@ public final class PackageBuilder {
         if self.manifest.packageKind.isRoot {
             // Snippets: depend on all available library targets in the package.
             // TODO: Do we need to filter out targets that aren't available on the host platform?
+            let productTargets = Set(manifest.products.flatMap { $0.targets })
             let snippetDependencies = targets
-                .filter { $0.type == .library }
+                .filter { $0.type == .library && productTargets.contains($0.name) }
                 .map { Target.Dependency.target($0, conditions: []) }
             snippetTargets = try createSnippetTargets(dependencies: snippetDependencies)
         } else {


### PR DESCRIPTION
Snippets illustrate how to use a package's products by design, so they shouldn't link to library targets that aren't exported as products.

If snippets link to all library targets, one negative result would be inadvertently linking to test support libraries, which could cause failures due to automatic linking of `@rpath/libXCTestSwiftSupport.dylib`, a library not available to snippets at runtime.

rdar://102746374