### PR TITLE
Fix `InstallDestination.run` function not invoked by ArgumentParser

### DIFF
--- a/Sources/CoreCommands/SwiftToolObservabilityHandler.swift
+++ b/Sources/CoreCommands/SwiftToolObservabilityHandler.swift
@@ -199,6 +199,6 @@ extension ObservabilitySystem {
         outputStream: OutputByteStream = stdoutStream,
         logLevel: Basics.Diagnostic.Severity = .warning
     ) -> ObservabilitySystem {
-        .init(SwiftToolObservabilityHandler(outputStream: stdoutStream, logLevel: .warning))
+        .init(SwiftToolObservabilityHandler(outputStream: stdoutStream, logLevel: logLevel))
     }
 }

--- a/Sources/CrossCompilationDestinationsTool/InstallDestination.swift
+++ b/Sources/CrossCompilationDestinationsTool/InstallDestination.swift
@@ -55,7 +55,7 @@ public struct InstallDestination: ParsableCommand {
             destinationsDirectory = try fileSystem.getOrCreateSwiftPMCrossCompilationDestinationsDirectory()
         }
 
-        let observabilitySystem = ObservabilitySystem.swiftTool(logLevel: .info)
+        let observabilitySystem = ObservabilitySystem.swiftTool()
         let observabilityScope = observabilitySystem.topScope
 
         if
@@ -65,7 +65,12 @@ public struct InstallDestination: ParsableCommand {
         {
             let response = try tsc_await { (completion: @escaping (Result<HTTPClientResponse, Error>) -> Void) in
                 let client = LegacyHTTPClient()
-                client.execute(.init(method: .get, url: bundleURL), progress: nil, completion: completion)
+                client.execute(
+                    .init(method: .get, url: bundleURL),
+                    observabilityScope: observabilityScope,
+                    progress: nil,
+                    completion: completion
+                )
             }
 
             guard let body = response.body else {
@@ -91,6 +96,6 @@ public struct InstallDestination: ParsableCommand {
             throw StringError("Argument `\(bundlePathOrURL)` is neither a valid filesystem path nor a URL.")
         }
 
-        observabilityScope.emit(info: "Destination artifact bundle at `\(bundlePathOrURL)` successfully installed.")
+        print("Destination artifact bundle at `\(bundlePathOrURL)` successfully installed.")
     }
 }

--- a/Sources/CrossCompilationDestinationsTool/InstallDestination.swift
+++ b/Sources/CrossCompilationDestinationsTool/InstallDestination.swift
@@ -38,7 +38,7 @@ public struct InstallDestination: ParsableCommand {
 
     public init() {}
 
-    public func run() async throws {
+    public func run() throws {
         let fileSystem = localFileSystem
 
         guard var destinationsDirectory = try fileSystem.getSharedCrossCompilationDestinationsDirectory(
@@ -46,7 +46,7 @@ public struct InstallDestination: ParsableCommand {
         ) else {
             let expectedPath = try fileSystem.swiftPMCrossCompilationDestinationsDirectory
             throw StringError(
-                "Couldn't find or create a directory where cross-compilation destinations are stored: \(expectedPath)"
+                "Couldn't find or create a directory where cross-compilation destinations are stored: `\(expectedPath)`"
             )
         }
 
@@ -55,7 +55,7 @@ public struct InstallDestination: ParsableCommand {
             destinationsDirectory = try fileSystem.getOrCreateSwiftPMCrossCompilationDestinationsDirectory()
         }
 
-        let observabilitySystem = ObservabilitySystem.swiftTool()
+        let observabilitySystem = ObservabilitySystem.swiftTool(logLevel: .info)
         let observabilityScope = observabilitySystem.topScope
 
         if
@@ -69,7 +69,7 @@ public struct InstallDestination: ParsableCommand {
             }
 
             guard let body = response.body else {
-                throw StringError("No downloadable data available at URL \(bundleURL).")
+                throw StringError("No downloadable data available at URL `\(bundleURL)`.")
             }
 
             let fileName = bundleURL.lastPathComponent
@@ -83,14 +83,14 @@ public struct InstallDestination: ParsableCommand {
         {
             let destinationPath = destinationsDirectory.appending(component: bundleName)
             if fileSystem.exists(destinationPath) {
-                throw StringError("Destination artifact bundle with name \(bundleName) is already installed.")
+                throw StringError("Destination artifact bundle with name `\(bundleName)` is already installed.")
             } else {
                 try fileSystem.copy(from: bundlePath, to: destinationPath)
             }
         } else {
-            throw StringError("Argument \(bundlePathOrURL) is neither a valid filesystem path nor a URL.")
+            throw StringError("Argument `\(bundlePathOrURL)` is neither a valid filesystem path nor a URL.")
         }
 
-        observabilityScope.emit(info: "Destination artifact bundle at \(bundlePathOrURL) successfully installed.")
+        observabilityScope.emit(info: "Destination artifact bundle at `\(bundlePathOrURL)` successfully installed.")
     }
 }


### PR DESCRIPTION
This type uses `ParsableCommand`, not `AsyncParsableCommand`, while the `run` function itself was marked as `async`. Because of this the default implementation of `run` was always called, printing the help description even when correct arguments were passed. Removing the `async` effect from the function fixes the issue, since the function doesn't use `await` in its body anyway (due to unrelated reasons).

Also added quotes around URLs and paths in logging output so that it's easier to parse them visually, especially when those contain spaces.
