### PR TITLE
`swift-test` cannot determine if output writes to a terminal (#6081)

### DIFF
--- a/Sources/Commands/Utilities/TestingSupport.swift
+++ b/Sources/Commands/Utilities/TestingSupport.swift
@@ -116,6 +116,14 @@ enum TestingSupport {
     ) throws -> EnvironmentVariables {
         var env = EnvironmentVariables.process()
 
+        // If the standard output or error stream is NOT a TTY, set the NO_COLOR
+        // environment variable. This environment variable is a de facto
+        // standard used to inform downstream processes not to add ANSI escape
+        // codes to their output. SEE: https://www.no-color.org
+        if !stdoutStream.isTTY || !stderrStream.isTTY {
+            env["NO_COLOR"] = "1"
+        }
+
         // Add the code coverage related variables.
         if buildParameters.enableCodeCoverage {
             // Defines the path at which the profraw files will be written on test execution.


### PR DESCRIPTION
This change sets an environment variable before spawning swift-test if the calling process appears to support ANSI control codes in its output.

### Motivation:

XCTest does not currently consume this information, but having it will allow for improvements to CLI output during testing.

### Modifications:

This change sets an environment variable before spawning swift-test if the calling process appears to support ANSI control codes in its output. This environment variable is then propagated to swift-test/xctest.

### Result:

With this change, the environment variable `XCTEST_COLOR_DIAGNOSTICS_ENABLED` should be set to `1` in test processes if the calling process (`swift`) supports ANSI control codes (i.e. is a TTY.)
