### PR TITLE
[5.8] SwiftPM outputs raw diagnostics from SwiftDriver without trailing newlines

### DIFF
--- a/Sources/Build/SwiftCompilerOutputParser.swift
+++ b/Sources/Build/SwiftCompilerOutputParser.swift
@@ -162,7 +162,7 @@ extension SwiftCompilerOutputParser: JSONMessageStreamingParserDelegate {
             return
         }
 
-        let message = SwiftCompilerMessage(name: "unknown", kind: .unparsableOutput(text))
+        let message = SwiftCompilerMessage(name: "unknown", kind: .unparsableOutput(text + "\n"))
         delegate?.swiftCompilerOutputParser(self, didParse: message)
     }
 

--- a/Tests/BuildTests/SwiftCompilerOutputParserTests.swift
+++ b/Tests/BuildTests/SwiftCompilerOutputParserTests.swift
@@ -156,7 +156,7 @@ class SwiftCompilerOutputParserTests: XCTestCase {
 
             """.utf8)
         delegate.assert(messages: [
-            SwiftCompilerMessage(name: "unknown", kind: .unparsableOutput("2A"))
+            SwiftCompilerMessage(name: "unknown", kind: .unparsableOutput("2A\n"))
         ], errorDescription: nil)
 
         parser.parse(bytes: """

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -390,4 +390,16 @@ final class BuildToolTests: CommandsTestCase {
             XCTAssertMatch(output, .prefix("digraph Jobs {"))
         }
     }
+    
+    func testSwiftDriverRawOutputGetsNewlines() throws {
+        try fixture(name: "DependencyResolution/Internal/Simple") { fixturePath in
+            // Building with `-wmo` should result in a `remark: Incremental compilation has been disabled: it is not compatible with whole module optimization` message, which should have a trailing newline.  Since that message won't be there at all when the legacy compiler driver is used, we gate this check on whether the remark is there in the first place.
+            let result = try execute(["-c", "release", "-Xswiftc", "-wmo"], packagePath: fixturePath)
+            if result.stdout.contains("remark: Incremental compilation has been disabled: it is not compatible with whole module optimization") {
+                XCTAssertMatch(result.stdout, .contains("optimization\n"))
+                XCTAssertNoMatch(result.stdout, .contains("optimization["))
+                XCTAssertNoMatch(result.stdout, .contains("optimizationremark"))
+            }
+        }
+    }
 }


### PR DESCRIPTION
This is the 5.8 nomination of https://github.com/apple/swift-package-manager/pull/5987.
rdar://103608636
(cherry picked from commit 14d05ccaa13b768449cd405fff81d630a520e04a)
