### PR TITLE
Disable implementationOnly Foundation import for resource accessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 Note: This is in reverse chronological order, so newer entries are added to the top.
 
+Swift Next
+-----------
+
+* [#5728]
+
+  In packages that specify resources using a future tools version, the generated resource bundle accessor will import `Foundation.Bundle` for its own implementation only. _Clients_ of such packages therefore no longer silently import `Foundation`, preventing inadvertent use of Foundation extensions to standard library APIs, which helps to avoid unexpected code size increases.
+
+
 Swift 5.8
 -----------
 
@@ -13,10 +21,6 @@ Swift 5.8
 * [#5874]
 
   In packages using tools version 5.8 or later, Foundation is no longer implicitly imported into package manifests. If Foundation APIs are used, the module needs to be imported explicitly.
-
-* [#5728]
-
-  In packages that specify resources using tools version 5.8 or later, the generated resource bundle accessor will import `Foundation.Bundle` for its own implementation only. _Clients_ of such packages therefore no longer silently import `Foundation`, preventing inadvertent use of Foundation extensions to standard library APIs, which helps to avoid unexpected code size increases.
 
 Swift 5.7
 -----------

--- a/Documentation/ReleaseNotes/5.8.md
+++ b/Documentation/ReleaseNotes/5.8.md
@@ -1,5 +1,1 @@
 # SwiftPM 5.8 Release Notes
-
-* [#5728]
-
-In packages that specify resources using tools version 5.8 or later, the generated resource bundle accessor will import `Foundation.Bundle` for its own implementation only. _Clients_ of such packages therefore no longer silently import `Foundation`, preventing inadvertent use of Foundation extensions to standard library APIs, which helps to avoid unexpected code size increases.

--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -309,7 +309,7 @@ public final class SwiftTargetBuildDescription {
 
         let stream = BufferedOutputByteStream()
         stream <<< """
-        \(self.toolsVersion < .v5_8 ? "import" : "@_implementationOnly import") class Foundation.Bundle
+        \(self.toolsVersion < .vNext ? "import" : "@_implementationOnly import") class Foundation.Bundle
 
         extension Foundation.Bundle {
             static let module: Bundle = {


### PR DESCRIPTION
This was a change that landed in #5728 but it has the unintended consequence of generating unfixable warnings for packages which do import Foundation. We can probably solve that with import scanning to decide between the two import types, but given where we are in the 5.8 schedule, this seems to be something better done for a future manifest version.

See also #5991
