### PR TITLE
[NFC] PackageModel: rename `validateDestinationsBundle` for consistency

### DIFF
--- a/Sources/PackageModel/DestinationBundle.swift
+++ b/Sources/PackageModel/DestinationBundle.swift
@@ -135,7 +135,7 @@ public struct DestinationBundle {
             rootPath: bundlePath
         )
 
-        return try parsedManifest.validateDestinationsBundle(
+        return try parsedManifest.validateDestinationBundle(
             bundlePath: bundlePath,
             fileSystem: fileSystem,
             observabilityScope: observabilityScope
@@ -144,7 +144,7 @@ public struct DestinationBundle {
 }
 
 extension ArtifactsArchiveMetadata {
-    fileprivate func validateDestinationsBundle(
+    fileprivate func validateDestinationBundle(
         bundlePath: AbsolutePath,
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope


### PR DESCRIPTION
We already use singular form everywhere, but somehow this method ended up having a different name, let's clean that up.