### PR TITLE
Pass along the duration in the remaining WorkspaceDelegate calls as well

### DIFF
--- a/Sources/Commands/ToolWorkspaceDelegate.swift
+++ b/Sources/Commands/ToolWorkspaceDelegate.swift
@@ -111,7 +111,7 @@ class ToolWorkspaceDelegate: WorkspaceDelegate {
         self.outputHandler("Creating working copy for \(url)", false)
     }
 
-    func didCheckOut(package: PackageIdentity, repository url: String, revision: String, at path: AbsolutePath) {
+    func didCheckOut(package: PackageIdentity, repository url: String, revision: String, at path: AbsolutePath, duration: DispatchTimeInterval) {
         self.outputHandler("Working copy of \(url) resolved at \(revision)", false)
     }
 
@@ -173,9 +173,9 @@ class ToolWorkspaceDelegate: WorkspaceDelegate {
     // noop
 
     func willLoadManifest(packageIdentity: PackageIdentity, packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind) {}
-    func didLoadManifest(packageIdentity: PackageIdentity, packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind, manifest: Manifest?, diagnostics: [Basics.Diagnostic]) {}
+    func didLoadManifest(packageIdentity: PackageIdentity, packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind, manifest: Manifest?, diagnostics: [Basics.Diagnostic], duration: DispatchTimeInterval) {}
     func willCheckOut(package: PackageIdentity, repository url: String, revision: String, at path: AbsolutePath) {}
-    func didCreateWorkingCopy(package: PackageIdentity, repository url: String, at path: AbsolutePath) {}
+    func didCreateWorkingCopy(package: PackageIdentity, repository url: String, at path: AbsolutePath, duration: DispatchTimeInterval) {}
     func resolvedFileChanged() {}
     func didDownloadAllBinaryArtifacts() {}
 }

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -814,7 +814,7 @@ public final class MockWorkspaceDelegate: WorkspaceDelegate {
         self.append("creating working copy for: \(url)")
     }
 
-    public func didCreateWorkingCopy(package: PackageIdentity, repository url: String, at path: AbsolutePath) {
+    public func didCreateWorkingCopy(package: PackageIdentity, repository url: String, at path: AbsolutePath, duration: DispatchTimeInterval) {
         self.append("finished creating working copy for: \(url)")
     }
 
@@ -822,7 +822,7 @@ public final class MockWorkspaceDelegate: WorkspaceDelegate {
         self.append("checking out repo: \(url)")
     }
 
-    public func didCheckOut(package: PackageIdentity, repository url: String, revision: String, at path: AbsolutePath) {
+    public func didCheckOut(package: PackageIdentity, repository url: String, revision: String, at path: AbsolutePath, duration: DispatchTimeInterval) {
         self.append("finished checking out repo: \(url)")
     }
 
@@ -838,7 +838,7 @@ public final class MockWorkspaceDelegate: WorkspaceDelegate {
         self.append("will load manifest for \(packageKind.displayName) package: \(url) (identity: \(packageIdentity))")
     }
 
-    public func didLoadManifest(packageIdentity: PackageIdentity, packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind, manifest: Manifest?, diagnostics: [Basics.Diagnostic]) {
+    public func didLoadManifest(packageIdentity: PackageIdentity, packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind, manifest: Manifest?, diagnostics: [Basics.Diagnostic], duration: DispatchTimeInterval) {
         self.append("did load manifest for \(packageKind.displayName) package: \(url) (identity: \(packageIdentity))")
         self.lock.withLock {
             self._manifest = manifest

--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -206,10 +206,10 @@ public class RepositoryManager: Cancellable {
                 return handle
             }
             // Update the repository when it is being looked up.
-            let start = DispatchTime.now()
             delegateQueue.async {
                 self.delegate?.willUpdate(package: package, repository: handle.repository)
             }
+            let start = DispatchTime.now()
             let repository = try handle.open()
             try repository.fetch()
             let duration = start.distance(to: .now())

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -64,7 +64,7 @@ public protocol WorkspaceDelegate: AnyObject {
     func willLoadManifest(packageIdentity: PackageIdentity, packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind)
     
     /// The workspace has loaded a package manifest, either successfully or not. The manifest is nil if an error occurs, in which case there will also be at least one error in the list of diagnostics (there may be warnings even if a manifest is loaded successfully).
-    func didLoadManifest(packageIdentity: PackageIdentity, packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind, manifest: Manifest?, diagnostics: [Basics.Diagnostic])
+    func didLoadManifest(packageIdentity: PackageIdentity, packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind, manifest: Manifest?, diagnostics: [Basics.Diagnostic], duration: DispatchTimeInterval)
 
     /// The workspace has started fetching this package.
     func willFetchPackage(package: PackageIdentity, packageLocation: String?, fetchDetails: PackageFetchDetails)
@@ -84,12 +84,12 @@ public protocol WorkspaceDelegate: AnyObject {
     /// The workspace is about to clone a repository from the local cache to a working directory.
     func willCreateWorkingCopy(package: PackageIdentity, repository url: String, at path: AbsolutePath)
     /// The workspace has cloned a repository from the local cache to a working directory. The error indicates whether the operation failed or succeeded.
-    func didCreateWorkingCopy(package: PackageIdentity, repository url: String, at path: AbsolutePath)
+    func didCreateWorkingCopy(package: PackageIdentity, repository url: String, at path: AbsolutePath, duration: DispatchTimeInterval)
 
     /// The workspace is about to check out a particular revision of a working directory.
     func willCheckOut(package: PackageIdentity, repository url: String, revision: String, at path: AbsolutePath)
     /// The workspace has checked out a particular revision of a working directory. The error indicates whether the operation failed or succeeded.
-    func didCheckOut(package: PackageIdentity, repository url: String, revision: String, at path: AbsolutePath)
+    func didCheckOut(package: PackageIdentity, repository url: String, revision: String, at path: AbsolutePath, duration: DispatchTimeInterval)
 
     /// The workspace is removing this repository because it is no longer needed.
     func removing(package: PackageIdentity, packageLocation: String?)
@@ -2020,6 +2020,7 @@ extension Workspace {
 
         var manifestLoadingDiagnostics = [Basics.Diagnostic]()
 
+        let start = DispatchTime.now()
         self.manifestLoader.load(
             packagePath: packagePath,
             packageIdentity: packageIdentity,
@@ -2033,11 +2034,12 @@ extension Workspace {
             delegateQueue: .sharedConcurrent,
             callbackQueue: .sharedConcurrent
         ) { result in
+            let duration = start.distance(to: .now())
             var result = result
             switch result {
             case .failure(let error):
                 manifestLoadingDiagnostics.append(.error(error))
-                self.delegate?.didLoadManifest(packageIdentity: packageIdentity, packagePath: packagePath, url: packageLocation, version: packageVersion, packageKind: packageKind, manifest: nil, diagnostics: manifestLoadingDiagnostics)
+                self.delegate?.didLoadManifest(packageIdentity: packageIdentity, packagePath: packagePath, url: packageLocation, version: packageVersion, packageKind: packageKind, manifest: nil, diagnostics: manifestLoadingDiagnostics, duration: duration)
             case .success(let manifest):
                 let validator = ManifestValidator(manifest: manifest, sourceControlValidator: self.repositoryManager, fileSystem: self.fileSystem)
                 let validationIssues = validator.validate()
@@ -2046,7 +2048,7 @@ extension Workspace {
                     result = .failure(Diagnostics.fatalError)
                     manifestLoadingDiagnostics.append(contentsOf: validationIssues)
                 }
-                self.delegate?.didLoadManifest(packageIdentity: packageIdentity, packagePath: packagePath, url: packageLocation, version: packageVersion, packageKind: packageKind, manifest: manifest, diagnostics: manifestLoadingDiagnostics)
+                self.delegate?.didLoadManifest(packageIdentity: packageIdentity, packagePath: packagePath, url: packageLocation, version: packageVersion, packageKind: packageKind, manifest: manifest, diagnostics: manifestLoadingDiagnostics, duration: duration)
             }
             manifestLoadingScope.emit(manifestLoadingDiagnostics)
             completion(result)
@@ -3128,8 +3130,9 @@ extension Workspace {
         // Check out the given revision.
         let workingCopy = try self.repositoryManager.openWorkingCopy(at: checkoutPath)
 
-        // Inform the delegate.
+        // Inform the delegate that we're about to start.
         delegate?.willCheckOut(package: package.identity, repository: repository.location.description, revision: checkoutState.description, at: checkoutPath)
+        let start = DispatchTime.now()
 
         // Do mutable-immutable dance because checkout operation modifies the disk state.
         try fileSystem.chmod(.userWritable, path: checkoutPath, options: [.recursive, .onlyFiles])
@@ -3147,7 +3150,9 @@ extension Workspace {
         )
         try self.state.save()
 
-        delegate?.didCheckOut(package: package.identity, repository: repository.location.description, revision: checkoutState.description, at: checkoutPath)
+        // Inform the delegate that we're done.
+        let duration = start.distance(to: .now())
+        delegate?.didCheckOut(package: package.identity, repository: repository.location.description, revision: checkoutState.description, at: checkoutPath, duration: duration)
 
         return checkoutPath
     }
@@ -3235,13 +3240,20 @@ extension Workspace {
         // Clone the repository into the checkouts.
         let path = self.location.repositoriesCheckoutsDirectory.appending(component: repository.basename)
 
+        // Remove any existing content at that path.
         try self.fileSystem.chmod(.userWritable, path: path, options: [.recursive, .onlyFiles])
         try self.fileSystem.removeFileTree(path)
 
-        // Inform the delegate that we're starting cloning.
+        // Inform the delegate that we're about to start.
         self.delegate?.willCreateWorkingCopy(package: package.identity, repository: handle.repository.location.description, at: path)
+        let start = DispatchTime.now()
+        
+        // Create the working copy.
         _ = try handle.createWorkingCopy(at: path, editable: false)
-        self.delegate?.didCreateWorkingCopy(package: package.identity, repository: handle.repository.location.description, at: path)
+        
+        // Inform the delegate that we're done.
+        let duration = start.distance(to: .now())
+        self.delegate?.didCreateWorkingCopy(package: package.identity, repository: handle.repository.location.description, at: path, duration: duration)
 
         return path
     }


### PR DESCRIPTION
### Motivation:

The wall clock duration is already passed in didFetch, didUpdate, etc.  For completeness, Workspace should pass along the duration in the didLoadManifest/didCreateWorkingCopy/didCheckOut calls as well, so that libSwiftPM clients that want to use this information has access to it.

### Modifications:

- capture the start and end times, and pass them in the delegate callback

### Result:

- clients of these delegate calls have access to the duration for all of the will/did delegate call pairs

### Note:

This builds on top of https://github.com/apple/swift-package-manager/pull/6019 (because the changes touch the same lines), so only the newer of the two commits is specific to this PR.