### PR TITLE
update plugin argument parsing so that execution arguments can be passed after command plugin name

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -695,7 +695,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         // The 'swift-argument-parser' version declared here must match that
         // used by 'swift-driver' and 'sourcekit-lsp'. Please coordinate
         // dependency version changes here with those projects.
-        .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.2.0")),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.1.4")),
         .package(url: "https://github.com/apple/swift-driver.git", .branch(relatedDependenciesBranch)),
         .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: minimumCryptoVersion)),
         .package(url: "https://github.com/apple/swift-system.git", .upToNextMinor(from: "1.1.1")),

--- a/Package.swift
+++ b/Package.swift
@@ -695,7 +695,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         // The 'swift-argument-parser' version declared here must match that
         // used by 'swift-driver' and 'sourcekit-lsp'. Please coordinate
         // dependency version changes here with those projects.
-        .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.1.4")),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.2.0")),
         .package(url: "https://github.com/apple/swift-driver.git", .branch(relatedDependenciesBranch)),
         .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: minimumCryptoVersion)),
         .package(url: "https://github.com/apple/swift-system.git", .upToNextMinor(from: "1.1.1")),

--- a/Sources/Basics/FileSystem/FileSystem+Extensions.swift
+++ b/Sources/Basics/FileSystem/FileSystem+Extensions.swift
@@ -306,7 +306,7 @@ extension FileSystem {
     }
 
     public func writeFileContents(_ path: AbsolutePath, provider: () -> String) throws {
-        return try self.writeFileContents(path, string: provider())
+        return try self.writeFileContents(path, body: { stream in stream <<< provider() })
     }
 }
 

--- a/Sources/Commands/PackageTools/PluginCommand.swift
+++ b/Sources/Commands/PackageTools/PluginCommand.swift
@@ -27,17 +27,23 @@ struct PluginCommand: SwiftCommand {
     @OptionGroup(visibility: .hidden)
     var globalOptions: GlobalOptions
 
-    @Flag(name: .customLong("list"),
-          help: "List the available command plugins")
+    @Flag(
+        name: .customLong("list"),
+        help: "List the available command plugins"
+    )
     var listCommands: Bool = false
 
     struct PluginOptions: ParsableArguments {
-        @Flag(name: .customLong("allow-writing-to-package-directory"),
-              help: "Allow the plugin to write to the package directory")
+        @Flag(
+            name: .customLong("allow-writing-to-package-directory"),
+            help: "Allow the plugin to write to the package directory"
+        )
         var allowWritingToPackageDirectory: Bool = false
 
-        @Option(name: .customLong("allow-writing-to-directory"),
-                help: "Allow the plugin to write to an additional directory")
+        @Option(
+            name: .customLong("allow-writing-to-directory"),
+            help: "Allow the plugin to write to an additional directory"
+        )
         var additionalAllowedWritableDirectories: [String] = []
 
         enum NetworkPermission: String, EnumerableFlag, ExpressibleByArgument {
@@ -58,27 +64,29 @@ struct PluginCommand: SwiftCommand {
     @Argument(help: "Verb of the command plugin to invoke")
     var command: String = ""
 
-    @Argument(parsing: .unconditionalRemaining,
-              help: "Arguments to pass to the command plugin")
+    @Argument(
+        parsing: .unconditionalRemaining,
+        help: "Arguments to pass to the command plugin"
+    )
     var arguments: [String] = []
 
     func run(_ swiftTool: SwiftTool) throws {
         // Check for a missing plugin command verb.
-        if command == "" && !listCommands {
+        if self.command == "" && !self.listCommands {
             throw ValidationError("Missing expected plugin command")
         }
 
-        // Load the workspace and resolve the package graph.
-        let packageGraph = try swiftTool.loadPackageGraph()
-
         // List the available plugins, if asked to.
-        if listCommands {
+        if self.listCommands {
+            let packageGraph = try swiftTool.loadPackageGraph()
             let allPlugins = PluginCommand.availableCommandPlugins(in: packageGraph)
             for plugin in allPlugins.sorted(by: { $0.name < $1.name }) {
                 guard case .command(let intent, _) = plugin.capability else { return }
                 var line = "‘\(intent.invocationVerb)’ (plugin ‘\(plugin.name)’"
-                if let package = packageGraph.packages.first(where: { $0.targets.contains(where: { $0.name == plugin.name }) }) {
-                    line +=  " in package ‘\(package.manifest.displayName)’"
+                if let package = packageGraph.packages
+                    .first(where: { $0.targets.contains(where: { $0.name == plugin.name }) })
+                {
+                    line += " in package ‘\(package.manifest.displayName)’"
                 }
                 line += ")"
                 print(line)
@@ -86,16 +94,41 @@ struct PluginCommand: SwiftCommand {
             return
         }
 
+        try Self.run(
+            command: self.command,
+            options: self.pluginOptions,
+            arguments: self.arguments,
+            swiftTool: swiftTool
+        )
+    }
+
+    static func run(
+        command: String,
+        options: PluginOptions,
+        arguments: [String],
+        swiftTool: SwiftTool
+    ) throws {
+        // Load the workspace and resolve the package graph.
+        let packageGraph = try swiftTool.loadPackageGraph()
+
         swiftTool.observabilityScope.emit(info: "Finding plugin for command ‘\(command)’")
         let matchingPlugins = PluginCommand.findPlugins(matching: command, in: packageGraph)
 
         // Complain if we didn't find exactly one.
         if matchingPlugins.isEmpty {
-            throw ValidationError("No command plugins found for ‘\(command)’")
-        }
-        else if matchingPlugins.count > 1 {
+            throw ValidationError("Unknown subcommand or plugin name ‘\(command)’")
+        } else if matchingPlugins.count > 1 {
             throw ValidationError("\(matchingPlugins.count) plugins found for ‘\(command)’")
         }
+
+        // handle plugin execution arguments that got passed after the plugin name
+        let unparsedArguments = Array(arguments.drop(while: { $0 == command }))
+        let pluginArguments = try PluginArguments.parse(unparsedArguments)
+        // merge the relevant plugin execution options
+        let pluginOptions = options.merged(with: pluginArguments.pluginOptions)
+        // sandbox is special since its generic not a specific plugin option
+        swiftTool.shouldDisableSandbox = swiftTool.shouldDisableSandbox || pluginArguments.globalOptions.security
+            .shouldDisableSandbox
 
         // At this point we know we found exactly one command plugin, so we run it. In SwiftPM CLI, we have only one root package.
         try PluginCommand.run(
@@ -103,8 +136,9 @@ struct PluginCommand: SwiftCommand {
             package: packageGraph.rootPackages[0],
             packageGraph: packageGraph,
             options: pluginOptions,
-            arguments: arguments,
-            swiftTool: swiftTool)
+            arguments: unparsedArguments,
+            swiftTool: swiftTool
+        )
     }
 
     static func run(
@@ -115,10 +149,14 @@ struct PluginCommand: SwiftCommand {
         arguments: [String],
         swiftTool: SwiftTool
     ) throws {
-        swiftTool.observabilityScope.emit(info: "Running command plugin \(plugin) on package \(package) with options \(options) and arguments \(arguments)")
+        swiftTool.observabilityScope
+            .emit(
+                info: "Running command plugin \(plugin) on package \(package) with options \(options) and arguments \(arguments)"
+            )
 
         // The `plugins` directory is inside the workspace's main data directory, and contains all temporary files related to this plugin in the workspace.
-        let pluginsDir = try swiftTool.getActiveWorkspace().location.pluginWorkingDirectory.appending(component: plugin.name)
+        let pluginsDir = try swiftTool.getActiveWorkspace().location.pluginWorkingDirectory
+            .appending(component: plugin.name)
 
         // The `cache` directory is in the plugin’s directory and is where the plugin script runner caches compiled plugin binaries and any other derived information for this plugin.
         let pluginScriptRunner = try swiftTool.getPluginScriptRunner(
@@ -128,7 +166,7 @@ struct PluginCommand: SwiftCommand {
         // The `outputs` directory contains subdirectories for each combination of package and command plugin. Each usage of a plugin has an output directory that is writable by the plugin, where it can write additional files, and to which it can configure tools to write their outputs, etc.
         let outputDir = pluginsDir.appending(component: "outputs")
 
-        var allowNetworkConnections = [SandboxNetworkPermission.init(options.allowNetworkConnections)]
+        var allowNetworkConnections = [SandboxNetworkPermission(options.allowNetworkConnections)]
         // Determine the set of directories under which plugins are allowed to write. We always include the output directory.
         var writableDirectories = [outputDir]
         if options.allowWritingToPackageDirectory {
@@ -154,7 +192,9 @@ struct PluginCommand: SwiftCommand {
 
                     switch scope {
                     case .all, .local:
-                        let portsString = scope.ports.isEmpty ? "on all ports" : "on ports: \(scope.ports.map { "\($0)" }.joined(separator: ", "))"
+                        let portsString = scope.ports
+                            .isEmpty ? "on all ports" :
+                            "on ports: \(scope.ports.map { "\($0)" }.joined(separator: ", "))"
                         permissionString = "allow \(scope.label) network connections \(portsString)"
                     case .docker, .unixDomainSocket:
                         permissionString = "allow \(scope.label) connections"
@@ -163,7 +203,8 @@ struct PluginCommand: SwiftCommand {
                     }
 
                     reasonString = reason
-                    remedyOption = "--allow-network-connections \(PluginCommand.PluginOptions.NetworkPermission.init(scope).defaultValueDescription)"
+                    remedyOption =
+                        "--allow-network-connections \(PluginCommand.PluginOptions.NetworkPermission(scope).defaultValueDescription)"
                 }
 
                 let problem = "Plugin ‘\(plugin.name)’ wants permission to \(permissionString)."
@@ -190,17 +231,18 @@ struct PluginCommand: SwiftCommand {
                     writableDirectories.append(package.path)
                 case .allowNetworkConnections(let scope, _):
                     allowNetworkConnections.append(.init(scope))
-                    break
                 }
             }
         }
 
         for pathString in options.additionalAllowedWritableDirectories {
-            writableDirectories.append(try AbsolutePath(validating: pathString, relativeTo: swiftTool.originalWorkingDirectory))
+            writableDirectories
+                .append(try AbsolutePath(validating: pathString, relativeTo: swiftTool.originalWorkingDirectory))
         }
 
         // Make sure that the package path is read-only unless it's covered by any of the explicitly writable directories.
-        let readOnlyDirectories = writableDirectories.contains{ package.path.isDescendantOfOrEqual(to: $0) } ? [] : [package.path]
+        let readOnlyDirectories = writableDirectories
+            .contains { package.path.isDescendantOfOrEqual(to: $0) } ? [] : [package.path]
 
         // Use the directory containing the compiler as an additional search directory, and add the $PATH.
         let toolSearchDirs = [try swiftTool.getDestinationToolchain().swiftCompilerPath.parentDirectory]
@@ -208,10 +250,15 @@ struct PluginCommand: SwiftCommand {
 
         // Build or bring up-to-date any executable host-side tools on which this plugin depends. Add them and any binary dependencies to the tool-names-to-path map.
         let buildSystem = try swiftTool.createBuildSystem(explicitBuildSystem: .native, cacheBuildManifest: false)
-        let accessibleTools = try plugin.processAccessibleTools(packageGraph: packageGraph, fileSystem: swiftTool.fileSystem, environment: try swiftTool.buildParameters().buildEnvironment, for: try pluginScriptRunner.hostTriple) { name, path in
+        let accessibleTools = try plugin.processAccessibleTools(
+            packageGraph: packageGraph,
+            fileSystem: swiftTool.fileSystem,
+            environment: try swiftTool.buildParameters().buildEnvironment,
+            for: try pluginScriptRunner.hostTriple
+        ) { name, _ in
             // Build the product referenced by the tool, and add the executable to the tool map. Product dependencies are not supported within a package, so if the tool happens to be from the same package, we instead find the executable that corresponds to the product. There is always one, because of autogeneration of implicit executables with the same name as the target if there isn't an explicit one.
             try buildSystem.build(subset: .product(name))
-            if let builtTool = try buildSystem.buildPlan.buildProducts.first(where: { $0.product.name == name}) {
+            if let builtTool = try buildSystem.buildPlan.buildProducts.first(where: { $0.product.name == name }) {
                 return builtTool.binaryPath
             } else {
                 return nil
@@ -240,23 +287,36 @@ struct PluginCommand: SwiftCommand {
             observabilityScope: swiftTool.observabilityScope,
             callbackQueue: delegateQueue,
             delegate: pluginDelegate,
-            completion: $0) }
+            completion: $0
+        ) }
 
         // TODO: We should also emit a final line of output regarding the result.
     }
 
     static func availableCommandPlugins(in graph: PackageGraph) -> [PluginTarget] {
-        return graph.allTargets.compactMap{ $0.underlyingTarget as? PluginTarget }
+        graph.allTargets.compactMap { $0.underlyingTarget as? PluginTarget }
     }
 
     static func findPlugins(matching verb: String, in graph: PackageGraph) -> [PluginTarget] {
         // Find and return the command plugins that match the command.
-        return Self.availableCommandPlugins(in: graph).filter {
+        Self.availableCommandPlugins(in: graph).filter {
             // Filter out any non-command plugins and any whose verb is different.
             guard case .command(let intent, _) = $0.capability else { return false }
             return verb == intent.invocationVerb
         }
     }
+}
+
+// helper to parse plugin arguments passed after the plugin name
+struct PluginArguments: ParsableCommand {
+    @OptionGroup
+    var globalOptions: GlobalOptions
+
+    @OptionGroup()
+    var pluginOptions: PluginCommand.PluginOptions
+
+    @Argument(parsing: .unconditionalRemaining)
+    var remaining: [String] = []
 }
 
 extension PluginCommandIntent {

--- a/Sources/CoreCommands/BuildSystemSupport.swift
+++ b/Sources/CoreCommands/BuildSystemSupport.swift
@@ -33,7 +33,7 @@ extension SwiftTool {
                         pluginConfiguration: .init(
                             scriptRunner: self.getPluginScriptRunner(),
                             workDirectory: try self.getActiveWorkspace().location.pluginWorkingDirectory,
-                            disableSandbox: self.options.security.shouldDisableSandbox
+                            disableSandbox: self.shouldDisableSandbox
                         ),
                         additionalFileRules: FileRuleDescription.swiftpmFileTypes,
                         pkgConfigDirectories: self.options.locations.pkgConfigDirectories,

--- a/Sources/CoreCommands/SwiftTool.swift
+++ b/Sources/CoreCommands/SwiftTool.swift
@@ -182,6 +182,9 @@ public final class SwiftTool {
     /// The min severity at which to log diagnostics
     public let logLevel: Basics.Diagnostic.Severity
 
+    // should use sandbox on external subcommands
+    public var shouldDisableSandbox: Bool
+
     /// The file system in use
     public let fileSystem: FileSystem
 
@@ -215,6 +218,7 @@ public final class SwiftTool {
         self.observabilityHandler = SwiftToolObservabilityHandler(outputStream: outputStream, logLevel: self.logLevel)
         let observabilitySystem = ObservabilitySystem(self.observabilityHandler)
         self.observabilityScope = observabilitySystem.topScope
+        self.shouldDisableSandbox = options.security.shouldDisableSandbox
         self.toolWorkspaceConfiguration = toolWorkspaceConfiguration
         self.workspaceDelegateProvider = workspaceDelegateProvider
         self.workspaceLoaderProvider = workspaceLoaderProvider
@@ -513,7 +517,7 @@ public final class SwiftTool {
             fileSystem: self.fileSystem,
             cacheDir: cacheDir,
             toolchain: self.getHostToolchain(),
-            enableSandbox: !self.options.security.shouldDisableSandbox,
+            enableSandbox: !self.shouldDisableSandbox,
             verboseOutput: self.logLevel <= .info
         )
         // register the plugin runner system with the cancellation handler
@@ -729,7 +733,7 @@ public final class SwiftTool {
             return try ManifestLoader(
                 // Always use the host toolchain's resources for parsing manifest.
                 toolchain: self.getHostToolchain(),
-                isManifestSandboxEnabled: !self.options.security.shouldDisableSandbox,
+                isManifestSandboxEnabled: !self.shouldDisableSandbox,
                 cacheDir: cachePath,
                 extraManifestFlags: extraManifestFlags,
                 restrictImports: nil

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -1829,7 +1829,7 @@ final class PackageToolTests: CommandsTestCase {
                 let result = try SwiftPMProduct.SwiftPackage.executeProcess(["my-nonexistent-cmd"], packagePath: packageDir)
                 let output = try result.utf8Output() + result.utf8stderrOutput()
                 XCTAssertNotEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
-                XCTAssertMatch(output, .contains("error: Unknown subcommand or plugin name 'my-nonexistent-cmd'"))
+                XCTAssertMatch(output, .contains("Unknown subcommand or plugin name ‘my-nonexistent-cmd’"))
             }
 
             // Check that the .docc file was properly vended to the plugin.
@@ -2044,6 +2044,104 @@ final class PackageToolTests: CommandsTestCase {
                 XCTAssertMatch(try result.utf8stderrOutput(), .contains("error: Couldn’t create file at path"))
             }
           #endif
+
+            // Check default command with arguments
+            do {
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["--allow-writing-to-package-directory", "PackageScribbler"], packagePath: packageDir, env: ["DECLARE_PACKAGE_WRITING_PERMISSION": "1"])
+                XCTAssertEqual(result.exitStatus, .terminated(code: 0))
+                XCTAssertMatch(try result.utf8Output(), .contains("successfully created it"))
+                XCTAssertNoMatch(try result.utf8stderrOutput(), .contains("error: Couldn’t create file at path"))
+            }
+
+            // Check plugin arguments after plugin name
+            do {
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["plugin", "PackageScribbler",  "--allow-writing-to-package-directory"], packagePath: packageDir, env: ["DECLARE_PACKAGE_WRITING_PERMISSION": "1"])
+                XCTAssertEqual(result.exitStatus, .terminated(code: 0))
+                XCTAssertMatch(try result.utf8Output(), .contains("successfully created it"))
+                XCTAssertNoMatch(try result.utf8stderrOutput(), .contains("error: Couldn’t create file at path"))
+            }
+
+            // Check default command with arguments after plugin name
+            do {
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["PackageScribbler", "--allow-writing-to-package-directory", ], packagePath: packageDir, env: ["DECLARE_PACKAGE_WRITING_PERMISSION": "1"])
+                XCTAssertEqual(result.exitStatus, .terminated(code: 0))
+                XCTAssertMatch(try result.utf8Output(), .contains("successfully created it"))
+                XCTAssertNoMatch(try result.utf8stderrOutput(), .contains("error: Couldn’t create file at path"))
+            }
+        }
+    }
+
+    func testCommandPluginArgumentsNotSwallowed() throws {
+        // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
+        try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+
+        try testWithTemporaryDirectory { tmpPath in
+            // Create a sample package with a library target and a plugin.
+            let packageDir = tmpPath.appending(components: "MyPackage")
+            try localFileSystem.writeFileContents(packageDir.appending(components: "Package.swift")) {
+                """
+                // swift-tools-version: 5.6
+                import PackageDescription
+                import Foundation
+                let package = Package(
+                    name: "MyPackage",
+                    targets: [
+                        .plugin(
+                            name: "MyPlugin",
+                            capability: .command(
+                                intent: .custom(verb: "MyPlugin", description: "Help description")
+                            )
+                        ),
+                    ]
+                )
+                """
+            }
+            try localFileSystem.writeFileContents(packageDir.appending(components: "Plugins", "MyPlugin", "plugin.swift")) {
+                """
+                import PackagePlugin
+                import Foundation
+
+                @main
+                struct MyCommandPlugin: CommandPlugin {
+                    func performCommand(
+                        context: PluginContext,
+                        arguments: [String]
+                    ) throws {
+                        print (arguments)
+                        guard arguments.contains("--foo") else {
+                            throw "expecting argument foo"
+                        }
+                        guard arguments.contains("--help") else {
+                            throw "expecting argument help"
+                        }
+                        guard arguments.contains("--version") else {
+                            throw "expecting argument version"
+                        }
+                        guard arguments.contains("--verbose") else {
+                            throw "expecting argument verbose"
+                        }
+                        print("success")
+                    }
+                }
+                extension String: Error {}
+                """
+            }
+
+            // Check arguments
+            do {
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["plugin", "MyPlugin", "--foo", "--help", "--version", "--verbose"], packagePath: packageDir)
+                XCTAssertEqual(result.exitStatus, .terminated(code: 0))
+                XCTAssertMatch(try result.utf8Output(), .contains("success"))
+                XCTAssertEqual(try result.utf8stderrOutput(), "")
+            }
+
+            // Check default command arguments
+            do {
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["MyPlugin", "--foo", "--help", "--version", "--verbose"], packagePath: packageDir, env: ["DECLARE_PACKAGE_WRITING_PERMISSION": "1"])
+                XCTAssertEqual(result.exitStatus, .terminated(code: 0))
+                XCTAssertMatch(try result.utf8Output(), .contains("success"))
+                XCTAssertEqual(try result.utf8stderrOutput(), "")
+            }
         }
     }
 

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -92,7 +92,7 @@ final class PackageToolTests: CommandsTestCase {
     func testUnknownSubommand() throws {
         try fixture(name: "Miscellaneous/ExeTest") { fixturePath in
             XCTAssertThrowsCommandExecutionError(try execute(["foo"], packagePath: fixturePath)) { error in
-                XCTAssertMatch(error.stderr, .contains("error: Unknown subcommand or plugin name 'foo'"))
+                XCTAssertMatch(error.stderr, .contains("Unknown subcommand or plugin name ‘foo’"))
             }
         }
     }


### PR DESCRIPTION
motivation: improve usability of command plugins

changes: re-parse the arguments that are passed after the plugin name and merge the relevant options before running the command plugin

this allows invocation like `swift package <plugin> --disable-sandbox` (instead of the lest intuitive `swift package --disable-sandbox <plugin> `