### PR TITLE
Fix PIF.Target model decoder

### DIFF
--- a/Sources/XCBuildSupport/PIF.swift
+++ b/Sources/XCBuildSupport/PIF.swift
@@ -649,14 +649,14 @@ public enum PIF {
             let type = try container.decode(String.self, forKey: .type)
 
             let buildPhases: [BuildPhase]
-            let impartedBuildProperties: BuildSettings
+            let impartedBuildProperties: ImpartedBuildProperties
 
             if type == "packageProduct" {
                 self.productType = .packageProduct
                 self.productName = ""
                 let fwkBuildPhase = try container.decodeIfPresent(FrameworksBuildPhase.self, forKey: .frameworksBuildPhase)
                 buildPhases = fwkBuildPhase.map{ [$0] } ?? []
-                impartedBuildProperties = BuildSettings()
+                impartedBuildProperties = ImpartedBuildProperties(settings: BuildSettings())
             } else if type == "standard" {
                 self.productType = try container.decode(ProductType.self, forKey: .productTypeIdentifier)
 
@@ -673,7 +673,7 @@ public enum PIF {
                     return try BuildPhase.decode(container: &buildPhasesContainer, type: type)
                 }
 
-                impartedBuildProperties = try container.decode(BuildSettings.self, forKey: .impartedBuildProperties)
+                impartedBuildProperties = try container.decode(ImpartedBuildProperties.self, forKey: .impartedBuildProperties)
             } else {
                 throw InternalError("Unhandled target type \(type)")
             }
@@ -684,7 +684,7 @@ public enum PIF {
                 buildConfigurations: buildConfigurations,
                 buildPhases: buildPhases,
                 dependencies: dependencies,
-                impartedBuildSettings: impartedBuildProperties,
+                impartedBuildSettings: impartedBuildProperties.buildSettings,
                 signature: nil
             )
         }


### PR DESCRIPTION
### Motivation:

`PIF.Target`'s Decodable initializer seems to be broken.

The encoder encodes `impartedBuildProperties` properties as `ImpartedBuildProperties` type.
https://github.com/apple/swift-package-manager/blob/2975732421aff9da0c03c66d191710a7e37055d7/Sources/XCBuildSupport/PIF.swift#L635

However, in the current decoder implementation, the decoder tries to decode them as `BuildSettings`.
https://github.com/apple/swift-package-manager/blob/2975732421aff9da0c03c66d191710a7e37055d7/Sources/XCBuildSupport/PIF.swift#L676

These are mismatched. So decoding always failed. As a result,`target.impartedBuildSettings` become always empty.

### Modifications:

The decoder has to try to decode `impartedBuildProperties` as `ImpartedBuildPropertis` type instead of `BuildSettings`.

### Result:

I can decode `PIF.Project` from dumped PIF JSONs.
