### PR TITLE
Registry spec disambiguation

### DIFF
--- a/Documentation/Registry.md
+++ b/Documentation/Registry.md
@@ -769,7 +769,7 @@ Digest: sha-256=a2ac54cf25fbc1ad0028f03f0aa4b96833b83bb05a14e510892bb27dea4dc812
 ### 4.5. Lookup package identifiers registered for a URL
 
 A client MAY send a `GET` request
-for a URI matching the expression `/identifiers{?url}`
+for a URI matching the expression `/identifiers?url={url}`
 to retrieve package identifiers associated with a particular URL.
 A client SHOULD set the `Accept` header with the value
 `application/vnd.swift.registry.v1+json`.
@@ -779,6 +779,10 @@ GET /identifiers?url=https://github.com/mona/LinkedList HTTP/1.1
 Host: packages.example.com
 Accept: application/vnd.swift.registry.v1
 ```
+
+A client MUST provide a URL for the `url` query parameter.
+When no `url` parameter is specified,
+a server SHOULD respond with a status code of `400` (Bad Request).
 
 If one or more package identifiers are associated with the specified URL,
 a server SHOULD respond with a status code of `200` (OK)

--- a/Documentation/Registry.md
+++ b/Documentation/Registry.md
@@ -66,6 +66,9 @@ The following terms, as used in this document, have the meanings indicated.
 - _Version Number_:
   An identifier for a package release
   in accordance with the [Semantic Versioning Specification (SemVer)][SemVer].
+- _Precedence_:
+  The ordering of version numbers relative to each other
+  as defined by the [Semantic Versioning Specification (SemVer)][SemVer].
 
 ## 3. Conventions
 
@@ -375,11 +378,11 @@ A client SHOULD consider any releases with an associated `problem`
 to be unavailable for the purposes of package resolution.
 
 A server SHOULD respond with
-a link to the latest published release of the package if one exists,
+a link to the highest precedence published release of the package if one exists,
 using a `Link` header field with a `latest-version` relation.
 
 A server SHOULD list releases in order of precedence,
-starting with the latest version.
+starting with the highest precedence version.
 However, a client SHOULD NOT assume
 any specific ordering of versions in a response.
 
@@ -469,11 +472,11 @@ The response body MUST contain a JSON object containing the following fields:
 
 A server SHOULD respond with a `Link` header containing the following entries:
 
-| Relation              | Description                                                    |
-| --------------------- | -------------------------------------------------------------- |
-| `latest-version`      | The latest published release of the package                    |
-| `successor-version`   | The next published release of the package, if one exists       |
-| `predecessor-version` | The previously published release of the package, if one exists |
+| Relation              | Description                                                                          |
+| --------------------- | ------------------------------------------------------------------------------------ |
+| `latest-version`      | The highest precedence published release of the package                              |
+| `successor-version`   | The next published release of the package ordered by precedence, if one exists       |
+| `predecessor-version` | The previously published release of the package ordered by precedence, if one exists |
 
 A link with the `latest-version` relation
 MAY correspond to the requested release.


### PR DESCRIPTION
This change clarifies two aspects of the registry specification per guidance from the Swift registry team. 

### Motivation:

After reviewing the SPM Registry spec, I had two questions regarding how to interpret functional behavior of the registry. I reached out to @yim-lee who helped answer these questions. To close the loop, I am proposing these changes to the registry spec so that others in the future can interpret the spec with clarity.

### Modifications:

1. Replace mentions of "latest version" with "highest precedence version" to clarify that it should be based on Semantic Versioning 2.0 precedence.
   * Previously, the language could have been interpreted to mean that relative version ordering should be based on the time that the release was published.
   * For example, package owners could publish a bugfix release versioned `1.1.1` _after_ they had published `2.0.1`; if ordered by published time then `1.1.1` would be the `latest-version` and not `2.0.1`.
2. Clarify that the `url` parameter in the `GET /identifiers` API is required and the server should reject the request when not specified.
   * It was previously unclear what the server should do if the parameter was not specified. One interpretation would be that the `url` parameter is a "filter," and with no filter applied, the registry should return all package identifiers for all packages on the registry.

### Result:

The registry specification will be more clear and have less likelihood for incorrect interpretation by future implementations of the spec.
