### PR TITLE
Support for building plugin dependencies for the host

### DIFF
--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -293,6 +293,50 @@ public struct BuildParameters: Encodable {
         self.verboseOutput = verboseOutput
     }
 
+    public func withDestination(_ destinationTriple: Triple) throws -> BuildParameters {
+        let forceTestDiscovery: Bool
+        let testEntryPointPath: AbsolutePath?
+        switch self.testProductStyle {
+        case .entryPointExecutable(let explicitlyEnabledDiscovery, let explicitlySpecifiedPath):
+            forceTestDiscovery = explicitlyEnabledDiscovery
+            testEntryPointPath = explicitlySpecifiedPath
+        case .loadableBundle:
+            forceTestDiscovery = false
+            testEntryPointPath = nil
+        }
+
+        return .init(
+            dataPath: self.dataPath.parentDirectory.appending(components: ["plugins", "tools"]),
+            configuration: self.configuration,
+            toolchain: try UserToolchain(destination: Destination.hostDestination()),
+            hostTriple: self.hostTriple,
+            destinationTriple: destinationTriple,
+            flags: BuildFlags(),
+            pkgConfigDirectories: self.pkgConfigDirectories,
+            architectures: nil,
+            workers: self.workers,
+            shouldLinkStaticSwiftStdlib: self.shouldLinkStaticSwiftStdlib,
+            shouldEnableManifestCaching: self.shouldEnableManifestCaching,
+            canRenameEntrypointFunctionName: self.canRenameEntrypointFunctionName,
+            shouldCreateDylibForDynamicProducts: self.shouldCreateDylibForDynamicProducts,
+            sanitizers: self.sanitizers,
+            enableCodeCoverage: self.enableCodeCoverage,
+            indexStoreMode: self.indexStoreMode,
+            enableParseableModuleInterfaces: self.enableParseableModuleInterfaces,
+            emitSwiftModuleSeparately: self.emitSwiftModuleSeparately,
+            useIntegratedSwiftDriver: self.useIntegratedSwiftDriver,
+            useExplicitModuleBuild: self.useExplicitModuleBuild,
+            isXcodeBuildSystemEnabled: self.isXcodeBuildSystemEnabled,
+            enableTestability: self.enableTestability,
+            forceTestDiscovery: forceTestDiscovery,
+            testEntryPointPath: testEntryPointPath,
+            explicitTargetDependencyImportCheckingMode: self.explicitTargetDependencyImportCheckingMode,
+            linkerDeadStrip: self.linkerDeadStrip,
+            colorizedOutput: self.colorizedOutput,
+            verboseOutput: self.verboseOutput
+        )
+    }
+
     /// The path to the build directory (inside the data directory).
     public var buildPath: AbsolutePath {
         if isXcodeBuildSystemEnabled {


### PR DESCRIPTION
Hacky support for building plugin dependencies for the host. This is achieved by creating a second build operation with altered build parameters and individually building dependencies using that build operation, somewhat similar to how command plugins operate.
