### PR TITLE
Fix PluginInvocationTests.testCompilationDiagnostics() to avoid throwing if no diagnostics at all are reported

### DIFF
--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -418,11 +418,11 @@ class PluginInvocationTests: XCTestCase {
                     let diaFileContents = try localFileSystem.readFileContents(result.diagnosticsFile)
                     let diagnosticsSet = try SerializedDiagnostics(bytes: diaFileContents)
                     let hasExpectedDiagnosticsCount = diagnosticsSet.diagnostics.count == 1
-                    let warningDiagnostic = try XCTUnwrap(diagnosticsSet.diagnostics.first)
-                    let hasExpectedWarningText = warningDiagnostic.text.hasPrefix("variable \'unused\' was never used")
+                    let warningDiagnosticText = diagnosticsSet.diagnostics.first?.text ?? ""
+                    let hasExpectedWarningText = warningDiagnosticText.hasPrefix("variable \'unused\' was never used")
                     if hasExpectedDiagnosticsCount && hasExpectedWarningText {
                         XCTAssertTrue(hasExpectedDiagnosticsCount, "unexpected diagnostics count in \(diagnosticsSet.diagnostics) from \(result.diagnosticsFile.pathString)")
-                        XCTAssertTrue(hasExpectedWarningText, "\(warningDiagnostic)")
+                        XCTAssertTrue(hasExpectedWarningText, "\(warningDiagnosticText)")
                     } else {
                         print("bytes of serialized diagnostics file `\(result.diagnosticsFile.pathString)`: \(diaFileContents.contents)")
                         try XCTSkipIf(true, "skipping because of unknown serialized diagnostics issue")


### PR DESCRIPTION
This is a follow-on to https://github.com/apple/swift-package-manager/pull/6076, which still contained a `XCTUnwrap()` that failed if there were no diagnostics.  See https://smooshbase.apple.com/swiftci/job/swift-pr-smoke-test/1860/console.