### PR TITLE
[NFC] Move ArtifactsArchiveMetadata to PackageModel

### DIFF
--- a/Sources/CoreCommands/SwiftTool.swift
+++ b/Sources/CoreCommands/SwiftTool.swift
@@ -776,7 +776,7 @@ public final class SwiftTool {
             {
                 destination = targetDestination
             } else if let destinationSelector = options.build.crossCompilationDestinationSelector {
-                destination = try DestinationsBundle.selectDestination(
+                destination = try DestinationBundle.selectDestination(
                     fromBundlesAt: sharedCrossCompilationDestinationsDirectory,
                     fileSystem: fileSystem,
                     matching: destinationSelector,

--- a/Sources/CrossCompilationDestinationsTool/ListDestinations.swift
+++ b/Sources/CrossCompilationDestinationsTool/ListDestinations.swift
@@ -36,7 +36,7 @@ public struct ListDestinations: DestinationCommand {
         let observabilityScope = observabilitySystem.topScope
         let destinationsDirectory = try self.getOrCreateDestinationsDirectory()
 
-        let validBundles = try DestinationsBundle.getAllValidBundles(
+        let validBundles = try DestinationBundle.getAllValidBundles(
             destinationsDirectory: destinationsDirectory,
             fileSystem: fileSystem,
             observabilityScope: observabilityScope

--- a/Sources/PackageModel/ArtifactsArchiveMetadata.swift
+++ b/Sources/PackageModel/ArtifactsArchiveMetadata.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import PackageModel
 import TSCBasic
 
 import struct TSCUtility.Triple
@@ -27,9 +26,9 @@ public struct ArtifactsArchiveMetadata: Equatable {
     }
 
     public struct Artifact: Equatable {
-        let type: ArtifactType
+        public let type: ArtifactType
         let version: String
-        let variants: [Variant]
+        public let variants: [Variant]
 
         public init(type: ArtifactsArchiveMetadata.ArtifactType, version: String, variants: [Variant]) {
             self.type = type
@@ -48,8 +47,8 @@ public struct ArtifactsArchiveMetadata: Equatable {
     }
 
     public struct Variant: Equatable {
-        let path: String
-        let supportedTriples: [Triple]
+        public let path: String
+        public let supportedTriples: [Triple]
 
         public init(path: String, supportedTriples: [Triple]) {
             self.path = path

--- a/Sources/PackageModel/CMakeLists.txt
+++ b/Sources/PackageModel/CMakeLists.txt
@@ -13,7 +13,7 @@ add_library(PackageModel
   BuildFlags.swift
   BuildSettings.swift
   Destination.swift
-  DestinationsBundle.swift
+  DestinationBundle.swift
   Diagnostics.swift
   IdentityResolver.swift
   Manifest/Manifest.swift

--- a/Sources/PackageModel/CMakeLists.txt
+++ b/Sources/PackageModel/CMakeLists.txt
@@ -7,11 +7,13 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_library(PackageModel
+  ArtifactsArchiveMetadata.swift
   BuildConfiguration.swift
   BuildEnvironment.swift
   BuildFlags.swift
   BuildSettings.swift
   Destination.swift
+  DestinationsBundle.swift
   Diagnostics.swift
   IdentityResolver.swift
   Manifest/Manifest.swift

--- a/Sources/PackageModel/DestinationBundle.swift
+++ b/Sources/PackageModel/DestinationBundle.swift
@@ -15,7 +15,7 @@ import TSCBasic
 import TSCUtility
 
 /// Represents an `.artifactbundle` on the filesystem that contains cross-compilation destinations.
-public struct DestinationsBundle {
+public struct DestinationBundle {
     public struct Variant: Equatable {
         let metadata: ArtifactsArchiveMetadata.Variant
         let destinations: [Destination]
@@ -86,7 +86,7 @@ public struct DestinationsBundle {
             )
         }
 
-        let validBundles = try DestinationsBundle.getAllValidBundles(
+        let validBundles = try DestinationBundle.getAllValidBundles(
             destinationsDirectory: destinationsDirectory,
             fileSystem: fileSystem,
             observabilityScope: observabilityScope
@@ -148,13 +148,13 @@ extension ArtifactsArchiveMetadata {
         bundlePath: AbsolutePath,
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope
-    ) throws -> DestinationsBundle {
-        var result = DestinationsBundle(path: bundlePath)
+    ) throws -> DestinationBundle {
+        var result = DestinationBundle(path: bundlePath)
 
         for (artifactID, artifactMetadata) in artifacts
             where artifactMetadata.type == .crossCompilationDestination
         {
-            var variants = [DestinationsBundle.Variant]()
+            var variants = [DestinationBundle.Variant]()
 
             for variantMetadata in artifactMetadata.variants {
                 let destinationJSONPath = try bundlePath
@@ -197,7 +197,7 @@ extension ArtifactsArchiveMetadata {
     }
 }
 
-extension Array where Element == DestinationsBundle {
+extension Array where Element == DestinationBundle {
     /// Select destinations matching a given query and host triple from a `self` array of available destinations.
     /// - Parameters:
     ///   - query: either an artifact ID or target triple to filter with.
@@ -209,8 +209,8 @@ extension Array where Element == DestinationsBundle {
         hostTriple: Triple,
         observabilityScope: ObservabilityScope
     ) -> Destination? {
-        var matchedByID: (path: AbsolutePath, variant: DestinationsBundle.Variant, destination: Destination)?
-        var matchedByTriple: (path: AbsolutePath, variant: DestinationsBundle.Variant, destination: Destination)?
+        var matchedByID: (path: AbsolutePath, variant: DestinationBundle.Variant, destination: Destination)?
+        var matchedByTriple: (path: AbsolutePath, variant: DestinationBundle.Variant, destination: Destination)?
 
         for bundle in self {
             for (artifactID, variants) in bundle.artifacts {

--- a/Sources/PackageModel/DestinationsBundle.swift
+++ b/Sources/PackageModel/DestinationsBundle.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
-import PackageModel
 import TSCBasic
 import TSCUtility
 

--- a/Sources/SPMBuildCore/CMakeLists.txt
+++ b/Sources/SPMBuildCore/CMakeLists.txt
@@ -7,14 +7,12 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_library(SPMBuildCore
-  ArtifactsArchiveMetadata.swift
   BinaryTarget+Extensions.swift
   BuildParameters.swift
   BuildSystem.swift
   BuildSystemCommand.swift
   BuildSystemDelegate.swift
   BuiltTestProduct.swift
-  DestinationsBundle.swift
   PluginContextSerializer.swift
   PluginInvocation.swift
   PluginMessages.swift

--- a/Tests/PackageModelTests/DestinationTests.swift
+++ b/Tests/PackageModelTests/DestinationTests.swift
@@ -346,7 +346,7 @@ final class DestinationTests: XCTestCase {
 
     func testSelectDestination() throws {
         let bundles = [
-            DestinationsBundle(
+            DestinationBundle(
                 path: try AbsolutePath(validating: "/destination.artifactsbundle"),
                 artifacts: [
                     "id1": [

--- a/Tests/SPMBuildCoreTests/ArtifactsArchiveMetadataTests.swift
+++ b/Tests/SPMBuildCoreTests/ArtifactsArchiveMetadataTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SPMBuildCore
+import PackageModel
 import TSCBasic
 import XCTest
 


### PR DESCRIPTION
For the new `swift experimental-destination configure` subcommand we need to add configuration storage logic, which is tightly coupled to serialized destination data, which is internal to `PackageModel`. It would be beneficial to keep those serialized model types internal, but we also need to be able to access `ArtifactsArchiveMetadata` from the configuration logic.

Since that type seems to be purely a model value type related to packages, it feels reasonable to move it to `PackageModel`. Configuration logic provided in a future PR can then stay in `PackageModel` as well, without a need to expose internal model types, only providing configuration methods as `public`.

Also using this as an opportunity to rename `DestinationsBundle` to `DestinationBundle` for consistency with other model types that don't use plural.