### PR TITLE
Update old link to Swift Jira in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The Swift package manager uses [llbuild](https://github.com/apple/swift-llbuild)
 If you have any trouble with the package manager, help is available. We recommend:
 
 * The [Swift Forums](https://forums.swift.org/c/development/swiftpm/),
-* Swift's [bug tracker](https://bugs.swift.org)
+* SwiftPM's [bug tracker](https://github.com/apple/swift-package-manager/issues)
 
 When reporting an issue please follow the bug reporting guidelines, they can be found in [contribution guide](./CONTRIBUTING.md#reporting-issues).
 


### PR DESCRIPTION
While bugs.swift.org no longer hosts Jira and redirect's to `swift` repository issue tracker, that's still wrong. We should direct people to SwiftPM's issue tracker.
