### PR TITLE
Init template cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ Swift Next
   }
   ```
 
-
 Swift 5.9
 -----------
 
@@ -29,6 +28,9 @@ Swift 5.9
 
   Support for building plugin dependencies for the host when cross-compiling.
 
+* [#6144]
+
+  Remove the `system-module` and `manifest` templates and clean up the remaining `empty`, `library`, and `executable` templates so they include the minimum information needed to get started, with links to documentation in the generated library, executable, and test content.
 
 Swift 5.8
 -----------

--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -158,9 +158,9 @@ initialize it as a package that builds a system module:
     example$ cd ..
     $ mkdir Clibgit
     $ cd Clibgit
-    Clibgit$ swift package init --type system-module
+    Clibgit$ swift package init --type empty
 
-This creates `Package.swift` and `module.modulemap` files in the directory.
+This creates a `Package.swift` file in the directory.
 Edit `Package.swift` and add `pkgConfig` parameter:
 
 ```swift
@@ -181,7 +181,7 @@ parameter you can pass the path of a directory containing the library using the
 
     example$ swift build -Xlinker -L/usr/local/lib/
 
-Edit `module.modulemap` so it consists of the following:
+Create a `module.modulemap` file so it consists of the following:
 
     module Clibgit [system] {
       header "/usr/local/include/git2.h"
@@ -258,10 +258,10 @@ initialize it as a package that builds a system module:
     example$ cd ..
     $ mkdir CJPEG
     $ cd CJPEG
-    CJPEG$ swift package init --type system-module
+    CJPEG$ swift package init --type empty
 
-This creates `Package.swift` and `module.modulemap` files in the directory.
-Edit `module.modulemap` so it consists of the following:
+This creates `Package.swift` file in the directory.
+Create a `module.modulemap` file so it consists of the following:
 
     module CJPEG [system] {
         header "shim.h"

--- a/IntegrationTests/Tests/IntegrationTests/BasicTests.swift
+++ b/IntegrationTests/Tests/IntegrationTests/BasicTests.swift
@@ -234,11 +234,11 @@ final class BasicTests: XCTestCase {
             try localFileSystem.createDirectory(packagePath)
             try sh(swiftPackage, "--package-path", packagePath, "init", "--type", "executable")
             // delete any files generated
-            for entry in try localFileSystem.getDirectoryContents(packagePath.appending(components: "Sources", "secho")) {
-                try localFileSystem.removeFileTree(packagePath.appending(components: "Sources", "secho", entry))
+            for entry in try localFileSystem.getDirectoryContents(packagePath.appending(components: "Sources")) {
+                try localFileSystem.removeFileTree(packagePath.appending(components: "Sources", entry))
             }
             try localFileSystem.writeFileContents(
-                packagePath.appending(components: "Sources", "secho", "main.swift"),
+                packagePath.appending(components: "Sources", "secho.swift"),
                 bytes: ByteString(encodingAsUTF8: """
                     import Foundation
                     print(CommandLine.arguments.dropFirst().joined(separator: " "))

--- a/IntegrationTests/Tests/IntegrationTests/SwiftPMTests.swift
+++ b/IntegrationTests/Tests/IntegrationTests/SwiftPMTests.swift
@@ -59,10 +59,10 @@ final class SwiftPMTests: XCTestCase {
             try localFileSystem.createDirectory(packagePath)
             try sh(swiftPackage, "--package-path", packagePath, "init", "--type", "executable")
             // delete any files generated
-            for entry in try localFileSystem.getDirectoryContents(packagePath.appending(components: "Sources", "foo")) {
-                try localFileSystem.removeFileTree(packagePath.appending(components: "Sources", "foo", entry))
+            for entry in try localFileSystem.getDirectoryContents(packagePath.appending(components: "Sources")) {
+                try localFileSystem.removeFileTree(packagePath.appending(components: "Sources", entry))
             }
-            try localFileSystem.writeFileContents(AbsolutePath(validating: "Sources/foo/main.m", relativeTo: packagePath)) {
+            try localFileSystem.writeFileContents(AbsolutePath(validating: "Sources/main.m", relativeTo: packagePath)) {
                 $0 <<< "int main() {}"
             }
             let archs = ["x86_64", "arm64"]

--- a/Sources/Commands/PackageTools/Init.swift
+++ b/Sources/Commands/PackageTools/Init.swift
@@ -25,12 +25,13 @@ extension SwiftPackageTool {
         
         @Option(
             name: .customLong("type"),
-            help: ArgumentHelp("Package type: empty | library | executable | system-module | manifest", discussion: """
-                empty - Create an empty package
-                library - Create a package that contains a library
-                executable - Create a package that contains a binary executable
-                system-module - Create a package that contains a system module
-                manifest - Create a Package.swift file
+            help: ArgumentHelp("Package type:", discussion: """
+                library           - A package with a library.
+                executable        - A package with an executable.
+                tool              - A package with an executable that uses
+                                    Swift Argument Parser. Use this template if you
+                                    plan to have a rich set of command-line arguments.
+                empty             - An empty package with a Package.swift manifest.
                 """))
         var initMode: InitPackage.PackageType = .library
 

--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -43,8 +43,7 @@ public final class InitPackage {
         case empty = "empty"
         case library = "library"
         case executable = "executable"
-        case systemModule = "system-module"
-        case manifest = "manifest"
+        case tool = "tool"
         case `extension` = "extension"
 
         public var description: String {
@@ -114,15 +113,8 @@ public final class InitPackage {
         // FIXME: We should form everything we want to write, then validate that
         // none of it exists, and then act.
         try writeManifestFile()
-
-        if packageType == .manifest {
-            return
-        }
-
-        try writeREADMEFile()
         try writeGitIgnore()
         try writeSources()
-        try writeModuleMap()
         try writeTests()
     }
 
@@ -171,16 +163,19 @@ public final class InitPackage {
 
                 platformsParams.append(param)
             }
+
+            // Package platforms
             if !options.platforms.isEmpty {
                 pkgParams.append("""
                         platforms: [\(platformsParams.joined(separator: ", "))]
                     """)
             }
 
-            if packageType == .library || packageType == .manifest {
+            // Package products
+            if packageType == .library {
                 pkgParams.append("""
                     products: [
-                        // Products define the executables and libraries a package produces, and make them visible to other packages.
+                        // Products define the executables and libraries a package produces, making them visible to other packages.
                         .library(
                             name: "\(pkgname)",
                             targets: ["\(pkgname)"]),
@@ -188,40 +183,52 @@ public final class InitPackage {
                 """)
             }
 
-            pkgParams.append("""
+            // Package dependencies
+            if packageType == .tool {
+                pkgParams.append("""
                     dependencies: [
-                        // Dependencies declare other packages that this package depends on.
-                        // .package(url: /* package url */, from: "1.0.0"),
+                        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.0"),
                     ]
                 """)
+            }
 
-            if packageType == .library || packageType == .executable || packageType == .manifest {
+            // Package targets
+            if packageType != .empty {
                 var param = ""
 
                 param += """
                     targets: [
-                        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-                        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+                        // Targets are the basic building blocks of a package, defining a module or a test suite.
+                        // Targets can depend on other targets in this package and products from dependencies.
 
                 """
                 if packageType == .executable {
                     param += """
                             .executableTarget(
+                                name: "\(pkgname)",
+                                path: "Sources"),
+                        ]
+                    """
+                } else if packageType == .tool {
+                    param += """
+                            .executableTarget(
+                                name: "\(pkgname)",
+                                dependencies: [
+                                    .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                                ],
+                                path: "Sources"),
+                        ]
                     """
                 } else {
                     param += """
                             .target(
+                                name: "\(pkgname)"),
+                            .testTarget(
+                                name: "\(pkgname)Tests",
+                                dependencies: ["\(pkgname)"]),
+                        ]
                     """
                 }
-                param += """
-
-                            name: "\(pkgname)",
-                            dependencies: []),
-                        .testTarget(
-                            name: "\(pkgname)Tests",
-                            dependencies: ["\(pkgname)"]),
-                    ]
-                """
 
                 pkgParams.append(param)
             }
@@ -242,23 +249,10 @@ public final class InitPackage {
         )
     }
 
-    private func writeREADMEFile() throws {
-        let readme = destinationPath.appending(component: "README.md")
-        guard self.fileSystem.exists(readme) == false else {
+    private func writeGitIgnore() throws {
+        guard packageType != .empty else {
             return
         }
-
-        try writePackageFile(readme) { stream in
-            stream <<< """
-                # \(pkgname)
-
-                A description of this package.
-
-                """
-        }
-    }
-
-    private func writeGitIgnore() throws {
         let gitignore = destinationPath.appending(component: ".gitignore")
         guard self.fileSystem.exists(gitignore) == false else {
             return
@@ -281,9 +275,10 @@ public final class InitPackage {
     }
 
     private func writeSources() throws {
-        if packageType == .systemModule || packageType == .manifest {
+        if packageType == .empty {
             return
         }
+
         let sources = destinationPath.appending(component: "Sources")
         guard self.fileSystem.exists(sources) == false else {
             return
@@ -291,11 +286,9 @@ public final class InitPackage {
         progressReporter?("Creating \(sources.relative(to: destinationPath))/")
         try makeDirectories(sources)
 
-        if packageType == .empty {
-            return
-        }
-
-        let moduleDir = sources.appending(component: "\(pkgname)")
+        let moduleDir = packageType == .executable || packageType == .tool
+          ? sources
+          : sources.appending(component: "\(pkgname)")
         try makeDirectories(moduleDir)
 
         let sourceFileName = "\(typeName).swift"
@@ -305,27 +298,36 @@ public final class InitPackage {
         switch packageType {
         case .library:
             content = """
-                public struct \(typeName) {
-                    public private(set) var text = "Hello, World!"
-
-                    public init() {
-                    }
-                }
+                // The Swift Programming Language
+                // https://docs.swift.org/swift-book
 
                 """
         case .executable:
             content = """
-                @main
-                struct \(typeName) {
-                    private(set) var text = "Hello, World!"
+                // The Swift Programming Language
+                // https://docs.swift.org/swift-book
 
-                    static func main() {
-                        print(\(typeName)().text)
-                    }
-                }
+                print("Hello, world!")
 
                 """
-        case .systemModule, .empty, .manifest, .`extension`:
+        case .tool:
+            content = """
+            // The Swift Programming Language
+            // https://docs.swift.org/swift-book
+            // 
+            // Swift Argument Parser
+            // https://swiftpackageindex.com/apple/swift-argument-parser/documentation
+
+            import ArgumentParser
+
+            @main
+            struct \(typeName): ParsableCommand {
+                mutating func run() throws {
+                    print("Hello, world!")
+                }
+            }
+            """
+        case .empty, .`extension`:
             throw InternalError("invalid packageType \(packageType)")
         }
 
@@ -334,30 +336,10 @@ public final class InitPackage {
         }
     }
 
-    private func writeModuleMap() throws {
-        if packageType != .systemModule {
-            return
-        }
-        let modulemap = destinationPath.appending(component: "module.modulemap")
-        guard self.fileSystem.exists(modulemap) == false else {
-            return
-        }
-
-        try writePackageFile(modulemap) { stream in
-            stream <<< """
-                module \(moduleName) [system] {
-                  header "/usr/include/\(moduleName).h"
-                  link "\(moduleName)"
-                  export *
-                }
-
-                """
-        }
-    }
-
     private func writeTests() throws {
-        if packageType == .systemModule {
-            return
+        switch packageType {
+        case .empty, .executable, .tool, .`extension`: return
+            default: break
         }
         let tests = destinationPath.appending(component: "Tests")
         guard self.fileSystem.exists(tests) == false else {
@@ -365,12 +347,7 @@ public final class InitPackage {
         }
         progressReporter?("Creating \(tests.relative(to: destinationPath))/")
         try makeDirectories(tests)
-
-        switch packageType {
-        case .systemModule, .empty, .manifest, .`extension`: break
-        case .library, .executable:
-            try writeTestFileStubs(testsPath: tests)
-        }
+        try writeTestFileStubs(testsPath: tests)
     }
 
     private func writeLibraryTestsFile(_ path: AbsolutePath) throws {
@@ -381,29 +358,11 @@ public final class InitPackage {
 
                 final class \(moduleName)Tests: XCTestCase {
                     func testExample() throws {
-                        // This is an example of a functional test case.
-                        // Use XCTAssert and related functions to verify your tests produce the correct
-                        // results.
-                        XCTAssertEqual(\(typeName)().text, "Hello, World!")
-                    }
-                }
+                        // XCTest Documenation
+                        // https://developer.apple.com/documentation/xctest
 
-                """
-        }
-    }
-
-    private func writeExecutableTestsFile(_ path: AbsolutePath) throws {
-        try writePackageFile(path) { stream in
-            stream <<< """
-                import XCTest
-                @testable import \(moduleName)
-
-                final class \(moduleName)Tests: XCTestCase {
-                    func testExample() throws {
-                        // This is an example of a functional test case.
-                        // Use XCTAssert and related functions to verify your tests produce the correct
-                        // results.
-                        XCTAssertEqual(\(typeName)().text, "Hello, World!")
+                        // Defining Test Cases and Test Methods
+                        // https://developer.apple.com/documentation/xctest/defining_test_cases_and_test_methods
                     }
                 }
 
@@ -418,11 +377,9 @@ public final class InitPackage {
 
         let testClassFile = try AbsolutePath(validating: "\(moduleName)Tests.swift", relativeTo: testModule)
         switch packageType {
-        case .systemModule, .empty, .manifest, .`extension`: break
+        case .empty, .`extension`, .executable, .tool: break
         case .library:
             try writeLibraryTestsFile(testClassFile)
-        case .executable:
-            try writeExecutableTestsFile(testClassFile)
         }
     }
 }

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -701,8 +701,6 @@ final class PackageToolTests: CommandsTestCase {
             _ = try execute(["init", "--type", "empty"], packagePath: path)
 
             XCTAssertFileExists(path.appending(component: "Package.swift"))
-            XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources")), [])
-            XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Tests")), [])
         }
     }
 
@@ -720,8 +718,7 @@ final class PackageToolTests: CommandsTestCase {
             XCTAssertMatch(contents, .prefix("// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"))
 
             XCTAssertFileExists(manifest)
-            XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources").appending(component: "Foo")), ["Foo.swift"])
-            XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Tests")).sorted(), ["FooTests"])
+            XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources")), ["Foo.swift"])
         }
     }
 
@@ -752,8 +749,7 @@ final class PackageToolTests: CommandsTestCase {
             XCTAssertMatch(contents, .prefix("// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"))
 
             XCTAssertFileExists(manifest)
-            XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources").appending(component: "CustomName")), ["CustomName.swift"])
-            XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Tests")).sorted(), ["CustomNameTests"])
+            XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources")), ["CustomName.swift"])
         }
     }
 


### PR DESCRIPTION
## Improve the `swift package init` experience using the following criteria:

- Simplify the templates to include only the minimum necessary to get started without making assumptions.
- Use documentation links instead of arbitrary template content to teach people about Swift.
- Improve the "front door" experience with the help usage.

## Detailed list of changes:

- Remove the `system-module` template.
- Remove the `manifest` template
- Add a `tool` template, an executable that uses `ArgumentParser`
- Remove README generation.
- Don't generate empty directories.
- Don't emit empty dependencies array in manifests.
- Update `library` template content:
  - Remove struct definition, use a simple public function instead.
  - Include documentation links for TSPL and the Standard Library.
  - Include documentation links for XCTest in the generated test case.
- Update `executable` template content
  - Use simpler top-level code instead of an `@main` struct.
  - Remove executable tests.
  - Put sources directly in `./Sources`.
- Clean up and align `type` argument help text
- Update Usage.md documentation

rdar://98999734

## Example resulting file listing

```
./executable
./executable/.gitignore
./executable/Package.swift
./executable/Sources
./executable/Sources/executable.swift

./tool
./tool/.gitignore
./tool/Package.swift
./tool/Sources
./tool/Sources/tool.swift

./empty
./empty/Package.swift

./library
./library/Tests
./library/Tests/libraryTests
./library/Tests/libraryTests/libraryTests.swift
./library/.gitignore
./library/Package.swift
./library/Sources
./library/Sources/library
./library/Sources/library/library.swift
```

## Resulting command line usage

```
OVERVIEW: Initialize a new package

USAGE: swift package init [--type <type>] [--name <name>]

OPTIONS:
  --type <type>           Package type: (default: library)
        library           - A package with a library.
        executable        - A package with an executable.
        tool              - A package with an executable that uses
                            Swift Argument Parser. Use this template if you
                            plan to have a rich set of command-line arguments.
        empty             - An empty package with a Package.swift manifest.
  --name <name>           Provide custom package name
  --version               Show the version.
  -h, -help, --help       Show help information.
```