### PR TITLE
[NFC] PackageGraph/ModuleAliasTracker.swift: fix typo

### DIFF
--- a/Sources/PackageGraph/ModuleAliasTracker.swift
+++ b/Sources/PackageGraph/ModuleAliasTracker.swift
@@ -14,7 +14,7 @@ import PackageModel
 import Basics
 
 // This is a helper class that tracks module aliases in a package dependency graph
-// and handles overriding upstream aliases where alises themselves conflict
+// and handles overriding upstream aliases where aliases themselves conflict.
 class ModuleAliasTracker {
     var aliasMap = [String: [ModuleAliasModel]]()
     var idToAliasMap = [PackageIdentity: [String: [ModuleAliasModel]]]()


### PR DESCRIPTION
`alises` -> `aliases`