### PR TITLE
update use of argument parser to latest API

### DIFF
--- a/Sources/Commands/PackageTools/APIDiff.swift
+++ b/Sources/Commands/PackageTools/APIDiff.swift
@@ -24,7 +24,7 @@ struct DeprecatedAPIDiff: ParsableCommand {
                                                     abstract: "Deprecated - use `swift package diagnose-api-breaking-changes` instead",
                                                     shouldDisplay: false)
 
-    @Argument(parsing: .unconditionalRemaining)
+    @Argument(parsing: .captureForPassthrough)
     var args: [String] = []
 
     func run() throws {

--- a/Sources/Commands/PackageTools/Format.swift
+++ b/Sources/Commands/PackageTools/Format.swift
@@ -24,7 +24,7 @@ extension SwiftPackageTool {
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
 
-        @Argument(parsing: .unconditionalRemaining,
+        @Argument(parsing: .captureForPassthrough,
                   help: "Pass flag through to the swift-format tool")
         var swiftFormatFlags: [String] = []
 

--- a/Sources/Commands/PackageTools/PluginCommand.swift
+++ b/Sources/Commands/PackageTools/PluginCommand.swift
@@ -65,7 +65,7 @@ struct PluginCommand: SwiftCommand {
     var command: String = ""
 
     @Argument(
-        parsing: .allUnrecognized,
+        parsing: .captureForPassthrough,
         help: "Arguments to pass to the command plugin"
     )
     var arguments: [String] = []
@@ -309,6 +309,10 @@ struct PluginCommand: SwiftCommand {
 
 // helper to parse plugin arguments passed after the plugin name
 struct PluginArguments: ParsableCommand {
+    static var configuration: CommandConfiguration {
+        .init(helpNames: [])
+    }
+
     @OptionGroup
     var globalOptions: GlobalOptions
 

--- a/Sources/Commands/PackageTools/PluginCommand.swift
+++ b/Sources/Commands/PackageTools/PluginCommand.swift
@@ -65,7 +65,7 @@ struct PluginCommand: SwiftCommand {
     var command: String = ""
 
     @Argument(
-        parsing: .unconditionalRemaining,
+        parsing: .allUnrecognized,
         help: "Arguments to pass to the command plugin"
     )
     var arguments: [String] = []
@@ -315,7 +315,7 @@ struct PluginArguments: ParsableCommand {
     @OptionGroup()
     var pluginOptions: PluginCommand.PluginOptions
 
-    @Argument(parsing: .unconditionalRemaining)
+    @Argument(parsing: .allUnrecognized)
     var remaining: [String] = []
 }
 

--- a/Sources/Commands/PackageTools/SwiftPackageTool.swift
+++ b/Sources/Commands/PackageTools/SwiftPackageTool.swift
@@ -90,7 +90,7 @@ extension SwiftPackageTool {
         @OptionGroup()
         var pluginOptions: PluginCommand.PluginOptions
 
-        @Argument(parsing: .allUnrecognized)
+        @Argument(parsing: .captureForPassthrough)
         var remaining: [String] = []
 
         func run(_ swiftTool: SwiftTool) throws {

--- a/Sources/Commands/PackageTools/SwiftPackageTool.swift
+++ b/Sources/Commands/PackageTools/SwiftPackageTool.swift
@@ -90,7 +90,7 @@ extension SwiftPackageTool {
         @OptionGroup()
         var pluginOptions: PluginCommand.PluginOptions
 
-        @Argument(parsing: .unconditionalRemaining)
+        @Argument(parsing: .allUnrecognized)
         var remaining: [String] = []
 
         func run(_ swiftTool: SwiftTool) throws {

--- a/Sources/Commands/SwiftRunTool.swift
+++ b/Sources/Commands/SwiftRunTool.swift
@@ -82,7 +82,7 @@ struct RunToolOptions: ParsableArguments {
     var executable: String?
 
     /// The arguments to pass to the executable.
-    @Argument(parsing: .unconditionalRemaining,
+    @Argument(parsing: .captureForPassthrough,
               help: "The arguments to pass to the executable")
     var arguments: [String] = []
 }

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -2137,7 +2137,7 @@ final class PackageToolTests: CommandsTestCase {
 
             // Check default command arguments
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["MyPlugin", "--foo", "--help", "--version", "--verbose"], packagePath: packageDir, env: ["DECLARE_PACKAGE_WRITING_PERMISSION": "1"])
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["MyPlugin", "--foo", "--help", "--version", "--verbose"], packagePath: packageDir)
                 XCTAssertEqual(result.exitStatus, .terminated(code: 0))
                 XCTAssertMatch(try result.utf8Output(), .contains("success"))
                 XCTAssertEqual(try result.utf8stderrOutput(), "")


### PR DESCRIPTION
motivation: Address warnings

changes: use newer API for retrieving unparsed arguments
