### PR TITLE
update purge cache to warn when failing to delete files

### DIFF
--- a/Sources/SPMTestSupport/MockManifestLoader.swift
+++ b/Sources/SPMTestSupport/MockManifestLoader.swift
@@ -72,8 +72,8 @@ public final class MockManifestLoader: ManifestLoaderProtocol {
         }
     }
 
-    public func resetCache() throws {}
-    public func purgeCache() throws {}
+    public func resetCache(observabilityScope: ObservabilityScope) {}
+    public func purgeCache(observabilityScope: ObservabilityScope) {}
 }
 
 extension ManifestLoader {

--- a/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
@@ -708,7 +708,8 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
 
             // Resetting the cache should allow us to remove the cache
             // directory without triggering assertions in sqlite.
-            try manifestLoader.purgeCache()
+            manifestLoader.purgeCache(observabilityScope: observability.topScope)
+            XCTAssertNoDiagnostics(observability.diagnostics)
             try localFileSystem.removeFileTree(path)
         }
     }

--- a/Tests/PackageRegistryTests/RegistryDownloadsManagerTests.swift
+++ b/Tests/PackageRegistryTests/RegistryDownloadsManagerTests.swift
@@ -231,7 +231,7 @@ class RegistryDownloadsManagerTests: XCTestCase {
 
         do {
             try manager.remove(package: package)
-            try manager.purgeCache()
+            manager.purgeCache(observabilityScope: observability.topScope)
 
             delegate.prepare(fetchExpected: true)
             let path = try manager.lookup(package: package, version: packageVersion, observabilityScope: observability.topScope)

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -232,7 +232,9 @@ class RepositoryManagerTests: XCTestCase {
             XCTAssertEqual(delegate.willFetch.count, 1)
             XCTAssertEqual(delegate.didFetch.count, 1)
 
-            try manager.reset()
+            manager.reset(observabilityScope: observability.topScope)
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            
             XCTAssertTrue(!fs.isDirectory(repos))
             try fs.createDirectory(repos, recursive: true)
 

--- a/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
@@ -274,8 +274,8 @@ class RegistryPackageContainerTests: XCTestCase {
                     ))
                 }
 
-                func resetCache() throws {}
-                func purgeCache() throws {}
+                func resetCache(observabilityScope: ObservabilityScope) {}
+                func purgeCache(observabilityScope: ObservabilityScope) {}
             }
         }
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -9867,8 +9867,8 @@ final class WorkspaceTests: XCTestCase {
                 }
             }
 
-            func resetCache() throws {}
-            func purgeCache() throws {}
+            func resetCache(observabilityScope: ObservabilityScope) {}
+            func purgeCache(observabilityScope: ObservabilityScope) {}
         }
 
         let fs = InMemoryFileSystem()


### PR DESCRIPTION
motivation: better error reporting, more forgiving cache purging

changes: pass observability scope and emit warning / error when running into purge issues instead of throwing

rdar://103959749