### PR TITLE
Fix typos in test cases

### DIFF
--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -526,7 +526,7 @@ class PackageGraphTests: XCTestCase {
         }
     }
 
-    func testTargetOnclyContainingHeaders() throws {
+    func testTargetOnlyContainingHeaders() throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/Bar/Sources/Bar/include/bar.h"
         )


### PR DESCRIPTION
This PR corrects a typo that was included in the following PR.

https://github.com/apple/swift-package-manager/pull/6006