### PR TITLE
Hide `dump-pif` command.

### DIFF
--- a/Sources/Commands/PackageTools/DumpCommands.swift
+++ b/Sources/Commands/PackageTools/DumpCommands.swift
@@ -118,7 +118,8 @@ struct DumpPackage: SwiftCommand {
 }
 
 struct DumpPIF: SwiftCommand {
-    static let configuration = CommandConfiguration(abstract: "Print the Package Interchange Format of the swift package.")
+    // hides this command from CLI --help output
+    static let configuration = CommandConfiguration(shouldDisplay: false) 
 
     @OptionGroup(visibility: .hidden)
     var globalOptions: GlobalOptions

--- a/Sources/Commands/PackageTools/DumpCommands.swift
+++ b/Sources/Commands/PackageTools/DumpCommands.swift
@@ -118,6 +118,8 @@ struct DumpPackage: SwiftCommand {
 }
 
 struct DumpPIF: SwiftCommand {
+    static let configuration = CommandConfiguration(abstract: "Print the Package Interchange Format of the swift package.")
+
     @OptionGroup(visibility: .hidden)
     var globalOptions: GlobalOptions
 


### PR DESCRIPTION
Hides the `dump-pif` command from generated help on `swift package`

### Motivation:

Clean up the UI/CLI experience.

### Modifications:

Hides the `dump-pif` command from --help or the default response from `swift package` with no further subcommands.

### Result:

`swift package` CLI is a bit cleaner
