### PR TITLE
Support for embedding resources in an executable

### DIFF
--- a/Fixtures/Resources/EmbedInCodeSimple/Package.swift
+++ b/Fixtures/Resources/EmbedInCodeSimple/Package.swift
@@ -1,0 +1,10 @@
+// swift-tools-version: 999.0
+
+import PackageDescription
+
+let package = Package(
+    name: "EmbedInCodeSimple",
+    targets: [
+        .executableTarget(name: "EmbedInCodeSimple", resources: [.embedInCode("best.txt")]),
+    ]
+)

--- a/Fixtures/Resources/EmbedInCodeSimple/Sources/EmbedInCodeSimple/best.txt
+++ b/Fixtures/Resources/EmbedInCodeSimple/Sources/EmbedInCodeSimple/best.txt
@@ -1,0 +1,1 @@
+hello world

--- a/Fixtures/Resources/EmbedInCodeSimple/Sources/EmbedInCodeSimple/main.swift
+++ b/Fixtures/Resources/EmbedInCodeSimple/Sources/EmbedInCodeSimple/main.swift
@@ -1,0 +1,3 @@
+import Foundation
+
+print("\(String(decoding: Data(PackageResources.best_txt), as: UTF8.self))")

--- a/Sources/Build/LLBuildManifestBuilder.swift
+++ b/Sources/Build/LLBuildManifestBuilder.swift
@@ -174,9 +174,14 @@ extension LLBuildManifestBuilder {
 
         // Create a copy command for each resource file.
         for resource in target.resources {
-            let destination = bundlePath.appending(resource.destination)
-            let (_, output) = addCopyCommand(from: resource.path, to: destination)
-            outputs.append(output)
+            switch resource.rule {
+            case .copy, .process:
+                let destination = bundlePath.appending(resource.destination)
+                let (_, output) = addCopyCommand(from: resource.path, to: destination)
+                outputs.append(output)
+            case .embedInCode:
+                break
+            }
         }
 
         // Create a copy command for the Info.plist if a resource with the same name doesn't exist yet.

--- a/Sources/PackageDescription/Resource.swift
+++ b/Sources/PackageDescription/Resource.swift
@@ -94,4 +94,10 @@ public struct Resource: Encodable {
     public static func copy(_ path: String) -> Resource {
         return Resource(rule: "copy", path: path, localization: nil)
     }
+
+    /// Applies the embed rule to a resource at the given path.
+    @available(_PackageDescription, introduced: 999.0)
+    public static func embedInCode(_ path: String) -> Resource {
+        return Resource(rule: "embedInCode", path: path, localization: nil)
+    }
 }

--- a/Sources/PackageLoading/ManifestJSONParser.swift
+++ b/Sources/PackageLoading/ManifestJSONParser.swift
@@ -362,6 +362,8 @@ enum ManifestJSONParser {
                 return .init(rule: .process(localization: localization), path: path.pathString)
             case "copy":
                 return .init(rule: .copy, path: path.pathString)
+            case "embedInCode":
+                return .init(rule: .embedInCode, path: path.pathString)
             default:
                 throw InternalError("invalid resource rule \(rule)")
             }

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -76,6 +76,9 @@ public enum ModuleError: Swift.Error {
 
     /// A plugin target didn't declare a capability.
     case pluginCapabilityNotDeclared(target: String)
+
+    /// A C target has declared an embedded resource
+    case embedInCodeNotSupported(target: String)
 }
 
 extension ModuleError: CustomStringConvertible {
@@ -124,6 +127,8 @@ extension ModuleError: CustomStringConvertible {
             return "manifest property 'defaultLocalization' not set; it is required in the presence of localized resources"
         case .pluginCapabilityNotDeclared(let target):
             return "plugin target '\(target)' doesn't have a 'capability' property"
+        case .embedInCodeNotSupported(let target):
+            return "embedding resources in code not supported for C-family language target \(target)"
         }
     }
 }
@@ -884,6 +889,10 @@ public final class PackageBuilder {
                 throw ModuleError.invalidPublicHeadersDirectory(potentialModule.name)
             } else {
                 moduleMapType = .none
+            }
+
+            if resources.contains(where: { $0.rule == .embedInCode }) {
+                throw ModuleError.embedInCodeNotSupported(target: potentialModule.name)
             }
 
             return try ClangTarget(

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -298,8 +298,10 @@ public struct TargetSourcesBuilder {
             }
 
             return Resource(rule: .process(localization: implicitLocalization ?? explicitLocalization), path: path)
-        case .copy:
+        case .copyResource:
             return Resource(rule: .copy, path: path)
+        case .embedResourceInCode:
+            return Resource(rule: .embedInCode, path: path)
         }
     }
 
@@ -504,7 +506,7 @@ public struct TargetSourcesBuilder {
                 } else {
                     observabilityScope.emit(warning: "Only Swift is supported for generated plugin source files at this time: \(absPath)")
                 }
-            case .copy, .processResource:
+            case .copyResource, .processResource, .embedResourceInCode:
                 if let resource = Self.resource(for: absPath, with: rule, defaultLocalization: defaultLocalization, targetName: targetName, targetPath: targetPath, observabilityScope: observabilityScope) {
                     resources.append(resource)
                 } else {
@@ -537,8 +539,11 @@ public struct FileRuleDescription {
         /// This defaults to copy if there's no specialized behavior.
         case processResource(localization: TargetDescription.Resource.Localization?)
 
+        /// The embed rule.
+        case embedResourceInCode
+
         /// The copy rule.
-        case copy
+        case copyResource
 
         /// The modulemap rule.
         case modulemap
@@ -709,7 +714,9 @@ extension FileRuleDescription.Rule {
         case .process(let localization):
             self = .processResource(localization: localization)
         case .copy:
-            self = .copy
+            self = .copyResource
+        case .embedInCode:
+            self = .embedResourceInCode
         }
     }
 }

--- a/Sources/PackageModel/Manifest/TargetDescription.swift
+++ b/Sources/PackageModel/Manifest/TargetDescription.swift
@@ -42,6 +42,7 @@ public struct TargetDescription: Equatable, Encodable {
         public enum Rule: Encodable, Equatable {
             case process(localization: Localization?)
             case copy
+            case embedInCode
         }
 
         public enum Localization: String, Encodable {

--- a/Sources/PackageModel/ManifestSourceGeneration.swift
+++ b/Sources/PackageModel/ManifestSourceGeneration.swift
@@ -422,6 +422,8 @@ fileprivate extension SourceCodeFragment {
             self.init(enum: "process", subnodes: params)
         case .copy:
             self.init(enum: "copy", subnodes: params)
+        case .embedInCode:
+            self.init(enum: "embedInCode", subnodes: params)
         }
     }
 

--- a/Sources/PackageModel/Resource.swift
+++ b/Sources/PackageModel/Resource.swift
@@ -44,5 +44,6 @@ public struct Resource: Codable, Equatable {
     public enum Rule: Codable, Equatable {
         case process(localization: String?)
         case copy
+        case embedInCode
     }
 }

--- a/Tests/FunctionalTests/ResourcesTests.swift
+++ b/Tests/FunctionalTests/ResourcesTests.swift
@@ -124,4 +124,11 @@ class ResourcesTests: XCTestCase {
             XCTAssertSwiftTest(fixturePath, extraArgs: ["--filter", "ClangResourceTests"])
         }
     }
+
+    func testResourcesEmbeddedInCode() throws {
+        try fixture(name: "Resources/EmbedInCodeSimple") { fixturePath in
+            let result = try executeSwiftRun(fixturePath, "EmbedInCodeSimple")
+            XCTAssertEqual(result.stdout, "hello world\n\n")
+        }
+    }
 }


### PR DESCRIPTION
Basic support for a new `.embed` resource rule which will allow embedding the contents of the resource into the executable code by generating a byte array, e.g.
    
```
@_implementationOnly import struct Foundation.Data
    
struct PackageResources {
static let best_txt = Data([104,101,108,108,111,32,119,111,114,108,100,10])
}
```
    
Note that the current naïve implementaton will not work well for larger resources as it is pretty memory inefficient.