### PR TITLE
[SwiftTestTool] Add test failure messages to xUnit report

### DIFF
--- a/Fixtures/Miscellaneous/ParallelTestsPkg/Tests/ParallelTestsPkgTests/ParallelTestsFailureTests.swift
+++ b/Fixtures/Miscellaneous/ParallelTestsPkg/Tests/ParallelTestsPkgTests/ParallelTestsFailureTests.swift
@@ -6,4 +6,13 @@ class ParallelTestsFailureTests: XCTestCase {
     func testSureFailure() {
         XCTFail("Giving up is the only sure way to fail.")
     }
+
+    func testAssertionFailure() {
+        XCTAssertTrue(false, "Expected assertion failure.")
+    }
+
+    func testExpectationFailure() {
+        let expectation = XCTestExpectation(description: "failing expectation")
+        wait(for: [expectation], timeout: 0.0)
+    }
 }

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -816,7 +816,7 @@ final class ParallelTestRunner {
                     var output = ""
                     let outputLock = NSLock()
                     let start = DispatchTime.now()
-                    let success = testRunner.test(outputHandler: { _output in outputLock.withLock{ output += _output }})
+                    let success = testRunner.test(outputHandler: { _output in outputLock.withLock{ output += _output.appending("\n") }})
                     let duration = start.distance(to: .now())
                     if !success {
                         self.ranSuccessfully = false
@@ -1034,9 +1034,17 @@ final class XUnitGenerator {
 
             """
 
+        /// Captured groups
+        /// $1 = file:line
+        /// $2 = reason
+        let testErrorRegex = try RegEx(pattern: #".*\/(.*\d+)\:\serror:.*\s\:\s(.*)"#)
+
+        // Captured groups
+        // $1 = file:line
+        // $2 = reason
+        let fatalErrorRegex = try RegEx(pattern: #".*\/(.*\d+)\:\s(Fatal error:.*)"#)
+
         // Generate a testcase entry for each result.
-        //
-        // FIXME: This is very minimal right now. We should allow including test output etc.
         for result in results {
             let test = result.unitTest
             let duration = result.duration.timeInterval() ?? 0.0
@@ -1046,7 +1054,13 @@ final class XUnitGenerator {
                 """
 
             if !result.success {
-                stream <<< "<failure message=\"failed\"></failure>\n"
+                let message = [testErrorRegex, fatalErrorRegex].map { $0.matchGroups(in: result.output) }
+                    .first(where: { !$0.isEmpty })?
+                    .first?
+                    .joined(separator: " ")
+                    .xmlEscaped ?? "failed"
+
+                stream <<< "<failure message=\"\(message)\"></failure>\n"
             }
 
             stream <<< "</testcase>\n"
@@ -1114,5 +1128,15 @@ extension BuildParameters {
 private extension Basics.Diagnostic {
     static var noMatchingTests: Self {
         .warning("No matching test cases were run")
+    }
+}
+
+private extension String {
+    var xmlEscaped: String {
+        self.replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&#39;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "<", with: "&lt;")
     }
 }

--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -101,7 +101,7 @@ final class TestToolTests: CommandsTestCase {
                 XCTAssertMatch(error.stdout, .contains("testExample2"))
                 XCTAssertNoMatch(error.stdout, .contains("'ParallelTestsTests' passed"))
                 XCTAssertMatch(error.stdout, .contains("'ParallelTestsFailureTests' failed"))
-                XCTAssertMatch(error.stdout, .contains("[3/3]"))
+                XCTAssertMatch(error.stdout, .contains("[5/5]"))
             }
 
             do {
@@ -115,15 +115,22 @@ final class TestToolTests: CommandsTestCase {
                     XCTAssertMatch(error.stdout, .contains("testExample2"))
                     XCTAssertMatch(error.stdout, .contains("'ParallelTestsTests' passed"))
                     XCTAssertMatch(error.stdout, .contains("'ParallelTestsFailureTests' failed"))
-                    XCTAssertMatch(error.stdout, .contains("[3/3]"))
+                    XCTAssertMatch(error.stdout, .contains("[5/5]"))
                 }
 
                 // Check the xUnit output.
                 XCTAssertFileExists(xUnitOutput)
                 let contents: String = try localFileSystem.readFileContents(xUnitOutput)
-                XCTAssertMatch(contents, .contains("tests=\"3\" failures=\"1\""))
+                XCTAssertMatch(contents, .contains("tests=\"5\" failures=\"3\""))
                 XCTAssertMatch(contents, .regex("time=\"[0-9]+\\.[0-9]+\""))
                 XCTAssertNoMatch(contents, .contains("time=\"0.0\""))
+                XCTAssertMatch(contents, .contains(#"message="ParallelTestsFailureTests.swift:7 failed - Giving up is the only sure way to fail."#))
+                XCTAssertMatch(contents, .contains(#"message="ParallelTestsFailureTests.swift:11 XCTAssertTrue failed - Expected assertion failure.""#))                
+#if os(Linux)
+                XCTAssertMatch(contents, .contains(#"message="ParallelTestsFailureTests.swift:16 Asynchronous wait failed - Exceeded timeout of 0.0 seconds, with unfulfilled expectations: failing expectation"#))
+#else
+                XCTAssertMatch(contents, .contains(#"message="ParallelTestsFailureTests.swift:16 Asynchronous wait failed: Exceeded timeout of 0 seconds, with unfulfilled expectations: &quot;failing expectation&quot;."#))   
+#endif
             }
         }
     }


### PR DESCRIPTION
### Motivation

The xUnit test run report does not provide detailed failure information and this makes it very difficult to investigate problems without additional viewing of stderr logs on some CI systems

### Modifications

1. Added the use of regular expressions to parse the output of test failures and crashes too (i think it's a simplest approach at this moment)
2. Added line breaks to the output of parallel testing in case of regular expressions usage
3. Added test coverage for introduced changes (except "Fatal Error" case for a known reason)

### Result

Better xUnit report with test failures

Before:
```
<testsuites>
<testsuite name="TestResults" errors="0" tests="5" failures="3" time="21.489489211">
<testcase classname="ParallelTestsPkgTests.ParallelTestsFailureTests" name="testExpectationFailure" time="4.297888375">
<failure message="failed"></failure>
</testcase>
<testcase classname="ParallelTestsPkgTests.ParallelTestsFailureTests" name="testAssertionFailure" time="4.297924834">
<failure message="failed"></failure>
</testcase>
<testcase classname="ParallelTestsPkgTests.ParallelTestsTests" name="testExample1" time="4.297897584">
</testcase>
<testcase classname="ParallelTestsPkgTests.ParallelTestsTests" name="testExample2" time="4.297898459">
</testcase>
<testcase classname="ParallelTestsPkgTests.ParallelTestsFailureTests" name="testSureFailure" time="4.297879959">
<failure message="failed"></failure>
</testcase>
</testsuite>
</testsuites>
```

After:
```
<?xml version="1.0" encoding="UTF-8"?>
<testsuites>
<testsuite name="TestResults" errors="0" tests="5" failures="3" time="15.821316957">
<testcase classname="ParallelTestsPkgTests.ParallelTestsTests" name="testExample2" time="0.04732175">
</testcase>
<testcase classname="ParallelTestsPkgTests.ParallelTestsFailureTests" name="testExpectationFailure" time="3.29376925">
<failure message="ParallelTestsFailureTests.swift:16 Asynchronous wait failed: Exceeded timeout of 0 seconds, with unfulfilled expectations: &quot;failing expectation&quot;."></failure>
</testcase>
<testcase classname="ParallelTestsPkgTests.ParallelTestsTests" name="testExample1" time="4.159991583">
</testcase>
<testcase classname="ParallelTestsPkgTests.ParallelTestsFailureTests" name="testSureFailure" time="4.160105583">
<failure message="ParallelTestsFailureTests.swift:7 failed - Giving up is the only sure way to fail."></failure>
</testcase>
<testcase classname="ParallelTestsPkgTests.ParallelTestsFailureTests" name="testAssertionFailure" time="4.160128791">
<failure message="ParallelTestsFailureTests.swift:11 XCTAssertTrue failed - Expected assertion failure."></failure>
</testcase>
</testsuite>
</testsuites>
```