### PR TITLE
Check existance of package resolver caches

### DIFF
--- a/Sources/PackageRegistry/RegistryDownloadsManager.swift
+++ b/Sources/PackageRegistry/RegistryDownloadsManager.swift
@@ -252,7 +252,7 @@ public class RegistryDownloadsManager: Cancellable {
     }
 
     public func purgeCache() throws {
-        guard let cachePath = self.cachePath else {
+        guard let cachePath = self.cachePath, fileSystem.exists(cachePath) else {
             return
         }
         try self.fileSystem.withLock(on: cachePath, type: .exclusive) {


### PR DESCRIPTION
### Motivation:

In some situations, `swift package purge-cache` raises the following error:

```
$ swift run swift-package purge-cache
Building for debugging...
[3/3] Linking swift-package
Build complete! (1.04s)
$HOME/Library/Caches/org.swift.swiftpm/registry/downloads
error: Error Domain=NSCocoaErrorDomain Code=260 "The folder “downloads” doesn’t exist." UserInfo={NSFilePath=$HOME/Library/Caches/org.swift.swiftpm/registry/downloads, NSUserStringVariant=(
    Folder
), NSUnderlyingError=0x6000019da940 {Error Domain=NSOSStatusErrorDomain Code=-43 "fnfErr: File not found"}}
```

It's better to check the existence of repository cache dirs.

### Modifications:

This error raises in `withLock`. So I added an existence check of cache directories before calling this.
https://github.com/apple/swift-tools-support-core/blob/4cac812e26a1c9ec0379de9ec86c7da2f9e87863/Sources/TSCBasic/Lock.swift#L184-L186

### Result:

For example, run `swift run swift-package purge-cache` in this repo. it will be succeeded.
