### PR TITLE
Refactor manifest serialization

### DIFF
--- a/Sources/Basics/Observability.swift
+++ b/Sources/Basics/Observability.swift
@@ -289,6 +289,8 @@ public struct Diagnostic: CustomStringConvertible {
             message = "\(diagnosticData)"
         } else if let convertible = error as? DiagnosticDataConvertible {
             message = "\(convertible.diagnosticData)"
+        } else if let decodingError = error as? DecodingError { // special case because `LocalizedError` conversion will hide the underlying error
+            message = "\(error)"
         } else if let localizedError = error as? LocalizedError {
             message = localizedError.errorDescription ?? localizedError.localizedDescription
         } else {

--- a/Sources/PackageDescription/BuildSettings.swift
+++ b/Sources/PackageDescription/BuildSettings.swift
@@ -11,8 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 /// The build configuration such as debug or release.
-public struct BuildConfiguration: Encodable {
-    private let config: String
+public struct BuildConfiguration {
+    let config: String
 
     private init(_ config: String) {
         self.config = config
@@ -53,10 +53,9 @@ public struct BuildConfiguration: Encodable {
 ///     ]
 /// ),
 /// ```
-public struct BuildSettingCondition: Encodable {
-
-    private let platforms: [Platform]?
-    private let config: BuildConfiguration?
+public struct BuildSettingCondition {
+    let platforms: [Platform]?
+    let config: BuildConfiguration?
 
     private init(platforms: [Platform]?, config: BuildConfiguration?) {
         self.platforms = platforms
@@ -100,7 +99,7 @@ public struct BuildSettingCondition: Encodable {
 }
 
 /// The underlying build setting data.
-fileprivate struct BuildSettingData: Encodable {
+struct BuildSettingData {
 
     /// The name of the build setting.
     let name: String
@@ -113,8 +112,8 @@ fileprivate struct BuildSettingData: Encodable {
 }
 
 /// A C-language build setting.
-public struct CSetting: Encodable {
-    private let data: BuildSettingData
+public struct CSetting {
+    let data: BuildSettingData
 
     private init(name: String, value: [String], condition: BuildSettingCondition?) {
         self.data = BuildSettingData(name: name, value: value, condition: condition)
@@ -179,8 +178,8 @@ public struct CSetting: Encodable {
 }
 
 /// A CXX-language build setting.
-public struct CXXSetting: Encodable {
-    private let data: BuildSettingData
+public struct CXXSetting {
+    let data: BuildSettingData
 
     private init(name: String, value: [String], condition: BuildSettingCondition?) {
         self.data = BuildSettingData(name: name, value: value, condition: condition)
@@ -244,8 +243,8 @@ public struct CXXSetting: Encodable {
 }
 
 /// A Swift language build setting.
-public struct SwiftSetting: Encodable {
-    private let data: BuildSettingData
+public struct SwiftSetting {
+    let data: BuildSettingData
 
     private init(name: String, value: [String], condition: BuildSettingCondition?) {
         self.data = BuildSettingData(name: name, value: value, condition: condition)
@@ -348,8 +347,8 @@ public struct SwiftSetting: Encodable {
 }
 
 /// A linker build setting.
-public struct LinkerSetting: Encodable {
-    private let data: BuildSettingData
+public struct LinkerSetting {
+    let data: BuildSettingData
 
     private init(name: String, value: [String], condition: BuildSettingCondition?) {
         self.data = BuildSettingData(name: name, value: value, condition: condition)

--- a/Sources/PackageDescription/CMakeLists.txt
+++ b/Sources/PackageDescription/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(PackageDescription
   LanguageStandardSettings.swift
   PackageDescription.swift
   PackageDescriptionSerialization.swift
+  PackageDescriptionSerializationConversion.swift
   PackageDependency.swift
   PackageRequirement.swift
   Product.swift

--- a/Sources/PackageDescription/LanguageStandardSettings.swift
+++ b/Sources/PackageDescription/LanguageStandardSettings.swift
@@ -12,7 +12,7 @@
 
 /// The supported C language standard you use to compile C sources in the
 /// package.
-public enum CLanguageStandard: String, Encodable {
+public enum CLanguageStandard: String {
 
     /// The identifier for the ISO C 1990 language standard.
     case c89
@@ -89,7 +89,7 @@ public enum CLanguageStandard: String, Encodable {
 /// Aliases are available for some C++ language standards. For example,
 /// use `cxx98` or `cxx03` for the "ISO C++ 1998 with amendments" standard.
 /// To learn more, see [C++ Support in Clang](https://clang.llvm.org/cxx_status.html).
-public enum CXXLanguageStandard: String, Encodable {
+public enum CXXLanguageStandard: String {
 
     /// The identifier for the ISO C++ 1998 language standard with amendments.
     case cxx98 = "c++98"

--- a/Sources/PackageDescription/PackageDependency.swift
+++ b/Sources/PackageDescription/PackageDependency.swift
@@ -10,9 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import Foundation
-
-// MARK: - file system
 
 extension Package {
     /// A package dependency of a Swift package.
@@ -27,7 +24,7 @@ extension Package {
     /// package. If you add the Swift package as a package dependency to an app
     /// for an Apple platform, you can find the `Package.resolved` file inside
     /// your `.xcodeproj` or `.xcworkspace`.
-    public class Dependency: Encodable {
+    public class Dependency {
         /// The kind of dependency.
         @available(_PackageDescription, introduced: 5.6)
         public enum Kind {

--- a/Sources/PackageDescription/PackageDescription.swift
+++ b/Sources/PackageDescription/PackageDescription.swift
@@ -441,11 +441,12 @@ func manifestToJSON(_ package: Package) -> String {
     struct Output: Codable {
         let package: Serialization.Package
         let errors: [String]
+        let version: Int
     }
 
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
-    let data = try! encoder.encode(Output(package: .init(package), errors: errors))
+    let data = try! encoder.encode(Output(package: .init(package), errors: errors, version: 2))
     return String(data: data, encoding: .utf8)!
 }
 

--- a/Sources/PackageDescription/PackageDescription.swift
+++ b/Sources/PackageDescription/PackageDescription.swift
@@ -438,14 +438,14 @@ public enum SystemPackageProvider {
 // MARK: - Package Dumping
 
 func manifestToJSON(_ package: Package) -> String {
-    struct Output: Encodable {
-        let package: Package
+    struct Output: Codable {
+        let package: Serialization.Package
         let errors: [String]
     }
 
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
-    let data = try! encoder.encode(Output(package: package, errors: errors))
+    let data = try! encoder.encode(Output(package: .init(package), errors: errors))
     return String(data: data, encoding: .utf8)!
 }
 

--- a/Sources/PackageDescription/PackageDescriptionSerializationConversion.swift
+++ b/Sources/PackageDescription/PackageDescriptionSerializationConversion.swift
@@ -1,0 +1,382 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+extension Serialization.BuildConfiguration {
+    init(_ configuration: PackageDescription.BuildConfiguration) {
+        self.config = configuration.config
+    }
+}
+
+extension Serialization.BuildSettingCondition {
+    init(_ condition: PackageDescription.BuildSettingCondition) {
+        self.platforms = condition.platforms?.map { .init($0) }
+        self.config = condition.config.map { .init($0) }
+    }
+}
+
+extension Serialization.BuildSettingData {
+    init(_ settingsData: PackageDescription.BuildSettingData) {
+        self.name = settingsData.name
+        self.value = settingsData.value
+        self.condition = settingsData.condition.map { .init($0) }
+    }
+}
+
+extension Serialization.CSetting {
+    init(_ setting: PackageDescription.CSetting) {
+        self.data = .init(setting.data)
+    }
+}
+
+extension Serialization.CXXSetting {
+    init(_ setting: PackageDescription.CXXSetting) {
+        self.data = .init(setting.data)
+    }
+}
+
+extension Serialization.SwiftSetting {
+    init(_ setting: PackageDescription.SwiftSetting) {
+        self.data = .init(setting.data)
+    }
+}
+
+extension Serialization.LinkerSetting {
+    init(_ setting: PackageDescription.LinkerSetting) {
+        self.data = .init(setting.data)
+    }
+}
+
+extension Serialization.CLanguageStandard {
+    init(_ languageStandard: PackageDescription.CLanguageStandard) {
+        switch languageStandard {
+        case .c89: self = .c89
+        case .c90: self = .c90
+        case .c99: self = .c99
+        case .c11: self = .c11
+        case .c17: self = .c17
+        case .c18: self = .c18
+        case .c2x: self = .c2x
+        case .gnu89: self = .gnu89
+        case .gnu90: self = .gnu90
+        case .gnu99: self = .gnu99
+        case .gnu11: self = .gnu11
+        case .gnu17: self = .gnu17
+        case .gnu18: self = .gnu18
+        case .gnu2x: self = .gnu2x
+        case .iso9899_1990: self = .iso9899_1990
+        case .iso9899_199409: self = .iso9899_199409
+        case .iso9899_1999: self = .iso9899_1999
+        case .iso9899_2011: self = .iso9899_2011
+        case .iso9899_2017: self = .iso9899_2017
+        case .iso9899_2018: self = .iso9899_2018
+        }
+    }
+}
+
+extension Serialization.CXXLanguageStandard {
+    init(_ languageStandard: PackageDescription.CXXLanguageStandard) {
+        switch languageStandard {
+        case .cxx98: self = .cxx98
+        case .cxx03: self = .cxx03
+        case .cxx11: self = .cxx11
+        case .cxx14: self = .cxx14
+        case .cxx17: self = .cxx17
+        case .cxx1z: self = .cxx1z
+        case .cxx20: self = .cxx20
+        case .cxx2b: self = .cxx2b
+        case .gnucxx98: self = .gnucxx98
+        case .gnucxx03: self = .gnucxx03
+        case .gnucxx11: self = .gnucxx11
+        case .gnucxx14: self = .gnucxx14
+        case .gnucxx17: self = .gnucxx17
+        case .gnucxx1z: self = .gnucxx1z
+        case .gnucxx20: self = .gnucxx20
+        case .gnucxx2b: self = .gnucxx2b
+        }
+    }
+}
+
+extension Serialization.SwiftVersion {
+    init(_ swiftVersion: PackageDescription.SwiftVersion) {
+        switch swiftVersion {
+        case .v3: self = .v3
+        case .v4: self = .v4
+        case .v4_2: self = .v4_2
+        case .v5: self = .v5
+        case .version(let version): self = .version(version)
+        }
+    }
+}
+
+extension Serialization.Version {
+    init(_ version: PackageDescription.Version) {
+        self.major = version.major
+        self.minor = version.minor
+        self.patch = version.patch
+        self.prereleaseIdentifiers = version.prereleaseIdentifiers
+        self.buildMetadataIdentifiers = version.buildMetadataIdentifiers
+    }
+}
+
+extension Serialization.PackageDependency.SourceControlRequirement {
+    init(_ requirement: PackageDescription.Package.Dependency.SourceControlRequirement) {
+        switch requirement {
+        case .range(let range):
+            self = .range(lowerBound: .init(range.lowerBound), upperBound: .init(range.upperBound))
+        case .exact(let version):
+            self = .exact(.init(version))
+        case .revision(let revision):
+            self = .revision(revision)
+        case .branch(let branch):
+            self = .branch(branch)
+        }
+    }
+}
+
+extension Serialization.PackageDependency.RegistryRequirement {
+    init(_ requirement: PackageDescription.Package.Dependency.RegistryRequirement) {
+        switch requirement {
+        case .exact(let version):
+            self = .exact(.init(version))
+        case .range(let range):
+            self = .range(lowerBound: .init(range.lowerBound), upperBound: .init(range.upperBound))
+        }
+    }
+}
+
+extension Serialization.PackageDependency.Kind {
+    init(_ kind: PackageDescription.Package.Dependency.Kind) {
+        switch kind {
+        case .fileSystem(let name, let path):
+            self = .fileSystem(name: name, path: path)
+        case .sourceControl(let name, let location, let requirement):
+            self = .sourceControl(name: name, location: location, requirement: .init(requirement))
+        case .registry(let identity, let requirement):
+            self = .registry(id: identity, requirement: .init(requirement))
+        }
+    }
+}
+
+extension Serialization.PackageDependency {
+    init(_ dependency: PackageDescription.Package.Dependency) {
+        self.kind = .init(dependency.kind)
+        self.moduleAliases = dependency.moduleAliases
+    }
+}
+
+extension Serialization.Platform {
+    init(_ platform: PackageDescription.Platform) {
+        self.name = platform.name
+    }
+}
+
+extension Serialization.SupportedPlatform {
+    init(_ platform: PackageDescription.SupportedPlatform) {
+        self.platform = .init(platform.platform)
+        self.version = platform.version
+    }
+}
+
+extension Serialization.TargetDependency.Condition {
+    init(_ condition: TargetDependencyCondition) {
+        self.platforms = condition.platforms?.map { .init($0) }
+    }
+}
+
+extension Serialization.TargetDependency {
+    init(_ dependency: PackageDescription.Target.Dependency) {
+        switch dependency {
+        case .targetItem(let name, let condition):
+            self = .target(name: name, condition: condition.map { .init($0) })
+        case .productItem(let name, let package, let moduleAliases, let condition):
+            self = .product(name: name, package: package, moduleAliases: moduleAliases, condition: condition.map { .init($0) })
+        case .byNameItem(let name, let condition):
+            self = .byName(name: name, condition: condition.map { .init($0) })
+        }
+    }
+}
+
+extension Serialization.TargetType {
+    init(_ type: PackageDescription.Target.TargetType) {
+        switch type {
+        case .regular: self = .regular
+        case .executable: self = .executable
+        case .test: self = .test
+        case .system: self = .system
+        case .binary: self = .binary
+        case .plugin: self = .plugin
+        }
+    }
+}
+
+extension Serialization.PluginCapability {
+    init(_ capability: PackageDescription.Target.PluginCapability) {
+        switch capability {
+        case ._buildTool: self = .buildTool
+        case ._command(let intent, let permissions): self = .command(intent: .init(intent), permissions: permissions.map { .init($0) })
+        }
+    }
+}
+
+extension Serialization.PluginCommandIntent {
+    init(_ intent: PackageDescription.PluginCommandIntent) {
+        switch intent {
+        case ._custom(let verb, let description): self = .custom(verb: verb, description: description)
+        case ._sourceCodeFormatting: self = .sourceCodeFormatting
+        case ._documentationGeneration: self = .documentationGeneration
+        }
+    }
+}
+
+extension Serialization.PluginPermission {
+    init(_ permission: PackageDescription.PluginPermission) {
+        switch permission {
+        case ._allowNetworkConnections(let scope, let reason): self = .allowNetworkConnections(scope: .init(scope), reason: reason)
+        case ._writeToPackageDirectory(let reason): self = .writeToPackageDirectory(reason: reason)
+        }
+    }
+}
+
+extension Serialization.PluginNetworkPermissionScope {
+    init(_ scope: PackageDescription.PluginNetworkPermissionScope) {
+        switch scope {
+        case .none: self = .none
+        case .local(let ports): self = .local(ports: ports)
+        case .all(let ports): self = .all(ports: ports)
+        case .docker: self = .docker
+        case .unixDomainSocket: self = .unixDomainSocket
+        }
+    }
+}
+
+extension Serialization.PluginUsage {
+    init(_ usage: PackageDescription.Target.PluginUsage) {
+        switch usage {
+        case ._pluginItem(let name, let package): self = .plugin(name: name, package: package)
+        }
+    }
+}
+
+extension Serialization.Target {
+    init(_ target: PackageDescription.Target) {
+        self.name = target.name
+        self.path = target.path
+        self.url = target.url
+        self.sources = target.sources
+        self.resources = target.resources?.map { .init($0) }
+        self.exclude = target.exclude
+        self.dependencies = target.dependencies.map { .init($0) }
+        self.publicHeadersPath = target.publicHeadersPath
+        self.type = .init(target.type)
+        self.pkgConfig = target.pkgConfig
+        self.providers = target.providers?.map { .init($0) }
+        self.pluginCapability = target.pluginCapability.map { .init($0) }
+        self.cSettings = target.cSettings?.map { .init($0) }
+        self.cxxSettings = target.cxxSettings?.map { .init($0) }
+        self.swiftSettings = target.swiftSettings?.map { .init($0) }
+        self.linkerSettings = target.linkerSettings?.map { .init($0) }
+        self.checksum = target.checksum
+        self.pluginUsages = target.plugins?.map { .init($0) }
+    }
+}
+
+extension Serialization.Resource {
+    init(_ resource: PackageDescription.Resource) {
+        self.rule = resource.rule
+        self.path = resource.path
+        self.localization = resource.localization.map { .init($0) }
+    }
+}
+
+extension Serialization.Resource.Localization {
+    init(_ localization: PackageDescription.Resource.Localization) {
+        switch localization {
+        case .base: self = .base
+        case .default: self = .default
+        }
+    }
+}
+
+extension Serialization.Product.ProductType.LibraryType {
+    init(_ type: PackageDescription.Product.Library.LibraryType) {
+        switch type {
+        case .dynamic: self = .dynamic
+        case .static: self = .static
+        }
+    }
+}
+
+extension Serialization.Product {
+    init(_ product: PackageDescription.Product) {
+        if let executable = product as? PackageDescription.Product.Executable {
+            self.init(executable)
+        } else if let library = product as? PackageDescription.Product.Library {
+            self.init(library)
+        } else if let plugin = product as? PackageDescription.Product.Plugin {
+            self.init(plugin)
+        } else {
+            fatalError("should not be reached")
+        }
+    }
+
+    init(_ executable: PackageDescription.Product.Executable) {
+        self.name = executable.name
+        self.targets = executable.targets
+        self.productType = .executable
+    }
+
+    init(_ library: PackageDescription.Product.Library) {
+        self.name = library.name
+        self.targets = library.targets
+        let libraryType = library.type.map { ProductType.LibraryType($0) } ?? .automatic
+        self.productType = .library(type: libraryType)
+    }
+
+    init(_ plugin: PackageDescription.Product.Plugin) {
+        self.name = plugin.name
+        self.targets = plugin.targets
+        self.productType = .plugin
+    }
+}
+
+extension Serialization.Package {
+    init(_ package: PackageDescription.Package) {
+        self.name = package.name
+        self.platforms = package.platforms?.map { .init($0) }
+        self.defaultLocalization = package.defaultLocalization.map { .init($0) }
+        self.pkgConfig = package.pkgConfig
+        self.providers = package.providers?.map { .init($0) }
+        self.targets = package.targets.map { .init($0) }
+        self.products = package.products.map { .init($0) }
+        self.dependencies = package.dependencies.map { .init($0) }
+        self.swiftLanguageVersions = package.swiftLanguageVersions?.map { .init($0) }
+        self.cLanguageStandard = package.cLanguageStandard.map { .init($0) }
+        self.cxxLanguageStandard = package.cxxLanguageStandard.map { .init($0) }
+    }
+}
+
+extension Serialization.LanguageTag {
+    init(_ language: PackageDescription.LanguageTag) {
+        self.tag = language.tag
+    }
+}
+
+extension Serialization.SystemPackageProvider {
+    init(_ provider: PackageDescription.SystemPackageProvider) {
+        switch provider {
+        case .brewItem(let values): self = .brew(values)
+        case .aptItem(let values): self = .apt(values)
+        case .yumItem(let values): self = .yum(values)
+        case .nugetItem(let values): self = .nuget(values)
+        }
+    }
+}

--- a/Sources/PackageDescription/Product.swift
+++ b/Sources/PackageDescription/Product.swift
@@ -59,12 +59,7 @@
 ///     ]
 /// )
 /// ```
-public class Product: Encodable {
-    private enum ProductCodingKeys: String, CodingKey {
-        case name
-        case type = "product_type"
-    }
-
+public class Product {
     /// The name of the package product.
     public let name: String
 
@@ -74,9 +69,6 @@ public class Product: Encodable {
 
     /// The executable product of a Swift package.
     public final class Executable: Product {
-        private enum ExecutableCodingKeys: CodingKey {
-            case targets
-        }
 
         /// The names of the targets in this product.
         public let targets: [String]
@@ -85,31 +77,10 @@ public class Product: Encodable {
             self.targets = targets
             super.init(name: name)
         }
-
-        /// Encodes this executable product type into the given encoder.
-        ///
-        /// This function throws an error if any values are invalid for the
-        /// given encoder's format.
-        ///
-        /// - Note: Do not call this function directly. It is public to satisfy conformance to Codable, but it is only for use by internal Swift Package Manager processes.
-        ///
-        /// - Parameter encoder: The encoder to write data to.
-        public override func encode(to encoder: Encoder) throws {
-            try super.encode(to: encoder)
-            var productContainer = encoder.container(keyedBy: ProductCodingKeys.self)
-            try productContainer.encode("executable", forKey: .type)
-            var executableContainer = encoder.container(keyedBy: ExecutableCodingKeys.self)
-            try executableContainer.encode(targets, forKey: .targets)
-        }
     }
 
     /// The library product of a Swift package.
     public final class Library: Product {
-        private enum LibraryCodingKeys: CodingKey {
-            case type
-            case targets
-        }
-
         /// The different types of a library product.
         public enum LibraryType: String, Encodable {
             /// A statically linked library.
@@ -132,46 +103,16 @@ public class Product: Encodable {
             self.targets = targets
             super.init(name: name)
         }
-
-        /// Encodes this value into the given encoder.
-        ///
-        /// If the value fails to encode anything, `encoder` will encode an
-        /// empty keyed container in its place.
-        ///
-        /// This function throws an error if any values are invalid for the
-        /// given encoder's format.
-        ///
-        /// - Parameter encoder: The encoder to write data to.
-        public override func encode(to encoder: Encoder) throws {
-            try super.encode(to: encoder)
-            var productContainer = encoder.container(keyedBy: ProductCodingKeys.self)
-            try productContainer.encode("library", forKey: .type)
-            var libraryContainer = encoder.container(keyedBy: LibraryCodingKeys.self)
-            try libraryContainer.encode(type, forKey: .type)
-            try libraryContainer.encode(targets, forKey: .targets)
-        }
     }
 
     /// The plugin product of a Swift package.
     public final class Plugin: Product {
-        private enum PluginCodingKeys: CodingKey {
-            case targets
-        }
-
         /// The name of the plugin target to vend as a product.
         public let targets: [String]
 
         init(name: String, targets: [String]) {
             self.targets = targets
             super.init(name: name)
-        }
-
-        public override func encode(to encoder: Encoder) throws {
-            try super.encode(to: encoder)
-            var productContainer = encoder.container(keyedBy: ProductCodingKeys.self)
-            try productContainer.encode("plugin", forKey: .type)
-            var pluginContainer = encoder.container(keyedBy: PluginCodingKeys.self)
-            try pluginContainer.encode(targets, forKey: .targets)
         }
     }
 
@@ -233,19 +174,5 @@ public static func executable(
         targets: [String]
     ) -> Product {
         return Plugin(name: name, targets: targets)
-    }
-
-    /// Encodes this value into the given encoder.
-    ///
-    /// If the value fails to encode anything, `encoder` will encode an empty
-    /// keyed container in its place.
-    ///
-    /// This function throws an error if any values are invalid for the given
-    /// encoder's format.
-    ///
-    /// - Parameter encoder: The encoder to write data to.
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: ProductCodingKeys.self)
-        try container.encode(name, forKey: .name)
     }
 }

--- a/Sources/PackageDescription/Resource.swift
+++ b/Sources/PackageDescription/Resource.swift
@@ -32,10 +32,10 @@
 ///
 /// To learn more about package resources, see
 /// <doc:bundling-resources-with-a-swift-package>.
-public struct Resource: Encodable {
+public struct Resource {
 
     /// Defines the explicit type of localization for resources.
-    public enum Localization: String, Encodable {
+    public enum Localization: String {
 
         /// A constant that represents default internationalization.
         case `default`
@@ -45,13 +45,13 @@ public struct Resource: Encodable {
     }
 
     /// The rule for the resource.
-    private let rule: String
+    let rule: String
 
     /// The path of the resource.
-    private let path: String
+    let path: String
 
     /// The explicit type of localization for the resource.
-    private let localization: Localization?
+    let localization: Localization?
 
     private init(rule: String, path: String, localization: Localization?) {
         self.rule = rule

--- a/Sources/PackageDescription/SupportedPlatforms.swift
+++ b/Sources/PackageDescription/SupportedPlatforms.swift
@@ -11,10 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 /// A platform supported by Swift Package Manager.
-public struct Platform: Encodable, Equatable {
+public struct Platform: Equatable {
 
     /// The name of the platform.
-    fileprivate let name: String
+    let name: String
 
     private init(name: String) {
         self.name = name
@@ -85,7 +85,7 @@ public struct Platform: Encodable, Equatable {
 /// package's deployment version. The deployment target of a package's
 /// dependencies must be lower than or equal to the top-level package's
 /// deployment target version for a particular platform.
-public struct SupportedPlatform: Encodable, Equatable {
+public struct SupportedPlatform: Equatable {
 
     /// The platform.
     let platform: Platform
@@ -265,7 +265,7 @@ public struct SupportedPlatform: Encodable, Equatable {
 extension SupportedPlatform {
 
     /// The supported macOS version.
-    public struct MacOSVersion: Encodable, AppleOSVersion {
+    public struct MacOSVersion: AppleOSVersion {
         fileprivate static let name = "macOS"
         fileprivate static let minimumMajorVersion = 10
 
@@ -339,7 +339,7 @@ extension SupportedPlatform {
     }
 
     /// The supported tvOS version.
-    public struct TVOSVersion: Encodable, AppleOSVersion {
+    public struct TVOSVersion: AppleOSVersion {
         fileprivate static let name = "tvOS"
         fileprivate static let minimumMajorVersion = 9
 
@@ -400,7 +400,7 @@ extension SupportedPlatform {
     }
 
     /// The supported Mac Catalyst version.
-    public struct MacCatalystVersion: Encodable, AppleOSVersion {
+    public struct MacCatalystVersion: AppleOSVersion {
         fileprivate static let name = "macCatalyst"
         fileprivate static let minimumMajorVersion = 13
 
@@ -437,7 +437,7 @@ extension SupportedPlatform {
     }
 
     /// The supported iOS version.
-    public struct IOSVersion: Encodable, AppleOSVersion {
+    public struct IOSVersion: AppleOSVersion {
         fileprivate static let name = "iOS"
         fileprivate static let minimumMajorVersion = 2
 
@@ -504,7 +504,7 @@ extension SupportedPlatform {
     }
 
     /// The supported watchOS version.
-    public struct WatchOSVersion: Encodable, AppleOSVersion {
+    public struct WatchOSVersion: AppleOSVersion {
         fileprivate static let name = "watchOS"
         fileprivate static let minimumMajorVersion = 2
 
@@ -565,7 +565,7 @@ extension SupportedPlatform {
     }
 
     /// The supported DriverKit version.
-    public struct DriverKitVersion: Encodable, AppleOSVersion {
+    public struct DriverKitVersion: AppleOSVersion {
         fileprivate static let name = "DriverKit"
         fileprivate static let minimumMajorVersion = 19
 

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -23,7 +23,7 @@
 public final class Target {
 
     /// The different types of a target.
-    public enum TargetType: String, Encodable {
+    public enum TargetType: String {
         /// A target that contains code for the Swift package's functionality.
         case regular
         /// A target that contains code for an executable's main module.
@@ -1103,8 +1103,8 @@ extension Target.Dependency {
 }
 
 /// A condition that limits the application of a target's dependency.
-public struct TargetDependencyCondition: Encodable {
-    private let platforms: [Platform]?
+public struct TargetDependencyCondition {
+    let platforms: [Platform]?
 
     private init(platforms: [Platform]?) {
         self.platforms = platforms

--- a/Sources/PackageLoading/CMakeLists.txt
+++ b/Sources/PackageLoading/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(PackageLoading
   ManifestLoader+Validation.swift
   ModuleMapGenerator.swift
   PackageBuilder.swift
+  PackageDescriptionSerialization.swift
   ManifestJSONParser.swift
   Platform.swift
   PkgConfig.swift

--- a/Sources/PackageLoading/ContextModel.swift
+++ b/Sources/PackageLoading/ContextModel.swift
@@ -25,20 +25,6 @@ struct ContextModel {
 }
 
 extension ContextModel : Codable {
-    private enum CodingKeys: CodingKey {
-        case packageDirectory
-    }
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.packageDirectory = try container.decode(String.self, forKey: .packageDirectory)
-    }
-    
-    func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(packageDirectory, forKey: .packageDirectory)
-    }
-
     func encode() throws -> String {
         let encoder = JSONEncoder()
         let data = try encoder.encode(self)

--- a/Sources/PackageLoading/ManifestJSONParser.swift
+++ b/Sources/PackageLoading/ManifestJSONParser.swift
@@ -10,15 +10,25 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Basics
 @_implementationOnly import Foundation
 import PackageModel
-import TSCBasic
 
+import struct Basics.InternalError
+import struct TSCBasic.AbsolutePath
+import protocol TSCBasic.FileSystem
+import enum TSCBasic.PathValidationError
+import struct TSCBasic.RegEx
+import struct TSCBasic.RelativePath
+import struct TSCBasic.StringError
 import struct TSCUtility.Version
 
 enum ManifestJSONParser {
     private static let filePrefix = "file://"
+
+    struct Input: Codable {
+        let package: Serialization.Package
+        let errors: [String]
+    }
 
     struct Result {
         var name: String
@@ -41,49 +51,70 @@ enum ManifestJSONParser {
         identityResolver: IdentityResolver,
         fileSystem: FileSystem
     ) throws -> ManifestJSONParser.Result {
-        let json = try JSON(string: jsonString)
+        let input = try JSONDecoder.makeWithDefaults().decode(Input.self, from: jsonString)
 
-        let errors: [String] = try json.get("errors")
-        guard errors.isEmpty else {
-            throw ManifestParseError.runtimeManifestErrors(errors)
+        guard input.errors.isEmpty else {
+            throw ManifestParseError.runtimeManifestErrors(input.errors)
         }
 
-        let package = try json.getJSON("package")
-        var manifest = Self.Result(name: try package.get(String.self, forKey: "name"))
-        manifest.defaultLocalization = try? package.get(String.self, forKey: "defaultLocalization")
-        manifest.pkgConfig = package.get("pkgConfig")
-        manifest.platforms = try Self.parsePlatforms(package)
-        manifest.swiftLanguageVersions = try Self.parseSwiftLanguageVersion(package)
-        manifest.products = try package.getArray("products").map(ProductDescription.init(v4:))
-        manifest.providers = try? package.getArray("providers").map(SystemPackageProviderDescription.init(v4:))
-        manifest.targets = try package.getArray("targets").map {
-            try Self.parseTarget(
-                json: $0,
-                identityResolver: identityResolver
-            )
-        }
-        manifest.dependencies = try package.getArray("dependencies").map {
+        let dependencies = try input.package.dependencies.map {
             try Self.parseDependency(
-                json: $0,
+                dependency: $0,
                 toolsVersion: toolsVersion,
                 packageKind: packageKind,
                 identityResolver: identityResolver,
                 fileSystem: fileSystem
             )
         }
-        manifest.cxxLanguageStandard = package.get("cxxLanguageStandard")
-        manifest.cLanguageStandard = package.get("cLanguageStandard")
 
-        return manifest
+        return Result(
+            name: input.package.name,
+            defaultLocalization: input.package.defaultLocalization?.tag,
+            platforms: try input.package.platforms.map { try Self.parsePlatforms($0) } ?? [],
+            targets: try input.package.targets.map { try Self.parseTarget(target: $0, identityResolver: identityResolver) },
+            pkgConfig: input.package.pkgConfig,
+            swiftLanguageVersions: try input.package.swiftLanguageVersions.map { try Self.parseSwiftLanguageVersions($0) },
+            dependencies: dependencies,
+            providers: input.package.providers?.map { .init($0) },
+            products: try input.package.products.map { try .init($0) },
+            cxxLanguageStandard: input.package.cxxLanguageStandard?.rawValue,
+            cLanguageStandard: input.package.cLanguageStandard?.rawValue
+        )
     }
 
-    private static func parseSwiftLanguageVersion(_ package: JSON) throws -> [SwiftLanguageVersion]?  {
-        guard let versionJSON = try? package.getArray("swiftLanguageVersions") else {
-            return nil
+    private static func parsePlatforms(_ declaredPlatforms: [Serialization.SupportedPlatform]) throws -> [PlatformDescription] {
+        // Empty list is not supported.
+        if declaredPlatforms.isEmpty {
+            throw ManifestParseError.runtimeManifestErrors(["supported platforms can't be empty"])
         }
 
-        return try versionJSON.map {
-            let languageVersionString = try String(json: $0)
+        var platforms: [PlatformDescription] = []
+
+        for platform in declaredPlatforms {
+            let description = PlatformDescription(platform)
+
+            // Check for duplicates.
+            if platforms.map({ $0.platformName }).contains(description.platformName) {
+                // FIXME: We need to emit the API name and not the internal platform name.
+                throw ManifestParseError.runtimeManifestErrors(["found multiple declaration for the platform: \(description.platformName)"])
+            }
+
+            platforms.append(description)
+        }
+
+        return platforms
+    }
+
+    private static func parseSwiftLanguageVersions(_ versions: [Serialization.SwiftVersion]) throws -> [SwiftLanguageVersion] {
+        return try versions.map {
+            let languageVersionString: String
+            switch $0 {
+            case .v3: languageVersionString = "3"
+            case .v4: languageVersionString = "4"
+            case .v4_2: languageVersionString = "4.2"
+            case .v5: languageVersionString = "5"
+            case .version(let version): languageVersionString = version
+            }
             guard let languageVersion = SwiftLanguageVersion(string: languageVersionString) else {
                 throw ManifestParseError.runtimeManifestErrors(["invalid Swift language version: \(languageVersionString)"])
             }
@@ -92,78 +123,36 @@ enum ManifestJSONParser {
     }
 
     private static func parseDependency(
-        json: JSON,
+        dependency: Serialization.PackageDependency,
         toolsVersion: ToolsVersion,
         packageKind: PackageReference.Kind,
         identityResolver: IdentityResolver,
         fileSystem: TSCBasic.FileSystem
     ) throws -> PackageDependency {
-        if let kindJSON = try? json.getJSON("kind") {
-            // new format introduced 7/2021
-            let type: String = try kindJSON.get("type")
-            if type == "fileSystem" {
-                let name: String? = kindJSON.get("name")
-                let path: String = try kindJSON.get("path")
-                return try Self.parseFileSystemDependency(
-                    packageKind: packageKind,
-                    at: path,
-                    name: name,
-                    identityResolver: identityResolver,
-                    fileSystem: fileSystem
-                )
-            } else if type == "sourceControl" {
-                let name: String? = kindJSON.get("name")
-                let location: String = try kindJSON.get("location")
-                let requirementJSON: JSON = try kindJSON.get("requirement")
-                let requirement = try PackageDependency.SourceControl.Requirement(v4: requirementJSON)
-                return try Self.parseSourceControlDependency(
-                    packageKind: packageKind,
-                    at: location,
-                    name: name,
-                    requirement: requirement,
-                    identityResolver: identityResolver,
-                    fileSystem: fileSystem
-                )
-            } else if type == "registry" {
-                let identity: String = try kindJSON.get("identity")
-                let requirementJSON: JSON = try kindJSON.get("requirement")
-                let requirement = try PackageDependency.Registry.Requirement(v4: requirementJSON)
-                return try Self.parseRegistryDependency(
-                    identity: .plain(identity),
-                    requirement: requirement,
-                    identityResolver: identityResolver
-                )
-            } else {
-                throw InternalError("Unknown dependency type \(kindJSON)")
-            }
-        } else {
-            // old format, deprecated 7/2021 but may be stored in caches, etc
-            let name: String? = json.get("name")
-            let url: String = try json.get("url")
-
-            // backwards compatibility 2/2021
-            let requirementJSON: JSON = try json.get("requirement")
-            let requirementType: String = try requirementJSON.get(String.self, forKey: "type")
-            switch requirementType {
-            case "localPackage":
-                return try Self.parseFileSystemDependency(
-                    packageKind: packageKind,
-                    at: url,
-                    name: name,
-                    identityResolver: identityResolver,
-                    fileSystem: fileSystem
-                )
-            default:
-                let requirement = try PackageDependency.SourceControl.Requirement(v4: requirementJSON)
-                return try Self.parseSourceControlDependency(
-                    packageKind: packageKind,
-                    at: url,
-                    name: name,
-                    requirement: requirement,
-                    identityResolver: identityResolver,
-                    fileSystem: fileSystem
-                )
-            }
+        switch dependency.kind {
+        case .registry(let identity, let requirement):
+            return try Self.parseRegistryDependency(
+                identity: .plain(identity),
+                requirement: .init(requirement),
+                identityResolver: identityResolver
+            )
+        case .sourceControl(let name, let location, let requirement):
+            return try Self.parseSourceControlDependency(
+                packageKind: packageKind,
+                at: location,
+                name: name,
+                requirement: .init(requirement),
+                identityResolver: identityResolver,
+                fileSystem: fileSystem
+            )
+        case .fileSystem(let name, let path):
+            return try Self.parseFileSystemDependency(
+                packageKind: packageKind,
+                at: path,
+                name: name,
+                identityResolver: identityResolver,
+                fileSystem: fileSystem
+            )
         }
     }
 
@@ -315,213 +304,70 @@ enum ManifestJSONParser {
         }
     }
 
-    private static func parsePlatforms(_ package: JSON) throws -> [PlatformDescription] {
-        guard let platformsJSON = try? package.getJSON("platforms") else {
-            return []
-        }
-
-        // Get the declared platform list.
-        let declaredPlatforms = try platformsJSON.getArray()
-
-        // Empty list is not supported.
-        if declaredPlatforms.isEmpty {
-            throw ManifestParseError.runtimeManifestErrors(["supported platforms can't be empty"])
-        }
-
-        // Start parsing platforms.
-        var platforms: [PlatformDescription] = []
-
-        for platformJSON in declaredPlatforms {
-            // Parse the version and validate that it can be used in the current
-            // manifest version.
-            let versionString: String = try platformJSON.get("version")
-
-            // Get the platform name.
-            let platformName: String = try platformJSON.getJSON("platform").get("name")
-
-            let versionComponents = versionString.split(
-                separator: ".",
-                omittingEmptySubsequences: false
-            )
-            var version: [String.SubSequence] = []
-            var options: [String.SubSequence] = []
-
-            for (idx, component) in versionComponents.enumerated() {
-                if idx < 2 {
-                    version.append(component)
-                    continue
-                }
-
-                if idx == 2, UInt(component) != nil {
-                    version.append(component)
-                    continue
-                }
-
-                options.append(component)
-            }
-
-            let description = PlatformDescription(
-                name: platformName,
-                version: version.joined(separator: "."),
-                options: options.map{ String($0) }
-            )
-
-            // Check for duplicates.
-            if platforms.map({ $0.platformName }).contains(platformName) {
-                // FIXME: We need to emit the API name and not the internal platform name.
-                throw ManifestParseError.runtimeManifestErrors(["found multiple declaration for the platform: \(platformName)"])
-            }
-
-            platforms.append(description)
-        }
-
-        return platforms
-    }
-
     private static func parseTarget(
-        json: JSON,
+        target: Serialization.Target,
         identityResolver: IdentityResolver
     ) throws -> TargetDescription {
-        let providers = try? json
-            .getArray("providers")
-            .map(SystemPackageProviderDescription.init(v4:))
+        let providers = target.providers?.map { SystemPackageProviderDescription($0) }
+        let pluginCapability = target.pluginCapability.map { TargetDescription.PluginCapability($0) }
+        let dependencies = try target.dependencies.map { try TargetDescription.Dependency($0, identityResolver: identityResolver) }
 
-        let pluginCapability = try? TargetDescription.PluginCapability(v4: json.getJSON("pluginCapability"))
+        try target.sources?.forEach{ _ = try RelativePath(validating: $0) }
+        try target.exclude.forEach{ _ = try RelativePath(validating: $0) }
 
-        let dependencies = try json
-            .getArray("dependencies")
-            .map {
-                try TargetDescription.Dependency.init(
-                    v4: $0,
-                    identityResolver: identityResolver
-                )
-            }
-
-        let sources: [String]? = try? json.get("sources")
-        try sources?.forEach{ _ = try RelativePath(validating: $0) }
-
-        let exclude: [String] = try json.get("exclude")
-        try exclude.forEach{ _ = try RelativePath(validating: $0) }
-
-        let pluginUsages = try? json
-            .getArray("pluginUsages")
-            .map(TargetDescription.PluginUsage.init(v4:))
+        let pluginUsages = target.pluginUsages?.map { TargetDescription.PluginUsage.init($0) }
 
         return try TargetDescription(
-            name: try json.get("name"),
+            name: target.name,
             dependencies: dependencies,
-            path: json.get("path"),
-            url: json.get("url"),
-            exclude: exclude,
-            sources: sources,
-            resources: try Self.parseResources(json),
-            publicHeadersPath: json.get("publicHeadersPath"),
-            type: try .init(v4: json.get("type")),
-            pkgConfig: json.get("pkgConfig"),
+            path: target.path,
+            url: target.url,
+            exclude: target.exclude,
+            sources: target.sources,
+            resources: try Self.parseResources(target.resources),
+            publicHeadersPath: target.publicHeadersPath,
+            type: .init(target.type),
+            pkgConfig: target.pkgConfig,
             providers: providers,
             pluginCapability: pluginCapability,
-            settings: try Self.parseBuildSettings(json),
-            checksum: json.get("checksum"),
+            settings: try Self.parseBuildSettings(target),
+            checksum: target.checksum,
             pluginUsages: pluginUsages
         )
     }
 
-    private static func parseResources(_ json: JSON) throws -> [TargetDescription.Resource] {
-        guard let resourcesJSON = try? json.getArray("resources") else { return [] }
-        return try resourcesJSON.map { json in
-            let rule = try json.get(String.self, forKey: "rule")
-            let path = try RelativePath(validating: json.get(String.self, forKey: "path"))
-            switch rule {
+    private static func parseResources(_ resources: [Serialization.Resource]?) throws -> [TargetDescription.Resource] {
+        return try resources?.map {
+            let path = try RelativePath(validating: $0.path)
+            switch $0.rule {
             case "process":
-                let localizationString = try? json.get(String.self, forKey: "localization")
-                let localization = localizationString.map({ TargetDescription.Resource.Localization(rawValue: $0)! })
+                let localization = $0.localization.map({ TargetDescription.Resource.Localization(rawValue: $0.rawValue)! })
                 return .init(rule: .process(localization: localization), path: path.pathString)
             case "copy":
                 return .init(rule: .copy, path: path.pathString)
             case "embedInCode":
                 return .init(rule: .embedInCode, path: path.pathString)
             default:
-                throw InternalError("invalid resource rule \(rule)")
+                throw InternalError("invalid resource rule \($0.rule)")
             }
-        }
+        } ?? []
     }
 
-    private static func parseBuildSettings(_ json: JSON) throws -> [TargetBuildSettingDescription.Setting] {
+    private static func parseBuildSettings(_ target: Serialization.Target) throws -> [TargetBuildSettingDescription.Setting] {
         var settings: [TargetBuildSettingDescription.Setting] = []
-        for tool in TargetBuildSettingDescription.Tool.allCases {
-            let key = tool.rawValue + "Settings"
-            if let settingsJSON = try? json.getJSON(key) {
-                settings += try Self.parseBuildSettings(settingsJSON, tool: tool, settingName: key)
-            }
+        try target.cSettings?.forEach {
+            settings.append(try .init($0))
+        }
+        try target.cxxSettings?.forEach {
+            settings.append(try .init($0))
+        }
+        try target.swiftSettings?.forEach {
+            settings.append(try .init($0))
+        }
+        try target.linkerSettings?.forEach {
+            settings.append(try .init($0))
         }
         return settings
-    }
-
-    private static func parseBuildSettings(_ json: JSON, tool: TargetBuildSettingDescription.Tool, settingName: String) throws -> [TargetBuildSettingDescription.Setting] {
-        let declaredSettings = try json.getArray()
-        return try declaredSettings.map({
-            try Self.parseBuildSetting($0, tool: tool)
-        })
-    }
-    
-    private static func parseBuildSetting(_ json: JSON, tool: TargetBuildSettingDescription.Tool) throws -> TargetBuildSettingDescription.Setting {
-        let json = try json.getJSON("data")
-        let name = try json.get(String.self, forKey: "name")
-        let values = try json.get([String].self, forKey: "value")
-        let condition = try (try? json.getJSON("condition")).flatMap(PackageConditionDescription.init(v4:))
-        
-        // Diagnose invalid values.
-        for item in values {
-            let groups = Self.invalidValueRegex.matchGroups(in: item).flatMap{ $0 }
-            if !groups.isEmpty {
-                let error = "the build setting '\(name)' contains invalid component(s): \(groups.joined(separator: " "))"
-                throw ManifestParseError.runtimeManifestErrors([error])
-            }
-        }
-        
-        let kind: TargetBuildSettingDescription.Kind
-        switch name {
-        case "headerSearchPath":
-            guard let value = values.first else {
-                throw InternalError("invalid (empty) build settings value")
-            }
-            kind = .headerSearchPath(value)
-        case "define":
-            guard let value = values.first else {
-                throw InternalError("invalid (empty) build settings value")
-            }
-            kind = .define(value)
-        case "linkedLibrary":
-            guard let value = values.first else {
-                throw InternalError("invalid (empty) build settings value")
-            }
-            kind = .linkedLibrary(value)
-        case "linkedFramework":
-            guard let value = values.first else {
-                throw InternalError("invalid (empty) build settings value")
-            }
-            kind = .linkedFramework(value)
-        case "enableUpcomingFeature":
-            guard let value = values.first else {
-                throw InternalError("invalid (empty) build settings value")
-            }
-            kind = .enableUpcomingFeature(value)
-        case "enableExperimentalFeature":
-            guard let value = values.first else {
-                throw InternalError("invalid (empty) build settings value")
-            }
-            kind = .enableExperimentalFeature(value)
-        case "unsafeFlags":
-            kind = .unsafeFlags(values)
-        default:
-            throw InternalError("invalid build setting \(name)")
-        }
-        
-        return .init(
-            tool: tool,
-            kind: kind,
-            condition: condition
-        )
     }
 
     /// Parses the URL type of a git repository
@@ -552,260 +398,317 @@ enum ManifestJSONParser {
     }
 
     /// Looks for Xcode-style build setting macros "$()".
-    private static let invalidValueRegex = try! RegEx(pattern: #"(\$\(.*?\))"#)
+    fileprivate static let invalidValueRegex = try! RegEx(pattern: #"(\$\(.*?\))"#)
 }
 
 extension SystemPackageProviderDescription {
-    fileprivate init(v4 json: JSON) throws {
-        let name = try json.get(String.self, forKey: "name")
-        let value = try json.get([String].self, forKey: "values")
-        switch name {
-        case "brew":
-            self = .brew(value)
-        case "apt":
-            self = .apt(value)
-        default:
-            throw InternalError("invalid provider \(name)")
+    init(_ provider: Serialization.SystemPackageProvider) {
+        switch provider {
+        case .brew(let values):
+            self = .brew(values)
+        case .apt(let values):
+            self = .apt(values)
+        case .yum(let values):
+            self = .yum(values)
+        case .nuget(let values):
+            self = .nuget(values)
         }
-    }
-}
-
-extension PackageModel.ProductType {
-    fileprivate init(v4 json: JSON) throws {
-        let productType = try json.get(String.self, forKey: "product_type")
-
-        switch productType {
-        case "executable":
-            self = .executable
-
-        case "library":
-            let libraryType: ProductType.LibraryType
-
-            let libraryTypeString: String? = json.get("type")
-            switch libraryTypeString {
-            case "static"?:
-                libraryType = .static
-            case "dynamic"?:
-                libraryType = .dynamic
-            case nil:
-                libraryType = .automatic
-            default:
-                throw InternalError("invalid product type \(productType)")
-            }
-
-            self = .library(libraryType)
-
-        case "plugin":
-            self = .plugin
-
-        default:
-            throw InternalError("unexpected product type: \(json)")
-        }
-    }
-}
-
-extension ProductDescription {
-    fileprivate init(v4 json: JSON) throws {
-        try self.init(
-            name: json.get("name"),
-            type: .init(v4: json),
-            targets: json.get("targets")
-        )
     }
 }
 
 extension PackageDependency.SourceControl.Requirement {
-    fileprivate init(v4 json: JSON) throws {
-        let type = try json.get(String.self, forKey: "type")
-        switch type {
-        case "branch":
-            self = try .branch(json.get("identifier"))
-
-        case "revision":
-            self = try .revision(json.get("identifier"))
-
-        case "range":
-            let lowerBoundString = try json.get(String.self, forKey: "lowerBound")
-            guard let lowerBound = Version(lowerBoundString) else {
-                throw InternalError("invalid version \(lowerBoundString)")
-            }
-            let upperBoundString = try json.get(String.self, forKey: "upperBound")
-            guard let upperBound = Version(upperBoundString) else {
-                throw InternalError("invalid version \(upperBoundString)")
-            }
-            self = .range(lowerBound ..< upperBound)
-
-        case "exact":
-            let versionString = try json.get(String.self, forKey: "identifier")
-            guard let version = Version(versionString) else {
-                throw InternalError("invalid version \(versionString)")
-            }
-            self = .exact(version)
-
-        default:
-            throw InternalError("invalid dependency requirement \(type)")
+    init(_ requirement: Serialization.PackageDependency.SourceControlRequirement) {
+        switch requirement {
+        case .exact(let version):
+            self = .exact(.init(version))
+        case .range(let lowerBound, let upperBound):
+            let lower: TSCUtility.Version = .init(lowerBound)
+            let upper: TSCUtility.Version = .init(upperBound)
+            self = .range(lower..<upper)
+        case .revision(let revision):
+            self = .revision(revision)
+        case .branch(let branch):
+            self = .branch(branch)
         }
     }
 }
 
 extension PackageDependency.Registry.Requirement {
-    fileprivate init(v4 json: JSON) throws {
-        let type = try json.get(String.self, forKey: "type")
-        switch type {
-        case "range":
-            let lowerBoundString = try json.get(String.self, forKey: "lowerBound")
-            guard let lowerBound = Version(lowerBoundString) else {
-                throw InternalError("invalid version \(lowerBoundString)")
-            }
-            let upperBoundString = try json.get(String.self, forKey: "upperBound")
-            guard let upperBound = Version(upperBoundString) else {
-                throw InternalError("invalid version \(upperBoundString)")
-            }
-            self = .range(lowerBound ..< upperBound)
-
-        case "exact":
-            let versionString = try json.get(String.self, forKey: "identifier")
-            guard let version = Version(versionString) else {
-                throw InternalError("invalid version \(versionString)")
-            }
-            self = .exact(version)
-
-        default:
-            throw InternalError("invalid dependency requirement \(type)")
+    init(_ requirement: Serialization.PackageDependency.RegistryRequirement) {
+        switch requirement {
+        case .exact(let version):
+            self = .exact(.init(version))
+        case .range(let lowerBound, let upperBound):
+            let lower: TSCUtility.Version = .init(lowerBound)
+            let upper: TSCUtility.Version = .init(upperBound)
+            self = .range(lower..<upper)
         }
     }
 }
 
-extension TargetDescription.TargetType {
-    fileprivate init(v4 string: String) throws {
-        switch string {
-        case "regular":
-            self = .regular
-        case "executable":
-            self = .executable
-        case "test":
-            self = .test
-        case "system":
-            self = .system
-        case "binary":
-            self = .binary
-        case "plugin":
-            self = .plugin
-        default:
-            throw InternalError("invalid target \(string)")
+extension ProductDescription {
+    init(_ product: Serialization.Product) throws {
+        let productType: ProductType
+        switch product.productType {
+        case .executable:
+            productType = .executable
+        case .plugin:
+            productType = .plugin
+        case .library(let type):
+            productType = .library(.init(type))
+        }
+        try self.init(name: product.name, type: productType, targets: product.targets)
+    }
+}
+
+extension ProductType.LibraryType {
+    init(_ libraryType: Serialization.Product.ProductType.LibraryType) {
+        switch libraryType {
+        case .dynamic:
+            self = .dynamic
+        case .static:
+            self = .static
+        case .automatic:
+            self = .automatic
         }
     }
 }
 
 extension TargetDescription.Dependency {
-    fileprivate init(v4 json: JSON, identityResolver: IdentityResolver) throws {
-        let type = try json.get(String.self, forKey: "type")
-        let condition = try (try? json.getJSON("condition")).flatMap(PackageConditionDescription.init(v4:))
-
-        switch type {
-        case "target":
-            self = try .target(name: json.get("name"), condition: condition)
-
-        case "product":
-            let name = try json.get(String.self, forKey: "name")
-            let moduleAliases: [String: String]? = try? json.get("moduleAliases")
-            var package: String? = json.get("package")
+    init(_ dependency: Serialization.TargetDependency, identityResolver: IdentityResolver) throws {
+        switch dependency {
+        case .target(let name, let condition):
+            self = .target(name: name, condition: condition.map { .init($0) })
+        case .product(let name, let package, let moduleAliases, let condition):
+            var package: String? = package
             if let packageName = package {
                 package = try identityResolver.mappedIdentity(for: .plain(packageName)).description
             }
-            self = .product(
-                name: name,
-                package: package,
-                moduleAliases: moduleAliases,
-                condition: condition
-            )
-
-        case "byname":
-            self = try .byName(name: json.get("name"), condition: condition)
-
-        default:
-            throw InternalError("invalid type \(type)")
-        }
-    }
-}
-
-extension TargetDescription.PluginCapability {
-    fileprivate init(v4 json: JSON) throws {
-        let type = try json.get(String.self, forKey: "type")
-        switch type {
-        case "buildTool":
-            self = .buildTool
-        case "command":
-            let intent = try TargetDescription.PluginCommandIntent(v4: json.getJSON("intent"))
-            let permissions = try json.getArray("permissions").map(TargetDescription.PluginPermission.init(v4:))
-            self = .command(intent: intent, permissions: permissions)
-        default:
-            throw InternalError("invalid type \(type)")
-        }
-    }
-}
-
-extension TargetDescription.PluginCommandIntent {
-    fileprivate init(v4 json: JSON) throws {
-        let type = try json.get(String.self, forKey: "type")
-        switch type {
-        case "documentationGeneration":
-            self = .documentationGeneration
-        case "sourceCodeFormatting":
-            self = .sourceCodeFormatting
-        case "custom":
-            let verb = try json.get(String.self, forKey: "verb")
-            let description = try json.get(String.self, forKey: "description")
-            self = .custom(verb: verb, description: description)
-        default:
-            throw InternalError("invalid type \(type)")
-        }
-    }
-}
-
-extension TargetDescription.PluginPermission {
-    fileprivate init(v4 json: JSON) throws {
-        let type = try json.get(String.self, forKey: "type")
-        switch type {
-        case "allowNetworkConnections":
-            let reason = try json.get(String.self, forKey: "reason")
-            let scope = try json.get(String.self, forKey: "scope")
-            let ports = try json.get([Int].self, forKey: "ports").map { UInt8($0) }
-            if let scope = TargetDescription.PluginNetworkPermissionScope(scope, ports: ports) {
-                self = .allowNetworkConnections(scope: scope, reason: reason)
-            } else {
-                throw JSON.MapError.custom(key: "scope", message: "invalid scope '\(scope)'")
-            }
-        case "writeToPackageDirectory":
-            let reason = try json.get(String.self, forKey: "reason")
-            self = .writeToPackageDirectory(reason: reason)
-        default:
-            throw InternalError("invalid type \(type)")
-        }
-    }
-}
-
-extension TargetDescription.PluginUsage {
-    fileprivate init(v4 json: JSON) throws {
-        let type = try json.get(String.self, forKey: "type")
-        switch type {
-        case "plugin":
-            let name = try json.get(String.self, forKey: "name")
-            let package = try? json.get(String.self, forKey: "package")
-            self = .plugin(name: name, package: package)
-        default:
-            throw InternalError("invalid type \(type)")
+            self = .product(name: name, package: package, moduleAliases: moduleAliases, condition: condition.map { .init($0) })
+        case .byName(let name, let condition):
+            self = .byName(name: name, condition: condition.map { .init($0) })
         }
     }
 }
 
 extension PackageConditionDescription {
-    fileprivate init?(v4 json: JSON) throws {
-        if case .null = json { return nil }
-        let platformNames: [String]? = try? json.getArray("platforms").map { try $0.get("name") }
+    init(_ condition: Serialization.TargetDependency.Condition) {
+        self.init(platformNames: condition.platforms?.map { $0.name } ?? [])
+    }
+}
+
+extension TargetDescription.TargetType {
+    init(_ type: Serialization.TargetType) {
+        switch type {
+        case .regular:
+            self = .regular
+        case .executable:
+            self = .executable
+        case .test:
+            self = .test
+        case .system:
+            self = .system
+        case .binary:
+            self = .binary
+        case .plugin:
+            self = .plugin
+        }
+    }
+}
+
+extension TargetDescription.PluginCapability {
+    init(_ capability: Serialization.PluginCapability) {
+        switch capability {
+        case .buildTool:
+            self = .buildTool
+        case .command(let intent, let permissions):
+            self = .command(intent: .init(intent), permissions: permissions.map { .init($0) })
+        }
+    }
+}
+
+extension TargetDescription.PluginCommandIntent {
+    init(_ intent: Serialization.PluginCommandIntent) {
+        switch intent {
+        case .documentationGeneration:
+            self = .documentationGeneration
+        case .sourceCodeFormatting:
+            self = .sourceCodeFormatting
+        case .custom(let verb, let description):
+            self = .custom(verb: verb, description: description)
+        }
+    }
+}
+
+extension TargetDescription.PluginPermission {
+    init(_ permission: Serialization.PluginPermission) {
+        switch permission {
+        case .allowNetworkConnections(let scope, let reason):
+            self = .allowNetworkConnections(scope: .init(scope), reason: reason)
+        case .writeToPackageDirectory(let reason):
+            self = .writeToPackageDirectory(reason: reason)
+        }
+    }
+}
+
+extension TargetDescription.PluginNetworkPermissionScope {
+    init(_ scope: Serialization.PluginNetworkPermissionScope) {
+        switch scope {
+        case .none:
+            self = .none
+        case .local(let ports):
+            self = .local(ports: ports)
+        case .all(ports: let ports):
+            self = .all(ports: ports)
+        case .docker:
+            self = .docker
+        case .unixDomainSocket:
+            self = .unixDomainSocket
+        }
+    }
+}
+
+extension TargetDescription.PluginUsage {
+    init(_ usage: Serialization.PluginUsage) {
+        switch usage {
+        case .plugin(let name, let package):
+            self = .plugin(name: name, package: package)
+        }
+    }
+}
+
+extension TSCUtility.Version {
+    init(_ version: Serialization.Version) {
         self.init(
-            platformNames: platformNames ?? [],
-            config: try? json.get("config").get("config")
+            version.major,
+            version.minor,
+            version.patch,
+            prereleaseIdentifiers: version.prereleaseIdentifiers,
+            buildMetadataIdentifiers: version.buildMetadataIdentifiers
+        )
+    }
+}
+
+extension PlatformDescription {
+    init(_ platform: Serialization.SupportedPlatform) {
+        let platformName = platform.platform.name
+        let versionString = platform.version ?? ""
+
+        let versionComponents = versionString.split(
+            separator: ".",
+            omittingEmptySubsequences: false
+        )
+        var version: [String.SubSequence] = []
+        var options: [String.SubSequence] = []
+
+        for (idx, component) in versionComponents.enumerated() {
+            if idx < 2 {
+                version.append(component)
+                continue
+            }
+
+            if idx == 2, UInt(component) != nil {
+                version.append(component)
+                continue
+            }
+
+            options.append(component)
+        }
+
+        self.init(
+            name: platformName,
+            version: version.joined(separator: "."),
+            options: options.map{ String($0) }
+        )
+    }
+}
+
+extension TargetBuildSettingDescription.Kind {
+    static func from(_ name: String, values: [String]) throws -> Self {
+        // Diagnose invalid values.
+        for item in values {
+            let groups = ManifestJSONParser.invalidValueRegex.matchGroups(in: item).flatMap{ $0 }
+            if !groups.isEmpty {
+                let error = "the build setting '\(name)' contains invalid component(s): \(groups.joined(separator: " "))"
+                throw ManifestParseError.runtimeManifestErrors([error])
+            }
+        }
+
+        switch name {
+        case "headerSearchPath":
+            guard let value = values.first else {
+                throw InternalError("invalid (empty) build settings value")
+            }
+            return .headerSearchPath(value)
+        case "define":
+            guard let value = values.first else {
+                throw InternalError("invalid (empty) build settings value")
+            }
+            return .define(value)
+        case "linkedLibrary":
+            guard let value = values.first else {
+                throw InternalError("invalid (empty) build settings value")
+            }
+            return .linkedLibrary(value)
+        case "linkedFramework":
+            guard let value = values.first else {
+                throw InternalError("invalid (empty) build settings value")
+            }
+            return .linkedFramework(value)
+        case "enableUpcomingFeature":
+            guard let value = values.first else {
+                throw InternalError("invalid (empty) build settings value")
+            }
+            return .enableUpcomingFeature(value)
+        case "enableExperimentalFeature":
+            guard let value = values.first else {
+                throw InternalError("invalid (empty) build settings value")
+            }
+            return .enableExperimentalFeature(value)
+        case "unsafeFlags":
+            return .unsafeFlags(values)
+        default:
+            throw InternalError("invalid build setting \(name)")
+        }
+    }
+}
+
+extension PackageConditionDescription {
+    init(_ condition: Serialization.BuildSettingCondition) {
+        self.init(platformNames: condition.platforms?.map { $0.name } ?? [], config: condition.config?.config)
+    }
+}
+
+extension TargetBuildSettingDescription.Setting {
+    init(_ setting: Serialization.CSetting) throws {
+        self.init(
+            tool: .c,
+            kind: try .from(setting.data.name, values: setting.data.value),
+            condition: setting.data.condition.map { .init($0) }
+        )
+    }
+
+    init(_ setting: Serialization.CXXSetting) throws {
+        self.init(
+            tool: .cxx,
+            kind: try .from(setting.data.name, values: setting.data.value),
+            condition: setting.data.condition.map { .init($0) }
+        )
+    }
+
+    init(_ setting: Serialization.LinkerSetting) throws {
+        self.init(
+            tool: .linker,
+            kind: try .from(setting.data.name, values: setting.data.value),
+            condition: setting.data.condition.map { .init($0) }
+        )
+    }
+
+    init(_ setting: Serialization.SwiftSetting) throws {
+        self.init(
+            tool: .swift,
+            kind: try .from(setting.data.name, values: setting.data.value),
+            condition: setting.data.condition.map { .init($0) }
         )
     }
 }

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -31,6 +31,9 @@ public enum ManifestParseError: Swift.Error, Equatable {
 
     /// The manifest loader specified import restrictions that the given manifest violated.
     case importsRestrictedModules([String])
+
+    /// The JSON payload received from executing the manifest has an unsupported version, usually indicating an invalid mix-and-match of SwiftPM and PackageDescription libraries.
+    case unsupportedVersion(version: Int, underlyingError: String? = nil)
 }
 
 // used to output the errors via the observability system
@@ -51,6 +54,12 @@ extension ManifestParseError: CustomStringConvertible {
             return "invalid manifest (evaluation failed)\n\(errors.joined(separator: "\n"))"
         case .importsRestrictedModules(let modules):
             return "invalid manifest, imports restricted modules: \(modules.joined(separator: ", "))"
+        case .unsupportedVersion(let version, let underlyingError):
+            let message = "serialized JSON uses unsupported version \(version), indicating use of a mismatched PackageDescription library"
+            if let underlyingError = underlyingError {
+                return "\(message), underlying error: \(underlyingError)"
+            }
+            return message
         }
     }
 }

--- a/Sources/PackageLoading/PackageDescriptionSerialization.swift
+++ b/Sources/PackageLoading/PackageDescriptionSerialization.swift
@@ -1,0 +1,1 @@
+../PackageDescription/PackageDescriptionSerialization.swift


### PR DESCRIPTION
This will be a fairly large change to refactor the manifest serialization to achieve two goals: 
- get rid of the custom deserialization in `ManifestJSONParser` to use `Codable` throughout
- decouple the user-facing `PackageDescription` model from its serialization.

Tasks:
- [x] Use `Codable` for `ManifestJSONParser`
- [x] Fix any outstanding issues
- [x] Remove `Codable` conformances from public facing PD types and create a private serialization model in `PackageDescriptionSerialization` that can be used for reading and writing
- [x] Fix any outstanding issues
- [x] Run package compatibility tests

Both of these have to happen in a single PR because of a few glaring issues with making the PD model fully codable.

There is further work here which can happen in subsequent PRs:

- Relocate business logic from `ManifestJSONParser` into `PackageModel` as much as possible
- Evaluate the existence of `TargetDescription` etc - it feels like we should be able to get rid of one layer of model objects here, potentially
- Evaluate other serialization code in SwiftPM, e.g. for `package describe`, the `ManifestSourceGeneration` stuff etc
