### PR TITLE
Enable Foundation-less manifests

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -501,10 +501,9 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         completion: @escaping (Result<EvaluationResult, Error>) -> Void
     ) throws {
         let manifestPreamble: ByteString
-        switch toolsVersion {
-        case .vNext:
+        if toolsVersion >= .v5_8 {
             manifestPreamble = ByteString()
-        default:
+        } else {
             manifestPreamble = ByteString("import Foundation\n")
         }
 


### PR DESCRIPTION
Looks like we missed enabling this for 5.8, but I think we should land it there.
