### PR TITLE
Target that does not contain source but only headers is made into a CLangTarget.

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -819,7 +819,7 @@ public final class PackageBuilder {
         // The name of the bundle, if one is being generated.
         let potentialBundleName = self.manifest.displayName + "_" + potentialModule.name
 
-        if sources.relativePaths.isEmpty && resources.isEmpty {
+        if sources.relativePaths.isEmpty && resources.isEmpty && headers.isEmpty {
             return nil
         }
         try validateSourcesOverlapping(forTarget: potentialModule.name, sources: sources.paths)

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -526,6 +526,35 @@ class PackageGraphTests: XCTestCase {
         }
     }
 
+    func testTargetOnclyContainingHeaders() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/Bar/Sources/Bar/include/bar.h"
+        )
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let g = try loadPackageGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    name: "Bar",
+                    path: .init(path: "/Bar"),
+                    products: [
+                        ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
+                    ],
+                    targets: [
+                        TargetDescription(name: "Bar"),
+                    ]),
+            ],
+            observabilityScope: observability.topScope
+        )
+
+        XCTAssertNoDiagnostics(observability.diagnostics)
+        PackageGraphTester(g) { result in
+            result.check(packages: "Bar")
+            result.check(targets: "Bar")
+        }
+    }
+
     func testProductDependencyNotFound() throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/Foo/Sources/FooTarget/foo.swift"


### PR DESCRIPTION
This PR change allows the generation of targets containing only header files.

### Motivation:

Closes https://github.com/apple/swift-package-manager/issues/4806 .
Currently, if we attempt to create a target that does not contain source files, the Swift Package Manager returns an error and prompts us to put the source files. Therefore, it is not possible to create a CLangTarget that only contains header files.

### Modifications:

In addition to the absence of a source file, Target generation now fails when a header file does not exist.

### Result:


With the changes in this PR, a target that does not contain a source file but does contain headers is a CLangTarget.
