### PR TITLE
Basics: don't point users to bugs.swift.org with `InternalError`

### DIFF
--- a/Sources/Basics/Errors.swift
+++ b/Sources/Basics/Errors.swift
@@ -18,6 +18,6 @@ public struct InternalError: Error {
     private let description: String
     public init(_ description: String) {
         assertionFailure(description)
-        self.description = "Internal error. Please file a bug at https://bugs.swift.org with this info. \(description)"
+        self.description = "Internal error. Please file a bug at https://github.com/apple/swift-package-manager/issues with this info. \(description)"
     }
 }


### PR DESCRIPTION
Since https://bugs.swift.org redirects to https://github.com/apple/swift/issues/, we'd like to point users to the SwiftPM repository issues instead.
