### PR TITLE
Pass through the package identity as a parameter to `willLoadManifest`/`didLoadManifest` callbacks

### DIFF
--- a/Sources/Commands/ToolWorkspaceDelegate.swift
+++ b/Sources/Commands/ToolWorkspaceDelegate.swift
@@ -172,8 +172,8 @@ class ToolWorkspaceDelegate: WorkspaceDelegate {
 
     // noop
 
-    func willLoadManifest(packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind) {}
-    func didLoadManifest(packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind, manifest: Manifest?, diagnostics: [Basics.Diagnostic]) {}
+    func willLoadManifest(packageIdentity: PackageIdentity, packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind) {}
+    func didLoadManifest(packageIdentity: PackageIdentity, packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind, manifest: Manifest?, diagnostics: [Basics.Diagnostic]) {}
     func willCheckOut(package: PackageIdentity, repository url: String, revision: String, at path: AbsolutePath) {}
     func didCreateWorkingCopy(package: PackageIdentity, repository url: String, at path: AbsolutePath) {}
     func resolvedFileChanged() {}

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -834,12 +834,12 @@ public final class MockWorkspaceDelegate: WorkspaceDelegate {
         self.append("will resolve dependencies")
     }
 
-    public func willLoadManifest(packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind) {
-        self.append("will load manifest for \(packageKind.displayName) package: \(url)")
+    public func willLoadManifest(packageIdentity: PackageIdentity, packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind) {
+        self.append("will load manifest for \(packageKind.displayName) package: \(url) (identity: \(packageIdentity))")
     }
 
-    public func didLoadManifest(packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind, manifest: Manifest?, diagnostics: [Basics.Diagnostic]) {
-        self.append("did load manifest for \(packageKind.displayName) package: \(url)")
+    public func didLoadManifest(packageIdentity: PackageIdentity, packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind, manifest: Manifest?, diagnostics: [Basics.Diagnostic]) {
+        self.append("did load manifest for \(packageKind.displayName) package: \(url) (identity: \(packageIdentity))")
         self.lock.withLock {
             self._manifest = manifest
             self._manifestLoadingDiagnostics = diagnostics

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -96,13 +96,13 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // Check the load-package callbacks.
-        XCTAssertMatch(workspace.delegate.events, ["will load manifest for root package: \(sandbox.appending(components: "roots", "Foo"))"])
-        XCTAssertMatch(workspace.delegate.events, ["did load manifest for root package: \(sandbox.appending(components: "roots", "Foo"))"])
+        XCTAssertMatch(workspace.delegate.events, ["will load manifest for root package: \(sandbox.appending(components: "roots", "Foo")) (identity: foo)"])
+        XCTAssertMatch(workspace.delegate.events, ["did load manifest for root package: \(sandbox.appending(components: "roots", "Foo")) (identity: foo)"])
 
-        XCTAssertMatch(workspace.delegate.events, ["will load manifest for localSourceControl package: \(sandbox.appending(components: "pkgs", "Quix"))"])
-        XCTAssertMatch(workspace.delegate.events, ["did load manifest for localSourceControl package: \(sandbox.appending(components: "pkgs", "Quix"))"])
-        XCTAssertMatch(workspace.delegate.events, ["will load manifest for localSourceControl package: \(sandbox.appending(components: "pkgs", "Baz"))"])
-        XCTAssertMatch(workspace.delegate.events, ["did load manifest for localSourceControl package: \(sandbox.appending(components: "pkgs", "Baz"))"])
+        XCTAssertMatch(workspace.delegate.events, ["will load manifest for localSourceControl package: \(sandbox.appending(components: "pkgs", "Quix")) (identity: quix)"])
+        XCTAssertMatch(workspace.delegate.events, ["did load manifest for localSourceControl package: \(sandbox.appending(components: "pkgs", "Quix")) (identity: quix)"])
+        XCTAssertMatch(workspace.delegate.events, ["will load manifest for localSourceControl package: \(sandbox.appending(components: "pkgs", "Baz")) (identity: baz)"])
+        XCTAssertMatch(workspace.delegate.events, ["did load manifest for localSourceControl package: \(sandbox.appending(components: "pkgs", "Baz")) (identity: baz)"])
 
         // Close and reopen workspace.
         try workspace.closeWorkspace(resetState: false)
@@ -9989,12 +9989,12 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // Check the load-package callbacks.
-        XCTAssertMatch(workspace.delegate.events, ["will load manifest for root package: \(sandbox.appending(components: "roots", "MyPackage"))"])
-        XCTAssertMatch(workspace.delegate.events, ["did load manifest for root package: \(sandbox.appending(components: "roots", "MyPackage"))"])
-        XCTAssertMatch(workspace.delegate.events, ["will load manifest for remoteSourceControl package: http://localhost/org/foo"])
-        XCTAssertMatch(workspace.delegate.events, ["did load manifest for remoteSourceControl package: http://localhost/org/foo"])
-        XCTAssertMatch(workspace.delegate.events, ["will load manifest for remoteSourceControl package: http://localhost/org/bar"])
-        XCTAssertMatch(workspace.delegate.events, ["did load manifest for remoteSourceControl package: http://localhost/org/bar"])
+        XCTAssertMatch(workspace.delegate.events, ["will load manifest for root package: \(sandbox.appending(components: "roots", "MyPackage")) (identity: mypackage)"])
+        XCTAssertMatch(workspace.delegate.events, ["did load manifest for root package: \(sandbox.appending(components: "roots", "MyPackage")) (identity: mypackage)"])
+        XCTAssertMatch(workspace.delegate.events, ["will load manifest for remoteSourceControl package: http://localhost/org/foo (identity: foo)"])
+        XCTAssertMatch(workspace.delegate.events, ["did load manifest for remoteSourceControl package: http://localhost/org/foo (identity: foo)"])
+        XCTAssertMatch(workspace.delegate.events, ["will load manifest for remoteSourceControl package: http://localhost/org/bar (identity: bar)"])
+        XCTAssertMatch(workspace.delegate.events, ["did load manifest for remoteSourceControl package: http://localhost/org/bar (identity: bar)"])
     }
 
     func testBasicTransitiveResolutionFromSourceControl() throws {
@@ -10099,14 +10099,14 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // Check the load-package callbacks.
-        XCTAssertMatch(workspace.delegate.events, ["will load manifest for root package: \(sandbox.appending(components: "roots", "MyPackage"))"])
-        XCTAssertMatch(workspace.delegate.events, ["did load manifest for root package: \(sandbox.appending(components: "roots", "MyPackage"))"])
-        XCTAssertMatch(workspace.delegate.events, ["will load manifest for remoteSourceControl package: http://localhost/org/foo"])
-        XCTAssertMatch(workspace.delegate.events, ["did load manifest for remoteSourceControl package: http://localhost/org/foo"])
-        XCTAssertMatch(workspace.delegate.events, ["will load manifest for remoteSourceControl package: http://localhost/org/bar"])
-        XCTAssertMatch(workspace.delegate.events, ["did load manifest for remoteSourceControl package: http://localhost/org/bar"])
-        XCTAssertMatch(workspace.delegate.events, ["will load manifest for remoteSourceControl package: http://localhost/org/baz"])
-        XCTAssertMatch(workspace.delegate.events, ["did load manifest for remoteSourceControl package: http://localhost/org/baz"])
+        XCTAssertMatch(workspace.delegate.events, ["will load manifest for root package: \(sandbox.appending(components: "roots", "MyPackage")) (identity: mypackage)"])
+        XCTAssertMatch(workspace.delegate.events, ["did load manifest for root package: \(sandbox.appending(components: "roots", "MyPackage")) (identity: mypackage)"])
+        XCTAssertMatch(workspace.delegate.events, ["will load manifest for remoteSourceControl package: http://localhost/org/foo (identity: foo)"])
+        XCTAssertMatch(workspace.delegate.events, ["did load manifest for remoteSourceControl package: http://localhost/org/foo (identity: foo)"])
+        XCTAssertMatch(workspace.delegate.events, ["will load manifest for remoteSourceControl package: http://localhost/org/bar (identity: bar)"])
+        XCTAssertMatch(workspace.delegate.events, ["did load manifest for remoteSourceControl package: http://localhost/org/bar (identity: bar)"])
+        XCTAssertMatch(workspace.delegate.events, ["will load manifest for remoteSourceControl package: http://localhost/org/baz (identity: baz)"])
+        XCTAssertMatch(workspace.delegate.events, ["did load manifest for remoteSourceControl package: http://localhost/org/baz (identity: baz)"])
     }
 
     func testBasicResolutionFromRegistry() throws {
@@ -10183,12 +10183,12 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // Check the load-package callbacks.
-        XCTAssertMatch(workspace.delegate.events, ["will load manifest for root package: \(sandbox.appending(components: "roots", "MyPackage"))"])
-        XCTAssertMatch(workspace.delegate.events, ["did load manifest for root package: \(sandbox.appending(components: "roots", "MyPackage"))"])
-        XCTAssertMatch(workspace.delegate.events, ["will load manifest for registry package: org.foo"])
-        XCTAssertMatch(workspace.delegate.events, ["did load manifest for registry package: org.foo"])
-        XCTAssertMatch(workspace.delegate.events, ["will load manifest for registry package: org.bar"])
-        XCTAssertMatch(workspace.delegate.events, ["did load manifest for registry package: org.bar"])
+        XCTAssertMatch(workspace.delegate.events, ["will load manifest for root package: \(sandbox.appending(components: "roots", "MyPackage")) (identity: mypackage)"])
+        XCTAssertMatch(workspace.delegate.events, ["did load manifest for root package: \(sandbox.appending(components: "roots", "MyPackage")) (identity: mypackage)"])
+        XCTAssertMatch(workspace.delegate.events, ["will load manifest for registry package: org.foo (identity: org.foo)"])
+        XCTAssertMatch(workspace.delegate.events, ["did load manifest for registry package: org.foo (identity: org.foo)"])
+        XCTAssertMatch(workspace.delegate.events, ["will load manifest for registry package: org.bar (identity: org.bar)"])
+        XCTAssertMatch(workspace.delegate.events, ["did load manifest for registry package: org.bar (identity: org.bar)"])
     }
 
     func testBasicTransitiveResolutionFromRegistry() throws {
@@ -10293,14 +10293,14 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // Check the load-package callbacks.
-        XCTAssertMatch(workspace.delegate.events, ["will load manifest for root package: \(sandbox.appending(components: "roots", "MyPackage"))"])
-        XCTAssertMatch(workspace.delegate.events, ["did load manifest for root package: \(sandbox.appending(components: "roots", "MyPackage"))"])
-        XCTAssertMatch(workspace.delegate.events, ["will load manifest for registry package: org.foo"])
-        XCTAssertMatch(workspace.delegate.events, ["did load manifest for registry package: org.foo"])
-        XCTAssertMatch(workspace.delegate.events, ["will load manifest for registry package: org.bar"])
-        XCTAssertMatch(workspace.delegate.events, ["did load manifest for registry package: org.bar"])
-        XCTAssertMatch(workspace.delegate.events, ["will load manifest for registry package: org.baz"])
-        XCTAssertMatch(workspace.delegate.events, ["did load manifest for registry package: org.baz"])
+        XCTAssertMatch(workspace.delegate.events, ["will load manifest for root package: \(sandbox.appending(components: "roots", "MyPackage")) (identity: mypackage)"])
+        XCTAssertMatch(workspace.delegate.events, ["did load manifest for root package: \(sandbox.appending(components: "roots", "MyPackage")) (identity: mypackage)"])
+        XCTAssertMatch(workspace.delegate.events, ["will load manifest for registry package: org.foo (identity: org.foo)"])
+        XCTAssertMatch(workspace.delegate.events, ["did load manifest for registry package: org.foo (identity: org.foo)"])
+        XCTAssertMatch(workspace.delegate.events, ["will load manifest for registry package: org.bar (identity: org.bar)"])
+        XCTAssertMatch(workspace.delegate.events, ["did load manifest for registry package: org.bar (identity: org.bar)"])
+        XCTAssertMatch(workspace.delegate.events, ["will load manifest for registry package: org.baz (identity: org.baz)"])
+        XCTAssertMatch(workspace.delegate.events, ["did load manifest for registry package: org.baz (identity: org.baz)"])
     }
 
     // no dups


### PR DESCRIPTION
Adds a new package identity parameter to the callbacks for loading manifests.

### Motivation:

Without this, implementors of these delegate calls that want the package identity have to re-derive it from the URL, which is lossy.  Instead the callbacks should pass through the package identity it already knows about.

### Modifications:

- add a package identity parameter to each of the will/did callbacks for the manifest

### Result:

- the client code has the original package identity