### PR TITLE
Build: create static libraries explicitly with libtool.

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -1387,7 +1387,7 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
             return [librarian, "/LIB", "/OUT:\(binaryPath.pathString)", "@\(linkFileListPath.pathString)"]
         }
         if triple.isDarwin(), librarian.hasSuffix("libtool") {
-            return [librarian, "-o", binaryPath.pathString, "@\(linkFileListPath.pathString)"]
+            return [librarian, "-static", "-o", binaryPath.pathString, "@\(linkFileListPath.pathString)"]
         }
         return [librarian, "crs", binaryPath.pathString, "@\(linkFileListPath.pathString)"]
     }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -3808,7 +3808,7 @@ final class BuildPlanTests: XCTestCase {
                 inputs: ["\(buildPath.appending(components: "rary.build", "rary.swift.o").escapedPathString())"]
                 outputs: ["\(buildPath.appending(components: "library.a").escapedPathString())"]
                 description: "Archiving \(buildPath.appending(components: "library.a").escapedPathString())"
-                args: ["\(result.plan.buildParameters.toolchain.librarianPath.escapedPathString())","-o","\(buildPath.appending(components: "library.a").escapedPathString())","@\(buildPath.appending(components: "rary.product", "Objects.LinkFileList").escapedPathString())"]
+                args: ["\(result.plan.buildParameters.toolchain.librarianPath.escapedPathString())","-static","-o","\(buildPath.appending(components: "library.a").escapedPathString())","@\(buildPath.appending(components: "rary.product", "Objects.LinkFileList").escapedPathString())"]
             """))
         } else {    // assume Unix `ar` is the librarian
             XCTAssertMatch(contents, .contains("""


### PR DESCRIPTION
Always pass the `-static` parameter, instead of relying on the default of `libtool`.

### Motivation:

This matches the implementation of the static linker in swift-driver, which always adds the explicit `-static`.

https://github.com/apple/swift-driver/blob/caa81e560362a4e14034cd4502114d03e45ea261/Sources/SwiftDriver/Jobs/DarwinToolchain%2BLinkerSupport.swift#L95-L102

Additionally, this improves the compatibility with LLVM's libtool, which does not (intentionally) default to static libraries (it defaults to do nothing).

### Modifications:

Adds a new parameter `-static` for every invocation of `libtool` to create static libraries in Darwin.

### Result:

The internal invocation of libtool always uses the `-static`. No changes should be experienced, since this is the default for cctools' `libtool`.

/cc @compnerd as the author of #5720 which added the usage of `libtool`
