### PR TITLE
Fix "Add emit extension block symbols option to `dump-symbol-graph` and `SymbolGraphOptions`"

### DIFF
--- a/Sources/Commands/PackageTools/DumpCommands.swift
+++ b/Sources/Commands/PackageTools/DumpCommands.swift
@@ -39,6 +39,9 @@ struct DumpSymbolGraph: SwiftCommand {
 
     @Flag(help: "Add symbols with SPI information to the symbol graph.")
     var includeSPISymbols = false
+    
+    @Flag(help: "Emit extension block symbols for extensions to external types or directly associate members and conformances with the extended nominal.")
+    var extensionBlockSymbolBehavior: ExtensionBlockSymbolBehavior = .omitExtensionBlockSymbols
 
     func run(_ swiftTool: SwiftTool) throws {
         // Build the current package.
@@ -51,10 +54,12 @@ struct DumpSymbolGraph: SwiftCommand {
         let symbolGraphExtractor = try SymbolGraphExtract(
             fileSystem: swiftTool.fileSystem,
             tool: swiftTool.getDestinationToolchain().getSymbolGraphExtract(),
+            observabilityScope: swiftTool.observabilityScope,
             skipSynthesizedMembers: skipSynthesizedMembers,
             minimumAccessLevel: minimumAccessLevel,
             skipInheritedDocs: skipInheritedDocs,
             includeSPISymbols: includeSPISymbols,
+            emitExtensionBlockSymbols: extensionBlockSymbolBehavior == .emitExtensionBlockSymbols,
             outputFormat: .json(pretty: prettyPrint)
         )
 
@@ -74,6 +79,11 @@ struct DumpSymbolGraph: SwiftCommand {
 
         print("Files written to", symbolGraphDirectory.pathString)
     }
+}
+
+enum ExtensionBlockSymbolBehavior: String, EnumerableFlag {
+    case emitExtensionBlockSymbols
+    case omitExtensionBlockSymbols
 }
 
 struct DumpPackage: SwiftCommand {

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -338,7 +338,8 @@ final class PluginDelegate: PluginInvocationDelegate {
         // Configure the symbol graph extractor.
         var symbolGraphExtractor = try SymbolGraphExtract(
             fileSystem: swiftTool.fileSystem,
-            tool: swiftTool.getDestinationToolchain().getSymbolGraphExtract()
+            tool: swiftTool.getDestinationToolchain().getSymbolGraphExtract(),
+            observabilityScope: swiftTool.observabilityScope
         )
         symbolGraphExtractor.skipSynthesizedMembers = !options.includeSynthesized
         switch options.minimumAccessLevel {
@@ -355,6 +356,7 @@ final class PluginDelegate: PluginInvocationDelegate {
         }
         symbolGraphExtractor.skipInheritedDocs = true
         symbolGraphExtractor.includeSPISymbols = options.includeSPI
+        symbolGraphExtractor.emitExtensionBlockSymbols = options.emitExtensionBlocks
 
         // Determine the output directory, and remove any old version if it already exists.
         guard let package = packageGraph.package(for: target) else {

--- a/Sources/Commands/Utilities/SymbolGraphExtract.swift
+++ b/Sources/Commands/Utilities/SymbolGraphExtract.swift
@@ -16,7 +16,7 @@ import PackageGraph
 import PackageModel
 import SPMBuildCore
 import TSCBasic
-import DriverSupport
+@_implementationOnly import DriverSupport
 
 /// A wrapper for swift-symbolgraph-extract tool.
 public struct SymbolGraphExtract {

--- a/Sources/PackagePlugin/PackageManagerProxy.swift
+++ b/Sources/PackagePlugin/PackageManagerProxy.swift
@@ -229,11 +229,15 @@ public struct PackageManager {
         
         /// Whether to include symbols marked as SPI.
         public var includeSPI: Bool
+
+        /// Whether to emit symbols for extensions to external types.
+        public var emitExtensionBlocks: Bool
         
-        public init(minimumAccessLevel: AccessLevel = .public, includeSynthesized: Bool = false, includeSPI: Bool = false) {
+        public init(minimumAccessLevel: AccessLevel = .public, includeSynthesized: Bool = false, includeSPI: Bool = false, emitExtensionBlocks: Bool = false) {
             self.minimumAccessLevel = minimumAccessLevel
             self.includeSynthesized = includeSynthesized
             self.includeSPI = includeSPI
+            self.emitExtensionBlocks = emitExtensionBlocks
         }
     }
 
@@ -410,6 +414,7 @@ fileprivate extension PluginToHostMessage.SymbolGraphOptions {
         self.minimumAccessLevel = .init(options.minimumAccessLevel)
         self.includeSynthesized = options.includeSynthesized
         self.includeSPI = options.includeSPI
+        self.emitExtensionBlocks = options.emitExtensionBlocks
     }
 }
 

--- a/Sources/PackagePlugin/PluginMessages.swift
+++ b/Sources/PackagePlugin/PluginMessages.swift
@@ -316,5 +316,6 @@ enum PluginToHostMessage: Codable {
             }
             var includeSynthesized: Bool
             var includeSPI: Bool
+            var emitExtensionBlocks: Bool
         }
 }

--- a/Sources/SPMBuildCore/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/PluginInvocation.swift
@@ -697,6 +697,7 @@ public struct PluginInvocationSymbolGraphOptions {
     }
     public var includeSynthesized: Bool
     public var includeSPI: Bool
+    public var emitExtensionBlocks: Bool
 }
 
 public struct PluginInvocationSymbolGraphResult {
@@ -957,6 +958,7 @@ fileprivate extension PluginInvocationSymbolGraphOptions {
         self.minimumAccessLevel = .init(options.minimumAccessLevel)
         self.includeSynthesized = options.includeSynthesized
         self.includeSPI = options.includeSPI
+        self.emitExtensionBlocks = options.emitExtensionBlocks
     }
 }
 


### PR DESCRIPTION
Fixes apple/swift-package-manager#5892. ~~Reverts apple/swift-package-manager#5975. The Windows build failure had nothing to do with the original PR #5892.~~

~~The [previous windows build](https://ci-external.swift.org/job/swiftpm-PR-windows/697/) for #5950, which does not include the changes from #5892 fails in exactly the same way.~~