### PR TITLE
PackageModel: fix error reporting for invalid toolsets

### DIFF
--- a/Sources/PackageModel/Destination.swift
+++ b/Sources/PackageModel/Destination.swift
@@ -338,7 +338,7 @@ extension Destination {
                 decoder: decoder,
                 observabilityScope: observabilityScope
             )
-        } catch {
+        } catch DecodingError.keyNotFound {
             let version = try decoder.decode(path: path, fileSystem: fileSystem, as: VersionInfo.self)
             return try [Destination(legacy: version, fromFile: path, fileSystem: fileSystem, decoder: decoder)]
         }
@@ -441,16 +441,14 @@ private struct VersionInfo: Codable {
 private struct SemanticVersionInfo: Decodable {
     let schemaVersion: Version
 
-    enum CodingKeys: CodingKey {
+    enum CodingKeys: String, CodingKey {
         case schemaVersion
     }
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.schemaVersion = try Version(
-            versionString: container.decode(String.self, forKey: .schemaVersion),
-            usesLenientParsing: true
-        )
+        let versionString = try container.decode(String.self, forKey: .schemaVersion)
+        self.schemaVersion = try Version(versionString: versionString, usesLenientParsing: true)
     }
 }
 

--- a/Sources/PackageModel/Toolset.swift
+++ b/Sources/PackageModel/Toolset.swift
@@ -69,10 +69,18 @@ extension Toolset {
         _ observabilityScope: ObservabilityScope
     ) throws {
         let decoder = JSONDecoder()
-        let decoded = try decoder.decode(path: toolsetPath, fileSystem: fileSystem, as: DecodedToolset.self)
+
+        let decoded: DecodedToolset
+        do {
+            decoded = try decoder.decode(path: toolsetPath, fileSystem: fileSystem, as: DecodedToolset.self)
+        } catch {
+            // Throw a more detailed warning that includes the location of the toolset file we couldn't parse.
+            throw StringError("Couldn't parse toolset configuration at `\(toolsetPath)`: \(error)")
+        }
+
         guard decoded.schemaVersion == Version(1, 0, 0) else {
             throw StringError(
-                "Unsupported `schemaVersion` \(decoded.schemaVersion) in toolset configuration at \(toolsetPath)"
+                "Unsupported `schemaVersion` \(decoded.schemaVersion) in toolset configuration at `\(toolsetPath)`"
             )
         }
 

--- a/Tests/PackageModelTests/DestinationTests.swift
+++ b/Tests/PackageModelTests/DestinationTests.swift
@@ -92,8 +92,8 @@ private let toolsetRootDestinationV3 = (
     """#)
 )
 
-private let toolsetInvalidDestinationV3 = (
-    path: try! AbsolutePath(validating: "\(bundleRootPath)/toolsetInvalidDestinationV3.json"),
+private let missingToolsetDestinationV3 = (
+    path: try! AbsolutePath(validating: "\(bundleRootPath)/missingToolsetDestinationV3.json"),
     json: ByteString(encodingAsUTF8: #"""
     {
         "runTimeTriples": {
@@ -107,8 +107,8 @@ private let toolsetInvalidDestinationV3 = (
     """#)
 )
 
-private let versionInvalidDestinationV3 = (
-    path: try! AbsolutePath(validating: "\(bundleRootPath)/versionInvalidDestinationV3.json"),
+private let invalidVersionDestinationV3 = (
+    path: try! AbsolutePath(validating: "\(bundleRootPath)/invalidVersionDestinationV3.json"),
     json: ByteString(encodingAsUTF8: #"""
     {
         "runTimeTriples": {
@@ -118,6 +118,21 @@ private let versionInvalidDestinationV3 = (
             }
         },
         "schemaVersion": "2.9"
+    }
+    """#)
+)
+
+private let invalidToolsetDestinationV3 = (
+    path: try! AbsolutePath(validating: "\(bundleRootPath)/invalidToolsetDestinationV3.json"),
+    json: ByteString(encodingAsUTF8: #"""
+    {
+        "runTimeTriples": {
+            "\#(linuxGNUTargetTriple.tripleString)": {
+                "sdkRootPath": "\#(sdkRootDir)",
+                "toolsetPaths": ["/tools/invalidToolset.json"]
+            }
+        },
+        "schemaVersion": "3.0"
     }
     """#)
 )
@@ -150,6 +165,36 @@ private let someToolsWithRoot = (
         "linker": { "path": "ld" },
         "librarian": { "path": "llvm-ar" },
         "debugger": { "path": "\#(usrBinTools[.debugger]!)" }
+    }
+    """#)
+)
+
+private let invalidToolset = (
+    path: try! AbsolutePath(validating: "/tools/invalidToolset.json"),
+    json: ByteString(encodingAsUTF8: #"""
+    {
+      "rootPath" : "swift.xctoolchain\/usr\/bin",
+      "tools" : [
+        "linker",
+        {
+          "path" : "ld.lld"
+        },
+        "swiftCompiler",
+        {
+          "extraCLIOptions" : [
+            "-use-ld=lld",
+            "-Xlinker",
+            "-R\/usr\/lib\/swift\/linux\/"
+          ]
+        },
+        "cxxCompiler",
+        {
+          "extraCLIOptions" : [
+            "-lstdc++"
+          ]
+        }
+      ],
+      "schemaVersion" : "1.0"
     }
     """#)
 )
@@ -209,10 +254,12 @@ final class DestinationTests: XCTestCase {
             destinationV2,
             toolsetNoRootDestinationV3,
             toolsetRootDestinationV3,
-            toolsetInvalidDestinationV3,
-            versionInvalidDestinationV3,
+            missingToolsetDestinationV3,
+            invalidVersionDestinationV3,
+            invalidToolsetDestinationV3,
             otherToolsNoRoot,
             someToolsWithRoot,
+            invalidToolset,
         ] {
             try fs.writeFileContents(testFile.path, bytes: testFile.json)
         }
@@ -265,15 +312,31 @@ final class DestinationTests: XCTestCase {
         XCTAssertEqual(toolsetRootDestinationV3Decoded, [parsedToolsetRootDestinationV3])
 
         XCTAssertThrowsError(try Destination.decode(
-            fromFile: toolsetInvalidDestinationV3.path,
+            fromFile: missingToolsetDestinationV3.path,
             fileSystem: fs,
             observabilityScope: observability
-        ))
+        )) {
+            XCTAssertEqual(
+                $0 as? StringError,
+                StringError("Couldn't parse toolset configuration at `/tools/asdf.json`: /tools/asdf.json doesn't exist in file system")
+            )
+        }
         XCTAssertThrowsError(try Destination.decode(
-            fromFile: versionInvalidDestinationV3.path,
+            fromFile: invalidVersionDestinationV3.path,
             fileSystem: fs,
             observabilityScope: observability
         ))
+
+        XCTAssertThrowsError(try Destination.decode(
+            fromFile: invalidToolsetDestinationV3.path,
+            fileSystem: fs,
+            observabilityScope: observability
+        )) {
+            XCTAssertEqual(
+                $0 as? StringError,
+                StringError(#"Couldn't parse toolset configuration at `/tools/invalidToolset.json`: typeMismatch(Swift.Dictionary<Swift.String, Any>, Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "tools", intValue: nil)], debugDescription: "Expected to decode Dictionary<String, Any> but found an array instead.", underlyingError: nil))"#)
+            )
+        }
     }
 
     func testSelectDestination() throws {

--- a/Tests/PackageModelTests/DestinationTests.swift
+++ b/Tests/PackageModelTests/DestinationTests.swift
@@ -318,7 +318,8 @@ final class DestinationTests: XCTestCase {
         )) {
             XCTAssertEqual(
                 $0 as? StringError,
-                StringError("""
+                StringError(
+                    """
                     Couldn't parse toolset configuration at `/tools/asdf.json`: /tools/asdf.json doesn't exist in file \
                     system
                     """

--- a/Tests/PackageModelTests/DestinationTests.swift
+++ b/Tests/PackageModelTests/DestinationTests.swift
@@ -318,7 +318,11 @@ final class DestinationTests: XCTestCase {
         )) {
             XCTAssertEqual(
                 $0 as? StringError,
-                StringError("Couldn't parse toolset configuration at `/tools/asdf.json`: /tools/asdf.json doesn't exist in file system")
+                StringError("""
+                    Couldn't parse toolset configuration at `/tools/asdf.json`: /tools/asdf.json doesn't exist in file \
+                    system
+                    """
+                )
             )
         }
         XCTAssertThrowsError(try Destination.decode(
@@ -334,7 +338,14 @@ final class DestinationTests: XCTestCase {
         )) {
             XCTAssertEqual(
                 $0 as? StringError,
-                StringError(#"Couldn't parse toolset configuration at `/tools/invalidToolset.json`: typeMismatch(Swift.Dictionary<Swift.String, Any>, Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "tools", intValue: nil)], debugDescription: "Expected to decode Dictionary<String, Any> but found an array instead.", underlyingError: nil))"#)
+                StringError(
+                    #"""
+                    Couldn't parse toolset configuration at `/tools/invalidToolset.json`: \#
+                    typeMismatch(Swift.Dictionary<Swift.String, Any>, Swift.DecodingError.Context(codingPath: \#
+                    [CodingKeys(stringValue: "tools", intValue: nil)], debugDescription: "Expected to decode \#
+                    Dictionary<String, Any> but found an array instead.", underlyingError: nil))
+                    """#
+                )
             )
         }
     }

--- a/Tests/PackageModelTests/DestinationTests.swift
+++ b/Tests/PackageModelTests/DestinationTests.swift
@@ -339,8 +339,7 @@ final class DestinationTests: XCTestCase {
         )) {
             XCTAssertTrue(
                 ($0 as? StringError)?.description
-                    .hasPrefix("Couldn't parse toolset configuration at `/tools/invalidToolset.json`: " ?? false
-                )
+                    .hasPrefix("Couldn't parse toolset configuration at `/tools/invalidToolset.json`: ") ?? false
             )
         }
     }

--- a/Tests/PackageModelTests/DestinationTests.swift
+++ b/Tests/PackageModelTests/DestinationTests.swift
@@ -337,15 +337,9 @@ final class DestinationTests: XCTestCase {
             fileSystem: fs,
             observabilityScope: observability
         )) {
-            XCTAssertEqual(
-                $0 as? StringError,
-                StringError(
-                    #"""
-                    Couldn't parse toolset configuration at `/tools/invalidToolset.json`: \#
-                    typeMismatch(Swift.Dictionary<Swift.String, Any>, Swift.DecodingError.Context(codingPath: \#
-                    [CodingKeys(stringValue: "tools", intValue: nil)], debugDescription: "Expected to decode \#
-                    Dictionary<String, Any> but found an array instead.", underlyingError: nil))
-                    """#
+            XCTAssertTrue(
+                ($0 as? StringError)?.description
+                    .hasPrefix("Couldn't parse toolset configuration at `/tools/invalidToolset.json`: " ?? false
                 )
             )
         }


### PR DESCRIPTION
Previously, when parsing a destination file that referenced an invalid toolset, a decoding error for the toolset was propagated as a `StringError` that mentioned the destination file, which was quite confusing. It looked as if the destination file itself couldn't be parsed, which wasn't true. Cleaning up error handling here to explicitly mention the toolset file and its path if an error is thrown during its decoding.
