### PR TITLE
Pass WorkspaceConfiguration from convenience constructor

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -402,6 +402,7 @@ public class Workspace {
         try self.init(
             fileSystem: fileSystem,
             location: location,
+            configuration: configuration,
             cancellator: cancellator,
             initializationWarningHandler: initializationWarningHandler,
             customManifestLoader: customManifestLoader,

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -402,6 +402,8 @@ public class Workspace {
         try self.init(
             fileSystem: fileSystem,
             location: location,
+            authorizationProvider: authorizationProvider,
+            registryAuthorizationProvider: registryAuthorizationProvider,
             configuration: configuration,
             cancellator: cancellator,
             initializationWarningHandler: initializationWarningHandler,


### PR DESCRIPTION
### Motivation:

A convenience constructor of `Workspace` received some arguments. However, they are ignored. 
It may be a simple mistake.

### Modifications:

I passed some arguments to the default constructor from arguments.

### Result:

_[After your change, what will change.]_
