### PR TITLE
Fix use of resources when using XCBuild

### DIFF
--- a/Sources/SPMTestSupport/PIFTester.swift
+++ b/Sources/SPMTestSupport/PIFTester.swift
@@ -55,7 +55,7 @@ public final class PIFProjectTester {
     fileprivate init(project: PIF.Project, targetMap: [PIF.GUID: PIF.BaseTarget]) throws {
         self.project = project
         self.targetMap = targetMap
-        self.fileMap = try collectFiles(from: project.groupTree, parentPath: project.path, projectPath: project.path)
+        self.fileMap = try collectFiles(from: project.groupTree, parentPath: project.path, projectPath: project.path, builtProductsPath: project.path)
     }
 
     public func checkTarget(_ guid: PIF.GUID, file: StaticString = #file, line: UInt = #line, body: ((PIFTargetTester) -> Void)? = nil) {
@@ -291,7 +291,8 @@ public final class PIFBuildSettingsTester {
 private func collectFiles(
     from reference: PIF.Reference,
     parentPath: AbsolutePath,
-    projectPath: AbsolutePath
+    projectPath: AbsolutePath,
+    builtProductsPath: AbsolutePath
 ) throws -> [PIF.GUID: String] {
     let referencePath: AbsolutePath
     switch reference.sourceTree {
@@ -302,7 +303,7 @@ private func collectFiles(
     case .sourceRoot:
         referencePath = try AbsolutePath(validating: reference.path, relativeTo: projectPath)
     case .builtProductsDir:
-        return [:]
+        referencePath = try AbsolutePath(validating: reference.path, relativeTo: builtProductsPath)
     }
 
     var files: [PIF.GUID: String] = [:]
@@ -312,7 +313,7 @@ private func collectFiles(
         files[reference.guid] = referencePath.pathString
     } else if let group = reference as? PIF.Group {
         for child in group.children {
-            let childFiles = try collectFiles(from: child, parentPath: referencePath, projectPath: projectPath)
+            let childFiles = try collectFiles(from: child, parentPath: referencePath, projectPath: projectPath, builtProductsPath: builtProductsPath)
             files.merge(childFiles, uniquingKeysWith: { _, _ in fatalError("non-unique GUID") })
         }
     }

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -848,6 +848,9 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
             resourcesTarget.addResourceFile(resourceFile)
         }
 
+        let targetGroup = groupTree.addGroup(path: "/", sourceTree: .group)
+        pifTarget.addResourceFile(targetGroup.addFileReference(path: "\(bundleName).bundle", sourceTree: .builtProductsDir))
+
         return bundleName
     }
 

--- a/Sources/XCBuildSupport/XCBuildDelegate.swift
+++ b/Sources/XCBuildSupport/XCBuildDelegate.swift
@@ -89,6 +89,20 @@ extension XCBuildDelegate: XCBuildOutputParserDelegate {
                 self.outputStream <<< "\n"
                 self.outputStream.flush()
             }
+        case .taskDiagnostic(let info):
+            queue.async {
+                self.progressAnimation.clear()
+                self.outputStream <<< info.message
+                self.outputStream <<< "\n"
+                self.outputStream.flush()
+            }
+        case .targetDiagnostic(let info):
+            queue.async {
+                self.progressAnimation.clear()
+                self.outputStream <<< info.message
+                self.outputStream <<< "\n"
+                self.outputStream.flush()
+            }
         case .buildOutput(let info):
             queue.async {
                 self.progressAnimation.clear()
@@ -116,7 +130,7 @@ extension XCBuildDelegate: XCBuildOutputParserDelegate {
                     self.buildSystem.delegate?.buildSystem(self.buildSystem, didFinishWithResult: true)
                 }
             }
-        default:
+        case .buildStarted, .preparationComplete, .targetUpToDate, .targetStarted, .targetComplete, .taskUpToDate:
             break
         }
     }


### PR DESCRIPTION
We were not embedding the resource bundle correctly when using XCBuild. This also fixes the delegate so that target and task diagnostics get emitted to the console.

rdar://102785735
