### PR TITLE
Add optional registry release information to `ResolvedPackage`

### DIFF
--- a/Sources/PackageGraph/CMakeLists.txt
+++ b/Sources/PackageGraph/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(PackageGraph
   PubGrub/PubGrubDependencyResolver.swift
   PubGrub/PubGrubPackageContainer.swift
   PubGrub/Term.swift
+  RegistryReleaseMetadata.swift
   ResolvedPackage.swift
   ResolvedProduct.swift
   ResolvedTarget.swift

--- a/Sources/PackageGraph/RegistryReleaseMetadata.swift
+++ b/Sources/PackageGraph/RegistryReleaseMetadata.swift
@@ -1,0 +1,57 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import struct Foundation.URL
+import struct TSCUtility.Version
+
+public struct RegistryReleaseMetadata {
+    /// Information from the signing certificate.
+    public enum Certificate {
+        case trusted(commonName: String, organization: String, identity: String?)
+        case untrusted(commonName: String, organization: String)
+        case none
+    }
+
+    /// Metadata of the given release, provided by the registry.
+    public struct Metadata {
+        public struct Author {
+            public let name: String
+            public let emailAddress: String?
+            public let description: String?
+            public let url: URL?
+            public let organization: Organization
+        }
+
+        public struct Organization {
+            public let name: String
+            public let emailAddress: String?
+            public let description: String?
+            public let url: URL?
+        }
+
+        public let author: Author?
+        public let description: String?
+        public let licenseURL: URL?
+        public let readmeURL: URL?
+        public let scmRepositoryURLs: [URL]
+        public let version: Version
+    }
+
+    /// Information about the source of the release.
+    public enum Source {
+        case registry(URL)
+    }
+
+    public let certificate: Certificate
+    public let metadata: Metadata
+    public let source: Source
+}

--- a/Sources/PackageGraph/ResolvedPackage.swift
+++ b/Sources/PackageGraph/ResolvedPackage.swift
@@ -48,13 +48,17 @@ public final class ResolvedPackage {
     /// The list of platforms that are supported by this target.
     public let platforms: SupportedPlatforms
 
+    /// If the given package's source is a registry release, this provides additional metadata and signature information.
+    public let registryMetadata: RegistryReleaseMetadata?
+
     public init(
         package: Package,
         defaultLocalization: String?,
         platforms: SupportedPlatforms,
         dependencies: [ResolvedPackage],
         targets: [ResolvedTarget],
-        products: [ResolvedProduct]
+        products: [ResolvedProduct],
+        registryMetadata: RegistryReleaseMetadata? = nil
     ) {
         self.underlyingPackage = package
         self.defaultLocalization = defaultLocalization
@@ -62,6 +66,7 @@ public final class ResolvedPackage {
         self.dependencies = dependencies
         self.targets = targets
         self.products = products
+        self.registryMetadata = registryMetadata
     }
 }
 


### PR DESCRIPTION
This adds optional information about a resolved package if it was obtained from a registry. This information includes metadata, as well as certificate/signing information if the package archive had been signed by the author.
