### PR TITLE
Remove *.xcodeproj from default gitignore

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -269,7 +269,6 @@ public final class InitPackage {
                 .DS_Store
                 /.build
                 /Packages
-                /*.xcodeproj
                 xcuserdata/
                 DerivedData/
                 .swiftpm/config/registries.json


### PR DESCRIPTION
This seems like a leftover from the days of `generate-xcodeproj`.
