### PR TITLE
NFC: cleanup usage of registry identifiers

### DIFF
--- a/Sources/PackageDescription/PackageDependency.swift
+++ b/Sources/PackageDescription/PackageDependency.swift
@@ -683,7 +683,7 @@ extension Package.Dependency {
     ) -> Package.Dependency {
         let pattern = #"\A[a-zA-Z\d](?:[a-zA-Z\d]|-(?=[a-zA-Z\d])){0,38}\.[a-zA-Z0-9](?:[a-zA-Z0-9]|[-_](?=[a-zA-Z0-9])){0,99}\z"#
         if id.range(of: pattern, options: .regularExpression) == nil {
-            errors.append("Invalid package identifier: \(id)")
+            errors.append("Invalid package identifier: '\(id)'")
         }
 
         return .init(id: id, requirement: requirement)

--- a/Sources/PackageGraph/DependencyMirrors.swift
+++ b/Sources/PackageGraph/DependencyMirrors.swift
@@ -160,7 +160,7 @@ public final class DependencyMirrors: Equatable {
     }
 
     private func parseLocation(_ location: String) throws -> PackageIdentity {
-        if PackageIdentity.plain(location).scopeAndName != nil {
+        if PackageIdentity.plain(location).isRegistry {
             return PackageIdentity.plain(location)
         } else if let path = try? AbsolutePath(validating: location)  {
             return PackageIdentity(path: path)

--- a/Sources/PackageLoading/ManifestJSONParser.swift
+++ b/Sources/PackageLoading/ManifestJSONParser.swift
@@ -207,7 +207,7 @@ enum ManifestJSONParser {
         var location = try sanitizeDependencyLocation(fileSystem: fileSystem, packageKind: packageKind, dependencyLocation: location)
         // location mapping (aka mirrors) if any
         location = identityResolver.mappedLocation(for: location)
-        if PackageIdentity.plain(location).scopeAndName != nil {
+        if PackageIdentity.plain(location).isRegistry {
             // re-mapped to registry
             let identity = PackageIdentity.plain(location)
             let registryRequirement: PackageDependency.Registry.Requirement
@@ -257,7 +257,7 @@ enum ManifestJSONParser {
     ) throws -> PackageDependency {
         // location mapping (aka mirrors) if any
         let location = identityResolver.mappedLocation(for: identity.description)
-        if PackageIdentity.plain(location).scopeAndName != nil {
+        if PackageIdentity.plain(location).isRegistry {
             // re-mapped to registry
             let identity = PackageIdentity.plain(location)
             return .registry(

--- a/Sources/PackageMetadata/PackageMetadata.swift
+++ b/Sources/PackageMetadata/PackageMetadata.swift
@@ -99,7 +99,6 @@ public struct PackageSearchClient {
         callback: @escaping (Result<[Package], Error>) -> Void
     ) {
         let identity = PackageIdentity.plain(query)
-        let isRegistryIdentity = identity.scopeAndName != nil
 
         // Search the package index and collections for a search term.
         let search = { (error: Error?) -> Void in
@@ -164,7 +163,7 @@ public struct PackageSearchClient {
         // package metadata for it from the configured registry. If there are any errors
         // or the search term does not work as a registry identity, we will fall back on
         // `fetchStandalonePackageByURL`.
-        if isRegistryIdentity {
+        if identity.isRegistry {
             return self.registryClient.getPackageMetadata(package: identity, observabilityScope: observabilityScope, callbackQueue: DispatchQueue.sharedConcurrent) { result in
                 do {
                     let metadata = try result.get()

--- a/Sources/PackageModel/PackageIdentity.swift
+++ b/Sources/PackageModel/PackageIdentity.swift
@@ -49,39 +49,59 @@ public struct PackageIdentity: CustomStringConvertible, Sendable {
         PackageIdentity(value)
     }
 
-    // TODO: formalize package registry identifier
+    @available(*, deprecated, message: "use .registry instead")
     public var scopeAndName: (scope: Scope, name: Name)? {
-        let components = description.split(separator: ".", maxSplits: 1, omittingEmptySubsequences: true)
+        self.registry.flatMap { (scope: $0.scope, name: $0.name) }
+    }
+
+    public var registry: RegistryIdentity? {
+        let components = self.description.split(separator: ".", maxSplits: 1, omittingEmptySubsequences: true)
         guard components.count == 2,
               let scope = Scope(components.first),
               let name = Name(components.last)
-        else { return .none }
+        else {
+            return .none
+        }
 
-        return (scope: scope, name: name)
+        return RegistryIdentity(
+            scope: scope,
+            name: name,
+            underlying: self
+        )
+    }
+
+    public var isRegistry: Bool {
+        self.registry != nil
+    }
+
+    public struct RegistryIdentity {
+        public let scope: PackageIdentity.Scope
+        public let name: PackageIdentity.Name
+        public let underlying: PackageIdentity
     }
 }
 
 extension PackageIdentity: Equatable, Comparable {
     private func compare(to other: PackageIdentity) -> ComparisonResult {
-        return self.description.caseInsensitiveCompare(other.description)
+        self.description.caseInsensitiveCompare(other.description)
     }
 
     public static func == (lhs: PackageIdentity, rhs: PackageIdentity) -> Bool {
-        return lhs.compare(to: rhs) == .orderedSame
+        lhs.compare(to: rhs) == .orderedSame
     }
 
     public static func < (lhs: PackageIdentity, rhs: PackageIdentity) -> Bool {
-        return lhs.compare(to: rhs) == .orderedAscending
+        lhs.compare(to: rhs) == .orderedAscending
     }
 
     public static func > (lhs: PackageIdentity, rhs: PackageIdentity) -> Bool {
-        return lhs.compare(to: rhs) == .orderedDescending
+        lhs.compare(to: rhs) == .orderedDescending
     }
 }
 
 extension PackageIdentity: Hashable {
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(description.lowercased())
+        hasher.combine(self.description.lowercased())
     }
 }
 
@@ -116,9 +136,9 @@ extension PackageIdentity {
 
             for (index, character) in zip(description.indices, description) {
                 guard character.isASCII,
-                        character.isLetter ||
-                        character.isNumber ||
-                        character == "-"
+                      character.isLetter ||
+                      character.isNumber ||
+                      character == "-"
                 else {
                     throw StringError("A package scope consists of alphanumeric characters and hyphens.")
                 }
@@ -154,25 +174,25 @@ extension PackageIdentity {
 
         private func compare(to other: Scope) -> ComparisonResult {
             // Package scopes are case-insensitive (for example, `mona` ≍ `MONA`).
-            return self.description.caseInsensitiveCompare(other.description)
+            self.description.caseInsensitiveCompare(other.description)
         }
 
         public static func == (lhs: Scope, rhs: Scope) -> Bool {
-            return lhs.compare(to: rhs) == .orderedSame
+            lhs.compare(to: rhs) == .orderedSame
         }
 
         public static func < (lhs: Scope, rhs: Scope) -> Bool {
-            return lhs.compare(to: rhs) == .orderedAscending
+            lhs.compare(to: rhs) == .orderedAscending
         }
 
         public static func > (lhs: Scope, rhs: Scope) -> Bool {
-            return lhs.compare(to: rhs) == .orderedDescending
+            lhs.compare(to: rhs) == .orderedDescending
         }
 
         // MARK: - Hashable
 
         public func hash(into hasher: inout Hasher) {
-            hasher.combine(description.lowercased())
+            hasher.combine(self.description.lowercased())
         }
 
         // MARK: - ExpressibleByStringLiteral
@@ -197,10 +217,10 @@ extension PackageIdentity {
 
             for (index, character) in zip(description.indices, description) {
                 guard character.isASCII,
-                        character.isLetter ||
-                        character.isNumber ||
-                        character == "-" ||
-                        character == "_"
+                      character.isLetter ||
+                      character.isNumber ||
+                      character == "-" ||
+                      character == "_"
                 else {
                     throw StringError("A package name consists of alphanumeric characters, underscores, and hyphens.")
                 }
@@ -236,25 +256,25 @@ extension PackageIdentity {
 
         private func compare(to other: Name) -> ComparisonResult {
             // Package scopes are case-insensitive (for example, `LinkedList` ≍ `LINKEDLIST`).
-            return self.description.caseInsensitiveCompare(other.description)
+            self.description.caseInsensitiveCompare(other.description)
         }
 
         public static func == (lhs: Name, rhs: Name) -> Bool {
-            return lhs.compare(to: rhs) == .orderedSame
+            lhs.compare(to: rhs) == .orderedSame
         }
 
         public static func < (lhs: Name, rhs: Name) -> Bool {
-            return lhs.compare(to: rhs) == .orderedAscending
+            lhs.compare(to: rhs) == .orderedAscending
         }
 
         public static func > (lhs: Name, rhs: Name) -> Bool {
-            return lhs.compare(to: rhs) == .orderedDescending
+            lhs.compare(to: rhs) == .orderedDescending
         }
 
         // MARK: - Hashable
 
         public func hash(into hasher: inout Hasher) {
-            hasher.combine(description.lowercased())
+            hasher.combine(self.description.lowercased())
         }
 
         // MARK: - ExpressibleByStringLiteral
@@ -289,9 +309,9 @@ struct PackageIdentityParser {
     /// Compute the default name of a package given its location.
     public static func computeDefaultName(fromLocation url: String) -> String {
         #if os(Windows)
-        let isSeparator : (Character) -> Bool = { $0 == "/" || $0 == "\\" }
+        let isSeparator: (Character) -> Bool = { $0 == "/" || $0 == "\\" }
         #else
-        let isSeparator : (Character) -> Bool = { $0 == "/" }
+        let isSeparator: (Character) -> Bool = { $0 == "/" }
         #endif
 
         // Get the last path component of the URL.
@@ -303,7 +323,7 @@ struct PackageIdentityParser {
 
         let separatorIndex = url[..<endIndex].lastIndex(where: isSeparator)
         let startIndex = separatorIndex.map { url.index(after: $0) } ?? url.startIndex
-        var lastComponent = url[startIndex..<endIndex]
+        var lastComponent = url[startIndex ..< endIndex]
 
         // Strip `.git` suffix if present.
         if lastComponent.hasSuffix(".git") {
@@ -443,8 +463,8 @@ fileprivate let isSeparator: (Character) -> Bool = { $0 == "/" || $0 == "\\" }
 fileprivate let isSeparator: (Character) -> Bool = { $0 == "/" }
 #endif
 
-private extension Character {
-    var isDigit: Bool {
+extension Character {
+    fileprivate var isDigit: Bool {
         switch self {
         case "0", "1", "2", "3", "4", "5", "6", "7", "8", "9":
             return true
@@ -453,31 +473,31 @@ private extension Character {
         }
     }
 
-    var isAllowedInURLScheme: Bool {
-        return isLetter || self.isDigit || self == "+" || self == "-" || self == "."
+    fileprivate var isAllowedInURLScheme: Bool {
+        isLetter || self.isDigit || self == "+" || self == "-" || self == "."
     }
 }
 
-private extension String {
+extension String {
     @discardableResult
-    mutating func removePrefixIfPresent<T: StringProtocol>(_ prefix: T) -> Bool {
+    private mutating func removePrefixIfPresent<T: StringProtocol>(_ prefix: T) -> Bool {
         guard hasPrefix(prefix) else { return false }
         removeFirst(prefix.count)
         return true
     }
 
     @discardableResult
-    mutating func removeSuffixIfPresent<T: StringProtocol>(_ suffix: T) -> Bool {
+    fileprivate mutating func removeSuffixIfPresent<T: StringProtocol>(_ suffix: T) -> Bool {
         guard hasSuffix(suffix) else { return false }
         removeLast(suffix.count)
         return true
     }
 
     @discardableResult
-    mutating func dropSchemeComponentPrefixIfPresent() -> String? {
+    fileprivate mutating func dropSchemeComponentPrefixIfPresent() -> String? {
         if let rangeOfDelimiter = range(of: "://"),
            self[startIndex].isLetter,
-           self[..<rangeOfDelimiter.lowerBound].allSatisfy({ $0.isAllowedInURLScheme })
+           self[..<rangeOfDelimiter.lowerBound].allSatisfy(\.isAllowedInURLScheme)
         {
             defer { self.removeSubrange(..<rangeOfDelimiter.upperBound) }
 
@@ -488,7 +508,7 @@ private extension String {
     }
 
     @discardableResult
-    mutating func dropUserinfoSubcomponentPrefixIfPresent() -> (user: String, password: String?)? {
+    fileprivate mutating func dropUserinfoSubcomponentPrefixIfPresent() -> (user: String, password: String?)? {
         if let indexOfAtSign = firstIndex(of: "@"),
            let indexOfFirstPathComponent = firstIndex(where: isSeparator),
            indexOfAtSign < indexOfFirstPathComponent
@@ -508,7 +528,7 @@ private extension String {
     }
 
     @discardableResult
-    mutating func removePortComponentIfPresent() -> Bool {
+    fileprivate mutating func removePortComponentIfPresent() -> Bool {
         if let indexOfFirstPathComponent = firstIndex(where: isSeparator),
            let startIndexOfPort = firstIndex(of: ":"),
            startIndexOfPort < endIndex,
@@ -523,7 +543,7 @@ private extension String {
     }
 
     @discardableResult
-    mutating func removeFragmentComponentIfPresent() -> Bool {
+    fileprivate mutating func removeFragmentComponentIfPresent() -> Bool {
         if let index = firstIndex(of: "#") {
             self.removeSubrange(index...)
         }
@@ -532,7 +552,7 @@ private extension String {
     }
 
     @discardableResult
-    mutating func removeQueryComponentIfPresent() -> Bool {
+    fileprivate mutating func removeQueryComponentIfPresent() -> Bool {
         if let index = firstIndex(of: "?") {
             self.removeSubrange(index...)
         }
@@ -541,7 +561,7 @@ private extension String {
     }
 
     @discardableResult
-    mutating func replaceFirstOccurenceIfPresent<T: StringProtocol, U: StringProtocol>(
+    fileprivate mutating func replaceFirstOccurenceIfPresent<T: StringProtocol, U: StringProtocol>(
         of string: T,
         before index: Index? = nil,
         with replacement: U
@@ -556,4 +576,3 @@ private extension String {
         return true
     }
 }
-

--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -92,18 +92,18 @@ public final class RegistryClient: Cancellable {
     ) {
         let completion = self.makeAsync(completion, on: callbackQueue)
 
-        guard case (let scope, let name)? = package.scopeAndName else {
-            return completion(.failure(RegistryError.invalidPackage(package)))
+        guard let registryIdentity = package.registry else {
+            return completion(.failure(RegistryError.invalidPackageIdentity(package)))
         }
 
-        guard let registry = configuration.registry(for: scope) else {
-            return completion(.failure(RegistryError.registryNotConfigured(scope: scope)))
+        guard let registry = configuration.registry(for: registryIdentity.scope) else {
+            return completion(.failure(RegistryError.registryNotConfigured(scope: registryIdentity.scope)))
         }
 
         guard var components = URLComponents(url: registry.url, resolvingAgainstBaseURL: true) else {
             return completion(.failure(RegistryError.invalidURL(registry.url)))
         }
-        components.appendPathComponents("\(scope)", "\(name)")
+        components.appendPathComponents("\(registryIdentity.scope)", "\(registryIdentity.name)")
         guard let url = components.url else {
             return completion(.failure(RegistryError.invalidURL(registry.url)))
         }
@@ -147,7 +147,7 @@ public final class RegistryClient: Cancellable {
             )
         }
     }
-    
+
     public func getPackageVersionMetadata(
         package: PackageIdentity,
         version: Version,
@@ -158,18 +158,18 @@ public final class RegistryClient: Cancellable {
     ) {
         let completion = self.makeAsync(completion, on: callbackQueue)
 
-        guard case (let scope, let name)? = package.scopeAndName else {
-            return completion(.failure(RegistryError.invalidPackage(package)))
+        guard let registryIdentity = package.registry else {
+            return completion(.failure(RegistryError.invalidPackageIdentity(package)))
         }
 
-        guard let registry = configuration.registry(for: scope) else {
-            return completion(.failure(RegistryError.registryNotConfigured(scope: scope)))
+        guard let registry = configuration.registry(for: registryIdentity.scope) else {
+            return completion(.failure(RegistryError.registryNotConfigured(scope: registryIdentity.scope)))
         }
 
         guard var components = URLComponents(url: registry.url, resolvingAgainstBaseURL: true) else {
             return completion(.failure(RegistryError.invalidURL(registry.url)))
         }
-        components.appendPathComponents("\(scope)", "\(name)", "\(version)")
+        components.appendPathComponents("\(registryIdentity.scope)", "\(registryIdentity.name)", "\(version)")
 
         guard let url = components.url else {
             return completion(.failure(RegistryError.invalidURL(registry.url)))
@@ -220,18 +220,23 @@ public final class RegistryClient: Cancellable {
     ) {
         let completion = self.makeAsync(completion, on: callbackQueue)
 
-        guard case (let scope, let name)? = package.scopeAndName else {
-            return completion(.failure(RegistryError.invalidPackage(package)))
+        guard let registryIdentity = package.registry else {
+            return completion(.failure(RegistryError.invalidPackageIdentity(package)))
         }
 
-        guard let registry = configuration.registry(for: scope) else {
-            return completion(.failure(RegistryError.registryNotConfigured(scope: scope)))
+        guard let registry = configuration.registry(for: registryIdentity.scope) else {
+            return completion(.failure(RegistryError.registryNotConfigured(scope: registryIdentity.scope)))
         }
 
         guard var components = URLComponents(url: registry.url, resolvingAgainstBaseURL: true) else {
             return completion(.failure(RegistryError.invalidURL(registry.url)))
         }
-        components.appendPathComponents("\(scope)", "\(name)", "\(version)", Manifest.filename)
+        components.appendPathComponents(
+            "\(registryIdentity.scope)",
+            "\(registryIdentity.name)",
+            "\(version)",
+            Manifest.filename
+        )
 
         guard let url = components.url else {
             return completion(.failure(RegistryError.invalidURL(registry.url)))
@@ -294,18 +299,23 @@ public final class RegistryClient: Cancellable {
     ) {
         let completion = self.makeAsync(completion, on: callbackQueue)
 
-        guard case (let scope, let name)? = package.scopeAndName else {
-            return completion(.failure(RegistryError.invalidPackage(package)))
+        guard let registryIdentity = package.registry else {
+            return completion(.failure(RegistryError.invalidPackageIdentity(package)))
         }
 
-        guard let registry = configuration.registry(for: scope) else {
-            return completion(.failure(RegistryError.registryNotConfigured(scope: scope)))
+        guard let registry = configuration.registry(for: registryIdentity.scope) else {
+            return completion(.failure(RegistryError.registryNotConfigured(scope: registryIdentity.scope)))
         }
 
         guard var components = URLComponents(url: registry.url, resolvingAgainstBaseURL: true) else {
             return completion(.failure(RegistryError.invalidURL(registry.url)))
         }
-        components.appendPathComponents("\(scope)", "\(name)", "\(version)", "Package.swift")
+        components.appendPathComponents(
+            "\(registryIdentity.scope)",
+            "\(registryIdentity.name)",
+            "\(version)",
+            "Package.swift"
+        )
 
         if let toolsVersion = customToolsVersion {
             components.queryItems = [
@@ -362,18 +372,18 @@ public final class RegistryClient: Cancellable {
     ) {
         let completion = self.makeAsync(completion, on: callbackQueue)
 
-        guard case (let scope, let name)? = package.scopeAndName else {
-            return completion(.failure(RegistryError.invalidPackage(package)))
+        guard let registryIdentity = package.registry else {
+            return completion(.failure(RegistryError.invalidPackageIdentity(package)))
         }
 
-        guard let registry = configuration.registry(for: scope) else {
-            return completion(.failure(RegistryError.registryNotConfigured(scope: scope)))
+        guard let registry = configuration.registry(for: registryIdentity.scope) else {
+            return completion(.failure(RegistryError.registryNotConfigured(scope: registryIdentity.scope)))
         }
 
         guard var components = URLComponents(url: registry.url, resolvingAgainstBaseURL: true) else {
             return completion(.failure(RegistryError.invalidURL(registry.url)))
         }
-        components.appendPathComponents("\(scope)", "\(name)", "\(version)")
+        components.appendPathComponents("\(registryIdentity.scope)", "\(registryIdentity.name)", "\(version)")
 
         guard let url = components.url else {
             return completion(.failure(RegistryError.invalidURL(registry.url)))
@@ -466,18 +476,18 @@ public final class RegistryClient: Cancellable {
     ) {
         let completion = self.makeAsync(completion, on: callbackQueue)
 
-        guard case (let scope, let name)? = package.scopeAndName else {
-            return completion(.failure(RegistryError.invalidPackage(package)))
+        guard let registryIdentity = package.registry else {
+            return completion(.failure(RegistryError.invalidPackageIdentity(package)))
         }
 
-        guard let registry = configuration.registry(for: scope) else {
-            return completion(.failure(RegistryError.registryNotConfigured(scope: scope)))
+        guard let registry = configuration.registry(for: registryIdentity.scope) else {
+            return completion(.failure(RegistryError.registryNotConfigured(scope: registryIdentity.scope)))
         }
 
         guard var components = URLComponents(url: registry.url, resolvingAgainstBaseURL: true) else {
             return completion(.failure(RegistryError.invalidURL(registry.url)))
         }
-        components.appendPathComponents("\(scope)", "\(name)", "\(version).zip")
+        components.appendPathComponents("\(registryIdentity.scope)", "\(registryIdentity.name)", "\(version).zip")
 
         guard let url = components.url else {
             return completion(.failure(RegistryError.invalidURL(registry.url)))
@@ -725,14 +735,14 @@ public final class RegistryClient: Cancellable {
     ) {
         let completion = self.makeAsync(completion, on: callbackQueue)
 
-        guard let scopeAndName = packageIdentity.scopeAndName else {
-            return completion(.failure(RegistryError.invalidPackage(packageIdentity)))
+        guard let registryIdentity = packageIdentity.registry else {
+            return completion(.failure(RegistryError.invalidPackageIdentity(packageIdentity)))
         }
         guard var components = URLComponents(url: registryURL, resolvingAgainstBaseURL: true) else {
             return completion(.failure(RegistryError.invalidURL(registryURL)))
         }
-        components.appendPathComponents(scopeAndName.scope.description)
-        components.appendPathComponents(scopeAndName.name.description)
+        components.appendPathComponents(registryIdentity.scope.description)
+        components.appendPathComponents(registryIdentity.name.description)
         components.appendPathComponents(packageVersion.description)
 
         guard let url = components.url else {
@@ -863,7 +873,7 @@ public final class RegistryClient: Cancellable {
 
 public enum RegistryError: Error, CustomStringConvertible {
     case registryNotConfigured(scope: PackageIdentity.Scope?)
-    case invalidPackage(PackageIdentity)
+    case invalidPackageIdentity(PackageIdentity)
     case invalidURL(URL)
     case invalidResponseStatus(expected: [Int], actual: Int)
     case invalidContentVersion(expected: String, actual: String?)
@@ -901,8 +911,8 @@ public enum RegistryError: Error, CustomStringConvertible {
             } else {
                 return "No registry configured'"
             }
-        case .invalidPackage(let package):
-            return "Invalid package '\(package)'"
+        case .invalidPackageIdentity(let packageIdentity):
+            return "Invalid package identifier '\(packageIdentity)'"
         case .invalidURL(let url):
             return "Invalid URL '\(url)'"
         case .invalidResponseStatus(let expected, let actual):
@@ -994,7 +1004,7 @@ extension RegistryClient {
         public let versions: [Version]
         public let alternateLocations: [URL]?
     }
-    
+
     public struct PackageVersionMetadata {
         public let registry: Registry
         public let licenseURL: URL?
@@ -1314,7 +1324,7 @@ extension RegistryClient {
                 public let licenseURL: String?
                 public let readmeURL: String?
                 public let repositoryURLs: [String]?
-                
+
                 public init(
                     author: Author? = nil,
                     description: String,
@@ -1329,7 +1339,7 @@ extension RegistryClient {
                     self.repositoryURLs = repositoryURLs
                 }
             }
-            
+
             public struct Author: Codable {
                 public let name: String
                 public let email: String?
@@ -1337,7 +1347,7 @@ extension RegistryClient {
                 public let organization: Organization?
                 public let url: String?
             }
-            
+
             public struct Organization: Codable {
                 public let name: String
                 public let email: String?

--- a/Sources/PackageRegistry/RegistryDownloadsManager.swift
+++ b/Sources/PackageRegistry/RegistryDownloadsManager.swift
@@ -13,9 +13,9 @@
 import Basics
 import Dispatch
 import Foundation
+import PackageLoading
 import PackageModel
 import TSCBasic
-import PackageLoading
 
 import struct TSCUtility.Version
 
@@ -54,11 +54,11 @@ public class RegistryDownloadsManager: Cancellable {
         observabilityScope: ObservabilityScope,
         delegateQueue: DispatchQueue,
         callbackQueue: DispatchQueue,
-        completion: @escaping  (Result<AbsolutePath, Error>) -> Void
+        completion: @escaping (Result<AbsolutePath, Error>) -> Void
     ) {
         // wrap the callback in the requested queue
         let completion = { result in callbackQueue.async { completion(result) } }
-        
+
         let packageRelativePath: RelativePath
         let packagePath: AbsolutePath
 
@@ -101,7 +101,7 @@ public class RegistryDownloadsManager: Cancellable {
 
             // inform delegate that we are starting to fetch
             // calculate if cached (for delegate call) outside queue as it may change while queue is processing
-            let isCached = self.cachePath.map{ self.fileSystem.exists($0.appending(packageRelativePath)) } ?? false
+            let isCached = self.cachePath.map { self.fileSystem.exists($0.appending(packageRelativePath)) } ?? false
             delegateQueue.async {
                 let details = FetchDetails(fromCache: isCached, updatedCache: false)
                 self.delegate?.willFetch(package: package, version: version, fetchDetails: details)
@@ -130,7 +130,7 @@ public class RegistryDownloadsManager: Cancellable {
                 self.pendingLookups[package] = nil
                 self.pendingLookupsLock.unlock()
                 // and done
-                completion(result.map{ _ in packagePath })
+                completion(result.map { _ in packagePath })
             }
         }
     }
@@ -147,7 +147,7 @@ public class RegistryDownloadsManager: Cancellable {
         observabilityScope: ObservabilityScope,
         delegateQueue: DispatchQueue,
         callbackQueue: DispatchQueue,
-        completion: @escaping  (Result<FetchDetails, Error>) -> Void
+        completion: @escaping (Result<FetchDetails, Error>) -> Void
     ) {
         if let cachePath = self.cachePath {
             do {
@@ -208,7 +208,7 @@ public class RegistryDownloadsManager: Cancellable {
                     observabilityScope: observabilityScope,
                     callbackQueue: callbackQueue
                 ) { result in
-                    completion(result.map{ FetchDetails(fromCache: false, updatedCache: false) })
+                    completion(result.map { FetchDetails(fromCache: false, updatedCache: false) })
                 }
             }
         } else {
@@ -225,13 +225,13 @@ public class RegistryDownloadsManager: Cancellable {
                 observabilityScope: observabilityScope,
                 callbackQueue: callbackQueue
             ) { result in
-                completion(result.map{ FetchDetails(fromCache: false, updatedCache: false) })
+                completion(result.map { FetchDetails(fromCache: false, updatedCache: false) })
             }
         }
 
         // utility to update progress
 
-        func updateDownloadProgress(downloaded: Int64, total: Int64?) -> Void {
+        func updateDownloadProgress(downloaded: Int64, total: Int64?) {
             delegateQueue.async {
                 self.delegate?.fetching(
                     package: package,
@@ -296,7 +296,12 @@ public protocol RegistryDownloadsManagerDelegate {
     func willFetch(package: PackageIdentity, version: Version, fetchDetails: RegistryDownloadsManager.FetchDetails)
 
     /// Called when a package has finished fetching.
-    func didFetch(package: PackageIdentity, version: Version, result: Result<RegistryDownloadsManager.FetchDetails, Error>, duration: DispatchTimeInterval)
+    func didFetch(
+        package: PackageIdentity,
+        version: Version,
+        result: Result<RegistryDownloadsManager.FetchDetails, Error>,
+        duration: DispatchTimeInterval
+    )
 
     /// Called every time the progress of a repository fetch operation updates.
     func fetching(package: PackageIdentity, version: Version, bytesDownloaded: Int64, totalBytesToDownload: Int64?)
@@ -312,7 +317,6 @@ extension RegistryDownloadsManager {
     }
 }
 
-
 extension FileSystem {
     func validPackageDirectory(_ path: AbsolutePath) throws -> Bool {
         if !self.exists(path) {
@@ -322,16 +326,15 @@ extension FileSystem {
     }
 }
 
-
 extension PackageIdentity {
     internal func downloadPath() throws -> RelativePath {
-        guard let (scope, name) = self.scopeAndName else {
-            throw StringError("invalid package identity, expected registry scope and name")
+        guard let registryIdentity = self.registry else {
+            throw StringError("invalid package identifier \(self), expected registry scope and name")
         }
-        return RelativePath(scope.description).appending(component: name.description)
+        return RelativePath(registryIdentity.scope.description).appending(component: registryIdentity.name.description)
     }
 
-    internal func downloadPath(version: Version) throws -> RelativePath  {
+    internal func downloadPath(version: Version) throws -> RelativePath {
         try self.downloadPath().appending(component: version.description)
     }
 }

--- a/Sources/PackageRegistryTool/PackageRegistryTool+Publish.swift
+++ b/Sources/PackageRegistryTool/PackageRegistryTool+Publish.swift
@@ -81,13 +81,13 @@ extension SwiftPackageRegistryTool {
             }
 
             // validate package identity
-            guard let packageScopeAndName = self.packageIdentity.scopeAndName else {
+            guard let registryIdentity = self.packageIdentity.registry else {
                 throw ValidationError.invalidPackageIdentity(self.packageIdentity)
             }
 
             // compute and validate registry URL
             let registryURL: URL? = self.registryURL ?? {
-                if let registry = configuration.registry(for: packageScopeAndName.scope) {
+                if let registry = configuration.registry(for: registryIdentity.scope) {
                     return registry.url
                 }
                 if let registry = configuration.defaultRegistry {

--- a/Sources/PackageRegistryTool/PackageRegistryTool.swift
+++ b/Sources/PackageRegistryTool/PackageRegistryTool.swift
@@ -172,7 +172,7 @@ extension SwiftPackageRegistryTool.ValidationError: CustomStringConvertible {
         case .invalidURL(let url):
             return "invalid URL: \(url)"
         case .invalidPackageIdentity(let identity):
-            return "invalid package identity: \(identity)"
+            return "invalid package identifier '\(identity)'"
         case .unknownRegistry:
             return "unknown registry, is one configured?"
         case .unknownCredentialStore:

--- a/Sources/SPMTestSupport/MockDependency.swift
+++ b/Sources/SPMTestSupport/MockDependency.swift
@@ -60,7 +60,7 @@ public struct MockDependency {
             )
         case .remoteSourceControl(let url, let _requirement):
             let mappedLocation = identityResolver.mappedLocation(for: url.absoluteString)
-            if PackageIdentity.plain(mappedLocation).scopeAndName != nil {
+            if PackageIdentity.plain(mappedLocation).isRegistry {
                 let identity = PackageIdentity.plain(mappedLocation)
                 let requirement: RegistryRequirement
                 switch _requirement {
@@ -91,7 +91,7 @@ public struct MockDependency {
             }
         case .registry(let identity, let _requirement):
             let mappedLocation = identityResolver.mappedLocation(for: identity.description)
-            if PackageIdentity.plain(mappedLocation).scopeAndName != nil {
+            if PackageIdentity.plain(mappedLocation).isRegistry {
                 let identity = PackageIdentity.plain(mappedLocation)
                 return .registry(
                     identity: identity,

--- a/Sources/SPMTestSupport/MockRegistry.swift
+++ b/Sources/SPMTestSupport/MockRegistry.swift
@@ -161,15 +161,15 @@ public class MockRegistry {
     }
 
     private func getPackageMetadata(packageIdentity: PackageIdentity) throws -> HTTPClientResponse {
-        guard let (scope, name) = packageIdentity.scopeAndName else {
-            throw StringError("invalid package identity \(packageIdentity)")
+        guard let registryIdentity = packageIdentity.registry else {
+            throw StringError("invalid package identifier '\(packageIdentity)'")
         }
 
         let versions = self.packageVersions[packageIdentity] ?? [:]
         let metadata = RegistryClient.Serialization.PackageMetadata(
             releases: versions.keys
                 .reduce(into: [String: RegistryClient.Serialization.PackageMetadata.Release]()) { partial, item in
-                    partial[item] = .init(url: "\(Self.mockRegistryURL.absoluteString)/\(scope)/\(name)/\(item)")
+                    partial[item] = .init(url: "\(Self.mockRegistryURL.absoluteString)/\(registryIdentity.scope)/\(registryIdentity.name)/\(item)")
                 }
         )
 

--- a/Tests/PackageRegistryTests/RegistryClientTests.swift
+++ b/Tests/PackageRegistryTests/RegistryClientTests.swift
@@ -26,8 +26,7 @@ final class RegistryClientTests: XCTestCase {
     func testGetPackageMetadata() throws {
         let registryURL = "https://packages.example.com"
         let identity = PackageIdentity.plain("mona.LinkedList")
-        let (scope, name) = identity.scopeAndName!
-        let releasesURL = URL(string: "\(registryURL)/\(scope)/\(name)")!
+        let releasesURL = URL(string: "\(registryURL)/\(identity.registry!.scope)/\(identity.registry!.name)")!
 
         let handler: LegacyHTTPClient.Handler = { request, _, completion in
             switch (request.method, request.url) {
@@ -98,8 +97,7 @@ final class RegistryClientTests: XCTestCase {
     func testGetPackageMetadata_ServerError() throws {
         let registryURL = "https://packages.example.com"
         let identity = PackageIdentity.plain("mona.LinkedList")
-        let (scope, name) = identity.scopeAndName!
-        let releasesURL = URL(string: "\(registryURL)/\(scope)/\(name)")!
+        let releasesURL = URL(string: "\(registryURL)/\(identity.registry!.scope)/\(identity.registry!.name)")!
 
         let serverErrorHandler = ServerErrorHandler(
             method: .get,
@@ -127,13 +125,13 @@ final class RegistryClientTests: XCTestCase {
             }
         }
     }
-    
+
     func testGetPackageVersionMetadata() throws {
         let registryURL = "https://packages.example.com"
         let identity = PackageIdentity.plain("mona.LinkedList")
-        let (scope, name) = identity.scopeAndName!
         let version = Version("1.1.1")
-        let releaseURL = URL(string: "\(registryURL)/\(scope)/\(name)/\(version)")!
+        let releaseURL =
+            URL(string: "\(registryURL)/\(identity.registry!.scope)/\(identity.registry!.name)/\(version)")!
 
         let handler: LegacyHTTPClient.Handler = { request, _, completion in
             switch (request.method, request.url) {
@@ -197,13 +195,13 @@ final class RegistryClientTests: XCTestCase {
             URL(string: "git@github.com:mona/LinkedList.git")!,
         ])
     }
-    
+
     func testGetPackageVersionMetadata_ServerError() throws {
         let registryURL = "https://packages.example.com"
         let identity = PackageIdentity.plain("mona.LinkedList")
-        let (scope, name) = identity.scopeAndName!
         let version = Version("1.1.1")
-        let releaseURL = URL(string: "\(registryURL)/\(scope)/\(name)/\(version)")!
+        let releaseURL =
+            URL(string: "\(registryURL)/\(identity.registry!.scope)/\(identity.registry!.name)/\(version)")!
 
         let serverErrorHandler = ServerErrorHandler(
             method: .get,
@@ -220,7 +218,10 @@ final class RegistryClientTests: XCTestCase {
         configuration.defaultRegistry = Registry(url: URL(string: registryURL)!)
 
         let registryClient = makeRegistryClient(configuration: configuration, httpClient: httpClient)
-        XCTAssertThrowsError(try registryClient.getPackageVersionMetadata(package: identity, version: version)) { error in
+        XCTAssertThrowsError(
+            try registryClient
+                .getPackageVersionMetadata(package: identity, version: version)
+        ) { error in
             guard case RegistryError
                 .failedRetrievingReleaseInfo(
                     RegistryError
@@ -235,9 +236,11 @@ final class RegistryClientTests: XCTestCase {
     func testAvailableManifests() throws {
         let registryURL = "https://packages.example.com"
         let identity = PackageIdentity.plain("mona.LinkedList")
-        let (scope, name) = identity.scopeAndName!
         let version = Version("1.1.1")
-        let manifestURL = URL(string: "\(registryURL)/\(scope)/\(name)/\(version)/Package.swift")!
+        let manifestURL =
+            URL(
+                string: "\(registryURL)/\(identity.registry!.scope)/\(identity.registry!.name)/\(version)/Package.swift"
+            )!
 
         let defaultManifest = """
         // swift-tools-version:5.5
@@ -310,9 +313,11 @@ final class RegistryClientTests: XCTestCase {
     func testAvailableManifests_ServerError() throws {
         let registryURL = "https://packages.example.com"
         let identity = PackageIdentity.plain("mona.LinkedList")
-        let (scope, name) = identity.scopeAndName!
         let version = Version("1.1.1")
-        let manifestURL = URL(string: "\(registryURL)/\(scope)/\(name)/\(version)/Package.swift")!
+        let manifestURL =
+            URL(
+                string: "\(registryURL)/\(identity.registry!.scope)/\(identity.registry!.name)/\(version)/Package.swift"
+            )!
 
         let serverErrorHandler = ServerErrorHandler(
             method: .get,
@@ -344,9 +349,11 @@ final class RegistryClientTests: XCTestCase {
     func testGetManifestContent() throws {
         let registryURL = "https://packages.example.com"
         let identity = PackageIdentity.plain("mona.LinkedList")
-        let (scope, name) = identity.scopeAndName!
         let version = Version("1.1.1")
-        let manifestURL = URL(string: "\(registryURL)/\(scope)/\(name)/\(version)/Package.swift")!
+        let manifestURL =
+            URL(
+                string: "\(registryURL)/\(identity.registry!.scope)/\(identity.registry!.name)/\(version)/Package.swift"
+            )!
 
         let handler: LegacyHTTPClient.Handler = { request, _, completion in
             var components = URLComponents(url: request.url, resolvingAgainstBaseURL: false)!
@@ -420,13 +427,15 @@ final class RegistryClientTests: XCTestCase {
             XCTAssertEqual(parsedToolsVersion, .v4)
         }
     }
-    
+
     func testGetManifestContent_optionalContentVersion() throws {
         let registryURL = "https://packages.example.com"
         let identity = PackageIdentity.plain("mona.LinkedList")
-        let (scope, name) = identity.scopeAndName!
         let version = Version("1.1.1")
-        let manifestURL = URL(string: "\(registryURL)/\(scope)/\(name)/\(version)/Package.swift")!
+        let manifestURL =
+            URL(
+                string: "\(registryURL)/\(identity.registry!.scope)/\(identity.registry!.name)/\(version)/Package.swift"
+            )!
 
         let handler: LegacyHTTPClient.Handler = { request, _, completion in
             var components = URLComponents(url: request.url, resolvingAgainstBaseURL: false)!
@@ -494,9 +503,11 @@ final class RegistryClientTests: XCTestCase {
     func testGetManifestContent_ServerError() throws {
         let registryURL = "https://packages.example.com"
         let identity = PackageIdentity.plain("mona.LinkedList")
-        let (scope, name) = identity.scopeAndName!
         let version = Version("1.1.1")
-        let manifestURL = URL(string: "\(registryURL)/\(scope)/\(name)/\(version)/Package.swift")!
+        let manifestURL =
+            URL(
+                string: "\(registryURL)/\(identity.registry!.scope)/\(identity.registry!.name)/\(version)/Package.swift"
+            )!
 
         let serverErrorHandler = ServerErrorHandler(
             method: .get,
@@ -531,9 +542,9 @@ final class RegistryClientTests: XCTestCase {
     func testFetchSourceArchiveChecksum() throws {
         let registryURL = "https://packages.example.com"
         let identity = PackageIdentity.plain("mona.LinkedList")
-        let (scope, name) = identity.scopeAndName!
         let version = Version("1.1.1")
-        let metadataURL = URL(string: "\(registryURL)/\(scope)/\(name)/\(version)")!
+        let metadataURL =
+            URL(string: "\(registryURL)/\(identity.registry!.scope)/\(identity.registry!.name)/\(version)")!
         let checksum = "a2ac54cf25fbc1ad0028f03f0aa4b96833b83bb05a14e510892bb27dea4dc812"
 
         let handler: LegacyHTTPClient.Handler = { request, _, completion in
@@ -608,9 +619,9 @@ final class RegistryClientTests: XCTestCase {
     func testFetchSourceArchiveChecksum_storageConflict() throws {
         let registryURL = "https://packages.example.com"
         let identity = PackageIdentity.plain("mona.LinkedList")
-        let (scope, name) = identity.scopeAndName!
         let version = Version("1.1.1")
-        let metadataURL = URL(string: "\(registryURL)/\(scope)/\(name)/\(version)")!
+        let metadataURL =
+            URL(string: "\(registryURL)/\(identity.registry!.scope)/\(identity.registry!.name)/\(version)")!
         let checksum = "a2ac54cf25fbc1ad0028f03f0aa4b96833b83bb05a14e510892bb27dea4dc812"
 
         let handler: LegacyHTTPClient.Handler = { request, _, completion in
@@ -684,9 +695,9 @@ final class RegistryClientTests: XCTestCase {
     func testFetchSourceArchiveChecksum_storageConflict_fingerprintChecking_warn() throws {
         let registryURL = "https://packages.example.com"
         let identity = PackageIdentity.plain("mona.LinkedList")
-        let (scope, name) = identity.scopeAndName!
         let version = Version("1.1.1")
-        let metadataURL = URL(string: "\(registryURL)/\(scope)/\(name)/\(version)")!
+        let metadataURL =
+            URL(string: "\(registryURL)/\(identity.registry!.scope)/\(identity.registry!.name)/\(version)")!
         let checksum = "a2ac54cf25fbc1ad0028f03f0aa4b96833b83bb05a14e510892bb27dea4dc812"
 
         let handler: LegacyHTTPClient.Handler = { request, _, completion in
@@ -780,9 +791,9 @@ final class RegistryClientTests: XCTestCase {
     func testFetchSourceArchiveChecksum_ServerError() throws {
         let registryURL = "https://packages.example.com"
         let identity = PackageIdentity.plain("mona.LinkedList")
-        let (scope, name) = identity.scopeAndName!
         let version = Version("1.1.1")
-        let metadataURL = URL(string: "\(registryURL)/\(scope)/\(name)/\(version)")!
+        let metadataURL =
+            URL(string: "\(registryURL)/\(identity.registry!.scope)/\(identity.registry!.name)/\(version)")!
 
         let serverErrorHandler = ServerErrorHandler(
             method: .get,
@@ -823,9 +834,9 @@ final class RegistryClientTests: XCTestCase {
     func testDownloadSourceArchive_matchingChecksumInStorage() throws {
         let registryURL = "https://packages.example.com"
         let identity = PackageIdentity.plain("mona.LinkedList")
-        let (scope, name) = identity.scopeAndName!
         let version = Version("1.1.1")
-        let downloadURL = URL(string: "\(registryURL)/\(scope)/\(name)/\(version).zip")!
+        let downloadURL =
+            URL(string: "\(registryURL)/\(identity.registry!.scope)/\(identity.registry!.name)/\(version).zip")!
 
         let checksumAlgorithm: HashAlgorithm = SHA256()
         let checksum = checksumAlgorithm.hash(emptyZipFile).hexadecimalRepresentation
@@ -905,9 +916,9 @@ final class RegistryClientTests: XCTestCase {
     func testDownloadSourceArchive_nonMatchingChecksumInStorage() throws {
         let registryURL = "https://packages.example.com"
         let identity = PackageIdentity.plain("mona.LinkedList")
-        let (scope, name) = identity.scopeAndName!
         let version = Version("1.1.1")
-        let downloadURL = URL(string: "\(registryURL)/\(scope)/\(name)/\(version).zip")!
+        let downloadURL =
+            URL(string: "\(registryURL)/\(identity.registry!.scope)/\(identity.registry!.name)/\(version).zip")!
 
         let checksumAlgorithm: HashAlgorithm = SHA256()
 
@@ -995,9 +1006,9 @@ final class RegistryClientTests: XCTestCase {
     func testDownloadSourceArchive_nonMatchingChecksumInStorage_fingerprintChecking_warn() throws {
         let registryURL = "https://packages.example.com"
         let identity = PackageIdentity.plain("mona.LinkedList")
-        let (scope, name) = identity.scopeAndName!
         let version = Version("1.1.1")
-        let downloadURL = URL(string: "\(registryURL)/\(scope)/\(name)/\(version).zip")!
+        let downloadURL =
+            URL(string: "\(registryURL)/\(identity.registry!.scope)/\(identity.registry!.name)/\(version).zip")!
 
         let checksumAlgorithm: HashAlgorithm = SHA256()
 
@@ -1088,10 +1099,11 @@ final class RegistryClientTests: XCTestCase {
     func testDownloadSourceArchive_checksumNotInStorage() throws {
         let registryURL = "https://packages.example.com"
         let identity = PackageIdentity.plain("mona.LinkedList")
-        let (scope, name) = identity.scopeAndName!
         let version = Version("1.1.1")
-        let downloadURL = URL(string: "\(registryURL)/\(scope)/\(name)/\(version).zip")!
-        let metadataURL = URL(string: "\(registryURL)/\(scope)/\(name)/\(version)")!
+        let downloadURL =
+            URL(string: "\(registryURL)/\(identity.registry!.scope)/\(identity.registry!.name)/\(version).zip")!
+        let metadataURL =
+            URL(string: "\(registryURL)/\(identity.registry!.scope)/\(identity.registry!.name)/\(version)")!
 
         let checksumAlgorithm: HashAlgorithm = SHA256()
         let checksum = checksumAlgorithm.hash(emptyZipFile).hexadecimalRepresentation
@@ -1208,14 +1220,15 @@ final class RegistryClientTests: XCTestCase {
         XCTAssertEqual(registryURL, fingerprint.origin.url?.absoluteString)
         XCTAssertEqual(checksum, fingerprint.value)
     }
-    
+
     func testDownloadSourceArchive_optionalContentVersion() throws {
         let registryURL = "https://packages.example.com"
         let identity = PackageIdentity.plain("mona.LinkedList")
-        let (scope, name) = identity.scopeAndName!
         let version = Version("1.1.1")
-        let downloadURL = URL(string: "\(registryURL)/\(scope)/\(name)/\(version).zip")!
-        let metadataURL = URL(string: "\(registryURL)/\(scope)/\(name)/\(version)")!
+        let downloadURL =
+            URL(string: "\(registryURL)/\(identity.registry!.scope)/\(identity.registry!.name)/\(version).zip")!
+        let metadataURL =
+            URL(string: "\(registryURL)/\(identity.registry!.scope)/\(identity.registry!.name)/\(version)")!
 
         let checksumAlgorithm: HashAlgorithm = SHA256()
         let checksum = checksumAlgorithm.hash(emptyZipFile).hexadecimalRepresentation
@@ -1321,9 +1334,9 @@ final class RegistryClientTests: XCTestCase {
     func testDownloadSourceArchive_ServerError() throws {
         let registryURL = "https://packages.example.com"
         let identity = PackageIdentity.plain("mona.LinkedList")
-        let (scope, name) = identity.scopeAndName!
         let version = Version("1.1.1")
-        let downloadURL = URL(string: "\(registryURL)/\(scope)/\(name)/\(version).zip")!
+        let downloadURL =
+            URL(string: "\(registryURL)/\(identity.registry!.scope)/\(identity.registry!.name)/\(version).zip")!
 
         let checksumAlgorithm: HashAlgorithm = SHA256()
         let checksum = checksumAlgorithm.hash(emptyZipFile).hexadecimalRepresentation
@@ -1728,11 +1741,14 @@ final class RegistryClientTests: XCTestCase {
     func testGetRegistryPublishSync() throws {
         let registryURL = URL(string: "https://packages.example.com")!
         let identity = PackageIdentity.plain("mona.LinkedList")
-        let (scope, name) = identity.scopeAndName!
         let version = Version("1.1.1")
-        let publishURL = URL(string: "\(registryURL)/\(scope)/\(name)/\(version)")!
+        let publishURL =
+            URL(string: "\(registryURL)/\(identity.registry!.scope)/\(identity.registry!.name)/\(version)")!
 
-        let expectedLocation = URL(string: "https://\(registryURL)/packages\(scope)/\(name)/\(version)")!
+        let expectedLocation =
+            URL(
+                string: "https://\(registryURL)/packages\(identity.registry!.scope)/\(identity.registry!.name)/\(version)"
+            )!
 
         let archiveContent = UUID().uuidString
         let metadataContent = UUID().uuidString
@@ -1760,7 +1776,7 @@ final class RegistryClientTests: XCTestCase {
             }
         }
 
-        try withTemporaryDirectory() { temporaryDirectory in
+        try withTemporaryDirectory { temporaryDirectory in
             let archivePath = temporaryDirectory.appending(component: "\(identity)-\(version).zip")
             try localFileSystem.writeFileContents(archivePath, string: archiveContent)
 
@@ -1792,11 +1808,14 @@ final class RegistryClientTests: XCTestCase {
     func testGetRegistryPublishAsync() throws {
         let registryURL = URL(string: "https://packages.example.com")!
         let identity = PackageIdentity.plain("mona.LinkedList")
-        let (scope, name) = identity.scopeAndName!
         let version = Version("1.1.1")
-        let publishURL = URL(string: "\(registryURL)/\(scope)/\(name)/\(version)")!
+        let publishURL =
+            URL(string: "\(registryURL)/\(identity.registry!.scope)/\(identity.registry!.name)/\(version)")!
 
-        let expectedLocation = URL(string: "https://\(registryURL)/status\(scope)/\(name)/\(version)")!
+        let expectedLocation =
+            URL(
+                string: "https://\(registryURL)/status\(identity.registry!.scope)/\(identity.registry!.name)/\(version)"
+            )!
         let expectedRetry = Int.random(in: 10 ..< 100)
 
         let archiveContent = UUID().uuidString
@@ -1826,7 +1845,7 @@ final class RegistryClientTests: XCTestCase {
             }
         }
 
-        try withTemporaryDirectory() { temporaryDirectory in
+        try withTemporaryDirectory { temporaryDirectory in
             let archivePath = temporaryDirectory.appending(component: "\(identity)-\(version).zip")
             try localFileSystem.writeFileContents(archivePath, string: archiveContent)
 
@@ -1858,9 +1877,9 @@ final class RegistryClientTests: XCTestCase {
     func testGetRegistryPublish_ServerError() throws {
         let registryURL = URL(string: "https://packages.example.com")!
         let identity = PackageIdentity.plain("mona.LinkedList")
-        let (scope, name) = identity.scopeAndName!
         let version = Version("1.1.1")
-        let publishURL = URL(string: "\(registryURL)/\(scope)/\(name)/\(version)")!
+        let publishURL =
+            URL(string: "\(registryURL)/\(identity.registry!.scope)/\(identity.registry!.name)/\(version)")!
 
         let serverErrorHandler = ServerErrorHandler(
             method: .put,
@@ -1869,7 +1888,7 @@ final class RegistryClientTests: XCTestCase {
             errorDescription: UUID().uuidString
         )
 
-        try withTemporaryDirectory() { temporaryDirectory in
+        try withTemporaryDirectory { temporaryDirectory in
             let archivePath = temporaryDirectory.appending(component: "\(identity)-\(version).zip")
             try localFileSystem.writeFileContents(archivePath, bytes: [])
 
@@ -1896,7 +1915,10 @@ final class RegistryClientTests: XCTestCase {
                 guard case RegistryError
                     .failedPublishing(
                         RegistryError
-                            .serverError(code: serverErrorHandler.errorCode, details: serverErrorHandler.errorDescription)
+                            .serverError(
+                                code: serverErrorHandler.errorCode,
+                                details: serverErrorHandler.errorDescription
+                            )
                     ) = error
                 else {
                     return XCTFail("unexpected error \(error)")
@@ -1910,13 +1932,13 @@ final class RegistryClientTests: XCTestCase {
         let identity = PackageIdentity.plain("mona.LinkedList")
         let version = Version("1.1.1")
 
-        let handler: LegacyHTTPClient.Handler = { request, _, completion in
+        let handler: LegacyHTTPClient.Handler = { _, _, completion in
             completion(.failure(StringError("should not be called")))
         }
 
-        try withTemporaryDirectory() { temporaryDirectory in
+        try withTemporaryDirectory { temporaryDirectory in
             let archivePath = temporaryDirectory.appending(component: "\(identity)-\(version).zip")
-            //try localFileSystem.writeFileContents(archivePath, bytes: [])
+            // try localFileSystem.writeFileContents(archivePath, bytes: [])
 
             let metadataPath = temporaryDirectory.appending(component: "\(identity)-\(version)-metadata.json")
 
@@ -1949,11 +1971,11 @@ final class RegistryClientTests: XCTestCase {
         let identity = PackageIdentity.plain("mona.LinkedList")
         let version = Version("1.1.1")
 
-        let handler: LegacyHTTPClient.Handler = { request, _, completion in
+        let handler: LegacyHTTPClient.Handler = { _, _, completion in
             completion(.failure(StringError("should not be called")))
         }
 
-        try withTemporaryDirectory() { temporaryDirectory in
+        try withTemporaryDirectory { temporaryDirectory in
             let archivePath = temporaryDirectory.appending(component: "\(identity)-\(version).zip")
             try localFileSystem.writeFileContents(archivePath, bytes: [])
 
@@ -1997,7 +2019,7 @@ extension RegistryClient {
             )
         }
     }
-    
+
     fileprivate func getPackageVersionMetadata(
         package: PackageIdentity,
         version: Version

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -12769,7 +12769,7 @@ final class WorkspaceTests: XCTestCase {
         let jsonEncoder = JSONEncoder.makeWithDefaults()
 
         guard let (packageScope, packageName) = packageIdentity.scopeAndName else {
-            throw StringError("Invalid package identity")
+            throw StringError("Invalid package identifier: '\(packageIdentity)'")
         }
 
         var configuration = configuration


### PR DESCRIPTION
motivation: make code easier to reason about

changes:
* deprecate scopeAndName accessor in favour of .registry one
* define RegistryIdentity struct to encapsulate such identity
* update call sites and tests
