### PR TITLE
PackageGraphRoot.swift: fix typo in comment

### DIFF
--- a/Sources/PackageGraph/PackageGraphRoot.swift
+++ b/Sources/PackageGraph/PackageGraphRoot.swift
@@ -66,7 +66,7 @@ public struct PackageGraphRoot {
         // FIXME: Deprecate special casing once the manifest supports declaring used executable products.
         // Special casing explicit products like this is necessary to pass the test suite and satisfy backwards compatibility.
         // However, changing the dependencies based on the command line arguments may force pins to temporarily change,
-        // which can become a nuissance.
+        // which can become a nuisance.
         // Such pin switching can currently be worked around by declaring the executable product as a dependency of a dummy target.
         // But in the future it might be worth providing a way of declaring them in the manifest without a dummy target,
         // at which time the current special casing can be deprecated.


### PR DESCRIPTION
`nuissance` -> `nuisance`