### PR TITLE
Fix path to registries configuration file in gitignore

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -265,7 +265,7 @@ public final class InitPackage {
                 /Packages
                 xcuserdata/
                 DerivedData/
-                .swiftpm/config/registries.json
+                .swiftpm/configuration/registries.json
                 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
                 .netrc
 


### PR DESCRIPTION
Update the path to the registries configuration file in the provided `.gitiginore` that is created when a new package is initialized via `swift package init`.

### Motivation:

Running `swift package init` then `swift package-registry set ...` might cause the `registries.json` file to be checked into the repository since the ignored path is wrong.

### Modifications:

Update the `swift package init` command to generate a file with the proper path to the `registries.json` file.

### Result:

Changes in the generated .gitignore file.
