### PR TITLE
There's no need to pretty-print the JSON that a compiled manifest sends back to SwiftPM

### DIFF
--- a/Sources/PackageDescription/PackageDescription.swift
+++ b/Sources/PackageDescription/PackageDescription.swift
@@ -444,7 +444,7 @@ func manifestToJSON(_ package: Package) -> String {
     }
 
     let encoder = JSONEncoder()
-    encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+    encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
     let data = try! encoder.encode(Output(package: package, errors: errors))
     return String(data: data, encoding: .utf8)!
 }


### PR DESCRIPTION
SwiftPM manifests are compiled and then run, and they communicate the results representing the package structure back to SwiftPM via a JSON-encoded dictionary.  This JSON is currently pretty-printed, which includes inserting a bunch of whitespace.

### Motivation

In my measurements we can save about 35%-40% of the byte size by just skipping this formatting.  Anybody who wants to look at it for debugging purposes can just run it through `json_pp` or a similar formatter.

We still keep `.sortedKeys` for stability, and `.withoutEscapingSlashes` to avoid adding unnecessary escapes for path separators.

### Modifications:

- remove the option to pretty-print the JSON emitted by the PackageDescription

### Result:

No functional change, but cached manifests should be between 35% and 40% smaller.
