### PR TITLE
NFC: add `.vscode` directory to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ Package.resolved
 /build
 *.pyc
 .docc-build
+.vscode


### PR DESCRIPTION
When opening the project with VS Code, it tends to create additional configuration files in this directory. So far I don't think it makes sense to share these settings between contributors, so let's ignore this directory for now.
