### PR TITLE
CrossCompilationDestinationsTool: fix `install` command help formatting

### DIFF
--- a/Sources/CrossCompilationDestinationsTool/InstallDestination.swift
+++ b/Sources/CrossCompilationDestinationsTool/InstallDestination.swift
@@ -25,7 +25,7 @@ public struct InstallDestination: ParsableCommand {
     public static let configuration = CommandConfiguration(
         commandName: "install",
         abstract: """
-        Installs a given destination artifact bundle to a location discoverable by SwiftPM. If the artifact bundle
+        Installs a given destination artifact bundle to a location discoverable by SwiftPM. If the artifact bundle \
         is at a remote location, it's downloaded to local filesystem first.
         """
     )


### PR DESCRIPTION
Currently, `swift experimental-destination help` produces output that's split into multiple lines at a wrong column:

```
  install                 Installs a given destination artifact bundle to a location discoverable by SwiftPM. If the
                          artifact bundle
                          is at a remote location, it's downloaded to local filesystem first.
```

By adding a backslash to the help multi-line string we leave the job of splitting this into multiple lines to the terminal renderer.