### PR TITLE
Add hide-build flag to swift-run

### DIFF
--- a/Tests/CommandsTests/RunToolTests.swift
+++ b/Tests/CommandsTests/RunToolTests.swift
@@ -93,6 +93,15 @@ final class RunToolTests: CommandsTestCase {
         }
     }
 
+    func testHideBuildOption() throws {
+        try fixture(name: "Miscellaneous/FlatPackage") { fixturePath in
+            var (_, stderr) = try execute(["--hide-build"], packagePath: fixturePath)
+            XCTAssertNoMatch(stderr, .contains("[0/1] Planning build"))
+            XCTAssertNoMatch(stderr, .contains("Building for debugging..."))
+            XCTAssertNoMatch(stderr, .contains("Build complete!"))
+        }
+    }
+
     func testMutualExclusiveFlags() throws {
         try fixture(name: "Miscellaneous/EchoExecutable") { fixturePath in
             XCTAssertThrowsCommandExecutionError(try execute(["--build-tests", "--skip-build"], packagePath: fixturePath)) { error in


### PR DESCRIPTION
A flag hide-build has been added to the swift-run command to hide the output of the build.

### Motivation:

closes https://github.com/apple/swift-package-manager/issues/4758

If the build log is mixed with the log output at runtime, it becomes cumbersome to see the log output at runtime.

### Modifications:

Add the hide-build flag and switch the standard error output to a different output when this flag is true.

### Result:

Logs that used to be sent to standard error output at build time will no longer be displayed.
