### PR TITLE
Bump SwiftPM's minimum deployment target to macOS 12

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -104,8 +104,8 @@ packageCollectionsSigningTargets.append(
 let package = Package(
     name: "SwiftPM",
     platforms: [
-        .macOS("10.15.4"),
-        .iOS("13.4")
+        .macOS("12.0"),
+        .iOS("15.0")
     ],
     products:
         autoProducts.flatMap {

--- a/Sources/Basics/Netrc.swift
+++ b/Sources/Basics/Netrc.swift
@@ -14,7 +14,6 @@ import Foundation
 import TSCBasic
 
 /// Representation of Netrc configuration
-@available (macOS 10.13, iOS 11, tvOS 11, watchOS 4, *)
 public struct Netrc {
     /// Representation of `machine` connection settings & `default` connection settings.
     /// If `default` connection settings present, they will be last element.
@@ -140,7 +139,6 @@ public enum NetrcError: Error, Equatable {
     case invalidDefaultMachinePosition
 }
 
-@available (macOS 10.13, iOS 11, tvOS 11, watchOS 4, *)
 fileprivate enum RegexUtil {
     @frozen fileprivate enum Token: String, CaseIterable {
         case machine, login, password, account, macdef, `default`

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1073,7 +1073,6 @@ extension Workspace {
     }
 
     /// Loads and returns manifests at the given paths.
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func loadRootManifests(packages: [AbsolutePath], observabilityScope: ObservabilityScope) async throws -> [AbsolutePath: Manifest] {
         return try await withCheckedThrowingContinuation{ continuation in
             self.loadRootManifests(packages: packages, observabilityScope: observabilityScope) { result in
@@ -1124,7 +1123,6 @@ extension Workspace {
     }
 
     /// Loads and returns manifest at the given path.
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func loadRootManifest(at path: AbsolutePath, observabilityScope: ObservabilityScope) async throws -> Manifest {
         return try await withCheckedThrowingContinuation{ continuation in
             self.loadRootManifest(at: path, observabilityScope: observabilityScope) { result in
@@ -1155,7 +1153,6 @@ extension Workspace {
     }
 
     /// Loads root package
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     public func loadRootPackage(at path: AbsolutePath, observabilityScope: ObservabilityScope) async throws -> Package {
         return try await withCheckedThrowingContinuation{ continuation in
             self.loadRootPackage(at: path, observabilityScope: observabilityScope) { result in

--- a/Tests/BasicsTests/NetrcTests.swift
+++ b/Tests/BasicsTests/NetrcTests.swift
@@ -15,7 +15,6 @@ import XCTest
 
 /// Netrc feature depends upon `NSTextCheckingResult.range(withName name: String) -> NSRange`,
 /// which is only available in macOS 10.13+ at this time.
-@available(macOS 10.13, iOS 11, tvOS 11, watchOS 4, *)
 class NetrcTests: XCTestCase {
     /// should load machines for a given inline format
     func testLoadMachinesInline() throws {

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -24,7 +24,7 @@ import shutil
 import subprocess
 from helpers import note, error, symlink_force, mkdir_p, call, call_output
 
-g_macos_deployment_target = '10.15'
+g_macos_deployment_target = '12.0'
 
 g_shared_lib_prefix = "lib"
 if platform.system() == 'Darwin':


### PR DESCRIPTION
It is time that we update our minimum deployment target, we haven't officially supported anything pre-12.0 since the 5.6 release.
