### PR TITLE
main.swift: fix `swift-experimental-destination` invocation

### DIFF
--- a/Sources/swift-package-manager/main.swift
+++ b/Sources/swift-package-manager/main.swift
@@ -25,7 +25,7 @@ case "swift-package":
     SwiftPackageTool.main()
 case "swift-build":
     SwiftBuildTool.main()
-case "swift-destination":
+case "swift-experimental-destination":
     SwiftDestinationTool.main()
 case "swift-test":
     SwiftTestTool.main()


### PR DESCRIPTION
Currently, it fails with an error:
```
swift_package_manager/main.swift:39: Fatal error: swift-package-manager launched with unexpected name: swift-experimental-destination
```
