### PR TITLE
Consider snippets in ResolvedProduct.executableTarget

### DIFF
--- a/Sources/PackageModel/Target.swift
+++ b/Sources/PackageModel/Target.swift
@@ -812,7 +812,7 @@ public extension Sequence where Iterator.Element == Target {
             switch $0.type {
             case .binary:
                 return ($0 as? BinaryTarget)?.containsExecutable == true
-            case .executable:
+            case .executable, .snippet:
                 return true
             default:
                 return false


### PR DESCRIPTION
When computing the underlying executable target for a resolved product, consider snippet targets as well. Otherwise, this results in a fatal error when building a package that contains snippets.

rdar://102784273