### PR TITLE
PackageModel: fix `Destination.init` default arguments

### DIFF
--- a/Sources/PackageModel/Destination.swift
+++ b/Sources/PackageModel/Destination.swift
@@ -113,7 +113,7 @@ public struct Destination: Encodable, Equatable {
         binDir: AbsolutePath,
         extraCCFlags: [String] = [],
         extraSwiftCFlags: [String] = [],
-        extraCPPFlags: [String]
+        extraCPPFlags: [String] = []
     ) {
         self.hostTriple = nil
         self.targetTriple = target


### PR DESCRIPTION
### Motivation:

`extraCPPFlags` previously had a default value, but after renaming to `extraCXXFlags` in https://github.com/apple/swift-package-manager/commit/75877ea8304339a5e54da6638f2e476f3f47b406 this default value was lost. Let's restore it for compatibility with libSwiftPM clients.

### Modifications:

`extraCPPFlags` argument of deprecated `Destination.init` now has a default argument, like it had before 75877ea8304339a5e54da6638f2e476f3f47b406.

### Result:

Code relying on libSwiftPM now can rely on the default argument, as it did before.
