### PR TITLE
Remove library evolution hacks from CMake build

### DIFF
--- a/Sources/CompilerPluginSupport/CMakeLists.txt
+++ b/Sources/CompilerPluginSupport/CMakeLists.txt
@@ -13,13 +13,8 @@ target_link_libraries(CompilerPluginSupport PRIVATE
 
 target_compile_options(CompilerPluginSupport PUBLIC
   $<$<COMPILE_LANGUAGE:Swift>:-package-description-version$<SEMICOLON>999.0>)
-target_compile_options(CompilerPluginSupport PUBLIC
-  $<$<COMPILE_LANGUAGE:Swift>:-enable-library-evolution>)
 
 if(CMAKE_HOST_SYSTEM_NAME STREQUAL Darwin)
-  set(SWIFT_INTERFACE_PATH ${CMAKE_BINARY_DIR}/pm/ManifestAPI/CompilerPluginSupport.swiftinterface)
-  target_compile_options(CompilerPluginSupport PUBLIC
-    $<$<COMPILE_LANGUAGE:Swift>:-emit-module-interface-path$<SEMICOLON>${SWIFT_INTERFACE_PATH}>)
   target_link_options(CompilerPluginSupport PRIVATE
     "SHELL:-Xlinker -install_name -Xlinker @rpath/CompilerPluginSupport.dylib")
 endif()
@@ -45,19 +40,11 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
     INSTALL_RPATH "$ORIGIN/../../$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>")
 endif()
 
-if(CMAKE_HOST_SYSTEM_NAME STREQUAL Darwin)
-  install(FILES
-    ${CMAKE_BINARY_DIR}/pm/ManifestAPI/CompilerPluginSupport.swiftinterface
-    ${CMAKE_BINARY_DIR}/pm/ManifestAPI/CompilerPluginSupport.swiftdoc
-    DESTINATION lib/swift/pm/ManifestAPI
-  )
-else()
-  install(FILES
-    ${CMAKE_BINARY_DIR}/pm/ManifestAPI/CompilerPluginSupport.swiftmodule
-    ${CMAKE_BINARY_DIR}/pm/ManifestAPI/CompilerPluginSupport.swiftdoc
-    DESTINATION lib/swift/pm/ManifestAPI
-  )
-endif()
+install(FILES
+  ${CMAKE_BINARY_DIR}/pm/ManifestAPI/CompilerPluginSupport.swiftmodule
+  ${CMAKE_BINARY_DIR}/pm/ManifestAPI/CompilerPluginSupport.swiftdoc
+  DESTINATION lib/swift/pm/ManifestAPI
+)
 
 install(TARGETS CompilerPluginSupport
   DESTINATION lib/swift/pm/ManifestAPI)

--- a/Sources/PackageDescription/CMakeLists.txt
+++ b/Sources/PackageDescription/CMakeLists.txt
@@ -25,13 +25,8 @@ add_library(PackageDescription
 
 target_compile_options(PackageDescription PUBLIC
   $<$<COMPILE_LANGUAGE:Swift>:-package-description-version$<SEMICOLON>999.0>)
-target_compile_options(PackageDescription PUBLIC
-  $<$<COMPILE_LANGUAGE:Swift>:-enable-library-evolution>)
 
 if(CMAKE_HOST_SYSTEM_NAME STREQUAL Darwin)
-  set(SWIFT_INTERFACE_PATH ${CMAKE_BINARY_DIR}/pm/ManifestAPI/PackageDescription.swiftinterface)
-  target_compile_options(PackageDescription PUBLIC
-    $<$<COMPILE_LANGUAGE:Swift>:-emit-module-interface-path$<SEMICOLON>${SWIFT_INTERFACE_PATH}>)
   target_link_options(PackageDescription PRIVATE
     "SHELL:-Xlinker -install_name -Xlinker @rpath/libPackageDescription.dylib")
 endif()
@@ -57,19 +52,11 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
     INSTALL_RPATH "$ORIGIN/../../$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>")
 endif()
 
-if(CMAKE_HOST_SYSTEM_NAME STREQUAL Darwin)
-  install(FILES
-    ${CMAKE_BINARY_DIR}/pm/ManifestAPI/PackageDescription.swiftinterface
-    ${CMAKE_BINARY_DIR}/pm/ManifestAPI/PackageDescription.swiftdoc
-    DESTINATION lib/swift/pm/ManifestAPI
-  )
-else()
-  install(FILES
-    ${CMAKE_BINARY_DIR}/pm/ManifestAPI/PackageDescription.swiftmodule
-    ${CMAKE_BINARY_DIR}/pm/ManifestAPI/PackageDescription.swiftdoc
-    DESTINATION lib/swift/pm/ManifestAPI
-  )
-endif()
+install(FILES
+  ${CMAKE_BINARY_DIR}/pm/ManifestAPI/PackageDescription.swiftmodule
+  ${CMAKE_BINARY_DIR}/pm/ManifestAPI/PackageDescription.swiftdoc
+  DESTINATION lib/swift/pm/ManifestAPI
+)
 
 install(TARGETS PackageDescription
   DESTINATION lib/swift/pm/ManifestAPI)

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -520,7 +520,6 @@ def build_with_cmake(args, cmake_args, ninja_args, source_path, build_dir, cmake
 
     if platform.system() == 'Darwin':
         call(["sed", "-i", "", "s/macosx10.10/macosx%s/" % (g_macos_deployment_target), "build.ninja"], cwd=build_dir)
-        call(["sed", "-i", "", "s/CompilerPluginSupport.swiftinterface .*pm\/ManifestAPI\/PackageDescription.swiftinterface/CompilerPluginSupport.swiftinterface/", "build.ninja"], cwd=build_dir)
 
     call(ninja_cmd + ninja_args, cwd=build_dir, verbose=args.verbose)
 


### PR DESCRIPTION
We were only doing these for macOS anyway where we throw away the produced content after the build, so there's no reason to do this.
