### PR TITLE
CrossCompilationDestinationsTool: add diagnostics for no destinations

### DIFF
--- a/Sources/CrossCompilationDestinationsTool/ListDestinations.swift
+++ b/Sources/CrossCompilationDestinationsTool/ListDestinations.swift
@@ -42,6 +42,11 @@ public struct ListDestinations: DestinationCommand {
             observabilityScope: observabilityScope
         )
 
+        guard !validBundles.isEmpty else {
+            print("No cross-compilation destinations are currently installed.")
+            return
+        }
+
         for bundle in validBundles {
             bundle.artifacts.keys.forEach { print($0) }
         }


### PR DESCRIPTION
Currently when no CC destinations are installed, `swift experimental-destination list` produces no output, which is confusing. Let's fix that by providing a message that clarifies that no installed destinations are available.