### PR TITLE
DNM: On ELF platforms, look for the runtime libraries in an architecture-specific directory.

### DIFF
--- a/Sources/Commands/Utilities/TestingSupport.swift
+++ b/Sources/Commands/Utilities/TestingSupport.swift
@@ -134,9 +134,10 @@ enum TestingSupport {
             env.prependPath("Path", value: location.pathString)
         }
         #elseif os(Linux)
-        var libraryPaths = ["/usr/lib/swift/linux"]
+        let arch = buildParameters.triple.arch.rawValue
+        var libraryPaths = ["/usr/lib/swift/linux/\(arch)"]
         if let path = env["PATH"], let firstPathEntry = path.components(separatedBy: ":").first {
-            libraryPaths.append("\(firstPathEntry)/../lib/swift/linux")
+            libraryPaths.append("\(firstPathEntry)/../lib/swift/linux/\(arch)")
         }
         if let originalLibraryPaths = env["LD_LIBRARY_PATH"] {
             libraryPaths.append(originalLibraryPaths)

--- a/Tests/PackageModelTests/DestinationTests.swift
+++ b/Tests/PackageModelTests/DestinationTests.swift
@@ -27,7 +27,7 @@ private let extraFlags = BuildFlags(
     cCompilerFlags: ["-fintegrated-as"],
     cxxCompilerFlags: ["-fno-exceptions"],
     swiftCompilerFlags: ["-enable-experimental-cxx-interop", "-use-ld=lld"],
-    linkerFlags: ["-R/usr/lib/swift/linux/"]
+    linkerFlags: ["-R/usr/lib/swift/linux/x86_64"]
 )
 
 private let destinationV1JSON =

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -784,7 +784,7 @@ def get_swiftpm_flags(args):
 
     platform_path = None
     for path in args.target_info["paths"]["runtimeLibraryPaths"]:
-        platform_path = re.search(r"(lib/swift/([^/]+))$", path)
+        platform_path = re.search(r"(lib/swift/([\w/]+))$", path)
         if platform_path:
             build_flags.extend(
                 [


### PR DESCRIPTION
This is needed for apple/swift#63782, which changes the Unix toolchain to look for libraries in architecture-specific directories.