### PR TITLE
[5.8] PackagePlugin: fix typo in `PackageManagerProxyError` case

### DIFF
--- a/Sources/PackagePlugin/PackageManagerProxy.swift
+++ b/Sources/PackagePlugin/PackageManagerProxy.swift
@@ -267,7 +267,7 @@ fileprivate extension PackageManager {
 
 public enum PackageManagerProxyError: Error {
     /// Indicates that the functionality isn't implemented in the plugin host.
-    case unimlemented(_ message: String)
+    case unimplemented(_ message: String)
     
     /// An unspecified other kind of error from the Package Manager proxy.
     case unspecified(_ message: String)


### PR DESCRIPTION
`unimlemented` -> `unimplemented`

Since it's a case in a `public enum` of `PackagePlugin` module, which plugins are supposed to import, this is technically a source-breaking change. OTOH, do we expect that anyone had a `switch` for every case of this `enum`? This error case isn't thrown from anywhere.