### PR TITLE
CrossCompilationDestinationsTool: add `remove` subcommand

### DIFF
--- a/Sources/CrossCompilationDestinationsTool/CMakeLists.txt
+++ b/Sources/CrossCompilationDestinationsTool/CMakeLists.txt
@@ -7,8 +7,10 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_library(CrossCompilationDestinationsTool
+  DestinationCommand.swift
   InstallDestination.swift
   ListDestinations.swift
+  RemoveDestination.swift
   SwiftDestinationTool.swift)
 target_link_libraries(CrossCompilationDestinationsTool PUBLIC
   ArgumentParser

--- a/Sources/CrossCompilationDestinationsTool/DestinationCommand.swift
+++ b/Sources/CrossCompilationDestinationsTool/DestinationCommand.swift
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import CoreCommands
+import TSCBasic
+
+/// A protocol for functions and properties common to all destination subcommands.
+protocol DestinationCommand: ParsableCommand {
+    /// Common locations options provided by ArgumentParser.
+    var locations: LocationOptions { get }
+}
+
+extension DestinationCommand {
+    /// The file system used by default by this command.
+    var fileSystem: FileSystem { localFileSystem }
+
+    /// Parses destinations directory option if provided or uses the default path for cross-compilation destinations
+    /// on the file system. A new directory at this path is created if one doesn't exist already.
+    /// - Returns: existing or a newly created directory at the computed location.
+    func getOrCreateDestinationsDirectory() throws -> AbsolutePath {
+        guard var destinationsDirectory = try fileSystem.getSharedCrossCompilationDestinationsDirectory(
+            explicitDirectory: locations.crossCompilationDestinationsDirectory
+        ) else {
+            let expectedPath = try fileSystem.swiftPMCrossCompilationDestinationsDirectory
+            throw StringError(
+                "Couldn't find or create a directory where cross-compilation destinations are stored: `\(expectedPath)`"
+            )
+        }
+
+        if !self.fileSystem.exists(destinationsDirectory) {
+            destinationsDirectory = try self.fileSystem.getOrCreateSwiftPMCrossCompilationDestinationsDirectory()
+        }
+
+        return destinationsDirectory
+    }
+}

--- a/Sources/CrossCompilationDestinationsTool/ListDestinations.swift
+++ b/Sources/CrossCompilationDestinationsTool/ListDestinations.swift
@@ -17,7 +17,7 @@ import PackageModel
 import SPMBuildCore
 import TSCBasic
 
-public struct ListDestinations: ParsableCommand {
+public struct ListDestinations: DestinationCommand {
     public static let configuration = CommandConfiguration(
         commandName: "list",
         abstract:
@@ -32,22 +32,9 @@ public struct ListDestinations: ParsableCommand {
     public init() {}
 
     public func run() throws {
-        let fileSystem = localFileSystem
         let observabilitySystem = ObservabilitySystem.swiftTool()
         let observabilityScope = observabilitySystem.topScope
-
-        guard var destinationsDirectory = try fileSystem.getSharedCrossCompilationDestinationsDirectory(
-            explicitDirectory: locations.crossCompilationDestinationsDirectory
-        ) else {
-            let expectedPath = try fileSystem.swiftPMCrossCompilationDestinationsDirectory
-            throw StringError(
-                "Couldn't find or create a directory where cross-compilation destinations are stored: \(expectedPath)"
-            )
-        }
-
-        if !fileSystem.exists(destinationsDirectory) {
-            destinationsDirectory = try fileSystem.getOrCreateSwiftPMCrossCompilationDestinationsDirectory()
-        }
+        let destinationsDirectory = try self.getOrCreateDestinationsDirectory()
 
         let validBundles = try DestinationsBundle.getAllValidBundles(
             destinationsDirectory: destinationsDirectory,

--- a/Sources/CrossCompilationDestinationsTool/RemoveDestination.swift
+++ b/Sources/CrossCompilationDestinationsTool/RemoveDestination.swift
@@ -1,0 +1,53 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import Basics
+import CoreCommands
+
+struct RemoveDestination: DestinationCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "remove",
+        abstract: """
+        Removes a previously installed destination artifact bundle from the filesystem.
+        """
+    )
+
+    @OptionGroup(visibility: .hidden)
+    var locations: LocationOptions
+
+    @Argument(help: "Name of the destination artifact bundle to remove from the filesystem.")
+    var bundleName: String
+
+    func run() throws {
+        let destinationsDirectory = try self.getOrCreateDestinationsDirectory()
+        let artifactBundleDirectory = destinationsDirectory.appending(component: self.bundleName)
+
+        guard fileSystem.exists(artifactBundleDirectory) else {
+            throw StringError(
+                """
+                Destination artifact bundle with name `\(self.bundleName)` is not currently installed, so \
+                it can't be removed.
+                """
+            )
+        }
+
+        try fileSystem.removeFileTree(artifactBundleDirectory)
+
+        print(
+            """
+            Destination artifact bundle at path `\(artifactBundleDirectory)` was successfully removed from the file \
+            system.
+            """
+        )
+    }
+}

--- a/Sources/CrossCompilationDestinationsTool/SwiftDestinationTool.swift
+++ b/Sources/CrossCompilationDestinationsTool/SwiftDestinationTool.swift
@@ -22,8 +22,10 @@ public struct SwiftDestinationTool: ParsableCommand {
         subcommands: [
             InstallDestination.self,
             ListDestinations.self,
+            RemoveDestination.self,
         ],
-        helpNames: [.short, .long, .customLong("help", withSingleDash: true)])
+        helpNames: [.short, .long, .customLong("help", withSingleDash: true)]
+    )
 
     public init() {}
 }


### PR DESCRIPTION
Adds new `swift experimental-destination remove` subcommand per [the cross-compilation destinations proposal](https://github.com/apple/swift-evolution/blob/139e51f120b20e2d6aa9a61d44474ec698d9ec8c/proposals/0387-cross-compilation-destinations.md#destination-bundle-installation-and-configuration).