### PR TITLE
Disable VFS overlay on Windows

### DIFF
--- a/Tests/PackageLoadingTests/PD_5_6_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_6_LoadingTests.swift
@@ -215,6 +215,10 @@ class PackageDescription5_6LoadingTests: PackageDescriptionLoadingTests {
 
     /// Tests access to the package's directory contents.
     func testPackageContextDirectory() throws {
+        #if os(Windows)
+        throw XCTSkip("Skipping since this tests does not fully work without the VFS overlay which is currently disabled on Windows")
+        #endif
+
         let content = """
             import PackageDescription
             import Foundation


### PR DESCRIPTION
It looks like we're seeing an issue with the use of the VFS overlay on Windows which leads to manifests being loaded from the current working directory instead of the path mapped by the VFS. While we are investigating a solution, disable the use of the overlay on Windows since its intent is having more correct paths in diagnostics which is mostly cosmetic.
