### PR TITLE
Add a convenience accessor for `SourceModuleTarget` nature of a target

### DIFF
--- a/Documentation/Plugins.md
+++ b/Documentation/Plugins.md
@@ -149,7 +149,7 @@ import PackagePlugin
 struct MyPlugin: BuildToolPlugin {
     
     func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
-        guard let target = target as? SourceModuleTarget else { return [] }
+        guard let target = target.sourceModule else { return [] }
         let inputFiles = target.sourceFiles.filter({ $0.path.extension == "dat" })
         return try inputFiles.map {
             let inputFile = $0
@@ -300,7 +300,7 @@ struct MyCommandPlugin: CommandPlugin {
         for target in targets {
             // Skip any type of target that doesn't have source files.
             // Note: We could choose to instead emit a warning or error here.
-            guard let target = target as? SourceModuleTarget else { continue }
+            guard let target = target.sourceModule else { continue }
 
             // Invoke `sometool` on the target directory, passing a configuration
             // file from the package directory.

--- a/Sources/PackagePlugin/PackageModel.swift
+++ b/Sources/PackagePlugin/PackageModel.swift
@@ -43,6 +43,12 @@ public struct Package {
     public let targets: [Target]
 }
 
+public extension Package {
+    var sourceModules: [SourceModuleTarget] {
+        return targets.compactMap { $0.sourceModule }
+    }
+}
+
 /// Represents the origin of a package as it appears in the graph.
 public enum PackageOrigin {
     /// A root package (unversioned).
@@ -105,6 +111,12 @@ public protocol Product {
     /// example, an executable product must have one and only one target that
     /// defines the main entry point for an executable).
     var targets: [Target] { get }
+}
+
+public extension Product {
+    var sourceModules: [SourceModuleTarget] {
+        return targets.compactMap { $0.sourceModule }
+    }
 }
 
 /// Represents an executable product defined in a package.
@@ -385,6 +397,13 @@ public struct SystemLibraryTarget: Target {
   
     /// Flags from `pkg-config` to pass to the platform linker.
     public let linkerFlags: [String]
+}
+
+public extension Target {
+    /// Convenience accessor which casts the receiver to`SourceModuleTarget` if possible.
+    var sourceModule: SourceModuleTarget? {
+        return self as? SourceModuleTarget
+    }
 }
 
 /// Provides information about a list of files. The order is not defined

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -1330,7 +1330,7 @@ final class PackageToolTests: CommandsTestCase {
                             }
 
                             // Create and return a build command that uses all the `.foo` files in the target as inputs, so they get counted as having been handled.
-                            let fooFiles = (target as? SourceModuleTarget)?.sourceFiles.compactMap{ $0.path.extension == "foo" ? $0.path : nil } ?? []
+                            let fooFiles = target.sourceModule?.sourceFiles.compactMap{ $0.path.extension == "foo" ? $0.path : nil } ?? []
                             return [ .buildCommand(displayName: "A command", executable: Path("/bin/echo"), arguments: fooFiles, inputFiles: fooFiles) ]
                         }
 
@@ -1616,7 +1616,7 @@ final class PackageToolTests: CommandsTestCase {
                         let targets = try context.package.targets(named: targetNames)
 
                         // Print out the source files so that we can check them.
-                        if let sourceFiles = (targets.first{ $0.name == "MyLibrary" } as? SourceModuleTarget)?.sourceFiles {
+                        if let sourceFiles = targets.first(where: { $0.name == "MyLibrary" })?.sourceModule?.sourceFiles {
                             for file in sourceFiles {
                                 print("  \\(file.path): \\(file.type)")
                             }
@@ -2332,9 +2332,14 @@ final class PackageToolTests: CommandsTestCase {
                         let swiftSources = swiftTargets.flatMap{ $0.sourceFiles(withSuffix: ".swift") }
                         print("swiftSources: \\(swiftSources.map{ $0.path.lastComponent })")
 
-                        if let target = target as? SourceModuleTarget {
+                        if let target = target.sourceModule {
                             print("Module kind of '\\(target.name)': \\(target.kind)")
                         }
+
+                        var sourceModules = context.package.sourceModules
+                        print("sourceModules in package: \\(sourceModules.map { $0.name })")
+                        sourceModules = context.package.products.first?.sourceModules ?? []
+                        print("sourceModules in first product: \\(sourceModules.map { $0.name })")
                     }
                 }
                 extension String: Error {}


### PR DESCRIPTION
This essentially just does a cast to the protocol, but that makes plugin source code slightly nicer to read since this is a very common pattern.

resolves #5504
