### PR TITLE
Remove re-export of `Version` from `PackageModel`

### DIFF
--- a/Sources/PackageModel/Manifest/Manifest.swift
+++ b/Sources/PackageModel/Manifest/Manifest.swift
@@ -14,6 +14,8 @@ import Basics
 import TSCBasic
 import Foundation
 
+import struct TSCUtility.Version
+
 /// This contains the declarative specification loaded from package manifest
 /// files, and the tools for working with the manifest.
 public final class Manifest: Sendable {

--- a/Sources/PackageModel/Manifest/PackageDependencyDescription.swift
+++ b/Sources/PackageModel/Manifest/PackageDependencyDescription.swift
@@ -14,6 +14,8 @@ import Foundation
 import Basics
 import TSCBasic
 
+import struct TSCUtility.Version
+
 /// Represents a package dependency.
 public enum PackageDependency: Equatable, Hashable, Sendable {
     case fileSystem(FileSystem)

--- a/Sources/PackageModel/PackageModel.swift
+++ b/Sources/PackageModel/PackageModel.swift
@@ -13,8 +13,7 @@
 import Basics
 import struct Foundation.URL
 import TSCBasic
-// Re-export Version from PackageModel, since it is a key part of the model.
-@_exported import struct TSCUtility.Version
+import struct TSCUtility.Version
 
 import enum TSCUtility.PackageLocation
 import struct TSCUtility.PolymorphicCodableArray

--- a/Sources/PackageModel/Platform.swift
+++ b/Sources/PackageModel/Platform.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import struct TSCUtility.Version
+
 /// Represents a platform.
 public struct Platform: Equatable, Hashable, Codable {
     /// The name of the platform.

--- a/Sources/PackageModel/SwiftLanguageVersion.swift
+++ b/Sources/PackageModel/SwiftLanguageVersion.swift
@@ -14,6 +14,8 @@ import TSCBasic
 
 import Foundation
 
+import struct TSCUtility.Version
+
 /// Represents a Swift language version.
 public struct SwiftLanguageVersion: Sendable {
 

--- a/Sources/PackageModel/ToolsVersion.swift
+++ b/Sources/PackageModel/ToolsVersion.swift
@@ -14,6 +14,8 @@ import Basics
 import Foundation
 import TSCBasic
 
+import struct TSCUtility.Version
+
 /// Tools version represents version of the Swift toolchain.
 public struct ToolsVersion: Equatable, Hashable, Codable, Sendable {
 


### PR DESCRIPTION
This doesn't seem to be working well (anymore?), so we should get rid of it to avoid flakiness.

Long term we may want to move the `Version` type to `PackageModel` directly or possibly to `Basics`. We also have a duplicate of it in `PackageDescription`.
