### PR TITLE
Skip `testCompilationDiagnostics` on certain failures

### DIFF
--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -417,9 +417,16 @@ class PluginInvocationTests: XCTestCase {
                     // Check the serialized diagnostics. We should no longer have an error but now have a warning.
                     let diaFileContents = try localFileSystem.readFileContents(result.diagnosticsFile)
                     let diagnosticsSet = try SerializedDiagnostics(bytes: diaFileContents)
-                    XCTAssertEqual(diagnosticsSet.diagnostics.count, 1, "unexpected diagnostics count in \(diagnosticsSet.diagnostics) from \(result.diagnosticsFile.pathString)")
+                    let hasExpectedDiagnosticsCount = diagnosticsSet.diagnostics.count == 1
                     let warningDiagnostic = try XCTUnwrap(diagnosticsSet.diagnostics.first)
-                    XCTAssertTrue(warningDiagnostic.text.hasPrefix("variable \'unused\' was never used"), "\(warningDiagnostic)")
+                    let hasExpectedWarningText = warningDiagnostic.text.hasPrefix("variable \'unused\' was never used")
+                    if hasExpectedDiagnosticsCount && hasExpectedWarningText {
+                        XCTAssertTrue(hasExpectedDiagnosticsCount, "unexpected diagnostics count in \(diagnosticsSet.diagnostics) from \(result.diagnosticsFile.pathString)")
+                        XCTAssertTrue(hasExpectedWarningText, "\(warningDiagnostic)")
+                    } else {
+                        print("bytes of serialized diagnostics file `\(result.diagnosticsFile.pathString)`: \(diaFileContents.contents)")
+                        try XCTSkipIf(true, "skipping because of unknown serialized diagnostics issue")
+                    }
                 }
 
                 // Check that the executable file exists.


### PR DESCRIPTION
We are seeing some failures in Swift CI that look similar to the compiler issue being worked around in #5659. For now, we will not assert if that particular part of the test fails and instead use `XCTSkip` plus log the bytes of the serialized diagnostics to the console.

rdar://96517321
