### PR TITLE
Display titles of option groups in `swift build --help`

### DIFF
--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -95,10 +95,10 @@ public struct SwiftBuildTool: SwiftCommand {
         version: SwiftVersion.current.completeDisplayString,
         helpNames: [.short, .long, .customLong("help", withSingleDash: true)])
 
-    @OptionGroup()
+    @OptionGroup(title: "Global options")
     public var globalOptions: GlobalOptions
 
-    @OptionGroup()
+    @OptionGroup(title: "Build options")
     var options: BuildToolOptions
 
     public func run(_ swiftTool: SwiftTool) throws {


### PR DESCRIPTION
Recent versions of ArgumentParser support visual grouping of options specified with `@OptionGroup` property wrapper when `title` argument is provided. Let's do it for `swift build` to make its `--help` output cleaner.

Help output before:

```
OVERVIEW: Build sources into binary products

SEE ALSO: swift run, swift package, swift test

USAGE: swift build <options>

OPTIONS:
  --package-path <package-path>
                          Specify the package path to operate on (default current directory). This changes the
                          working directory before any other operation
<multiple ungrouped options skipped>
```

Help output after:

```
OVERVIEW: Build sources into binary products

SEE ALSO: swift run, swift package, swift test

USAGE: swift build <options>

GLOBAL OPTIONS:
  --package-path <package-path>
                          Specify the package path to operate on (default current directory). This changes the
                          working directory before any other operation
<multiple global options skipped>

BUILD OPTIONS:
  --build-tests           Build both source and test targets
  --show-bin-path         Print the binary output path
  --print-manifest-job-graph
                          Write the command graph for the build manifest as a graphviz file
  --target <target>       Build the specified target
  --product <product>     Build the specified product

OPTIONS:
  --version               Show the version.
  -h, -help, --help       Show help information.
```