### PR TITLE
Add quiet flag (-q, --quiet) to LoggingOptions.

### DIFF
--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -138,6 +138,10 @@ public struct LoggingOptions: ParsableArguments {
     /// The verbosity of informational output.
     @Flag(name: [.long, .customLong("vv")], help: "Increase verbosity to include debug output")
     public var veryVerbose: Bool = false
+
+    /// Whether logging output should be limited to error.
+    @Flag(name: .shortAndLong, help: "Decrease verbosity to only include error output.")
+    public var quiet: Bool = false
 }
 
 public struct SecurityOptions: ParsableArguments {

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -139,7 +139,7 @@ public struct LoggingOptions: ParsableArguments {
     @Flag(name: [.long, .customLong("vv")], help: "Increase verbosity to include debug output")
     public var veryVerbose: Bool = false
 
-    /// Whether logging output should be limited to error.
+    /// Whether logging output should be limited to `.error`.
     @Flag(name: .shortAndLong, help: "Decrease verbosity to only include error output.")
     public var quiet: Bool = false
 }

--- a/Sources/CoreCommands/SwiftTool.swift
+++ b/Sources/CoreCommands/SwiftTool.swift
@@ -822,6 +822,8 @@ extension LoggingOptions {
             return .info
         } else if self.veryVerbose {
             return .debug
+        } else if self.quiet {
+            return .error
         } else {
             return .warning
         }

--- a/Tests/CommandsTests/SwiftToolTests.swift
+++ b/Tests/CommandsTests/SwiftToolTests.swift
@@ -115,6 +115,44 @@ final class SwiftToolTests: CommandsTestCase {
                 XCTAssertMatch(outputStream.bytes.validDescription, .contains("info: info"))
                 XCTAssertMatch(outputStream.bytes.validDescription, .contains("debug: debug"))
             }
+
+            do {
+                let outputStream = BufferedOutputByteStream()
+                let options = try GlobalOptions.parse(["--package-path", fixturePath.pathString, "--quiet"])
+                let tool = try SwiftTool.createSwiftToolForTest(outputStream: outputStream, options: options)
+                XCTAssertEqual(tool.logLevel, .error)
+
+                tool.observabilityScope.emit(error: "error")
+                tool.observabilityScope.emit(warning: "warning")
+                tool.observabilityScope.emit(info: "info")
+                tool.observabilityScope.emit(debug: "debug")
+
+                tool.waitForObservabilityEvents(timeout: .now() + .seconds(1))
+
+                XCTAssertMatch(outputStream.bytes.validDescription, .contains("error: error"))
+                XCTAssertNoMatch(outputStream.bytes.validDescription, .contains("warning: warning"))
+                XCTAssertNoMatch(outputStream.bytes.validDescription, .contains("info: info"))
+                XCTAssertNoMatch(outputStream.bytes.validDescription, .contains("debug: debug"))
+            }
+
+            do {
+                let outputStream = BufferedOutputByteStream()
+                let options = try GlobalOptions.parse(["--package-path", fixturePath.pathString, "-q"])
+                let tool = try SwiftTool.createSwiftToolForTest(outputStream: outputStream, options: options)
+                XCTAssertEqual(tool.logLevel, .error)
+
+                tool.observabilityScope.emit(error: "error")
+                tool.observabilityScope.emit(warning: "warning")
+                tool.observabilityScope.emit(info: "info")
+                tool.observabilityScope.emit(debug: "debug")
+
+                tool.waitForObservabilityEvents(timeout: .now() + .seconds(1))
+
+                XCTAssertMatch(outputStream.bytes.validDescription, .contains("error: error"))
+                XCTAssertNoMatch(outputStream.bytes.validDescription, .contains("warning: warning"))
+                XCTAssertNoMatch(outputStream.bytes.validDescription, .contains("info: info"))
+                XCTAssertNoMatch(outputStream.bytes.validDescription, .contains("debug: debug"))
+            }
         }
     }
 


### PR DESCRIPTION
This PR adds a quiet flag (`-q`, `--quiet`) to `swift` commands which suppresses all but error output.

### Motivation:

Closes #4395. Executable targets often depend on the output of other executable targets. When an executable target is run with `swift`, there is currently no way to suppress the build output, which makes it more difficult to pass the output of one executable as the input of another. The new quiet flag suppresses all output except errors.

### Modifications:

- Added a `@Flag` to `LoggingOptions`
- Interpret that flag as a `Diagnostic.Severity` in `LoggingOptions.logLevel`.
- Added tests for both the short and long flag.

### Result:

When a user passes the quiet flag, only errors will be logged.
