### PR TITLE
PackageLoading: fix tuple element wording

### DIFF
--- a/Sources/PackageLoading/README.md
+++ b/Sources/PackageLoading/README.md
@@ -4,7 +4,7 @@ This library defines the logic which translates between the Swift package
 manager conventions and the underlying project model.
 
 The intent is that it is largely a transformation taking the input project model
-objects descripted in a manifest applying the conventions.
+objects described in a manifest.
 
 Ultimately, this library should *only* deal with the content which is _local_ to
 a single package. Any cross-package information should be managed by the

--- a/Tests/PackageLoadingTests/PkgConfigAllowlistTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigAllowlistTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2014-2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -17,21 +17,21 @@ final class PkgConfigAllowlistTests: XCTestCase {
     func testSimpleFlags() throws {
         let cFlags = ["-I/usr/local/Cellar/gtk+3/3.18.9/include/gtk-3.0"]
         let libs = ["-L/usr/local/Cellar/gtk+3/3.18.9/lib", "-lgtk-3", "-w"]
-        XCTAssertTrue(try allowlist(pcFile: "dummy", flags: (cFlags, libs)).unallowed.isEmpty)
+        XCTAssertTrue(try allowlist(pcFile: "dummy", flags: (cFlags, libs)).disallowed.isEmpty)
     }
 
     func testFlagsWithInvalidFlags() throws {
         let cFlags = ["-I/usr/local/Cellar/gtk+3/3.18.9/include/gtk-3.0", "-L/hello"]
         let libs = ["-L/usr/local/Cellar/gtk+3/3.18.9/lib", "-lgtk-3", "-module-name", "name", "-werror"]
-        let unallowed = try allowlist(pcFile: "dummy", flags: (cFlags, libs)).unallowed
-        XCTAssertEqual(unallowed, ["-L/hello", "-module-name", "name", "-werror"])
+        let disallowed = try allowlist(pcFile: "dummy", flags: (cFlags, libs)).disallowed
+        XCTAssertEqual(disallowed, ["-L/hello", "-module-name", "name", "-werror"])
     }
 
     func testFlagsWithValueInNextFlag() throws {
         let cFlags = ["-I/usr/local", "-I", "/usr/local/Cellar/gtk+3/3.18.9/include/gtk-3.0", "-L/hello"]
         let libs = ["-L", "/usr/lib", "-L/usr/local/Cellar/gtk+3/3.18.9/lib", "-lgtk-3", "-module-name", "-lcool", "ok", "name"]
-        let unallowed = try allowlist(pcFile: "dummy", flags: (cFlags, libs)).unallowed
-        XCTAssertEqual(unallowed, ["-L/hello", "-module-name", "ok", "name"])
+        let disallowed = try allowlist(pcFile: "dummy", flags: (cFlags, libs)).disallowed
+        XCTAssertEqual(disallowed, ["-L/hello", "-module-name", "ok", "name"])
     }
 
     func testRemoveDefaultFlags() throws {


### PR DESCRIPTION
`unallowed` -> `disallowed`, since `unallowed` is not recognized by system spellcheckers, and is marked in Wiktionary as an obsolete form. Also cleaned up wording in `Sources/PackageLoading/README.md`