### PR TITLE
Fix error message

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -102,7 +102,7 @@ extension ModuleError: CustomStringConvertible {
         case .invalidPublicHeadersDirectory(let name):
             return "public headers (\"include\") directory path for '\(name)' is invalid or not contained in the target"
         case .overlappingSources(let target, let sources):
-            return "target '\(target)' has sources overlapping sources: " +
+            return "target '\(target)' has overlapping sources: " +
                 sources.map({ $0.description }).joined(separator: ", ")
         case .multipleTestEntryPointFilesFound(let package, let files):
             return "package '\(package)' has multiple test entry point files: " +

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -706,8 +706,8 @@ class PackageBuilderTests: XCTestCase {
                     type: .test),
             ]
         )
-        PackageBuilderTester(manifest, in: fs) { package, diagnotics in
-            diagnotics.check(diagnostic: "target 'barTests' has overlapping sources: \(bar.appending(components: "Tests", "barTests.swift"))", severity: .error)
+        PackageBuilderTester(manifest, in: fs) { package, diagnostics in
+            diagnostics.check(diagnostic: "target 'barTests' has overlapping sources: \(bar.appending(components: "Tests", "barTests.swift"))", severity: .error)
         }
 
         manifest = Manifest.createRootManifest(

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -707,7 +707,7 @@ class PackageBuilderTests: XCTestCase {
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, diagnotics in
-            diagnotics.check(diagnostic: "target 'barTests' has sources overlapping sources: \(bar.appending(components: "Tests", "barTests.swift"))", severity: .error)
+            diagnotics.check(diagnostic: "target 'barTests' has overlapping sources: \(bar.appending(components: "Tests", "barTests.swift"))", severity: .error)
         }
 
         manifest = Manifest.createRootManifest(


### PR DESCRIPTION
### Motivation:

Following error message has word "sources" duplicated:

```
error: 'swift-png': target 'PNGUnitTests' has sources overlapping sources: /Users/*****/swift-png/tests/unit/XCTestManifests.swift, /Users/*****/swift-png/tests/unit/PNGTests.swift
```

### Modifications:

Fixed above error message into following:
```
error: 'swift-png': target 'PNGUnitTests' has overlapping sources: /Users/*****/swift-png/tests/unit/XCTestManifests.swift, /Users/*****/swift-png/tests/unit/PNGTests.swift
```


### Result:

👆🏻