### PR TITLE
Add missing dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -245,7 +245,8 @@ let package = Package(
             dependencies: [
                 "Basics",
                 "PackageLoading",
-                "PackageModel"
+                "PackageModel",
+                "SourceControl",
             ],
             exclude: ["CMakeLists.txt", "README.md"]
         ),


### PR DESCRIPTION
`PackageGraph` imports `SourceControl` so it needs a dependency.