### PR TITLE
Sanitize environment for XCBuild

### DIFF
--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -139,7 +139,11 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
             stderrBuffer.append(contentsOf: bytes)
         })
 
-        let process = TSCBasic.Process(arguments: arguments, outputRedirection: redirection)
+        // We need to sanitize the environment we are passing to XCBuild because we could otherwise interfere with its linked dependencies e.g. when we have a custom swift-driver dynamic library in the path.
+        var sanitizedEnvironment = ProcessEnv.vars
+        sanitizedEnvironment["DYLD_LIBRARY_PATH"] = nil
+
+        let process = TSCBasic.Process(arguments: arguments, environment: sanitizedEnvironment, outputRedirection: redirection)
         try process.launch()
         let result = try process.waitUntilExit()
 


### PR DESCRIPTION
We need to sanitize `DYLD_LIBRARY_PATH` in the environment before launching XCBuild because otherwise just built dependencies of SwiftPM can interfere with the linked dependencies of XCBuild which will typically not end well. This can e.g. happen during bootstrap builds.
