### PR TITLE
skip zip compression tests in certain environments

### DIFF
--- a/Tests/BasicsTests/ZipArchiverTests.swift
+++ b/Tests/BasicsTests/ZipArchiverTests.swift
@@ -14,6 +14,7 @@ import Basics
 import TSCBasic
 import TSCTestSupport
 import XCTest
+import TSCclibc // for SPM_posix_spawn_file_actions_addchdir_np_supported
 
 class ZipArchiverTests: XCTestCase {
     func testZipArchiverSuccess() throws {
@@ -95,6 +96,12 @@ class ZipArchiverTests: XCTestCase {
     }
 
     func testCompress() throws {
+        #if os(Linux)
+        guard SPM_posix_spawn_file_actions_addchdir_np_supported() else {
+            throw XCTSkip("working directory not supported on this platform")
+        }
+        #endif
+
          try testWithTemporaryDirectory { tmpdir in
              let archiver = ZipArchiver(fileSystem: localFileSystem)
 

--- a/Tests/CommandsTests/PackageRegistryToolTests.swift
+++ b/Tests/CommandsTests/PackageRegistryToolTests.swift
@@ -17,6 +17,7 @@ import PackageModel
 @testable import PackageRegistryTool
 import SPMTestSupport
 import TSCBasic
+import TSCclibc // for SPM_posix_spawn_file_actions_addchdir_np_supported
 import Workspace
 import XCTest
 
@@ -218,6 +219,12 @@ final class PackageRegistryToolTests: CommandsTestCase {
     // TODO: Test example with login and password
 
     func testArchiving() throws {
+        #if os(Linux)
+        guard SPM_posix_spawn_file_actions_addchdir_np_supported() else {
+            throw XCTSkip("working directory not supported on this platform")
+        }
+        #endif
+
         let observability = ObservabilitySystem.makeForTesting()
         let publishTool = SwiftPackageRegistryTool.Publish()
 


### PR DESCRIPTION
motivation: stable ci

changes: skip new zip compression tests where setting the process working environment is not supported

rdar://105175770