### PR TITLE
Basics/Concurrency: make thread-safe containers `Sendable`

### DIFF
--- a/Sources/Basics/Concurrency/ThreadSafeArrayStore.swift
+++ b/Sources/Basics/Concurrency/ThreadSafeArrayStore.swift
@@ -83,4 +83,8 @@ public final class ThreadSafeArrayStore<Value> {
     }
 }
 
+#if swift(<5.7)
+extension ThreadSafeArrayStore: UnsafeSendable where Value: Sendable {}
+#else
 extension ThreadSafeArrayStore: @unchecked Sendable where Value: Sendable {}
+#endif

--- a/Sources/Basics/Concurrency/ThreadSafeArrayStore.swift
+++ b/Sources/Basics/Concurrency/ThreadSafeArrayStore.swift
@@ -82,3 +82,5 @@ public final class ThreadSafeArrayStore<Value> {
         }
     }
 }
+
+extension ThreadSafeArrayStore: @unchecked Sendable where Value: Sendable {}

--- a/Sources/Basics/Concurrency/ThreadSafeBox.swift
+++ b/Sources/Basics/Concurrency/ThreadSafeBox.swift
@@ -99,3 +99,9 @@ extension ThreadSafeBox where Value == Int {
         }
     }
 }
+
+#if swift(<5.7)
+extension ThreadSafeBox: UnsafeSendable where Value: Sendable {}
+#else
+extension ThreadSafeBox: @unchecked Sendable where Value: Sendable {}
+#endif

--- a/Sources/Basics/Observability.swift
+++ b/Sources/Basics/Observability.swift
@@ -254,7 +254,7 @@ public struct DiagnosticsEmitter: DiagnosticsEmitterProtocol {
     }
 }
 
-public struct Diagnostic: CustomStringConvertible {
+public struct Diagnostic: CustomStringConvertible, Sendable {
     public let severity: Severity
     public let message: String
     public internal (set) var metadata: ObservabilityMetadata?

--- a/Sources/Basics/Observability.swift
+++ b/Sources/Basics/Observability.swift
@@ -485,7 +485,7 @@ public struct ObservabilityMetadata: CustomDebugStringConvertible, Sendable {
 
 public protocol ObservabilityMetadataKey {
     /// The type of value uniquely identified by this key.
-    associatedtype Value
+    associatedtype Value: Sendable
 }
 
 extension ObservabilityMetadata.AnyKey: Hashable {
@@ -512,7 +512,7 @@ extension ObservabilityMetadata {
         typealias Value = Error
     }
 
-    public struct UnderlyingError: CustomStringConvertible {
+    public struct UnderlyingError: CustomStringConvertible, Sendable {
         let underlying: Error
 
         public init (_ underlying: Error) {
@@ -573,7 +573,7 @@ extension ObservabilityMetadata {
         typealias Value = DiagnosticLocationWrapper
     }
 
-    public struct DiagnosticLocationWrapper: CustomStringConvertible {
+    public struct DiagnosticLocationWrapper: CustomStringConvertible, Sendable {
         let underlying: DiagnosticLocation
 
         public init (_ underlying: DiagnosticLocation) {
@@ -601,7 +601,7 @@ extension ObservabilityMetadata {
         typealias Value = DiagnosticDataWrapper
     }
 
-    struct DiagnosticDataWrapper: CustomStringConvertible {
+    struct DiagnosticDataWrapper: CustomStringConvertible, Sendable {
         let underlying: DiagnosticData
 
         public init (_ underlying: DiagnosticData) {

--- a/Sources/Basics/Observability.swift
+++ b/Sources/Basics/Observability.swift
@@ -414,7 +414,7 @@ public struct ObservabilityMetadata: CustomDebugStringConvertible, Sendable {
     ///
     /// - Parameter body: The closure to be invoked for each item stored in this `ObservabilityMetadata`,
     /// passing the type-erased key and the associated value.
-    public func forEach(_ body: (AnyKey, Any) throws -> Void) rethrows {
+    public func forEach(_ body: (AnyKey, Sendable) throws -> Void) rethrows {
         try self._storage.forEach { key, value in
             try body(key, value)
         }

--- a/Sources/CoreCommands/SwiftToolObservabilityHandler.swift
+++ b/Sources/CoreCommands/SwiftToolObservabilityHandler.swift
@@ -52,7 +52,7 @@ public struct SwiftToolObservabilityHandler: ObservabilityHandlerProvider {
         self.outputHandler.wait(timeout: timeout)
     }
 
-    struct OutputHandler: DiagnosticsHandler {
+    struct OutputHandler {
         private let logLevel: Diagnostic.Severity
         internal let outputStream: ThreadSafeOutputByteStream
         private let writer: InteractiveWriter
@@ -139,6 +139,14 @@ public struct SwiftToolObservabilityHandler: ObservabilityHandlerProvider {
         }
     }
 }
+
+#if swift(<5.7)
+extension SwiftToolObservabilityHandler.OutputHandler: UnsafeSendable {}
+#else
+extension SwiftToolObservabilityHandler.OutputHandler: @unchecked Sendable {}
+#endif
+
+extension SwiftToolObservabilityHandler.OutputHandler: DiagnosticsHandler {}
 
 /// This type is used to write on the underlying stream.
 ///

--- a/Sources/PackageCollections/Model/PackageTypes.swift
+++ b/Sources/PackageCollections/Model/PackageTypes.swift
@@ -15,6 +15,7 @@ import struct Foundation.URL
 
 import PackageModel
 import SourceControl
+import TSCUtility
 
 extension PackageCollectionsModel {
     /// Package metadata

--- a/Sources/PackageCollections/Model/TargetListResult.swift
+++ b/Sources/PackageCollections/Model/TargetListResult.swift
@@ -14,6 +14,7 @@ import Foundation
 
 import PackageModel
 import SourceControl
+import TSCUtility
 
 extension PackageCollectionsModel {
     public typealias TargetListResult = [TargetListItem]

--- a/Sources/PackageCollections/PackageCollections+Validation.swift
+++ b/Sources/PackageCollections/PackageCollections+Validation.swift
@@ -15,6 +15,7 @@ import TSCBasic
 import Basics
 import PackageCollectionsModel
 import PackageModel
+import TSCUtility
 
 // MARK: - Model validations
 

--- a/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
@@ -19,6 +19,7 @@ import class Foundation.NSRegularExpression
 import struct Foundation.URL
 import PackageModel
 import TSCBasic
+import TSCUtility
 
 struct GitHubPackageMetadataProvider: PackageMetadataProvider, Closable {
     private static let apiHostPrefix = "api."

--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -23,6 +23,7 @@ import PackageCollectionsSigning
 import PackageModel
 import SourceControl
 import TSCBasic
+import TSCUtility
 
 private typealias JSONModel = PackageCollectionModel.V1
 

--- a/Sources/PackageCollections/Providers/PackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/PackageMetadataProvider.swift
@@ -15,6 +15,7 @@ import struct Foundation.URL
 
 import PackageModel
 import TSCBasic
+import TSCUtility
 
 /// `PackageBasicMetadata` provider
 protocol PackageMetadataProvider {

--- a/Sources/PackageFingerprint/FilePackageFingerprintStorage.swift
+++ b/Sources/PackageFingerprint/FilePackageFingerprintStorage.swift
@@ -15,6 +15,7 @@ import Dispatch
 import Foundation
 import PackageModel
 import TSCBasic
+import struct TSCUtility.Version
 
 public struct FilePackageFingerprintStorage: PackageFingerprintStorage {
     let fileSystem: FileSystem

--- a/Sources/PackageFingerprint/PackageFingerprintStorage.swift
+++ b/Sources/PackageFingerprint/PackageFingerprintStorage.swift
@@ -14,6 +14,8 @@ import Basics
 import Dispatch
 import PackageModel
 
+import struct TSCUtility.Version
+
 public protocol PackageFingerprintStorage {
     func get(package: PackageIdentity,
              version: Version,

--- a/Sources/PackageGraph/DependencyResolver.swift
+++ b/Sources/PackageGraph/DependencyResolver.swift
@@ -15,6 +15,8 @@ import Dispatch
 import PackageModel
 import TSCBasic
 
+import struct TSCUtility.Version
+
 public protocol DependencyResolver {
     typealias Binding = (package: PackageReference, binding: BoundVersion, products: ProductFilter)
     typealias Delegate = DependencyResolverDelegate

--- a/Sources/SPMBuildCore/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/PluginInvocation.swift
@@ -1003,7 +1003,7 @@ extension ObservabilityMetadata {
     }
 }
 
-public struct FileLocation: Equatable, CustomStringConvertible {
+public struct FileLocation: Equatable, CustomStringConvertible, Sendable {
     public let file: AbsolutePath
     public let line: Int?
 


### PR DESCRIPTION
### Motivation:

Splitting up https://github.com/apple/swift-package-manager/pull/6089 into smaller PRs to track down crashes in tests reproducible only on CI.

### Modifications:

Made `ThreadSafeArrayStore` conform to `Sendable`.
