### PR TITLE
Add macOS version to Package.swift for newly generated packages

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import Foundation
 import TSCBasic
 import PackageModel
 
@@ -31,7 +32,7 @@ public final class InitPackage {
 
         public init(
             packageType: PackageType,
-            platforms: [SupportedPlatform] = []
+            platforms: [SupportedPlatform]
         ) {
             self.packageType = packageType
             self.platforms = platforms
@@ -87,7 +88,7 @@ public final class InitPackage {
     ) throws {
         try self.init(
             name: name,
-            options: InitPackageOptions(packageType: packageType),
+            options: InitPackageOptions(packageType: packageType, platforms: getDefaultPlatforms()),
             destinationPath: destinationPath,
             fileSystem: fileSystem
         )
@@ -497,4 +498,14 @@ extension SupportedPlatform {
             return false
         }
     }
+}
+
+private func getDefaultPlatforms() -> [SupportedPlatform] {
+    #if os(macOS)
+    let hostVersion = ProcessInfo.processInfo.operatingSystemVersion
+    let version = PlatformVersion("\(hostVersion.majorVersion).\(hostVersion.minorVersion)")
+    return [SupportedPlatform(platform: .macOS, version: version)]
+    #else
+    return []
+    #endif
 }


### PR DESCRIPTION
Previously if you created a new basic Swift package and added a dependency, such as swift-syntax, that requires a minimum version greater than macOS 10.13, you would have to set the platform version to something above that in the Package.swift. With this change newly generated packages on macOS automatically generate the current macOS version as the minimum supported version, and if the developer wants a lower version they can reduce it as usual in the Package.swift.