### PR TITLE
allow mirror between source control and registry dependencies

### DIFF
--- a/Sources/PackageGraph/DependencyMirrors.swift
+++ b/Sources/PackageGraph/DependencyMirrors.swift
@@ -157,17 +157,17 @@ public final class DependencyMirrors: Equatable {
         })
 
         return mirrorIndex[identity] ?? identity
+    }
 
-        func parseLocation(_ location: String) throws -> PackageIdentity {
-            if PackageIdentity.plain(location).scopeAndName != nil {
-                return PackageIdentity.plain(location)
-            } else if let path = try? AbsolutePath(validating: location)  {
-                return PackageIdentity(path: path)
-            } else if let url = URL(string: location) {
-                return PackageIdentity(url: url)
-            } else {
-                throw StringError("invalid location \(location), cannot extract identity")
-            }
+    private func parseLocation(_ location: String) throws -> PackageIdentity {
+        if PackageIdentity.plain(location).scopeAndName != nil {
+            return PackageIdentity.plain(location)
+        } else if let path = try? AbsolutePath(validating: location)  {
+            return PackageIdentity(path: path)
+        } else if let url = URL(string: location) {
+            return PackageIdentity(url: url)
+        } else {
+            throw StringError("invalid location \(location), cannot extract identity")
         }
     }
 }

--- a/Sources/PackageGraph/DependencyMirrors.swift
+++ b/Sources/PackageGraph/DependencyMirrors.swift
@@ -12,6 +12,7 @@
 
 import Foundation
 import OrderedCollections
+import PackageModel
 import TSCBasic
 
 /// A collection of dependency mirrors.
@@ -146,6 +147,27 @@ public final class DependencyMirrors: Equatable {
                 }
             })
             return sorted?.first
+        }
+    }
+
+    public func effectiveIdentity(for identity: PackageIdentity) throws -> PackageIdentity {
+        // TODO: cache
+        let mirrorIndex = try self.mapping.reduce(into: [PackageIdentity: PackageIdentity](), { partial, item in
+            try partial[parseLocation(item.key)] = parseLocation(item.value)
+        })
+
+        return mirrorIndex[identity] ?? identity
+
+        func parseLocation(_ location: String) throws -> PackageIdentity {
+            if PackageIdentity.plain(location).scopeAndName != nil {
+                return PackageIdentity.plain(location)
+            } else if let path = try? AbsolutePath(validating: location)  {
+                return PackageIdentity(path: path)
+            } else if let url = URL(string: location) {
+                return PackageIdentity(url: url)
+            } else {
+                throw StringError("invalid location \(location), cannot extract identity")
+            }
         }
     }
 }

--- a/Sources/PackageLoading/ManifestJSONParser.swift
+++ b/Sources/PackageLoading/ManifestJSONParser.swift
@@ -128,7 +128,6 @@ enum ManifestJSONParser {
                 let identity: String = try kindJSON.get("identity")
                 let requirementJSON: JSON = try kindJSON.get("requirement")
                 let requirement = try PackageDependency.Registry.Requirement(v4: requirementJSON)
-                //return .registry(identity: .plain(identity), requirement: requirement, productFilter: .everything)
                 return try Self.parseRegistryDependency(
                     identity: .plain(identity),
                     requirement: requirement,
@@ -207,7 +206,7 @@ enum ManifestJSONParser {
             let registryRequirement: PackageDependency.Registry.Requirement
             switch requirement {
             case .branch, .revision:
-                throw StringError("invalid mapping of source control to registry, requirement information mismatch.")
+                throw StringError("invalid mapping of source control to registry, requirement information mismatch: cannot map branch or revision based dependencies to registry.")
             case .exact(let value):
                 registryRequirement = .exact(value)
             case .range(let value):

--- a/Sources/PackageLoading/ManifestJSONParser.swift
+++ b/Sources/PackageLoading/ManifestJSONParser.swift
@@ -56,8 +56,13 @@ enum ManifestJSONParser {
         manifest.swiftLanguageVersions = try Self.parseSwiftLanguageVersion(package)
         manifest.products = try package.getArray("products").map(ProductDescription.init(v4:))
         manifest.providers = try? package.getArray("providers").map(SystemPackageProviderDescription.init(v4:))
-        manifest.targets = try package.getArray("targets").map(Self.parseTarget(json:))
-        manifest.dependencies = try package.getArray("dependencies").map{
+        manifest.targets = try package.getArray("targets").map {
+            try Self.parseTarget(
+                json: $0,
+                identityResolver: identityResolver
+            )
+        }
+        manifest.dependencies = try package.getArray("dependencies").map {
             try Self.parseDependency(
                 json: $0,
                 toolsVersion: toolsVersion,
@@ -99,29 +104,36 @@ enum ManifestJSONParser {
             if type == "fileSystem" {
                 let name: String? = kindJSON.get("name")
                 let path: String = try kindJSON.get("path")
-                return try Self.makeFileSystemDependency(
+                return try Self.parseFileSystemDependency(
                     packageKind: packageKind,
                     at: path,
                     name: name,
                     identityResolver: identityResolver,
-                    fileSystem: fileSystem)
+                    fileSystem: fileSystem
+                )
             } else if type == "sourceControl" {
                 let name: String? = kindJSON.get("name")
                 let location: String = try kindJSON.get("location")
                 let requirementJSON: JSON = try kindJSON.get("requirement")
                 let requirement = try PackageDependency.SourceControl.Requirement(v4: requirementJSON)
-                return try Self.makeSourceControlDependency(
+                return try Self.parseSourceControlDependency(
                     packageKind: packageKind,
                     at: location,
                     name: name,
                     requirement: requirement,
                     identityResolver: identityResolver,
-                    fileSystem: fileSystem)
+                    fileSystem: fileSystem
+                )
             } else if type == "registry" {
                 let identity: String = try kindJSON.get("identity")
                 let requirementJSON: JSON = try kindJSON.get("requirement")
                 let requirement = try PackageDependency.Registry.Requirement(v4: requirementJSON)
-                return .registry(identity: .plain(identity), requirement: requirement, productFilter: .everything)
+                //return .registry(identity: .plain(identity), requirement: requirement, productFilter: .everything)
+                return try Self.parseRegistryDependency(
+                    identity: .plain(identity),
+                    requirement: requirement,
+                    identityResolver: identityResolver
+                )
             } else {
                 throw InternalError("Unknown dependency type \(kindJSON)")
             }
@@ -135,27 +147,28 @@ enum ManifestJSONParser {
             let requirementType: String = try requirementJSON.get(String.self, forKey: "type")
             switch requirementType {
             case "localPackage":
-                return try Self.makeFileSystemDependency(
+                return try Self.parseFileSystemDependency(
                     packageKind: packageKind,
                     at: url,
                     name: name,
                     identityResolver: identityResolver,
-                    fileSystem: fileSystem)
-
+                    fileSystem: fileSystem
+                )
             default:
                 let requirement = try PackageDependency.SourceControl.Requirement(v4: requirementJSON)
-                return try Self.makeSourceControlDependency(
+                return try Self.parseSourceControlDependency(
                     packageKind: packageKind,
                     at: url,
                     name: name,
                     requirement: requirement,
                     identityResolver: identityResolver,
-                    fileSystem: fileSystem)
+                    fileSystem: fileSystem
+                )
             }
         }
     }
 
-    private static func makeFileSystemDependency(
+    private static func parseFileSystemDependency(
         packageKind: PackageReference.Kind,
         at location: String,
         name: String?,
@@ -176,7 +189,7 @@ enum ManifestJSONParser {
                            productFilter: .everything)
     }
 
-    private static func makeSourceControlDependency(
+    private static func parseSourceControlDependency(
         packageKind: PackageReference.Kind,
         at location: String,
         name: String?,
@@ -188,8 +201,25 @@ enum ManifestJSONParser {
         var location = try sanitizeDependencyLocation(fileSystem: fileSystem, packageKind: packageKind, dependencyLocation: location)
         // location mapping (aka mirrors) if any
         location = identityResolver.mappedLocation(for: location)
-        // a package in a git location, may be a remote URL or on disk
-        if let localPath = try? AbsolutePath(validating: location) {
+        if PackageIdentity.plain(location).scopeAndName != nil {
+            // re-mapped to registry
+            let identity = PackageIdentity.plain(location)
+            let registryRequirement: PackageDependency.Registry.Requirement
+            switch requirement {
+            case .branch, .revision:
+                throw StringError("invalid mapping of source control to registry, requirement information mismatch.")
+            case .exact(let value):
+                registryRequirement = .exact(value)
+            case .range(let value):
+                registryRequirement = .range(value)
+            }
+            return .registry(
+                identity: identity,
+                requirement: registryRequirement,
+                productFilter: .everything
+            )
+        } else if let localPath = try? AbsolutePath(validating: location) {
+            // a package in a git location, may be a remote URL or on disk
             // in the future this will check with the registries for the identity of the URL
             let identity = try identityResolver.resolveIdentity(for: localPath)
             return .localSourceControl(
@@ -207,6 +237,43 @@ enum ManifestJSONParser {
                 nameForTargetDependencyResolutionOnly: name,
                 url: url,
                 requirement: requirement,
+                productFilter: .everything
+            )
+        } else {
+            throw StringError("invalid location: \(location)")
+        }
+    }
+
+    private static func parseRegistryDependency(
+        identity: PackageIdentity,
+        requirement: PackageDependency.Registry.Requirement,
+        identityResolver: IdentityResolver
+    ) throws -> PackageDependency {
+        // location mapping (aka mirrors) if any
+        let location = identityResolver.mappedLocation(for: identity.description)
+        if PackageIdentity.plain(location).scopeAndName != nil {
+            // re-mapped to registry
+            let identity = PackageIdentity.plain(location)
+            return .registry(
+                identity: identity,
+                requirement: requirement,
+                productFilter: .everything
+            )
+        } else if let url = URL(string: location){
+            // in the future this will check with the registries for the identity of the URL
+            let identity = try identityResolver.resolveIdentity(for: url)
+            let sourceControlRequirement: PackageDependency.SourceControl.Requirement
+            switch requirement {
+            case .exact(let value):
+                sourceControlRequirement = .exact(value)
+            case .range(let value):
+                sourceControlRequirement = .range(value)
+            }
+            return .remoteSourceControl(
+                identity: identity,
+                nameForTargetDependencyResolutionOnly: identity.description,
+                url: url,
+                requirement: sourceControlRequirement,
                 productFilter: .everything
             )
         } else {
@@ -312,7 +379,10 @@ enum ManifestJSONParser {
         return platforms
     }
 
-    private static func parseTarget(json: JSON) throws -> TargetDescription {
+    private static func parseTarget(
+        json: JSON,
+        identityResolver: IdentityResolver
+    ) throws -> TargetDescription {
         let providers = try? json
             .getArray("providers")
             .map(SystemPackageProviderDescription.init(v4:))
@@ -321,7 +391,12 @@ enum ManifestJSONParser {
 
         let dependencies = try json
             .getArray("dependencies")
-            .map(TargetDescription.Dependency.init(v4:))
+            .map {
+                try TargetDescription.Dependency.init(
+                    v4: $0,
+                    identityResolver: identityResolver
+                )
+            }
 
         let sources: [String]? = try? json.get("sources")
         try sources?.forEach{ _ = try RelativePath(validating: $0) }
@@ -622,7 +697,7 @@ extension TargetDescription.TargetType {
 }
 
 extension TargetDescription.Dependency {
-    fileprivate init(v4 json: JSON) throws {
+    fileprivate init(v4 json: JSON, identityResolver: IdentityResolver) throws {
         let type = try json.get(String.self, forKey: "type")
         let condition = try (try? json.getJSON("condition")).flatMap(PackageConditionDescription.init(v4:))
 
@@ -633,7 +708,16 @@ extension TargetDescription.Dependency {
         case "product":
             let name = try json.get(String.self, forKey: "name")
             let moduleAliases: [String: String]? = try? json.get("moduleAliases")
-            self = .product(name: name, package: json.get("package"), moduleAliases: moduleAliases, condition: condition)
+            var package: String? = json.get("package")
+            if let packageName = package {
+                package = try identityResolver.mappedIdentity(for: .plain(packageName)).description
+            }
+            self = .product(
+                name: name,
+                package: package,
+                moduleAliases: moduleAliases,
+                condition: condition
+            )
 
         case "byname":
             self = try .byName(name: json.get("name"), condition: condition)

--- a/Sources/PackageModel/IdentityResolver.swift
+++ b/Sources/PackageModel/IdentityResolver.swift
@@ -19,13 +19,19 @@ public protocol IdentityResolver {
     func resolveIdentity(for url: URL) throws -> PackageIdentity
     func resolveIdentity(for path: AbsolutePath) throws -> PackageIdentity
     func mappedLocation(for location: String) -> String
+    func mappedIdentity(for identity: PackageIdentity) throws -> PackageIdentity
 }
 
 public struct DefaultIdentityResolver: IdentityResolver {
     let locationMapper: (String) -> String
+    let identityMapper: (PackageIdentity) throws -> PackageIdentity
 
-    public init(locationMapper: @escaping (String) -> String = { $0 }) {
+    public init(
+        locationMapper: @escaping (String) -> String = { $0 },
+        identityMapper: @escaping (PackageIdentity) throws -> PackageIdentity = { $0 }
+    ) {
         self.locationMapper = locationMapper
+        self.identityMapper = identityMapper
     }
 
     public func resolveIdentity(for packageKind: PackageReference.Kind) throws -> PackageIdentity {
@@ -66,6 +72,10 @@ public struct DefaultIdentityResolver: IdentityResolver {
     }
 
     public func mappedLocation(for location: String) -> String {
-        return self.locationMapper(location)
+        self.locationMapper(location)
+    }
+
+    public func mappedIdentity(for identity: PackageIdentity) throws -> PackageIdentity {
+        try self.identityMapper(identity)
     }
 }

--- a/Sources/SPMTestSupport/MockDependency.swift
+++ b/Sources/SPMTestSupport/MockDependency.swift
@@ -29,50 +29,96 @@ public struct MockDependency {
         self.products = products
     }
 
-    // TODO: refactor this when adding registry support
     public func convert(baseURL: AbsolutePath, identityResolver: IdentityResolver) throws -> PackageDependency {
         switch self.location {
         case .fileSystem(let path):
-            let path = baseURL.appending(path)
-            let remappedPath = try AbsolutePath(validating: identityResolver.mappedLocation(for: path.pathString))
-            let identity = try identityResolver.resolveIdentity(for: remappedPath)
+            let absolutePath = baseURL.appending(path)
+            let mappedLocation = identityResolver.mappedLocation(for: absolutePath.pathString)
+            guard let mappedPath = try? AbsolutePath(validating: mappedLocation) else {
+                throw StringError("invalid mapping of '\(path)' to '\(mappedLocation)', no requirement information available.")
+            }
+            let identity = try identityResolver.resolveIdentity(for: mappedPath)
             return .fileSystem(
                 identity: identity,
                 deprecatedName: self.deprecatedName,
-                path: remappedPath,
+                path: mappedPath,
                 productFilter: self.products
             )
         case .localSourceControl(let path, let requirement):
             let absolutePath = baseURL.appending(path)
-            let remappedPath = try AbsolutePath(validating: identityResolver.mappedLocation(for: absolutePath.pathString))
-            let identity = try identityResolver.resolveIdentity(for: remappedPath)
+            let mappedLocation = identityResolver.mappedLocation(for: absolutePath.pathString)
+            guard let mappedPath = try? AbsolutePath(validating: mappedLocation) else {
+                throw StringError("invalid mapping of '\(path)' to '\(mappedLocation)', no requirement information available.")
+            }
+            let identity = try identityResolver.resolveIdentity(for: mappedPath)
             return .localSourceControl(
                 identity: identity,
                 deprecatedName: self.deprecatedName,
-                path: remappedPath,
+                path: mappedPath,
                 requirement: requirement,
                 productFilter: self.products
             )
-        case .remoteSourceControl(let url, let requirement):
-            let remappedURLString = identityResolver.mappedLocation(for: url.absoluteString)
-            guard let remappedURL = URL(string: remappedURLString) else {
-                throw StringError("invalid url: \(remappedURLString))")
+        case .remoteSourceControl(let url, let _requirement):
+            let mappedLocation = identityResolver.mappedLocation(for: url.absoluteString)
+            if PackageIdentity.plain(mappedLocation).scopeAndName != nil {
+                let identity = PackageIdentity.plain(mappedLocation)
+                let requirement: RegistryRequirement
+                switch _requirement {
+                case .branch, .revision:
+                    throw StringError("invalid mapping of source control to registry, requirement information mismatch.")
+                case .exact(let value):
+                    requirement = .exact(value)
+                case .range(let value):
+                    requirement = .range(value)
+                }
+                return .registry(
+                    identity: identity,
+                    requirement: requirement,
+                    productFilter: self.products
+                )
+
+            } else if let mappedURL = URL(string: mappedLocation) {
+                let identity = try identityResolver.resolveIdentity(for: mappedURL)
+                return .remoteSourceControl(
+                    identity: identity,
+                    deprecatedName: self.deprecatedName,
+                    url: mappedURL,
+                    requirement: _requirement,
+                    productFilter: self.products
+                )
+            } else {
+                throw StringError("invalid mapping of '\(url)' to '\(mappedLocation)'")
             }
-            let identity = try identityResolver.resolveIdentity(for: remappedURL)
-            return .remoteSourceControl(
-                identity: identity,
-                deprecatedName: self.deprecatedName,
-                url: remappedURL,
-                requirement: requirement,
-                productFilter: self.products
-            )
-        case .registry(let identity, let requirement):
-            return .registry(
-                identity: identity,
-                requirement: requirement,
-                productFilter: self.products
-            )
+        case .registry(let identity, let _requirement):
+            let mappedLocation = identityResolver.mappedLocation(for: identity.description)
+            if PackageIdentity.plain(mappedLocation).scopeAndName != nil {
+                let identity = PackageIdentity.plain(mappedLocation)
+                return .registry(
+                    identity: identity,
+                    requirement: _requirement,
+                    productFilter: self.products
+                )
+            } else if let mappedURL = URL(string: mappedLocation) {
+                let identity = try identityResolver.resolveIdentity(for: mappedURL)
+                let requirement: SourceControlRequirement
+                switch _requirement {
+                case .exact(let value):
+                    requirement = .exact(value)
+                case .range(let value):
+                    requirement = .range(value)
+                }
+                return .remoteSourceControl(
+                    identity: identity,
+                    deprecatedName: self.deprecatedName,
+                    url: mappedURL,
+                    requirement: requirement,
+                    productFilter: self.products
+                )
+            } else {
+                throw StringError("invalid mapping of '\(identity)' to '\(mappedLocation)'")
+            }
         }
+        
     }
 
     public static func fileSystem(path: String, products: ProductFilter = .everything) -> MockDependency {

--- a/Sources/SPMTestSupport/MockPackage.swift
+++ b/Sources/SPMTestSupport/MockPackage.swift
@@ -94,7 +94,7 @@ public struct MockPackage {
         self.toolsVersion = toolsVersion
     }
 
-    public static func genericPackage1(named name: String) throws -> MockPackage {
+    public static func genericPackage(named name: String) throws -> MockPackage {
         return MockPackage(
             name: name,
             targets: [

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -65,7 +65,10 @@ public final class MockWorkspace {
         self.packages = packages
         self.fingerprints = customFingerprints ?? MockPackageFingerprintStorage()
         self.mirrors = customMirrors ?? DependencyMirrors()
-        self.identityResolver = DefaultIdentityResolver(locationMapper: self.mirrors.effectiveURL(for:))
+        self.identityResolver = DefaultIdentityResolver(
+            locationMapper: self.mirrors.effectiveURL(for:),
+            identityMapper: self.mirrors.effectiveIdentity(for:)
+        )
         self.manifestLoader = MockManifestLoader(manifests: [:])
         self.customPackageContainerProvider = customPackageContainerProvider
         self.repositoryProvider = InMemoryGitRepositoryProvider()
@@ -210,7 +213,7 @@ public final class MockWorkspace {
                     toolsVersion: packageToolsVersion,
                     dependencies: package.dependencies.map { try $0.convert(baseURL: packagesDir, identityResolver: self.identityResolver) },
                     products: package.products.map { try ProductDescription(name: $0.name, type: .library(.automatic), targets: $0.targets) },
-                    targets: try package.targets.map { try $0.convert() }
+                    targets: try package.targets.map { try $0.convert(identityResolver: self.identityResolver) }
                 )
             }
 

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -573,7 +573,11 @@ public class Workspace {
             sharedMirrorsFile: location.sharedMirrorsConfigurationFile
         ).mirrors
 
-        let identityResolver = customIdentityResolver ?? DefaultIdentityResolver(locationMapper: mirrors.effectiveURL(for:))
+        
+        let identityResolver = customIdentityResolver ?? DefaultIdentityResolver(
+            locationMapper: mirrors.effectiveURL(for:),
+            identityMapper: mirrors.effectiveIdentity(for:)
+        )
         let checksumAlgorithm = customChecksumAlgorithm ?? SHA256()
 
         let repositoryProvider = customRepositoryProvider ?? GitRepositoryProvider()

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -1326,9 +1326,9 @@ final class WorkspaceTests: XCTestCase {
             sandbox: sandbox,
             fileSystem: fs,
             roots: [
-                .genericPackage1(named: "A"),
-                .genericPackage1(named: "B"),
-                .genericPackage1(named: "C"),
+                .genericPackage(named: "A"),
+                .genericPackage(named: "B"),
+                .genericPackage(named: "C"),
             ],
             packages: []
         )
@@ -1746,8 +1746,8 @@ final class WorkspaceTests: XCTestCase {
                 ),
             ],
             packages: [
-                .genericPackage1(named: "Foo"),
-                .genericPackage1(named: "Bar"),
+                .genericPackage(named: "Foo"),
+                .genericPackage(named: "Bar"),
             ]
         )
 
@@ -1823,7 +1823,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     versions: ["1.0.0"]
                 ),
-                .genericPackage1(named: "Bar"),
+                .genericPackage(named: "Bar"),
                 MockPackage(
                     name: "Baz",
                     targets: [
@@ -1837,7 +1837,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     versions: ["1.0.0"]
                 ),
-                .genericPackage1(named: "Bam"),
+                .genericPackage(named: "Bam"),
             ]
         )
 
@@ -2009,7 +2009,7 @@ final class WorkspaceTests: XCTestCase {
                 ),
             ],
             packages: [
-                .genericPackage1(named: "Foo"),
+                .genericPackage(named: "Foo"),
             ]
         )
 
@@ -3795,13 +3795,13 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
-    func testPackageMirror() throws {
+    func testPackageSimpleMirrorPath() throws {
         let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let mirrors = DependencyMirrors()
-        mirrors.set(mirrorURL: sandbox.appending(components: "pkgs", "Baz").pathString, forURL: sandbox.appending(components: "pkgs", "Bar").pathString)
-        mirrors.set(mirrorURL: sandbox.appending(components: "pkgs", "Baz").pathString, forURL: sandbox.appending(components: "pkgs", "Bam").pathString)
+        mirrors.set(mirrorURL: sandbox.appending(components: "pkgs", "BarMirror").pathString, forURL: sandbox.appending(components: "pkgs", "Bar").pathString)
+        mirrors.set(mirrorURL: sandbox.appending(components: "pkgs", "BazMirror").pathString, forURL: sandbox.appending(components: "pkgs", "Baz").pathString)
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
@@ -3810,22 +3810,111 @@ final class WorkspaceTests: XCTestCase {
                 MockPackage(
                     name: "Foo",
                     targets: [
-                        MockTarget(name: "Foo", dependencies: ["Dep"]),
+                        MockTarget(name: "Foo", dependencies: [
+                            .product(name: "Dep", package: "dep"),
+                        ]),
                     ],
                     products: [
                         MockProduct(name: "Foo", targets: ["Foo"]),
                     ],
                     dependencies: [
                         .sourceControl(path: "./Dep", requirement: .upToNextMajor(from: "1.0.0")),
-                    ],
-                    toolsVersion: .v5
-                ),
+                    ]
+                )
             ],
             packages: [
                 MockPackage(
                     name: "Dep",
                     targets: [
-                        MockTarget(name: "Dep", dependencies: ["Bar"]),
+                        MockTarget(name: "Dep", dependencies: [
+                            .product(name: "Bar", package: "bar"),
+                            .product(name: "Baz", package: "baz"),
+                        ]),
+                    ],
+                    products: [
+                        MockProduct(name: "Dep", targets: ["Dep"]),
+                    ],
+                    dependencies: [
+                        .sourceControl(path: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .sourceControl(path: "Baz", requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    versions: ["1.0.0", "1.4.0"]
+                ),
+                MockPackage(
+                    name: "BarMirror",
+                    targets: [
+                        MockTarget(name: "Bar"),
+                    ],
+                    products: [
+                        MockProduct(name: "Bar", targets: ["Bar"]),
+                    ],
+                    versions: ["1.0.0", "1.5.0"]
+                ),
+                MockPackage(
+                    name: "BazMirror",
+                    targets: [
+                        MockTarget(name: "Baz"),
+                    ],
+                    products: [
+                        MockProduct(name: "Baz", targets: ["Baz"]),
+                    ],
+                    versions: ["1.0.0", "1.6.0"]
+                )
+            ],
+            mirrors: mirrors
+        )
+
+        try workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
+            PackageGraphTester(graph) { result in
+                result.check(roots: "Foo")
+                result.check(packages: "BarMirror", "BazMirror", "Foo", "Dep")
+                result.check(targets: "Bar", "Baz", "Foo", "Dep")
+            }
+            XCTAssertNoDiagnostics(diagnostics)
+        }
+        workspace.checkManagedDependencies { result in
+            result.check(dependency: "dep", at: .checkout(.version("1.4.0")))
+            result.check(dependency: "barmirror", at: .checkout(.version("1.5.0")))
+            result.check(dependency: "bazmirror", at: .checkout(.version("1.6.0")))
+            result.check(notPresent: "bar")
+            result.check(notPresent: "baz")
+        }
+    }
+
+    func testPackageMirrorPath() throws {
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let fs = InMemoryFileSystem()
+
+        let mirrors = DependencyMirrors()
+        mirrors.set(mirrorURL: sandbox.appending(components: "pkgs", "BarMirror").pathString, forURL: sandbox.appending(components: "pkgs", "Bar").pathString)
+        mirrors.set(mirrorURL: sandbox.appending(components: "pkgs", "BarMirror").pathString, forURL: sandbox.appending(components: "pkgs", "Baz").pathString)
+
+        let workspace = try MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                MockPackage(
+                    name: "Foo",
+                    targets: [
+                        MockTarget(name: "Foo", dependencies: [
+                            .product(name: "Dep", package: "dep"),
+                        ]),
+                    ],
+                    products: [
+                        MockProduct(name: "Foo", targets: ["Foo"]),
+                    ],
+                    dependencies: [
+                        .sourceControl(path: "./Dep", requirement: .upToNextMajor(from: "1.0.0")),
+                    ]
+                )
+            ],
+            packages: [
+                MockPackage(
+                    name: "Dep",
+                    targets: [
+                        MockTarget(name: "Dep", dependencies: [
+                            .product(name: "Bar", package: "bar"),
+                        ]),
                     ],
                     products: [
                         MockProduct(name: "Dep", targets: ["Dep"]),
@@ -3833,8 +3922,7 @@ final class WorkspaceTests: XCTestCase {
                     dependencies: [
                         .sourceControl(path: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
-                    versions: ["1.0.0", "1.5.0"],
-                    toolsVersion: .v5
+                    versions: ["1.0.0", "1.4.0"]
                 ),
                 MockPackage(
                     name: "Bar",
@@ -3852,17 +3940,17 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Baz"),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Baz"]),
+                        MockProduct(name: "Baz", targets: ["Baz"]),
                     ],
-                    versions: ["1.0.0", "1.4.0"]
+                    versions: ["1.0.0", "1.6.0"]
                 ),
                 MockPackage(
-                    name: "Bam",
+                    name: "BarMirror",
                     targets: [
-                        MockTarget(name: "Bam"),
+                        MockTarget(name: "Bar"),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bam"]),
+                        MockProduct(name: "Bar", targets: ["Bar"]),
                     ],
                     versions: ["1.0.0", "1.5.0"]
                 ),
@@ -3871,22 +3959,352 @@ final class WorkspaceTests: XCTestCase {
         )
 
         let deps: [MockDependency] = [
-            .sourceControl(path: "./Bam", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Bar"])),
+            .sourceControl(path: "./Baz", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Baz"])),
         ]
 
         try workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Foo")
-                result.check(packages: "Foo", "Dep", "Baz")
-                result.check(targets: "Foo", "Dep", "Baz")
+                result.check(packages: "BarMirror", "Foo", "Dep")
+                result.check(targets: "Bar", "Foo", "Dep")
             }
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
-            result.check(dependency: "dep", at: .checkout(.version("1.5.0")))
-            result.check(dependency: "baz", at: .checkout(.version("1.4.0")))
+            result.check(dependency: "dep", at: .checkout(.version("1.4.0")))
+            result.check(dependency: "barmirror", at: .checkout(.version("1.5.0")))
+            result.check(notPresent: "baz")
             result.check(notPresent: "bar")
-            result.check(notPresent: "bam")
+        }
+    }
+
+    func testPackageSimpleMirrorURL() throws {
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let fs = InMemoryFileSystem()
+
+        let mirrors = DependencyMirrors()
+        mirrors.set(mirrorURL: "https://scm.com/org/bar-mirror", forURL: "https://scm.com/org/bar")
+        mirrors.set(mirrorURL: "https://scm.com/org/baz-mirror", forURL: "https://scm.com/org/baz")
+
+        let workspace = try MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                MockPackage(
+                    name: "Foo",
+                    targets: [
+                        MockTarget(name: "Foo", dependencies: [
+                            .product(name: "Dep", package: "dep"),
+                        ]),
+                    ],
+                    products: [
+                        MockProduct(name: "Foo", targets: ["Foo"]),
+                    ],
+                    dependencies: [
+                        .sourceControl(url: "https://scm.com/org/dep", requirement: .upToNextMajor(from: "1.0.0")),
+                    ]
+                )
+            ],
+            packages: [
+                MockPackage(
+                    name: "Dep",
+                    url: "https://scm.com/org/dep",
+                    targets: [
+                        MockTarget(name: "Dep", dependencies: [
+                            .product(name: "Bar", package: "bar"),
+                            .product(name: "Baz", package: "baz"),
+                        ]),
+                    ],
+                    products: [
+                        MockProduct(name: "Dep", targets: ["Dep"]),
+                    ],
+                    dependencies: [
+                        .sourceControl(url: "https://scm.com/org/bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .sourceControl(url: "https://scm.com/org/baz", requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    versions: ["1.0.0", "1.4.0"]
+                ),
+                MockPackage(
+                    name: "BarMirror",
+                    url: "https://scm.com/org/bar-mirror",
+                    targets: [
+                        MockTarget(name: "Bar"),
+                    ],
+                    products: [
+                        MockProduct(name: "Bar", targets: ["Bar"]),
+                    ],
+                    versions: ["1.0.0", "1.5.0"]
+                ),
+                MockPackage(
+                    name: "BazMirror",
+                    url: "https://scm.com/org/baz-mirror",
+                    targets: [
+                        MockTarget(name: "Baz"),
+                    ],
+                    products: [
+                        MockProduct(name: "Baz", targets: ["Baz"]),
+                    ],
+                    versions: ["1.0.0", "1.6.0"]
+                )
+            ],
+            mirrors: mirrors
+        )
+
+        try workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
+            PackageGraphTester(graph) { result in
+                result.check(roots: "Foo")
+                result.check(packages: "BarMirror", "BazMirror", "Foo", "Dep")
+                result.check(targets: "Bar", "Baz", "Foo", "Dep")
+            }
+            XCTAssertNoDiagnostics(diagnostics)
+        }
+        workspace.checkManagedDependencies { result in
+            result.check(dependency: "dep", at: .checkout(.version("1.4.0")))
+            result.check(dependency: "bar-mirror", at: .checkout(.version("1.5.0")))
+            result.check(dependency: "baz-mirror", at: .checkout(.version("1.6.0")))
+            result.check(notPresent: "bar")
+            result.check(notPresent: "baz")
+        }
+    }
+
+    func testPackageMirrorURL() throws {
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let fs = InMemoryFileSystem()
+
+        let mirrors = DependencyMirrors()
+        mirrors.set(mirrorURL: "https://scm.com/org/bar-mirror", forURL: "https://scm.com/org/bar")
+        mirrors.set(mirrorURL: "https://scm.com/org/bar-mirror", forURL: "https://scm.com/org/baz")
+
+        let workspace = try MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                MockPackage(
+                    name: "Foo",
+                    targets: [
+                        MockTarget(name: "Foo", dependencies: [
+                            .product(name: "Dep", package: "dep"),
+                        ]),
+                    ],
+                    products: [
+                        MockProduct(name: "Foo", targets: ["Foo"]),
+                    ],
+                    dependencies: [
+                        .sourceControl(url: "https://scm.com/org/dep", requirement: .upToNextMajor(from: "1.0.0")),
+                    ]
+                )
+            ],
+            packages: [
+                MockPackage(
+                    name: "Dep",
+                    url: "https://scm.com/org/dep",
+                    targets: [
+                        MockTarget(name: "Dep", dependencies: [
+                            .product(name: "Bar", package: "bar"),
+                        ]),
+                    ],
+                    products: [
+                        MockProduct(name: "Dep", targets: ["Dep"]),
+                    ],
+                    dependencies: [
+                        .sourceControl(url: "https://scm.com/org/bar", requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    versions: ["1.0.0", "1.4.0"]
+                ),
+                MockPackage(
+                    name: "Bar",
+                    url: "https://scm.com/org/bar",
+                    targets: [
+                        MockTarget(name: "Bar"),
+                    ],
+                    products: [
+                        MockProduct(name: "Bar", targets: ["Bar"]),
+                    ],
+                    versions: ["1.0.0", "1.5.0"]
+                ),
+                MockPackage(
+                    name: "Baz",
+                    url: "https://scm.com/org/baz",
+                    targets: [
+                        MockTarget(name: "Baz"),
+                    ],
+                    products: [
+                        MockProduct(name: "Baz", targets: ["Baz"]),
+                    ],
+                    versions: ["1.0.0", "1.6.0"]
+                ),
+                MockPackage(
+                    name: "BarMirror",
+                    url: "https://scm.com/org/bar-mirror",
+                    targets: [
+                        MockTarget(name: "Bar"),
+                    ],
+                    products: [
+                        MockProduct(name: "Bar", targets: ["Bar"]),
+                    ],
+                    versions: ["1.0.0", "1.5.0"]
+                ),
+            ],
+            mirrors: mirrors
+        )
+
+        let deps: [MockDependency] = [
+            .sourceControl(url: "https://scm.com/org/baz", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Baz"])),
+        ]
+
+        try workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { graph, diagnostics in
+            PackageGraphTester(graph) { result in
+                result.check(roots: "Foo")
+                result.check(packages: "BarMirror", "Foo", "Dep")
+                result.check(targets: "Bar", "Foo", "Dep")
+            }
+            XCTAssertNoDiagnostics(diagnostics)
+        }
+        workspace.checkManagedDependencies { result in
+            result.check(dependency: "dep", at: .checkout(.version("1.4.0")))
+            result.check(dependency: "bar-mirror", at: .checkout(.version("1.5.0")))
+            result.check(notPresent: "bar")
+            result.check(notPresent: "baz")
+        }
+    }
+
+    func testPackageMirrorURLToRegistry() throws {
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let fs = InMemoryFileSystem()
+
+        let mirrors = DependencyMirrors()
+        mirrors.set(mirrorURL: "org.bar-mirror", forURL: "https://scm.com/org/bar")
+
+        let workspace = try MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                MockPackage(
+                    name: "Foo",
+                    targets: [
+                        MockTarget(name: "Foo", dependencies: [
+                            .product(name: "Bar", package: "bar"),
+                            .product(name: "Baz", package: "baz")
+                        ]),
+                    ],
+                    products: [
+                        MockProduct(name: "Foo", targets: ["Foo"]),
+                    ],
+                    dependencies: [
+                        .sourceControl(url: "https://scm.com/org/bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .sourceControl(url: "https://scm.com/org/baz", requirement: .upToNextMajor(from: "1.0.0"))
+                    ]
+                )
+            ],
+            packages: [
+                MockPackage(
+                    name: "BarMirror",
+                    identity: "org.bar-mirror",
+                    targets: [
+                        MockTarget(name: "Bar"),
+                    ],
+                    products: [
+                        MockProduct(name: "Bar", targets: ["Bar"]),
+                    ],
+                    versions: ["1.0.0", "1.5.0"]
+                ),
+                MockPackage(
+                    name: "Baz",
+                    url: "https://scm.com/org/baz",
+                    targets: [
+                        MockTarget(name: "Baz"),
+                    ],
+                    products: [
+                        MockProduct(name: "Baz", targets: ["Baz"]),
+                    ],
+                    versions: ["1.0.0", "1.6.0"]
+                )
+            ],
+            mirrors: mirrors
+        )
+
+        try workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
+            PackageGraphTester(graph) { result in
+                result.check(roots: "Foo")
+                result.check(packages: "BarMirror", "Baz", "Foo")
+                result.check(targets: "Bar", "Baz", "Foo")
+            }
+            XCTAssertNoDiagnostics(diagnostics)
+        }
+        workspace.checkManagedDependencies { result in
+            result.check(dependency: "org.bar-mirror", at: .registryDownload("1.5.0"))
+            result.check(dependency: "baz", at: .checkout(.version("1.6.0")))
+            result.check(notPresent: "bar")
+        }
+    }
+
+    func testPackageMirrorRegistryToURL() throws {
+        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let fs = InMemoryFileSystem()
+
+        let mirrors = DependencyMirrors()
+        mirrors.set(mirrorURL: "https://scm.com/org/bar-mirror", forURL: "org.bar")
+
+        let workspace = try MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                MockPackage(
+                    name: "Foo",
+                    targets: [
+                        MockTarget(name: "Foo", dependencies: [
+                            .product(name: "Bar", package: "org.bar"),
+                            .product(name: "Baz", package: "org.baz")
+                        ]),
+                    ],
+                    products: [
+                        MockProduct(name: "Foo", targets: ["Foo"]),
+                    ],
+                    dependencies: [
+                        .registry(identity: "org.bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .registry(identity: "org.baz", requirement: .upToNextMajor(from: "1.0.0"))
+                    ]
+                )
+            ],
+            packages: [
+                MockPackage(
+                    name: "BarMirror",
+                    url: "https://scm.com/org/bar-mirror",
+                    targets: [
+                        MockTarget(name: "Bar"),
+                    ],
+                    products: [
+                        MockProduct(name: "Bar", targets: ["Bar"]),
+                    ],
+                    versions: ["1.0.0", "1.5.0"]
+                ),
+                MockPackage(
+                    name: "Baz",
+                    identity: "org.baz",
+                    targets: [
+                        MockTarget(name: "Baz"),
+                    ],
+                    products: [
+                        MockProduct(name: "Baz", targets: ["Baz"]),
+                    ],
+                    versions: ["1.0.0", "1.6.0"]
+                )
+            ],
+            mirrors: mirrors
+        )
+
+        try workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
+            PackageGraphTester(graph) { result in
+                result.check(roots: "Foo")
+                result.check(packages: "BarMirror", "Baz", "Foo")
+                result.check(targets: "Bar", "Baz", "Foo")
+            }
+            XCTAssertNoDiagnostics(diagnostics)
+        }
+        workspace.checkManagedDependencies { result in
+            result.check(dependency: "bar-mirror", at: .checkout(.version("1.5.0")))
+            result.check(dependency: "org.baz", at:  .registryDownload("1.6.0"))
+            result.check(notPresent: "org.bar")
         }
     }
 


### PR DESCRIPTION
motivation: ease the transition to registry based dependencies

changes:
* extend the mirror API to allow mirror between source control and registry dependencies
* make sure target based dependencies take potentially different identity into account
* add tests
