### PR TITLE
Fix "Add emit extension block symbols option to dump-symbol-graph and SymbolGraphOptions"

### DIFF
--- a/Sources/Commands/PackageTools/DumpCommands.swift
+++ b/Sources/Commands/PackageTools/DumpCommands.swift
@@ -39,6 +39,9 @@ struct DumpSymbolGraph: SwiftCommand {
 
     @Flag(help: "Add symbols with SPI information to the symbol graph.")
     var includeSPISymbols = false
+    
+    @Flag(help: "Emit extension block symbols for extensions to external types or directly associate members and conformances with the extended nominal.")
+    var extensionBlockSymbolBehavior: ExtensionBlockSymbolBehavior = .omitExtensionBlockSymbols
 
     func run(_ swiftTool: SwiftTool) throws {
         // Build the current package.
@@ -51,10 +54,12 @@ struct DumpSymbolGraph: SwiftCommand {
         let symbolGraphExtractor = try SymbolGraphExtract(
             fileSystem: swiftTool.fileSystem,
             tool: swiftTool.getDestinationToolchain().getSymbolGraphExtract(),
+            observabilityScope: swiftTool.observabilityScope,
             skipSynthesizedMembers: skipSynthesizedMembers,
             minimumAccessLevel: minimumAccessLevel,
             skipInheritedDocs: skipInheritedDocs,
             includeSPISymbols: includeSPISymbols,
+            emitExtensionBlockSymbols: extensionBlockSymbolBehavior == .emitExtensionBlockSymbols,
             outputFormat: .json(pretty: prettyPrint)
         )
 
@@ -74,6 +79,11 @@ struct DumpSymbolGraph: SwiftCommand {
 
         print("Files written to", symbolGraphDirectory.pathString)
     }
+}
+
+enum ExtensionBlockSymbolBehavior: String, EnumerableFlag {
+    case emitExtensionBlockSymbols
+    case omitExtensionBlockSymbols
 }
 
 struct DumpPackage: SwiftCommand {

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -338,7 +338,8 @@ final class PluginDelegate: PluginInvocationDelegate {
         // Configure the symbol graph extractor.
         var symbolGraphExtractor = try SymbolGraphExtract(
             fileSystem: swiftTool.fileSystem,
-            tool: swiftTool.getDestinationToolchain().getSymbolGraphExtract()
+            tool: swiftTool.getDestinationToolchain().getSymbolGraphExtract(),
+            observabilityScope: swiftTool.observabilityScope
         )
         symbolGraphExtractor.skipSynthesizedMembers = !options.includeSynthesized
         switch options.minimumAccessLevel {
@@ -355,6 +356,7 @@ final class PluginDelegate: PluginInvocationDelegate {
         }
         symbolGraphExtractor.skipInheritedDocs = true
         symbolGraphExtractor.includeSPISymbols = options.includeSPI
+        symbolGraphExtractor.emitExtensionBlockSymbols = options.emitExtensionBlocks
 
         // Determine the output directory, and remove any old version if it already exists.
         guard let package = packageGraph.package(for: target) else {

--- a/Sources/Commands/Utilities/SymbolGraphExtract.swift
+++ b/Sources/Commands/Utilities/SymbolGraphExtract.swift
@@ -16,7 +16,7 @@ import PackageGraph
 import PackageModel
 import SPMBuildCore
 import TSCBasic
-import DriverSupport
+@_implementationOnly import DriverSupport
 
 /// A wrapper for swift-symbolgraph-extract tool.
 public struct SymbolGraphExtract {

--- a/Sources/PackagePlugin/PackageManagerProxy.swift
+++ b/Sources/PackagePlugin/PackageManagerProxy.swift
@@ -229,11 +229,15 @@ public struct PackageManager {
         
         /// Whether to include symbols marked as SPI.
         public var includeSPI: Bool
+
+        /// Whether to emit symbols for extensions to external types.
+        public var emitExtensionBlocks: Bool
         
-        public init(minimumAccessLevel: AccessLevel = .public, includeSynthesized: Bool = false, includeSPI: Bool = false) {
+        public init(minimumAccessLevel: AccessLevel = .public, includeSynthesized: Bool = false, includeSPI: Bool = false, emitExtensionBlocks: Bool = false) {
             self.minimumAccessLevel = minimumAccessLevel
             self.includeSynthesized = includeSynthesized
             self.includeSPI = includeSPI
+            self.emitExtensionBlocks = emitExtensionBlocks
         }
     }
 
@@ -410,6 +414,7 @@ fileprivate extension PluginToHostMessage.SymbolGraphOptions {
         self.minimumAccessLevel = .init(options.minimumAccessLevel)
         self.includeSynthesized = options.includeSynthesized
         self.includeSPI = options.includeSPI
+        self.emitExtensionBlocks = options.emitExtensionBlocks
     }
 }
 

--- a/Sources/PackagePlugin/PluginMessages.swift
+++ b/Sources/PackagePlugin/PluginMessages.swift
@@ -316,5 +316,6 @@ enum PluginToHostMessage: Codable {
             }
             var includeSynthesized: Bool
             var includeSPI: Bool
+            var emitExtensionBlocks: Bool
         }
 }

--- a/Sources/SPMBuildCore/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/PluginInvocation.swift
@@ -697,6 +697,7 @@ public struct PluginInvocationSymbolGraphOptions {
     }
     public var includeSynthesized: Bool
     public var includeSPI: Bool
+    public var emitExtensionBlocks: Bool
 }
 
 public struct PluginInvocationSymbolGraphResult {
@@ -957,6 +958,7 @@ fileprivate extension PluginInvocationSymbolGraphOptions {
         self.minimumAccessLevel = .init(options.minimumAccessLevel)
         self.includeSynthesized = options.includeSynthesized
         self.includeSPI = options.includeSPI
+        self.emitExtensionBlocks = options.emitExtensionBlocks
     }
 }
 


### PR DESCRIPTION
This PR reintroduces support for emitting extension block symbols for the `dump-symbol-graph` command originally introduced by #5892 and reverted by #5975.

### Reversion

The original PR #5892 was reverted because it caused a CMake build failure on Windows that hadn't been reported in the GitHub CI overview for the PR. This was fixed with 1de306b15aa4c386102d9295e68e313609419a7a. #5978, which contains the exact same changes as this PR, already landed on main. However, due to an unrelated build failure in the toolchain (see comments on #5978), merging #5978 was delayed until after the Swift 5.8 branch off. 

The following sections are taken from #5892 and should provide a good overview over the scope of this change and its impact on the Swift 5.8 release.

### Motivation:

Extension block symbols with the respective command line flags `-emit-extension-block-symbols` and `-omit-extension-block-symbols` were introduced in apple/swift#59047 and apple/swift#61637 as part of an ongoing effort to solve apple/swift-docc#210. These flags should be exposed in higher-level commands such as `swift package dump-symbol-graph` as well as the package plugin API, so that users and package manager plugins such as [apple/swift-docc-plugin](https://github.com/apple/swift-docc-plugin) can access them more easily. This PR is the last step before we can provide extension support in the DocC Package Plugin.

### Modifications:

This PR adds the flag-pair `--emit-extension-block-symbols`/`--omit-extension-block-symbols` to the `DumpSymbolGraph` command and exposes the `emitExtensionBlocks` option in `PluginToHostMessage.SymbolGraphOptions`. `SymbolGraphExtract` was also extended by an `emitExtensionBlockSymbols` option and its `extractSymbolGraph` function adds the respective compiler command line flag accordingly.

### Result:

`swift package dump-symbol-graph --emit-extension-block-symbols` dumps symbol graph files that extension block symbol format. The default behavior does not change. The `--omit-extension-block-symbols` flag will be used to explicitly disable the feature once the default behavior has been changed to `--emit-extension-block-symbols` in the future.

Package Plugins can specify the `emitExtensionBlocks` property requesting symbol graphs, e.g.:

```swift
import PackagePlugin

// ...
try getSymbolGraph(for: target, options: PackageManager.SymbolGraphOptions(
            minimumAccessLevel: targetMinimumAccessLevel,
            includeSynthesized: true,
            includeSPI: false,
            emitExtensionBlocks: true
        ))
```

**The default behavior for package plugins also does not change.**
