### PR TITLE
Remove checks for pre-5.5 versions of Swift.

### DIFF
--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -76,9 +76,6 @@ final class BuildToolTests: CommandsTestCase {
     }
 
     func testImportOfMissedDepWarning() throws {
-        #if swift(<5.5)
-        try XCTSkipIf(true, "skipping because host compiler doesn't support '-import-prescan'")
-        #endif
         // Verify the warning flow
         try fixture(name: "Miscellaneous/ImportOfMissingDependency") { path in
             let fullPath = try resolveSymlinks(path)

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -388,11 +388,6 @@ class MiscellaneousTestCase: XCTestCase {
     }
 
     func testTestsCanLinkAgainstExecutable() throws {
-        // Check if the host compiler supports the '-entry-point-function-name' flag.
-        #if swift(<5.5)
-        try XCTSkipIf(true, "skipping because host compiler doesn't support '-entry-point-function-name'")
-        #endif
-
         try fixture(name: "Miscellaneous/TestableExe") { fixturePath in
             do {
                 let (stdout, stderr) = try executeSwiftTest(fixturePath)

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -95,9 +95,6 @@ class InitTests: XCTestCase {
 
             XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources").appending(component: "Foo")), ["Foo.swift"])
             XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Tests")).sorted(), ["FooTests"])
-            
-            // If we have a compiler that supports `-entry-point-function-name`, we try building it (we need that flag now).
-            #if swift(>=5.5)
             XCTAssertBuilds(path)
             let triple = try UserToolchain.default.triple
             let binPath = path.appending(components: ".build", triple.platformBuildPathComponent(), "debug")
@@ -107,7 +104,6 @@ class InitTests: XCTestCase {
             XCTAssertFileExists(binPath.appending(component: "Foo"))
 #endif
             XCTAssertFileExists(binPath.appending(components: "Foo.swiftmodule"))
-            #endif
         }
     }
 


### PR DESCRIPTION
We are requiring tools-version 5.5 for a while, so these checks should not be required anymore.
