### PR TITLE
[NFC] PackageModel: add `Toolset` model type

### DIFF
--- a/Sources/PackageModel/CMakeLists.txt
+++ b/Sources/PackageModel/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(PackageModel
   Target.swift
   Toolchain.swift
   ToolchainConfiguration.swift
+  Toolset.swift
   ToolsVersion.swift
   ToolsVersionSpecificationGeneration.swift
   UserToolchain.swift

--- a/Sources/PackageModel/Toolset.swift
+++ b/Sources/PackageModel/Toolset.swift
@@ -1,0 +1,212 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2014-2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+import class Basics.ObservabilityScope
+import struct TSCBasic.AbsolutePath
+import protocol TSCBasic.FileSystem
+import struct TSCBasic.RelativePath
+import struct TSCBasic.StringError
+import struct TSCUtility.Version
+
+/// A set of paths and flags for tools used for building Swift packages. This type unifies pre-existing assorted ways
+/// to specify these properties across SwiftPM codebase.
+public struct Toolset {
+    public enum KnownTool: String, Hashable, CaseIterable {
+        case swiftCompiler
+        case cCompiler
+        case cxxCompiler
+        case linker
+        case librarian
+        case debugger
+    }
+
+    /// Properties of a known tool in a ``Toolset``.
+    public struct ToolProperties: Equatable {
+        /// Absolute path to the tool on the filesystem. If absent, implies a default tool is used.
+        public fileprivate(set) var path: AbsolutePath?
+
+        /// Command-line options to be passed to the tool when it's invoked.
+        public fileprivate(set) var extraCLIOptions: [String]?
+    }
+
+    /// A dictionary of known tools in this toolset.
+    public fileprivate(set) var knownTools: [KnownTool: ToolProperties]
+}
+
+extension Toolset {
+    /// Initialize a toolset from an encoded file on a file system.
+    /// - Parameters:
+    ///   - path: absolute path on the `fileSystem`.
+    ///   - fileSystem: file system from which the toolset should be read.
+    ///   - observability: an instance of `ObservabilityScope` to log warnings about unknown tools.
+    public init(from toolsetPath: AbsolutePath, at fileSystem: FileSystem, _ observability: ObservabilityScope) throws {
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(path: toolsetPath, fileSystem: fileSystem, as: DecodedToolset.self)
+        guard decoded.schemaVersion == Version(1, 0, 0) else {
+            throw StringError(
+                "Unsupported `schemaVersion` \(decoded.schemaVersion) in toolset configuration at \(toolsetPath)"
+            )
+        }
+
+        var knownTools = [KnownTool: ToolProperties]()
+        for (tool, properties) in decoded.tools {
+            guard let knownTool = KnownTool(rawValue: tool) else {
+                observability.emit(warning: "Unknown tool `\(tool)` in toolset configuration at `\(toolsetPath)`")
+                continue
+            }
+
+            let toolPath: AbsolutePath?
+            if let path = properties.path {
+                if let absolutePath = try? AbsolutePath(validating: path) {
+                    toolPath = absolutePath
+                } else {
+                    let rootPath = decoded.rootPath ?? toolsetPath.parentDirectory
+                    toolPath = rootPath.appending(RelativePath(path))
+                }
+            } else {
+                toolPath = nil
+            }
+
+            guard toolPath != nil || !(properties.extraCLIOptions?.isEmpty ?? true) else {
+                // don't keep track of a tool with no path and CLI options specified.
+                observability.emit(warning:
+                    """
+                    Tool `\(knownTool.rawValue) in toolset configuration at `\(toolsetPath)` has neither `path` nor \
+                    `extraCLIOptions` properties specified with valid values, skipping it.
+                    """
+                )
+                continue
+            }
+
+            knownTools[knownTool] = ToolProperties(
+                path: toolPath,
+                extraCLIOptions: properties.extraCLIOptions
+            )
+        }
+
+        self.init(knownTools: knownTools)
+    }
+
+    /// Merges toolsets together into a single configuration. Tools passed in a new toolset will shadow tools with
+    /// same names from previous toolsets. When no `path` is specified for a new tool, its `extraCLIOptions` are
+    /// appended to `extraCLIOptions` of a tool from a previous toolset, which allows augmenting existing tools instead
+    /// of replacing them.
+    /// - Parameter newToolset: new toolset to merge into the existing `self` toolset.
+    public mutating func merge(with newToolset: Toolset) {
+        for (newTool, newProperties) in newToolset.knownTools {
+            if newProperties.path != nil {
+                // if `newTool` has `path` specified, it overrides the existing tool completely.
+                knownTools[newTool] = newProperties
+            } else if let newExtraCLIOptions = newProperties.extraCLIOptions, !newExtraCLIOptions.isEmpty {
+                // if `newTool` has no `path` specified, `newExtraCLIOptions` are appended to the existing tool.
+                if var existingTool = knownTools[newTool] {
+                    // either update the existing tool and store it back...
+                    if existingTool.extraCLIOptions == nil {
+                        existingTool.extraCLIOptions = newExtraCLIOptions
+                    } else {
+                        existingTool.extraCLIOptions?.append(contentsOf: newExtraCLIOptions)
+                    }
+                    knownTools[newTool] = existingTool
+                } else {
+                    // ...or store a new tool if no existing tool is found.
+                    knownTools[newTool] = newProperties
+                }
+            }
+        }
+    }
+}
+
+/// A raw decoding of toolset configuration stored on disk.
+private struct DecodedToolset {
+    /// Version of a toolset schema used for decoding a toolset file.
+    let schemaVersion: Version
+
+    /// Root path of the toolset, if present. When filling in ``Toolset.ToolProperties/path``, if a raw path string in
+    /// ``DecodedToolset`` is inferred to be relative, it's resolved as absolute path relatively to `rootPath`.
+    let rootPath: AbsolutePath?
+
+    /// Dictionary of raw tools that haven't been validated yet to match ``Toolset.KnownTool``.
+    var tools: [String: ToolProperties]
+
+    /// Properties of a tool in a ``DecodedToolset``.
+    public struct ToolProperties {
+        /// Either a relative or an absolute path to the tool on the filesystem.
+        let path: String?
+
+        /// Command-line options to be passed to the tool when it's invoked.
+        let extraCLIOptions: [String]?
+    }
+}
+
+extension DecodedToolset.ToolProperties: Decodable {}
+
+extension DecodedToolset: Decodable {
+    /// Custom decoding keys that allow decoding tools with arbitrary names,
+    enum CodingKeys: Equatable {
+        case schemaVersion
+        case rootPath
+        case tool(String)
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.schemaVersion = try Version(
+            versionString: container.decode(String.self, forKey: .schemaVersion),
+            usesLenientParsing: true
+        )
+        self.rootPath = try container.decodeIfPresent(AbsolutePath.self, forKey: .rootPath)
+
+        self.tools = [String: DecodedToolset.ToolProperties]()
+        for key in container.allKeys {
+            switch key {
+            case .rootPath, .schemaVersion:
+                // These keys were already decoded before entering this loop, skipping.
+                continue
+            case .tool(let tool):
+                self.tools[tool] = try container.decode(DecodedToolset.ToolProperties.self, forKey: key)
+            }
+        }
+    }
+}
+
+extension DecodedToolset.CodingKeys: CodingKey {
+    var stringValue: String {
+        switch self {
+        case .schemaVersion:
+            return "schemaVersion"
+        case .rootPath:
+            return "rootPath"
+        case .tool(let toolName):
+            return toolName
+        }
+    }
+
+    init?(stringValue: String) {
+        switch stringValue {
+        case "schemaVersion":
+            self = .schemaVersion
+        case "rootPath":
+            self = .rootPath
+        default:
+            self = .tool(stringValue)
+        }
+    }
+
+    var intValue: Int? { nil }
+
+    init?(intValue: Int) {
+        nil
+    }
+}

--- a/Sources/PackageModel/Toolset.swift
+++ b/Sources/PackageModel/Toolset.swift
@@ -84,8 +84,7 @@ extension Toolset {
                     """
                     Tool `\(knownTool.rawValue) in toolset configuration at `\(toolsetPath)` has neither `path` nor \
                     `extraCLIOptions` properties specified with valid values, skipping it.
-                    """
-                )
+                    """)
                 continue
             }
 

--- a/Sources/PackageModel/Toolset.swift
+++ b/Sources/PackageModel/Toolset.swift
@@ -49,7 +49,7 @@ extension Toolset {
     /// - Parameters:
     ///   - path: absolute path on the `fileSystem`.
     ///   - fileSystem: file system from which the toolset should be read.
-    ///   - observability: an instance of `ObservabilityScope` to log warnings about unknown tools.
+    ///   - observability: an instance of `ObservabilityScope` to log warnings about unknown or invalid tools.
     public init(from toolsetPath: AbsolutePath, at fileSystem: FileSystem, _ observability: ObservabilityScope) throws {
         let decoder = JSONDecoder()
         let decoded = try decoder.decode(path: toolsetPath, fileSystem: fileSystem, as: DecodedToolset.self)
@@ -180,6 +180,9 @@ extension DecodedToolset: Decodable {
     }
 }
 
+/// Custom `CodingKey` implementation for `DecodedToolset`, which allows us to resiliently decode unknown tools and emit
+/// multiple diagnostic messages about them separately from the decoding process, instead of emitting a single error
+/// that will disrupt whole decoding at once.
 extension DecodedToolset.CodingKeys: CodingKey {
     var stringValue: String {
         switch self {

--- a/Sources/PackageRegistryTool/SwiftPackageRegistryTool+Publish.swift
+++ b/Sources/PackageRegistryTool/SwiftPackageRegistryTool+Publish.swift
@@ -19,6 +19,8 @@ import PackageModel
 import PackageRegistry
 import TSCBasic
 
+import struct TSCUtility.Version
+
 extension SwiftPackageRegistryTool {
     struct Publish: SwiftCommand {
         static let configuration = CommandConfiguration(

--- a/Sources/SPMTestSupport/Observability.swift
+++ b/Sources/SPMTestSupport/Observability.swift
@@ -12,8 +12,8 @@
 
 import Basics
 import struct TSCBasic.StringError
-import func XCTest.XCTFail
 import func XCTest.XCTAssertEqual
+import func XCTest.XCTFail
 
 extension ObservabilitySystem {
     public static func makeForTesting(verbose: Bool = true) -> TestingObservability {
@@ -23,7 +23,7 @@ extension ObservabilitySystem {
     }
 
     public static var NOOP: ObservabilityScope {
-        ObservabilitySystem({ _, _ in }).topScope
+        ObservabilitySystem { _, _ in }.topScope
     }
 }
 
@@ -57,7 +57,7 @@ public struct TestingObservability {
     }
 
     final class Collector: ObservabilityHandlerProvider, DiagnosticsHandler, CustomStringConvertible {
-        var diagnosticsHandler: DiagnosticsHandler { return self }
+        var diagnosticsHandler: DiagnosticsHandler { self }
 
         let diagnostics: ThreadSafeArrayStore<Basics.Diagnostic>
         private let verbose: Bool
@@ -76,11 +76,11 @@ public struct TestingObservability {
         }
 
         var hasErrors: Bool {
-            return self.diagnostics.get().hasErrors
+            self.diagnostics.get().hasErrors
         }
 
         var hasWarnings: Bool {
-            return self.diagnostics.get().hasWarnings
+            self.diagnostics.get().hasWarnings
         }
 
         var description: String {
@@ -90,10 +90,15 @@ public struct TestingObservability {
     }
 }
 
-public func XCTAssertNoDiagnostics(_ diagnostics: [Basics.Diagnostic], problemsOnly: Bool = true, file: StaticString = #file, line: UInt = #line) {
-    let diagnostics = problemsOnly ? diagnostics.filter({ $0.severity >= .warning }) : diagnostics
+public func XCTAssertNoDiagnostics(
+    _ diagnostics: [Basics.Diagnostic],
+    problemsOnly: Bool = true,
+    file: StaticString = #file,
+    line: UInt = #line
+) {
+    let diagnostics = problemsOnly ? diagnostics.filter { $0.severity >= .warning } : diagnostics
     if diagnostics.isEmpty { return }
-    let description = diagnostics.map({ "- " + $0.description }).joined(separator: "\n")
+    let description = diagnostics.map { "- " + $0.description }.joined(separator: "\n")
     XCTFail("Found unexpected diagnostics: \n\(description)", file: file, line: line)
 }
 
@@ -104,7 +109,13 @@ public func testDiagnostics(
     line: UInt = #line,
     handler: (DiagnosticsTestResult) throws -> Void
 ) {
-    testDiagnostics(diagnostics, minSeverity: problemsOnly ? .warning : .debug, file: file, line: line, handler: handler)
+    testDiagnostics(
+        diagnostics,
+        minSeverity: problemsOnly ? .warning : .debug,
+        file: file,
+        line: line,
+        handler: handler
+    )
 }
 
 public func testDiagnostics(
@@ -114,7 +125,7 @@ public func testDiagnostics(
     line: UInt = #line,
     handler: (DiagnosticsTestResult) throws -> Void
 ) {
-    let diagnostics = diagnostics.filter{ $0.severity >= minSeverity }
+    let diagnostics = diagnostics.filter { $0.severity >= minSeverity }
     let testResult = DiagnosticsTestResult(diagnostics)
 
     do {
@@ -173,7 +184,8 @@ public class DiagnosticsTestResult {
             return nil
         }
 
-        let matching = self.uncheckedDiagnostics.indices.filter { diagnosticPattern ~= self.uncheckedDiagnostics[$0].message }
+        let matching = self.uncheckedDiagnostics.indices
+            .filter { diagnosticPattern ~= self.uncheckedDiagnostics[$0].message }
         if matching.isEmpty {
             XCTFail("No diagnostics match \(diagnosticPattern)", file: file, line: line)
             return nil

--- a/Sources/SPMTestSupport/Observability.swift
+++ b/Sources/SPMTestSupport/Observability.swift
@@ -40,6 +40,14 @@ public struct TestingObservability {
         self.collector.diagnostics.get()
     }
 
+    public var errors: [Basics.Diagnostic] {
+        self.diagnostics.filter { $0.severity == .error }
+    }
+
+    public var warnings: [Basics.Diagnostic] {
+        self.diagnostics.filter { $0.severity == .warning }
+    }
+
     public var hasErrorDiagnostics: Bool {
         self.collector.hasErrors
     }

--- a/Tests/PackageModelTests/ToolsetTests.swift
+++ b/Tests/PackageModelTests/ToolsetTests.swift
@@ -1,0 +1,189 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+@testable import PackageModel
+import SPMTestSupport
+import XCTest
+
+import class TSCBasic.InMemoryFileSystem
+import struct TSCBasic.AbsolutePath
+
+private let usrBinTools = Dictionary(uniqueKeysWithValues: Toolset.KnownTool.allCases.map {
+    ($0, try! AbsolutePath(validating: "/usr/bin/\($0.rawValue)"))
+})
+
+private let cCompilerOptions = ["-fopenmp"]
+private let newCCompilerOptions = ["-pedantic"]
+private let cxxCompilerOptions = ["-nostdinc++"]
+
+private let compilersNoRoot = (
+    path: try! AbsolutePath(validating: "/tools/compilersNoRoot.json"),
+    json: #"""
+    {
+        "schemaVersion": "1.0",
+        "swiftCompiler": { "path": "\#(usrBinTools[.swiftCompiler]!)" },
+        "cCompiler": { "path": "\#(usrBinTools[.cCompiler]!)", "extraCLIOptions": \#(cCompilerOptions) },
+        "cxxCompiler": { "path": "\#(usrBinTools[.cxxCompiler]!)", "extraCLIOptions": \#(cxxCompilerOptions) },
+    }
+    """#
+)
+
+private let noValidToolsNoRoot = (
+    path: try! AbsolutePath(validating: "/tools/noValidToolsNoRoot.json"),
+    json: #"""
+    {
+        "schemaVersion": "1.0",
+        "cCompiler": {}
+    }
+    """#
+)
+
+private let unknownToolsNoRoot = (
+    path: try! AbsolutePath(validating: "/tools/unknownToolsNoRoot.json"),
+    json: #"""
+    {
+        "schemaVersion": "1.0",
+        "foo": {},
+        "bar": {}
+    }
+    """#
+)
+
+private let otherToolsNoRoot = (
+    path: try! AbsolutePath(validating: "/tools/otherToolsNoRoot.json"),
+    json: #"""
+    {
+        "schemaVersion": "1.0",
+        "librarian": { "path": "\#(usrBinTools[.librarian]!)" },
+        "linker": { "path": "\#(usrBinTools[.linker]!)" },
+        "debugger": { "path": "\#(usrBinTools[.debugger]!)" }
+    }
+    """#
+)
+
+private let someToolsWithRoot = (
+    path: try! AbsolutePath(validating: "/tools/someToolsWithRoot.json"),
+    json: #"""
+    {
+        "schemaVersion": "1.0",
+        "rootPath": "/custom",
+        "cCompiler": { "extraCLIOptions": \#(newCCompilerOptions) },
+        "linker": { "path": "ld" },
+        "librarian": { "path": "llvm-ar" },
+        "debugger": { "path": "\#(usrBinTools[.debugger]!)" }
+    }
+    """#
+)
+
+final class ToolsetTests: XCTestCase {
+    func testToolset() throws {
+        let fileSystem = InMemoryFileSystem()
+        try fileSystem.createDirectory(.init(validating: "/tools"))
+        for testFile in [compilersNoRoot, noValidToolsNoRoot, unknownToolsNoRoot, otherToolsNoRoot, someToolsWithRoot] {
+            try fileSystem.writeFileContents(testFile.path, data: .init(testFile.json.utf8))
+        }
+        let observability = ObservabilitySystem.makeForTesting()
+
+        let compilersToolset = try Toolset(from: compilersNoRoot.path, at: fileSystem, observability.topScope)
+
+        XCTAssertEqual(
+            compilersToolset.knownTools[.swiftCompiler],
+            Toolset.ToolProperties(path: usrBinTools[.swiftCompiler]!)
+        )
+        XCTAssertEqual(
+            compilersToolset.knownTools[.cCompiler],
+            Toolset.ToolProperties(path: usrBinTools[.cCompiler]!, extraCLIOptions: cCompilerOptions)
+        )
+        XCTAssertEqual(
+            compilersToolset.knownTools[.cxxCompiler],
+            Toolset.ToolProperties(path: usrBinTools[.cxxCompiler]!, extraCLIOptions: cxxCompilerOptions)
+        )
+
+        let noValidToolsToolset = try Toolset(from: noValidToolsNoRoot.path, at: fileSystem, observability.topScope)
+
+        XCTAssertTrue(noValidToolsToolset.knownTools.isEmpty)
+        XCTAssertEqual(observability.warnings.count, 1)
+
+        let unknownToolsToolset = try Toolset(from: unknownToolsNoRoot.path, at: fileSystem, observability.topScope)
+
+        XCTAssertTrue(unknownToolsToolset.knownTools.isEmpty)
+        // +2 warnings for each unknown tool
+        XCTAssertEqual(observability.warnings.count, 3)
+
+        var otherToolsToolset = try Toolset(from: otherToolsNoRoot.path, at: fileSystem, observability.topScope)
+
+        XCTAssertEqual(otherToolsToolset.knownTools.count, 3)
+        // no new warnings emitted
+        XCTAssertEqual(observability.warnings.count, 3)
+
+        otherToolsToolset.merge(with: compilersToolset)
+
+        XCTAssertEqual(
+            compilersToolset.knownTools[.swiftCompiler],
+            Toolset.ToolProperties(path: usrBinTools[.swiftCompiler]!)
+        )
+        XCTAssertEqual(
+            compilersToolset.knownTools[.cCompiler],
+            Toolset.ToolProperties(path: usrBinTools[.cCompiler]!, extraCLIOptions: cCompilerOptions)
+        )
+        XCTAssertEqual(
+            compilersToolset.knownTools[.cxxCompiler],
+            Toolset.ToolProperties(path: usrBinTools[.cxxCompiler]!, extraCLIOptions: cxxCompilerOptions)
+        )
+        XCTAssertEqual(
+            otherToolsToolset.knownTools[.librarian],
+            Toolset.ToolProperties(path: usrBinTools[.librarian]!)
+        )
+        XCTAssertEqual(
+            otherToolsToolset.knownTools[.linker],
+            Toolset.ToolProperties(path: usrBinTools[.linker]!)
+        )
+        XCTAssertEqual(
+            otherToolsToolset.knownTools[.debugger],
+            Toolset.ToolProperties(path: usrBinTools[.debugger]!)
+        )
+
+        let someToolsWithRoot = try Toolset(from: someToolsWithRoot.path, at: fileSystem, observability.topScope)
+
+        XCTAssertEqual(someToolsWithRoot.knownTools.count, 4)
+        // no new warnings emitted
+        XCTAssertEqual(observability.warnings.count, 3)
+
+        otherToolsToolset.merge(with: someToolsWithRoot)
+        XCTAssertEqual(
+            otherToolsToolset.knownTools[.swiftCompiler],
+            Toolset.ToolProperties(path: usrBinTools[.swiftCompiler]!)
+        )
+        XCTAssertEqual(
+            otherToolsToolset.knownTools[.cCompiler],
+            Toolset.ToolProperties(path: usrBinTools[.cCompiler]!, extraCLIOptions: cCompilerOptions + newCCompilerOptions)
+        )
+        XCTAssertEqual(
+            otherToolsToolset.knownTools[.cxxCompiler],
+            Toolset.ToolProperties(path: usrBinTools[.cxxCompiler]!, extraCLIOptions: cxxCompilerOptions)
+        )
+        XCTAssertEqual(
+            otherToolsToolset.knownTools[.librarian],
+            Toolset.ToolProperties(path: try! AbsolutePath(validating: "/custom/llvm-ar"))
+        )
+        XCTAssertEqual(
+            otherToolsToolset.knownTools[.linker],
+            Toolset.ToolProperties(path: try! AbsolutePath(validating: "/custom/ld"))
+        )
+        XCTAssertEqual(
+            otherToolsToolset.knownTools[.debugger],
+            Toolset.ToolProperties(path: usrBinTools[.debugger]!)
+        )
+
+    }
+}

--- a/Tests/PackageModelTests/ToolsetTests.swift
+++ b/Tests/PackageModelTests/ToolsetTests.swift
@@ -109,22 +109,24 @@ final class ToolsetTests: XCTestCase {
             Toolset.ToolProperties(path: usrBinTools[.cxxCompiler]!, extraCLIOptions: cxxCompilerOptions)
         )
 
-        let noValidToolsToolset = try Toolset(from: noValidToolsNoRoot.path, at: fileSystem, observability.topScope)
+        XCTAssertThrowsError(try Toolset(from: noValidToolsNoRoot.path, at: fileSystem, observability.topScope))
 
-        XCTAssertTrue(noValidToolsToolset.knownTools.isEmpty)
-        XCTAssertEqual(observability.warnings.count, 1)
+        XCTAssertEqual(observability.errors.count, 1)
+        XCTAssertEqual(observability.warnings.count, 0)
 
         let unknownToolsToolset = try Toolset(from: unknownToolsNoRoot.path, at: fileSystem, observability.topScope)
 
         XCTAssertTrue(unknownToolsToolset.knownTools.isEmpty)
-        // +2 warnings for each unknown tool
-        XCTAssertEqual(observability.warnings.count, 3)
+        // +2 warnings for each unknown tool, no new errors
+        XCTAssertEqual(observability.errors.count, 1)
+        XCTAssertEqual(observability.warnings.count, 2)
 
         var otherToolsToolset = try Toolset(from: otherToolsNoRoot.path, at: fileSystem, observability.topScope)
 
         XCTAssertEqual(otherToolsToolset.knownTools.count, 3)
-        // no new warnings emitted
-        XCTAssertEqual(observability.warnings.count, 3)
+        // no new warnings and errors were emitted
+        XCTAssertEqual(observability.errors.count, 1)
+        XCTAssertEqual(observability.warnings.count, 2)
 
         otherToolsToolset.merge(with: compilersToolset)
 
@@ -156,8 +158,9 @@ final class ToolsetTests: XCTestCase {
         let someToolsWithRoot = try Toolset(from: someToolsWithRoot.path, at: fileSystem, observability.topScope)
 
         XCTAssertEqual(someToolsWithRoot.knownTools.count, 4)
-        // no new warnings emitted
-        XCTAssertEqual(observability.warnings.count, 3)
+        // no new warnings and errors emitted
+        XCTAssertEqual(observability.errors.count, 1)
+        XCTAssertEqual(observability.warnings.count, 2)
 
         otherToolsToolset.merge(with: someToolsWithRoot)
         XCTAssertEqual(

--- a/Tests/PackageModelTests/ToolsetTests.swift
+++ b/Tests/PackageModelTests/ToolsetTests.swift
@@ -15,8 +15,8 @@ import Basics
 import SPMTestSupport
 import XCTest
 
-import class TSCBasic.InMemoryFileSystem
 import struct TSCBasic.AbsolutePath
+import class TSCBasic.InMemoryFileSystem
 
 private let usrBinTools = Dictionary(uniqueKeysWithValues: Toolset.KnownTool.allCases.map {
     ($0, try! AbsolutePath(validating: "/usr/bin/\($0.rawValue)"))
@@ -166,7 +166,10 @@ final class ToolsetTests: XCTestCase {
         )
         XCTAssertEqual(
             otherToolsToolset.knownTools[.cCompiler],
-            Toolset.ToolProperties(path: usrBinTools[.cCompiler]!, extraCLIOptions: cCompilerOptions + newCCompilerOptions)
+            Toolset.ToolProperties(
+                path: usrBinTools[.cCompiler]!,
+                extraCLIOptions: cCompilerOptions + newCCompilerOptions
+            )
         )
         XCTAssertEqual(
             otherToolsToolset.knownTools[.cxxCompiler],
@@ -184,6 +187,5 @@ final class ToolsetTests: XCTestCase {
             otherToolsToolset.knownTools[.debugger],
             Toolset.ToolProperties(path: usrBinTools[.debugger]!)
         )
-
     }
 }


### PR DESCRIPTION
### Motivation:

As proposed in [SE-0387](https://github.com/apple/swift-evolution/blob/main/proposals/0387-cross-compilation-destinations.md#toolsetjson-files), toolsets allow us to group paths and options for build tools. Adding this model to the codebase is a required step for fully implementing the proposal in case of its acceptance.

### Modifications:

Added `Toolset` and `DecodedToolset` types. The latter is used for decoding from JSON, while the former is produced out of `DecodedToolset` after validation. Warnings are emitted into `ObservabilityScope` if unknown or invalid tools are found in `DecodedToolset`.

### Result:

`Toolset` type in `PackageModel` can be used for new features as specified in the proposal. Note that it isn't actually used anywhere, so it's technically an NFC.
