### PR TITLE
SwiftPM outputs raw diagnostics from SwiftDriver without trailing newlines [5968]

### DIFF
--- a/Sources/Build/SwiftCompilerOutputParser.swift
+++ b/Sources/Build/SwiftCompilerOutputParser.swift
@@ -162,7 +162,7 @@ extension SwiftCompilerOutputParser: JSONMessageStreamingParserDelegate {
             return
         }
 
-        let message = SwiftCompilerMessage(name: "unknown", kind: .unparsableOutput(text))
+        let message = SwiftCompilerMessage(name: "unknown", kind: .unparsableOutput(text + "\n"))
         delegate?.swiftCompilerOutputParser(self, didParse: message)
     }
 

--- a/Tests/BuildTests/SwiftCompilerOutputParserTests.swift
+++ b/Tests/BuildTests/SwiftCompilerOutputParserTests.swift
@@ -156,7 +156,7 @@ class SwiftCompilerOutputParserTests: XCTestCase {
 
             """.utf8)
         delegate.assert(messages: [
-            SwiftCompilerMessage(name: "unknown", kind: .unparsableOutput("2A"))
+            SwiftCompilerMessage(name: "unknown", kind: .unparsableOutput("2A\n"))
         ], errorDescription: nil)
 
         parser.parse(bytes: """

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -390,4 +390,16 @@ final class BuildToolTests: CommandsTestCase {
             XCTAssertMatch(output, .prefix("digraph Jobs {"))
         }
     }
+    
+    func testSwiftDriverRawOutputGetsNewlines() throws {
+        try fixture(name: "DependencyResolution/Internal/Simple") { fixturePath in
+            // Building with `-wmo` should result in a `remark: Incremental compilation has been disabled: it is not compatible with whole module optimization` message, which should have a trailing newline.  Since that message won't be there at all when the legacy compiler driver is used, we gate this check on whether the remark is there in the first place.
+            let result = try execute(["-c", "release", "-Xswiftc", "-wmo"], packagePath: fixturePath)
+            if result.stdout.contains("remark: Incremental compilation has been disabled: it is not compatible with whole module optimization") {
+                XCTAssertMatch(result.stdout, .contains("optimization\n"))
+                XCTAssertNoMatch(result.stdout, .contains("optimization["))
+                XCTAssertNoMatch(result.stdout, .contains("optimizationremark"))
+            }
+        }
+    }
 }


### PR DESCRIPTION
SwiftPM uses the Swift Driver's `-parseable-output` flag to get a sequence of length-prefixed JSON-encoded messages that it can read.  Unfortunately the Swift Driver doesn't JSON-encode its own diagnostics, leading to things like https://github.com/apple/swift-package-manager/issues/5968.

I filed https://github.com/apple/swift-driver/issues/1241 on the Swift Driver to get it to encode its JSON messages, but meanwhile, it turns out that we can fairly easily fix the fallback logic that SwiftPM uses when it emits raw output.  It was simply missing a newline.  It's safe to always add one, since the logic that parses JSON splits by newlines, so we won't find any terminating newlines.

### Modifications:

- add a newline after emitting the unparseable line of Swift Driver output
- add a unit test

### Result:

Raw output from the Swift Driver has trailing newlines.

rdar://103608636