### PR TITLE
fix a regression in swift run signal handling

### DIFF
--- a/Sources/Commands/SwiftRunTool.swift
+++ b/Sources/Commands/SwiftRunTool.swift
@@ -13,7 +13,7 @@
 import ArgumentParser
 import Basics
 import CoreCommands
-import Dispatch
+import Foundation
 import PackageGraph
 import PackageModel
 import TSCBasic

--- a/Sources/CoreCommands/SwiftTool.swift
+++ b/Sources/CoreCommands/SwiftTool.swift
@@ -102,17 +102,6 @@ extension SwiftCommand {
     }
 }
 
-/// A safe wrapper of TSCBasic.exec.
-func exec(path: String, args: [String]) throws -> Never {
-    #if !os(Windows)
-    // On platforms other than Windows, signal(SIGINT, SIG_IGN) is used for handling SIGINT by DispatchSourceSignal,
-    // but this process is about to be replaced by exec, so SIG_IGN must be returned to default.
-    signal(SIGINT, SIG_DFL)
-    #endif
-
-    try TSCBasic.exec(path: path, args: args)
-}
-
 public final class SwiftTool {
     #if os(Windows)
     // unfortunately this is needed for C callback handlers used by Windows shutdown handler

--- a/Tests/CommandsTests/RunToolTests.swift
+++ b/Tests/CommandsTests/RunToolTests.swift
@@ -142,7 +142,7 @@ final class RunToolTests: CommandsTestCase {
 #if os(Windows)
             XCTAssertEqual(result.exitStatus, .abnormal(exception: 2))
 #else
-            XCTAssertEqual(result.exitStatus, .signalled(signal: 2))
+            XCTAssertEqual(result.exitStatus, .signalled(signal: SIGINT))
 #endif
         }
 


### PR DESCRIPTION
motivation: swift run should handle signals correctly, recent refactoring broke it

changes: move the exec wrapper back to SwiftRunTool and rename it so its harder to regress

