### PR TITLE
Add package metadata to observability scopes used by PackageContainers

### DIFF
--- a/Sources/PackageModel/PackageReference.swift
+++ b/Sources/PackageModel/PackageReference.swift
@@ -173,6 +173,12 @@ extension PackageReference: Hashable {
     }
 }
 
+extension PackageReference {
+    public var diagnosticsMetadata: ObservabilityMetadata {
+        return .packageMetadata(identity: self.identity, kind: self.kind)
+    }
+}
+
 extension PackageReference: CustomStringConvertible {
     public var description: String {
         return "\(self.identity) \(self.kind)"

--- a/Sources/Workspace/FileSystemPackageContainer.swift
+++ b/Sources/Workspace/FileSystemPackageContainer.swift
@@ -57,7 +57,9 @@ public struct FileSystemPackageContainer: PackageContainer {
         self.manifestLoader = manifestLoader
         self.currentToolsVersion = currentToolsVersion
         self.fileSystem = fileSystem
-        self.observabilityScope = observabilityScope
+        self.observabilityScope = observabilityScope.makeChildScope(
+            description: "FileSystemPackageContainer",
+            metadata: package.diagnosticsMetadata)
     }
 
     private func loadManifest() throws -> Manifest {

--- a/Sources/Workspace/RegistryPackageContainer.swift
+++ b/Sources/Workspace/RegistryPackageContainer.swift
@@ -46,7 +46,9 @@ public class RegistryPackageContainer: PackageContainer {
         self.registryClient = registryClient
         self.manifestLoader = manifestLoader
         self.currentToolsVersion = currentToolsVersion
-        self.observabilityScope = observabilityScope
+        self.observabilityScope = observabilityScope.makeChildScope(
+            description: "RegistryPackageContainer",
+            metadata: package.diagnosticsMetadata)
     }
 
     // MARK: - PackageContainer

--- a/Sources/Workspace/SourceControlPackageContainer.swift
+++ b/Sources/Workspace/SourceControlPackageContainer.swift
@@ -92,7 +92,9 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
         self.currentToolsVersion = currentToolsVersion
         self.fingerprintStorage = fingerprintStorage
         self.fingerprintCheckingMode = fingerprintCheckingMode
-        self.observabilityScope = observabilityScope
+        self.observabilityScope = observabilityScope.makeChildScope(
+            description: "SourceControlPackageContainer",
+            metadata: package.diagnosticsMetadata)
     }
 
     // Compute the map of known versions.

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -3129,7 +3129,7 @@ extension Workspace {
         try? fileSystem.chmod(.userUnWritable, path: checkoutPath, options: [.recursive, .onlyFiles])
 
         // Record the new state.
-        observabilityScope.emit(debug: "adding '\(package.identity)' (\(package.locationString)) to managed dependencies")
+        observabilityScope.emit(debug: "adding '\(package.identity)' (\(package.locationString)) to managed dependencies", metadata: package.diagnosticsMetadata)
         self.state.dependencies.add(
             try .sourceControlCheckout(
                 packageRef: package,
@@ -3280,7 +3280,7 @@ extension Workspace {
          }
 
          // Record the new state.
-         observabilityScope.emit(debug: "adding '\(package.identity)' (\(package.locationString)) to managed dependencies")
+         observabilityScope.emit(debug: "adding '\(package.identity)' (\(package.locationString)) to managed dependencies", metadata: package.diagnosticsMetadata)
          self.state.dependencies.add(
             try .registryDownload(
                 packageRef: package,


### PR DESCRIPTION
`PackageContainer` is a protocol that is implemented by various types involved in SwiftPM package resolution.  They can emit messages but those messages don't get associated with the diagnostics.

There are currently three implementors of this protocol:  `FileSystemPackageContainer`, `SourceControlPackageContainer`, and `RegistryPackageContainer`.  All three just assign a given `ObservabilityScope`, and setting a package location metadata on that scope is a good way to make sure that all the diagnostics emitted to that scope get associated with the package.

This fix makes sure that diagnostics emitted through these scopes get properly associated with the package.  This is particularly useful for manifest-related diagnostics, which inherit the scope used by the various kinds of `PackageContainer`.

### Changes
- add `diagnosticsMetadata` property in extension on `PackageRerference`, similar to the one on `Package`
- use this property to associate package metadata with the `ObservabilityScope`
- add this metadata with a couple of standalone `emit` calls in `Workspace`

rdar://103229985
