### PR TITLE
Add headerVisibility support on PIFBuilder

### DIFF
--- a/Sources/XCBuildSupport/PIF.swift
+++ b/Sources/XCBuildSupport/PIF.swift
@@ -806,13 +806,14 @@ public enum PIF {
         }
 
         private enum CodingKeys: CodingKey {
-            case guid, platformFilters, fileReference, targetReference
+            case guid, platformFilters, fileReference, targetReference, headerVisibility
         }
 
         public func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(guid, forKey: .guid)
             try container.encode(platformFilters, forKey: .platformFilters)
+            try container.encodeIfPresent(headerVisibility, forKey: .headerVisibility)
 
             switch self.reference {
             case .file(let fileGUID):
@@ -826,6 +827,7 @@ public enum PIF {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             guid = try container.decode(GUID.self, forKey: .guid)
             platformFilters = try container.decode([PlatformFilter].self, forKey: .platformFilters)
+            headerVisibility = try container.decodeIfPresent(HeaderVisibility.self, forKey: .headerVisibility)
 
             if container.allKeys.contains(.fileReference) {
                 reference = try .file(guid: container.decode(GUID.self, forKey: .fileReference))

--- a/Sources/XCBuildSupport/PIF.swift
+++ b/Sources/XCBuildSupport/PIF.swift
@@ -775,34 +775,39 @@ public enum PIF {
         public var headerVisibility: HeaderVisibility? = nil
         public var platformFilters: [PlatformFilter]
 
-        public init(guid: GUID, file: FileReference, platformFilters: [PlatformFilter]) {
+        public init(guid: GUID, file: FileReference, platformFilters: [PlatformFilter], headerVisibility: HeaderVisibility? = nil) {
             self.guid = guid
             self.reference = .file(guid: file.guid)
             self.platformFilters = platformFilters
+            self.headerVisibility = headerVisibility
         }
 
-        public init(guid: GUID, fileGUID: PIF.GUID, platformFilters: [PlatformFilter]) {
+        public init(guid: GUID, fileGUID: PIF.GUID, platformFilters: [PlatformFilter], headerVisibility: HeaderVisibility? = nil) {
             self.guid = guid
             self.reference = .file(guid: fileGUID)
             self.platformFilters = platformFilters
+            self.headerVisibility = headerVisibility
         }
 
-        public init(guid: GUID, target: PIF.BaseTarget, platformFilters: [PlatformFilter]) {
+        public init(guid: GUID, target: PIF.BaseTarget, platformFilters: [PlatformFilter], headerVisibility: HeaderVisibility? = nil) {
             self.guid = guid
             self.reference = .target(guid: target.guid)
             self.platformFilters = platformFilters
+            self.headerVisibility = headerVisibility
         }
 
-        public init(guid: GUID, targetGUID: PIF.GUID, platformFilters: [PlatformFilter]) {
+        public init(guid: GUID, targetGUID: PIF.GUID, platformFilters: [PlatformFilter], headerVisibility: HeaderVisibility? = nil) {
             self.guid = guid
             self.reference = .target(guid: targetGUID)
             self.platformFilters = platformFilters
+            self.headerVisibility = headerVisibility
         }
 
-        public init(guid: GUID, reference: Reference, platformFilters: [PlatformFilter]) {
+        public init(guid: GUID, reference: Reference, platformFilters: [PlatformFilter], headerVisibility: HeaderVisibility? = nil) {
             self.guid = guid
             self.reference = reference
             self.platformFilters = platformFilters
+            self.headerVisibility = headerVisibility
         }
 
         private enum CodingKeys: CodingKey {

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -1331,9 +1331,7 @@ final class PIFBuildFileBuilder {
     }
 
     func construct() -> PIF.BuildFile {
-        var buildFile = PIF.BuildFile(guid: guid, reference: reference.pifReference, platformFilters: platformFilters)
-        buildFile.headerVisibility = headerVisibility
-        return buildFile
+        PIF.BuildFile(guid: guid, reference: reference.pifReference, platformFilters: platformFilters, headerVisibility: headerVisibility)
     }
 }
 

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -1148,9 +1148,9 @@ class PIFBaseTargetBuilder {
 
     /// Convenience function to add a file reference to the Headers build phase, after creating it if needed.
     @discardableResult
-    public func addHeaderFile(_ fileReference: PIFFileReferenceBuilder) -> PIFBuildFileBuilder {
+    public func addHeaderFile(_ fileReference: PIFFileReferenceBuilder, headerVisibility: PIF.BuildFile.HeaderVisibility) -> PIFBuildFileBuilder {
         let headerPhase = buildPhases.first { $0 is PIFHeadersBuildPhaseBuilder } ?? addHeadersBuildPhase()
-        return headerPhase.addBuildFile(to: fileReference, platformFilters: [])
+        return headerPhase.addBuildFile(to: fileReference, platformFilters: [], headerVisibility: headerVisibility)
     }
 
     /// Convenience function to add a file reference to the Sources build phase, after creating it if needed.
@@ -1241,8 +1241,8 @@ class PIFBuildPhaseBuilder {
     /// - Parameters:
     ///   - file: The builder for the file reference.
     @discardableResult
-    func addBuildFile(to file: PIFFileReferenceBuilder, platformFilters: [PIF.PlatformFilter]) -> PIFBuildFileBuilder {
-        let builder = PIFBuildFileBuilder(file: file, platformFilters: platformFilters)
+    func addBuildFile(to file: PIFFileReferenceBuilder, platformFilters: [PIF.PlatformFilter], headerVisibility: PIF.BuildFile.HeaderVisibility? = nil) -> PIFBuildFileBuilder {
+        let builder = PIFBuildFileBuilder(file: file, platformFilters: platformFilters, headerVisibility: headerVisibility)
         buildFiles.append(builder)
         return builder
     }
@@ -1316,18 +1316,24 @@ final class PIFBuildFileBuilder {
 
     let platformFilters: [PIF.PlatformFilter]
 
-    fileprivate init(file: PIFFileReferenceBuilder, platformFilters: [PIF.PlatformFilter]) {
+    let headerVisibility: PIF.BuildFile.HeaderVisibility?
+
+    fileprivate init(file: PIFFileReferenceBuilder, platformFilters: [PIF.PlatformFilter], headerVisibility: PIF.BuildFile.HeaderVisibility? = nil) {
         reference = .file(builder: file)
         self.platformFilters = platformFilters
+        self.headerVisibility = headerVisibility
     }
 
-    fileprivate init(targetGUID: PIF.GUID, platformFilters: [PIF.PlatformFilter]) {
+    fileprivate init(targetGUID: PIF.GUID, platformFilters: [PIF.PlatformFilter], headerVisibility: PIF.BuildFile.HeaderVisibility? = nil) {
         reference = .target(guid: targetGUID)
         self.platformFilters = platformFilters
+        self.headerVisibility = headerVisibility
     }
 
     func construct() -> PIF.BuildFile {
-        return PIF.BuildFile(guid: guid, reference: reference.pifReference, platformFilters: platformFilters)
+        var buildFile = PIF.BuildFile(guid: guid, reference: reference.pifReference, platformFilters: platformFilters)
+        buildFile.headerVisibility = headerVisibility
+        return buildFile
     }
 }
 

--- a/Tests/XCBuildSupportTests/PIFTests.swift
+++ b/Tests/XCBuildSupportTests/PIFTests.swift
@@ -103,6 +103,17 @@ class PIFTests: XCTestCase {
                                             platformFilters: []
                                         )
                                     ]
+                                ),
+                                PIF.HeadersBuildPhase(
+                                    guid: "target-exe-headers-build-phase-guid",
+                                    buildFiles: [
+                                        PIF.BuildFile(
+                                            guid: "target-exe-headers-build-file-guid",
+                                            targetGUID: "target-lib-guid",
+                                            platformFilters: [],
+                                            headerVisibility: .public
+                                        )
+                                    ]
                                 )
                             ],
                             dependencies: [
@@ -371,7 +382,7 @@ class PIFTests: XCTestCase {
             XCTFail("invalid number of build configurations")
         }
 
-        if let buildPhases = exeTargetContents["buildPhases"]?.array, buildPhases.count == 2 {
+        if let buildPhases = exeTargetContents["buildPhases"]?.array, buildPhases.count == 3 {
             let buildPhase1 = buildPhases[0]
             XCTAssertEqual(buildPhase1["guid"]?.string, "target-exe-sources-build-phase-guid")
             XCTAssertEqual(buildPhase1["type"]?.string, "com.apple.buildphase.sources")
@@ -388,6 +399,17 @@ class PIFTests: XCTestCase {
             if let frameworks = buildPhase2["buildFiles"]?.array, frameworks.count == 1 {
                 XCTAssertEqual(frameworks[0]["guid"]?.string, "target-exe-frameworks-build-file-guid")
                 XCTAssertEqual(frameworks[0]["targetReference"]?.string, "target-lib-guid@11")
+            } else {
+                XCTFail("invalid number of build files")
+            }
+
+            let buildPhase3 = buildPhases[2]
+            XCTAssertEqual(buildPhase3["guid"]?.string, "target-exe-headers-build-phase-guid")
+            XCTAssertEqual(buildPhase3["type"]?.string, "com.apple.buildphase.headers")
+            if let frameworks = buildPhase3["buildFiles"]?.array, frameworks.count == 1 {
+                XCTAssertEqual(frameworks[0]["guid"]?.string, "target-exe-headers-build-file-guid")
+                XCTAssertEqual(frameworks[0]["targetReference"]?.string, "target-lib-guid@11")
+                XCTAssertEqual(frameworks[0]["headerVisibility"]?.string, "public")
             } else {
                 XCTFail("invalid number of build files")
             }


### PR DESCRIPTION
### Motivation:

PIF has headerVisibility for each BuildFile, however, we can't add headerVisibility in any way.

### Modifications:

- Enable encoding and decoding of `headerVisibility`
- Add constructors to set `headerVisibility`
- Add tests for encode/decode

### Result:


