### PR TITLE
[5.8] Refactor how we are diagnosing unsafe flags

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -2473,7 +2473,8 @@ private extension PackageModel.SwiftTarget {
             path: .root,
             sources: sources,
             dependencies: dependencies,
-            swiftVersion: .v5
+            swiftVersion: .v5,
+            usesUnsafeFlags: false
         )
     }
 }

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -783,12 +783,8 @@ private final class ResolvedTargetBuilder: ResolvedBuilder<ResolvedTarget> {
     func diagnoseInvalidUseOfUnsafeFlags(_ product: ResolvedProduct) throws {
         // Diagnose if any target in this product uses an unsafe flag.
         for target in try product.recursiveTargetDependencies() {
-            for (decl, assignments) in target.underlyingTarget.buildSettings.assignments {
-                let flags = assignments.flatMap(\.values)
-                if BuildSettings.Declaration.unsafeSettings.contains(decl) && !flags.isEmpty {
-                    self.diagnosticsEmitter.emit(.productUsesUnsafeFlags(product: product.name, target: target.name))
-                    break
-                }
+            if target.underlyingTarget.usesUnsafeFlags {
+                self.diagnosticsEmitter.emit(.productUsesUnsafeFlags(product: product.name, target: target.name))
             }
         }
     }

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -867,7 +867,8 @@ public final class PackageBuilder {
                 others: others,
                 dependencies: dependencies,
                 swiftVersion: try swiftVersion(),
-                buildSettings: buildSettings
+                buildSettings: buildSettings,
+                usesUnsafeFlags: manifestTarget.usesUnsafeFlags
             )
         } else {
             // It's not a Swift target, so it's a Clang target (those are the only two types of source target currently supported).
@@ -899,7 +900,8 @@ public final class PackageBuilder {
                 resources: resources,
                 ignored: ignored,
                 dependencies: dependencies,
-                buildSettings: buildSettings
+                buildSettings: buildSettings,
+                usesUnsafeFlags: manifestTarget.usesUnsafeFlags
             )
         }
     }
@@ -1474,7 +1476,8 @@ extension PackageBuilder {
                     sources: sources,
                     dependencies: dependencies,
                     swiftVersion: try swiftVersion(),
-                    buildSettings: buildSettings
+                    buildSettings: buildSettings,
+                    usesUnsafeFlags: false
                 )
             }
     }
@@ -1497,5 +1500,11 @@ fileprivate extension Sequence {
             results.append(element)
         }
         return results
+    }
+}
+
+fileprivate extension TargetDescription {
+    var usesUnsafeFlags: Bool {
+        return settings.filter { $0.kind.isUnsafeFlags }.isEmpty == false
     }
 }

--- a/Sources/PackageModel/BuildSettings.swift
+++ b/Sources/PackageModel/BuildSettings.swift
@@ -38,11 +38,6 @@ public enum BuildSettings {
         private init(_ name: String) {
             self.name = name
         }
-
-        /// The list of settings that are considered as unsafe build settings.
-        public static let unsafeSettings: Set<Declaration> = [
-            OTHER_CFLAGS,  OTHER_CPLUSPLUSFLAGS, OTHER_SWIFT_FLAGS, OTHER_LDFLAGS,
-        ]
     }
 
     /// An individual build setting assignment.

--- a/Sources/PackageModel/Manifest/TargetBuildSettingDescription.swift
+++ b/Sources/PackageModel/Manifest/TargetBuildSettingDescription.swift
@@ -31,6 +31,16 @@ public enum TargetBuildSettingDescription {
         case unsafeFlags([String])
         case upcomingFeatures([String])
         case experimentalFeatures([String])
+
+        public var isUnsafeFlags: Bool {
+            switch self {
+            case .unsafeFlags(let flags):
+                // If `.unsafeFlags` is used, but doesn't specify any flags, we treat it the same way as not specifying it.
+                return !flags.isEmpty
+            case .headerSearchPath, .define, .linkedLibrary, .linkedFramework, .upcomingFeatures, .experimentalFeatures:
+                return false
+            }
+        }
     }
 
     /// An individual build setting.

--- a/Sources/PackageModel/Target.swift
+++ b/Sources/PackageModel/Target.swift
@@ -225,6 +225,9 @@ public class Target: PolymorphicCodableProtocol {
     /// The usages of package plugins by this target.
     public let pluginUsages: [PluginUsage]
 
+    /// Whether or not this target uses any custom unsafe flags.
+    public let usesUnsafeFlags: Bool
+
     fileprivate init(
         name: String,
         potentialBundleName: String? = nil,
@@ -236,7 +239,8 @@ public class Target: PolymorphicCodableProtocol {
         others: [AbsolutePath] = [],
         dependencies: [Target.Dependency],
         buildSettings: BuildSettings.AssignmentTable,
-        pluginUsages: [PluginUsage]
+        pluginUsages: [PluginUsage],
+        usesUnsafeFlags: Bool
     ) {
         self.name = name
         self.potentialBundleName = potentialBundleName
@@ -250,10 +254,11 @@ public class Target: PolymorphicCodableProtocol {
         self.c99name = self.name.spm_mangledToC99ExtendedIdentifier()
         self.buildSettings = buildSettings
         self.pluginUsages = pluginUsages
+        self.usesUnsafeFlags = usesUnsafeFlags
     }
 
     private enum CodingKeys: String, CodingKey {
-        case name, potentialBundleName, defaultLocalization, platforms, type, path, sources, resources, ignored, others, buildSettings, pluginUsages
+        case name, potentialBundleName, defaultLocalization, platforms, type, path, sources, resources, ignored, others, buildSettings, pluginUsages, usesUnsafeFlags
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -272,6 +277,7 @@ public class Target: PolymorphicCodableProtocol {
         try container.encode(buildSettings, forKey: .buildSettings)
         // FIXME: pluginUsages property is skipped on purpose as it points to
         // the actual target dependency object.
+        try container.encode(usesUnsafeFlags, forKey: .usesUnsafeFlags)
     }
 
     required public init(from decoder: Decoder) throws {
@@ -292,6 +298,7 @@ public class Target: PolymorphicCodableProtocol {
         // FIXME: pluginUsages property is skipped on purpose as it points to
         // the actual target dependency object.
         self.pluginUsages = []
+        self.usesUnsafeFlags = try container.decode(Bool.self, forKey: .usesUnsafeFlags)
     }
 }
 
@@ -331,7 +338,8 @@ public final class SwiftTarget: Target {
             sources: testDiscoverySrc,
             dependencies: dependencies,
             buildSettings: .init(),
-            pluginUsages: []
+            pluginUsages: [],
+            usesUnsafeFlags: false
         )
     }
 
@@ -350,7 +358,8 @@ public final class SwiftTarget: Target {
         dependencies: [Target.Dependency] = [],
         swiftVersion: SwiftLanguageVersion,
         buildSettings: BuildSettings.AssignmentTable = .init(),
-        pluginUsages: [PluginUsage] = []
+        pluginUsages: [PluginUsage] = [],
+        usesUnsafeFlags: Bool
     ) {
         self.swiftVersion = swiftVersion
         super.init(
@@ -364,7 +373,8 @@ public final class SwiftTarget: Target {
             others: others,
             dependencies: dependencies,
             buildSettings: buildSettings,
-            pluginUsages: pluginUsages
+            pluginUsages: pluginUsages,
+            usesUnsafeFlags: usesUnsafeFlags
         )
     }
 
@@ -392,7 +402,8 @@ public final class SwiftTarget: Target {
             sources: sources,
             dependencies: dependencies,
             buildSettings: .init(),
-            pluginUsages: []
+            pluginUsages: [],
+            usesUnsafeFlags: false
         )
     }
 
@@ -443,7 +454,8 @@ public final class SystemLibraryTarget: Target {
             sources: sources,
             dependencies: [],
             buildSettings: .init(),
-            pluginUsages: []
+            pluginUsages: [],
+            usesUnsafeFlags: false
         )
     }
 
@@ -508,7 +520,8 @@ public final class ClangTarget: Target {
         ignored: [AbsolutePath] = [],
         others: [AbsolutePath] = [],
         dependencies: [Target.Dependency] = [],
-        buildSettings: BuildSettings.AssignmentTable = .init()
+        buildSettings: BuildSettings.AssignmentTable = .init(),
+        usesUnsafeFlags: Bool
     ) throws {
         guard includeDir.isDescendantOfOrEqual(to: sources.root) else {
             throw StringError("\(includeDir) should be contained in the source root \(sources.root)")
@@ -530,7 +543,8 @@ public final class ClangTarget: Target {
             others: others,
             dependencies: dependencies,
             buildSettings: buildSettings,
-            pluginUsages: []
+            pluginUsages: [],
+            usesUnsafeFlags: usesUnsafeFlags
         )
     }
 
@@ -589,7 +603,8 @@ public final class BinaryTarget: Target {
             sources: sources,
             dependencies: [],
             buildSettings: .init(),
-            pluginUsages: []
+            pluginUsages: [],
+            usesUnsafeFlags: false
         )
     }
 
@@ -708,7 +723,8 @@ public final class PluginTarget: Target {
             sources: sources,
             dependencies: dependencies,
             buildSettings: .init(),
-            pluginUsages: []
+            pluginUsages: [],
+            usesUnsafeFlags: false
         )
     }
 

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -1421,10 +1421,6 @@ extension Target {
     var isCxx: Bool {
         (self as? ClangTarget)?.isCXX ?? false
     }
-
-    var usesUnsafeFlags: Bool {
-        Set(buildSettings.assignments.keys).contains(where: BuildSettings.Declaration.unsafeSettings.contains)
-    }
 }
 
 extension ProductType {

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -2253,6 +2253,69 @@ class PackageGraphTests: XCTestCase {
             }
         }
     }
+
+    func testDependencyOnUpcomingFeatures() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/Foo/Sources/Foo/foo.swift",
+            "/Foo/Sources/Foo2/foo.swift",
+            "/Bar/Sources/Bar/bar.swift",
+            "/Bar/Sources/Bar2/bar.swift",
+            "/Bar/Sources/Bar3/bar.swift",
+            "/Bar/Sources/TransitiveBar/bar.swift",
+            "<end>"
+        )
+
+        let observability = ObservabilitySystem.makeForTesting()
+        _ = try loadPackageGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    name: "Foo",
+                    path: .init(path: "/Foo"),
+                    dependencies: [
+                        .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    targets: [
+                        TargetDescription(name: "Foo", dependencies: ["Bar"]),
+                        TargetDescription(name: "Foo2", dependencies: ["TransitiveBar"]),
+                    ]),
+                Manifest.createFileSystemManifest(
+                    name: "Bar",
+                    path: .init(path: "/Bar"),
+                    products: [
+                        ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar", "Bar2", "Bar3"]),
+                        ProductDescription(name: "TransitiveBar", type: .library(.automatic), targets: ["TransitiveBar"]),
+                    ],
+                    targets: [
+                        TargetDescription(
+                            name: "Bar",
+                            settings: [
+                                .init(tool: .swift, kind: .upcomingFeatures(["ConciseMagicFile"])),
+                            ]
+                        ),
+                        TargetDescription(
+                            name: "Bar2",
+                            settings: [
+                                .init(tool: .swift, kind: .upcomingFeatures(["UnknownToTheseTools"])),
+                            ]
+                        ),
+                        TargetDescription(
+                            name: "Bar3",
+                            settings: [
+                                .init(tool: .swift, kind: .upcomingFeatures(["ExistentialAny", "UnknownToTheseTools"])),
+                            ]
+                        ),
+                        TargetDescription(
+                            name: "TransitiveBar",
+                            dependencies: ["Bar2"]
+                        ),
+                    ]),
+            ],
+            observabilityScope: observability.topScope
+        )
+
+        XCTAssertEqual(observability.diagnostics.count, 0, "unexpected diagnostics: \(observability.diagnostics.map { $0.description })")
+    }
 }
 
 

--- a/Tests/PackageGraphTests/TargetTests.swift
+++ b/Tests/PackageGraphTests/TargetTests.swift
@@ -25,7 +25,8 @@ private extension ResolvedTarget {
                 path: .root,
                 sources: Sources(paths: [], root: AbsolutePath(path: "/")),
                 dependencies: [],
-                swiftVersion: .v4
+                swiftVersion: .v4,
+                usesUnsafeFlags: false
             ),
             dependencies: deps.map { .target($0, conditions: []) },
             defaultLocalization: nil,


### PR DESCRIPTION
Currently, we are diagnosing unsafe flags in a bit of a backwards way, trying to infer them from build settings that were derived from them. This adds an explicit `usesUnsafeFlags` model property that is driven by whether the `unsafeFlags` API was used in a given target.

fixes #5965