### PR TITLE
[5.8] Fix manifest source generation for `enableUpcomingFeature`/`enableExp…

### DIFF
--- a/Sources/PackageDescription/BuildSettings.swift
+++ b/Sources/PackageDescription/BuildSettings.swift
@@ -319,7 +319,7 @@ public struct SwiftSetting: Encodable {
         _ condition: BuildSettingCondition? = nil
     ) -> SwiftSetting {
         return SwiftSetting(
-            name: "upcomingFeatures", value: [name], condition: condition)
+            name: "enableUpcomingFeature", value: [name], condition: condition)
     }
 
     /// Enable an experimental feature with the given name.
@@ -343,7 +343,7 @@ public struct SwiftSetting: Encodable {
         _ condition: BuildSettingCondition? = nil
     ) -> SwiftSetting {
         return SwiftSetting(
-            name: "experimentalFeatures", value: [name], condition: condition)
+            name: "enableExperimentalFeature", value: [name], condition: condition)
     }
 }
 

--- a/Sources/PackageLoading/ManifestJSONParser.swift
+++ b/Sources/PackageLoading/ManifestJSONParser.swift
@@ -423,12 +423,18 @@ enum ManifestJSONParser {
                 throw InternalError("invalid (empty) build settings value")
             }
             kind = .linkedFramework(value)
+        case "enableUpcomingFeature":
+            guard let value = values.first else {
+                throw InternalError("invalid (empty) build settings value")
+            }
+            kind = .enableUpcomingFeature(value)
+        case "enableExperimentalFeature":
+            guard let value = values.first else {
+                throw InternalError("invalid (empty) build settings value")
+            }
+            kind = .enableExperimentalFeature(value)
         case "unsafeFlags":
             kind = .unsafeFlags(values)
-        case "upcomingFeatures":
-            kind = .upcomingFeatures(values)
-        case "experimentalFeatures":
-            kind = .experimentalFeatures(values)
         default:
             throw InternalError("invalid build setting \(name)")
         }

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -980,7 +980,7 @@ public final class PackageBuilder {
                     decl = .OTHER_LDFLAGS
                 }
 
-            case .upcomingFeatures(let _values):
+            case .enableUpcomingFeature(let value):
                 switch setting.tool {
                 case .c, .cxx, .linker:
                     throw InternalError("only Swift supports upcoming features")
@@ -989,9 +989,9 @@ public final class PackageBuilder {
                     decl = .OTHER_SWIFT_FLAGS
                 }
 
-                values = _values.precedeElements(with: "-enable-upcoming-feature")
+                values = ["-enable-upcoming-feature", value]
 
-            case .experimentalFeatures(let _values):
+            case .enableExperimentalFeature(let value):
                 switch setting.tool {
                 case .c, .cxx, .linker:
                     throw InternalError(
@@ -1001,8 +1001,7 @@ public final class PackageBuilder {
                     decl = .OTHER_SWIFT_FLAGS
                 }
 
-                values = _values.precedeElements(
-                    with: "-enable-experimental-feature")
+                values = ["-enable-experimental-feature", value]
             }
 
             // Create an assignment for this setting.

--- a/Sources/PackageModel/Manifest/TargetBuildSettingDescription.swift
+++ b/Sources/PackageModel/Manifest/TargetBuildSettingDescription.swift
@@ -28,16 +28,17 @@ public enum TargetBuildSettingDescription {
         case linkedLibrary(String)
         case linkedFramework(String)
 
+        case enableUpcomingFeature(String)
+        case enableExperimentalFeature(String)
+
         case unsafeFlags([String])
-        case upcomingFeatures([String])
-        case experimentalFeatures([String])
 
         public var isUnsafeFlags: Bool {
             switch self {
             case .unsafeFlags(let flags):
                 // If `.unsafeFlags` is used, but doesn't specify any flags, we treat it the same way as not specifying it.
                 return !flags.isEmpty
-            case .headerSearchPath, .define, .linkedLibrary, .linkedFramework, .upcomingFeatures, .experimentalFeatures:
+            case .headerSearchPath, .define, .linkedLibrary, .linkedFramework, .enableUpcomingFeature, .enableExperimentalFeature:
                 return false
             }
         }

--- a/Sources/PackageModel/ManifestSourceGeneration.swift
+++ b/Sources/PackageModel/ManifestSourceGeneration.swift
@@ -470,7 +470,7 @@ fileprivate extension SourceCodeFragment {
         var params: [SourceCodeFragment] = []
 
         switch setting.kind {
-        case .headerSearchPath(let value), .linkedLibrary(let value), .linkedFramework(let value):
+        case .headerSearchPath(let value), .linkedLibrary(let value), .linkedFramework(let value), .enableUpcomingFeature(let value), .enableExperimentalFeature(let value):
             params.append(SourceCodeFragment(string: value))
             if let condition = setting.condition {
                 params.append(SourceCodeFragment(from: condition))
@@ -487,7 +487,7 @@ fileprivate extension SourceCodeFragment {
                 params.append(SourceCodeFragment(from: condition))
             }
             self.init(enum: setting.kind.name, subnodes: params)
-        case .unsafeFlags(let values), .upcomingFeatures(let values), .experimentalFeatures(let values):
+        case .unsafeFlags(let values):
             params.append(SourceCodeFragment(strings: values))
             if let condition = setting.condition {
                 params.append(SourceCodeFragment(from: condition))
@@ -639,10 +639,10 @@ extension TargetBuildSettingDescription.Kind {
             return "linkedFramework"
         case .unsafeFlags:
             return "unsafeFlags"
-        case .upcomingFeatures:
-            return "upcomingFeatures"
-        case .experimentalFeatures:
-            return "experimentalFeatures"
+        case .enableUpcomingFeature:
+            return "enableUpcomingFeature"
+        case .enableExperimentalFeature:
+            return "enableExperimentalFeature"
         }
     }
 }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -3219,8 +3219,8 @@ final class BuildPlanTests: XCTestCase {
                         .init(tool: .swift, kind: .define("RLINUX"), condition: .init(platformNames: ["linux"], config: "release")),
                         .init(tool: .swift, kind: .define("DMACOS"), condition: .init(platformNames: ["macos"], config: "debug")),
                         .init(tool: .swift, kind: .unsafeFlags(["-Isfoo", "-L", "sbar"])),
-                        .init(tool: .swift, kind: .upcomingFeatures(["BestFeature"])),
-                        .init(tool: .swift, kind: .upcomingFeatures(["WorstFeature"]), condition: .init(platformNames: ["macos"], config: "debug"))
+                        .init(tool: .swift, kind: .enableUpcomingFeature("BestFeature")),
+                        .init(tool: .swift, kind: .enableUpcomingFeature("WorstFeature"), condition: .init(platformNames: ["macos"], config: "debug"))
                     ]
                 ),
                 try TargetDescription(

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -2290,19 +2290,20 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(
                             name: "Bar",
                             settings: [
-                                .init(tool: .swift, kind: .upcomingFeatures(["ConciseMagicFile"])),
+                                .init(tool: .swift, kind: .enableUpcomingFeature("ConciseMagicFile")),
                             ]
                         ),
                         TargetDescription(
                             name: "Bar2",
                             settings: [
-                                .init(tool: .swift, kind: .upcomingFeatures(["UnknownToTheseTools"])),
+                                .init(tool: .swift, kind: .enableUpcomingFeature("UnknownToTheseTools")),
                             ]
                         ),
                         TargetDescription(
                             name: "Bar3",
                             settings: [
-                                .init(tool: .swift, kind: .upcomingFeatures(["ExistentialAny", "UnknownToTheseTools"])),
+                                .init(tool: .swift, kind: .enableUpcomingFeature("ExistentialAny")),
+                                .init(tool: .swift, kind: .enableUpcomingFeature("UnknownToTheseTools")),
                             ]
                         ),
                         TargetDescription(


### PR DESCRIPTION
…erimentalFeature`.

Manifest source generation was previously transforming:

    .enableUpcomingFeature("FeatureName")

to:

    .upcomingFeatures(["FeatureName"])

because of how the build setting was stored internally.

This commit fixes the issue by switching the internal model for these build settings to match the external model so they can be properly regenerated. This also matches how other build settings (like `linkedFramework`) are modeled internally.

This addresses <rdar://problem/104718971>.

(cherry picked from commit 366e79b8f0a40252bb7a01e3ca8c0c35f2647450)