### PR TITLE
[NFC] Resolve `Tests/FunctionalTests/PluginTests.swift` test file's build errors.

### DIFF
--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -463,6 +463,7 @@ class PluginTests: XCTestCase {
                         accessibleTools: [:],
                         writableDirectories: [pluginDir.appending(component: "output")],
                         readOnlyDirectories: [package.path],
+                        pkgConfigDirectories: [],
                         fileSystem: localFileSystem,
                         observabilityScope: observability.topScope,
                         callbackQueue: delegateQueue,
@@ -645,10 +646,14 @@ class PluginTests: XCTestCase {
             XCTAssertNoDiagnostics(observability.diagnostics)
             XCTAssert(packageGraph.packages.count == 1, "\(packageGraph.packages)")
             XCTAssert(packageGraph.rootPackages.count == 1, "\(packageGraph.rootPackages)")
-            let package = try XCTUnwrap(packageGraph.rootPackages.first)
+            let package: ResolvedPackage = try XCTUnwrap(packageGraph.rootPackages.first)
             
             // Find the regular target in our test package.
-            let libraryTarget = try XCTUnwrap(package.targets.map(\.underlyingTarget).first{ $0.name == "MyLibrary" } as? SwiftTarget)
+            let libraryTarget = try XCTUnwrap(
+                package.targets
+                    .map(\.underlyingTarget)
+                    .first{ $0.name == "MyLibrary" } as? SwiftTarget
+            )
             XCTAssertEqual(libraryTarget.type, .library)
             
             // Set up a delegate to handle callbacks from the command plugin.  In particular we want to know the process identifier.
@@ -724,6 +729,7 @@ class PluginTests: XCTestCase {
                 accessibleTools: [:],
                 writableDirectories: [pluginDir.appending(component: "output")],
                 readOnlyDirectories: [package.path],
+                pkgConfigDirectories: [],
                 fileSystem: localFileSystem,
                 observabilityScope: observability.topScope,
                 callbackQueue: delegateQueue,


### PR DESCRIPTION
[`Tests/FunctionalTests/PluginTests.swift`](../../blob/main/Tests/FunctionalTests/PluginTests.swift) now compiles.

### Motivation:

The [`FunctionalTests` target is currently disabled](https://github.com/apple/swift-package-manager/blob/main/Package.swift#L554-L564), but I've been developing functional tests for #5919. In the time that it has been disabled, I guess there have been some API changes that broke the tests. This PR just fixes the test file so it compiles.

Up until now, I have just been commenting out the file, but we might as well fix it so everything works when the `FunctionalTests` is re-enabled.

### Modifications:

Fixed build errors in [`Tests/FunctionalTests/PluginTests.swift`](../../blob/main/Tests/FunctionalTests/PluginTests.swift).

### Result:

If you uncomment the `FunctionalTests` target locally, the target now builds without needing to comment out [`Tests/FunctionalTests/PluginTests.swift`](../../blob/main/Tests/FunctionalTests/PluginTests.swift).
