### PR TITLE
Pass -enable-library-evolution for PackageDescription/Plugin in Linux

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -158,7 +158,7 @@ let package = Package(
             exclude: ["CMakeLists.txt"],
             swiftSettings: [
                 .unsafeFlags(["-package-description-version", "999.0"]),
-                .unsafeFlags(["-enable-library-evolution"], .when(platforms: [.macOS]))
+                .unsafeFlags(["-enable-library-evolution"]),
             ]
         ),
 
@@ -170,7 +170,7 @@ let package = Package(
             exclude: ["CMakeLists.txt"],
             swiftSettings: [
                 .unsafeFlags(["-package-description-version", "999.0"]),
-                .unsafeFlags(["-enable-library-evolution"], .when(platforms: [.macOS]))
+                .unsafeFlags(["-enable-library-evolution"]),
             ]
         ),
 

--- a/Sources/PackageDescription/CMakeLists.txt
+++ b/Sources/PackageDescription/CMakeLists.txt
@@ -24,10 +24,10 @@ add_library(PackageDescription
 
 target_compile_options(PackageDescription PUBLIC
   $<$<COMPILE_LANGUAGE:Swift>:-package-description-version$<SEMICOLON>999.0>)
+target_compile_options(PackageDescription PUBLIC
+  $<$<COMPILE_LANGUAGE:Swift>:-enable-library-evolution>)
 
 if(CMAKE_HOST_SYSTEM_NAME STREQUAL Darwin)
-  target_compile_options(PackageDescription PUBLIC
-    $<$<COMPILE_LANGUAGE:Swift>:-enable-library-evolution>)
   set(SWIFT_INTERFACE_PATH ${CMAKE_BINARY_DIR}/pm/ManifestAPI/PackageDescription.swiftinterface)
   target_compile_options(PackageDescription PUBLIC
     $<$<COMPILE_LANGUAGE:Swift>:-emit-module-interface-path$<SEMICOLON>${SWIFT_INTERFACE_PATH}>)

--- a/Sources/PackagePlugin/CMakeLists.txt
+++ b/Sources/PackagePlugin/CMakeLists.txt
@@ -23,10 +23,10 @@ add_library(PackagePlugin SHARED
 
 target_compile_options(PackagePlugin PUBLIC
   $<$<COMPILE_LANGUAGE:Swift>:-package-description-version$<SEMICOLON>999.0>)
+target_compile_options(PackagePlugin PUBLIC
+  $<$<COMPILE_LANGUAGE:Swift>:-enable-library-evolution>)
   
 if(CMAKE_HOST_SYSTEM_NAME STREQUAL Darwin)
-  target_compile_options(PackagePlugin PUBLIC
-    $<$<COMPILE_LANGUAGE:Swift>:-enable-library-evolution>)
   set(SWIFT_INTERFACE_PATH ${CMAKE_BINARY_DIR}/pm/PluginAPI/PackagePlugin.swiftinterface)
   target_compile_options(PackagePlugin PUBLIC
     $<$<COMPILE_LANGUAGE:Swift>:-emit-module-interface-path$<SEMICOLON>${SWIFT_INTERFACE_PATH}>)


### PR DESCRIPTION
Enable library evolution for Linux builds of PackageDescription and PackagePlugin.

### Motivation:

Since #3526 was merged, #5874 tried to apply the original idea of using `@_implementationOnly Foundation` in PackageDescription/Plugin to avoid leaking `Foundation` into the manifests.

Related to SR-14718 (#4416).

### Modifications:

Reverts 19982848f86d3ce1621e35ac0d8a6ee3f9a9a0a5 / #3526

### Result:

PackageDescription and PackagePlugin produce `.swiftinterface` files also in Linux, not just macOS.
