### PR TITLE
PackageModel: partially address #5719

### DIFF
--- a/Tests/PackageModelTests/PackageModelTests.swift
+++ b/Tests/PackageModelTests/PackageModelTests.swift
@@ -39,7 +39,7 @@ class PackageModelTests: XCTestCase {
         checkCodable(.executable)
         checkCodable(.test)
     }
-    
+
     func testProductFilterCodable() throws {
         // Test ProductFilter.everything
         try {
@@ -66,9 +66,77 @@ class PackageModelTests: XCTestCase {
             toolchainBinDir: toolchainPath.appending(components: "usr", "bin")
         )
 
-        XCTAssertEqual(try UserToolchain.deriveSwiftCFlags(triple: triple, destination: destination, environment: .process()), [
-            // Needed when cross‐compiling for Android. 2020‐03‐01
-            "-sdk", sdkDir.pathString,
-        ])
+        XCTAssertEqual(
+            try UserToolchain.deriveSwiftCFlags(triple: triple, destination: destination, environment: .process()),
+            [
+                // Needed when cross‐compiling for Android. 2020‐03‐01
+                "-sdk", sdkDir.pathString,
+            ]
+        )
+    }
+
+    func testWindowsLibrarianSelection() throws {
+        // tiny PE binary from: https://archive.is/w01DO
+        let contents: [UInt8] = [
+            0x4D, 0x5A, 0x00, 0x00, 0x50, 0x45, 0x00, 0x00, 0x4C, 0x01, 0x01, 0x00,
+            0x6A, 0x2A, 0x58, 0xC3, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x04, 0x00, 0x03, 0x01, 0x0B, 0x01, 0x08, 0x00, 0x04, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x0C, 0x00, 0x00, 0x00,
+            0x04, 0x00, 0x00, 0x00, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00,
+            0x04, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x68, 0x00, 0x00, 0x00, 0x64, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x02,
+        ]
+
+        #if os(Windows)
+        let suffix = ".exe"
+        #else
+        let suffix = ""
+        #endif
+
+        let triple = try Triple("x86_64-unknown-windows-msvc")
+        let fs = TSCBasic.localFileSystem
+
+        try withTemporaryFile { [contents] _ in
+            try withTemporaryDirectory(removeTreeOnDeinit: true) { [contents] tmp in
+                let bin = tmp.appending(component: "bin")
+                try fs.createDirectory(bin)
+
+                let lld = bin.appending(component: "lld-link\(suffix)")
+                try fs.writeFileContents(lld, bytes: ByteString(contents))
+
+                let not = bin.appending(component: "not-link\(suffix)")
+                try fs.writeFileContents(not, bytes: ByteString(contents))
+
+                #if !os(Windows)
+                try fs.chmod(.executable, path: lld, options: [])
+                try fs.chmod(.executable, path: not, options: [])
+                #endif
+
+                try XCTAssertEqual(
+                    UserToolchain.determineLibrarian(
+                        triple: triple, binDir: bin, useXcrun: false, environment: [:], searchPaths: [],
+                        extraSwiftFlags: ["-Xswiftc", "-use-ld=lld"]
+                    ),
+                    lld
+                )
+
+                try XCTAssertEqual(
+                    UserToolchain.determineLibrarian(
+                        triple: triple, binDir: bin, useXcrun: false, environment: [:], searchPaths: [],
+                        extraSwiftFlags: ["-Xswiftc", "-use-ld=not-link\(suffix)"]
+                    ),
+                    not
+                )
+
+                try XCTAssertThrowsError(
+                    UserToolchain.determineLibrarian(
+                        triple: triple, binDir: bin, useXcrun: false, environment: [:], searchPaths: [],
+                        extraSwiftFlags: []
+                    )
+                )
+            }
+        }
     }
 }


### PR DESCRIPTION
Handle `-use-ld=` from the configuration in the selection of the librarian.  We do not honour the `-Xmanifest` or `-Xswiftc` flags being passed on the command line rather than the plist as we cannot pre-compute the flags.