### PR TITLE
[NFC] Use `@main` attribute in `swift-package-manager` target

### DIFF
--- a/Sources/swift-package-manager/SwiftPM.swift
+++ b/Sources/swift-package-manager/SwiftPM.swift
@@ -20,21 +20,27 @@ let firstArg = CommandLine.arguments[0]
 let execName = (try? AbsolutePath(validating: firstArg).basenameWithoutExt) ??
     (try? RelativePath(validating: firstArg).basenameWithoutExt)
 
-switch execName {
-case "swift-package":
-    SwiftPackageTool.main()
-case "swift-build":
-    SwiftBuildTool.main()
-case "swift-experimental-destination":
-    SwiftDestinationTool.main()
-case "swift-test":
-    SwiftTestTool.main()
-case "swift-run":
-    SwiftRunTool.main()
-case "swift-package-collection":
-    SwiftPackageCollectionsTool.main()
-case "swift-package-registry":
-    SwiftPackageRegistryTool.main()
-default:
-    fatalError("swift-package-manager launched with unexpected name: \(execName ?? "(unknown)")")
+@main
+struct SwiftPM {
+    static func main() {
+        switch execName {
+        case "swift-package":
+            SwiftPackageTool.main()
+        case "swift-build":
+            SwiftBuildTool.main()
+        case "swift-experimental-destination":
+            SwiftDestinationTool.main()
+        case "swift-test":
+            SwiftTestTool.main()
+        case "swift-run":
+            SwiftRunTool.main()
+        case "swift-package-collection":
+            SwiftPackageCollectionsTool.main()
+        case "swift-package-registry":
+            SwiftPackageRegistryTool.main()
+        default:
+            fatalError("swift-package-manager launched with unexpected name: \(execName ?? "(unknown)")")
+        }
+
+    }
 }


### PR DESCRIPTION
### Motivation:

We'd like to use Swift Concurrency in `CrossCompilationDestinationsTool` target, but for that its commands need to conform to `AsyncParsableCommand` protocol. We have to use `@main` attribute to be able to invoke these commands from the top level.

### Modifications:

Renamed `swift-package-manager/main.swift` to `swift-package-manager/SwiftPM.swift`, since files with `main.swift` name are always assumed to contain top-level code and `@main` attribute can't be placed in files with top-level code.

### Result:

This allows `SwiftDestinationTool` to conform to `AsyncParsableCommand` instead of `ParsableCommand` in the future.