### PR TITLE
Add PackageSigningEntityStorage

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -294,6 +294,7 @@ let package = Package(
             name: "PackageSigning",
             dependencies: [
                 "Basics",
+                "PackageModel",
             ]
         ),
 

--- a/Sources/PackageSigning/SigningEntity/FilePackageSigningEntityStorage.swift
+++ b/Sources/PackageSigning/SigningEntity/FilePackageSigningEntityStorage.swift
@@ -1,0 +1,174 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import Dispatch
+import Foundation
+import PackageModel
+import TSCBasic
+
+import struct TSCUtility.Version
+
+public struct FilePackageSigningEntityStorage: PackageSigningEntityStorage {
+    let fileSystem: FileSystem
+    let directoryPath: AbsolutePath
+
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    public init(fileSystem: FileSystem, directoryPath: AbsolutePath) {
+        self.fileSystem = fileSystem
+        self.directoryPath = directoryPath
+
+        self.encoder = JSONEncoder.makeWithDefaults()
+        self.decoder = JSONDecoder.makeWithDefaults()
+    }
+
+    public func get(
+        package: PackageIdentity,
+        observabilityScope: ObservabilityScope,
+        callbackQueue: DispatchQueue,
+        callback: @escaping (Result<[SigningEntity: Set<Version>], Error>) -> Void
+    ) {
+        let callback = self.makeAsync(callback, on: callbackQueue)
+
+        do {
+            let signedVersions = try self.withLock {
+                try self.loadFromDisk(package: package)
+            }
+            callback(.success(signedVersions))
+        } catch {
+            callback(.failure(error))
+        }
+    }
+
+    public func put(
+        package: PackageIdentity,
+        version: Version,
+        signingEntity: SigningEntity,
+        observabilityScope: ObservabilityScope,
+        callbackQueue: DispatchQueue,
+        callback: @escaping (Result<Void, Error>) -> Void
+    ) {
+        let callback = self.makeAsync(callback, on: callbackQueue)
+
+        do {
+            try self.withLock {
+                var signedVersions = try self.loadFromDisk(package: package)
+
+                if let existing = signedVersions.signingEntity(of: version) {
+                    // Error if we try to write a different signing entity for a version
+                    guard signingEntity == existing else {
+                        throw PackageSigningEntityStorageError.conflict(
+                            package: package,
+                            version: version,
+                            given: signingEntity,
+                            existing: existing
+                        )
+                    }
+                    // Don't need to do anything if signing entities are the same
+                    return
+                }
+
+                var versions = signedVersions.removeValue(forKey: signingEntity) ?? []
+                versions.insert(version)
+                signedVersions[signingEntity] = versions
+
+                try self.saveToDisk(package: package, signedVersions: signedVersions)
+            }
+            callback(.success(()))
+        } catch {
+            callback(.failure(error))
+        }
+    }
+
+    private func loadFromDisk(package: PackageIdentity) throws -> [SigningEntity: Set<Version>] {
+        let path = self.directoryPath.appending(component: package.signedVersionsFilename)
+
+        guard self.fileSystem.exists(path) else {
+            return [:]
+        }
+
+        let data: Data = try fileSystem.readFileContents(path)
+        guard data.count > 0 else {
+            return [:]
+        }
+
+        let container = try self.decoder.decode(StorageModel.Container.self, from: data)
+        return try container.signedVersionsByEntity()
+    }
+
+    private func saveToDisk(package: PackageIdentity, signedVersions: [SigningEntity: Set<Version>]) throws {
+        if !self.fileSystem.exists(self.directoryPath) {
+            try self.fileSystem.createDirectory(self.directoryPath, recursive: true)
+        }
+
+        let container = try StorageModel.Container(signedVersions)
+        let buffer = try encoder.encode(container)
+
+        let path = self.directoryPath.appending(component: package.signedVersionsFilename)
+        try self.fileSystem.writeFileContents(path, bytes: ByteString(buffer))
+    }
+
+    private func withLock<T>(_ body: () throws -> T) throws -> T {
+        if !self.fileSystem.exists(self.directoryPath) {
+            try self.fileSystem.createDirectory(self.directoryPath, recursive: true)
+        }
+        return try self.fileSystem.withLock(on: self.directoryPath, type: .exclusive, body)
+    }
+
+    private func makeAsync<T>(
+        _ closure: @escaping (Result<T, Error>) -> Void,
+        on queue: DispatchQueue
+    ) -> (Result<T, Error>) -> Void {
+        { result in queue.async { closure(result) } }
+    }
+}
+
+private enum StorageModel {
+    struct Container: Codable {
+        let signedVersions: [SignedVersions]
+
+        init(_ signedVersionsByEntity: [SigningEntity: Set<Version>]) throws {
+            self.signedVersions = signedVersionsByEntity
+                .map { SignedVersions(signingEntity: $0.key, versions: $0.value) }
+        }
+
+        func signedVersionsByEntity() throws -> [SigningEntity: Set<Version>] {
+            try Dictionary(throwingUniqueKeysWithValues: self.signedVersions.map {
+                ($0.signingEntity, $0.versions)
+            })
+        }
+    }
+
+    struct SignedVersions: Codable {
+        let signingEntity: SigningEntity
+        let versions: Set<Version>
+    }
+}
+
+extension PackageIdentity {
+    var signedVersionsFilename: String {
+        "\(self.description).json"
+    }
+}
+
+extension Dictionary where Key == SigningEntity, Value == Set<Version> {
+    fileprivate func signingEntity(of version: Version) -> SigningEntity? {
+        for (signingEntity, versions) in self {
+            if versions.contains(version) {
+                return signingEntity
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/PackageSigning/SigningEntity/PackageSigningEntityStorage.swift
+++ b/Sources/PackageSigning/SigningEntity/PackageSigningEntityStorage.swift
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import Dispatch
+import PackageModel
+
+import struct TSCUtility.Version
+
+public protocol PackageSigningEntityStorage {
+    /// For a given package, return the signing entities and the package versions that each of them signed.
+    func get(
+        package: PackageIdentity,
+        observabilityScope: ObservabilityScope,
+        callbackQueue: DispatchQueue,
+        callback: @escaping (Result<[SigningEntity: Set<Version>], Error>) -> Void
+    )
+
+    /// Record signing entity for a given package version.
+    func put(
+        package: PackageIdentity,
+        version: Version,
+        signingEntity: SigningEntity,
+        observabilityScope: ObservabilityScope,
+        callbackQueue: DispatchQueue,
+        callback: @escaping (Result<Void, Error>) -> Void
+    )
+}
+
+public enum PackageSigningEntityStorageError: Error, Equatable, CustomStringConvertible {
+    case conflict(package: PackageIdentity, version: Version, given: SigningEntity, existing: SigningEntity)
+
+    public var description: String {
+        switch self {
+        case .conflict(let package, let version, let given, let existing):
+            return "\(package)@\(version) was previously signed by \(existing), which is different from \(given)."
+        }
+    }
+}

--- a/Sources/PackageSigning/SigningEntity/SigningEntity.swift
+++ b/Sources/PackageSigning/SigningEntity/SigningEntity.swift
@@ -18,7 +18,7 @@ import Security
 
 // MARK: - SigningEntity is the entity that generated the signature
 
-public struct SigningEntity {
+public struct SigningEntity: Hashable, Codable, CustomStringConvertible {
     public let type: SigningEntityType?
     public let name: String?
     public let organizationalUnit: String?
@@ -26,6 +26,18 @@ public struct SigningEntity {
 
     public var isRecognized: Bool {
         self.type != nil
+    }
+
+    public init(
+        type: SigningEntityType?,
+        name: String?,
+        organizationalUnit: String?,
+        organization: String?
+    ) {
+        self.type = type
+        self.name = name
+        self.organizationalUnit = organizationalUnit
+        self.organization = organization
     }
 
     public init(of signature: Data, signatureFormat: SignatureFormat) throws {
@@ -62,11 +74,15 @@ public struct SigningEntity {
         // TODO: extract id, name, organization, etc. from cert
         fatalError("TO BE IMPLEMENTED")
     }
+
+    public var description: String {
+        "SigningEntity[type=\(String(describing: self.type)), name=\(String(describing: self.name)), organizationalUnit=\(String(describing: self.organizationalUnit)), organization=\(String(describing: self.organization))]"
+    }
 }
 
 // MARK: - SigningEntity types that SwiftPM recognizes
 
-public enum SigningEntityType {
+public enum SigningEntityType: String, Hashable, Codable {
     case adp // Apple Developer Program
 
     static let oid_adpSwiftPackageMarker = "1.2.840.113635.100.6.1.35"

--- a/Tests/PackageSigningTests/FilePackageSigningEntityStorageTests.swift
+++ b/Tests/PackageSigningTests/FilePackageSigningEntityStorageTests.swift
@@ -1,0 +1,109 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import PackageModel
+@testable import PackageSigning
+import SPMTestSupport
+import TSCBasic
+import XCTest
+
+import struct TSCUtility.Version
+
+final class FilePackageSigningEntityStorageTests: XCTestCase {
+    func testHappyCase() throws {
+        let mockFileSystem = InMemoryFileSystem()
+        let directoryPath = AbsolutePath(path: "/signing")
+        let storage = FilePackageSigningEntityStorage(fileSystem: mockFileSystem, directoryPath: directoryPath)
+
+        // Record signing entities for mona.LinkedList
+        let package = PackageIdentity.plain("mona.LinkedList")
+        let appleseed = SigningEntity(type: nil, name: "J. Appleseed", organizationalUnit: nil, organization: nil)
+        let davinci = SigningEntity(type: nil, name: "L. da Vinci", organizationalUnit: nil, organization: nil)
+        try storage.put(package: package, version: Version("1.0.0"), signingEntity: davinci)
+        try storage.put(package: package, version: Version("1.1.0"), signingEntity: davinci)
+        try storage.put(package: package, version: Version("2.0.0"), signingEntity: appleseed)
+        // Record signing entity for another package
+        let otherPackage = PackageIdentity.plain("other.LinkedList")
+        try storage.put(package: otherPackage, version: Version("1.0.0"), signingEntity: appleseed)
+
+        // A data file should have been created for each package
+        XCTAssertTrue(mockFileSystem.exists(storage.directoryPath.appending(component: package.signedVersionsFilename)))
+        XCTAssertTrue(
+            mockFileSystem
+                .exists(storage.directoryPath.appending(component: otherPackage.signedVersionsFilename))
+        )
+
+        // Signed versions should be saved
+        do {
+            let signedVersions = try storage.get(package: package)
+            XCTAssertEqual(signedVersions.count, 2)
+            XCTAssertEqual(signedVersions[davinci], [Version("1.0.0"), Version("1.1.0")])
+            XCTAssertEqual(signedVersions[appleseed], [Version("2.0.0")])
+        }
+
+        do {
+            let signedVersions = try storage.get(package: otherPackage)
+            XCTAssertEqual(signedVersions.count, 1)
+            XCTAssertEqual(signedVersions[appleseed], [Version("1.0.0")])
+        }
+    }
+
+    func testSingleFingerprintPerKind() throws {
+        let mockFileSystem = InMemoryFileSystem()
+        let directoryPath = AbsolutePath(path: "/signing")
+        let storage = FilePackageSigningEntityStorage(fileSystem: mockFileSystem, directoryPath: directoryPath)
+
+        let package = PackageIdentity.plain("mona.LinkedList")
+        let appleseed = SigningEntity(type: nil, name: "J. Appleseed", organizationalUnit: nil, organization: nil)
+        let davinci = SigningEntity(type: nil, name: "L. da Vinci", organizationalUnit: nil, organization: nil)
+        let version = Version("1.0.0")
+        try storage.put(package: package, version: version, signingEntity: davinci)
+
+        // Writing different signing entities for the same version should fail
+        XCTAssertThrowsError(try storage.put(package: package, version: version, signingEntity: appleseed)) { error in
+            guard case PackageSigningEntityStorageError.conflict = error else {
+                return XCTFail("Expected PackageSigningEntityStorageError.conflict, got \(error)")
+            }
+        }
+    }
+}
+
+extension PackageSigningEntityStorage {
+    fileprivate func get(package: PackageIdentity) throws -> [SigningEntity: Set<Version>] {
+        try tsc_await {
+            self.get(
+                package: package,
+                observabilityScope: ObservabilitySystem.NOOP,
+                callbackQueue: .sharedConcurrent,
+                callback: $0
+            )
+        }
+    }
+
+    fileprivate func put(
+        package: PackageIdentity,
+        version: Version,
+        signingEntity: SigningEntity
+    ) throws {
+        try tsc_await {
+            self.put(
+                package: package,
+                version: version,
+                signingEntity: signingEntity,
+                observabilityScope: ObservabilitySystem.NOOP,
+                callbackQueue: .sharedConcurrent,
+                callback: $0
+            )
+        }
+    }
+}


### PR DESCRIPTION
Motivation:
A signing entity is one that signs a package. Per the [proposal](https://github.com/apple/swift-evolution/pull/1925), SwiftPM can perform additional TOFU to ensure different versions of a package are signed by the same entity. `PackageSigningEntityStorage` will be used to store data for this purpose.
