### PR TITLE
Update `.swiftformat` for Swift 5.5

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,6 +1,6 @@
 # file options
 
---swiftversion 5.0
+--swiftversion 5.5
 --exclude .build
 
 # format options

--- a/.swiftformat
+++ b/.swiftformat
@@ -9,5 +9,6 @@
 --patternlet inline
 --stripunusedargs unnamed-only
 --ifdef no-indent
+--maxwidth 120
 
 # rules


### PR DESCRIPTION
Since `Package.swift` specifies the lowest supported version as 5.5, let's update `.swiftformat` config accordingly.
