### PR TITLE
Revert "Add emit extension block symbols option to `dump-symbol-graph` and `SymbolGraphOptions`"

### DIFF
--- a/Sources/Commands/PackageTools/DumpCommands.swift
+++ b/Sources/Commands/PackageTools/DumpCommands.swift
@@ -39,9 +39,6 @@ struct DumpSymbolGraph: SwiftCommand {
 
     @Flag(help: "Add symbols with SPI information to the symbol graph.")
     var includeSPISymbols = false
-    
-    @Flag(help: "Emit extension block symbols for extensions to external types or directly associate members and conformances with the extended nominal.")
-    var extensionBlockSymbolBehavior: ExtensionBlockSymbolBehavior = .omitExtensionBlockSymbols
 
     func run(_ swiftTool: SwiftTool) throws {
         // Build the current package.
@@ -54,12 +51,10 @@ struct DumpSymbolGraph: SwiftCommand {
         let symbolGraphExtractor = try SymbolGraphExtract(
             fileSystem: swiftTool.fileSystem,
             tool: swiftTool.getDestinationToolchain().getSymbolGraphExtract(),
-            observabilityScope: swiftTool.observabilityScope,
             skipSynthesizedMembers: skipSynthesizedMembers,
             minimumAccessLevel: minimumAccessLevel,
             skipInheritedDocs: skipInheritedDocs,
             includeSPISymbols: includeSPISymbols,
-            emitExtensionBlockSymbols: extensionBlockSymbolBehavior == .emitExtensionBlockSymbols,
             outputFormat: .json(pretty: prettyPrint)
         )
 
@@ -79,11 +74,6 @@ struct DumpSymbolGraph: SwiftCommand {
 
         print("Files written to", symbolGraphDirectory.pathString)
     }
-}
-
-enum ExtensionBlockSymbolBehavior: String, EnumerableFlag {
-    case emitExtensionBlockSymbols
-    case omitExtensionBlockSymbols
 }
 
 struct DumpPackage: SwiftCommand {

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -338,8 +338,7 @@ final class PluginDelegate: PluginInvocationDelegate {
         // Configure the symbol graph extractor.
         var symbolGraphExtractor = try SymbolGraphExtract(
             fileSystem: swiftTool.fileSystem,
-            tool: swiftTool.getDestinationToolchain().getSymbolGraphExtract(),
-            observabilityScope: swiftTool.observabilityScope
+            tool: swiftTool.getDestinationToolchain().getSymbolGraphExtract()
         )
         symbolGraphExtractor.skipSynthesizedMembers = !options.includeSynthesized
         switch options.minimumAccessLevel {
@@ -356,7 +355,6 @@ final class PluginDelegate: PluginInvocationDelegate {
         }
         symbolGraphExtractor.skipInheritedDocs = true
         symbolGraphExtractor.includeSPISymbols = options.includeSPI
-        symbolGraphExtractor.emitExtensionBlockSymbols = options.emitExtensionBlocks
 
         // Determine the output directory, and remove any old version if it already exists.
         guard let package = packageGraph.package(for: target) else {

--- a/Sources/Commands/Utilities/SymbolGraphExtract.swift
+++ b/Sources/Commands/Utilities/SymbolGraphExtract.swift
@@ -16,19 +16,16 @@ import PackageGraph
 import PackageModel
 import SPMBuildCore
 import TSCBasic
-import DriverSupport
 
 /// A wrapper for swift-symbolgraph-extract tool.
 public struct SymbolGraphExtract {
     let fileSystem: FileSystem
     let tool: AbsolutePath
-    let observabilityScope: ObservabilityScope
     
     var skipSynthesizedMembers = false
     var minimumAccessLevel = AccessLevel.public
     var skipInheritedDocs = false
     var includeSPISymbols = false
-    var emitExtensionBlockSymbols = false
     var outputFormat = OutputFormat.json(pretty: false)
 
     /// Access control levels.
@@ -73,14 +70,6 @@ public struct SymbolGraphExtract {
         if includeSPISymbols {
             commandLine += ["-include-spi-symbols"]
         }
-        
-        let extensionBlockSymbolsFlag = emitExtensionBlockSymbols ? "-emit-extension-block-symbols" : "-omit-extension-block-symbols"
-        if DriverSupport.checkSupportedFrontendFlags(flags: [extensionBlockSymbolsFlag.trimmingCharacters(in: ["-"])], fileSystem: fileSystem) {
-            commandLine += [extensionBlockSymbolsFlag]
-        } else {
-            observabilityScope.emit(warning: "dropped \(extensionBlockSymbolsFlag) flag because it is not supported by this compiler version")
-        }
-        
         switch outputFormat {
         case .json(let pretty):
             if pretty {

--- a/Sources/PackagePlugin/PackageManagerProxy.swift
+++ b/Sources/PackagePlugin/PackageManagerProxy.swift
@@ -229,15 +229,11 @@ public struct PackageManager {
         
         /// Whether to include symbols marked as SPI.
         public var includeSPI: Bool
-
-        /// Whether to emit symbols for extensions to external types.
-        public var emitExtensionBlocks: Bool
         
-        public init(minimumAccessLevel: AccessLevel = .public, includeSynthesized: Bool = false, includeSPI: Bool = false, emitExtensionBlocks: Bool = false) {
+        public init(minimumAccessLevel: AccessLevel = .public, includeSynthesized: Bool = false, includeSPI: Bool = false) {
             self.minimumAccessLevel = minimumAccessLevel
             self.includeSynthesized = includeSynthesized
             self.includeSPI = includeSPI
-            self.emitExtensionBlocks = emitExtensionBlocks
         }
     }
 
@@ -414,7 +410,6 @@ fileprivate extension PluginToHostMessage.SymbolGraphOptions {
         self.minimumAccessLevel = .init(options.minimumAccessLevel)
         self.includeSynthesized = options.includeSynthesized
         self.includeSPI = options.includeSPI
-        self.emitExtensionBlocks = options.emitExtensionBlocks
     }
 }
 

--- a/Sources/PackagePlugin/PluginMessages.swift
+++ b/Sources/PackagePlugin/PluginMessages.swift
@@ -316,6 +316,5 @@ enum PluginToHostMessage: Codable {
             }
             var includeSynthesized: Bool
             var includeSPI: Bool
-            var emitExtensionBlocks: Bool
         }
 }

--- a/Sources/SPMBuildCore/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/PluginInvocation.swift
@@ -697,7 +697,6 @@ public struct PluginInvocationSymbolGraphOptions {
     }
     public var includeSynthesized: Bool
     public var includeSPI: Bool
-    public var emitExtensionBlocks: Bool
 }
 
 public struct PluginInvocationSymbolGraphResult {
@@ -958,7 +957,6 @@ fileprivate extension PluginInvocationSymbolGraphOptions {
         self.minimumAccessLevel = .init(options.minimumAccessLevel)
         self.includeSynthesized = options.includeSynthesized
         self.includeSPI = options.includeSPI
-        self.emitExtensionBlocks = options.emitExtensionBlocks
     }
 }
 


### PR DESCRIPTION
Reverts apple/swift-package-manager#5892

Breaks the windows build due to missing dependencies.