### PR TITLE
[5.8] There's no need to pretty-print the JSON that a compiled manifest sent back to SwiftPM (#5995)

### DIFF
--- a/Sources/PackageDescription/PackageDescription.swift
+++ b/Sources/PackageDescription/PackageDescription.swift
@@ -444,7 +444,7 @@ func manifestToJSON(_ package: Package) -> String {
     }
 
     let encoder = JSONEncoder()
-    encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+    encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
     let data = try! encoder.encode(Output(package: package, errors: errors))
     return String(data: data, encoding: .utf8)!
 }


### PR DESCRIPTION
This is a 5.8 nomination of https://github.com/apple/swift-package-manager/pull/5995.  The change is already in main.