### PR TITLE
Fix imparted build properties when building with XCBuild

### DIFF
--- a/Sources/SPMTestSupport/PIFTester.swift
+++ b/Sources/SPMTestSupport/PIFTester.swift
@@ -164,18 +164,18 @@ public class PIFBaseTargetTester {
     }
 
     public func checkImpartedBuildSettings(file: StaticString = #file, line: UInt = #line, _ body: (PIFBuildSettingsTester) -> Void) {
-        let buildSettingsTester = PIFBuildSettingsTester(buildSettings: baseTarget.impartedBuildProperties.buildSettings)
+        let buildSettingsTester = PIFBuildSettingsTester(buildSettings: baseTarget.buildConfigurations.first!.impartedBuildProperties.buildSettings)
         body(buildSettingsTester)
     }
 
     public func checkAllImpartedBuildSettings(file: StaticString = #file, line: UInt = #line, _ body: (PIFBuildSettingsTester) -> Void) {
-        let buildSettingsTester = PIFBuildSettingsTester(buildSettings: baseTarget.impartedBuildProperties.buildSettings)
+        let buildSettingsTester = PIFBuildSettingsTester(buildSettings: baseTarget.buildConfigurations.first!.impartedBuildProperties.buildSettings)
         body(buildSettingsTester)
         buildSettingsTester.checkUncheckedSettings(file: file, line: line)
     }
 
     public func checkNoImpartedBuildSettings(file: StaticString = #file, line: UInt = #line) {
-        let buildSettingsTester = PIFBuildSettingsTester(buildSettings: baseTarget.impartedBuildProperties.buildSettings)
+        let buildSettingsTester = PIFBuildSettingsTester(buildSettings: baseTarget.buildConfigurations.first!.impartedBuildProperties.buildSettings)
         buildSettingsTester.checkUncheckedSettings(file: file, line: line)
     }
 }

--- a/Sources/XCBuildSupport/PIF.swift
+++ b/Sources/XCBuildSupport/PIF.swift
@@ -862,14 +862,16 @@ public enum PIF {
         public let guid: GUID
         public var name: String
         public var buildSettings: BuildSettings
+        public let impartedBuildProperties: ImpartedBuildProperties
 
-        public init(guid: GUID, name: String, buildSettings: BuildSettings) {
+        public init(guid: GUID, name: String, buildSettings: BuildSettings, impartedBuildProperties: ImpartedBuildProperties = ImpartedBuildProperties(settings: BuildSettings())) {
             precondition(!guid.isEmpty)
             precondition(!name.isEmpty)
 
             self.guid = guid
             self.name = name
             self.buildSettings = buildSettings
+            self.impartedBuildProperties = impartedBuildProperties
         }
     }
 

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -175,9 +175,10 @@ class PIFProjectBuilder {
     @discardableResult
     func addBuildConfiguration(
         name: String,
-        settings: PIF.BuildSettings = PIF.BuildSettings()
+        settings: PIF.BuildSettings = PIF.BuildSettings(),
+        impartedBuildProperties: PIF.ImpartedBuildProperties = PIF.ImpartedBuildProperties(settings: PIF.BuildSettings())
     ) -> PIFBuildConfigurationBuilder {
-        let builder = PIFBuildConfigurationBuilder(name: name, settings: settings)
+        let builder = PIFBuildConfigurationBuilder(name: name, settings: settings, impartedBuildProperties: impartedBuildProperties)
         buildConfigurations.append(builder)
         return builder
     }
@@ -480,8 +481,9 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
             impartedSettings: &impartedSettings
         )
 
-        pifTarget.addBuildConfiguration(name: "Debug", settings: debugSettings)
-        pifTarget.addBuildConfiguration(name: "Release", settings: releaseSettings)
+        let impartedBuildProperties = PIF.ImpartedBuildProperties(settings: impartedSettings)
+        pifTarget.addBuildConfiguration(name: "Debug", settings: debugSettings, impartedBuildProperties: impartedBuildProperties)
+        pifTarget.addBuildConfiguration(name: "Release", settings: releaseSettings, impartedBuildProperties: impartedBuildProperties)
     }
 
     private func addLibraryTarget(for product: ResolvedProduct) {
@@ -691,8 +693,9 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
             impartedSettings: &impartedSettings
         )
 
-        pifTarget.addBuildConfiguration(name: "Debug", settings: debugSettings)
-        pifTarget.addBuildConfiguration(name: "Release", settings: releaseSettings)
+        let impartedBuildProperties = PIF.ImpartedBuildProperties(settings: impartedSettings)
+        pifTarget.addBuildConfiguration(name: "Debug", settings: debugSettings, impartedBuildProperties: impartedBuildProperties)
+        pifTarget.addBuildConfiguration(name: "Release", settings: releaseSettings, impartedBuildProperties: impartedBuildProperties)
         pifTarget.impartedBuildSettings = impartedSettings
     }
 
@@ -700,11 +703,6 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         guard let systemTarget = target.underlyingTarget as? SystemLibraryTarget else {
             throw InternalError("unexpected target type")
         }
-
-        // Create an aggregate PIF target (which doesn't have an actual product).
-        let pifTarget = addAggregateTarget(guid: target.pifTargetGUID, name: target.name)
-        pifTarget.addBuildConfiguration(name: "Debug", settings: PIF.BuildSettings())
-        pifTarget.addBuildConfiguration(name: "Release", settings: PIF.BuildSettings())
 
         // Impart the header search path to all direct and indirect clients.
         var impartedSettings = PIF.BuildSettings()
@@ -725,6 +723,12 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         impartedSettings[.OTHER_LDRFLAGS] = []
         impartedSettings[.OTHER_CFLAGS, default: ["$(inherited)"]] += ["-fmodule-map-file=\(systemTarget.moduleMapPath)"] + cFlags
         impartedSettings[.OTHER_SWIFT_FLAGS, default: ["$(inherited)"]] += ["-Xcc", "-fmodule-map-file=\(systemTarget.moduleMapPath)"] + cFlags
+        let impartedBuildProperties = PIF.ImpartedBuildProperties(settings: impartedSettings)
+
+        // Create an aggregate PIF target (which doesn't have an actual product).
+        let pifTarget = addAggregateTarget(guid: target.pifTargetGUID, name: target.name)
+        pifTarget.addBuildConfiguration(name: "Debug", settings: PIF.BuildSettings(), impartedBuildProperties: impartedBuildProperties)
+        pifTarget.addBuildConfiguration(name: "Release", settings: PIF.BuildSettings(), impartedBuildProperties: impartedBuildProperties)
         pifTarget.impartedBuildSettings = impartedSettings
     }
 
@@ -1082,9 +1086,10 @@ class PIFBaseTargetBuilder {
     @discardableResult
     public func addBuildConfiguration(
         name: String,
-        settings: PIF.BuildSettings = PIF.BuildSettings()
+        settings: PIF.BuildSettings = PIF.BuildSettings(),
+        impartedBuildProperties: PIF.ImpartedBuildProperties = PIF.ImpartedBuildProperties(settings: PIF.BuildSettings())
     ) -> PIFBuildConfigurationBuilder {
-        let builder = PIFBuildConfigurationBuilder(name: name, settings: settings)
+        let builder = PIFBuildConfigurationBuilder(name: name, settings: settings, impartedBuildProperties: impartedBuildProperties)
         buildConfigurations.append(builder)
         return builder
     }
@@ -1328,18 +1333,20 @@ final class PIFBuildFileBuilder {
 final class PIFBuildConfigurationBuilder {
     let name: String
     let settings: PIF.BuildSettings
+    let impartedBuildProperties: PIF.ImpartedBuildProperties
 
     @DelayedImmutable
     var guid: PIF.GUID
 
-    public init(name: String, settings: PIF.BuildSettings) {
+    public init(name: String, settings: PIF.BuildSettings, impartedBuildProperties: PIF.ImpartedBuildProperties) {
         precondition(!name.isEmpty)
         self.name = name
         self.settings = settings
+        self.impartedBuildProperties = impartedBuildProperties
     }
 
     func construct() -> PIF.BuildConfiguration {
-        PIF.BuildConfiguration(guid: guid, name: name, buildSettings: settings)
+        PIF.BuildConfiguration(guid: guid, name: name, buildSettings: settings, impartedBuildProperties: impartedBuildProperties)
     }
 }
 


### PR DESCRIPTION
Imparted settings are now per-configuration instead of per-target in XCBuild, this adopts SwiftPM's support for XCBuild to that change. We are still also passing them to the target for backwards compatibility, newer versions of XCBuild will ignore those extra keys in the JSON.

rdar://102779919
