### PR TITLE
[5.8] Add package metadata to a few more ObservabilityScopes in workspace-wide package operations

### DIFF
--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -353,7 +353,7 @@ private func createResolvedPackages(
         )
 
         // Create target builders for each target in the package.
-        let targetBuilders = package.targets.map{ ResolvedTargetBuilder(target: $0, observabilityScope: observabilityScope) }
+        let targetBuilders = package.targets.map{ ResolvedTargetBuilder(target: $0, observabilityScope: packageObservabilityScope) }
         packageBuilder.targets = targetBuilders
 
         // Establish dependencies between the targets. A target can only depend on another target present in the same package.

--- a/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
+++ b/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
@@ -1315,7 +1315,7 @@ private final class ContainerProvider {
             self.underlying.getContainer(
                 for: package,
                 skipUpdate: self.skipUpdate,
-                observabilityScope: self.observabilityScope,
+                observabilityScope: self.observabilityScope.makeChildScope(description: "getting package container", metadata: package.diagnosticsMetadata),
                 on: .sharedConcurrent
             ) { result in
                 let result = result.tryMap { container -> PubGrubPackageContainer in
@@ -1344,7 +1344,7 @@ private final class ContainerProvider {
                 self.underlying.getContainer(
                     for: identifier,
                     skipUpdate: self.skipUpdate,
-                    observabilityScope: self.observabilityScope,
+                    observabilityScope: self.observabilityScope.makeChildScope(description: "prefetcing package container", metadata: identifier.diagnosticsMetadata),
                     on: .sharedConcurrent
                 ) { result in
                     defer { self.prefetches[identifier]?.leave() }

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -4603,11 +4603,13 @@ final class WorkspaceTests: XCTestCase {
                     diagnostic: .equal("the target 'Baz' in product 'Baz' contains unsafe build flags"),
                     severity: .error
                 )
+                XCTAssertEqual(diagnostic1?.metadata?.packageIdentity, .plain("foo"))
                 XCTAssertEqual(diagnostic1?.metadata?.targetName, "Foo")
                 let diagnostic2 = result.checkUnordered(
                     diagnostic: .equal("the target 'Bar' in product 'Baz' contains unsafe build flags"),
                     severity: .error
                 )
+                XCTAssertEqual(diagnostic2?.metadata?.packageIdentity, .plain("foo"))
                 XCTAssertEqual(diagnostic2?.metadata?.targetName, "Foo")
             }
         }


### PR DESCRIPTION
SwiftPM 5.8 nomination of https://github.com/apple/swift-package-manager/pull/5984.

rdar://103561534
(cherry picked from commit 723a5925412f756333a77fee74aedae13569814e)
