### PR TITLE
Fix `MockHashAlgorithm` conformance to `Sendable`

### DIFF
--- a/Sources/Basics/Concurrency/ThreadSafeArrayStore.swift
+++ b/Sources/Basics/Concurrency/ThreadSafeArrayStore.swift
@@ -82,3 +82,9 @@ public final class ThreadSafeArrayStore<Value> {
         }
     }
 }
+
+#if swift(<5.7)
+extension ThreadSafeArrayStore: UnsafeSendable where Value: Sendable {}
+#else
+extension ThreadSafeArrayStore: @unchecked Sendable where Value: Sendable {}
+#endif

--- a/Sources/SPMTestSupport/MockHashAlgorithm.swift
+++ b/Sources/SPMTestSupport/MockHashAlgorithm.swift
@@ -33,7 +33,6 @@ public final class MockHashAlgorithm {
     }
 }
 
-
 // Older compilers are unable to infer sendability for `Optional` closures even when those are `@Sendable`.
 #if swift(<5.6)
 extension MockHashAlgorithm: UnsafeSendable {}

--- a/Sources/SPMTestSupport/MockHashAlgorithm.swift
+++ b/Sources/SPMTestSupport/MockHashAlgorithm.swift
@@ -10,13 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Basics
-import TSCBasic
+public final class MockHashAlgorithm {
+    public typealias Handler = @Sendable (ByteString) -> ByteString
 
-public class MockHashAlgorithm: HashAlgorithm {
-    public typealias Handler = (ByteString) -> ByteString
-
-    public private(set) var hashes = ThreadSafeArrayStore<ByteString>()
+    public let hashes = ThreadSafeArrayStore<ByteString>()
     private let handler: Handler?
 
     public init(handler: Handler? = nil) {
@@ -32,3 +29,11 @@ public class MockHashAlgorithm: HashAlgorithm {
         }
     }
 }
+
+
+// Older compilers are unable to infer sendability for `Optional` closures even when those are `@Sendable`.
+#if swift(<5.6)
+extension MockHashAlgorithm: UnsafeSendable {}
+#endif
+
+extension MockHashAlgorithm: HashAlgorithm {}

--- a/Sources/SPMTestSupport/MockHashAlgorithm.swift
+++ b/Sources/SPMTestSupport/MockHashAlgorithm.swift
@@ -10,6 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Basics
+import TSCBasic
+
 public final class MockHashAlgorithm {
     public typealias Handler = @Sendable (ByteString) -> ByteString
 


### PR DESCRIPTION
This `Sendable` requirement on `HashAlgorithm` appeared in recent commits of TSC.
