### PR TITLE
Add package metadata to a few more ObservabilityScopes in workspace-wide and package graph loading operations

### DIFF
--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -353,7 +353,7 @@ private func createResolvedPackages(
         )
 
         // Create target builders for each target in the package.
-        let targetBuilders = package.targets.map{ ResolvedTargetBuilder(target: $0, observabilityScope: observabilityScope) }
+        let targetBuilders = package.targets.map{ ResolvedTargetBuilder(target: $0, observabilityScope: packageObservabilityScope) }
         packageBuilder.targets = targetBuilders
 
         // Establish dependencies between the targets. A target can only depend on another target present in the same package.

--- a/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
+++ b/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
@@ -1315,7 +1315,7 @@ private final class ContainerProvider {
             self.underlying.getContainer(
                 for: package,
                 skipUpdate: self.skipUpdate,
-                observabilityScope: self.observabilityScope,
+                observabilityScope: self.observabilityScope.makeChildScope(description: "getting package container", metadata: package.diagnosticsMetadata),
                 on: .sharedConcurrent
             ) { result in
                 let result = result.tryMap { container -> PubGrubPackageContainer in
@@ -1344,7 +1344,7 @@ private final class ContainerProvider {
                 self.underlying.getContainer(
                     for: identifier,
                     skipUpdate: self.skipUpdate,
-                    observabilityScope: self.observabilityScope,
+                    observabilityScope: self.observabilityScope.makeChildScope(description: "prefetcing package container", metadata: identifier.diagnosticsMetadata),
                     on: .sharedConcurrent
                 ) { result in
                     defer { self.prefetches[identifier]?.leave() }

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -4603,11 +4603,13 @@ final class WorkspaceTests: XCTestCase {
                     diagnostic: .equal("the target 'Baz' in product 'Baz' contains unsafe build flags"),
                     severity: .error
                 )
+                XCTAssertEqual(diagnostic1?.metadata?.packageIdentity, .plain("foo"))
                 XCTAssertEqual(diagnostic1?.metadata?.targetName, "Foo")
                 let diagnostic2 = result.checkUnordered(
                     diagnostic: .equal("the target 'Bar' in product 'Baz' contains unsafe build flags"),
                     severity: .error
                 )
+                XCTAssertEqual(diagnostic2?.metadata?.packageIdentity, .plain("foo"))
                 XCTAssertEqual(diagnostic2?.metadata?.targetName, "Foo")
             }
         }


### PR DESCRIPTION
Fix more cases in which there is a relevant package or package reference, but where the `ObservabilityScope` didn't have the metadata.

### Motivation:

Clients of libSwiftPM that present diagnostics use the package metadata that can optionally be attached to an emitted `Diagnostic` to associate it with the package in the user interface.
### Modifications:

This change addresses a few more cases in which no package metadata was associated.  Where possible, the metadata is associated with the `ObservabilityScope` at the highest place in the call stack so that any diagnostic emitted below it gets the package metadata.

- create child scopes with associated package metadata
- add the metadata directly to a couple of `emit()` calls where it wasn't clearly correct to create a new child scope
- extend a unit test

### Result:

The diagnostic's metadata will have the package identity in more of the cases where there is a relevant package.

rdar://103561534
