### PR TITLE
improve internal target dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -246,9 +246,7 @@ let package = Package(
             dependencies: [
                 "Basics",
                 "PackageLoading",
-                "PackageModel",
-                "PackageRegistry",
-                "SourceControl"
+                "PackageModel"
             ],
             exclude: ["CMakeLists.txt", "README.md"]
         ),
@@ -334,6 +332,7 @@ let package = Package(
                 "PackageFingerprint",
                 "PackageGraph",
                 "PackageModel",
+                "PackageRegistry",
                 "SourceControl",
                 "SPMBuildCore",
             ],


### PR DESCRIPTION
motivation: more accuratly reflect internal target dependenies

changes: PackageGraph does not depend on SourceControl or Registry, only Workspace does
