### PR TITLE
Basics: explicitly mark `SQLite` as non-Sendable reference type

### DIFF
--- a/Sources/Basics/SQLite.swift
+++ b/Sources/Basics/SQLite.swift
@@ -17,7 +17,7 @@ import TSCBasic
 @_implementationOnly import SPMSQLite3
 
 /// A minimal SQLite wrapper.
-public struct SQLite {
+public final class SQLite {
     /// The location of the database.
     public let location: Location
 
@@ -57,7 +57,7 @@ public struct SQLite {
     }
 
     @available(*, deprecated, message: "use init(location:configuration) instead")
-    public init(dbPath: AbsolutePath) throws {
+    public convenience init(dbPath: AbsolutePath) throws {
         try self.init(location: .path(dbPath))
     }
 
@@ -293,6 +293,10 @@ public struct SQLite {
         case databaseFull
     }
 }
+
+// Explicitly mark this class as non-Sendable
+@available(*, unavailable)
+extension SQLite: Sendable {}
 
 private func sqlite_callback(
     _ ctx: UnsafeMutableRawPointer?,

--- a/Sources/Basics/SQLite.swift
+++ b/Sources/Basics/SQLite.swift
@@ -294,9 +294,11 @@ public final class SQLite {
     }
 }
 
+#if swift(>=5.6)
 // Explicitly mark this class as non-Sendable
 @available(*, unavailable)
 extension SQLite: Sendable {}
+#endif
 
 private func sqlite_callback(
     _ ctx: UnsafeMutableRawPointer?,


### PR DESCRIPTION
### Motivation:

`SQLite` should be a reference type as it stores a pointer to the database. For some reason it was declared as `struct`, but to indicate its reference semantics it would be cleaner to mark it as `final class`. Additionally, this type should never be `Sendable` as it provides no locking, thus an explicit annotation should be added to indicate this.

### Modifications:

Changed the `SQLite` type from `struct` to `final class`  and added a declaration that marks it as non-Sendable.

### Result:

It's more obvious now that `SQLite` has reference semantics. In the future we could also call `close()` automatically from `SQLite.deinit`, but that needs a separate audit of existing calls to `close()`.