### PR TITLE
Warn instead of error when non-Swift sources may be included in a target with module aliases

### DIFF
--- a/Sources/PackageGraph/ModuleAliasTracker.swift
+++ b/Sources/PackageGraph/ModuleAliasTracker.swift
@@ -100,14 +100,16 @@ class ModuleAliasTracker {
     }
 
     func validateAndApplyAliases(product: Product,
-                                 package: PackageIdentity) throws {
+                                 package: PackageIdentity,
+                                 observabilityScope: ObservabilityScope) throws {
         guard let targets = idToProductToAllTargets[package]?[product.identity] else { return }
         let targetsWithAliases = targets.filter{ $0.moduleAliases != nil }
-        for target in targetsWithAliases {
-            if target.sources.containsNonSwiftFiles {
-                throw PackageGraphError.invalidSourcesForModuleAliasing(target: target.name, product: product.name, package: package.description)
+        for targetWithAlias in targetsWithAliases {
+            if targetWithAlias.sources.containsNonSwiftFiles {
+                let aliasesMsg = targetWithAlias.moduleAliases?.map{"'\($0.key)' as '\($0.value)'"}.joined(separator: ", ") ?? ""
+                observabilityScope.emit(warning: "target '\(targetWithAlias.name)' for product '\(product.name)' from package '\(package.description)' has module aliases: [\(aliasesMsg)] but may contain non-Swift sources; there might be a conflict among non-Swift symbols")
             }
-            target.applyAlias()
+            targetWithAlias.applyAlias()
         }
     }
 

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -699,7 +699,8 @@ private func resolveModuleAliases(packageBuilders: [ResolvedPackageBuilder],
     for packageBuilder in packageBuilders {
         for product in packageBuilder.package.products {
             try aliasTracker.validateAndApplyAliases(product: product,
-                                                     package: packageBuilder.package.identity)
+                                                     package: packageBuilder.package.identity,
+                                                     observabilityScope: observabilityScope)
         }
     }
     return true

--- a/Sources/PackageGraph/PackageGraph.swift
+++ b/Sources/PackageGraph/PackageGraph.swift
@@ -46,12 +46,6 @@ enum PackageGraphError: Swift.Error {
                                product: String,
                                package: String,
                                aliases: [String])
-
-    /// Invalid sources found (only Swift files allowed) for aliasing a module
-    /// specified by a given target/product/package.
-    case invalidSourcesForModuleAliasing(target: String,
-                                         product: String,
-                                         package: String)
 }
 
 /// A collection of packages.
@@ -253,8 +247,6 @@ extension PackageGraphError: CustomStringConvertible {
             return "multiple products named '\(product)' in: '\(packages.joined(separator: "', '"))'"
         case .multipleModuleAliases(let target, let product, let package, let aliases):
             return "multiple aliases: ['\(aliases.joined(separator: "', '"))'] found for target '\(target)' in product '\(product)' from package '\(package)'"
-        case .invalidSourcesForModuleAliasing(let target, let product, let package):
-            return "module aliasing can only be used for Swift based targets; non-Swift sources found in target '\(target)' for product '\(product)' from package '\(package)'"
         case .unsupportedPluginDependency(let targetName, let dependencyName, let dependencyType,  let dependencyPackage):
             var trailingMsg = ""
             if let depPkg = dependencyPackage {

--- a/Tests/BuildTests/ModuleAliasingBuildTests.swift
+++ b/Tests/BuildTests/ModuleAliasingBuildTests.swift
@@ -814,7 +814,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                     "/fooPkg/Sources/Logging/include/fileLogging.h"
         )
         let observability = ObservabilitySystem.makeForTesting()
-        XCTAssertThrowsError(try loadPackageGraph(
+        let _ = try loadPackageGraph(
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
@@ -844,13 +844,10 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
             ],
             observabilityScope: observability.topScope
-        )) { error in
-            var diagnosed = false
-            if let realError = error as? PackageGraphError,
-                    realError.description == "module aliasing can only be used for Swift based targets; non-Swift sources found in target 'Logging' for product 'Utils' from package 'foopkg'" {
-                diagnosed = true
-            }
-            XCTAssertTrue(diagnosed)
+        )
+
+        testDiagnostics(observability.diagnostics) { result in
+            result.check(diagnostic: "target 'Logging' for product 'Utils' from package 'foopkg' has module aliases: ['Logging' as 'FooLogging'] but may contain non-Swift sources; there might be a conflict among non-Swift symbols", severity: .warning)
         }
     }
 
@@ -864,7 +861,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
         )
 
         let observability = ObservabilitySystem.makeForTesting()
-        XCTAssertThrowsError(try loadPackageGraph(
+        let _ = try loadPackageGraph(
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
@@ -906,13 +903,10 @@ final class ModuleAliasingBuildTests: XCTestCase {
                     ]),
             ],
             observabilityScope: observability.topScope
-        )) { error in
-            var diagnosed = false
-            if let realError = error as? PackageGraphError,
-                    realError.description == "module aliasing can only be used for Swift based targets; non-Swift sources found in target 'Logging' for product 'Logging' from package 'barpkg'" {
-                diagnosed = true
-            }
-            XCTAssertTrue(diagnosed)
+        )
+
+        testDiagnostics(observability.diagnostics) { result in
+            result.check(diagnostic: "target 'Logging' for product 'Logging' from package 'barpkg' has module aliases: ['Logging' as 'FooLogging'] but may contain non-Swift sources; there might be a conflict among non-Swift symbols", severity: .warning)
         }
     }
 


### PR DESCRIPTION
Warn instead of error when non-Swift sources may be included in a target that has module aliases. This helps when a Swift target being aliased in a package is in a dependency graph of another package which contains non-Swift sources.
Resolves rdar://102137567
