### PR TITLE
do not use base64 encoding when publishing archives

### DIFF
--- a/Tests/PackageRegistryTests/RegistryClientTests.swift
+++ b/Tests/PackageRegistryTests/RegistryClientTests.swift
@@ -1640,7 +1640,7 @@ final class RegistryClientTests: XCTestCase {
 
                 // TODO: implement multipart form parsing
                 let body = String(data: request.body!, encoding: .utf8)
-                XCTAssertMatch(body, .contains(Data(archiveContent.utf8).base64EncodedString()))
+                XCTAssertMatch(body, .contains(archiveContent))
                 XCTAssertMatch(body, .contains(metadataContent))
 
                 completion(.success(.init(
@@ -1705,7 +1705,7 @@ final class RegistryClientTests: XCTestCase {
 
                 // TODO: implement multipart form parsing
                 let body = String(data: request.body!, encoding: .utf8)
-                XCTAssertMatch(body, .contains(Data(archiveContent.utf8).base64EncodedString()))
+                XCTAssertMatch(body, .contains(archiveContent))
                 XCTAssertMatch(body, .contains(metadataContent))
 
                 completion(.success(.init(


### PR DESCRIPTION
motivation: base64 emcoding is redundant in this case

changes:
* upload the archive in binary form instead of base64 encoded
* refactor the multi-part form construction logic
