### PR TITLE
Make PackageCollectionsSigningLibc dep conditional on supported platforms.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -82,7 +82,14 @@ packageCollectionsSigningTargets.append(
         ]
     )
 )
-packageCollectionsSigningDeps.append("PackageCollectionsSigningLibc")
+packageCollectionsSigningDeps.append(
+    .target(
+        name: "PackageCollectionsSigningLibc",
+        condition: .when(
+            platforms: [.linux, .android, .windows]
+        )
+    )
+)
 #endif
 // Define PackageCollectionsSigning target always
 packageCollectionsSigningTargets.append(


### PR DESCRIPTION
PackageCollectionsSigningLibc is only available in Linux, Android and Windows. However, PackageCollectionsSigning dependency on it is unconditional.

This does not matter in because the target and the dependency are added only for the supported platforms, but with the recently introduced #5784, the conditional code can be removed and the manifest can be simplified.

At the moment we can only add the dependency condition, because #5784 is not released yet, and Xcode's `swift build` will not correctly discard the target when building all targets just yet.

/cc @yim-lee