### PR TITLE
[5.8] Enable Foundation-less manifests

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -500,10 +500,9 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         completion: @escaping (Result<EvaluationResult, Error>) -> Void
     ) throws {
         let manifestPreamble: ByteString
-        switch toolsVersion {
-        case .vNext:
+        if toolsVersion >= .v5_8 {
             manifestPreamble = ByteString()
-        default:
+        } else {
             manifestPreamble = ByteString("import Foundation\n")
         }
 


### PR DESCRIPTION
Looks like we missed enabling this for 5.8, but I think we should land it there.

(cherry picked from commit f23ab80b32b0fc89b0181602542e8125fd854615)