### PR TITLE
Ignore `CODEOWNERS` in `XCBuildSupport`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -324,7 +324,7 @@ let package = Package(
             /** Support for building using Xcode's build system */
             name: "XCBuildSupport",
             dependencies: ["SPMBuildCore", "PackageGraph"],
-            exclude: ["CMakeLists.txt"]
+            exclude: ["CMakeLists.txt", "CODEOWNERS"]
         ),
         .target(
             /** High level functionality */


### PR DESCRIPTION
This was recently added, but generates a warning if unhandled, so we should mark it as excluded.
