### PR TITLE
InitPackage.swift: remove redundant `public`

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -316,10 +316,10 @@ public final class InitPackage {
         case .executable:
             content = """
                 @main
-                public struct \(typeName) {
-                    public private(set) var text = "Hello, World!"
+                struct \(typeName) {
+                    private(set) var text = "Hello, World!"
 
-                    public static func main() {
+                    static func main() {
                         print(\(typeName)().text)
                     }
                 }


### PR DESCRIPTION
Sample code for `swift package init --type executable` contains redundant `public` access modifiers on a `@main` type that isn't supposed to be available anywhere outside of its own module. 

### Motivation:

Thus, `public` seems to be unneeded in sample code generated in `InitPackage.swift`

### Modifications:

Remove `public` access modifiers from sample code generated by `swift package init --type executable`.

### Result:

Sample code that's more lightweight.
