### PR TITLE
Added a test for manifest source generation of `enableUpcomingFeature…

### DIFF
--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -505,4 +505,26 @@ class ManifestSourceGenerationTests: XCTestCase {
 
         try testManifestWritingRoundTrip(manifestContents: contents, toolsVersion: .v5_8)
     }
+
+    func testUpcomingAndExperimentalFeatures() throws {
+        let manifestContents = """
+            // swift-tools-version:5.8
+            import PackageDescription
+
+            let package = Package(
+                name: "UpcomingAndExperimentalFeatures",
+                targets: [
+                    .target(
+                        name: "MyTool",
+                        swiftSettings: [
+                            .enableUpcomingFeature("UpcomingFeatureOne"),
+                            .enableUpcomingFeature("UpcomingFeatureTwo"),
+                            .enableExperimentalFeature("ExperimentalFeature")
+                        ]
+                    ),
+                ]
+            )
+            """
+        try testManifestWritingRoundTrip(manifestContents: manifestContents, toolsVersion: .v5_8)
+    }
 }


### PR DESCRIPTION
…`/`enableExperimentalFeature`.

This ensures that we can properly round-trip these build settings through manifest source generation.