### PR TITLE
Add missing `TSCUtility.Version` import

### DIFF
--- a/Sources/Commands/ToolWorkspaceDelegate.swift
+++ b/Sources/Commands/ToolWorkspaceDelegate.swift
@@ -22,6 +22,7 @@ import Workspace
 
 import struct TSCBasic.AbsolutePath
 import protocol TSCBasic.OutputByteStream
+import struct TSCUtility.Version
 
 class ToolWorkspaceDelegate: WorkspaceDelegate {
     private struct DownloadProgress {

--- a/Sources/PackageCollections/Model/PackageTypes.swift
+++ b/Sources/PackageCollections/Model/PackageTypes.swift
@@ -16,6 +16,8 @@ import struct Foundation.URL
 import PackageModel
 import SourceControl
 
+import struct TSCUtility.Version
+
 extension PackageCollectionsModel {
     /// Package metadata
     public struct Package: Codable, Equatable {

--- a/Sources/PackageCollections/Model/TargetListResult.swift
+++ b/Sources/PackageCollections/Model/TargetListResult.swift
@@ -15,6 +15,8 @@ import Foundation
 import PackageModel
 import SourceControl
 
+import struct TSCUtility.Version
+
 extension PackageCollectionsModel {
     public typealias TargetListResult = [TargetListItem]
 

--- a/Sources/PackageCollections/PackageCollections+Validation.swift
+++ b/Sources/PackageCollections/PackageCollections+Validation.swift
@@ -16,6 +16,8 @@ import Basics
 import PackageCollectionsModel
 import PackageModel
 
+import struct TSCUtility.Version
+
 // MARK: - Model validations
 
 extension Model.CollectionSource {

--- a/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
@@ -20,6 +20,8 @@ import struct Foundation.URL
 import PackageModel
 import TSCBasic
 
+import struct TSCUtility.Version
+
 struct GitHubPackageMetadataProvider: PackageMetadataProvider, Closable {
     private static let apiHostPrefix = "api."
 

--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -24,6 +24,8 @@ import PackageModel
 import SourceControl
 import TSCBasic
 
+import struct TSCUtility.Version
+
 private typealias JSONModel = PackageCollectionModel.V1
 
 struct JSONPackageCollectionProvider: PackageCollectionProvider {

--- a/Sources/PackageCollections/Providers/PackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/PackageMetadataProvider.swift
@@ -16,6 +16,8 @@ import struct Foundation.URL
 import PackageModel
 import TSCBasic
 
+import struct TSCUtility.Version
+
 /// `PackageBasicMetadata` provider
 protocol PackageMetadataProvider {
     /// Retrieves metadata for a package with the given identity and repository address.

--- a/Sources/PackageCollectionsTool/SwiftPackageCollectionsTool.swift
+++ b/Sources/PackageCollectionsTool/SwiftPackageCollectionsTool.swift
@@ -19,6 +19,8 @@ import PackageCollections
 import PackageModel
 import TSCBasic
 
+import struct TSCUtility.Version
+
 private enum CollectionsError: Swift.Error {
     case invalidArgument(String)
     case invalidVersionString(String)

--- a/Sources/PackageFingerprint/FilePackageFingerprintStorage.swift
+++ b/Sources/PackageFingerprint/FilePackageFingerprintStorage.swift
@@ -16,6 +16,8 @@ import Foundation
 import PackageModel
 import TSCBasic
 
+import struct TSCUtility.Version
+
 public struct FilePackageFingerprintStorage: PackageFingerprintStorage {
     let fileSystem: FileSystem
     let directoryPath: AbsolutePath

--- a/Sources/PackageFingerprint/PackageFingerprintStorage.swift
+++ b/Sources/PackageFingerprint/PackageFingerprintStorage.swift
@@ -14,6 +14,8 @@ import Basics
 import Dispatch
 import PackageModel
 
+import struct TSCUtility.Version
+
 public protocol PackageFingerprintStorage {
     func get(package: PackageIdentity,
              version: Version,

--- a/Sources/PackageGraph/DependencyResolver.swift
+++ b/Sources/PackageGraph/DependencyResolver.swift
@@ -15,6 +15,8 @@ import Dispatch
 import PackageModel
 import TSCBasic
 
+import struct TSCUtility.Version
+
 public protocol DependencyResolver {
     typealias Binding = (package: PackageReference, binding: BoundVersion, products: ProductFilter)
     typealias Delegate = DependencyResolverDelegate

--- a/Sources/PackageGraph/PinsStore.swift
+++ b/Sources/PackageGraph/PinsStore.swift
@@ -15,6 +15,8 @@ import Foundation
 import PackageModel
 import TSCBasic
 
+import struct TSCUtility.Version
+
 public final class PinsStore {
     public typealias PinsMap = [PackageIdentity: PinsStore.Pin]
 

--- a/Sources/PackageGraph/PubGrub/PubGrubDependencyResolver.swift
+++ b/Sources/PackageGraph/PubGrub/PubGrubDependencyResolver.swift
@@ -17,6 +17,8 @@ import OrderedCollections
 import PackageModel
 import TSCBasic
 
+import struct TSCUtility.Version
+
 /// The solver that is able to transitively resolve a set of package constraints
 /// specified by a root package.
 public struct PubGrubDependencyResolver {

--- a/Sources/PackageGraph/PubGrub/PubGrubPackageContainer.swift
+++ b/Sources/PackageGraph/PubGrub/PubGrubPackageContainer.swift
@@ -14,6 +14,8 @@ import Basics
 import OrderedCollections
 import PackageModel
 
+import struct TSCUtility.Version
+
 /// A container for an individual package. This enhances PackageContainer to add PubGrub specific
 /// logic which is mostly related to computing incompatibilities at a particular version.
 internal final class PubGrubPackageContainer {

--- a/Sources/PackageLoading/ManifestJSONParser.swift
+++ b/Sources/PackageLoading/ManifestJSONParser.swift
@@ -15,6 +15,8 @@ import Basics
 import PackageModel
 import TSCBasic
 
+import struct TSCUtility.Version
+
 enum ManifestJSONParser {
     private static let filePrefix = "file://"
 

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -16,6 +16,7 @@ import Dispatch
 import PackageModel
 import TSCBasic
 import enum TSCUtility.Diagnostics
+import struct TSCUtility.Version
 
 public enum ManifestParseError: Swift.Error, Equatable {
     /// The manifest is empty, or at least from SwiftPM's perspective it is.

--- a/Sources/PackageLoading/ToolsVersionParser.swift
+++ b/Sources/PackageLoading/ToolsVersionParser.swift
@@ -15,6 +15,8 @@ import Basics
 import PackageModel
 import TSCBasic
 
+import struct TSCUtility.Version
+
 /// Protocol for the manifest loader interface.
 public struct ToolsVersionParser {
     // designed to be used as a static utility

--- a/Sources/PackageMetadata/PackageMetadata.swift
+++ b/Sources/PackageMetadata/PackageMetadata.swift
@@ -21,6 +21,7 @@ import struct Foundation.URL
 import struct TSCBasic.AbsolutePath
 import protocol TSCBasic.FileSystem
 import func TSCBasic.withTemporaryDirectory
+import struct TSCUtility.Version
 
 public struct Package {
     public enum Source {

--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -18,6 +18,8 @@ import PackageLoading
 import PackageModel
 import TSCBasic
 
+import struct TSCUtility.Version
+
 /// Package registry client.
 /// API specification: https://github.com/apple/swift-package-manager/blob/main/Documentation/Registry.md
 public final class RegistryClient: Cancellable {

--- a/Sources/PackageRegistry/RegistryDownloadsManager.swift
+++ b/Sources/PackageRegistry/RegistryDownloadsManager.swift
@@ -17,6 +17,8 @@ import PackageModel
 import TSCBasic
 import PackageLoading
 
+import struct TSCUtility.Version
+
 public class RegistryDownloadsManager: Cancellable {
     public typealias Delegate = RegistryDownloadsManagerDelegate
 

--- a/Sources/SPMTestSupport/ManifestExtensions.swift
+++ b/Sources/SPMTestSupport/ManifestExtensions.swift
@@ -13,6 +13,7 @@
 import Foundation
 import PackageModel
 import TSCBasic
+import struct TSCUtility.Version
 
 public extension Manifest {
 

--- a/Sources/SPMTestSupport/MockManifestLoader.swift
+++ b/Sources/SPMTestSupport/MockManifestLoader.swift
@@ -18,6 +18,8 @@ import PackageGraph
 import TSCBasic
 import func XCTest.XCTFail
 
+import struct TSCUtility.Version
+
 public enum MockManifestLoaderError: Swift.Error {
     case unknownRequest(String)
 }

--- a/Sources/SPMTestSupport/MockPackageFingerprintStorage.swift
+++ b/Sources/SPMTestSupport/MockPackageFingerprintStorage.swift
@@ -16,6 +16,8 @@ import class Foundation.NSLock
 import PackageFingerprint
 import PackageModel
 
+import struct TSCUtility.Version
+
 public class MockPackageFingerprintStorage: PackageFingerprintStorage {
     private var packageFingerprints: [PackageIdentity: [Version: [Fingerprint.Kind: Fingerprint]]]
     private let lock = NSLock()

--- a/Sources/SPMTestSupport/MockRegistry.swift
+++ b/Sources/SPMTestSupport/MockRegistry.swift
@@ -19,6 +19,8 @@ import PackageModel
 import PackageRegistry
 import TSCBasic
 
+import struct TSCUtility.Version
+
 public class MockRegistry {
     private static let mockRegistryURL = URL(string: "http://localhost/registry/mock")!
 

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -20,6 +20,8 @@ import TSCBasic
 import Workspace
 import XCTest
 
+import struct TSCUtility.Version
+
 public typealias Diagnostic = TSCBasic.Diagnostic
 
 public final class MockWorkspace {

--- a/Sources/SPMTestSupport/PackageDependencyDescriptionExtensions.swift
+++ b/Sources/SPMTestSupport/PackageDependencyDescriptionExtensions.swift
@@ -14,6 +14,8 @@ import Foundation
 import PackageModel
 import TSCBasic
 
+import struct TSCUtility.Version
+
 public extension PackageDependency {
     static func fileSystem(identity: PackageIdentity? = nil,
                            deprecatedName: String? = nil,

--- a/Sources/Workspace/FileSystemPackageContainer.swift
+++ b/Sources/Workspace/FileSystemPackageContainer.swift
@@ -17,6 +17,8 @@ import PackageLoading
 import PackageModel
 import TSCBasic
 
+import struct TSCUtility.Version
+
 /// Local file system package container.
 ///
 /// This class represent packages that are referenced locally in the file system.

--- a/Sources/Workspace/ManagedDependency.swift
+++ b/Sources/Workspace/ManagedDependency.swift
@@ -16,6 +16,8 @@ import PackageModel
 import SourceControl
 import TSCBasic
 
+import struct TSCUtility.Version
+
 extension Workspace {
     /// An individual managed dependency.
     ///

--- a/Sources/Workspace/RegistryPackageContainer.swift
+++ b/Sources/Workspace/RegistryPackageContainer.swift
@@ -18,6 +18,8 @@ import PackageModel
 import PackageRegistry
 import TSCBasic
 
+import struct TSCUtility.Version
+
 public class RegistryPackageContainer: PackageContainer {
     public let package: PackageReference
 

--- a/Sources/Workspace/ResolverPrecomputationProvider.swift
+++ b/Sources/Workspace/ResolverPrecomputationProvider.swift
@@ -17,6 +17,8 @@ import PackageModel
 import SourceControl
 import TSCBasic
 
+import struct TSCUtility.Version
+
 /// Enumeration of the different errors that can arise from the `ResolverPrecomputationProvider` provider.
 enum ResolverPrecomputationError: Error {
     /// Represents the error when a package was requested but couldn't be found.

--- a/Sources/Workspace/SourceControlPackageContainer.swift
+++ b/Sources/Workspace/SourceControlPackageContainer.swift
@@ -21,6 +21,7 @@ import SourceControl
 import TSCBasic
 
 import enum TSCUtility.Git
+import struct TSCUtility.Version
 
 /// Adaptor to expose an individual repository as a package container.
 internal final class SourceControlPackageContainer: PackageContainer, CustomStringConvertible {

--- a/Sources/Workspace/Workspace+State.swift
+++ b/Sources/Workspace/Workspace+State.swift
@@ -17,6 +17,8 @@ import PackageModel
 import SourceControl
 import TSCBasic
 
+import struct TSCUtility.Version
+
 /// Represents the workspace internal state persisted on disk.
 public final class WorkspaceState {
     /// The dependencies managed by the Workspace.

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -25,6 +25,7 @@ import TSCBasic
 import enum TSCUtility.Diagnostics
 import enum TSCUtility.SignpostName
 import struct TSCUtility.Triple
+import struct TSCUtility.Version
 
 public typealias Diagnostic = TSCBasic.Diagnostic
 

--- a/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
+++ b/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
@@ -20,6 +20,8 @@ import SourceControl
 import SPMTestSupport
 import TSCBasic
 
+import struct TSCUtility.Version
+
 class GitHubPackageMetadataProviderTests: XCTestCase {
     func testBaseURL() throws {
         let apiURL = URL(string: "https://api.github.com/repos/octocat/Hello-World")

--- a/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
@@ -19,6 +19,8 @@ import PackageModel
 import SourceControl
 import TSCBasic
 
+import struct TSCUtility.Version
+
 final class PackageCollectionsTests: XCTestCase {
     func testUpdateAuthTokens() throws {
         let authTokens = ThreadSafeKeyValueStore<AuthTokenType, String>()

--- a/Tests/PackageCollectionsTests/PackageIndexAndCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageIndexAndCollectionsTests.swift
@@ -18,6 +18,8 @@ import SPMTestSupport
 import TSCBasic
 import XCTest
 
+import struct TSCUtility.Version
+
 class PackageIndexAndCollectionsTests: XCTestCase {
     func testCollectionAddRemoveGetList() throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()

--- a/Tests/PackageCollectionsTests/Utility.swift
+++ b/Tests/PackageCollectionsTests/Utility.swift
@@ -21,6 +21,8 @@ import PackageModel
 import SourceControl
 import TSCBasic
 
+import struct TSCUtility.Version
+
 func makeMockSources(count: Int = Int.random(in: 5 ... 10)) -> [PackageCollectionsModel.CollectionSource] {
     let isTrusted: [Bool?] = [true, false, nil]
     return (0 ..< count).map { index in

--- a/Tests/PackageFingerprintTests/FilePackageFingerprintStorageTests.swift
+++ b/Tests/PackageFingerprintTests/FilePackageFingerprintStorageTests.swift
@@ -18,6 +18,8 @@ import SPMTestSupport
 import TSCBasic
 import XCTest
 
+import struct TSCUtility.Version
+
 final class FilePackageFingerprintStorageTests: XCTestCase {
     func testHappyCase() throws {
         let mockFileSystem = InMemoryFileSystem()

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -20,6 +20,8 @@ import SPMTestSupport
 import TSCBasic
 import XCTest
 
+import struct TSCUtility.Version
+
 // There's some useful helper utilities defined below for easier testing:
 //
 // Terms conform to ExpressibleByStringLiteral in this test module and their

--- a/Tests/PackageRegistryTests/RegistryClientTests.swift
+++ b/Tests/PackageRegistryTests/RegistryClientTests.swift
@@ -20,6 +20,8 @@ import SPMTestSupport
 import TSCBasic
 import XCTest
 
+import struct TSCUtility.Version
+
 final class RegistryClientTests: XCTestCase {
     func testGetPackageMetadata() throws {
         let registryURL = "https://packages.example.com"

--- a/Tests/PackageRegistryTests/RegistryDownloadsManagerTests.swift
+++ b/Tests/PackageRegistryTests/RegistryDownloadsManagerTests.swift
@@ -18,6 +18,8 @@ import SPMTestSupport
 import TSCBasic
 import XCTest
 
+import struct TSCUtility.Version
+
 class RegistryDownloadsManagerTests: XCTestCase {
     func testNoCache() throws {
         let observability = ObservabilitySystem.makeForTesting()

--- a/Tests/WorkspaceTests/PinsStoreTests.swift
+++ b/Tests/WorkspaceTests/PinsStoreTests.swift
@@ -19,6 +19,8 @@ import SPMTestSupport
 import SourceControl
 import Workspace
 
+import struct TSCUtility.Version
+
 final class PinsStoreTests: XCTestCase {
 
     let v1: Version = "1.0.0"

--- a/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
@@ -21,6 +21,8 @@ import TSCBasic
 @testable import Workspace
 import XCTest
 
+import struct TSCUtility.Version
+
 class RegistryPackageContainerTests: XCTestCase {
 
     func testToolsVersionCompatibleVersions() throws {

--- a/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
@@ -22,6 +22,7 @@ import TSCBasic
 import XCTest
 
 import enum TSCUtility.Git
+import struct TSCUtility.Version
 
 private class MockRepository: Repository {
     /// The fake location of the repository.

--- a/Tests/WorkspaceTests/ToolsVersionSpecificationGenerationTests.swift
+++ b/Tests/WorkspaceTests/ToolsVersionSpecificationGenerationTests.swift
@@ -17,6 +17,8 @@
 import XCTest
 import PackageModel
 
+import struct TSCUtility.Version
+
 /// Test cases for the generation of Swift tools version specifications.
 class ToolsVersionSpecificationGenerationTests: XCTestCase {
     /// Tests the generation of Swift tools version specifications.

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -25,6 +25,7 @@ import XCTest
 
 import enum TSCUtility.Diagnostics
 import struct TSCUtility.Triple
+import struct TSCUtility.Version
 
 final class WorkspaceTests: XCTestCase {
     func testBasics() throws {


### PR DESCRIPTION
`TSCUtility.Version` identifier is somehow implicitly re-exported in a lot of places. In some circumstances this re-exporting doesn't happen, which breaks the build.

### Motivation:

When building `main` I've multiple times stumbled upon errors showing that `TSCUtility.Version` is not available in scope. This could only surface in certain incremental build conditions, maybe dependency scanner not allowing this identifier to be re-exported.

### Modifications:

Added explicit `import struct TSCUtility.Version` where this identifier is used.

### Result:

Importing it explicitly seems safer and fixes build errors when incremental builds fail.
