### PR TITLE
BuildPlan: provide user-actionable error description for `.noBuildableTarget`

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -1645,7 +1645,10 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
         public var description: String {
             switch self {
             case .noBuildableTarget:
-                return "the package does not contain a buildable target"
+                return """
+                The package does not contain a buildable target. 
+                Add at least one `.target` or `.executableTarget` to your `Package.swift`.
+                """
             }
         }
     }


### PR DESCRIPTION
### Motivation:

Currently, the error message `BuildPlan.Error.noBuildableTarget` doesn't specify any actions that a user could take to resolve the issue.

### Modifications:

Expanded the string literal returned from `description` of this error type to include a suggestion for users to take to resolve it.

### Result:

Users who stumble upon the error are less confused by the error message.
