### PR TITLE
hide the experimental _format command

### DIFF
--- a/Sources/Commands/PackageTools/Format.swift
+++ b/Sources/Commands/PackageTools/Format.swift
@@ -19,7 +19,7 @@ import TSCUtility
 extension SwiftPackageTool {
     struct Format: SwiftCommand {
         static let configuration = CommandConfiguration(
-            commandName: "_format")
+            commandName: "_format", shouldDisplay: false)
 
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions


### PR DESCRIPTION
hide the experimental `_format` package command

### Motivation:

I want to clean up the CLI face of `swift package`, and the `_format` command stood out undocumented, likely experimental, and with no explanation. Based on the forum thread inquiring about `_format` and it's status, this PR hides the command from being displayed in `--help` and such.

### Modifications:

Hides the _format command

### Result:

`swift package` invocation no longer shows `_format` in the list of available commands.
