### PR TITLE
5.8: set `relatedDependenciesBranch` to 5.8 in `Package.swift`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -651,7 +651,7 @@ let package = Package(
 // this right now.
 
 /// When not using local dependencies, the branch to use for llbuild and TSC repositories.
-let relatedDependenciesBranch = "main"
+let relatedDependenciesBranch = "release/5.8"
 
 if ProcessInfo.processInfo.environment["SWIFTPM_LLBUILD_FWK"] == nil {
     if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {


### PR DESCRIPTION
This makes sure that dependencies of SwiftPM built with SwiftPM and coming from the Swift project use `release/5.8` branch.
