### PR TITLE
PackageModel: add `Sendable` conformance to `Manifest`

### DIFF
--- a/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
+++ b/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
@@ -13,6 +13,7 @@
 import Dispatch
 import class Foundation.NSLock
 import class Foundation.ProcessInfo
+import struct Foundation.URL
 import enum TSCBasic.ProcessEnv
 import func TSCBasic.tsc_await
 
@@ -44,3 +45,10 @@ extension DispatchQueue {
         attributes: .concurrent
     )
 }
+
+#if swift(<5.7)
+public extension URL: UnsafeSendable {}
+#elseif !canImport(Darwin)
+// As of Swift 5.7 and 5.8 swift-corelibs-foundation doesn't have `Sendable` annotations yet.
+extension URL: @unchecked Sendable {}
+#endif

--- a/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
+++ b/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
@@ -47,7 +47,7 @@ extension DispatchQueue {
 }
 
 #if swift(<5.7)
-public extension URL: UnsafeSendable {}
+extension URL: UnsafeSendable {}
 #elseif !canImport(Darwin)
 // As of Swift 5.7 and 5.8 swift-corelibs-foundation doesn't have `Sendable` annotations yet.
 extension URL: @unchecked Sendable {}

--- a/Sources/Basics/Concurrency/ThreadSafeKeyValueStore.swift
+++ b/Sources/Basics/Concurrency/ThreadSafeKeyValueStore.swift
@@ -92,3 +92,9 @@ public final class ThreadSafeKeyValueStore<Key, Value> where Key: Hashable {
         }
     }
 }
+
+#if swift(<5.7)
+extension ThreadSafeKeyValueStore: UnsafeSendable where Key: Sendable, Value: Sendable {}
+#else
+extension ThreadSafeKeyValueStore: @unchecked Sendable where Key: Sendable, Value: Sendable {}
+#endif

--- a/Sources/PackageModel/CMakeLists.txt
+++ b/Sources/PackageModel/CMakeLists.txt
@@ -14,7 +14,7 @@ add_library(PackageModel
   Destination.swift
   Diagnostics.swift
   IdentityResolver.swift
-  Manifest.swift
+  Manifest/Manifest.swift
   Manifest/PackageConditionDescription.swift
   Manifest/PackageDependencyDescription.swift
   Manifest/PlatformDescription.swift

--- a/Sources/PackageModel/Manifest/Manifest.swift
+++ b/Sources/PackageModel/Manifest/Manifest.swift
@@ -16,7 +16,7 @@ import Foundation
 
 /// This contains the declarative specification loaded from package manifest
 /// files, and the tools for working with the manifest.
-public final class Manifest {
+public final class Manifest: Sendable {
 
     /// The standard filename for the manifest.
     public static let filename = basename + ".swift"
@@ -94,10 +94,10 @@ public final class Manifest {
     public let providers: [SystemPackageProviderDescription]?
 
     /// Targets required for building particular product filters.
-    private var _requiredTargets = ThreadSafeKeyValueStore<ProductFilter, [TargetDescription]>()
+    private let _requiredTargets = ThreadSafeKeyValueStore<ProductFilter, [TargetDescription]>()
 
     /// Dependencies required for building particular product filters.
-    private var _requiredDependencies = ThreadSafeKeyValueStore<ProductFilter, [PackageDependency]>()
+    private let _requiredDependencies = ThreadSafeKeyValueStore<ProductFilter, [PackageDependency]>()
 
     public init(
         displayName: String,

--- a/Sources/PackageModel/Manifest/PackageConditionDescription.swift
+++ b/Sources/PackageModel/Manifest/PackageConditionDescription.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Represents a manifest condition.
-public struct PackageConditionDescription: Codable, Equatable {
+public struct PackageConditionDescription: Codable, Equatable, Sendable {
     public let platformNames: [String]
     public let config: String?
 

--- a/Sources/PackageModel/Manifest/PackageDependencyDescription.swift
+++ b/Sources/PackageModel/Manifest/PackageDependencyDescription.swift
@@ -14,45 +14,45 @@ import Foundation
 import TSCBasic
 
 /// Represents a package dependency.
-public enum PackageDependency: Equatable, Hashable {
+public enum PackageDependency: Equatable, Hashable, Sendable {
     case fileSystem(FileSystem)
     case sourceControl(SourceControl)
     case registry(Registry)
     
-    public struct FileSystem: Equatable, Hashable, Encodable {
+    public struct FileSystem: Equatable, Hashable, Encodable, Sendable {
         public let identity: PackageIdentity
         public let nameForTargetDependencyResolutionOnly: String?
         public let path: AbsolutePath
         public let productFilter: ProductFilter
     }
 
-    public struct SourceControl: Equatable, Hashable, Encodable {
+    public struct SourceControl: Equatable, Hashable, Encodable, Sendable {
         public let identity: PackageIdentity
         public let nameForTargetDependencyResolutionOnly: String?
         public let location: Location
         public let requirement: Requirement
         public let productFilter: ProductFilter
 
-        public enum Requirement: Equatable, Hashable {
+        public enum Requirement: Equatable, Hashable, Sendable {
             case exact(Version)
             case range(Range<Version>)
             case revision(String)
             case branch(String)
         }
 
-        public enum Location: Equatable, Hashable {
+        public enum Location: Equatable, Hashable, Sendable {
             case local(AbsolutePath)
             case remote(URL)
         }
     }
 
-    public struct Registry: Equatable, Hashable, Encodable {
+    public struct Registry: Equatable, Hashable, Encodable, Sendable {
         public let identity: PackageIdentity
         public let requirement: Requirement
         public let productFilter: ProductFilter
 
         /// The dependency requirement.
-        public enum Requirement: Equatable, Hashable {
+        public enum Requirement: Equatable, Hashable, Sendable {
             case exact(Version)
             case range(Range<Version>)
         }

--- a/Sources/PackageModel/Manifest/PackageDependencyDescription.swift
+++ b/Sources/PackageModel/Manifest/PackageDependencyDescription.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+import Basics
 import TSCBasic
 
 /// Represents a package dependency.

--- a/Sources/PackageModel/Manifest/PlatformDescription.swift
+++ b/Sources/PackageModel/Manifest/PlatformDescription.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public struct PlatformDescription: Codable, Equatable {
+public struct PlatformDescription: Codable, Equatable, Sendable {
     public let platformName: String
     public let version: String
     public let options: [String]

--- a/Sources/PackageModel/Manifest/ProductDescription.swift
+++ b/Sources/PackageModel/Manifest/ProductDescription.swift
@@ -13,7 +13,7 @@
 import Basics
 
 /// The product description
-public struct ProductDescription: Equatable, Codable {
+public struct ProductDescription: Equatable, Codable, Sendable {
 
     /// The name of the product.
     public let name: String

--- a/Sources/PackageModel/Manifest/SystemPackageProviderDescription.swift
+++ b/Sources/PackageModel/Manifest/SystemPackageProviderDescription.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Represents system package providers.
-public enum SystemPackageProviderDescription: Equatable, Codable {
+public enum SystemPackageProviderDescription: Equatable, Codable, Sendable {
     case brew([String])
     case apt([String])
     case yum([String])

--- a/Sources/PackageModel/Manifest/TargetBuildSettingDescription.swift
+++ b/Sources/PackageModel/Manifest/TargetBuildSettingDescription.swift
@@ -14,7 +14,7 @@
 public enum TargetBuildSettingDescription {
 
     /// The tool for which a build setting is declared.
-    public enum Tool: String, Codable, Equatable, CaseIterable {
+    public enum Tool: String, Codable, Equatable, CaseIterable, Sendable {
         case c
         case cxx
         case swift
@@ -22,7 +22,7 @@ public enum TargetBuildSettingDescription {
     }
 
     /// The kind of the build setting, with associate configuration
-    public enum Kind: Codable, Equatable {
+    public enum Kind: Codable, Equatable, Sendable {
         case headerSearchPath(String)
         case define(String)
         case linkedLibrary(String)
@@ -44,7 +44,7 @@ public enum TargetBuildSettingDescription {
     }
 
     /// An individual build setting.
-    public struct Setting: Codable, Equatable {
+    public struct Setting: Codable, Equatable, Sendable {
 
         /// The tool associated with this setting.
         public let tool: Tool

--- a/Sources/PackageModel/Manifest/TargetDescription.swift
+++ b/Sources/PackageModel/Manifest/TargetDescription.swift
@@ -11,10 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 /// The description of an individual target.
-public struct TargetDescription: Equatable, Encodable {
+public struct TargetDescription: Equatable, Encodable, Sendable {
 
     /// The target type.
-    public enum TargetType: String, Equatable, Encodable {
+    public enum TargetType: String, Equatable, Encodable, Sendable {
         case regular
         case executable
         case test
@@ -24,7 +24,7 @@ public struct TargetDescription: Equatable, Encodable {
     }
 
     /// Represents a target's dependency on another entity.
-    public enum Dependency: Equatable {
+    public enum Dependency: Equatable, Sendable {
         case target(name: String, condition: PackageConditionDescription?)
         case product(name: String, package: String?, moduleAliases: [String: String]? = nil, condition: PackageConditionDescription?)
         case byName(name: String, condition: PackageConditionDescription?)
@@ -38,13 +38,13 @@ public struct TargetDescription: Equatable, Encodable {
         }
     }
 
-    public struct Resource: Encodable, Equatable {
-        public enum Rule: Encodable, Equatable {
+    public struct Resource: Encodable, Equatable, Sendable {
+        public enum Rule: Encodable, Equatable, Sendable {
             case process(localization: Localization?)
             case copy
         }
 
-        public enum Localization: String, Encodable {
+        public enum Localization: String, Encodable, Sendable {
             case `default`
             case base
         }
@@ -105,18 +105,18 @@ public struct TargetDescription: Equatable, Encodable {
     public let pluginCapability: PluginCapability?
     
     /// Represents the declared capability of a package plugin.
-    public enum PluginCapability: Equatable {
+    public enum PluginCapability: Equatable, Sendable {
         case buildTool
         case command(intent: PluginCommandIntent, permissions: [PluginPermission])
     }
     
-    public enum PluginCommandIntent: Equatable, Codable {
+    public enum PluginCommandIntent: Equatable, Codable, Sendable {
         case documentationGeneration
         case sourceCodeFormatting
         case custom(verb: String, description: String)
     }
 
-    public enum PluginPermission: Equatable, Codable {
+    public enum PluginPermission: Equatable, Codable, Sendable {
         case writeToPackageDirectory(reason: String)
     }
 
@@ -130,7 +130,7 @@ public struct TargetDescription: Equatable, Encodable {
     public let pluginUsages: [PluginUsage]?
 
     /// Represents a target's usage of a plugin target or product.
-    public enum PluginUsage: Equatable {
+    public enum PluginUsage: Equatable, Sendable {
         case plugin(name: String, package: String?)
     }
 

--- a/Sources/PackageModel/PackageIdentity.swift
+++ b/Sources/PackageModel/PackageIdentity.swift
@@ -14,7 +14,7 @@ import Foundation
 import TSCBasic
 
 /// The canonical identifier for a package, based on its source location.
-public struct PackageIdentity: CustomStringConvertible {
+public struct PackageIdentity: CustomStringConvertible, Sendable {
     /// A textual representation of this instance.
     public let description: String
 

--- a/Sources/PackageModel/PackageReference.swift
+++ b/Sources/PackageModel/PackageReference.swift
@@ -19,7 +19,7 @@ import TSCBasic
 /// This represents a reference to a package containing its identity and location.
 public struct PackageReference {
     /// The kind of package reference.
-    public enum Kind: Equatable, CustomStringConvertible {
+    public enum Kind: Equatable, CustomStringConvertible, Sendable {
         /// A root package.
         case root(AbsolutePath)
 

--- a/Sources/PackageModel/Product.swift
+++ b/Sources/PackageModel/Product.swift
@@ -71,10 +71,10 @@ extension Product: Hashable {
 }
 
 /// The type of product.
-public enum ProductType: Equatable, Hashable {
+public enum ProductType: Equatable, Hashable, Sendable {
 
     /// The type of library.
-    public enum LibraryType: String, Codable {
+    public enum LibraryType: String, Codable, Sendable {
 
         /// Static library.
         case `static`
@@ -113,7 +113,7 @@ public enum ProductType: Equatable, Hashable {
 /// Any product which matches the filter will be used for dependency resolution, whereas unrequested products will be ignored.
 ///
 /// Requested products need not actually exist in the package. Under certain circumstances, the resolver may request names whose package of origin are unknown. The intended package will recognize and fulfill the request; packages that do not know what it is will simply ignore it.
-public enum ProductFilter: Equatable, Hashable {
+public enum ProductFilter: Equatable, Hashable, Sendable {
 
     /// All products, targets, and tests are requested.
     ///

--- a/Sources/PackageModel/SwiftLanguageVersion.swift
+++ b/Sources/PackageModel/SwiftLanguageVersion.swift
@@ -15,7 +15,7 @@ import TSCBasic
 import Foundation
 
 /// Represents a Swift language version.
-public struct SwiftLanguageVersion {
+public struct SwiftLanguageVersion: Sendable {
 
     /// Swift language version 3.
     public static let v3 = SwiftLanguageVersion(uncheckedString: "3")

--- a/Sources/PackageModel/ToolsVersion.swift
+++ b/Sources/PackageModel/ToolsVersion.swift
@@ -15,7 +15,7 @@ import Foundation
 import TSCBasic
 
 /// Tools version represents version of the Swift toolchain.
-public struct ToolsVersion: Equatable, Hashable, Codable {
+public struct ToolsVersion: Equatable, Hashable, Codable, Sendable {
 
     public static let v3 = ToolsVersion(version: "3.1.0")
     public static let v4 = ToolsVersion(version: "4.0.0")

--- a/Sources/SourceControl/Repository.swift
+++ b/Sources/SourceControl/Repository.swift
@@ -299,7 +299,3 @@ public protocol FetchProgress {
     /// The current download speed including the unit
     var downloadSpeed: String? { get }
 }
-
-#if swift(<5.7)
-extension URL: UnsafeSendable {}
-#endif


### PR DESCRIPTION
### Motivation:

This is a first step towards making all model types in `PackageModel` compatible with Swift Concurrency. The only state that `class Manifest` had is `private` and is related to caching targets and dependencies. That state uses `ThreadSafeKeyValueStore`, which itself is `Sendable`.

### Modifications:

Made `Manifest` conform to `Sendable`, since it's a model type and has no base classes or subclasses and all of its properties are declared with `let`.

### Result:

`Manifest` is now `Sendable`, which removes a sendability warning when using `func loadRootManifest(at path: AbsolutePath, observabilityScope: ObservabilityScope) async throws -> Manifest` declared on `Workspace`.
