### PR TITLE
Fix registry package tool

### DIFF
--- a/Sources/PackageRegistryTool/PackageRegistryTool+Publish.swift
+++ b/Sources/PackageRegistryTool/PackageRegistryTool+Publish.swift
@@ -153,14 +153,8 @@ extension SwiftPackageRegistryTool {
                 )
             }
 
-            if publishConfiguration.signing.privateKeyPath == nil {
+            if publishConfiguration.signing.privateKeyPath != nil {
                 guard !publishConfiguration.signing.certificateChainPaths.isEmpty else {
-                    throw StringError(
-                        "Both 'privateKeyPath' and 'certificateChainPaths' are required when one of them is set."
-                    )
-                }
-            } else {
-                guard publishConfiguration.signing.certificateChainPaths.isEmpty else {
                     throw StringError(
                         "Both 'privateKeyPath' and 'certificateChainPaths' are required when one of them is set."
                     )
@@ -192,7 +186,7 @@ extension SwiftPackageRegistryTool {
             // step 4: publish the package
             guard !self.dryRun else {
                 print(
-                    "\(packageIdentity)@\(packageVersion) was successfully prepared for publishing but was not published due to dry run  flag. artifacts available at '\(workingDirectory)'."
+                    "\(packageIdentity)@\(packageVersion) was successfully prepared for publishing but was not published due to dry run flag. Artifacts available at '\(workingDirectory)'."
                 )
                 return
             }

--- a/Sources/PackageRegistryTool/PackageRegistryTool+Publish.swift
+++ b/Sources/PackageRegistryTool/PackageRegistryTool+Publish.swift
@@ -159,6 +159,12 @@ extension SwiftPackageRegistryTool {
                         "Both 'privateKeyPath' and 'certificateChainPaths' are required when one of them is set."
                     )
                 }
+            } else {
+                guard publishConfiguration.signing.certificateChainPaths.isEmpty else {
+                    throw StringError(
+                        "Both 'privateKeyPath' and 'certificateChainPaths' are required when one of them is set."
+                    )
+                }
             }
 
             // step 2: generate source archive for the package release


### PR DESCRIPTION
- `certificateChainPaths` is an empty array by default (can't be `nil`), so even though neither `privateKeyPath` nor `certificateChainPaths` is specified, thus signing is not needed, the tool fails with missing signing inputs error.
- Fix typo in error message
