### PR TITLE
Fix flaky RegistryClientTests.testLookupIdentities_ServerError

### DIFF
--- a/Tests/PackageRegistryTests/RegistryClientTests.swift
+++ b/Tests/PackageRegistryTests/RegistryClientTests.swift
@@ -1361,7 +1361,7 @@ final class RegistryClientTests: XCTestCase {
         let serverErrorHandler = ServerErrorHandler(
             method: .get,
             url: identifiersURL,
-            errorCode: Int.random(in: 400 ..< 500),
+            errorCode: Int.random(in: 405 ..< 500),
             errorDescription: UUID().uuidString
         )
 

--- a/Tests/PackageRegistryTests/RegistryClientTests.swift
+++ b/Tests/PackageRegistryTests/RegistryClientTests.swift
@@ -1361,7 +1361,7 @@ final class RegistryClientTests: XCTestCase {
         let serverErrorHandler = ServerErrorHandler(
             method: .get,
             url: identifiersURL,
-            errorCode: Int.random(in: 405 ..< 500),
+            errorCode: Int.random(in: 405 ..< 500), // avoid 404 since it is not considered an error
             errorDescription: UUID().uuidString
         )
 


### PR DESCRIPTION
Motivation:
Status `404` is not considered an error for "lookup identities" endpoint. As such, when the test generates a random error status in range of 400-500 and lands on `404`, the test doesn't get the error it expects.

Modification:
Change random status code range such that `404` can't be an option.

rdar://105519502
