### PR TITLE
NFC: cleanup manifest constructor defaults

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -676,7 +676,6 @@ let package = Package(
             dependencies: ["XCBuildSupport", "SPMTestSupport"],
             exclude: ["Inputs/Foo.pc"]
         ),
-
         // Examples (These are built to ensure they stay up to date with the API.)
         .executableTarget(
             name: "package-info",

--- a/Sources/PackageModel/Manifest/Manifest.swift
+++ b/Sources/PackageModel/Manifest/Manifest.swift
@@ -11,15 +11,14 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
-import TSCBasic
 import Foundation
+import TSCBasic
 
 import struct TSCUtility.Version
 
 /// This contains the declarative specification loaded from package manifest
 /// files, and the tools for working with the manifest.
 public final class Manifest: Sendable {
-
     /// The standard filename for the manifest.
     public static let filename = basename + ".swift"
 
@@ -35,7 +34,7 @@ public final class Manifest: Sendable {
     // to the repository state, it shouldn't matter where it is.
     //
     /// The path of the manifest file.
-    //@available(*, deprecated)
+    // @available(*, deprecated)
     public let path: AbsolutePath
 
     // FIXME: deprecate this, this is not part of the manifest information, we just use it as a container for this data
@@ -106,16 +105,16 @@ public final class Manifest: Sendable {
         path: AbsolutePath,
         packageKind: PackageReference.Kind,
         packageLocation: String,
-        defaultLocalization: String? = nil,
+        defaultLocalization: String?,
         platforms: [PlatformDescription],
-        version: TSCUtility.Version? = nil,
-        revision: String? = nil,
+        version: TSCUtility.Version?,
+        revision: String?,
         toolsVersion: ToolsVersion,
-        pkgConfig: String? = nil,
-        providers: [SystemPackageProviderDescription]? = nil,
-        cLanguageStandard: String? = nil,
-        cxxLanguageStandard: String? = nil,
-        swiftLanguageVersions: [SwiftLanguageVersion]? = nil,
+        pkgConfig: String?,
+        providers: [SystemPackageProviderDescription]?,
+        cLanguageStandard: String?,
+        cxxLanguageStandard: String?,
+        swiftLanguageVersions: [SwiftLanguageVersion]?,
         dependencies: [PackageDependency] = [],
         products: [ProductDescription] = [],
         targets: [TargetDescription] = []
@@ -137,7 +136,7 @@ public final class Manifest: Sendable {
         self.dependencies = dependencies
         self.products = products
         self.targets = targets
-        self.targetMap = Dictionary(targets.lazy.map({ ($0.name, $0) }), uniquingKeysWith: { $1 })
+        self.targetMap = Dictionary(targets.lazy.map { ($0.name, $0) }, uniquingKeysWith: { $1 })
     }
 
     /// Returns the targets required for a particular product filter.
@@ -202,9 +201,9 @@ public final class Manifest: Sendable {
 
     /// Returns the targets required for building the provided products.
     public func targetsRequired(for products: [ProductDescription]) -> [TargetDescription] {
-        let productsByName = Dictionary(products.map({ ($0.name, $0) }), uniquingKeysWith: { $1 })
-        let targetsByName = Dictionary(targets.map({ ($0.name, $0) }), uniquingKeysWith: { $1 })
-        let productTargetNames = products.flatMap({ $0.targets })
+        let productsByName = Dictionary(products.map { ($0.name, $0) }, uniquingKeysWith: { $1 })
+        let targetsByName = Dictionary(targets.map { ($0.name, $0) }, uniquingKeysWith: { $1 })
+        let productTargetNames = products.flatMap(\.targets)
 
         let dependentTargetNames = transitiveClosure(productTargetNames, successors: { targetName in
 
@@ -239,11 +238,10 @@ public final class Manifest: Sendable {
 
             return []
 
-
         })
 
         let requiredTargetNames = Set(productTargetNames).union(dependentTargetNames)
-        let requiredTargets = requiredTargetNames.compactMap{ targetsByName[$0] }
+        let requiredTargets = requiredTargetNames.compactMap { targetsByName[$0] }
         return requiredTargets
     }
 
@@ -254,9 +252,8 @@ public final class Manifest: Sendable {
         for targets: [TargetDescription],
         keepUnused: Bool = false
     ) -> [PackageDependency] {
-
         var registry: (known: [PackageIdentity: ProductFilter], unknown: Set<String>) = ([:], [])
-        let availablePackages = Set(dependencies.lazy.map{ $0.identity })
+        let availablePackages = Set(dependencies.lazy.map(\.identity))
 
         for target in targets {
             for targetDependency in target.dependencies {
@@ -312,9 +309,10 @@ public final class Manifest: Sendable {
     /// Finds the package dependency referenced by the specified plugin usage.
     /// - Returns: Returns `nil` if  the used plugin is from the same package or if the package the used plugin is from cannot be found.
     public func packageDependency(
-        referencedBy pluginUsage: TargetDescription.PluginUsage) -> PackageDependency? {
+        referencedBy pluginUsage: TargetDescription.PluginUsage
+    ) -> PackageDependency? {
         switch pluginUsage {
-        case .plugin(_, let .some(package)):
+        case .plugin(_, .some(let package)):
             return packageDependency(referencedBy: package)
         default:
             return nil
@@ -324,7 +322,7 @@ public final class Manifest: Sendable {
     private func packageDependency(
         referencedBy packageName: String
     ) -> PackageDependency? {
-        return self.dependencies.first(where: {
+        self.dependencies.first(where: {
             // rdar://80594761 make sure validation is case insensitive
             $0.nameForTargetDependencyResolutionOnly.lowercased() == packageName.lowercased()
         })
@@ -336,8 +334,8 @@ public final class Manifest: Sendable {
     /// If none is found, it is assumed that the string is the package identity itself
     /// (although it may actually be a dangling reference diagnosed later).
     private func packageIdentity(referencedBy packageName: String) -> PackageIdentity {
-        return packageDependency(referencedBy: packageName)?.identity
-        ?? .plain(packageName)
+        packageDependency(referencedBy: packageName)?.identity
+            ?? .plain(packageName)
     }
 
     /// Registers a required product with a particular dependency if possible, or registers it as unknown.
@@ -360,9 +358,10 @@ public final class Manifest: Sendable {
                     product: product,
                     inPackage: packageIdentity(referencedBy: package),
                     registry: &registry.known,
-                    availablePackages: availablePackages) {
-                        // This is an invalid manifest condition diagnosed later. (No such package.)
-                        // Treating it as unknown gracefully allows resolution to continue for now.
+                    availablePackages: availablePackages
+                ) {
+                    // This is an invalid manifest condition diagnosed later. (No such package.)
+                    // Treating it as unknown gracefully allows resolution to continue for now.
                     registry.unknown.insert(product)
                 }
             } else { // < 5.2
@@ -383,17 +382,18 @@ public final class Manifest: Sendable {
                     product: product,
                     inPackage: packageIdentity(referencedBy: product),
                     registry: &registry.known,
-                    availablePackages: availablePackages) {
-                        // If it doesn’t match a package, it should be a target, not a product.
-                        if targets.contains(where: { $0.name == product }) {
-                            break
-                        } else {
-                            // But in case the user is trying to reference a product,
-                            // we still need to pass on the invalid reference
-                            // so that the resolver fetches all dependencies
-                            // in order to provide the diagnostic pass with the information it needs.
-                            registry.unknown.insert(product)
-                        }
+                    availablePackages: availablePackages
+                ) {
+                    // If it doesn’t match a package, it should be a target, not a product.
+                    if targets.contains(where: { $0.name == product }) {
+                        break
+                    } else {
+                        // But in case the user is trying to reference a product,
+                        // we still need to pass on the invalid reference
+                        // so that the resolver fetches all dependencies
+                        // in order to provide the diagnostic pass with the information it needs.
+                        registry.unknown.insert(product)
+                    }
                 }
             }
         }
@@ -417,7 +417,8 @@ public final class Manifest: Sendable {
                     product: name,
                     inPackage: packageIdentity(referencedBy: package),
                     registry: &registry.known,
-                    availablePackages: availablePackages) {
+                    availablePackages: availablePackages
+                ) {
                     // Invalid, diagnosed later; see the dependency version of this method.
                     registry.unknown.insert(name)
                 }
@@ -467,21 +468,22 @@ extension Manifest: Hashable {
 
 extension Manifest: CustomStringConvertible {
     public var description: String {
-        return "<Manifest: \(self.displayName)>"
+        "<Manifest: \(self.displayName)>"
     }
 }
 
 extension Manifest: Encodable {
     private enum CodingKeys: CodingKey {
-         case name, path, url, version, targetMap, toolsVersion,
-              pkgConfig,providers, cLanguageStandard, cxxLanguageStandard, swiftLanguageVersions,
-              dependencies, products, targets, platforms, packageKind, revision,
-              defaultLocalization
+        case name, path, url, version, targetMap, toolsVersion,
+             pkgConfig, providers, cLanguageStandard, cxxLanguageStandard, swiftLanguageVersions,
+             dependencies, products, targets, platforms, packageKind, revision,
+             defaultLocalization
     }
+
     /// Coding user info key for dump-package command.
     ///
     /// Presence of this key will hide some keys when encoding the Manifest object.
-    public static let dumpPackageKey: CodingUserInfoKey = CodingUserInfoKey(rawValue: "dumpPackage")!
+    public static let dumpPackageKey: CodingUserInfoKey = .init(rawValue: "dumpPackage")!
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)

--- a/Sources/SPMTestSupport/ManifestExtensions.swift
+++ b/Sources/SPMTestSupport/ManifestExtensions.swift
@@ -179,9 +179,9 @@ extension Manifest {
         products: [ProductDescription] = [],
         targets: [TargetDescription] = []
     ) -> Manifest {
-        Manifest(
+        return Manifest(
             displayName: displayName,
-            path: path.appending(component: Manifest.filename),
+            path: path.basename == Manifest.filename ? path : path.appending(component: Manifest.filename) ,
             packageKind: packageKind,
             packageLocation: packageLocation ?? path.pathString,
             defaultLocalization: defaultLocalization,

--- a/Sources/SPMTestSupport/ManifestExtensions.swift
+++ b/Sources/SPMTestSupport/ManifestExtensions.swift
@@ -15,10 +15,9 @@ import PackageModel
 import TSCBasic
 import struct TSCUtility.Version
 
-public extension Manifest {
-
-    static func createRootManifest(
-        name: String,
+extension Manifest {
+    public static func createRootManifest(
+        displayName: String,
         path: AbsolutePath = .root,
         defaultLocalization: String? = nil,
         platforms: [PlatformDescription] = [],
@@ -34,7 +33,7 @@ public extension Manifest {
         targets: [TargetDescription] = []
     ) -> Manifest {
         Self.createManifest(
-            name: name,
+            displayName: displayName,
             path: path,
             packageKind: .root(path),
             packageLocation: path.pathString,
@@ -53,8 +52,8 @@ public extension Manifest {
         )
     }
 
-    static func createFileSystemManifest(
-        name: String,
+    public static func createFileSystemManifest(
+        displayName: String,
         path: AbsolutePath,
         defaultLocalization: String? = nil,
         platforms: [PlatformDescription] = [],
@@ -70,7 +69,7 @@ public extension Manifest {
         targets: [TargetDescription] = []
     ) -> Manifest {
         Self.createManifest(
-            name: name,
+            displayName: displayName,
             path: path,
             packageKind: .fileSystem(path),
             packageLocation: path.pathString,
@@ -89,8 +88,8 @@ public extension Manifest {
         )
     }
 
-    static func createLocalSourceControlManifest(
-        name: String,
+    public static func createLocalSourceControlManifest(
+        displayName: String,
         path: AbsolutePath,
         defaultLocalization: String? = nil,
         platforms: [PlatformDescription] = [],
@@ -106,7 +105,7 @@ public extension Manifest {
         targets: [TargetDescription] = []
     ) -> Manifest {
         Self.createManifest(
-            name: name,
+            displayName: displayName,
             path: path,
             packageKind: .localSourceControl(path),
             packageLocation: path.pathString,
@@ -125,8 +124,8 @@ public extension Manifest {
         )
     }
 
-    static func createRemoteSourceControlManifest(
-        name: String,
+    public static func createRemoteSourceControlManifest(
+        displayName: String,
         url: URL,
         path: AbsolutePath,
         defaultLocalization: String? = nil,
@@ -143,7 +142,7 @@ public extension Manifest {
         targets: [TargetDescription] = []
     ) -> Manifest {
         Self.createManifest(
-            name: name,
+            displayName: displayName,
             path: path,
             packageKind: .remoteSourceControl(url),
             packageLocation: url.absoluteString,
@@ -162,8 +161,8 @@ public extension Manifest {
         )
     }
 
-    static func createManifest(
-        name: String,
+    public static func createManifest(
+        displayName: String,
         path: AbsolutePath = .root,
         packageKind: PackageReference.Kind,
         packageLocation: String? = nil,
@@ -180,14 +179,15 @@ public extension Manifest {
         products: [ProductDescription] = [],
         targets: [TargetDescription] = []
     ) -> Manifest {
-        return Manifest(
-            displayName: name,
+        Manifest(
+            displayName: displayName,
             path: path.appending(component: Manifest.filename),
             packageKind: packageKind,
             packageLocation: packageLocation ?? path.pathString,
             defaultLocalization: defaultLocalization,
             platforms: platforms,
             version: version,
+            revision: .none,
             toolsVersion: toolsVersion,
             pkgConfig: pkgConfig,
             providers: providers,
@@ -200,14 +200,16 @@ public extension Manifest {
         )
     }
 
-    func with(location: String) -> Manifest {
-        return Manifest(
+    public func with(location: String) -> Manifest {
+        Manifest(
             displayName: self.displayName,
             path: self.path,
             packageKind: self.packageKind,
             packageLocation: location,
+            defaultLocalization: self.defaultLocalization,
             platforms: self.platforms,
             version: self.version,
+            revision: self.revision,
             toolsVersion: self.toolsVersion,
             pkgConfig: self.pkgConfig,
             providers: self.providers,

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -214,7 +214,7 @@ public final class MockWorkspace {
             let manifestPath = packagePath.appending(component: Manifest.filename)
             for version in packageVersions {
                 let v = version.flatMap(Version.init(_:))
-                manifests[.init(url: packageLocation, version: v)] = try Manifest(
+                manifests[.init(url: packageLocation, version: v)] = try Manifest.createManifest(
                     displayName: package.name,
                     path: manifestPath,
                     packageKind: packageKind,

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -211,12 +211,11 @@ public final class MockWorkspace {
                 throw InternalError("unknown package type")
             }
 
-            let manifestPath = packagePath.appending(component: Manifest.filename)
             for version in packageVersions {
                 let v = version.flatMap(Version.init(_:))
                 manifests[.init(url: packageLocation, version: v)] = try Manifest.createManifest(
                     displayName: package.name,
-                    path: manifestPath,
+                    path: packagePath,
                     packageKind: packageKind,
                     packageLocation: packageLocation,
                     platforms: package.platforms,

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -45,7 +45,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
-                    name: "fooPkg",
+                    displayName: "fooPkg",
                     path: .init(path: "/fooPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.dynamic), targets: ["FooLogging"]),
@@ -54,7 +54,7 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "FooLogging", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "barPkg",
+                    displayName: "barPkg",
                     path: .init(path: "/barPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.static), targets: ["BarLogging"]),
@@ -63,7 +63,7 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "BarLogging", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "thisPkg",
+                    displayName: "thisPkg",
                     path: .init(path: "/thisPkg"),
                     toolsVersion: .v5_8,
                     dependencies: [
@@ -104,7 +104,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
-                    name: "fooPkg",
+                    displayName: "fooPkg",
                     path: .init(path: "/fooPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.dynamic), targets: ["FooLogging"]),
@@ -113,7 +113,7 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "FooLogging", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "barPkg",
+                    displayName: "barPkg",
                     path: .init(path: "/barPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["BarLogging"]),
@@ -122,7 +122,7 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "BarLogging", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "thisPkg",
+                    displayName: "thisPkg",
                     path: .init(path: "/thisPkg"),
                     toolsVersion: .v5_8,
                     dependencies: [
@@ -170,7 +170,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
-                    name: "bazPkg",
+                    displayName: "bazPkg",
                     path: .init(path: "/bazPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["BazLogging"]),
@@ -179,7 +179,7 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "BazLogging", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "barPkg",
+                    displayName: "barPkg",
                     path: .init(path: "/barPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["BarLogging"]),
@@ -188,7 +188,7 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "BarLogging", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "fooPkg",
+                    displayName: "fooPkg",
                     path: .init(path: "/fooPkg"),
                     toolsVersion: .v5_8,
                     dependencies: [
@@ -209,7 +209,7 @@ final class BuildPlanTests: XCTestCase {
                                           ]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "xPkg",
+                    displayName: "xPkg",
                     path: .init(path: "/xPkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["XUtils"]),
@@ -218,7 +218,7 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "XUtils", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "yPkg",
+                    displayName: "yPkg",
                     path: .init(path: "/yPkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["YUtils"]),
@@ -227,7 +227,7 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "YUtils", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "thisPkg",
+                    displayName: "thisPkg",
                     path: .init(path: "/thisPkg"),
                     toolsVersion: .v5_8,
                     dependencies: [
@@ -280,7 +280,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
-                    name: "bazPkg",
+                    displayName: "bazPkg",
                     path: .init(path: "/bazPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["BazLogging"]),
@@ -289,7 +289,7 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "BazLogging", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "barPkg",
+                    displayName: "barPkg",
                     path: .init(path: "/barPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["BarLogging"]),
@@ -298,7 +298,7 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "BarLogging", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "fooPkg",
+                    displayName: "fooPkg",
                     path: .init(path: "/fooPkg"),
                     toolsVersion: .v5_8,
                     dependencies: [
@@ -319,7 +319,7 @@ final class BuildPlanTests: XCTestCase {
                                           ]),
                     ]),
                 Manifest.createRootManifest(
-                    name: "thisPkg",
+                    displayName: "thisPkg",
                     path: .init(path: "/thisPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -360,7 +360,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
-                    name: "fooPkg",
+                    displayName: "fooPkg",
                     path: .init(path: "/fooPkg"),
                     toolsVersion: .v5_8,
                     dependencies: [
@@ -377,7 +377,7 @@ final class BuildPlanTests: XCTestCase {
                                           ]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "barPkg",
+                    displayName: "barPkg",
                     path: .init(path: "/barPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["BarLogging"]),
@@ -386,7 +386,7 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "BarLogging", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "thisPkg",
+                    displayName: "thisPkg",
                     path: .init(path: "/thisPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -426,7 +426,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
-                    name: "fooPkg",
+                    displayName: "fooPkg",
                     path: .init(path: "/fooPkg"),
                     toolsVersion: .v5_8,
                     products: [
@@ -436,7 +436,7 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "FooLogging", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "barPkg",
+                    displayName: "barPkg",
                     path: .init(path: "/barPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["BarLogging"]),
@@ -445,7 +445,7 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "BarLogging", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "thisPkg",
+                    displayName: "thisPkg",
                     path: .init(path: "/thisPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -485,7 +485,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
-                    name: "fooPkg",
+                    displayName: "fooPkg",
                     path: .init(path: "/fooPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["FooLogging"]),
@@ -494,7 +494,7 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "FooLogging", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "barPkg",
+                    displayName: "barPkg",
                     path: .init(path: "/barPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["BarLogging"]),
@@ -503,7 +503,7 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "BarLogging", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "thisPkg",
+                    displayName: "thisPkg",
                     path: .init(path: "/thisPkg"),
                     toolsVersion: .v5_8,
                     dependencies: [
@@ -570,7 +570,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Pkg",
+                    displayName: "Pkg",
                     path: .init(path: "/Pkg"),
                     targets: [
                         TargetDescription(name: "exe", dependencies: ["lib"]),
@@ -695,7 +695,7 @@ final class BuildPlanTests: XCTestCase {
                 fileSystem: fs,
                 manifests: [
                     Manifest.createRootManifest(
-                        name: "ExplicitTest",
+                        displayName: "ExplicitTest",
                         path: testDirPath,
                         targets: [
                             TargetDescription(name: "A", dependencies: ["B"]),
@@ -758,7 +758,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Pkg",
+                    displayName: "Pkg",
                     path: try .init(validating: Pkg.pathString),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/ExtPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -783,7 +783,7 @@ final class BuildPlanTests: XCTestCase {
                     ]
                 ),
                 Manifest.createLocalSourceControlManifest(
-                    name: "ExtPkg",
+                    displayName: "ExtPkg",
                     path: .init(path: "/ExtPkg"),
                     products: [
                         ProductDescription(name: "ExtLib", type: .library(.automatic), targets: ["ExtLib"]),
@@ -793,7 +793,7 @@ final class BuildPlanTests: XCTestCase {
                     ]
                 ),
                 Manifest.createLocalSourceControlManifest(
-                    name: "PlatformPkg",
+                    displayName: "PlatformPkg",
                     path: .init(path: "/PlatformPkg"),
                     platforms: [PlatformDescription(name: "macos", version: "50.0")],
                     products: [
@@ -876,7 +876,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fileSystem,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "A",
+                    displayName: "A",
                     path: .init(path: "/A"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/B"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -886,7 +886,7 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "ATargetTests", dependencies: ["ATarget"], type: .test),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "B",
+                    displayName: "B",
                     path: .init(path: "/B"),
                     products: [
                         ProductDescription(name: "BLibrary", type: .library(.automatic), targets: ["BTarget"]),
@@ -931,7 +931,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Pkg",
+                    displayName: "Pkg",
                     path: .init(path: "/Pkg"),
                     targets: [
                         TargetDescription(name: "exe", dependencies: []),
@@ -1007,7 +1007,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Pkg",
+                    displayName: "Pkg",
                     path: .init(path: "/Pkg"),
                     targets: [
                         TargetDescription(name: "exe", dependencies: []),
@@ -1089,7 +1089,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Pkg",
+                    displayName: "Pkg",
                     path: try .init(validating: Pkg.pathString),
                     dependencies: [
                         .localSourceControl(path: try .init(validating: ExtPkg.pathString), requirement: .upToNextMajor(from: "1.0.0")),
@@ -1099,7 +1099,7 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "lib", dependencies: ["ExtPkg"]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "ExtPkg",
+                    displayName: "ExtPkg",
                     path: try .init(validating: ExtPkg.pathString),
                     products: [
                         ProductDescription(name: "ExtPkg", type: .library(.automatic), targets: ["extlib"]),
@@ -1241,7 +1241,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Pkg",
+                    displayName: "Pkg",
                     path: .init(path: "/Pkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/ExtPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -1261,7 +1261,7 @@ final class BuildPlanTests: XCTestCase {
                         ]),
                     ]),
                 Manifest.createLocalSourceControlManifest(
-                    name: "ExtPkg",
+                    displayName: "ExtPkg",
                     path: .init(path: "/ExtPkg"),
                     products: [
                         ProductDescription(name: "ExtPkg", type: .library(.automatic), targets: ["ExtLib"]),
@@ -1328,7 +1328,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Pkg",
+                    displayName: "Pkg",
                     path: try .init(validating: Pkg.pathString),
                     cLanguageStandard: "gnu99",
                     cxxLanguageStandard: "c++1z",
@@ -1416,7 +1416,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Pkg",
+                    displayName: "Pkg",
                     path: try .init(validating: Pkg.pathString),
                     targets: [
                         TargetDescription(name: "exe", dependencies: ["lib"]),
@@ -1517,7 +1517,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Pkg",
+                    displayName: "Pkg",
                     path: .init(path: "/Pkg"),
                     toolsVersion: .v5,
                     targets: [
@@ -1563,7 +1563,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Pkg",
+                    displayName: "Pkg",
                     path: .init(path: "/Pkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/Dep"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -1574,7 +1574,7 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "lib", dependencies: ["Dep"]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "Dep",
+                    displayName: "Dep",
                     path: .init(path: "/Dep"),
                     products: [
                         ProductDescription(name: "Dep", type: .library(.automatic), targets: ["Dep"]),
@@ -1619,7 +1619,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Pkg",
+                    displayName: "Pkg",
                     path: .init(path: "/Pkg"),
                     targets: [
                         TargetDescription(name: "Foo", dependencies: []),
@@ -1701,7 +1701,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Pkg",
+                    displayName: "Pkg",
                     path: .init(path: "/Pkg"),
                     platforms: [
                         PlatformDescription(name: "macos", version: "12.0"),
@@ -1920,7 +1920,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Pkg",
+                    displayName: "Pkg",
                     path: .init(path: "/Pkg"),
                     toolsVersion: .v5_5,
                     targets: [
@@ -2029,7 +2029,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Pkg",
+                    displayName: "Pkg",
                     path: .init(path: "/Pkg"),
                     dependencies: [
                         .localSourceControl(path: try .init(validating: Clibgit.pathString), requirement: .upToNextMajor(from: "1.0.0"))
@@ -2038,7 +2038,7 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "exe", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "Clibgit",
+                    displayName: "Clibgit",
                     path: .init(path: "/Clibgit")
                 ),
             ],
@@ -2108,7 +2108,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Pkg",
+                    displayName: "Pkg",
                     path: .init(path: "/Pkg"),
                     targets: [
                         TargetDescription(name: "lib", dependencies: []),
@@ -2147,7 +2147,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
-                    name: "Bar",
+                    displayName: "Bar",
                     path: .init(path: "/Bar"),
                     products: [
                         ProductDescription(name: "Bar-Baz", type: .library(.dynamic), targets: ["Bar"]),
@@ -2156,7 +2156,7 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "Bar", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "Foo",
+                    displayName: "Foo",
                     path: .init(path: "/Foo"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -2279,7 +2279,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Pkg",
+                    displayName: "Pkg",
                     path: .init(path: "/Pkg"),
                     products: [
                         ProductDescription(name: "lib", type: .library(.dynamic), targets: ["lib"]),
@@ -2365,7 +2365,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Pkg",
+                    displayName: "Pkg",
                     path: try .init(validating: Pkg.pathString),
                     products: [
                         ProductDescription(name: "lib", type: .library(.dynamic), targets: ["lib"]),
@@ -2517,7 +2517,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fileSystem,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "A",
+                    displayName: "A",
                     path: .init(path: "/A"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/B"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -2530,7 +2530,7 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "ATarget", dependencies: ["BLibrary"]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "B",
+                    displayName: "B",
                     path: .init(path: "/B"),
                     products: [
                         ProductDescription(name: "BLibrary", type: .library(.static), targets: ["BTarget1"]),
@@ -2541,7 +2541,7 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "BTarget2", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "C",
+                    displayName: "C",
                     path: .init(path: "/C"),
                     products: [
                         ProductDescription(name: "cexec", type: .executable, targets: ["CTarget"])
@@ -2603,7 +2603,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fileSystem,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "A",
+                    displayName: "A",
                     path: .init(path: "/A"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/B"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -2630,7 +2630,7 @@ final class BuildPlanTests: XCTestCase {
                     ]
                 ),
                 Manifest.createLocalSourceControlManifest(
-                    name: "B",
+                    displayName: "B",
                     path: .init(path: "/B"),
                     products: [
                         ProductDescription(name: "BLibrary1", type: .library(.static), targets: ["BTarget1"]),
@@ -2648,7 +2648,7 @@ final class BuildPlanTests: XCTestCase {
                     ]
                 ),
                 Manifest.createLocalSourceControlManifest(
-                    name: "C",
+                    displayName: "C",
                     path: .init(path: "/C"),
                     products: [
                         ProductDescription(name: "CLibrary", type: .library(.static), targets: ["CTarget"])
@@ -2720,7 +2720,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Pkg",
+                    displayName: "Pkg",
                     path: .init(path: "/Pkg")
                 )
             ],
@@ -2749,7 +2749,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fileSystem,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "A",
+                    displayName: "A",
                     path: .init(path: "/A"),
                     targets: [
                         TargetDescription(name: "ATarget", dependencies: ["BTarget"]),
@@ -2794,7 +2794,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fileSystem,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "A",
+                    displayName: "A",
                     path: .init(path: "/A"),
                     targets: [
                         TargetDescription(name: "ATarget", dependencies: ["BTarget"]),
@@ -2836,7 +2836,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Pkg",
+                    displayName: "Pkg",
                     path: try .init(validating: Pkg.pathString),
                     targets: [
                     TargetDescription(name: "exe", dependencies: ["lib"]),
@@ -2898,7 +2898,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Pkg",
+                    displayName: "Pkg",
                     path: try .init(validating: Pkg.pathString),
                     targets: [
                         TargetDescription(name: "app", dependencies: ["lib"]),
@@ -2992,7 +2992,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Pkg",
+                    displayName: "Pkg",
                     path: .init(path: "/Pkg"),
                     toolsVersion: .v5_5,
                     targets: [
@@ -3039,7 +3039,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Pkg",
+                    displayName: "Pkg",
                     path: .init(path: "/Pkg"),
                     targets: [
                         TargetDescription(name: "exe", dependencies: ["lib"]),
@@ -3087,7 +3087,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fileSystem,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "A",
+                    displayName: "A",
                     path: .init(path: "/A"),
                     platforms: [
                         PlatformDescription(name: "macos", version: "10.13"),
@@ -3100,7 +3100,7 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "ATarget", dependencies: ["BLibrary"]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "B",
+                    displayName: "B",
                     path: .init(path: "/B"),
                     platforms: [
                         PlatformDescription(name: "macos", version: "10.12"),
@@ -3150,7 +3150,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fileSystem,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "A",
+                    displayName: "A",
                     path: .init(path: "/A"),
                     platforms: [
                         PlatformDescription(name: "macos", version: "10.13"),
@@ -3164,7 +3164,7 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "ATarget", dependencies: ["BLibrary"]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "B",
+                    displayName: "B",
                     path: .init(path: "/B"),
                     platforms: [
                         PlatformDescription(name: "macos", version: "10.14"),
@@ -3217,7 +3217,7 @@ final class BuildPlanTests: XCTestCase {
         )
 
         let aManifest = Manifest.createRootManifest(
-            name: "A",
+            displayName: "A",
             path: .init(path: "/A"),
             toolsVersion: .v5,
             dependencies: [
@@ -3260,7 +3260,7 @@ final class BuildPlanTests: XCTestCase {
         )
 
         let bManifest = Manifest.createFileSystemManifest(
-            name: "B",
+            displayName: "B",
             path: .init(path: "/B"),
             toolsVersion: .v5,
             products: [
@@ -3345,7 +3345,7 @@ final class BuildPlanTests: XCTestCase {
         )
 
         let aManifest = Manifest.createRootManifest(
-            name: "A",
+            displayName: "A",
             path: .init(path: "/A"),
             toolsVersion: .v5,
             targets: [
@@ -3386,7 +3386,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Pkg",
+                    displayName: "Pkg",
                     path: .init(path: "/Pkg"),
                     targets: [
                         TargetDescription(name: "exe", dependencies: ["lib"]),
@@ -3449,7 +3449,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
-                    name: "PkgA",
+                    displayName: "PkgA",
                     path: try .init(validating: PkgA.pathString),
                     products: [
                         ProductDescription(name: "swiftlib", type: .library(.automatic), targets: ["swiftlib"]),
@@ -3460,7 +3460,7 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "swiftlib", dependencies: ["exe"]),
                     ]),
                 Manifest.createRootManifest(
-                    name: "PkgB",
+                    displayName: "PkgB",
                     path: .init(path: "/PkgB"),
                     dependencies: [
                         .localSourceControl(path: try .init(validating: PkgA.pathString), requirement: .upToNextMajor(from: "1.0.0")),
@@ -3515,7 +3515,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "PkgA",
+                    displayName: "PkgA",
                     path: try .init(validating: PkgA.pathString),
                     targets: [
                         TargetDescription(name: "Foo", dependencies: []),
@@ -3578,7 +3578,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "PkgA",
+                    displayName: "PkgA",
                     path: try .init(validating: PkgA.pathString),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/PkgB"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -3587,7 +3587,7 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "Bar", dependencies: ["Foo"]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "PkgB",
+                    displayName: "PkgB",
                     path: .init(path: "/PkgB"),
                     products: [
                         ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Foo"]),
@@ -3652,7 +3652,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "PkgA",
+                    displayName: "PkgA",
                     path: try .init(validating: PkgA.pathString),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/PkgB"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -3661,7 +3661,7 @@ final class BuildPlanTests: XCTestCase {
                         TargetDescription(name: "Bar", dependencies: ["Foo"]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "PkgB",
+                    displayName: "PkgB",
                     path: .init(path: "/PkgB"),
                     products: [
                         ProductDescription(name: "Foo", type: .library(.dynamic), targets: ["Foo"]),
@@ -3729,7 +3729,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Pkg",
+                    displayName: "Pkg",
                     path: .init(path: "/Pkg"),
                     targets: [
                         TargetDescription(name: "exe", dependencies: ["lib"]),
@@ -3787,7 +3787,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Package",
+                    displayName: "Package",
                     path: .init(path: "/Package"),
                     products: [
                         ProductDescription(name: "rary", type: .library(.static), targets: ["rary"]),
@@ -3863,7 +3863,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "PkgA",
+                    displayName: "PkgA",
                     path: .init(path: "/PkgA"),
                     toolsVersion: .v5_2,
                     targets: [
@@ -3929,7 +3929,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "PkgA",
+                    displayName: "PkgA",
                     path: .init(path: "/PkgA"),
                     toolsVersion: .v5_2,
                     targets: [
@@ -3995,7 +3995,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Pkg",
+                    displayName: "Pkg",
                     path: .init(path: "/Pkg"),
                     toolsVersion: .current,
                     targets: [
@@ -4067,7 +4067,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Pkg",
+                    displayName: "Pkg",
                     path: .init(path: "/Pkg"),
                     targets: [
                         TargetDescription(name: "exe", dependencies: ["lib"]),
@@ -4175,7 +4175,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Pkg",
+                    displayName: "Pkg",
                     path: try .init(validating: Pkg.pathString),
                     products: [
                         ProductDescription(name: "exe", type: .executable, targets: ["exe"]),
@@ -4289,7 +4289,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Pkg",
+                    displayName: "Pkg",
                     path: .init(path: "/Pkg"),
                     products: [
                         ProductDescription(name: "exe", type: .executable, targets: ["exe"]),
@@ -4366,7 +4366,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Lib",
+                    displayName: "Lib",
                     path: .init(path: "/Pkg"),
                     toolsVersion: .vNext,
                     dependencies: [],
@@ -4418,7 +4418,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Pkg",
+                    displayName: "Pkg",
                     path: .init(path: "/Pkg"),
                     targets: [
                         TargetDescription(name: "exe", dependencies: ["lib", "clib"]),

--- a/Tests/BuildTests/ModuleAliasingBuildTests.swift
+++ b/Tests/BuildTests/ModuleAliasingBuildTests.swift
@@ -36,7 +36,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "fooPkg",
+                    displayName: "fooPkg",
                     path: .init(path: "/fooPkg"),
                     products: [
                         ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Logging"]),
@@ -45,7 +45,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Logging", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "thisPkg",
+                    displayName: "thisPkg",
                     path: .init(path: "/thisPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -81,7 +81,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "fooPkg",
+                    displayName: "fooPkg",
                     path: .init(path: "/fooPkg"),
                     products: [
                         ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Logging"]),
@@ -90,7 +90,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Logging", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "thisPkg",
+                    displayName: "thisPkg",
                     path: .init(path: "/thisPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -125,7 +125,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
-                    name: "fooPkg",
+                    displayName: "fooPkg",
                     path: .init(path: "/fooPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
@@ -134,7 +134,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Logging", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "barPkg",
+                    displayName: "barPkg",
                     path: .init(path: "/barPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
@@ -143,7 +143,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Logging", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "thisPkg",
+                    displayName: "thisPkg",
                     path: .init(path: "/thisPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -187,7 +187,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
-                    name: "fooPkg",
+                    displayName: "fooPkg",
                     path: .init(path: "/fooPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.dynamic), targets: ["Logging"]),
@@ -196,7 +196,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Logging", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "barPkg",
+                    displayName: "barPkg",
                     path: .init(path: "/barPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.dynamic), targets: ["Logging"]),
@@ -205,7 +205,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Logging", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "thisPkg",
+                    displayName: "thisPkg",
                     path: .init(path: "/thisPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -245,7 +245,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
-                    name: "fooPkg",
+                    displayName: "fooPkg",
                     path: .init(path: "/fooPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.dynamic), targets: ["Logging"]),
@@ -254,7 +254,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Logging", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "barPkg",
+                    displayName: "barPkg",
                     path: .init(path: "/barPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.static), targets: ["Logging"]),
@@ -263,7 +263,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Logging", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "thisPkg",
+                    displayName: "thisPkg",
                     path: .init(path: "/thisPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -304,7 +304,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
-                    name: "fooPkg",
+                    displayName: "fooPkg",
                     path: .init(path: "/fooPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
@@ -313,7 +313,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Logging", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "barPkg",
+                    displayName: "barPkg",
                     path: .init(path: "/barPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.dynamic), targets: ["Logging"]),
@@ -322,7 +322,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Logging", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "thisPkg",
+                    displayName: "thisPkg",
                     path: .init(path: "/thisPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -370,7 +370,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
-                    name: "fooPkg",
+                    displayName: "fooPkg",
                     path: .init(path: "/fooPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
@@ -379,7 +379,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Logging", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "bazPkg",
+                    displayName: "bazPkg",
                     path: .init(path: "/bazPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.static), targets: ["Logging"]),
@@ -388,7 +388,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Logging", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "thisPkg",
+                    displayName: "thisPkg",
                     path: .init(path: "/thisPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -439,7 +439,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
-                name: "xPkg",
+                    displayName: "xPkg",
                 path: .init(path: "/xPkg"),
                 products: [
                     ProductDescription(name: "Logging", type: .library(.dynamic), targets: ["Logging"]),
@@ -449,7 +449,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                       dependencies: []),
                 ]),
                 Manifest.createFileSystemManifest(
-                    name: "yPkg",
+                    displayName: "yPkg",
                     path: .init(path: "/yPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
@@ -460,7 +460,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
 
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "aPkg",
+                    displayName: "aPkg",
                     path: .init(path: "/aPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/xPkg"), requirement: .upToNextMajor(from: "1.0.0"))
@@ -475,7 +475,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           ]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "bPkg",
+                    displayName: "bPkg",
                     path: .init(path: "/bPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/yPkg"), requirement: .upToNextMajor(from: "1.0.0"))
@@ -490,7 +490,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           ]),
                     ]),
                 Manifest.createRootManifest(
-                    name: "thisPkg",
+                    displayName: "thisPkg",
                     path: .init(path: "/thisPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/aPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -542,7 +542,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
-                    name: "fooPkg",
+                    displayName: "fooPkg",
                     path: .init(path: "/fooPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
@@ -551,7 +551,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Logging", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "barPkg",
+                    displayName: "barPkg",
                     path: .init(path: "/barPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
@@ -560,7 +560,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Logging", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "thisPkg",
+                    displayName: "thisPkg",
                     path: .init(path: "/thisPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -629,7 +629,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "otherPkg",
+                    displayName: "otherPkg",
                     path: .init(path: "/otherPkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
@@ -642,7 +642,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Tools", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "thisPkg",
+                    displayName: "thisPkg",
                     path: .init(path: "/thisPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/otherPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -701,7 +701,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "otherPkg",
+                    displayName: "otherPkg",
                     path: .init(path: "/otherPkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
@@ -712,7 +712,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Logging", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "thisPkg",
+                    displayName: "thisPkg",
                     path: .init(path: "/thisPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/otherPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -752,7 +752,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
-                    name: "swift-log",
+                    displayName: "swift-log",
                     path: .init(path: "/swift-log"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
@@ -761,7 +761,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Logging", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "swift-metrics",
+                    displayName: "swift-metrics",
                     path: .init(path: "/swift-metrics"),
                     products: [
                         ProductDescription(name: "Metrics", type: .library(.automatic), targets: ["Metrics"]),
@@ -771,7 +771,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Logging", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "appPkg",
+                    displayName: "appPkg",
                     path: .init(path: "/appPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/swift-log"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -818,7 +818,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "fooPkg",
+                    displayName: "fooPkg",
                     path: .init(path: "/fooPkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
@@ -828,7 +828,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Logging", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "thisPkg",
+                    displayName: "thisPkg",
                     path: .init(path: "/thisPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -865,7 +865,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "barPkg",
+                    displayName: "barPkg",
                     path: .init(path: "/barPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
@@ -874,7 +874,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Logging", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "fooPkg",
+                    displayName: "fooPkg",
                     path: .init(path: "/fooPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -887,7 +887,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           dependencies: [.product(name: "Logging", package: "barPkg")]),
                     ]),
                 Manifest.createRootManifest(
-                    name: "thisPkg",
+                    displayName: "thisPkg",
                     path: .init(path: "/thisPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -925,7 +925,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "fooPkg",
+                    displayName: "fooPkg",
                     path: .init(path: "/fooPkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
@@ -937,7 +937,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Perf", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "thisPkg",
+                    displayName: "thisPkg",
                     path: .init(path: "/thisPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -972,7 +972,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "barPkg",
+                    displayName: "barPkg",
                     path: .init(path: "/barPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
@@ -983,7 +983,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Perf", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "fooPkg",
+                    displayName: "fooPkg",
                     path: .init(path: "/fooPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -996,7 +996,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           dependencies: [.product(name: "Logging", package: "barPkg")]),
                     ]),
                 Manifest.createRootManifest(
-                    name: "thisPkg",
+                    displayName: "thisPkg",
                     path: .init(path: "/thisPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -1027,7 +1027,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "barPkg",
+                    displayName: "barPkg",
                     path: .init(path: "/barPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
@@ -1036,7 +1036,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Logging", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "fooPkg",
+                    displayName: "fooPkg",
                     path: .init(path: "/fooPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -1049,7 +1049,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           dependencies: [.product(name: "Logging", package: "barPkg")]),
                     ]),
                 Manifest.createRootManifest(
-                    name: "thisPkg",
+                    displayName: "thisPkg",
                     path: .init(path: "/thisPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -1098,7 +1098,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
-                    name: "barPkg",
+                    displayName: "barPkg",
                     path: .init(path: "/barPkg"),
                     products: [
                         ProductDescription(name: "LoggingProd", type: .library(.automatic), targets: ["Logging"]),
@@ -1109,7 +1109,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Math", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "fooPkg",
+                    displayName: "fooPkg",
                     path: .init(path: "/fooPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -1129,7 +1129,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           ]),
                     ]),
                 Manifest.createRootManifest(
-                    name: "thisPkg",
+                    displayName: "thisPkg",
                     path: .init(path: "/thisPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -1189,7 +1189,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
-                    name: "cPkg",
+                    displayName: "cPkg",
                     path: .init(path: "/cPkg"),
                     products: [
                         ProductDescription(name: "C", type: .library(.automatic), targets: ["C"]),
@@ -1199,7 +1199,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Foo", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "dPkg",
+                    displayName: "dPkg",
                     path: .init(path: "/dPkg"),
                     products: [
                         ProductDescription(name: "D", type: .library(.automatic), targets: ["D"]),
@@ -1208,7 +1208,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "D", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "bPkg",
+                    displayName: "bPkg",
                     path: .init(path: "/bPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/cPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -1227,7 +1227,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           ]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "aPkg",
+                    displayName: "aPkg",
                     path: .init(path: "/aPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/bPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -1243,7 +1243,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           ]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "zPkg",
+                    displayName: "zPkg",
                     path: .init(path: "/zPkg"),
                     products: [
                         ProductDescription(name: "Z", type: .library(.automatic), targets: ["Z"]),
@@ -1253,7 +1253,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Foo", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "yPkg",
+                    displayName: "yPkg",
                     path: .init(path: "/yPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/zPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -1269,7 +1269,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           )]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "xPkg",
+                    displayName: "xPkg",
                     path: .init(path: "/xPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/yPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -1285,7 +1285,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           ]),
                     ]),
                 Manifest.createRootManifest(
-                    name: "appPkg",
+                    displayName: "appPkg",
                     path: .init(path: "/appPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/aPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -1350,7 +1350,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
-                    name: "gPkg",
+                    displayName: "gPkg",
                     path: .init(path: "/gPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/dPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -1366,7 +1366,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           ]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "dPkg",
+                    displayName: "dPkg",
                     path: .init(path: "/dPkg"),
                     products: [
                         ProductDescription(name: "D", type: .library(.automatic), targets: ["D"]),
@@ -1377,7 +1377,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Log", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "cPkg",
+                    displayName: "cPkg",
                     path: .init(path: "/cPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/dPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -1397,7 +1397,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           ]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "bPkg",
+                    displayName: "bPkg",
                     path: .init(path: "/bPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/cPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -1419,7 +1419,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Utils", dependencies: [])
                     ]),
                 Manifest.createRootManifest(
-                    name: "aPkg",
+                    displayName: "aPkg",
                     path: .init(path: "/aPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/bPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -1482,7 +1482,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
-                    name: "hPkg",
+                    displayName: "hPkg",
                     path: .init(path: "/hPkg"),
                     dependencies: [
                     ],
@@ -1494,7 +1494,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "gPkg",
+                    displayName: "gPkg",
                     path: .init(path: "/gPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/hPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -1510,7 +1510,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           ]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "dPkg",
+                    displayName: "dPkg",
                     path: .init(path: "/dPkg"),
                     products: [
                         ProductDescription(name: "D", type: .library(.automatic), targets: ["D"]),
@@ -1521,7 +1521,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Log", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "cPkg",
+                    displayName: "cPkg",
                     path: .init(path: "/cPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/dPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -1539,7 +1539,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           ]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "bPkg",
+                    displayName: "bPkg",
                     path: .init(path: "/bPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/cPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -1559,7 +1559,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           ]),
                     ]),
                 Manifest.createRootManifest(
-                    name: "aPkg",
+                    displayName: "aPkg",
                     path: .init(path: "/aPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/bPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -1623,7 +1623,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
-                    name: "hPkg",
+                    displayName: "hPkg",
                     path: .init(path: "/hPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/dPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -1639,7 +1639,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           ]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "gPkg",
+                    displayName: "gPkg",
                     path: .init(path: "/gPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/hPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -1659,7 +1659,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           ]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "dPkg",
+                    displayName: "dPkg",
                     path: .init(path: "/dPkg"),
                     products: [
                         ProductDescription(name: "D", type: .library(.automatic), targets: ["D"]),
@@ -1670,7 +1670,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Log", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "cPkg",
+                    displayName: "cPkg",
                     path: .init(path: "/cPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/dPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -1688,7 +1688,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           ]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "bPkg",
+                    displayName: "bPkg",
                     path: .init(path: "/bPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/cPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -1708,7 +1708,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           ]),
                     ]),
                 Manifest.createRootManifest(
-                    name: "aPkg",
+                    displayName: "aPkg",
                     path: .init(path: "/aPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/bPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -1769,7 +1769,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
-                    name: "drawPkg",
+                    displayName: "drawPkg",
                     path: .init(path: "/drawPkg"),
                     products: [
                         ProductDescription(name: "DrawProd", type: .library(.automatic), targets: ["Render"]),
@@ -1778,7 +1778,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Render", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "gamePkg",
+                    displayName: "gamePkg",
                     path: .init(path: "/gamePkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/drawPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -1799,7 +1799,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           )]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "libPkg",
+                    displayName: "libPkg",
                     path: .init(path: "/libPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/gamePkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -1821,7 +1821,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           ]),
                     ]),
                 Manifest.createRootManifest(
-                    name: "appPkg",
+                    displayName: "appPkg",
                     path: .init(path: "/appPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/libPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -1880,7 +1880,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
-                    name: "drawPkg",
+                    displayName: "drawPkg",
                     path: .init(path: "/drawPkg"),
                     products: [
                         ProductDescription(name: "DrawProd", type: .library(.automatic), targets: ["Render"]),
@@ -1889,7 +1889,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Render", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "gamePkg",
+                    displayName: "gamePkg",
                     path: .init(path: "/gamePkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/drawPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -1910,7 +1910,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           )]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "libPkg",
+                    displayName: "libPkg",
                     path: .init(path: "/libPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/gamePkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -1931,7 +1931,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           ]),
                     ]),
                 Manifest.createRootManifest(
-                    name: "appPkg",
+                    displayName: "appPkg",
                     path: .init(path: "/appPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/libPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -1987,7 +1987,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
-                    name: "drawPkg",
+                    displayName: "drawPkg",
                     path: .init(path: "/drawPkg"),
                     products: [
                         ProductDescription(name: "DrawProd", type: .library(.automatic), targets: ["Render"]),
@@ -1996,7 +1996,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Render", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "gamePkg",
+                    displayName: "gamePkg",
                     path: .init(path: "/gamePkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/drawPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -2019,7 +2019,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           )]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "libPkg",
+                    displayName: "libPkg",
                     path: .init(path: "/libPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/gamePkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -2043,7 +2043,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           ]),
                     ]),
                 Manifest.createRootManifest(
-                    name: "appPkg",
+                    displayName: "appPkg",
                     path: .init(path: "/appPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/libPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -2099,7 +2099,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
-                    name: "drawPkg",
+                    displayName: "drawPkg",
                     path: .init(path: "/drawPkg"),
                     products: [
                         ProductDescription(name: "DrawProd", type: .library(.automatic), targets: ["Render"]),
@@ -2108,7 +2108,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Render", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "gamePkg",
+                    displayName: "gamePkg",
                     path: .init(path: "/gamePkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/drawPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -2133,7 +2133,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           ]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "libPkg",
+                    displayName: "libPkg",
                     path: .init(path: "/libPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/gamePkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -2150,7 +2150,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           ]),
                     ]),
                 Manifest.createRootManifest(
-                    name: "appPkg",
+                    displayName: "appPkg",
                     path: .init(path: "/appPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/libPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -2209,7 +2209,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
-                    name: "drawPkg",
+                    displayName: "drawPkg",
                     path: .init(path: "/drawPkg"),
                     products: [
                         ProductDescription(name: "DrawProd", type: .library(.automatic), targets: ["Render"]),
@@ -2218,7 +2218,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Render", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "gamePkg",
+                    displayName: "gamePkg",
                     path: .init(path: "/gamePkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/drawPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -2241,7 +2241,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           )]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "libPkg",
+                    displayName: "libPkg",
                     path: .init(path: "/libPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/gamePkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -2265,7 +2265,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           ]),
                     ]),
                 Manifest.createRootManifest(
-                    name: "appPkg",
+                    displayName: "appPkg",
                     path: .init(path: "/appPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/libPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -2320,7 +2320,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
-                    name: "barPkg",
+                    displayName: "barPkg",
                     path: .init(path: "/barPkg"),
                     products: [
                         ProductDescription(name: "Logging", type: .library(.automatic), targets: ["Logging"]),
@@ -2329,7 +2329,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Logging", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "fooPkg",
+                    displayName: "fooPkg",
                     path: .init(path: "/fooPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -2344,7 +2344,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                                                  )]),
                     ]),
                 Manifest.createRootManifest(
-                    name: "thisPkg",
+                    displayName: "thisPkg",
                     path: .init(path: "/thisPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -2396,7 +2396,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
-                    name: "carPkg",
+                    displayName: "carPkg",
                     path: .init(path: "/carPkg"),
                     products: [
                         ProductDescription(name: "CarLog", type: .library(.automatic), targets: ["Logging"]),
@@ -2405,7 +2405,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Logging", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "barPkg",
+                    displayName: "barPkg",
                     path: .init(path: "/barPkg"),
                     products: [
                         ProductDescription(name: "BarLog", type: .library(.automatic), targets: ["Logging"]),
@@ -2414,7 +2414,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Logging", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "fooPkg",
+                    displayName: "fooPkg",
                     path: .init(path: "/fooPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/barPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -2429,7 +2429,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                                                  )]),
                     ]),
                 Manifest.createRootManifest(
-                    name: "thisPkg",
+                    displayName: "thisPkg",
                     path: .init(path: "/thisPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/fooPkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -2481,7 +2481,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "xpkg",
+                    displayName: "xpkg",
                     path: .init(path: "/xpkg"),
                     products: [
                         ProductDescription(name: "X", type: .library(.automatic), targets: ["X"]),
@@ -2491,7 +2491,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Utils", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "appPkg",
+                    displayName: "appPkg",
                     path: .init(path: "/appPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -2537,7 +2537,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "cpkg",
+                    displayName: "cpkg",
                     path: .init(path: "/cpkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
@@ -2546,7 +2546,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Utils", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "bpkg",
+                    displayName: "bpkg",
                     path: .init(path: "/bpkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/cpkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -2563,7 +2563,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           ]),
                     ]),
                 Manifest.createRootManifest(
-                    name: "apkg",
+                    displayName: "apkg",
                     path: .init(path: "/apkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/bpkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -2580,7 +2580,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           ]),
                     ]),
                 Manifest.createRootManifest(
-                    name: "ypkg",
+                    displayName: "ypkg",
                     path: .init(path: "/ypkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
@@ -2589,7 +2589,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Utils", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "xpkg",
+                    displayName: "xpkg",
                     path: .init(path: "/xpkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/ypkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -2606,7 +2606,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           ]),
                     ]),
                 Manifest.createRootManifest(
-                    name: "appPkg",
+                    displayName: "appPkg",
                     path: .init(path: "/appPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -2661,7 +2661,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "zpkg",
+                    displayName: "zpkg",
                     path: .init(path: "/zpkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
@@ -2670,7 +2670,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Utils", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "ypkg",
+                    displayName: "ypkg",
                     path: .init(path: "/ypkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
@@ -2679,7 +2679,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Utils", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "xpkg",
+                    displayName: "xpkg",
                     path: .init(path: "/xpkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/ypkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -2700,7 +2700,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           ]),
                     ]),
                 Manifest.createRootManifest(
-                    name: "cpkg",
+                    displayName: "cpkg",
                     path: .init(path: "/cpkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
@@ -2709,7 +2709,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Utils", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "bpkg",
+                    displayName: "bpkg",
                     path: .init(path: "/bpkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
@@ -2718,7 +2718,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Utils", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "apkg",
+                    displayName: "apkg",
                     path: .init(path: "/apkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/bpkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -2739,7 +2739,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           ]),
                     ]),
                 Manifest.createRootManifest(
-                    name: "appPkg",
+                    displayName: "appPkg",
                     path: .init(path: "/appPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -2793,7 +2793,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "zpkg",
+                    displayName: "zpkg",
                     path: .init(path: "/zpkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
@@ -2802,7 +2802,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Utils", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "ypkg",
+                    displayName: "ypkg",
                     path: .init(path: "/ypkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
@@ -2811,7 +2811,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Utils", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "xpkg",
+                    displayName: "xpkg",
                     path: .init(path: "/xpkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/ypkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -2832,7 +2832,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           ]),
                     ]),
                 Manifest.createRootManifest(
-                    name: "apkg",
+                    displayName: "apkg",
                     path: .init(path: "/apkg"),
                     products: [
                         ProductDescription(name: "A", type: .library(.automatic), targets: ["A"]),
@@ -2842,7 +2842,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Utils", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "appPkg",
+                    displayName: "appPkg",
                     path: .init(path: "/appPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -2894,7 +2894,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "zpkg",
+                    displayName: "zpkg",
                     path: .init(path: "/zpkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
@@ -2903,7 +2903,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Utils", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "ypkg",
+                    displayName: "ypkg",
                     path: .init(path: "/ypkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
@@ -2912,7 +2912,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Utils", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "xpkg",
+                    displayName: "xpkg",
                     path: .init(path: "/xpkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/ypkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -2933,7 +2933,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           ]),
                     ]),
                 Manifest.createRootManifest(
-                    name: "apkg",
+                    displayName: "apkg",
                     path: .init(path: "/apkg"),
                     products: [
                         ProductDescription(name: "A", type: .library(.automatic), targets: ["Utils"]),
@@ -2942,7 +2942,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Utils", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "appPkg",
+                    displayName: "appPkg",
                     path: .init(path: "/appPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/xpkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -2996,7 +2996,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
-                    name: "ypkg",
+                    displayName: "ypkg",
                     path: .init(path: "/ypkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
@@ -3005,7 +3005,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Utils", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "xpkg",
+                    displayName: "xpkg",
                     path: .init(path: "/xpkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/ypkg"), requirement: .upToNextMajor(from: "1.0.0"))
@@ -3025,7 +3025,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Utils", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "bpkg",
+                    displayName: "bpkg",
                     path: .init(path: "/bpkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
@@ -3034,7 +3034,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Utils", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "apkg",
+                    displayName: "apkg",
                     path: .init(path: "/apkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/bpkg"), requirement: .upToNextMajor(from: "1.0.0"))
@@ -3054,7 +3054,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Utils", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "appPkg",
+                    displayName: "appPkg",
                     path: .init(path: "/appPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/apkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -3107,7 +3107,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
-                    name: "zpkg",
+                    displayName: "zpkg",
                     path: .init(path: "/zpkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
@@ -3116,7 +3116,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Utils", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "ypkg",
+                    displayName: "ypkg",
                     path: .init(path: "/ypkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
@@ -3125,7 +3125,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Utils", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "xpkg",
+                    displayName: "xpkg",
                     path: .init(path: "/xpkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/ypkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -3147,7 +3147,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                             ]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "bpkg",
+                    displayName: "bpkg",
                     path: .init(path: "/bpkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
@@ -3156,7 +3156,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Utils", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "apkg",
+                    displayName: "apkg",
                     path: .init(path: "/apkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/bpkg"), requirement: .upToNextMajor(from: "1.0.0"))
@@ -3176,7 +3176,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Utils", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "appPkg",
+                    displayName: "appPkg",
                     path: .init(path: "/appPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/apkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -3229,7 +3229,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
-                    name: "zpkg",
+                    displayName: "zpkg",
                     path: .init(path: "/zpkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
@@ -3238,7 +3238,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Utils", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "ypkg",
+                    displayName: "ypkg",
                     path: .init(path: "/ypkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
@@ -3247,7 +3247,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Utils", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "xpkg",
+                    displayName: "xpkg",
                     path: .init(path: "/xpkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/ypkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -3270,7 +3270,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                             ]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "bpkg",
+                    displayName: "bpkg",
                     path: .init(path: "/bpkg"),
                     products: [
                         ProductDescription(name: "Utils", type: .library(.automatic), targets: ["Utils"]),
@@ -3279,7 +3279,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Utils", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "apkg",
+                    displayName: "apkg",
                     path: .init(path: "/apkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/bpkg"), requirement: .upToNextMajor(from: "1.0.0"))
@@ -3299,7 +3299,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Utils", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "appPkg",
+                    displayName: "appPkg",
                     path: .init(path: "/appPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/apkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -3351,16 +3351,17 @@ final class ModuleAliasingBuildTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
-                name: "apkg",
-                path: .init(path: "/apkg"),
-                products: [
-                    ProductDescription(name: "A", type: .library(.automatic), targets: ["Utils"]),
-                ],
-                targets: [
-                    TargetDescription(name: "Utils", dependencies: []),
-                ]),
+                    displayName: "apkg",
+                    path: .init(path: "/apkg"),
+                    products: [
+                        ProductDescription(name: "A", type: .library(.automatic), targets: ["Utils"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "Utils", dependencies: []),
+                    ]
+                ),
                 Manifest.createFileSystemManifest(
-                    name: "wpkg",
+                    displayName: "wpkg",
                     path: .init(path: "/wpkg"),
                     products: [
                         ProductDescription(name: "W", type: .library(.automatic), targets: ["Utils"]),
@@ -3369,7 +3370,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Utils", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "zpkg",
+                    displayName: "zpkg",
                     path: .init(path: "/zpkg"),
                     products: [
                         ProductDescription(name: "Z", type: .library(.automatic), targets: ["Utils"]),
@@ -3378,7 +3379,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                         TargetDescription(name: "Utils", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "ypkg",
+                    displayName: "ypkg",
                     path: .init(path: "/ypkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/zpkg"), requirement: .upToNextMajor(from: "1.0.0"))
@@ -3396,7 +3397,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                           ]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "xpkg",
+                    displayName: "xpkg",
                     path: .init(path: "/xpkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/ypkg"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -3419,7 +3420,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                             ]),
                     ]),
                 Manifest.createRootManifest(
-                    name: "appPkg",
+                    displayName: "appPkg",
                     path: .init(path: "/appPkg"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/apkg"), requirement: .upToNextMajor(from: "1.0.0")),

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -545,7 +545,7 @@ final class PackageToolTests: CommandsTestCase {
         ])
 
         let manifestA = Manifest.createRootManifest(
-            name: "PackageA",
+            displayName: "PackageA",
             path: .init(path: "/PackageA"),
             toolsVersion: .v5_3,
             dependencies: [
@@ -561,7 +561,7 @@ final class PackageToolTests: CommandsTestCase {
         )
 
         let manifestB = Manifest.createFileSystemManifest(
-            name: "PackageB",
+            displayName: "PackageB",
             path: .init(path: "/PackageB"),
             toolsVersion: .v5_3,
             dependencies: [
@@ -577,7 +577,7 @@ final class PackageToolTests: CommandsTestCase {
         )
 
         let manifestC = Manifest.createFileSystemManifest(
-            name: "PackageC",
+            displayName: "PackageC",
             path: .init(path: "/PackageC"),
             toolsVersion: .v5_3,
             dependencies: [
@@ -592,7 +592,7 @@ final class PackageToolTests: CommandsTestCase {
         )
 
         let manifestD = Manifest.createFileSystemManifest(
-            name: "PackageD",
+            displayName: "PackageD",
             path: .init(path: "/PackageD"),
             toolsVersion: .v5_3,
             products: [

--- a/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
@@ -51,7 +51,7 @@ class PackageGraphPerfTests: XCTestCasePerf {
             }
             // Create manifest.
             let isRoot = pkg == 1
-            let manifest = Manifest(
+            let manifest = Manifest.createManifest(
                 displayName: name,
                 path: try AbsolutePath(validating: location).appending(component: Manifest.filename),
                 packageKind: isRoot ? .root(try .init(validating: location)) : .localSourceControl(try .init(validating: location)),
@@ -97,7 +97,7 @@ class PackageGraphPerfTests: XCTestCasePerf {
         let packageSequence: [Manifest] = try packageNumberSequence.map { (sequenceNumber: Int) -> Manifest in
             let dependencySequence = sequenceNumber < lastPackageNumber ? Array((sequenceNumber + 1)...lastPackageNumber) : []
             return Manifest.createFileSystemManifest(
-                name: "Package\(sequenceNumber)",
+                displayName: "Package\(sequenceNumber)",
                 path: try .init(validating: "/Package\(sequenceNumber)"),
                 toolsVersion: .v5_7,
                 dependencies: try dependencySequence.map({ .fileSystem(path: try .init(validating: "/Package\($0)")) }),
@@ -111,7 +111,7 @@ class PackageGraphPerfTests: XCTestCasePerf {
         }
 
         let root = Manifest.createRootManifest(
-            name: "PackageA",
+            displayName: "PackageA",
             path: .init(path: "/PackageA"),
             toolsVersion: .v5_7,
             dependencies: try packageNumberSequence.map({ .fileSystem(path: try .init(validating: "/Package\($0)")) }),

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -34,7 +34,7 @@ class PackageGraphTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
-                    name: "Foo",
+                    displayName: "Foo",
                     path: .init(path: "/Foo"),
                     products: [
                         ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Foo"])
@@ -44,7 +44,7 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "FooDep", dependencies: []),
                     ]),
                 Manifest.createRootManifest(
-                    name: "Bar",
+                    displayName: "Bar",
                     path: .init(path: "/Bar"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/Foo"), requirement: .upToNextMajor(from: "1.0.0"))
@@ -56,7 +56,7 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "Bar", dependencies: ["Foo"], path: "./")
                     ]),
                 Manifest.createRootManifest(
-                    name: "Baz",
+                    displayName: "Baz",
                     path: .init(path: "/Baz"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0"))
@@ -101,7 +101,7 @@ class PackageGraphTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Foo",
+                    displayName: "Foo",
                     path: .init(path: "/Foo"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0"))
@@ -110,7 +110,7 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "Foo", dependencies: ["Bar", "CBar"]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "Bar",
+                    displayName: "Bar",
                     path: .init(path: "/Bar"),
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"]),
@@ -145,7 +145,7 @@ class PackageGraphTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Foo",
+                    displayName: "Foo",
                     path: .init(path: "/Foo"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0"))
@@ -154,7 +154,7 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "Foo", dependencies: ["Bar"]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "Bar",
+                    displayName: "Bar",
                     path: .init(path: "/Bar"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/Baz"), requirement: .upToNextMajor(from: "1.0.0"))
@@ -166,7 +166,7 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "Bar", dependencies: ["Baz"]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "Baz",
+                    displayName: "Baz",
                     path: .init(path: "/Baz"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0"))
@@ -198,7 +198,7 @@ class PackageGraphTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Foo",
+                    displayName: "Foo",
                     path: .init(path: "/Foo"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/Foo"), requirement: .upToNextMajor(from: "1.0.0"))
@@ -230,7 +230,7 @@ class PackageGraphTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Bar",
+                    displayName: "Bar",
                     path: .init(path: "/Bar"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/Foo"), requirement: .upToNextMajor(from: "1.0.0"))
@@ -240,7 +240,7 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "BarTests", dependencies: ["Bar"], type: .test),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "Foo",
+                    displayName: "Foo",
                     path: .init(path: "/Foo"),
                     products: [
                         ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Foo"]),
@@ -272,7 +272,7 @@ class PackageGraphTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Foo",
+                    displayName: "Foo",
                     path: .init(path: "/Foo"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0"))
@@ -281,7 +281,7 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "Bar"),
                     ]),
                 Manifest.createRootManifest(
-                    name: "Bar",
+                    displayName: "Bar",
                     path: .init(path: "/Bar"),
                     targets: [
                         TargetDescription(name: "Bar"),
@@ -308,7 +308,7 @@ class PackageGraphTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
-                    name: "Fourth",
+                    displayName: "Fourth",
                     path: .init(path: "/Fourth"),
                     products: [
                         ProductDescription(name: "Fourth", type: .library(.automatic), targets: ["First"])
@@ -317,7 +317,7 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "First"),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "Third",
+                    displayName: "Third",
                     path: .init(path: "/Third"),
                     products: [
                         ProductDescription(name: "Third", type: .library(.automatic), targets: ["First"])
@@ -326,7 +326,7 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "First"),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "Second",
+                    displayName: "Second",
                     path: .init(path: "/Second"),
                     products: [
                         ProductDescription(name: "Second", type: .library(.automatic), targets: ["First"])
@@ -335,7 +335,7 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "First"),
                     ]),
                 Manifest.createRootManifest(
-                    name: "First",
+                    displayName: "First",
                     path: .init(path: "/First"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/Second"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -367,7 +367,7 @@ class PackageGraphTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
-                    name: "Fourth",
+                    displayName: "Fourth",
                     path: .init(path: "/Fourth"),
                     products: [
                         ProductDescription(name: "Fourth", type: .library(.automatic), targets: ["Bar"])
@@ -376,7 +376,7 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "Bar"),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "Third",
+                    displayName: "Third",
                     path: .init(path: "/Third"),
                     products: [
                         ProductDescription(name: "Third", type: .library(.automatic), targets: ["Bar"])
@@ -385,7 +385,7 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "Bar"),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "Second",
+                    displayName: "Second",
                     path: .init(path: "/Second"),
                     products: [
                         ProductDescription(name: "Second", type: .library(.automatic), targets: ["Foo"])
@@ -394,7 +394,7 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "Foo"),
                     ]),
                 Manifest.createRootManifest(
-                    name: "First",
+                    displayName: "First",
                     path: .init(path: "/First"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/Second"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -427,7 +427,7 @@ class PackageGraphTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createFileSystemManifest(
-                    name: "Fourth",
+                    displayName: "Fourth",
                     path: .init(path: "/Fourth"),
                     products: [
                         ProductDescription(name: "Fourth", type: .library(.automatic), targets: ["First"])
@@ -436,7 +436,7 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "First"),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "Third",
+                    displayName: "Third",
                     path: .init(path: "/Third"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/Fourth"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -448,7 +448,7 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "Third", dependencies: ["Fourth"]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "Second",
+                    displayName: "Second",
                     path: .init(path: "/Second"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/Third"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -460,7 +460,7 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "Second", dependencies: ["Third"]),
                     ]),
                 Manifest.createRootManifest(
-                    name: "First",
+                    displayName: "First",
                     path: .init(path: "/First"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/Second"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -493,7 +493,7 @@ class PackageGraphTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Foo",
+                    displayName: "Foo",
                     path: .init(path: "/Foo"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -502,7 +502,7 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "Foo", dependencies: ["Bar"]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "Bar",
+                    displayName: "Bar",
                     path: try .init(validating: Bar.pathString),
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
@@ -536,7 +536,7 @@ class PackageGraphTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Bar",
+                    displayName: "Bar",
                     path: .init(path: "/Bar"),
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
@@ -565,7 +565,7 @@ class PackageGraphTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Foo",
+                    displayName: "Foo",
                     path: .init(path: "/Foo"),
                     targets: [
                         TargetDescription(name: "FooTarget", dependencies: ["Barx"]),
@@ -593,7 +593,7 @@ class PackageGraphTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Foo",
+                    displayName: "Foo",
                     path: .init(path: "/Foo"),
                     products: [
                         ProductDescription(name: "Foo", type: .library(.automatic), targets: ["FooTarget"]),
@@ -624,7 +624,7 @@ class PackageGraphTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "XYZ",
+                    displayName: "XYZ",
                     path: .init(path: "/XYZ"),
                     targets: [
                         TargetDescription(name: "XYZ", dependencies: [], type: .executable),
@@ -648,7 +648,7 @@ class PackageGraphTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Foo",
+                    displayName: "Foo",
                     path: .init(path: "/Foo"),
                     products: [
                         ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Foo"]),
@@ -673,7 +673,7 @@ class PackageGraphTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Foo",
+                    displayName: "Foo",
                     path: .init(path: "/Foo"),
                     toolsVersion: .v5_2,
                     targets: [
@@ -702,7 +702,7 @@ class PackageGraphTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Foo",
+                    displayName: "Foo",
                     path: .init(path: "/Foo"),
                     toolsVersion: .v5_2,
                     targets: [
@@ -734,7 +734,7 @@ class PackageGraphTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Foo",
+                    displayName: "Foo",
                     path: .init(path: "/Foo"),
                     toolsVersion: .v5_2,
                     dependencies: [
@@ -746,7 +746,7 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "Foo", dependencies: ["BarLib", "Biz", "FizLib"]),
                     ]),
                 Manifest.createLocalSourceControlManifest(
-                    name: "Bar",
+                    displayName: "Bar",
                     path: .init(path: "/Bar"),
                     products: [
                         ProductDescription(name: "BarLib", type: .library(.automatic), targets: ["BarLib"])
@@ -755,7 +755,7 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "BarLib"),
                     ]),
                 Manifest.createLocalSourceControlManifest(
-                    name: "Biz",
+                    displayName: "Biz",
                     path: .init(path: "/BizPath"),
                     version: "1.2.3",
                     products: [
@@ -765,7 +765,7 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "Biz"),
                     ]),
                 Manifest.createLocalSourceControlManifest(
-                    name: "Fiz",
+                    displayName: "Fiz",
                     path: .init(path: "/FizPath"),
                     version: "1.2.3",
                     products: [
@@ -811,7 +811,7 @@ class PackageGraphTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Foo",
+                    displayName: "Foo",
                     path: .init(path: "/Foo"),
                     toolsVersion: .v5_2,
                     dependencies: [
@@ -821,7 +821,7 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "Foo", dependencies: [.product(name: "BarProduct", package: "UnBar")]),
                     ]),
                 Manifest.createLocalSourceControlManifest(
-                    name: "UnBar",
+                    displayName: "UnBar",
                     path: .init(path: "/Bar"),
                     products: [
                         ProductDescription(name: "BarProduct", type: .library(.automatic), targets: ["Bar"])
@@ -850,7 +850,7 @@ class PackageGraphTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Foo",
+                    displayName: "Foo",
                     path: .init(path: "/Foo"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -861,7 +861,7 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "Foo", dependencies: ["BarLibrary"]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "Biz",
+                    displayName: "Biz",
                     path: .init(path: "/Biz"),
                     products: [
                         ProductDescription(name: "biz", type: .executable, targets: ["Biz"])
@@ -870,7 +870,7 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "Biz"),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "Bar",
+                    displayName: "Bar",
                     path: .init(path: "/Bar"),
                     products: [
                         ProductDescription(name: "BarLibrary", type: .library(.automatic), targets: ["Bar"])
@@ -879,7 +879,7 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "Bar"),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "Baz",
+                    displayName: "Baz",
                     path: .init(path: "/Baz"),
                     products: [
                         ProductDescription(name: "BazLibrary", type: .library(.automatic), targets: ["Baz"])
@@ -910,7 +910,7 @@ class PackageGraphTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Bar",
+                    displayName: "Bar",
                     path: .init(path: "/Bar"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/Foo"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -919,7 +919,7 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "Bar"),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "Foo",
+                    displayName: "Foo",
                     path: .init(path: "/Foo")
                 ),
             ],
@@ -944,7 +944,7 @@ class PackageGraphTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Start",
+                    displayName: "Start",
                     path: .init(path: "/Start"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/Dep1"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -954,7 +954,7 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "Bar"),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "Dep1",
+                    displayName: "Dep1",
                     path: .init(path: "/Dep1"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/Dep2"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -966,7 +966,7 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "Baz", dependencies: ["FooLibrary"]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "Dep2",
+                    displayName: "Dep2",
                     path: .init(path: "/Dep2"),
                     products: [
                         ProductDescription(name: "FooLibrary", type: .library(.automatic), targets: ["Foo"]),
@@ -997,7 +997,7 @@ class PackageGraphTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Foo",
+                    displayName: "Foo",
                     path: .init(path: "/Foo"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -1007,7 +1007,7 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "Foo", dependencies: ["Bar"]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "Bar",
+                    displayName: "Bar",
                     path: .init(path: "/Bar"),
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
@@ -1016,7 +1016,7 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "Bar"),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "Baz",
+                    displayName: "Baz",
                     path: .init(path: "/Baz"),
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Baz"])
@@ -1052,7 +1052,7 @@ class PackageGraphTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Foo",
+                    displayName: "Foo",
                     path: .init(path: "/Foo"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -1062,7 +1062,7 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "Foo2", dependencies: ["TransitiveBar"]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "Bar",
+                    displayName: "Bar",
                     path: .init(path: "/Bar"),
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar", "Bar2", "Bar3"]),
@@ -1124,7 +1124,7 @@ class PackageGraphTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Foo",
+                    displayName: "Foo",
                     path: .init(path: "/Foo"),
                     dependencies: [
                         .fileSystem(path: .init(path: "/Biz")),
@@ -1149,7 +1149,7 @@ class PackageGraphTests: XCTestCase {
                     ]
                 ),
                 Manifest.createLocalSourceControlManifest(
-                    name: "Biz",
+                    displayName: "Biz",
                     path: .init(path: "/Biz"),
                     products: [
                         ProductDescription(name: "Biz", type: .library(.automatic), targets: ["Biz"])
@@ -1206,7 +1206,7 @@ class PackageGraphTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Root",
+                    displayName: "Root",
                     path: .init(path: "/Root"),
                     toolsVersion: .v5_2,
                     dependencies: [
@@ -1219,7 +1219,7 @@ class PackageGraphTests: XCTestCase {
                     ]
                 ),
                 Manifest.createFileSystemManifest(
-                    name: "Immediate",
+                    displayName: "Immediate",
                     path: .init(path: "/Immediate"),
                     toolsVersion: .v5_2,
                     dependencies: [
@@ -1247,7 +1247,7 @@ class PackageGraphTests: XCTestCase {
                     ]
                 ),
                 Manifest.createFileSystemManifest(
-                    name: "Transitive",
+                    displayName: "Transitive",
                     path: .init(path: "/Transitive"),
                     toolsVersion: .v5_2,
                     dependencies: [
@@ -1325,7 +1325,7 @@ class PackageGraphTests: XCTestCase {
             fileSystem: fileSystem,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "A",
+                    displayName: "A",
                     path: .init(path: "/A"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/B"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -1338,7 +1338,7 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "A", dependencies: []),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "B",
+                    displayName: "B",
                     path: .init(path: "/B"),
                     products: [
                         ProductDescription(name: "B", type: .library(.automatic), targets: ["B"])
@@ -1348,7 +1348,7 @@ class PackageGraphTests: XCTestCase {
                     ]
                 ),
                 Manifest.createFileSystemManifest(
-                    name: "C",
+                    displayName: "C",
                     path: .init(path: "/C"),
                     products: [
                         ProductDescription(name: "C", type: .library(.automatic), targets: ["C"])
@@ -1358,7 +1358,7 @@ class PackageGraphTests: XCTestCase {
                     ]
                 ),
                 Manifest.createFileSystemManifest(
-                    name: "D",
+                    displayName: "D",
                     path: .init(path: "/D"),
                     products: [
                         ProductDescription(name: "D", type: .library(.automatic), targets: ["D"])
@@ -1368,7 +1368,7 @@ class PackageGraphTests: XCTestCase {
                     ]
                 ),
                 Manifest.createFileSystemManifest(
-                    name: "E",
+                    displayName: "E",
                     path: .init(path: "/E"),
                     products: [
                         ProductDescription(name: "E", type: .library(.automatic), targets: ["E"])
@@ -1378,7 +1378,7 @@ class PackageGraphTests: XCTestCase {
                     ]
                 ),
                 Manifest.createFileSystemManifest(
-                    name: "F",
+                    displayName: "F",
                     path: .init(path: "/F"),
                     products: [
                         ProductDescription(name: "F", type: .library(.automatic), targets: ["F"])
@@ -1411,7 +1411,7 @@ class PackageGraphTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Foo",
+                    displayName: "Foo",
                     path: .init(path: "/Foo"),
                     toolsVersion: .v5,
                     dependencies: [
@@ -1421,7 +1421,7 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "Foo", dependencies: ["Bar"]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "Bar",
+                    displayName: "Bar",
                     path: .init(path: "/Bar"),
                     toolsVersion: .v5,
                     products: [
@@ -1448,7 +1448,7 @@ class PackageGraphTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Foo",
+                    displayName: "Foo",
                     path: .init(path: "/Foo"),
                     toolsVersion: .v5,
                     dependencies: [
@@ -1458,7 +1458,7 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "Foo", dependencies: ["Unknown"]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "Bar",
+                    displayName: "Bar",
                     path: .init(path: "/Bar"),
                     toolsVersion: .v5,
                     products: [
@@ -1492,7 +1492,7 @@ class PackageGraphTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Foo",
+                    displayName: "Foo",
                     path: .init(path: "/Foo"),
                     toolsVersion: .v5_2,
                     dependencies: [
@@ -1502,7 +1502,7 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "Foo", dependencies: ["Bar"]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "Bar",
+                    displayName: "Bar",
                     path: .init(path: "/Bar"),
                     toolsVersion: .v5_2,
                     products: [
@@ -1529,7 +1529,7 @@ class PackageGraphTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Foo",
+                    displayName: "Foo",
                     path: .init(path: "/Foo"),
                     toolsVersion: .v5_2,
                     dependencies: [
@@ -1539,7 +1539,7 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "Foo", dependencies: ["Unknown"]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "Bar",
+                    displayName: "Bar",
                     path: .init(path: "/Bar"),
                     toolsVersion: .v5_2,
                     products: [
@@ -1570,7 +1570,7 @@ class PackageGraphTests: XCTestCase {
 
         let manifests = try [
             Manifest.createRootManifest(
-                name: "Foo",
+                displayName: "Foo",
                 path: .init(path: "/Foo"),
                 toolsVersion: .v5_2,
                 dependencies: [
@@ -1580,7 +1580,7 @@ class PackageGraphTests: XCTestCase {
                     TargetDescription(name: "Foo", dependencies: ["ProductBar"]),
                 ]),
             Manifest.createFileSystemManifest(
-                name: "Bar",
+                displayName: "Bar",
                 path: .init(path: "/Bar"),
                 toolsVersion: .v5_2,
                 products: [
@@ -1630,7 +1630,7 @@ class PackageGraphTests: XCTestCase {
 
         let manifests = try [
             Manifest.createRootManifest(
-                name: "Foo",
+                displayName: "Foo",
                 path: .init(path: "/Foo"),
                 toolsVersion: .v5_2,
                 dependencies: [
@@ -1640,7 +1640,7 @@ class PackageGraphTests: XCTestCase {
                     TargetDescription(name: "Foo", dependencies: ["ProductBar"]),
                 ]),
             Manifest.createFileSystemManifest(
-                name: "Bar",
+                displayName: "Bar",
                 path: .init(path: "/Bar"),
                 toolsVersion: .v5_2,
                 products: [
@@ -1689,7 +1689,7 @@ class PackageGraphTests: XCTestCase {
 
         let manifests = try [
             Manifest.createRootManifest(
-                name: "Foo",
+                displayName: "Foo",
                 path: .init(path: "/Foo"),
                 toolsVersion: .v5_2,
                 dependencies: [
@@ -1699,7 +1699,7 @@ class PackageGraphTests: XCTestCase {
                     TargetDescription(name: "Foo", dependencies: ["Bar"]),
                 ]),
             Manifest.createFileSystemManifest(
-                name: "Bar",
+                displayName: "Bar",
                 path: .init(path: "/Some-Bar"),
                 toolsVersion: .v5_2,
                 products: [
@@ -1747,7 +1747,7 @@ class PackageGraphTests: XCTestCase {
 
         let manifests = try [
             Manifest.createRootManifest(
-                name: "Foo",
+                displayName: "Foo",
                 path: .init(path: "/Foo"),
                 toolsVersion: .v5_2,
                 dependencies: [
@@ -1757,7 +1757,7 @@ class PackageGraphTests: XCTestCase {
                     TargetDescription(name: "Foo", dependencies: ["ProductBar"]),
                 ]),
             Manifest.createFileSystemManifest(
-                name: "Bar",
+                displayName: "Bar",
                 path: .init(path: "/Some-Bar"),
                 toolsVersion: .v5_2,
                 products: [
@@ -1808,7 +1808,7 @@ class PackageGraphTests: XCTestCase {
 
         let manifests = try [
             Manifest.createRootManifest(
-                name: "Foo",
+                displayName: "Foo",
                 path: .init(path: "/Foo"),
                 toolsVersion: .v5_2,
                 dependencies: [
@@ -1818,7 +1818,7 @@ class PackageGraphTests: XCTestCase {
                     TargetDescription(name: "Foo", dependencies: ["Bar"]),
                 ]),
             Manifest.createFileSystemManifest(
-                name: "Bar",
+                displayName: "Bar",
                 path: .init(path: "/Some-Bar"),
                 toolsVersion: .v5_2,
                 products: [
@@ -1844,7 +1844,7 @@ class PackageGraphTests: XCTestCase {
 
         let manifests = try [
             Manifest.createRootManifest(
-                name: "Foo",
+                displayName: "Foo",
                 path: .init(path: "/Foo"),
                 toolsVersion: .v5_2,
                 dependencies: [
@@ -1854,7 +1854,7 @@ class PackageGraphTests: XCTestCase {
                     TargetDescription(name: "Foo", dependencies: ["ProductBar"]),
                 ]),
             Manifest.createFileSystemManifest(
-                name: "Bar",
+                displayName: "Bar",
                 path: .init(path: "/Some-Bar"),
                 toolsVersion: .v5_2,
                 products: [
@@ -1899,7 +1899,7 @@ class PackageGraphTests: XCTestCase {
     // TODO: remove this when we remove explicit dependency name
     func testTargetDependencies_Post52_AliasFindsIdentity() throws {
         let manifest = Manifest.createRootManifest(
-            name: "Package",
+            displayName: "Package",
             path: .init(path: "/Package"),
             toolsVersion: .v5_2,
             dependencies: [
@@ -1965,7 +1965,7 @@ class PackageGraphTests: XCTestCase {
         do {
             // One platform with an override.
             let manifest = Manifest.createRootManifest(
-                name: "pkg",
+                displayName: "pkg",
                 platforms: [
                     PlatformDescription(name: "macos", version: "10.14", options: ["option1"]),
                 ],
@@ -2062,7 +2062,7 @@ class PackageGraphTests: XCTestCase {
         do {
             // Two platforms with overrides.
             let manifest = Manifest.createRootManifest(
-                name: "pkg",
+                displayName: "pkg",
                 platforms: [
                     PlatformDescription(name: "macos", version: "10.14"),
                     PlatformDescription(name: "tvos", version: "12.0"),
@@ -2126,7 +2126,7 @@ class PackageGraphTests: XCTestCase {
         do {
             // Test MacCatalyst overriding behavior.
             let manifest = Manifest.createRootManifest(
-                name: "pkg",
+                displayName: "pkg",
                 platforms: [
                     PlatformDescription(name: "ios", version: "15.0"),
                 ],
@@ -2199,7 +2199,7 @@ class PackageGraphTests: XCTestCase {
         do {
             // One custom platform.
             let manifest = Manifest.createRootManifest(
-                name: "pkg",
+                displayName: "pkg",
                 platforms: [
                     PlatformDescription(name: "customos", version: "1.0"),
                 ],
@@ -2241,7 +2241,7 @@ class PackageGraphTests: XCTestCase {
         do {
             // Two platforms with overrides.
             let manifest = Manifest.createRootManifest(
-                name: "pkg",
+                displayName: "pkg",
                 platforms: [
                     PlatformDescription(name: "customos", version: "1.0"),
                     PlatformDescription(name: "anothercustomos", version: "2.3"),
@@ -2299,7 +2299,7 @@ class PackageGraphTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Foo",
+                    displayName: "Foo",
                     path: .init(path: "/Foo"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -2309,7 +2309,7 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "Foo2", dependencies: ["TransitiveBar"]),
                     ]),
                 Manifest.createFileSystemManifest(
-                    name: "Bar",
+                    displayName: "Bar",
                     path: .init(path: "/Bar"),
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar", "Bar2", "Bar3"]),
@@ -2352,7 +2352,7 @@ class PackageGraphTests: XCTestCase {
 extension Manifest {
     func withTargets(_ targets: [TargetDescription]) -> Manifest {
         Manifest.createManifest(
-            name: self.displayName,
+            displayName: self.displayName,
             path: self.path.parentDirectory,
             packageKind: self.packageKind,
             packageLocation: self.packageLocation,
@@ -2364,7 +2364,7 @@ extension Manifest {
 
     func withDependencies(_ dependencies: [PackageDependency]) -> Manifest {
         Manifest.createManifest(
-            name: self.displayName,
+            displayName: self.displayName,
             path: self.path.parentDirectory,
             packageKind: self.packageKind,
             packageLocation: self.packageLocation,

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -26,7 +26,7 @@ class PackageBuilderTests: XCTestCase {
             "/Sources/foo/Foo.swift")
 
         let manifest = Manifest.createRootManifest(
-            name: "pkg",
+            displayName: "pkg",
             path: .root,
             targets: [
                 try TargetDescription(name: "foo"),
@@ -49,7 +49,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         let manifest = Manifest.createRootManifest(
-            name: "pkg",
+            displayName: "pkg",
             path: .root,
             targets: [
                 try TargetDescription(name: "foo"),
@@ -76,7 +76,7 @@ class PackageBuilderTests: XCTestCase {
             try fs.removeFileTree(linkDestPath)
 
             let manifest = Manifest.createRootManifest(
-                name: "pkg",
+                displayName: "pkg",
                 path: path,
                 targets: [
                     try TargetDescription(name: "foo"),
@@ -107,7 +107,7 @@ class PackageBuilderTests: XCTestCase {
             try fs.createSymbolicLink(bar, pointingAt: foo, relative: false)
 
             let manifest = Manifest.createRootManifest(
-                name: "pkg",
+                displayName: "pkg",
                 targets: [
                     try TargetDescription(name: "bar"),
                 ]
@@ -125,7 +125,7 @@ class PackageBuilderTests: XCTestCase {
             "/Tests/MyPackageTests/abc.c")
 
         let manifest = Manifest.createRootManifest(
-            name: "MyPackage",
+            displayName: "MyPackage",
             targets: [
                 try TargetDescription(name: "MyPackage"),
                 try TargetDescription(name: "MyPackageTests", dependencies: ["MyPackage"], type: .test),
@@ -167,7 +167,7 @@ class PackageBuilderTests: XCTestCase {
             "/Packages/MyPackage/main.c")
 
         let manifest = Manifest.createRootManifest(
-            name: "pkg",
+            displayName: "pkg",
             targets: [
                 try TargetDescription(name: "pkg"),
             ]
@@ -190,7 +190,7 @@ class PackageBuilderTests: XCTestCase {
 
         let name = "Foo"
         let manifest = Manifest.createRootManifest(
-            name: name,
+            displayName: name,
             targets: [
                 try TargetDescription(name: name),
             ]
@@ -211,7 +211,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         let manifest = Manifest.createRootManifest(
-            name: "MyPackage",
+            displayName: "MyPackage",
             targets: [
                 try TargetDescription(name: "clib"),
             ]
@@ -239,7 +239,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         let manifest = Manifest.createRootManifest(
-            name: "MyPackage",
+            displayName: "MyPackage",
             targets: [
                 try TargetDescription(
                     name: "clib",
@@ -275,7 +275,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         let manifest = Manifest.createRootManifest(
-            name: "MyPackage",
+            displayName: "MyPackage",
             targets: [
                 try TargetDescription(
                     name: "swift.lib"
@@ -321,7 +321,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         let manifest = Manifest.createRootManifest(
-            name: "MyPackage",
+            displayName: "MyPackage",
             targets: [
                 try TargetDescription(
                     name: "clib",
@@ -346,7 +346,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         var manifest = Manifest.createRootManifest(
-            name: "pkg",
+            displayName: "pkg",
             products: [
                 try ProductDescription(name: "exec", type: .executable, targets: ["exec", "foo"]),
             ],
@@ -364,7 +364,7 @@ class PackageBuilderTests: XCTestCase {
         }
 
         manifest = Manifest.createRootManifest(
-            name: "pkg",
+            displayName: "pkg",
             products: [],
             targets: [
                 try TargetDescription(name: "foo"),
@@ -382,7 +382,7 @@ class PackageBuilderTests: XCTestCase {
         // If we already have an explicit product, we shouldn't create an
         // implicit one.
         manifest = Manifest.createRootManifest(
-            name: "pkg",
+            displayName: "pkg",
             products: [
                 try ProductDescription(name: "exec1", type: .executable, targets: ["exec"]),
             ],
@@ -409,7 +409,7 @@ class PackageBuilderTests: XCTestCase {
 
         // Check that an explicitly declared target without a main source file works.
         var manifest = Manifest.createRootManifest(
-            name: "pkg",
+            displayName: "pkg",
             toolsVersion: .v5_5,
             products: [
                 try ProductDescription(name: "exec1", type: .executable, targets: ["exec1", "lib"]),
@@ -429,7 +429,7 @@ class PackageBuilderTests: XCTestCase {
 
         // Check that products are inferred for explicitly declared executable targets.
         manifest = Manifest.createRootManifest(
-            name: "pkg",
+            displayName: "pkg",
             toolsVersion: .v5_5,
             products: [],
             targets: [
@@ -447,7 +447,7 @@ class PackageBuilderTests: XCTestCase {
 
         // Check that products are not inferred if there is an explicit executable product.
         manifest = Manifest.createRootManifest(
-            name: "pkg",
+            displayName: "pkg",
             toolsVersion: .v5_5,
             products: [
                 try ProductDescription(name: "exec1", type: .executable, targets: ["exec1"]),
@@ -467,7 +467,7 @@ class PackageBuilderTests: XCTestCase {
 
         // Check that an explicitly declared target with a main source file still works.
         manifest = Manifest.createRootManifest(
-            name: "pkg",
+            displayName: "pkg",
             toolsVersion: .v5_5,
             products: [
                 try ProductDescription(name: "exec1", type: .executable, targets: ["exec1"]),
@@ -487,7 +487,7 @@ class PackageBuilderTests: XCTestCase {
 
         // Check that a inferred target with a main source file still works but yields a warning.
         manifest = Manifest.createRootManifest(
-            name: "pkg",
+            displayName: "pkg",
             toolsVersion: .v5_5,
             products: [
                 try ProductDescription(name: "exec2", type: .executable, targets: ["exec2"]),
@@ -519,7 +519,7 @@ class PackageBuilderTests: XCTestCase {
             )
 
             let manifest = Manifest.createRootManifest(
-                name: "pkg",
+                displayName: "pkg",
                 targets: [
                     try TargetDescription(name: "exe", path: "swift/exe"),
                     try TargetDescription(name: "tests", path: "swift/tests", type: .test),
@@ -551,7 +551,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         let manifest = Manifest.createRootManifest(
-            name: "pkg",
+            displayName: "pkg",
             targets: [
                 try TargetDescription(
                     name: "exe",
@@ -581,7 +581,7 @@ class PackageBuilderTests: XCTestCase {
         let fs = InMemoryFileSystem(emptyFiles: "/Sources/best/best.swift")
 
         let manifest = Manifest.createRootManifest(
-            name: "pkg",
+            displayName: "pkg",
             products: [
                 try ProductDescription(name: "", type: .library(.automatic), targets: ["best"]),
             ],
@@ -606,7 +606,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         let manifest = Manifest.createRootManifest(
-            name: "pkg",
+            displayName: "pkg",
             targets: [
                 try TargetDescription(
                     name: "tests",
@@ -639,7 +639,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         let manifest = Manifest.createRootManifest(
-            name: "pkg",
+            displayName: "pkg",
             targets: [
                 try TargetDescription(
                     name: "exe",
@@ -695,7 +695,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         var manifest = Manifest.createRootManifest(
-            name: "pkg",
+            displayName: "pkg",
             targets: [
                 try TargetDescription(
                     name: "bar",
@@ -711,7 +711,7 @@ class PackageBuilderTests: XCTestCase {
         }
 
         manifest = Manifest.createRootManifest(
-            name: "pkg",
+            displayName: "pkg",
             targets: [
                 try TargetDescription(
                     name: "bar",
@@ -755,7 +755,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         let manifest = Manifest.createRootManifest(
-            name: "Foo",
+            displayName: "Foo",
             targets: [
                 try TargetDescription(
                     name: "Foo",
@@ -797,7 +797,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         let manifest = Manifest.createRootManifest(
-            name: "Foo",
+            displayName: "Foo",
             targets: [
                 try TargetDescription(
                     name: "Foo",
@@ -823,7 +823,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         let manifest = Manifest.createRootManifest(
-            name: "Foo",
+            displayName: "Foo",
             targets: [
                 try TargetDescription(name: "A"),
                 try TargetDescription(name: "TheTestOfA", dependencies: ["A"], type: .test),
@@ -870,7 +870,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         let manifest = Manifest.createRootManifest(
-            name: "pkg",
+            displayName: "pkg",
             targets: [
                 try TargetDescription(name: "foo"),
                 try TargetDescription(name: "fooTests", type: .test),
@@ -908,7 +908,7 @@ class PackageBuilderTests: XCTestCase {
 
         // Direct.
         var manifest = Manifest.createRootManifest(
-            name: "pkg",
+            displayName: "pkg",
             targets: [
                 try TargetDescription(name: "Foo", dependencies: ["Bar"]),
                 try TargetDescription(name: "Bar"),
@@ -932,7 +932,7 @@ class PackageBuilderTests: XCTestCase {
 
         // Transitive.
         manifest = Manifest.createRootManifest(
-            name: "pkg",
+            displayName: "pkg",
             targets: [
                 try TargetDescription(name: "Foo", dependencies: ["Bar"]),
                 try TargetDescription(name: "Bar", dependencies: ["Baz"]),
@@ -969,7 +969,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         let manifest = Manifest.createRootManifest(
-            name: "pkg",
+            displayName: "pkg",
             targets: [
                 try TargetDescription(name: "Bar"),
                 try TargetDescription(name: "Baz"),
@@ -1005,7 +1005,7 @@ class PackageBuilderTests: XCTestCase {
                 "/Foo.swift")
 
             let manifest = Manifest.createRootManifest(
-                name: "pkg",
+                displayName: "pkg",
                 targets: [
                     try TargetDescription(name: "Random"),
                 ]
@@ -1020,7 +1020,7 @@ class PackageBuilderTests: XCTestCase {
                 "/src/pkg/Foo.swift")
             // Reference an invalid dependency.
             let manifest = Manifest.createRootManifest(
-                name: "pkg",
+                displayName: "pkg",
                 targets: [
                     try TargetDescription(name: "pkg", dependencies: [.target(name: "Foo")]),
                 ]
@@ -1034,7 +1034,7 @@ class PackageBuilderTests: XCTestCase {
             let fs = InMemoryFileSystem(emptyFiles:
                 "/Sources/pkg/Foo.swift")
             let manifest = Manifest.createRootManifest(
-                name: "pkg",
+                displayName: "pkg",
                 targets: [
                     try TargetDescription(name: "pkg", dependencies: []),
                     try TargetDescription(name: "pkgTests", dependencies: [], type: .test),
@@ -1050,7 +1050,7 @@ class PackageBuilderTests: XCTestCase {
                 "/Source/pkg/Foo.swift")
             // Reference self in dependencies.
             let manifest = Manifest.createRootManifest(
-                name: "pkg",
+                displayName: "pkg",
                 targets: [
                     try TargetDescription(name: "pkg", dependencies: [.target(name: "pkg")]),
                 ]
@@ -1065,7 +1065,7 @@ class PackageBuilderTests: XCTestCase {
                 "/Source/pkg/Foo.swift")
             // Reference invalid target.
             let manifest = Manifest.createRootManifest(
-                name: "pkg",
+                displayName: "pkg",
                 targets: [
                     try TargetDescription(name: "foo"),
                 ]
@@ -1079,7 +1079,7 @@ class PackageBuilderTests: XCTestCase {
             let fs = InMemoryFileSystem()
             // Binary target.
             let manifest = Manifest.createRootManifest(
-                name: "pkg",
+                displayName: "pkg",
                 targets: [
                     try TargetDescription(name: "foo", url: "https://foo.com/foo.zip", type: .binary, checksum: "checksum"),
                     try TargetDescription(name: "foo2", path: "./foo2.zip", type: .binary)
@@ -1106,7 +1106,7 @@ class PackageBuilderTests: XCTestCase {
             )
             // Cyclic dependency.
             var manifest = Manifest.createRootManifest(
-                name: "pkg",
+                displayName: "pkg",
                 targets: [
                     try TargetDescription(name: "pkg1", dependencies: ["pkg2"]),
                     try TargetDescription(name: "pkg2", dependencies: ["pkg3"]),
@@ -1118,7 +1118,7 @@ class PackageBuilderTests: XCTestCase {
             }
 
             manifest = Manifest.createRootManifest(
-                name: "pkg",
+                displayName: "pkg",
                 targets: [
                     try TargetDescription(name: "pkg1", dependencies: ["pkg2"]),
                     try TargetDescription(name: "pkg2", dependencies: ["pkg3"]),
@@ -1140,7 +1140,7 @@ class PackageBuilderTests: XCTestCase {
             )
 
             let manifest = Manifest.createRootManifest(
-                name: "pkg",
+                displayName: "pkg",
                 targets: [
                     try TargetDescription(name: "pkg1", dependencies: ["pkg2"]),
                     try TargetDescription(name: "pkg2"),
@@ -1164,7 +1164,7 @@ class PackageBuilderTests: XCTestCase {
                 "/Sources/Bar/Bar.c")
 
             var manifest = Manifest.createRootManifest(
-                name: "Foo",
+                displayName: "Foo",
                 targets: [
                     try TargetDescription(name: "Foo", publicHeadersPath: "../inc"),
                 ]
@@ -1175,7 +1175,7 @@ class PackageBuilderTests: XCTestCase {
             }
 
             manifest = Manifest.createRootManifest(
-                name: "Foo",
+                displayName: "Foo",
                 targets: [
                     try TargetDescription(name: "Bar", publicHeadersPath: "inc/../../../foo"),
                 ]
@@ -1191,7 +1191,7 @@ class PackageBuilderTests: XCTestCase {
                 "/foo/Bar.c")
 
             let manifest = Manifest.createRootManifest(
-                name: "Foo",
+                displayName: "Foo",
                 targets: [
                     try TargetDescription(name: "Foo", path: "../foo"),
                 ]
@@ -1206,7 +1206,7 @@ class PackageBuilderTests: XCTestCase {
                 "/foo/Bar.c")
 
             let manifest = Manifest.createRootManifest(
-                name: "Foo",
+                displayName: "Foo",
                 targets: [
                     try TargetDescription(name: "Foo", path: "/foo"),
                 ]
@@ -1222,7 +1222,7 @@ class PackageBuilderTests: XCTestCase {
                 "/foo/Bar.c")
 
             let manifest = Manifest.createRootManifest(
-                name: "Foo",
+                displayName: "Foo",
                 targets: [
                     try TargetDescription(name: "Foo", path: "~/foo"),
                 ]
@@ -1240,7 +1240,7 @@ class PackageBuilderTests: XCTestCase {
             "/Sources/lib/lib.swift")
 
         let manifest = Manifest.createRootManifest(
-            name: "pkg",
+            displayName: "pkg",
             targets: [
                 try TargetDescription(name: "lib", dependencies: ["exec"]),
                 try TargetDescription(name: "exec"),
@@ -1267,7 +1267,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         var manifest = Manifest.createRootManifest(
-            name: "pkg",
+            displayName: "pkg",
             pkgConfig: "foo"
         )
 
@@ -1281,7 +1281,7 @@ class PackageBuilderTests: XCTestCase {
             "/Sources/Foo/main.c"
         )
         manifest = Manifest.createRootManifest(
-            name: "pkg",
+            displayName: "pkg",
             providers: [.brew(["foo"])]
         )
 
@@ -1296,7 +1296,7 @@ class PackageBuilderTests: XCTestCase {
         let fs = InMemoryFileSystem(emptyFiles:
             "/module.modulemap")
 
-        let manifest = Manifest.createRootManifest(name: "SystemModulePackage")
+        let manifest = Manifest.createRootManifest(displayName: "SystemModulePackage")
         PackageBuilderTester(manifest, in: fs) { package, _ in
             package.checkModule("SystemModulePackage") { module in
                 module.check(c99name: "SystemModulePackage", type: .systemModule)
@@ -1313,7 +1313,7 @@ class PackageBuilderTests: XCTestCase {
 
         func createManifest(swiftVersions: [SwiftLanguageVersion]?) throws -> Manifest {
             return Manifest.createRootManifest(
-                name: "pkg",
+                displayName: "pkg",
                 swiftLanguageVersions: swiftVersions,
                 targets: [
                     try TargetDescription(name: "foo", path: "foo"),
@@ -1375,7 +1375,7 @@ class PackageBuilderTests: XCTestCase {
                 "/src/Bar/Bar.swift")
 
             let manifest = Manifest.createRootManifest(
-                name: "pkg",
+                displayName: "pkg",
                 targets: [
                     try TargetDescription(name: "Foo", dependencies: ["Bar"]),
                     try TargetDescription(name: "Bar"),
@@ -1395,7 +1395,7 @@ class PackageBuilderTests: XCTestCase {
                 "/Source/BarTests/Foo.swift")
 
             var manifest = Manifest.createRootManifest(
-                name: "pkg",
+                displayName: "pkg",
                 targets: [
                     try TargetDescription(name: "BarTests", type: .test),
                     try TargetDescription(name: "FooTests", type: .test),
@@ -1407,7 +1407,7 @@ class PackageBuilderTests: XCTestCase {
 
             // We should be able to fix this by using custom paths.
             manifest = Manifest.createRootManifest(
-                name: "pkg",
+                displayName: "pkg",
                 targets: [
                     try TargetDescription(name: "BarTests", path: "Source/BarTests", type: .test),
                     try TargetDescription(name: "FooTests", type: .test),
@@ -1429,7 +1429,7 @@ class PackageBuilderTests: XCTestCase {
         let fs = InMemoryFileSystem(emptyFiles: "/Foo.swift")
 
         let manifest = Manifest.createRootManifest(
-            name: "Foo",
+            displayName: "Foo",
             targets: [
                 try TargetDescription(name: "Foo", path: "./NotExist")
             ]
@@ -1449,7 +1449,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         let manifest = Manifest.createRootManifest(
-            name: "Foo",
+            displayName: "Foo",
             targets: [
                 try TargetDescription(name: "A"),
                 try TargetDescription(name: "ATests", type: .test),
@@ -1478,7 +1478,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         let manifest = Manifest.createRootManifest(
-            name: "pkg",
+            displayName: "pkg",
             targets: [
                 try TargetDescription(
                     name: "bar",
@@ -1503,7 +1503,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         let manifest = Manifest.createRootManifest(
-            name: "pkg",
+            displayName: "pkg",
             products: [
                 try ProductDescription(name: "foo", type: .library(.automatic), targets: ["foo"]),
                 try ProductDescription(name: "foo", type: .library(.static), targets: ["foo"]),
@@ -1541,7 +1541,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         let manifest = Manifest.createRootManifest(
-            name: "SystemModulePackage",
+            displayName: "SystemModulePackage",
             targets: [
                 try TargetDescription(name: "foo"),
                 try TargetDescription(name: "bar"),
@@ -1566,7 +1566,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         let manifest = Manifest.createRootManifest(
-            name: "pkg",
+            displayName: "pkg",
             products: [
                 try ProductDescription(name: "foo", type: .library(.automatic), targets: ["foo"]),
             ],
@@ -1600,7 +1600,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         var manifest = Manifest.createRootManifest(
-            name: "SystemModulePackage",
+            displayName: "SystemModulePackage",
             products: [
                 try ProductDescription(name: "foo", type: .library(.automatic), targets: ["foo", "bar"]),
             ],
@@ -1619,7 +1619,7 @@ class PackageBuilderTests: XCTestCase {
         }
 
         manifest = Manifest.createRootManifest(
-            name: "SystemModulePackage",
+            displayName: "SystemModulePackage",
             products: [
                 try ProductDescription(name: "foo", type: .library(.static), targets: ["foo"]),
             ],
@@ -1638,7 +1638,7 @@ class PackageBuilderTests: XCTestCase {
         }
 
         manifest = Manifest.createRootManifest(
-            name: "bar",
+            displayName: "bar",
             products: [
                 try ProductDescription(name: "bar", type: .library(.automatic), targets: ["bar"])
             ],
@@ -1664,7 +1664,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         let manifest = Manifest.createRootManifest(
-            name: "MyPackage",
+            displayName: "MyPackage",
             products: [
                 try ProductDescription(name: "foo1", type: .executable, targets: ["FooLib1"]),
                 try ProductDescription(name: "foo2", type: .executable, targets: ["FooLib1", "FooLib2"]),
@@ -1717,7 +1717,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         let manifest = Manifest.createRootManifest(
-            name: "MyPackage",
+            displayName: "MyPackage",
             products: [
                 try ProductDescription(name: "MyLibrary", type: .library(.automatic), targets: ["MyLibrary", "MyPlugin"])
             ],
@@ -1745,7 +1745,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         let manifest = Manifest.createRootManifest(
-            name: "Pkg",
+            displayName: "Pkg",
             targets: [
                 try TargetDescription(name: "exe"),
             ]
@@ -1771,7 +1771,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         let manifest = Manifest.createRootManifest(
-            name: "pkg",
+            displayName: "pkg",
             toolsVersion: .v4_2,
             targets: [
                 try TargetDescription(name: "lib", dependencies: []),
@@ -1795,7 +1795,7 @@ class PackageBuilderTests: XCTestCase {
 
         //let observability = ObservabilitySystem.makeForTesting()
         let manifest = Manifest.createRootManifest(
-            name: "Pkg",
+            displayName: "Pkg",
             toolsVersion: .v5,
             targets: [
                 try TargetDescription(name: "lib", dependencies: []),
@@ -1821,7 +1821,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         let manifest = Manifest.createRootManifest(
-            name: "pkg",
+            displayName: "pkg",
             toolsVersion: .v5_2,
             targets: [
                 try TargetDescription(name: "lib", dependencies: [], path: "./Sources/lib", sources: ["."]),
@@ -1848,7 +1848,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         let manifest = Manifest.createRootManifest(
-            name: "pkg",
+            displayName: "pkg",
             toolsVersion: .v5_3,
             targets: [
                 try TargetDescription(name: "lib", dependencies: [], path: "./Sources/lib", sources: ["."]),
@@ -1874,7 +1874,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         let manifest = Manifest.createRootManifest(
-            name: "pkg",
+            displayName: "pkg",
             toolsVersion: .v5,
             targets: [
                 try TargetDescription(
@@ -1985,7 +1985,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         let manifest = Manifest.createRootManifest(
-            name: "pkg",
+            displayName: "pkg",
             toolsVersion: .v5,
             targets: [
                 try TargetDescription(
@@ -2058,7 +2058,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         let manifest1 = Manifest.createRootManifest(
-            name: "pkg",
+            displayName: "pkg",
             toolsVersion: .v5,
             targets: [
                 try TargetDescription(
@@ -2075,7 +2075,7 @@ class PackageBuilderTests: XCTestCase {
         }
 
         let manifest2 = Manifest.createRootManifest(
-            name: "pkg",
+            displayName: "pkg",
             toolsVersion: .v5,
             targets: [
                 try TargetDescription(
@@ -2104,7 +2104,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         let manifest = Manifest.createRootManifest(
-            name: "Foo",
+            displayName: "Foo",
             toolsVersion: .v5,
             dependencies: [
                 .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0")),
@@ -2171,7 +2171,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         let manifest = Manifest.createRootManifest(
-            name: "Foo",
+            displayName: "Foo",
             toolsVersion: .v5,
             dependencies: [
                 .fileSystem(path: .init(path: "/Biz")),
@@ -2235,7 +2235,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         let manifest = Manifest.createRootManifest(
-            name: "Foo",
+            displayName: "Foo",
             toolsVersion: .v5_3,
             targets: [
                 try TargetDescription(name: "Foo", resources: [
@@ -2262,7 +2262,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         let manifest = Manifest.createRootManifest(
-            name: "Foo",
+            displayName: "Foo",
             toolsVersion: .v5_3,
             targets: [
                 try TargetDescription(name: "Foo"),
@@ -2293,7 +2293,7 @@ class PackageBuilderTests: XCTestCase {
             snippetsDir.appending(component: "ASnippet.swift").pathString)
         
         let manifest = Manifest.createRootManifest(
-            name: "Foo", toolsVersion: .v5_7,
+            displayName: "Foo", toolsVersion: .v5_7,
             products: [
                 try ProductDescription(name: "Product", type: .library(.automatic), targets: ["Product"])
             ],

--- a/Tests/PackageModelTests/ManifestTests.swift
+++ b/Tests/PackageModelTests/ManifestTests.swift
@@ -31,7 +31,7 @@ class ManifestTests: XCTestCase {
 
         do {
             let manifest = Manifest.createRootManifest(
-                name: "Foo",
+                displayName: "Foo",
                 path: .init(path: "/Foo"),
                 toolsVersion: .v5_2,
                 products: products,
@@ -49,7 +49,7 @@ class ManifestTests: XCTestCase {
 
         do {
             let manifest = Manifest.createLocalSourceControlManifest(
-                name: "Foo",
+                displayName: "Foo",
                 path: .init(path: "/Foo"),
                 toolsVersion: .v5_2,
                 products: products,
@@ -84,7 +84,7 @@ class ManifestTests: XCTestCase {
 
         do {
             let manifest = Manifest.createRootManifest(
-                name: "Foo",
+                displayName: "Foo",
                 path: .init(path: "/Foo"),
                 toolsVersion: .v5,
                 dependencies: dependencies,
@@ -101,7 +101,7 @@ class ManifestTests: XCTestCase {
 
         do {
             let manifest = Manifest.createLocalSourceControlManifest(
-                name: "Foo",
+                displayName: "Foo",
                 path: .init(path: "/Foo"),
                 toolsVersion: .v5,
                 dependencies: dependencies,
@@ -118,7 +118,7 @@ class ManifestTests: XCTestCase {
 
         do {
             let manifest = Manifest.createRootManifest(
-                name: "Foo",
+                displayName: "Foo",
                 path: .init(path: "/Foo"),
                 toolsVersion: .v5_2,
                 dependencies: dependencies,
@@ -135,7 +135,7 @@ class ManifestTests: XCTestCase {
 
         do {
             let manifest = Manifest.createLocalSourceControlManifest(
-                name: "Foo",
+                displayName: "Foo",
                 path: .init(path: "/Foo"),
                 toolsVersion: .v5_2,
                 dependencies: dependencies,

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -38,7 +38,7 @@ class PluginInvocationTests: XCTestCase {
             fileSystem: fileSystem,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Foo",
+                    displayName: "Foo",
                     path: .init(path: "/Foo"),
                     products: [
                         ProductDescription(

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -426,7 +426,7 @@ class ManifestSourceGenerationTests: XCTestCase {
     func testCustomProductSourceGeneration() throws {
         // Create a manifest containing a product for which we'd like to do custom source fragment generation.
         let packageDir = AbsolutePath(path: "/tmp/MyLibrary")
-        let manifest = Manifest(
+        let manifest = Manifest.createManifest(
             displayName: "MyLibrary",
             path: packageDir.appending(component: "Package.swift"),
             packageKind: .root(AbsolutePath(path: "/tmp/MyLibrary")),
@@ -464,7 +464,7 @@ class ManifestSourceGenerationTests: XCTestCase {
 
     func testModuleAliasGeneration() throws {
         let manifest = Manifest.createRootManifest(
-            name: "thisPkg",
+            displayName: "thisPkg",
             path: .init(path: "/thisPkg"),
             toolsVersion: .v5_7,
             dependencies: [
@@ -530,7 +530,7 @@ class ManifestSourceGenerationTests: XCTestCase {
 
     func testPluginNetworkingPermissionGeneration() throws {
         let manifest = Manifest.createRootManifest(
-            name: "thisPkg",
+            displayName: "thisPkg",
             path: .init(path: "/thisPkg"),
             toolsVersion: .v5_9,
             dependencies: [],

--- a/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
@@ -265,7 +265,7 @@ class RegistryPackageContainerTests: XCTestCase {
                           callbackQueue: DispatchQueue,
                           completion: @escaping (Result<Manifest, Error>) -> Void) {
                     completion(.success(
-                        Manifest(
+                        Manifest.createManifest(
                             displayName: packageIdentity.description,
                             path: manifestPath,
                             packageKind: packageKind,

--- a/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
@@ -457,7 +457,7 @@ class SourceControlPackageContainerTests: XCTestCase {
 
         do {
             let manifest = Manifest.createRootManifest(
-                name: "Foo",
+                displayName: "Foo",
                 path: .init(path: "/Foo"),
                 toolsVersion: .v5,
                 dependencies: dependencies,
@@ -479,7 +479,7 @@ class SourceControlPackageContainerTests: XCTestCase {
 
         do {
             let manifest = Manifest.createFileSystemManifest(
-                name: "Foo",
+                displayName: "Foo",
                 path: .init(path: "/Foo"),
                 toolsVersion: .v5,
                 dependencies: dependencies,
@@ -501,7 +501,7 @@ class SourceControlPackageContainerTests: XCTestCase {
 
         do {
             let manifest = Manifest.createRootManifest(
-                name: "Foo",
+                displayName: "Foo",
                 path: .init(path: "/Foo"),
                 toolsVersion: .v5_2,
                 dependencies: dependencies,
@@ -523,7 +523,7 @@ class SourceControlPackageContainerTests: XCTestCase {
 
         do {
             let manifest = Manifest.createFileSystemManifest(
-                name: "Foo",
+                displayName: "Foo",
                 path: .init(path: "/Foo"),
                 toolsVersion: .v5_2,
                 dependencies: dependencies,
@@ -574,7 +574,7 @@ class SourceControlPackageContainerTests: XCTestCase {
 
             // Create a container provider, configured with a mock manifest loader that will return the package manifest.
             let manifest = Manifest.createRootManifest(
-                name: packageDir.basename,
+                displayName: packageDir.basename,
                 path: packageDir,
                 targets: [
                     try TargetDescription(name: packageDir.basename, path: packageDir.pathString),
@@ -639,7 +639,7 @@ class SourceControlPackageContainerTests: XCTestCase {
 
             let version = Version(1, 0, 0)
             let manifest = Manifest.createRootManifest(
-                name: packageDirectory.basename,
+                displayName: packageDirectory.basename,
                 path: packageDirectory,
                 toolsVersion: .v5_2,
                 dependencies: [

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -2657,7 +2657,7 @@ final class WorkspaceTests: XCTestCase {
                 productFilter: settings.productFilter
             )
 
-            workspace.manifestLoader.manifests[fooKey] = Manifest(
+            workspace.manifestLoader.manifests[fooKey] = Manifest.createManifest(
                 displayName: manifest.displayName,
                 path: manifest.path,
                 packageKind: manifest.packageKind,
@@ -10275,7 +10275,7 @@ final class WorkspaceTests: XCTestCase {
                 } else {
                     callbackQueue.async {
                         completion(.success(
-                            Manifest(
+                            Manifest.createManifest(
                                 displayName: packageIdentity.description,
                                 path: manifestPath,
                                 packageKind: packageKind,

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -28,7 +28,6 @@ import enum TSCUtility.Diagnostics
 import struct TSCUtility.Triple
 import struct TSCUtility.Version
 
-
 final class WorkspaceTests: XCTestCase {
     func testBasics() throws {
         let sandbox = AbsolutePath(path: "/tmp/ws/")

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -98,13 +98,39 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // Check the load-package callbacks.
-        XCTAssertMatch(workspace.delegate.events, ["will load manifest for root package: \(sandbox.appending(components: "roots", "Foo")) (identity: foo)"])
-        XCTAssertMatch(workspace.delegate.events, ["did load manifest for root package: \(sandbox.appending(components: "roots", "Foo")) (identity: foo)"])
+        XCTAssertMatch(
+            workspace.delegate.events,
+            ["will load manifest for root package: \(sandbox.appending(components: "roots", "Foo")) (identity: foo)"]
+        )
+        XCTAssertMatch(
+            workspace.delegate.events,
+            ["did load manifest for root package: \(sandbox.appending(components: "roots", "Foo")) (identity: foo)"]
+        )
 
-        XCTAssertMatch(workspace.delegate.events, ["will load manifest for localSourceControl package: \(sandbox.appending(components: "pkgs", "Quix")) (identity: quix)"])
-        XCTAssertMatch(workspace.delegate.events, ["did load manifest for localSourceControl package: \(sandbox.appending(components: "pkgs", "Quix")) (identity: quix)"])
-        XCTAssertMatch(workspace.delegate.events, ["will load manifest for localSourceControl package: \(sandbox.appending(components: "pkgs", "Baz")) (identity: baz)"])
-        XCTAssertMatch(workspace.delegate.events, ["did load manifest for localSourceControl package: \(sandbox.appending(components: "pkgs", "Baz")) (identity: baz)"])
+        XCTAssertMatch(
+            workspace.delegate.events,
+            [
+                "will load manifest for localSourceControl package: \(sandbox.appending(components: "pkgs", "Quix")) (identity: quix)",
+            ]
+        )
+        XCTAssertMatch(
+            workspace.delegate.events,
+            [
+                "did load manifest for localSourceControl package: \(sandbox.appending(components: "pkgs", "Quix")) (identity: quix)",
+            ]
+        )
+        XCTAssertMatch(
+            workspace.delegate.events,
+            [
+                "will load manifest for localSourceControl package: \(sandbox.appending(components: "pkgs", "Baz")) (identity: baz)",
+            ]
+        )
+        XCTAssertMatch(
+            workspace.delegate.events,
+            [
+                "did load manifest for localSourceControl package: \(sandbox.appending(components: "pkgs", "Baz")) (identity: baz)",
+            ]
+        )
 
         // Close and reopen workspace.
         try workspace.closeWorkspace(resetState: false)
@@ -154,13 +180,13 @@ final class WorkspaceTests: XCTestCase {
             do {
                 let ws = try createWorkspace {
                     $0 <<<
-                          """
-                          // swift-tools-version:4.0
-                          import PackageDescription
-                          let package = Package(
-                              name: "foo"
-                          )
-                          """
+                        """
+                        // swift-tools-version:4.0
+                        import PackageDescription
+                        let package = Package(
+                            name: "foo"
+                        )
+                        """
                 }
 
                 XCTAssertMatch(ws.interpreterFlags(for: foo), [.equal("-swift-version"), .equal("4")])
@@ -169,13 +195,13 @@ final class WorkspaceTests: XCTestCase {
             do {
                 let ws = try createWorkspace {
                     $0 <<<
-                          """
-                          // swift-tools-version:3.1
-                          import PackageDescription
-                          let package = Package(
-                              name: "foo"
-                          )
-                          """
+                        """
+                        // swift-tools-version:3.1
+                        import PackageDescription
+                        let package = Package(
+                            name: "foo"
+                        )
+                        """
                 }
 
                 XCTAssertEqual(ws.interpreterFlags(for: foo), [])
@@ -217,7 +243,12 @@ final class WorkspaceTests: XCTestCase {
             XCTAssert(rootManifests.count == 0, "\(rootManifests)")
 
             testDiagnostics(observability.diagnostics) { result in
-                let diagnostic = result.check(diagnostic: .contains("\(path.appending(components: "MyPkg", "Package.swift")):4:8: error: An error in MyPkg"), severity: .error)
+                let diagnostic = result.check(
+                    diagnostic: .contains(
+                        "\(path.appending(components: "MyPkg", "Package.swift")):4:8: error: An error in MyPkg"
+                    ),
+                    severity: .error
+                )
                 XCTAssertEqual(diagnostic?.metadata?.packageIdentity, .init(path: pkgDir))
                 XCTAssertEqual(diagnostic?.metadata?.packageKind, .root(pkgDir))
             }
@@ -392,11 +423,18 @@ final class WorkspaceTests: XCTestCase {
                     name: "FooPackage",
                     path: "foo-package",
                     targets: [
-                        MockTarget(name: "FooTarget", dependencies: [.product(name: "BarProduct", package: "BarPackage")]),
+                        MockTarget(
+                            name: "FooTarget",
+                            dependencies: [.product(name: "BarProduct", package: "BarPackage")]
+                        ),
                     ],
                     products: [],
                     dependencies: [
-                        .sourceControlWithDeprecatedName(name: "BarPackage", path: "bar-package", requirement: .upToNextMajor(from: "1.0.0")),
+                        .sourceControlWithDeprecatedName(
+                            name: "BarPackage",
+                            path: "bar-package",
+                            requirement: .upToNextMajor(from: "1.0.0")
+                        ),
                     ],
                     toolsVersion: .v5
                 ),
@@ -430,7 +468,10 @@ final class WorkspaceTests: XCTestCase {
         try workspace.checkPackageGraph(
             roots: ["foo-package", "bar-package"],
             dependencies: [
-                .localSourceControl(path: .init(path: "/tmp/ws/pkgs/bar-package"), requirement: .upToNextMajor(from: "1.0.0"))
+                .localSourceControl(
+                    path: .init(path: "/tmp/ws/pkgs/bar-package"),
+                    requirement: .upToNextMajor(from: "1.0.0")
+                ),
             ]
         ) { graph, diagnostics in
             PackageGraphTester(graph) { result in
@@ -560,7 +601,10 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkManagedDependencies { result in
             result.check(dependency: "baz", at: .checkout(.version("1.0.0")))
         }
-        XCTAssertMatch(workspace.delegate.events, [.equal("fetching package: \(sandbox.appending(components: "pkgs", "Baz"))")])
+        XCTAssertMatch(
+            workspace.delegate.events,
+            [.equal("fetching package: \(sandbox.appending(components: "pkgs", "Baz"))")]
+        )
         XCTAssertMatch(workspace.delegate.events, [.equal("will resolve dependencies")])
 
         // Now load with Baz as a root package.
@@ -577,9 +621,15 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkManagedDependencies { result in
             result.check(notPresent: "baz")
         }
-        XCTAssertNoMatch(workspace.delegate.events, [.equal("fetching package: \(sandbox.appending(components: "pkgs", "Baz"))")])
+        XCTAssertNoMatch(
+            workspace.delegate.events,
+            [.equal("fetching package: \(sandbox.appending(components: "pkgs", "Baz"))")]
+        )
         XCTAssertNoMatch(workspace.delegate.events, [.equal("will resolve dependencies")])
-        XCTAssertMatch(workspace.delegate.events, [.equal("removing repo: \(sandbox.appending(components: "pkgs", "Baz"))")])
+        XCTAssertMatch(
+            workspace.delegate.events,
+            [.equal("removing repo: \(sandbox.appending(components: "pkgs", "Baz"))")]
+        )
     }
 
     func testGraphRootDependencies() throws {
@@ -734,8 +784,14 @@ final class WorkspaceTests: XCTestCase {
                 result.check(dependency: "a", at: .checkout(.version("1.0.1")))
                 result.check(dependency: "aa", at: .checkout(.version("2.0.0")))
             }
-            XCTAssertMatch(workspace.delegate.events, [.equal("updating repo: \(sandbox.appending(components: "pkgs", "A"))")])
-            XCTAssertMatch(workspace.delegate.events, [.equal("updating repo: \(sandbox.appending(components: "pkgs", "AA"))")])
+            XCTAssertMatch(
+                workspace.delegate.events,
+                [.equal("updating repo: \(sandbox.appending(components: "pkgs", "A"))")]
+            )
+            XCTAssertMatch(
+                workspace.delegate.events,
+                [.equal("updating repo: \(sandbox.appending(components: "pkgs", "AA"))")]
+            )
             XCTAssertEqual(workspace.delegate.events.filter { $0.hasPrefix("updating repo") }.count, 2)
         }
     }
@@ -822,10 +878,16 @@ final class WorkspaceTests: XCTestCase {
         )
 
         let bPackagePath = try workspace.pathToPackage(withName: "B")
-        let bRef = PackageReference.localSourceControl(identity: PackageIdentity(path: bPackagePath), path: bPackagePath)
+        let bRef = PackageReference.localSourceControl(
+            identity: PackageIdentity(path: bPackagePath),
+            path: bPackagePath
+        )
 
         let cPackagePath = try workspace.pathToPackage(withName: "C")
-        let cRef = PackageReference.localSourceControl(identity: PackageIdentity(path: cPackagePath), path: cPackagePath)
+        let cRef = PackageReference.localSourceControl(
+            identity: PackageIdentity(path: cPackagePath),
+            path: cPackagePath
+        )
 
         try workspace.set(
             pins: [bRef: v1_5, cRef: v2],
@@ -879,15 +941,21 @@ final class WorkspaceTests: XCTestCase {
         )
 
         let bPackagePath = try workspace.pathToPackage(withName: "B")
-        let bRef = PackageReference.localSourceControl(identity: PackageIdentity(path: bPackagePath), path: bPackagePath)
+        let bRef = PackageReference.localSourceControl(
+            identity: PackageIdentity(path: bPackagePath),
+            path: bPackagePath
+        )
 
         let cPackagePath = try workspace.pathToPackage(withName: "C")
-        let cRef = PackageReference.localSourceControl(identity: PackageIdentity(path: cPackagePath), path: cPackagePath)
+        let cRef = PackageReference.localSourceControl(
+            identity: PackageIdentity(path: cPackagePath),
+            path: cPackagePath
+        )
 
         try workspace.set(
             pins: [bRef: v1],
             managedDependencies: [
-                bPackagePath: .sourceControlCheckout(packageRef: bRef, state: v1, subpath: bPath)
+                bPackagePath: .sourceControlCheckout(packageRef: bRef, state: v1, subpath: bPath),
             ]
         )
 
@@ -937,10 +1005,16 @@ final class WorkspaceTests: XCTestCase {
         )
 
         let bPackagePath = try workspace.pathToPackage(withName: "B")
-        let bRef = PackageReference.localSourceControl(identity: PackageIdentity(path: bPackagePath), path: bPackagePath)
+        let bRef = PackageReference.localSourceControl(
+            identity: PackageIdentity(path: bPackagePath),
+            path: bPackagePath
+        )
 
         let cPackagePath = try workspace.pathToPackage(withName: "C")
-        let cRef = PackageReference.localSourceControl(identity: PackageIdentity(path: cPackagePath), path: cPackagePath)
+        let cRef = PackageReference.localSourceControl(
+            identity: PackageIdentity(path: cPackagePath),
+            path: cPackagePath
+        )
 
         try workspace.set(
             pins: [bRef: v1_5, cRef: v1_5],
@@ -990,7 +1064,10 @@ final class WorkspaceTests: XCTestCase {
         )
 
         let cPackagePath = try testWorkspace.pathToPackage(withName: "C")
-        let cRef = PackageReference.localSourceControl(identity: PackageIdentity(path: cPackagePath), path: cPackagePath)
+        let cRef = PackageReference.localSourceControl(
+            identity: PackageIdentity(path: cPackagePath),
+            path: cPackagePath
+        )
 
         try testWorkspace.set(
             pins: [cRef: v1_5],
@@ -1048,10 +1125,16 @@ final class WorkspaceTests: XCTestCase {
         )
 
         let bPackagePath = try workspace.pathToPackage(withName: "B")
-        let bRef = PackageReference.localSourceControl(identity: PackageIdentity(path: bPackagePath), path: bPackagePath)
+        let bRef = PackageReference.localSourceControl(
+            identity: PackageIdentity(path: bPackagePath),
+            path: bPackagePath
+        )
 
         let cPackagePath = try workspace.pathToPackage(withName: "C")
-        let cRef = PackageReference.localSourceControl(identity: PackageIdentity(path: cPackagePath), path: cPackagePath)
+        let cRef = PackageReference.localSourceControl(
+            identity: PackageIdentity(path: cPackagePath),
+            path: cPackagePath
+        )
 
         try workspace.set(
             pins: [bRef: v1_5],
@@ -1110,10 +1193,16 @@ final class WorkspaceTests: XCTestCase {
         )
 
         let bPackagePath = try workspace.pathToPackage(withName: "B")
-        let bRef = PackageReference.localSourceControl(identity: PackageIdentity(path: bPackagePath), path: bPackagePath)
+        let bRef = PackageReference.localSourceControl(
+            identity: PackageIdentity(path: bPackagePath),
+            path: bPackagePath
+        )
 
         let cPackagePath = try workspace.pathToPackage(withName: "C")
-        let cRef = PackageReference.localSourceControl(identity: PackageIdentity(path: cPackagePath), path: cPackagePath)
+        let cRef = PackageReference.localSourceControl(
+            identity: PackageIdentity(path: cPackagePath),
+            path: cPackagePath
+        )
 
         try workspace.set(
             pins: [bRef: v1_5, cRef: v1_5],
@@ -1173,11 +1262,16 @@ final class WorkspaceTests: XCTestCase {
         )
 
         let bPackagePath = try workspace.pathToPackage(withName: "B")
-        let bRef = PackageReference.localSourceControl(identity: PackageIdentity(path: bPackagePath), path: bPackagePath)
+        let bRef = PackageReference.localSourceControl(
+            identity: PackageIdentity(path: bPackagePath),
+            path: bPackagePath
+        )
 
         let cPackagePath = try workspace.pathToPackage(withName: "C")
-        let cRef = PackageReference.localSourceControl(identity: PackageIdentity(path: cPackagePath), path: cPackagePath)
-
+        let cRef = PackageReference.localSourceControl(
+            identity: PackageIdentity(path: cPackagePath),
+            path: cPackagePath
+        )
 
         try workspace.set(
             pins: [bRef: v1_5, cRef: master],
@@ -1237,10 +1331,16 @@ final class WorkspaceTests: XCTestCase {
         )
 
         let bPackagePath = try workspace.pathToPackage(withName: "B")
-        let bRef = PackageReference.localSourceControl(identity: PackageIdentity(path: bPackagePath), path: bPackagePath)
+        let bRef = PackageReference.localSourceControl(
+            identity: PackageIdentity(path: bPackagePath),
+            path: bPackagePath
+        )
 
         let cPackagePath = try workspace.pathToPackage(withName: "C")
-        let cRef = PackageReference.localSourceControl(identity: PackageIdentity(path: cPackagePath), path: cPackagePath)
+        let cRef = PackageReference.localSourceControl(
+            identity: PackageIdentity(path: cPackagePath),
+            path: cPackagePath
+        )
 
         try workspace.set(
             pins: [bRef: v1_5, cRef: v1_5],
@@ -1254,7 +1354,11 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertNoDiagnostics(result.diagnostics)
             XCTAssertEqual(
                 result.result,
-                .required(reason: .other("Dependencies could not be resolved because no versions of \'c\' match the requirement 2.0.0..<3.0.0 and root depends on \'c\' 2.0.0..<3.0.0."))
+                .required(
+                    reason: .other(
+                        "Dependencies could not be resolved because no versions of \'c\' match the requirement 2.0.0..<3.0.0 and root depends on \'c\' 2.0.0..<3.0.0."
+                    )
+                )
             )
         }
     }
@@ -1300,10 +1404,16 @@ final class WorkspaceTests: XCTestCase {
         )
 
         let bPackagePath = try workspace.pathToPackage(withName: "B")
-        let bRef = PackageReference.localSourceControl(identity: PackageIdentity(path: bPackagePath), path: bPackagePath)
+        let bRef = PackageReference.localSourceControl(
+            identity: PackageIdentity(path: bPackagePath),
+            path: bPackagePath
+        )
 
         let cPackagePath = try workspace.pathToPackage(withName: "C")
-        let cRef = PackageReference.localSourceControl(identity: PackageIdentity(path: cPackagePath), path: cPackagePath)
+        let cRef = PackageReference.localSourceControl(
+            identity: PackageIdentity(path: cPackagePath),
+            path: cPackagePath
+        )
 
         try workspace.set(
             pins: [bRef: v1_5, cRef: v2],
@@ -1431,7 +1541,10 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkManagedDependencies { result in
             result.check(dependency: "foo", at: .checkout(.version("1.5.0")))
         }
-        XCTAssertMatch(workspace.delegate.events, [.equal("removing repo: \(sandbox.appending(components: "pkgs", "Bar"))")])
+        XCTAssertMatch(
+            workspace.delegate.events,
+            [.equal("removing repo: \(sandbox.appending(components: "pkgs", "Bar"))")]
+        )
 
         // Run update again.
         // Ensure that up-to-date delegate is called when there is nothing to update.
@@ -1506,9 +1619,11 @@ final class WorkspaceTests: XCTestCase {
         try workspace.checkUpdateDryRun(roots: ["Root"]) { changes, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
-            let stateChange = Workspace.PackageStateChange.updated(.init(requirement: .version(Version("1.5.0")), products: .specific(["Foo"])))
+            let stateChange = Workspace.PackageStateChange
+                .updated(.init(requirement: .version(Version("1.5.0")), products: .specific(["Foo"])))
             #else
-            let stateChange = Workspace.PackageStateChange.updated(.init(requirement: .version(Version("1.5.0")), products: .everything))
+            let stateChange = Workspace.PackageStateChange
+                .updated(.init(requirement: .version(Version("1.5.0")), products: .everything))
             #endif
 
             let path = AbsolutePath(path: "/tmp/ws/pkgs/Foo")
@@ -1754,7 +1869,13 @@ final class WorkspaceTests: XCTestCase {
 
         // Check that we can compute missing dependencies.
         try workspace.loadDependencyManifests(roots: ["Root1", "Root2"]) { manifests, diagnostics in
-            XCTAssertEqual(try! manifests.missingPackages().map { $0.locationString }.sorted(), [sandbox.appending(components: "pkgs", "Bar").pathString, sandbox.appending(components: "pkgs", "Foo").pathString])
+            XCTAssertEqual(
+                try! manifests.missingPackages().map(\.locationString).sorted(),
+                [
+                    sandbox.appending(components: "pkgs", "Bar").pathString,
+                    sandbox.appending(components: "pkgs", "Foo").pathString,
+                ]
+            )
             XCTAssertNoDiagnostics(diagnostics)
         }
 
@@ -1768,7 +1889,10 @@ final class WorkspaceTests: XCTestCase {
 
         // Check that we compute the correct missing dependencies.
         try workspace.loadDependencyManifests(roots: ["Root1", "Root2"]) { manifests, diagnostics in
-            XCTAssertEqual(try! manifests.missingPackages().map { $0.locationString }.sorted(), [sandbox.appending(components: "pkgs", "Bar").pathString])
+            XCTAssertEqual(
+                try! manifests.missingPackages().map(\.locationString).sorted(),
+                [sandbox.appending(components: "pkgs", "Bar").pathString]
+            )
             XCTAssertNoDiagnostics(diagnostics)
         }
 
@@ -1782,7 +1906,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Check that we compute the correct missing dependencies.
         try workspace.loadDependencyManifests(roots: ["Root1", "Root2"]) { manifests, diagnostics in
-            XCTAssertEqual(try! manifests.missingPackages().map { $0.locationString }.sorted(), [])
+            XCTAssertEqual(try! manifests.missingPackages().map(\.locationString).sorted(), [])
             XCTAssertNoDiagnostics(diagnostics)
         }
     }
@@ -1848,7 +1972,10 @@ final class WorkspaceTests: XCTestCase {
 
         try workspace.loadDependencyManifests(roots: ["Root1"]) { manifests, diagnostics in
             // Ensure that the order of the manifests is stable.
-            XCTAssertEqual(manifests.allDependencyManifests().map { $0.value.manifest.displayName }, ["Foo", "Baz", "Bam", "Bar"])
+            XCTAssertEqual(
+                manifests.allDependencyManifests().map(\.value.manifest.displayName),
+                ["Foo", "Baz", "Bam", "Bar"]
+            )
             XCTAssertNoDiagnostics(diagnostics)
         }
     }
@@ -2121,11 +2248,12 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertNoDiagnostics(diagnostics)
         }
 
-
         workspace.checkPackageGraphFailure(roots: ["Bar"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
                 let diagnostic = result.check(
-                    diagnostic: .equal("package 'bar' is using Swift tools version 4.1.0 but the installed version is 4.0.0"),
+                    diagnostic: .equal(
+                        "package 'bar' is using Swift tools version 4.1.0 but the installed version is 4.0.0"
+                    ),
                     severity: .error
                 )
                 XCTAssertEqual(diagnostic?.metadata?.packageIdentity, .plain("bar"))
@@ -2134,7 +2262,9 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkPackageGraphFailure(roots: ["Foo", "Bar"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
                 let diagnostic = result.check(
-                    diagnostic: .equal("package 'bar' is using Swift tools version 4.1.0 but the installed version is 4.0.0"),
+                    diagnostic: .equal(
+                        "package 'bar' is using Swift tools version 4.1.0 but the installed version is 4.0.0"
+                    ),
                     severity: .error
                 )
                 XCTAssertEqual(diagnostic?.metadata?.packageIdentity, .plain("bar"))
@@ -2143,7 +2273,9 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkPackageGraphFailure(roots: ["Baz"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
                 let diagnostic = result.check(
-                    diagnostic: .equal("package 'baz' is using Swift tools version 3.1.0 which is no longer supported; consider using '// swift-tools-version:4.0' to specify the current tools version"),
+                    diagnostic: .equal(
+                        "package 'baz' is using Swift tools version 3.1.0 which is no longer supported; consider using '// swift-tools-version:4.0' to specify the current tools version"
+                    ),
                     severity: .error
                 )
                 XCTAssertEqual(diagnostic?.metadata?.packageIdentity, .plain("baz"))
@@ -2216,7 +2348,7 @@ final class WorkspaceTests: XCTestCase {
 
         try workspace.loadDependencyManifests(roots: ["Root"]) { manifests, diagnostics in
             let editedPackages = manifests.editedPackagesConstraints()
-            XCTAssertEqual(editedPackages.map { $0.package.locationString }, [fooPath.pathString])
+            XCTAssertEqual(editedPackages.map(\.package.locationString), [fooPath.pathString])
             XCTAssertNoDiagnostics(diagnostics)
         }
 
@@ -2309,7 +2441,12 @@ final class WorkspaceTests: XCTestCase {
         try fs.removeFileTree(fooPath)
         try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
-                result.check(diagnostic: .equal("dependency 'foo' was being edited but is missing; falling back to original checkout"), severity: .warning)
+                result.check(
+                    diagnostic: .equal(
+                        "dependency 'foo' was being edited but is missing; falling back to original checkout"
+                    ),
+                    severity: .warning
+                )
             }
         }
         workspace.checkManagedDependencies { result in
@@ -2362,7 +2499,10 @@ final class WorkspaceTests: XCTestCase {
         try workspace.checkUpdate { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
-        XCTAssertMatch(workspace.delegate.events, [.equal("removing repo: \(sandbox.appending(components: "pkgs", "Foo"))")])
+        XCTAssertMatch(
+            workspace.delegate.events,
+            [.equal("removing repo: \(sandbox.appending(components: "pkgs", "Foo"))")]
+        )
         try workspace.checkPackageGraph(deps: []) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
@@ -2611,7 +2751,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Foo", targets: ["Foo"]),
                     ],
                     dependencies: [
-                        .sourceControl(path: "./Bar", requirement: .exact("1.0.0"))
+                        .sourceControl(path: "./Bar", requirement: .exact("1.0.0")),
                     ]
                 ),
             ],
@@ -2772,7 +2912,7 @@ final class WorkspaceTests: XCTestCase {
                     targets: [
                         MockTarget(name: "Root", dependencies: [
                             .product(name: "Foo", package: "foo"),
-                            .product(name: "Bar", package: "bar")
+                            .product(name: "Bar", package: "bar"),
                         ]),
                     ],
                     dependencies: [
@@ -2820,17 +2960,24 @@ final class WorkspaceTests: XCTestCase {
         // mimic external process putting a dependency into edit mode
         do {
             try fs.createDirectory(fooEditPath, recursive: true)
-            try fs.writeFileContents(fooEditPath.appending(component: "Package.swift"), bytes: "// swift-tools-version: 5.6")
+            try fs.writeFileContents(
+                fooEditPath.appending(component: "Package.swift"),
+                bytes: "// swift-tools-version: 5.6"
+            )
 
             let fooState = underlying.state.dependencies[.plain("foo")]!
-            let externalState = WorkspaceState(fileSystem: fs, storageDirectory: underlying.state.storagePath.parentDirectory, initializationWarningHandler: { _ in })
+            let externalState = WorkspaceState(
+                fileSystem: fs,
+                storageDirectory: underlying.state.storagePath.parentDirectory,
+                initializationWarningHandler: { _ in }
+            )
             externalState.dependencies.remove(fooState.packageRef.identity)
             externalState.dependencies.add(try fooState.edited(subpath: .init("foo"), unmanagedPath: fooEditPath))
             try externalState.save()
         }
 
         // reload graph after "external" change
-        try workspace.checkPackageGraph(roots: ["Root"], deps: []) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"], deps: []) { graph, _ in
             PackageGraphTester(graph) { result in
                 result.check(packages: "Bar", "Foo", "Root")
             }
@@ -2839,7 +2986,9 @@ final class WorkspaceTests: XCTestCase {
         do {
             let fooState = underlying.state.dependencies[.plain("foo")]!
             guard case .edited(basedOn: _, unmanagedPath: fooEditPath) = fooState.state else {
-                XCTFail("'\(fooState.packageRef.identity)' dependency expected to be in edit mode, but was: \(fooState)")
+                XCTFail(
+                    "'\(fooState.packageRef.identity)' dependency expected to be in edit mode, but was: \(fooState)"
+                )
                 return
             }
         }
@@ -3026,7 +3175,10 @@ final class WorkspaceTests: XCTestCase {
                 result.check(targets: "Foo")
             }
             testDiagnostics(diagnostics) { result in
-                result.check(diagnostic: .contains("'bar' {1.0.0..<1.5.0, 1.5.1..<2.0.0} cannot be used"), severity: .error)
+                result.check(
+                    diagnostic: .contains("'bar' {1.0.0..<1.5.0, 1.5.1..<2.0.0} cannot be used"),
+                    severity: .error
+                )
             }
         }
     }
@@ -3125,7 +3277,12 @@ final class WorkspaceTests: XCTestCase {
                 result.check(targets: "Foo")
             }
             testDiagnostics(diagnostics) { result in
-                result.check(diagnostic: .contains("the package at '\(sandbox.appending(components: "pkgs", "Bar"))' cannot be accessed (\(sandbox.appending(components: "pkgs", "Bar")) doesn't exist in file system"), severity: .error)
+                result.check(
+                    diagnostic: .contains(
+                        "the package at '\(sandbox.appending(components: "pkgs", "Bar"))' cannot be accessed (\(sandbox.appending(components: "pkgs", "Bar")) doesn't exist in file system"
+                    ),
+                    severity: .error
+                )
             }
         }
     }
@@ -3338,7 +3495,6 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
-
     // Test that switching between two same local packages placed at
     // different locations works correctly.
     func testDependencySwitchLocalWithSameIdentity() throws {
@@ -3395,7 +3551,10 @@ final class WorkspaceTests: XCTestCase {
         }
         workspace.checkManagedDependencies { result in
             result.check(dependency: "foo", at: .local)
-            XCTAssertEqual(result.managedDependencies[.plain("foo")]?.packageRef.locationString, sandbox.appending(components: "pkgs", "Foo").pathString)
+            XCTAssertEqual(
+                result.managedDependencies[.plain("foo")]?.packageRef.locationString,
+                sandbox.appending(components: "pkgs", "Foo").pathString
+            )
         }
 
         deps = [
@@ -3406,7 +3565,10 @@ final class WorkspaceTests: XCTestCase {
         }
         workspace.checkManagedDependencies { result in
             result.check(dependency: "foo", at: .local)
-            XCTAssertEqual(result.managedDependencies[.plain("foo")]?.packageRef.locationString, sandbox.appending(components: "pkgs", "Nested", "Foo").pathString)
+            XCTAssertEqual(
+                result.managedDependencies[.plain("foo")]?.packageRef.locationString,
+                sandbox.appending(components: "pkgs", "Nested", "Foo").pathString
+            )
         }
     }
 
@@ -3474,7 +3636,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         deps = [
-            .sourceControl(url: "https://scm.com/other/foo", requirement: .exact("1.1.0"))
+            .sourceControl(url: "https://scm.com/other/foo", requirement: .exact("1.1.0")),
         ]
         try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
@@ -3546,7 +3708,11 @@ final class WorkspaceTests: XCTestCase {
     func testResolvedFileSchemeToolsVersion() throws {
         let fs = InMemoryFileSystem()
 
-        for pair in [(ToolsVersion.v5_2, ToolsVersion.v5_2), (ToolsVersion.v5_6, ToolsVersion.v5_6), (ToolsVersion.v5_2, ToolsVersion.v5_6)] {
+        for pair in [
+            (ToolsVersion.v5_2, ToolsVersion.v5_2),
+            (ToolsVersion.v5_6, ToolsVersion.v5_6),
+            (ToolsVersion.v5_2, ToolsVersion.v5_6),
+        ] {
             let sandbox = AbsolutePath(path: "/tmp/ws/")
             let workspace = try MockWorkspace(
                 sandbox: sandbox,
@@ -3559,7 +3725,11 @@ final class WorkspaceTests: XCTestCase {
                         ],
                         products: [],
                         dependencies: [
-                            .sourceControl(path: "./Foo", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Foo"])),
+                            .sourceControl(
+                                path: "./Foo",
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                                products: .specific(["Foo"])
+                            ),
                         ],
                         toolsVersion: pair.0
                     ),
@@ -3690,14 +3860,20 @@ final class WorkspaceTests: XCTestCase {
             .sourceControl(url: "https://localhost/org/foo", requirement: .exact("1.0.0")),
             .sourceControl(url: "https://localhost/org/bar", requirement: .exact("1.0.0")),
         ]
-        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
-            XCTAssertEqual(result.managedDependencies[.plain("foo")]?.packageRef.locationString, "https://localhost/org/foo")
-            XCTAssertEqual(result.managedDependencies[.plain("bar")]?.packageRef.locationString, "https://localhost/org/bar")
+            XCTAssertEqual(
+                result.managedDependencies[.plain("foo")]?.packageRef.locationString,
+                "https://localhost/org/foo"
+            )
+            XCTAssertEqual(
+                result.managedDependencies[.plain("bar")]?.packageRef.locationString,
+                "https://localhost/org/bar"
+            )
         }
         workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
@@ -3725,8 +3901,14 @@ final class WorkspaceTests: XCTestCase {
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
             // URLs should reflect the actual dependencies
-            XCTAssertEqual(result.managedDependencies[.plain("foo")]?.packageRef.locationString, "https://localhost/ORG/FOO")
-            XCTAssertEqual(result.managedDependencies[.plain("bar")]?.packageRef.locationString, "https://localhost/org/bar.git")
+            XCTAssertEqual(
+                result.managedDependencies[.plain("foo")]?.packageRef.locationString,
+                "https://localhost/ORG/FOO"
+            )
+            XCTAssertEqual(
+                result.managedDependencies[.plain("bar")]?.packageRef.locationString,
+                "https://localhost/org/bar.git"
+            )
         }
         workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
@@ -3754,15 +3936,24 @@ final class WorkspaceTests: XCTestCase {
             result.check(dependency: "foo", at: .checkout(.version("1.1.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.1.0")))
             // URLs should reflect the actual dependencies
-            XCTAssertEqual(result.managedDependencies[.plain("foo")]?.packageRef.locationString, "https://localhost/ORG/FOO")
-            XCTAssertEqual(result.managedDependencies[.plain("bar")]?.packageRef.locationString, "https://localhost/org/bar.git")
+            XCTAssertEqual(
+                result.managedDependencies[.plain("foo")]?.packageRef.locationString,
+                "https://localhost/ORG/FOO"
+            )
+            XCTAssertEqual(
+                result.managedDependencies[.plain("bar")]?.packageRef.locationString,
+                "https://localhost/org/bar.git"
+            )
         }
         workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.1.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.1.0")))
             // URLs should reflect the actual dependencies since the new version forces rewrite of the resolved file
             XCTAssertEqual(result.store.pinsMap[.plain("foo")]?.packageRef.locationString, "https://localhost/ORG/FOO")
-            XCTAssertEqual(result.store.pinsMap[.plain("bar")]?.packageRef.locationString, "https://localhost/org/bar.git")
+            XCTAssertEqual(
+                result.store.pinsMap[.plain("bar")]?.packageRef.locationString,
+                "https://localhost/org/bar.git"
+            )
         }
 
         // case 3: set state with slightly different URLs that are canonically the same but remove resolved file
@@ -3784,15 +3975,27 @@ final class WorkspaceTests: XCTestCase {
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
             // URLs should reflect the actual dependencies
-            XCTAssertEqual(result.managedDependencies[.plain("foo")]?.packageRef.locationString, "https://localhost/org/foo.git")
-            XCTAssertEqual(result.managedDependencies[.plain("bar")]?.packageRef.locationString, "https://localhost/org/bar.git")
+            XCTAssertEqual(
+                result.managedDependencies[.plain("foo")]?.packageRef.locationString,
+                "https://localhost/org/foo.git"
+            )
+            XCTAssertEqual(
+                result.managedDependencies[.plain("bar")]?.packageRef.locationString,
+                "https://localhost/org/bar.git"
+            )
         }
         workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
             // URLs should reflect the actual dependencies since we deleted the resolved file
-            XCTAssertEqual(result.store.pinsMap[.plain("foo")]?.packageRef.locationString, "https://localhost/org/foo.git")
-            XCTAssertEqual(result.store.pinsMap[.plain("bar")]?.packageRef.locationString, "https://localhost/org/bar.git")
+            XCTAssertEqual(
+                result.store.pinsMap[.plain("foo")]?.packageRef.locationString,
+                "https://localhost/org/foo.git"
+            )
+            XCTAssertEqual(
+                result.store.pinsMap[.plain("bar")]?.packageRef.locationString,
+                "https://localhost/org/bar.git"
+            )
         }
     }
 
@@ -3801,8 +4004,14 @@ final class WorkspaceTests: XCTestCase {
         let fs = InMemoryFileSystem()
 
         let mirrors = DependencyMirrors()
-        mirrors.set(mirrorURL: sandbox.appending(components: "pkgs", "BarMirror").pathString, forURL: sandbox.appending(components: "pkgs", "Bar").pathString)
-        mirrors.set(mirrorURL: sandbox.appending(components: "pkgs", "BazMirror").pathString, forURL: sandbox.appending(components: "pkgs", "Baz").pathString)
+        mirrors.set(
+            mirrorURL: sandbox.appending(components: "pkgs", "BarMirror").pathString,
+            forURL: sandbox.appending(components: "pkgs", "Bar").pathString
+        )
+        mirrors.set(
+            mirrorURL: sandbox.appending(components: "pkgs", "BazMirror").pathString,
+            forURL: sandbox.appending(components: "pkgs", "Baz").pathString
+        )
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
@@ -3821,7 +4030,7 @@ final class WorkspaceTests: XCTestCase {
                     dependencies: [
                         .sourceControl(path: "./Dep", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
-                )
+                ),
             ],
             packages: [
                 MockPackage(
@@ -3860,7 +4069,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Baz", targets: ["Baz"]),
                     ],
                     versions: ["1.0.0", "1.6.0"]
-                )
+                ),
             ],
             mirrors: mirrors
         )
@@ -3887,8 +4096,14 @@ final class WorkspaceTests: XCTestCase {
         let fs = InMemoryFileSystem()
 
         let mirrors = DependencyMirrors()
-        mirrors.set(mirrorURL: sandbox.appending(components: "pkgs", "BarMirror").pathString, forURL: sandbox.appending(components: "pkgs", "Bar").pathString)
-        mirrors.set(mirrorURL: sandbox.appending(components: "pkgs", "BarMirror").pathString, forURL: sandbox.appending(components: "pkgs", "Baz").pathString)
+        mirrors.set(
+            mirrorURL: sandbox.appending(components: "pkgs", "BarMirror").pathString,
+            forURL: sandbox.appending(components: "pkgs", "Bar").pathString
+        )
+        mirrors.set(
+            mirrorURL: sandbox.appending(components: "pkgs", "BarMirror").pathString,
+            forURL: sandbox.appending(components: "pkgs", "Baz").pathString
+        )
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
@@ -3907,7 +4122,7 @@ final class WorkspaceTests: XCTestCase {
                     dependencies: [
                         .sourceControl(path: "./Dep", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
-                )
+                ),
             ],
             packages: [
                 MockPackage(
@@ -4004,7 +4219,7 @@ final class WorkspaceTests: XCTestCase {
                     dependencies: [
                         .sourceControl(url: "https://scm.com/org/dep", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
-                )
+                ),
             ],
             packages: [
                 MockPackage(
@@ -4046,7 +4261,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Baz", targets: ["Baz"]),
                     ],
                     versions: ["1.0.0", "1.6.0"]
-                )
+                ),
             ],
             mirrors: mirrors
         )
@@ -4093,7 +4308,7 @@ final class WorkspaceTests: XCTestCase {
                     dependencies: [
                         .sourceControl(url: "https://scm.com/org/dep", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
-                )
+                ),
             ],
             packages: [
                 MockPackage(
@@ -4150,7 +4365,11 @@ final class WorkspaceTests: XCTestCase {
         )
 
         let deps: [MockDependency] = [
-            .sourceControl(url: "https://scm.com/org/baz", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Baz"])),
+            .sourceControl(
+                url: "https://scm.com/org/baz",
+                requirement: .upToNextMajor(from: "1.0.0"),
+                products: .specific(["Baz"])
+            ),
         ]
 
         try workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { graph, diagnostics in
@@ -4185,7 +4404,7 @@ final class WorkspaceTests: XCTestCase {
                     targets: [
                         MockTarget(name: "Foo", dependencies: [
                             .product(name: "Bar", package: "bar"),
-                            .product(name: "Baz", package: "baz")
+                            .product(name: "Baz", package: "baz"),
                         ]),
                     ],
                     products: [
@@ -4193,9 +4412,9 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     dependencies: [
                         .sourceControl(url: "https://scm.com/org/bar", requirement: .upToNextMajor(from: "1.0.0")),
-                        .sourceControl(url: "https://scm.com/org/baz", requirement: .upToNextMajor(from: "1.0.0"))
+                        .sourceControl(url: "https://scm.com/org/baz", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
-                )
+                ),
             ],
             packages: [
                 MockPackage(
@@ -4219,7 +4438,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Baz", targets: ["Baz"]),
                     ],
                     versions: ["1.0.0", "1.6.0"]
-                )
+                ),
             ],
             mirrors: mirrors
         )
@@ -4255,7 +4474,7 @@ final class WorkspaceTests: XCTestCase {
                     targets: [
                         MockTarget(name: "Foo", dependencies: [
                             .product(name: "Bar", package: "org.bar"),
-                            .product(name: "Baz", package: "org.baz")
+                            .product(name: "Baz", package: "org.baz"),
                         ]),
                     ],
                     products: [
@@ -4263,9 +4482,9 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     dependencies: [
                         .registry(identity: "org.bar", requirement: .upToNextMajor(from: "1.0.0")),
-                        .registry(identity: "org.baz", requirement: .upToNextMajor(from: "1.0.0"))
+                        .registry(identity: "org.baz", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
-                )
+                ),
             ],
             packages: [
                 MockPackage(
@@ -4289,7 +4508,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Baz", targets: ["Baz"]),
                     ],
                     versions: ["1.0.0", "1.6.0"]
-                )
+                ),
             ],
             mirrors: mirrors
         )
@@ -4304,7 +4523,7 @@ final class WorkspaceTests: XCTestCase {
         }
         workspace.checkManagedDependencies { result in
             result.check(dependency: "bar-mirror", at: .checkout(.version("1.5.0")))
-            result.check(dependency: "org.baz", at:  .registryDownload("1.6.0"))
+            result.check(dependency: "org.baz", at: .registryDownload("1.6.0"))
             result.check(notPresent: "org.bar")
         }
     }
@@ -4330,8 +4549,9 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(
                             name: "Root",
                             dependencies: [
-                                .product(name: "Bar", package: "bar")
-                            ]),
+                                .product(name: "Bar", package: "bar"),
+                            ]
+                        ),
                     ],
                     products: [],
                     dependencies: [
@@ -4347,8 +4567,9 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(
                             name: "Bar",
                             dependencies: [
-                                .product(name: "Foo", package: "foo")
-                            ]),
+                                .product(name: "Foo", package: "foo"),
+                            ]
+                        ),
                     ],
                     products: [
                         MockProduct(name: "Bar", targets: ["Bar"]),
@@ -4365,8 +4586,9 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(
                             name: "Bar",
                             dependencies: [
-                                .product(name: "OtherFoo", package: "foo")
-                            ]),
+                                .product(name: "OtherFoo", package: "foo"),
+                            ]
+                        ),
                     ],
                     products: [
                         MockProduct(name: "Bar", targets: ["Bar"]),
@@ -4417,7 +4639,10 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkManagedDependencies { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
-            XCTAssertEqual(result.managedDependencies[.plain("foo")]?.packageRef.locationString, "https://scm.com/org/foo")
+            XCTAssertEqual(
+                result.managedDependencies[.plain("foo")]?.packageRef.locationString,
+                "https://scm.com/org/foo"
+            )
         }
         workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
@@ -4441,7 +4666,10 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkManagedDependencies { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.1.0")))
-            XCTAssertEqual(result.managedDependencies[.plain("foo")]?.packageRef.locationString, "https://scm.com/other/foo")
+            XCTAssertEqual(
+                result.managedDependencies[.plain("foo")]?.packageRef.locationString,
+                "https://scm.com/other/foo"
+            )
         }
         workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
@@ -4516,7 +4744,11 @@ final class WorkspaceTests: XCTestCase {
             let pinsStore = try ws.pinsStore.load()
             let fooPin = pinsStore.pins.first(where: { $0.packageRef.identity.description == "foo" })!
 
-            let fooRepo = workspace.repositoryProvider.specifierMap[RepositorySpecifier(path: try AbsolutePath(validating: fooPin.packageRef.locationString))]!
+            let fooRepo = workspace.repositoryProvider
+                .specifierMap[RepositorySpecifier(path: try AbsolutePath(
+                    validating: fooPin.packageRef
+                        .locationString
+                ))]!
             let revision = try fooRepo.resolveRevision(tag: "1.0.0")
             let newState = PinsStore.PinState.version("1.0.0", revision: revision.identifier)
 
@@ -4527,7 +4759,10 @@ final class WorkspaceTests: XCTestCase {
         // Check force resolve. This should produce an error because the resolved file is out-of-date.
         workspace.checkPackageGraphFailure(roots: ["Root"], forceResolvedVersions: true) { diagnostics in
             testDiagnostics(diagnostics) { result in
-                result.check(diagnostic: "an out-of-date resolved file was detected at \(sandbox.appending(components: "Package.resolved")), which is not allowed when automatic dependency resolution is disabled; please make sure to update the file to reflect the changes in dependencies. Running resolver because requirements have changed.", severity: .error)
+                result.check(
+                    diagnostic: "an out-of-date resolved file was detected at \(sandbox.appending(components: "Package.resolved")), which is not allowed when automatic dependency resolution is disabled; please make sure to update the file to reflect the changes in dependencies. Running resolver because requirements have changed.",
+                    severity: .error
+                )
             }
         }
         workspace.checkManagedDependencies { result in
@@ -4664,7 +4899,13 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkPackageGraphFailure(roots: ["Root"], forceResolvedVersions: true) { diagnostics in
             guard let diagnostic = diagnostics.first else { return XCTFail("unexpectedly got no diagnostics") }
             // rdar://82544922 (`WorkspaceResolveReason` is non-deterministic)
-            XCTAssertTrue(diagnostic.message.hasPrefix("a resolved file is required when automatic dependency resolution is disabled and should be placed at \(sandbox.appending(components: "Package.resolved")). Running resolver because the following dependencies were added:"), "unexpected diagnostic message")
+            XCTAssertTrue(
+                diagnostic.message
+                    .hasPrefix(
+                        "a resolved file is required when automatic dependency resolution is disabled and should be placed at \(sandbox.appending(components: "Package.resolved")). Running resolver because the following dependencies were added:"
+                    ),
+                "unexpected diagnostic message"
+            )
         }
     }
 
@@ -4761,15 +5002,17 @@ final class WorkspaceTests: XCTestCase {
             XCTAssert(graph.reachableProducts.contains(where: { $0.name == "MyPkg" }))
 
             let reloadedPackage = try tsc_await {
-                workspace.loadPackage(with: package.identity,
-                                      packageGraph: graph,
-                                      observabilityScope: observability.topScope,
-                                      completion: $0)
+                workspace.loadPackage(
+                    with: package.identity,
+                    packageGraph: graph,
+                    observabilityScope: observability.topScope,
+                    completion: $0
+                )
             }
 
             XCTAssertEqual(package.identity, reloadedPackage.identity)
             XCTAssertEqual(package.manifest.displayName, reloadedPackage.manifest.displayName)
-            XCTAssertEqual(package.products.map { $0.name }, reloadedPackage.products.map { $0.name })
+            XCTAssertEqual(package.products.map(\.name), reloadedPackage.products.map(\.name))
         }
     }
 
@@ -4821,7 +5064,12 @@ final class WorkspaceTests: XCTestCase {
 
         try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
-                result.check(diagnostic: .equal("package 'foo' is required using a revision-based requirement and it depends on local package 'local', which is not supported"), severity: .error)
+                result.check(
+                    diagnostic: .equal(
+                        "package 'foo' is required using a revision-based requirement and it depends on local package 'local', which is not supported"
+                    ),
+                    severity: .error
+                )
             }
         }
     }
@@ -4866,7 +5114,12 @@ final class WorkspaceTests: XCTestCase {
 
         try workspace.checkPackageGraphFailure(roots: ["Overridden/bazzz-master"], deps: deps) { diagnostics in
             testDiagnostics(diagnostics) { result in
-                result.check(diagnostic: .equal("unable to override package 'Baz' because its identity 'bazzz' doesn't match override's identity (directory name) 'bazzz-master'"), severity: .error)
+                result.check(
+                    diagnostic: .equal(
+                        "unable to override package 'Baz' because its identity 'bazzz' doesn't match override's identity (directory name) 'bazzz-master'"
+                    ),
+                    severity: .error
+                )
             }
         }
     }
@@ -4884,13 +5137,13 @@ final class WorkspaceTests: XCTestCase {
                     targets: [
                         MockTarget(name: "Foo", dependencies: [
                             .product(name: "Bar", package: "bar"),
-                            .product(name: "Baz", package: "baz")
-                        ])
+                            .product(name: "Baz", package: "baz"),
+                        ]),
                     ],
                     products: [],
                     dependencies: [
                         .sourceControl(url: "https://localhost/org/bar", requirement: .upToNextMajor(from: "1.0.0")),
-                        .sourceControl(url: "https://localhost/org/baz", requirement: .upToNextMajor(from: "1.0.0"))
+                        .sourceControl(url: "https://localhost/org/baz", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -4900,14 +5153,14 @@ final class WorkspaceTests: XCTestCase {
                     url: "https://localhost/org/bar",
                     targets: [
                         MockTarget(name: "Bar", dependencies: [
-                            .product(name: "Baz", package: "Baz")
+                            .product(name: "Baz", package: "Baz"),
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"])
+                        MockProduct(name: "Bar", targets: ["Bar"]),
                     ],
                     dependencies: [
-                        .sourceControl(url: "https://localhost/org/Baz", requirement: .upToNextMajor(from: "1.0.0"))
+                        .sourceControl(url: "https://localhost/org/Baz", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -4918,7 +5171,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Baz"),
                     ],
                     products: [
-                        MockProduct(name: "Baz", targets: ["Baz"])
+                        MockProduct(name: "Baz", targets: ["Baz"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -4929,7 +5182,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Baz"),
                     ],
                     products: [
-                        MockProduct(name: "Baz", targets: ["Baz"])
+                        MockProduct(name: "Baz", targets: ["Baz"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -4953,9 +5206,15 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkManagedDependencies { result in
             result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
             result.check(dependency: "baz", at: .checkout(.version("1.0.0")))
-            XCTAssertEqual(result.managedDependencies[.plain("bar")]?.packageRef.locationString, "https://localhost/org/bar")
+            XCTAssertEqual(
+                result.managedDependencies[.plain("bar")]?.packageRef.locationString,
+                "https://localhost/org/bar"
+            )
             // root casing should win, so testing for lower case
-            XCTAssertEqual(result.managedDependencies[.plain("baz")]?.packageRef.locationString, "https://localhost/org/baz")
+            XCTAssertEqual(
+                result.managedDependencies[.plain("baz")]?.packageRef.locationString,
+                "https://localhost/org/baz"
+            )
         }
     }
 
@@ -5003,7 +5262,11 @@ final class WorkspaceTests: XCTestCase {
                 MockPackage(
                     name: "Baz",
                     targets: [
-                        MockTarget(name: "Baz", dependencies: ["Bar"], settings: [.init(tool: .swift, kind: .unsafeFlags(["-F", "/tmp"]))]),
+                        MockTarget(
+                            name: "Baz",
+                            dependencies: ["Bar"],
+                            settings: [.init(tool: .swift, kind: .unsafeFlags(["-F", "/tmp"]))]
+                        ),
                     ],
                     products: [
                         MockProduct(name: "Baz", targets: ["Baz"]),
@@ -5142,7 +5405,10 @@ final class WorkspaceTests: XCTestCase {
 
         let barProducts: [MockProduct]
         #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
-        barProducts = [MockProduct(name: "Bar", targets: ["Bar"]), MockProduct(name: "BarUnused", targets: ["BarUnused"])]
+        barProducts = [
+            MockProduct(name: "Bar", targets: ["Bar"]),
+            MockProduct(name: "BarUnused", targets: ["BarUnused"]),
+        ]
         #else
         // Whether a product is being used does not affect dependency resolution in this case, so we omit the unused product.
         barProducts = [MockProduct(name: "Bar", targets: ["Bar"])]
@@ -5257,7 +5523,8 @@ final class WorkspaceTests: XCTestCase {
                 default:
                     throw StringError("unexpected archivePath \(archivePath)")
                 }
-                archiver.extractions.append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
+                archiver.extractions
+                    .append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
                 completion(.success(()))
             } catch {
                 completion(.failure(error))
@@ -5275,7 +5542,7 @@ final class WorkspaceTests: XCTestCase {
                             .product(name: "A1", package: "A"),
                             .product(name: "A2", package: "A"),
                             .product(name: "B", package: "B"),
-                        ])
+                        ]),
                     ],
                     products: [],
                     dependencies: [
@@ -5312,13 +5579,13 @@ final class WorkspaceTests: XCTestCase {
                             name: "B",
                             type: .binary,
                             path: "XCFrameworks/B.zip"
-                        )
+                        ),
                     ],
                     products: [
-                        MockProduct(name: "B", targets: ["B"])
+                        MockProduct(name: "B", targets: ["B"]),
                     ],
                     versions: ["1.0.0"]
-                )
+                ),
             ],
             binaryArtifactsManager: .init(archiver: archiver)
         )
@@ -5348,7 +5615,7 @@ final class WorkspaceTests: XCTestCase {
         XCTAssertFalse(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/A/A2.artifactbundle")))
         XCTAssertFalse(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/B/B.xcframework")))
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
 
             // Ensure that the artifacts have been properly extracted
@@ -5362,33 +5629,45 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertTrue(fs.exists(bFrameworkArchivePath))
 
             // Ensure that the temporary folders have been properly created
-            XCTAssertEqual(archiver.extractions.map { $0.destinationPath.parentDirectory }.sorted(), [
+            XCTAssertEqual(archiver.extractions.map(\.destinationPath.parentDirectory).sorted(), [
                 AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A1"),
                 AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A2"),
-                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/b/B")
+                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/b/B"),
             ])
 
             // Ensure that the temporary directories have been removed
-            XCTAssertTrue(try! fs.getDirectoryContents(AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A1")).isEmpty)
-            XCTAssertTrue(try! fs.getDirectoryContents(AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A2")).isEmpty)
-            XCTAssertTrue(try! fs.getDirectoryContents(AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/b/B")).isEmpty)
+            XCTAssertTrue(
+                try! fs.getDirectoryContents(AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A1"))
+                    .isEmpty
+            )
+            XCTAssertTrue(
+                try! fs.getDirectoryContents(AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A2"))
+                    .isEmpty
+            )
+            XCTAssertTrue(
+                try! fs.getDirectoryContents(AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/b/B"))
+                    .isEmpty
+            )
         }
 
         workspace.checkManagedArtifacts { result in
-            result.check(packageIdentity: .plain("a"),
-                         targetName: "A1",
-                         source: .local(checksum: "a1"),
-                         path: workspace.artifactsDir.appending(components: "a", "A1", "A1.xcframework")
+            result.check(
+                packageIdentity: .plain("a"),
+                targetName: "A1",
+                source: .local(checksum: "a1"),
+                path: workspace.artifactsDir.appending(components: "a", "A1", "A1.xcframework")
             )
-            result.check(packageIdentity: .plain("a"),
-                         targetName: "A2",
-                         source: .local(checksum: "a2"),
-                         path: workspace.artifactsDir.appending(components: "a", "A2", "A2.artifactbundle")
+            result.check(
+                packageIdentity: .plain("a"),
+                targetName: "A2",
+                source: .local(checksum: "a2"),
+                path: workspace.artifactsDir.appending(components: "a", "A2", "A2.artifactbundle")
             )
-            result.check(packageIdentity: .plain("b"),
-                         targetName: "B",
-                         source: .local(checksum: "b0"),
-                         path: workspace.artifactsDir.appending(components: "b", "B", "B.xcframework")
+            result.check(
+                packageIdentity: .plain("b"),
+                targetName: "B",
+                source: .local(checksum: "b0"),
+                path: workspace.artifactsDir.appending(components: "b", "B", "B.xcframework")
             )
         }
     }
@@ -5446,7 +5725,7 @@ final class WorkspaceTests: XCTestCase {
         // create a dummy xcframework directory (with a marker subdirectory) from the request archive
         let archiver = MockArchiver(handler: { archiver, archivePath, destinationPath, completion in
             do {
-                //var subdirectoryName: String?
+                // var subdirectoryName: String?
                 switch archivePath.basename {
                 case "A1.zip":
                     try createDummyXCFramework(fileSystem: fs, path: destinationPath, name: "A1")
@@ -5454,15 +5733,22 @@ final class WorkspaceTests: XCTestCase {
                     try createDummyXCFramework(fileSystem: fs, path: destinationPath, name: "A2")
                 case "A3.zip":
                     try createDummyXCFramework(fileSystem: fs, path: destinationPath, name: "A3")
-                    try fs.createDirectory(destinationPath.appending(components: [a3FrameworkName, "local-archived"]), recursive: false)
+                    try fs.createDirectory(
+                        destinationPath.appending(components: [a3FrameworkName, "local-archived"]),
+                        recursive: false
+                    )
                 case "a4.zip":
                     try createDummyXCFramework(fileSystem: fs, path: destinationPath, name: "A4")
-                    try fs.createDirectory(destinationPath.appending(components: [a4FrameworkName, "remote"]), recursive: false)
+                    try fs.createDirectory(
+                        destinationPath.appending(components: [a4FrameworkName, "remote"]),
+                        recursive: false
+                    )
                 default:
                     throw StringError("unexpected archivePath \(archivePath)")
                 }
 
-                archiver.extractions.append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
+                archiver.extractions
+                    .append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
                 completion(.success(()))
             } catch {
                 completion(.failure(error))
@@ -5480,12 +5766,12 @@ final class WorkspaceTests: XCTestCase {
                             .product(name: "A1", package: "A"),
                             .product(name: "A2", package: "A"),
                             .product(name: "A3", package: "A"),
-                            .product(name: "A4", package: "A")
+                            .product(name: "A4", package: "A"),
                         ]),
                     ],
                     products: [],
                     dependencies: [
-                        .sourceControl(path: "./A", requirement: .exact("1.0.0"))
+                        .sourceControl(path: "./A", requirement: .exact("1.0.0")),
                     ]
                 ),
             ],
@@ -5513,16 +5799,16 @@ final class WorkspaceTests: XCTestCase {
                             type: .binary,
                             url: "https://a.com/a4.zip",
                             checksum: "a4"
-                        )
+                        ),
                     ],
                     products: [
                         MockProduct(name: "A1", targets: ["A1"]),
                         MockProduct(name: "A2", targets: ["A2"]),
                         MockProduct(name: "A3", targets: ["A3"]),
-                        MockProduct(name: "A4", targets: ["A4"])
+                        MockProduct(name: "A4", targets: ["A4"]),
                     ],
                     versions: ["1.0.0"]
-                )
+                ),
             ],
             binaryArtifactsManager: .init(
                 httpClient: httpClient,
@@ -5595,15 +5881,21 @@ final class WorkspaceTests: XCTestCase {
                     source: .local(checksum: "a5"),
                     path: workspace.artifactsDir.appending(components: "A", a5FrameworkName),
                     kind: .xcframework
-                )
+                ),
             ]
         )
 
         // Create marker folders to later check that the frameworks' content is properly overwritten
-        try fs.createDirectory(workspace.artifactsDir.appending(components: "A", "A3", a3FrameworkName, "remote"), recursive: true)
-        try fs.createDirectory(workspace.artifactsDir.appending(components: "A", "A4", a4FrameworkName, "local-archived"), recursive: true)
+        try fs.createDirectory(
+            workspace.artifactsDir.appending(components: "A", "A3", a3FrameworkName, "remote"),
+            recursive: true
+        )
+        try fs.createDirectory(
+            workspace.artifactsDir.appending(components: "A", "A4", a4FrameworkName, "local-archived"),
+            recursive: true
+        )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
 
             // Ensure that the original archives have been untouched
@@ -5614,36 +5906,56 @@ final class WorkspaceTests: XCTestCase {
 
             // Ensure that the new artifacts have been properly extracted
             XCTAssertTrue(fs.exists(try AbsolutePath(validating: "/tmp/ws/.build/artifacts/a/A1/\(a1FrameworkName)")))
-            XCTAssertTrue(fs.exists(try AbsolutePath(validating: "/tmp/ws/.build/artifacts/a/A3/\(a3FrameworkName)/local-archived")))
-            XCTAssertTrue(fs.exists(try AbsolutePath(validating: "/tmp/ws/.build/artifacts/a/A4/\(a4FrameworkName)/remote")))
+            XCTAssertTrue(
+                fs
+                    .exists(
+                        try AbsolutePath(validating: "/tmp/ws/.build/artifacts/a/A3/\(a3FrameworkName)/local-archived")
+                    )
+            )
+            XCTAssertTrue(
+                fs
+                    .exists(try AbsolutePath(validating: "/tmp/ws/.build/artifacts/a/A4/\(a4FrameworkName)/remote"))
+            )
 
             // Ensure that the old artifacts have been removed
             XCTAssertFalse(fs.exists(try AbsolutePath(validating: "/tmp/ws/.build/artifacts/a/A2/\(a2FrameworkName)")))
-            XCTAssertFalse(fs.exists(try AbsolutePath(validating: "/tmp/ws/.build/artifacts/a/A3/\(a3FrameworkName)/remote")))
-            XCTAssertFalse(fs.exists(try AbsolutePath(validating: "/tmp/ws/.build/artifacts/a/A4/\(a4FrameworkName)/local-archived")))
+            XCTAssertFalse(
+                fs
+                    .exists(try AbsolutePath(validating: "/tmp/ws/.build/artifacts/a/A3/\(a3FrameworkName)/remote"))
+            )
+            XCTAssertFalse(
+                fs
+                    .exists(
+                        try AbsolutePath(validating: "/tmp/ws/.build/artifacts/a/A4/\(a4FrameworkName)/local-archived")
+                    )
+            )
             XCTAssertFalse(fs.exists(try AbsolutePath(validating: "/tmp/ws/.build/artifacts/a/A5/\(a5FrameworkName)")))
         }
 
         workspace.checkManagedArtifacts { result in
-            result.check(packageIdentity: .plain("a"),
-                         targetName: "A1",
-                         source: .local(checksum: "a1"),
-                         path: workspace.artifactsDir.appending(components: "a", "A1", a1FrameworkName)
+            result.check(
+                packageIdentity: .plain("a"),
+                targetName: "A1",
+                source: .local(checksum: "a1"),
+                path: workspace.artifactsDir.appending(components: "a", "A1", a1FrameworkName)
             )
-            result.check(packageIdentity: .plain("a"),
-                         targetName: "A2",
-                         source: .local(),
-                         path: a2FrameworkPath
+            result.check(
+                packageIdentity: .plain("a"),
+                targetName: "A2",
+                source: .local(),
+                path: a2FrameworkPath
             )
-            result.check(packageIdentity: .plain("a"),
-                         targetName: "A3",
-                         source: .local(checksum: "a3"),
-                         path: workspace.artifactsDir.appending(components: "a", "A3", a3FrameworkName)
+            result.check(
+                packageIdentity: .plain("a"),
+                targetName: "A3",
+                source: .local(checksum: "a3"),
+                path: workspace.artifactsDir.appending(components: "a", "A3", a3FrameworkName)
             )
-            result.check(packageIdentity: .plain("a"),
-                         targetName: "A4",
-                         source: .remote(url: "https://a.com/a4.zip", checksum: "a4"),
-                         path: workspace.artifactsDir.appending(components: "a", "A4", a4FrameworkName)
+            result.check(
+                packageIdentity: .plain("a"),
+                targetName: "A4",
+                source: .remote(url: "https://a.com/a4.zip", checksum: "a4"),
+                path: workspace.artifactsDir.appending(components: "a", "A4", a4FrameworkName)
             )
         }
     }
@@ -5657,11 +5969,16 @@ final class WorkspaceTests: XCTestCase {
             do {
                 switch archivePath.basename {
                 case "archived-does-not-match-target-name.zip":
-                    try createDummyXCFramework(fileSystem: fs, path: destinationPath, name: "artifact-does-not-match-target-name")
+                    try createDummyXCFramework(
+                        fileSystem: fs,
+                        path: destinationPath,
+                        name: "artifact-does-not-match-target-name"
+                    )
                 default:
                     throw StringError("unexpected archivePath \(archivePath)")
                 }
-                archiver.extractions.append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
+                archiver.extractions
+                    .append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
                 completion(.success(()))
             } catch {
                 completion(.failure(error))
@@ -5679,9 +5996,9 @@ final class WorkspaceTests: XCTestCase {
                             name: "A1",
                             type: .binary,
                             path: "XCFrameworks/archived-does-not-match-target-name.zip"
-                        )
+                        ),
                     ]
-                )
+                ),
             ],
             binaryArtifactsManager: .init(
                 archiver: archiver
@@ -5692,9 +6009,12 @@ final class WorkspaceTests: XCTestCase {
         let rootPath = try workspace.pathToRoot(withName: "Root")
         let frameworksPath = rootPath.appending(component: "XCFrameworks")
         try fs.createDirectory(frameworksPath, recursive: true)
-        try fs.writeFileContents(frameworksPath.appending(component: "archived-does-not-match-target-name.zip"), bytes: ByteString([0xA1]))
+        try fs.writeFileContents(
+            frameworksPath.appending(component: "archived-does-not-match-target-name.zip"),
+            bytes: ByteString([0xA1])
+        )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { result, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
     }
@@ -5703,7 +6023,7 @@ final class WorkspaceTests: XCTestCase {
         let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
-        let archiver = MockArchiver(handler: { _, _, destinationPath, completion in
+        let archiver = MockArchiver(handler: { _, _, _, completion in
             completion(.failure(DummyError()))
         })
 
@@ -5723,9 +6043,9 @@ final class WorkspaceTests: XCTestCase {
                             name: "A2",
                             type: .binary,
                             path: "ArtifactBundles/A2.zip"
-                        )
+                        ),
                     ]
-                )
+                ),
             ],
             binaryArtifactsManager: .init(
                 archiver: archiver
@@ -5734,8 +6054,18 @@ final class WorkspaceTests: XCTestCase {
 
         workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
-                result.checkUnordered(diagnostic: .contains("failed extracting '\(sandbox.appending(components: "roots", "Root", "XCFrameworks", "A1.zip"))' which is required by binary target 'A1': dummy error"), severity: .error)
-                result.checkUnordered(diagnostic: .contains("failed extracting '\(sandbox.appending(components: "roots", "Root", "ArtifactBundles", "A2.zip"))' which is required by binary target 'A2': dummy error"), severity: .error)
+                result.checkUnordered(
+                    diagnostic: .contains(
+                        "failed extracting '\(sandbox.appending(components: "roots", "Root", "XCFrameworks", "A1.zip"))' which is required by binary target 'A1': dummy error"
+                    ),
+                    severity: .error
+                )
+                result.checkUnordered(
+                    diagnostic: .contains(
+                        "failed extracting '\(sandbox.appending(components: "roots", "Root", "ArtifactBundles", "A2.zip"))' which is required by binary target 'A2': dummy error"
+                    ),
+                    severity: .error
+                )
             }
         }
     }
@@ -5745,7 +6075,7 @@ final class WorkspaceTests: XCTestCase {
         let fs = InMemoryFileSystem()
 
         // create dummy xcframework and artifactbundle directories from the request archive
-        let archiver = MockArchiver(handler: { archiver, archivePath, destinationPath, completion in
+        let archiver = MockArchiver(handler: { _, archivePath, destinationPath, completion in
             do {
                 switch archivePath.basename {
                 case "A1.zip":
@@ -5776,9 +6106,9 @@ final class WorkspaceTests: XCTestCase {
                             name: "A2",
                             type: .binary,
                             path: "ArtifactBundles/A2.zip"
-                        )
+                        ),
                     ]
-                )
+                ),
             ],
             binaryArtifactsManager: .init(
                 archiver: archiver
@@ -5795,20 +6125,22 @@ final class WorkspaceTests: XCTestCase {
         try fs.createDirectory(aArtifactBundlesPath, recursive: true)
         try fs.writeFileContents(aArtifactBundlesPath.appending(component: "A2.zip"), bytes: ByteString([0xA2]))
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
 
         workspace.checkManagedArtifacts { result in
-            result.check(packageIdentity: .plain("root"),
-                         targetName: "A1",
-                         source: .local(checksum: "a1"),
-                         path: workspace.artifactsDir.appending(components: "root", "A1", "foo.xcframework")
+            result.check(
+                packageIdentity: .plain("root"),
+                targetName: "A1",
+                source: .local(checksum: "a1"),
+                path: workspace.artifactsDir.appending(components: "root", "A1", "foo.xcframework")
             )
-            result.check(packageIdentity: .plain("root"),
-                         targetName: "A2",
-                         source: .local(checksum: "a2"),
-                         path: workspace.artifactsDir.appending(components: "root", "A2", "bar.artifactbundle")
+            result.check(
+                packageIdentity: .plain("root"),
+                targetName: "A2",
+                source: .local(checksum: "a2"),
+                path: workspace.artifactsDir.appending(components: "root", "A2", "bar.artifactbundle")
             )
         }
     }
@@ -5828,7 +6160,8 @@ final class WorkspaceTests: XCTestCase {
                 default:
                     throw StringError("unexpected archivePath \(archivePath)")
                 }
-                archiver.extractions.append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
+                archiver.extractions
+                    .append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
                 completion(.success(()))
             } catch {
                 completion(.failure(error))
@@ -5851,7 +6184,7 @@ final class WorkspaceTests: XCTestCase {
                             name: "A2",
                             type: .binary,
                             path: "XCFrameworks/A2.zip"
-                        )
+                        ),
                     ]
                 ),
             ],
@@ -5879,7 +6212,7 @@ final class WorkspaceTests: XCTestCase {
                     source: .local(checksum: "a2"),
                     path: workspace.artifactsDir.appending(components: "root", "A2", "A2.xcframework"),
                     kind: .xcframework
-                )
+                ),
             ]
         )
 
@@ -5893,23 +6226,25 @@ final class WorkspaceTests: XCTestCase {
         let a2FrameworkArchivePath = frameworksPath.appending(component: "A2.zip")
         try fs.writeFileContents(a2FrameworkArchivePath, bytes: ByteString([0xA2]))
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"]) { _, _ in
             // Ensure that only the artifact archive with the changed checksum has been extracted
-            XCTAssertEqual(archiver.extractions.map { $0.destinationPath.parentDirectory }.sorted(), [
-                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/A1")
+            XCTAssertEqual(archiver.extractions.map(\.destinationPath.parentDirectory).sorted(), [
+                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/A1"),
             ])
         }
 
         workspace.checkManagedArtifacts { result in
-            result.check(packageIdentity: .plain("root"),
-                         targetName: "A1",
-                         source: .local(checksum: "a1"),
-                         path: workspace.artifactsDir.appending(components: "root", "A1", "A1.xcframework")
+            result.check(
+                packageIdentity: .plain("root"),
+                targetName: "A1",
+                source: .local(checksum: "a1"),
+                path: workspace.artifactsDir.appending(components: "root", "A1", "A1.xcframework")
             )
-            result.check(packageIdentity: .plain("root"),
-                         targetName: "A2",
-                         source: .local(checksum: "a2"),
-                         path: workspace.artifactsDir.appending(components: "root", "A2", "A2.xcframework")
+            result.check(
+                packageIdentity: .plain("root"),
+                targetName: "A2",
+                source: .local(checksum: "a2"),
+                path: workspace.artifactsDir.appending(components: "root", "A2", "A2.xcframework")
             )
         }
     }
@@ -5917,7 +6252,6 @@ final class WorkspaceTests: XCTestCase {
     func testLocalArchivedArtifactStripFirstComponent() throws {
         let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
-
 
         // create a dummy xcframework directory from the request archive
         let archiver = MockArchiver(handler: { archiver, archivePath, destinationPath, completion in
@@ -5933,11 +6267,16 @@ final class WorkspaceTests: XCTestCase {
                     let nestedPath = destinationPath.appending(component: "root")
                     try fs.createDirectory(nestedPath, recursive: true)
                     try createDummyXCFramework(fileSystem: fs, path: destinationPath, name: "nested2")
-                    try fs.writeFileContents(nestedPath.appending(component: ".DS_Store"), bytes: []) // add a file next to the directory
+                    try fs
+                        .writeFileContents(
+                            nestedPath.appending(component: ".DS_Store"),
+                            bytes: []
+                        ) // add a file next to the directory
                 default:
                     throw StringError("unexpected archivePath \(archivePath)")
                 }
-                archiver.extractions.append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
+                archiver.extractions
+                    .append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
                 completion(.success(()))
             } catch {
                 completion(.failure(error))
@@ -5960,15 +6299,15 @@ final class WorkspaceTests: XCTestCase {
                             name: "nested",
                             type: .binary,
                             path: "frameworks/nested.zip"
-                        )
-                        ,
+                        ),
+
                         MockTarget(
                             name: "nested2",
                             type: .binary,
                             path: "frameworks/nested2.zip"
-                        )
+                        ),
                     ]
-                )
+                ),
             ],
             binaryArtifactsManager: .init(
                 archiver: archiver
@@ -5988,10 +6327,10 @@ final class WorkspaceTests: XCTestCase {
         XCTAssertFalse(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/root/nested/nested.artifactbundle")))
         XCTAssertFalse(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/root/nested2/nested2.xcframework")))
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             XCTAssert(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/root")))
-            XCTAssertEqual(archiver.extractions.map { $0.destinationPath.parentDirectory }.sorted(), [
+            XCTAssertEqual(archiver.extractions.map(\.destinationPath.parentDirectory).sorted(), [
                 AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/flat"),
                 AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/nested"),
                 AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/nested2"),
@@ -5999,20 +6338,23 @@ final class WorkspaceTests: XCTestCase {
         }
 
         workspace.checkManagedArtifacts { result in
-            result.check(packageIdentity: .plain("root"),
-                         targetName: "flat",
-                         source: .local(checksum: "01"),
-                         path: workspace.artifactsDir.appending(components: "root", "flat", "flat.xcframework")
+            result.check(
+                packageIdentity: .plain("root"),
+                targetName: "flat",
+                source: .local(checksum: "01"),
+                path: workspace.artifactsDir.appending(components: "root", "flat", "flat.xcframework")
             )
-            result.check(packageIdentity: .plain("root"),
-                         targetName: "nested",
-                         source: .local(checksum: "02"),
-                         path: workspace.artifactsDir.appending(components: "root", "nested", "nested.xcframework")
+            result.check(
+                packageIdentity: .plain("root"),
+                targetName: "nested",
+                source: .local(checksum: "02"),
+                path: workspace.artifactsDir.appending(components: "root", "nested", "nested.xcframework")
             )
-            result.check(packageIdentity: .plain("root"),
-                         targetName: "nested2",
-                         source: .local(checksum: "03"),
-                         path: workspace.artifactsDir.appending(components: "root", "nested2", "nested2.xcframework")
+            result.check(
+                packageIdentity: .plain("root"),
+                targetName: "nested2",
+                source: .local(checksum: "03"),
+                path: workspace.artifactsDir.appending(components: "root", "nested2", "nested2.xcframework")
             )
         }
     }
@@ -6037,9 +6379,9 @@ final class WorkspaceTests: XCTestCase {
                             name: "A2",
                             type: .binary,
                             path: "ArtifactBundles/A2.artifactbundle"
-                        )
+                        ),
                     ]
-                )
+                ),
             ]
         )
 
@@ -6047,22 +6389,28 @@ final class WorkspaceTests: XCTestCase {
 
         // make sure the directory exist in their destined location
         try createDummyXCFramework(fileSystem: fs, path: rootPath.appending(component: "XCFrameworks"), name: "A1")
-        try createDummyArtifactBundle(fileSystem: fs, path: rootPath.appending(component: "ArtifactBundles"), name: "A2")
+        try createDummyArtifactBundle(
+            fileSystem: fs,
+            path: rootPath.appending(component: "ArtifactBundles"),
+            name: "A2"
+        )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
 
         workspace.checkManagedArtifacts { result in
-            result.check(packageIdentity: .plain("root"),
-                         targetName: "A1",
-                         source: .local(checksum: .none),
-                         path: rootPath.appending(components: "XCFrameworks", "A1.xcframework")
+            result.check(
+                packageIdentity: .plain("root"),
+                targetName: "A1",
+                source: .local(checksum: .none),
+                path: rootPath.appending(components: "XCFrameworks", "A1.xcframework")
             )
-            result.check(packageIdentity: .plain("root"),
-                         targetName: "A2",
-                         source: .local(checksum: .none),
-                         path: rootPath.appending(components: "ArtifactBundles", "A2.artifactbundle")
+            result.check(
+                packageIdentity: .plain("root"),
+                targetName: "A2",
+                source: .local(checksum: .none),
+                path: rootPath.appending(components: "ArtifactBundles", "A2.artifactbundle")
             )
         }
     }
@@ -6087,16 +6435,26 @@ final class WorkspaceTests: XCTestCase {
                             name: "A2",
                             type: .binary,
                             path: "ArtifactBundles/incorrect.artifactbundle"
-                        )
+                        ),
                     ]
-                )
+                ),
             ]
         )
 
         workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
-                result.checkUnordered(diagnostic: .contains("local binary target 'A1' at '\(AbsolutePath(path: "/tmp/ws/roots/Root/XCFrameworks/incorrect.xcframework"))' does not contain a binary artifact.") , severity: .error)
-                result.checkUnordered(diagnostic: .contains("local binary target 'A2' at '\(AbsolutePath(path: "/tmp/ws/roots/Root/ArtifactBundles/incorrect.artifactbundle"))' does not contain a binary artifact.") , severity: .error)
+                result.checkUnordered(
+                    diagnostic: .contains(
+                        "local binary target 'A1' at '\(AbsolutePath(path: "/tmp/ws/roots/Root/XCFrameworks/incorrect.xcframework"))' does not contain a binary artifact."
+                    ),
+                    severity: .error
+                )
+                result.checkUnordered(
+                    diagnostic: .contains(
+                        "local binary target 'A2' at '\(AbsolutePath(path: "/tmp/ws/roots/Root/ArtifactBundles/incorrect.artifactbundle"))' does not contain a binary artifact."
+                    ),
+                    severity: .error
+                )
             }
         }
     }
@@ -6151,7 +6509,8 @@ final class WorkspaceTests: XCTestCase {
                 default:
                     throw StringError("unexpected archivePath \(archivePath)")
                 }
-                archiver.extractions.append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
+                archiver.extractions
+                    .append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
                 completion(.success(()))
             } catch {
                 completion(.failure(error))
@@ -6168,7 +6527,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "RootTarget", dependencies: [
                             .product(name: "A1", package: "A"),
                             .product(name: "A2", package: "A"),
-                            "B"
+                            "B",
                         ]),
                     ],
                     products: [],
@@ -6193,11 +6552,11 @@ final class WorkspaceTests: XCTestCase {
                             type: .binary,
                             url: "https://a.com/a2.zip",
                             checksum: "a2"
-                        )
+                        ),
                     ],
                     products: [
                         MockProduct(name: "A1", targets: ["A1"]),
-                        MockProduct(name: "A2", targets: ["A2"])
+                        MockProduct(name: "A2", targets: ["A2"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -6223,63 +6582,72 @@ final class WorkspaceTests: XCTestCase {
             )
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             XCTAssert(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/a")))
             XCTAssert(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/b")))
-            XCTAssertEqual(downloads.map { $0.key.absoluteString }.sorted(), [
+            XCTAssertEqual(downloads.map(\.key.absoluteString).sorted(), [
                 "https://a.com/a1.zip",
                 "https://a.com/a2.zip",
                 "https://b.com/b.zip",
             ])
-            XCTAssertEqual(workspace.checksumAlgorithm.hashes.map{ $0.hexadecimalRepresentation }.sorted(), [
+            XCTAssertEqual(workspace.checksumAlgorithm.hashes.map(\.hexadecimalRepresentation).sorted(), [
                 ByteString([0xA1]).hexadecimalRepresentation,
                 ByteString([0xA2]).hexadecimalRepresentation,
                 ByteString([0xB0]).hexadecimalRepresentation,
             ])
-            XCTAssertEqual(archiver.extractions.map { $0.destinationPath.parentDirectory }.sorted(), [
+            XCTAssertEqual(archiver.extractions.map(\.destinationPath.parentDirectory).sorted(), [
                 AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A1"),
                 AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A2"),
-                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/b/B")
+                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/b/B"),
             ])
             XCTAssertEqual(
-                downloads.map { $0.value }.sorted(),
-                archiver.extractions.map { $0.archivePath }.sorted()
+                downloads.map(\.value).sorted(),
+                archiver.extractions.map(\.archivePath).sorted()
             )
         }
 
         workspace.checkManagedArtifacts { result in
-            result.check(packageIdentity: .plain("a"),
-                         targetName: "A1",
-                         source: .remote(
-                            url: "https://a.com/a1.zip",
-                            checksum: "a1"
-                         ),
-                         path: workspace.artifactsDir.appending(components: "a", "A1", "A1.xcframework")
+            result.check(
+                packageIdentity: .plain("a"),
+                targetName: "A1",
+                source: .remote(
+                    url: "https://a.com/a1.zip",
+                    checksum: "a1"
+                ),
+                path: workspace.artifactsDir.appending(components: "a", "A1", "A1.xcframework")
             )
-            result.check(packageIdentity: .plain("a"),
-                         targetName: "A2",
-                         source: .remote(
-                            url: "https://a.com/a2.zip",
-                            checksum: "a2"
-                         ),
-                         path: workspace.artifactsDir.appending(components: "a", "A2", "A2.xcframework")
+            result.check(
+                packageIdentity: .plain("a"),
+                targetName: "A2",
+                source: .remote(
+                    url: "https://a.com/a2.zip",
+                    checksum: "a2"
+                ),
+                path: workspace.artifactsDir.appending(components: "a", "A2", "A2.xcframework")
             )
-            result.check(packageIdentity: .plain("b"),
-                         targetName: "B",
-                         source: .remote(
-                            url: "https://b.com/b.zip",
-                            checksum: "b0"
-                         ),
-                         path: workspace.artifactsDir.appending(components: "b", "B", "B.xcframework")
+            result.check(
+                packageIdentity: .plain("b"),
+                targetName: "B",
+                source: .remote(
+                    url: "https://b.com/b.zip",
+                    checksum: "b0"
+                ),
+                path: workspace.artifactsDir.appending(components: "b", "B", "B.xcframework")
             )
         }
 
         XCTAssertMatch(workspace.delegate.events, ["downloading binary artifact package: https://a.com/a1.zip"])
         XCTAssertMatch(workspace.delegate.events, ["downloading binary artifact package: https://a.com/a2.zip"])
         XCTAssertMatch(workspace.delegate.events, ["downloading binary artifact package: https://b.com/b.zip"])
-        XCTAssertMatch(workspace.delegate.events, ["finished downloading binary artifact package: https://a.com/a1.zip"])
-        XCTAssertMatch(workspace.delegate.events, ["finished downloading binary artifact package: https://a.com/a2.zip"])
+        XCTAssertMatch(
+            workspace.delegate.events,
+            ["finished downloading binary artifact package: https://a.com/a1.zip"]
+        )
+        XCTAssertMatch(
+            workspace.delegate.events,
+            ["finished downloading binary artifact package: https://a.com/a2.zip"]
+        )
         XCTAssertMatch(workspace.delegate.events, ["finished downloading binary artifact package: https://b.com/b.zip"])
     }
 
@@ -6341,7 +6709,8 @@ final class WorkspaceTests: XCTestCase {
                 default:
                     throw StringError("unexpected archivePath \(archivePath)")
                 }
-                archiver.extractions.append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
+                archiver.extractions
+                    .append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
                 completion(.success(()))
             } catch {
                 completion(.failure(error))
@@ -6361,7 +6730,7 @@ final class WorkspaceTests: XCTestCase {
                             .product(name: "A2", package: "A"),
                             .product(name: "A3", package: "A"),
                             .product(name: "A4", package: "A"),
-                            .product(name: "A7", package: "A")
+                            .product(name: "A7", package: "A"),
                         ]),
                     ],
                     products: [],
@@ -6403,14 +6772,14 @@ final class WorkspaceTests: XCTestCase {
                             type: .binary,
                             url: "https://a.com/a7.zip",
                             checksum: "a7"
-                        )
+                        ),
                     ],
                     products: [
                         MockProduct(name: "A1", targets: ["A1"]),
                         MockProduct(name: "A2", targets: ["A2"]),
                         MockProduct(name: "A3", targets: ["A3"]),
                         MockProduct(name: "A4", targets: ["A4"]),
-                        MockProduct(name: "A7", targets: ["A7"])
+                        MockProduct(name: "A7", targets: ["A7"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -6486,7 +6855,7 @@ final class WorkspaceTests: XCTestCase {
                         url: "https://a.com/a5.zip",
                         checksum: "a5"
                     ),
-                    path: workspace.artifactsDir.appending(components: "a", "A5","A5.xcframework"),
+                    path: workspace.artifactsDir.appending(components: "a", "A5", "A5.xcframework"),
                     kind: .xcframework
                 ),
                 .init(
@@ -6502,13 +6871,16 @@ final class WorkspaceTests: XCTestCase {
                     source: .local(),
                     path: workspace.packagesDir.appending(components: "a", "XCFrameworks", "A7.xcframework"),
                     kind: .xcframework
-                )
+                ),
             ]
         )
 
         workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
-                result.check(diagnostic: "downloaded archive of binary target 'A3' from 'https://a.com/a3.zip' does not contain a binary artifact.", severity: .error)
+                result.check(
+                    diagnostic: "downloaded archive of binary target 'A3' from 'https://a.com/a3.zip' does not contain a binary artifact.",
+                    severity: .error
+                )
             }
             XCTAssert(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/b")))
             XCTAssert(fs.exists(AbsolutePath(path: "/tmp/ws/.build/artifacts/a/A1/A1.xcframework")))
@@ -6518,69 +6890,74 @@ final class WorkspaceTests: XCTestCase {
             XCTAssert(!fs.exists(AbsolutePath(path: "/tmp/ws/.build/artifacts/a/A5/A5.xcframework")))
             XCTAssert(fs.exists(AbsolutePath(path: "/tmp/ws/pkgs/a/XCFrameworks/A7.xcframework")))
             XCTAssert(!fs.exists(AbsolutePath(path: "/tmp/ws/.build/artifacts/Foo")))
-            XCTAssertEqual(downloads.map { $0.key.absoluteString }.sorted(), [
+            XCTAssertEqual(downloads.map(\.key.absoluteString).sorted(), [
                 "https://a.com/a2.zip",
                 "https://a.com/a3.zip",
                 "https://a.com/a7.zip",
                 "https://b.com/b.zip",
             ])
-            XCTAssertEqual(workspace.checksumAlgorithm.hashes.map{ $0.hexadecimalRepresentation }.sorted(), [
+            XCTAssertEqual(workspace.checksumAlgorithm.hashes.map(\.hexadecimalRepresentation).sorted(), [
                 ByteString([0xA2]).hexadecimalRepresentation,
                 ByteString([0xA3]).hexadecimalRepresentation,
                 ByteString([0xA7]).hexadecimalRepresentation,
                 ByteString([0xB0]).hexadecimalRepresentation,
             ])
-            XCTAssertEqual(archiver.extractions.map { $0.destinationPath.parentDirectory }.sorted(), [
+            XCTAssertEqual(archiver.extractions.map(\.destinationPath.parentDirectory).sorted(), [
                 AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A2"),
                 AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A3"),
                 AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A7"),
                 AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/b/B"),
             ])
             XCTAssertEqual(
-                downloads.map { $0.value }.sorted(),
-                archiver.extractions.map { $0.archivePath }.sorted()
+                downloads.map(\.value).sorted(),
+                archiver.extractions.map(\.archivePath).sorted()
             )
         }
 
         workspace.checkManagedArtifacts { result in
-            result.check(packageIdentity: .plain("a"),
-                         targetName: "A1",
-                         source: .remote(
-                            url: "https://a.com/a1.zip",
-                            checksum: "a1"
-                         ),
-                         path: workspace.artifactsDir.appending(components: "a", "A1", "A1.xcframework")
+            result.check(
+                packageIdentity: .plain("a"),
+                targetName: "A1",
+                source: .remote(
+                    url: "https://a.com/a1.zip",
+                    checksum: "a1"
+                ),
+                path: workspace.artifactsDir.appending(components: "a", "A1", "A1.xcframework")
             )
-            result.check(packageIdentity: .plain("a"),
-                         targetName: "A2",
-                         source: .remote(
-                            url: "https://a.com/a2.zip",
-                            checksum: "a2"
-                         ),
-                         path: workspace.artifactsDir.appending(components: "a", "A2", "A2.xcframework")
+            result.check(
+                packageIdentity: .plain("a"),
+                targetName: "A2",
+                source: .remote(
+                    url: "https://a.com/a2.zip",
+                    checksum: "a2"
+                ),
+                path: workspace.artifactsDir.appending(components: "a", "A2", "A2.xcframework")
             )
             result.checkNotPresent(packageName: "A", targetName: "A3")
-            result.check(packageIdentity: .plain("a"),
-                         targetName: "A4",
-                         source: .local(),
-                         path: a4FrameworkPath
+            result.check(
+                packageIdentity: .plain("a"),
+                targetName: "A4",
+                source: .local(),
+                path: a4FrameworkPath
             )
-            result.check(packageIdentity: .plain("a"),
-                         targetName: "A7",
-                         source: .remote(
-                            url: "https://a.com/a7.zip",
-                            checksum: "a7"
-                         ),
-                         path: workspace.artifactsDir.appending(components: "a", "A7", "A7.xcframework")
+            result.check(
+                packageIdentity: .plain("a"),
+                targetName: "A7",
+                source: .remote(
+                    url: "https://a.com/a7.zip",
+                    checksum: "a7"
+                ),
+                path: workspace.artifactsDir.appending(components: "a", "A7", "A7.xcframework")
             )
             result.checkNotPresent(packageName: "A", targetName: "A5")
-            result.check(packageIdentity: .plain("b"),
-                         targetName: "B",
-                         source: .remote(
-                            url: "https://b.com/b.zip",
-                            checksum: "b0"
-                         ),
-                         path: workspace.artifactsDir.appending(components: "b", "B", "B.xcframework")
+            result.check(
+                packageIdentity: .plain("b"),
+                targetName: "B",
+                source: .remote(
+                    url: "https://b.com/b.zip",
+                    checksum: "b0"
+                ),
+                path: workspace.artifactsDir.appending(components: "b", "B", "B.xcframework")
             )
         }
     }
@@ -6633,7 +7010,8 @@ final class WorkspaceTests: XCTestCase {
                     throw StringError("\(path) already exists")
                 }
                 try createDummyXCFramework(fileSystem: fs, path: path.parentDirectory, name: "A1")
-                archiver.extractions.append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
+                archiver.extractions
+                    .append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
                 completion(.success(()))
             } catch {
                 completion(.failure(error))
@@ -6654,7 +7032,7 @@ final class WorkspaceTests: XCTestCase {
                             checksum: "a1"
                         ),
                     ]
-                )
+                ),
             ],
             binaryArtifactsManager: .init(
                 httpClient: httpClient,
@@ -6662,23 +7040,23 @@ final class WorkspaceTests: XCTestCase {
             )
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             XCTAssert(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/root")))
-            XCTAssertEqual(workspace.checksumAlgorithm.hashes.map{ $0.hexadecimalRepresentation }.sorted(), [
+            XCTAssertEqual(workspace.checksumAlgorithm.hashes.map(\.hexadecimalRepresentation).sorted(), [
                 ByteString([0xA1]).hexadecimalRepresentation,
             ])
         }
 
-        XCTAssertEqual(downloads.map { $0.0.absoluteString }.sorted(), [
+        XCTAssertEqual(downloads.map(\.0.absoluteString).sorted(), [
             "https://a.com/a1.zip",
         ])
-        XCTAssertEqual(archiver.extractions.map { $0.destinationPath.parentDirectory }.sorted(), [
+        XCTAssertEqual(archiver.extractions.map(\.destinationPath.parentDirectory).sorted(), [
             AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/A1"),
         ])
         XCTAssertEqual(
-            downloads.map { $0.1 }.sorted(),
-            archiver.extractions.map { $0.archivePath }.sorted()
+            downloads.map(\.1).sorted(),
+            archiver.extractions.map(\.archivePath).sorted()
         )
 
         // reset
@@ -6687,25 +7065,25 @@ final class WorkspaceTests: XCTestCase {
 
         // do it again
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             XCTAssert(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/root")))
 
-            XCTAssertEqual(workspace.checksumAlgorithm.hashes.map{ $0.hexadecimalRepresentation }.sorted(), [
+            XCTAssertEqual(workspace.checksumAlgorithm.hashes.map(\.hexadecimalRepresentation).sorted(), [
                 ByteString([0xA1]).hexadecimalRepresentation, ByteString([0xA1]).hexadecimalRepresentation,
             ])
         }
 
-        XCTAssertEqual(downloads.map { $0.0.absoluteString }.sorted(), [
+        XCTAssertEqual(downloads.map(\.0.absoluteString).sorted(), [
             "https://a.com/a1.zip", "https://a.com/a1.zip",
         ])
-        XCTAssertEqual(archiver.extractions.map { $0.destinationPath.parentDirectory }.sorted(), [
+        XCTAssertEqual(archiver.extractions.map(\.destinationPath.parentDirectory).sorted(), [
             AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/A1"),
             AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/A1"),
         ])
         XCTAssertEqual(
-            downloads.map { $0.1 }.sorted(),
-            archiver.extractions.map { $0.archivePath }.sorted()
+            downloads.map(\.1).sorted(),
+            archiver.extractions.map(\.archivePath).sorted()
         )
     }
 
@@ -6756,7 +7134,12 @@ final class WorkspaceTests: XCTestCase {
 
         workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
-                result.check(diagnostic: .contains("failed downloading 'https://a.com/a.zip' which is required by binary target 'A1': badResponseStatusCode(404)"), severity: .error)
+                result.check(
+                    diagnostic: .contains(
+                        "failed downloading 'https://a.com/a.zip' which is required by binary target 'A1': badResponseStatusCode(404)"
+                    ),
+                    severity: .error
+                )
             }
         }
 
@@ -6794,7 +7177,10 @@ final class WorkspaceTests: XCTestCase {
         })
 
         let archiver = MockArchiver(handler: { _, _, destinationPath, completion in
-            XCTAssertEqual(destinationPath.parentDirectory, AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/A2"))
+            XCTAssertEqual(
+                destinationPath.parentDirectory,
+                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/A2")
+            )
             completion(.failure(DummyError()))
         })
 
@@ -6834,9 +7220,24 @@ final class WorkspaceTests: XCTestCase {
 
         workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
-                result.checkUnordered(diagnostic: .contains("failed downloading 'https://a.com/a1.zip' which is required by binary target 'A1': badResponseStatusCode(500)"), severity: .error)
-                result.checkUnordered(diagnostic: .contains("failed extracting 'https://a.com/a2.zip' which is required by binary target 'A2': dummy error"), severity: .error)
-                result.checkUnordered(diagnostic: .contains("checksum of downloaded artifact of binary target 'A3' (6d75736b6365686320746e65726566666964203d2073746e65746e6f6320746e65726566666964) does not match checksum specified by the manifest (a3)"), severity: .error)
+                result.checkUnordered(
+                    diagnostic: .contains(
+                        "failed downloading 'https://a.com/a1.zip' which is required by binary target 'A1': badResponseStatusCode(500)"
+                    ),
+                    severity: .error
+                )
+                result.checkUnordered(
+                    diagnostic: .contains(
+                        "failed extracting 'https://a.com/a2.zip' which is required by binary target 'A2': dummy error"
+                    ),
+                    severity: .error
+                )
+                result.checkUnordered(
+                    diagnostic: .contains(
+                        "checksum of downloaded artifact of binary target 'A3' (6d75736b6365686320746e65726566666964203d2073746e65746e6f6320746e65726566666964) does not match checksum specified by the manifest (a3)"
+                    ),
+                    severity: .error
+                )
             }
         }
     }
@@ -6875,7 +7276,8 @@ final class WorkspaceTests: XCTestCase {
                 do {
                     if archivePath.basenameWithoutExt == "a1" {
                         try createDummyXCFramework(fileSystem: fs, path: destinationPath, name: "A1")
-                        archiver.extractions.append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
+                        archiver.extractions
+                            .append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
                         completion(.success(()))
                     } else {
                         throw StringError("unexpected path")
@@ -6895,7 +7297,8 @@ final class WorkspaceTests: XCTestCase {
                     XCTFail("unexpected path")
                     completion(.success(false))
                 }
-            })
+            }
+        )
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
@@ -6935,8 +7338,18 @@ final class WorkspaceTests: XCTestCase {
 
         workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
-                result.checkUnordered(diagnostic: .contains("invalid archive returned from 'https://a.com/a2.zip' which is required by binary target 'A2'"), severity: .error)
-                result.checkUnordered(diagnostic: .contains("failed validating archive from 'https://a.com/a3.zip' which is required by binary target 'A3': dummy error"), severity: .error)
+                result.checkUnordered(
+                    diagnostic: .contains(
+                        "invalid archive returned from 'https://a.com/a2.zip' which is required by binary target 'A2'"
+                    ),
+                    severity: .error
+                )
+                result.checkUnordered(
+                    diagnostic: .contains(
+                        "failed validating archive from 'https://a.com/a3.zip' which is required by binary target 'A3': dummy error"
+                    ),
+                    severity: .error
+                )
             }
         }
     }
@@ -6965,7 +7378,7 @@ final class WorkspaceTests: XCTestCase {
         })
 
         let archiver = MockArchiver(
-            extractionHandler: { archiver, archivePath, destinationPath, completion in
+            extractionHandler: { _, archivePath, destinationPath, completion in
                 do {
                     if archivePath.basenameWithoutExt == "a1" {
                         // create file instead of directory
@@ -6977,7 +7390,8 @@ final class WorkspaceTests: XCTestCase {
                 } catch {
                     completion(.failure(error))
                 }
-            })
+            }
+        )
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
@@ -6991,7 +7405,7 @@ final class WorkspaceTests: XCTestCase {
                             type: .binary,
                             url: "https://a.com/a1.zip",
                             checksum: "a1"
-                        )
+                        ),
                     ],
                     products: [],
                     dependencies: []
@@ -7005,7 +7419,12 @@ final class WorkspaceTests: XCTestCase {
 
         workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
-                result.checkUnordered(diagnostic: .contains("downloaded archive of binary target 'A1' from 'https://a.com/a1.zip' does not contain a binary artifact."), severity: .error)
+                result.checkUnordered(
+                    diagnostic: .contains(
+                        "downloaded archive of binary target 'A1' from 'https://a.com/a1.zip' does not contain a binary artifact."
+                    ),
+                    severity: .error
+                )
             }
         }
     }
@@ -7034,7 +7453,7 @@ final class WorkspaceTests: XCTestCase {
         })
 
         let archiver = MockArchiver(
-            extractionHandler: { archiver, archivePath, destinationPath, completion in
+            extractionHandler: { _, archivePath, destinationPath, completion in
                 do {
                     if archivePath.basename == "foo.zip" {
                         try createDummyXCFramework(fileSystem: fs, path: destinationPath, name: "bar")
@@ -7045,7 +7464,8 @@ final class WorkspaceTests: XCTestCase {
                 } catch {
                     completion(.failure(error))
                 }
-            })
+            }
+        )
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
@@ -7059,7 +7479,7 @@ final class WorkspaceTests: XCTestCase {
                             type: .binary,
                             url: "https://a.com/foo.zip",
                             checksum: "a1"
-                        )
+                        ),
                     ],
                     products: [],
                     dependencies: []
@@ -7076,13 +7496,14 @@ final class WorkspaceTests: XCTestCase {
         }
 
         workspace.checkManagedArtifacts { result in
-            result.check(packageIdentity: .plain("root"),
-                         targetName: "A1",
-                         source: .remote(
-                            url: "https://a.com/foo.zip",
-                            checksum: "a1"
-                         ),
-                         path: workspace.artifactsDir.appending(components: "root", "A1", "bar.xcframework")
+            result.check(
+                packageIdentity: .plain("root"),
+                targetName: "A1",
+                source: .remote(
+                    url: "https://a.com/foo.zip",
+                    checksum: "a1"
+                ),
+                path: workspace.artifactsDir.appending(components: "root", "A1", "bar.xcframework")
             )
         }
     }
@@ -7109,23 +7530,35 @@ final class WorkspaceTests: XCTestCase {
             try fs.writeFileContents(binaryPath, bytes: ByteString([0xAA, 0xBB, 0xCC]))
 
             let checksum = try binaryArtifactsManager.checksum(forBinaryArtifactAt: binaryPath)
-            XCTAssertEqual(checksumAlgorithm.hashes.map { $0.contents }, [[0xAA, 0xBB, 0xCC]])
+            XCTAssertEqual(checksumAlgorithm.hashes.map(\.contents), [[0xAA, 0xBB, 0xCC]])
             XCTAssertEqual(checksum, "ccbbaa")
         }
 
         // Checks an unsupported extension.
         do {
             let unknownPath = sandbox.appending(component: "unknown")
-            XCTAssertThrowsError(try binaryArtifactsManager.checksum(forBinaryArtifactAt: unknownPath), "error expected") { error in
-                XCTAssertEqual(error as? StringError, StringError("unexpected file type; supported extensions are: zip"))
+            XCTAssertThrowsError(
+                try binaryArtifactsManager.checksum(forBinaryArtifactAt: unknownPath),
+                "error expected"
+            ) { error in
+                XCTAssertEqual(
+                    error as? StringError,
+                    StringError("unexpected file type; supported extensions are: zip")
+                )
             }
         }
 
         // Checks a supported extension that is not a file (does not exist).
         do {
             let unknownPath = sandbox.appending(component: "missingFile.zip")
-            XCTAssertThrowsError(try binaryArtifactsManager.checksum(forBinaryArtifactAt: unknownPath), "error expected") { error in
-                XCTAssertEqual(error as? StringError, StringError("file not found at path: \(sandbox.appending(component: "missingFile.zip"))"))
+            XCTAssertThrowsError(
+                try binaryArtifactsManager.checksum(forBinaryArtifactAt: unknownPath),
+                "error expected"
+            ) { error in
+                XCTAssertEqual(
+                    error as? StringError,
+                    StringError("file not found at path: \(sandbox.appending(component: "missingFile.zip"))")
+                )
             }
         }
 
@@ -7133,8 +7566,14 @@ final class WorkspaceTests: XCTestCase {
         do {
             let unknownPath = sandbox.appending(component: "aDirectory.zip")
             try fs.createDirectory(unknownPath)
-            XCTAssertThrowsError(try binaryArtifactsManager.checksum(forBinaryArtifactAt: unknownPath), "error expected") { error in
-                XCTAssertEqual(error as? StringError, StringError("file not found at path: \(sandbox.appending(component: "aDirectory.zip"))"))
+            XCTAssertThrowsError(
+                try binaryArtifactsManager.checksum(forBinaryArtifactAt: unknownPath),
+                "error expected"
+            ) { error in
+                XCTAssertEqual(
+                    error as? StringError,
+                    StringError("file not found at path: \(sandbox.appending(component: "aDirectory.zip"))")
+                )
             }
         }
     }
@@ -7143,7 +7582,7 @@ final class WorkspaceTests: XCTestCase {
         let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
 
-        let httpClient = LegacyHTTPClient(handler: { request, _, completion in
+        let httpClient = LegacyHTTPClient(handler: { _, _, _ in
             XCTFail("should not be called")
         })
 
@@ -7156,7 +7595,7 @@ final class WorkspaceTests: XCTestCase {
                     targets: [
                         MockTarget(name: "A", type: .binary, url: "https://a.com/a.zip", checksum: "new-checksum"),
                     ]
-                )
+                ),
             ],
             binaryArtifactsManager: .init(
                 httpClient: httpClient
@@ -7183,7 +7622,10 @@ final class WorkspaceTests: XCTestCase {
 
         workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
-                result.check(diagnostic: .contains("artifact of binary target 'A' has changed checksum"), severity: .error)
+                result.check(
+                    diagnostic: .contains("artifact of binary target 'A' has changed checksum"),
+                    severity: .error
+                )
             }
         }
     }
@@ -7230,7 +7672,8 @@ final class WorkspaceTests: XCTestCase {
                 default:
                     throw StringError("unexpected archivePath \(archivePath)")
                 }
-                archiver.extractions.append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
+                archiver.extractions
+                    .append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
                 completion(.success(()))
             } catch {
                 completion(.failure(error))
@@ -7244,10 +7687,14 @@ final class WorkspaceTests: XCTestCase {
                 MockPackage(
                     name: "Root",
                     targets: [
-                        MockTarget(name: "A", type: .binary, url: "https://a.com/b.zip",
-                                   checksum: "b1"),
+                        MockTarget(
+                            name: "A",
+                            type: .binary,
+                            url: "https://a.com/b.zip",
+                            checksum: "b1"
+                        ),
                     ]
-                )
+                ),
             ],
             binaryArtifactsManager: .init(
                 httpClient: httpClient,
@@ -7294,10 +7741,10 @@ final class WorkspaceTests: XCTestCase {
 
                 let contents: [UInt8]
                 switch request.url.lastPathComponent {
-                    case "a1.zip":
-                        contents = [0xA1]
-                    default:
-                        throw StringError("unexpected url \(request.url)")
+                case "a1.zip":
+                    contents = [0xA1]
+                default:
+                    throw StringError("unexpected url \(request.url)")
                 }
 
                 try fileSystem.writeFileContents(
@@ -7322,7 +7769,8 @@ final class WorkspaceTests: XCTestCase {
                 default:
                     throw StringError("unexpected archivePath \(archivePath)")
                 }
-                archiver.extractions.append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
+                archiver.extractions
+                    .append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
                 completion(.success(()))
             } catch {
                 completion(.failure(error))
@@ -7351,10 +7799,10 @@ final class WorkspaceTests: XCTestCase {
             )
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             XCTAssertEqual(acceptHeaders, [
-                "application/octet-stream"
+                "application/octet-stream",
             ])
         }
     }
@@ -7409,7 +7857,8 @@ final class WorkspaceTests: XCTestCase {
                     throw StringError("\(archivePath) already extracted")
                 }
 
-                archiver.extractions.append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
+                archiver.extractions
+                    .append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
                 completion(.success(()))
             } catch {
                 completion(.failure(error))
@@ -7439,7 +7888,7 @@ final class WorkspaceTests: XCTestCase {
                 MockPackage(
                     name: "A",
                     targets: [
-                        MockTarget(name: "A", type: .binary, url: "https://a.com/a.zip", checksum: "0a")
+                        MockTarget(name: "A", type: .binary, url: "https://a.com/a.zip", checksum: "0a"),
                     ],
                     products: [
                         MockProduct(name: "A", targets: ["A"]),
@@ -7492,7 +7941,7 @@ final class WorkspaceTests: XCTestCase {
                         .sourceControl(path: "./A", requirement: .exact("1.0.0")),
                     ],
                     versions: ["1.0.0"]
-                )
+                ),
             ],
             binaryArtifactsManager: .init(
                 httpClient: httpClient,
@@ -7500,21 +7949,21 @@ final class WorkspaceTests: XCTestCase {
             )
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             XCTAssert(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/a")))
-            XCTAssertEqual(downloads.map { $0.key.absoluteString }.sorted(), [
-                "https://a.com/a.zip"
+            XCTAssertEqual(downloads.map(\.key.absoluteString).sorted(), [
+                "https://a.com/a.zip",
             ])
-            XCTAssertEqual(workspace.checksumAlgorithm.hashes.map{ $0.hexadecimalRepresentation }.sorted(), [
-                ByteString([0xA]).hexadecimalRepresentation
+            XCTAssertEqual(workspace.checksumAlgorithm.hashes.map(\.hexadecimalRepresentation).sorted(), [
+                ByteString([0xA]).hexadecimalRepresentation,
             ])
-            XCTAssertEqual(archiver.extractions.map { $0.destinationPath.parentDirectory }.sorted(), [
-                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A")
+            XCTAssertEqual(archiver.extractions.map(\.destinationPath.parentDirectory).sorted(), [
+                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A"),
             ])
             XCTAssertEqual(
-                downloads.map { $0.value }.sorted(),
-                archiver.extractions.map { $0.archivePath }.sorted()
+                downloads.map(\.value).sorted(),
+                archiver.extractions.map(\.archivePath).sorted()
             )
         }
 
@@ -7535,7 +7984,13 @@ final class WorkspaceTests: XCTestCase {
         let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
         // this relies on internal knowledge of the destination path construction
-        let expectedDownloadDestination = sandbox.appending(components: ".build", "artifacts", "root", "binary", "binary.zip")
+        let expectedDownloadDestination = sandbox.appending(
+            components: ".build",
+            "artifacts",
+            "root",
+            "binary",
+            "binary.zip"
+        )
 
         // returns a dummy zipfile for the requested artifact
         let httpClient = LegacyHTTPClient(handler: { request, _, completion in
@@ -7551,10 +8006,10 @@ final class WorkspaceTests: XCTestCase {
 
                 let contents: [UInt8]
                 switch request.url.lastPathComponent {
-                    case "binary.zip":
-                        contents = [0x01]
-                    default:
-                        throw StringError("unexpected url \(request.url)")
+                case "binary.zip":
+                    contents = [0x01]
+                default:
+                    throw StringError("unexpected url \(request.url)")
                 }
 
                 // in-memory fs does not check for this!
@@ -7580,7 +8035,8 @@ final class WorkspaceTests: XCTestCase {
                 switch archivePath.basename {
                 case "binary.zip":
                     try createDummyXCFramework(fileSystem: fs, path: destinationPath, name: "binary")
-                    archiver.extractions.append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
+                    archiver.extractions
+                        .append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
                 default:
                     throw StringError("unexpected archivePath \(archivePath)")
                 }
@@ -7604,7 +8060,7 @@ final class WorkspaceTests: XCTestCase {
                             checksum: "01"
                         ),
                     ]
-                )
+                ),
             ],
             binaryArtifactsManager: .init(
                 httpClient: httpClient,
@@ -7621,7 +8077,7 @@ final class WorkspaceTests: XCTestCase {
             atomically: true
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
 
@@ -7681,7 +8137,7 @@ final class WorkspaceTests: XCTestCase {
         })
 
         // create a dummy xcframework directory from the request archive
-        let archiver = MockArchiver(handler: { archiver, archivePath, destinationPath, completion in
+        let archiver = MockArchiver(handler: { _, archivePath, destinationPath, completion in
             do {
                 try createDummyXCFramework(fileSystem: fs, path: destinationPath, name: archivePath.basenameWithoutExt)
                 completion(.success(()))
@@ -7699,7 +8155,7 @@ final class WorkspaceTests: XCTestCase {
                         type: .binary,
                         url: "https://somwhere.com/binary\(index).zip",
                         checksum: "01"
-                    )
+                    ),
                 ],
                 products: [
                     MockProduct(name: "binary\(index)", targets: ["binary\(index)"]),
@@ -7735,7 +8191,7 @@ final class WorkspaceTests: XCTestCase {
             )
         )
 
-        try workspace.checkPackageGraph(roots: ["App"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["App"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
 
@@ -7749,7 +8205,11 @@ final class WorkspaceTests: XCTestCase {
                         url: "https://somwhere.com/\(targetName).zip",
                         checksum: "01"
                     ),
-                    path: workspace.artifactsDir.appending(components: package.name, targetName, "\(targetName).xcframework")
+                    path: workspace.artifactsDir.appending(
+                        components: package.name,
+                        targetName,
+                        "\(targetName).xcframework"
+                    )
                 )
             }
         }
@@ -7798,19 +8258,26 @@ final class WorkspaceTests: XCTestCase {
                 switch archivePath.basename {
                 case "flat.zip":
                     try createDummyXCFramework(fileSystem: fs, path: destinationPath, name: "flat")
-                    archiver.extractions.append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
+                    archiver.extractions
+                        .append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
                 case "nested.zip":
                     let nestedPath = destinationPath.appending(component: "root")
                     try fs.createDirectory(nestedPath)
                     try createDummyXCFramework(fileSystem: fs, path: nestedPath, name: "nested")
-                    archiver.extractions.append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
+                    archiver.extractions
+                        .append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
                 case "nested2.zip":
                     let nestedPath = destinationPath.appending(component: "root")
                     try fs.createDirectory(nestedPath)
                     try createDummyXCFramework(fileSystem: fs, path: nestedPath, name: "nested2")
-                    try fs.writeFileContents(nestedPath.appending(component: ".DS_Store"), bytes: []) // add a file next to the directory
+                    try fs
+                        .writeFileContents(
+                            nestedPath.appending(component: ".DS_Store"),
+                            bytes: []
+                        ) // add a file next to the directory
 
-                    archiver.extractions.append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
+                    archiver.extractions
+                        .append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
                 default:
                     throw StringError("unexpected archivePath \(archivePath)")
                 }
@@ -7839,14 +8306,14 @@ final class WorkspaceTests: XCTestCase {
                             type: .binary,
                             url: "https://a.com/nested.zip",
                             checksum: "02"
-                        )
-                        ,
+                        ),
+
                         MockTarget(
                             name: "nested2",
                             type: .binary,
                             url: "https://a.com/nested2.zip",
                             checksum: "03"
-                        )
+                        ),
                     ]
                 ),
             ],
@@ -7856,54 +8323,57 @@ final class WorkspaceTests: XCTestCase {
             )
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             XCTAssert(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/root")))
-            XCTAssertEqual(downloads.map { $0.key.absoluteString }.sorted(), [
+            XCTAssertEqual(downloads.map(\.key.absoluteString).sorted(), [
                 "https://a.com/flat.zip",
                 "https://a.com/nested.zip",
                 "https://a.com/nested2.zip",
             ])
-            XCTAssertEqual(workspace.checksumAlgorithm.hashes.map{ $0.hexadecimalRepresentation }.sorted(), [
+            XCTAssertEqual(workspace.checksumAlgorithm.hashes.map(\.hexadecimalRepresentation).sorted(), [
                 ByteString([0x01]).hexadecimalRepresentation,
                 ByteString([0x02]).hexadecimalRepresentation,
                 ByteString([0x03]).hexadecimalRepresentation,
             ])
-            XCTAssertEqual(archiver.extractions.map { $0.destinationPath.parentDirectory }.sorted(), [
+            XCTAssertEqual(archiver.extractions.map(\.destinationPath.parentDirectory).sorted(), [
                 AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/flat"),
                 AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/nested"),
                 AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/nested2"),
             ])
             XCTAssertEqual(
-                downloads.map { $0.value }.sorted(),
-                archiver.extractions.map { $0.archivePath }.sorted()
+                downloads.map(\.value).sorted(),
+                archiver.extractions.map(\.archivePath).sorted()
             )
         }
 
         workspace.checkManagedArtifacts { result in
-            result.check(packageIdentity: .plain("root"),
-                         targetName: "flat",
-                         source: .remote(
-                            url: "https://a.com/flat.zip",
-                            checksum: "01"
-                         ),
-                         path: workspace.artifactsDir.appending(components: "root", "flat", "flat.xcframework")
+            result.check(
+                packageIdentity: .plain("root"),
+                targetName: "flat",
+                source: .remote(
+                    url: "https://a.com/flat.zip",
+                    checksum: "01"
+                ),
+                path: workspace.artifactsDir.appending(components: "root", "flat", "flat.xcframework")
             )
-            result.check(packageIdentity: .plain("root"),
-                         targetName: "nested",
-                         source: .remote(
-                            url: "https://a.com/nested.zip",
-                            checksum: "02"
-                         ),
-                         path: workspace.artifactsDir.appending(components: "root", "nested", "nested.xcframework")
+            result.check(
+                packageIdentity: .plain("root"),
+                targetName: "nested",
+                source: .remote(
+                    url: "https://a.com/nested.zip",
+                    checksum: "02"
+                ),
+                path: workspace.artifactsDir.appending(components: "root", "nested", "nested.xcframework")
             )
-            result.check(packageIdentity: .plain("root"),
-                         targetName: "nested2",
-                         source: .remote(
-                            url: "https://a.com/nested2.zip",
-                            checksum: "03"
-                         ),
-                         path: workspace.artifactsDir.appending(components: "root", "nested2", "nested2.xcframework")
+            result.check(
+                packageIdentity: .plain("root"),
+                targetName: "nested2",
+                source: .remote(
+                    url: "https://a.com/nested2.zip",
+                    checksum: "03"
+                ),
+                path: workspace.artifactsDir.appending(components: "root", "nested2", "nested2.xcframework")
             )
         }
     }
@@ -7956,7 +8426,8 @@ final class WorkspaceTests: XCTestCase {
                     throw StringError("unexpected archivePath \(archivePath)")
                 }
                 try createDummyXCFramework(fileSystem: fs, path: destinationPath, name: name)
-                archiver.extractions.append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
+                archiver.extractions
+                    .append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
                 completion(.success(()))
             } catch {
                 completion(.failure(error))
@@ -7981,10 +8452,10 @@ final class WorkspaceTests: XCTestCase {
                             type: .binary,
                             url: "https://a.com/a2.zip.zip",
                             checksum: "a2"
-                        )
+                        ),
                     ],
                     products: []
-                )
+                ),
             ],
             binaryArtifactsManager: .init(
                 httpClient: httpClient,
@@ -7992,42 +8463,44 @@ final class WorkspaceTests: XCTestCase {
             )
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            XCTAssertEqual(downloads.map { $0.key.absoluteString }.sorted(), [
+            XCTAssertEqual(downloads.map(\.key.absoluteString).sorted(), [
                 "https://a.com/a1.xcframework.zip",
                 "https://a.com/a2.zip.zip",
             ])
-            XCTAssertEqual(workspace.checksumAlgorithm.hashes.map{ $0.hexadecimalRepresentation }.sorted(), [
+            XCTAssertEqual(workspace.checksumAlgorithm.hashes.map(\.hexadecimalRepresentation).sorted(), [
                 ByteString([0xA1]).hexadecimalRepresentation,
                 ByteString([0xA2]).hexadecimalRepresentation,
             ])
-            XCTAssertEqual(archiver.extractions.map { $0.destinationPath.parentDirectory }.sorted(), [
+            XCTAssertEqual(archiver.extractions.map(\.destinationPath.parentDirectory).sorted(), [
                 AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/A1"),
                 AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/A2"),
             ])
             XCTAssertEqual(
-                downloads.map { $0.value }.sorted(),
-                archiver.extractions.map { $0.archivePath }.sorted()
+                downloads.map(\.value).sorted(),
+                archiver.extractions.map(\.archivePath).sorted()
             )
         }
 
         workspace.checkManagedArtifacts { result in
-            result.check(packageIdentity: .plain("root"),
-                         targetName: "A1",
-                         source: .remote(
-                            url: "https://a.com/a1.xcframework.zip",
-                            checksum: "a1"
-                         ),
-                         path: workspace.artifactsDir.appending(components: "root", "A1", "A1.xcframework")
+            result.check(
+                packageIdentity: .plain("root"),
+                targetName: "A1",
+                source: .remote(
+                    url: "https://a.com/a1.xcframework.zip",
+                    checksum: "a1"
+                ),
+                path: workspace.artifactsDir.appending(components: "root", "A1", "A1.xcframework")
             )
-            result.check(packageIdentity: .plain("root"),
-                         targetName: "A2",
-                         source: .remote(
-                            url: "https://a.com/a2.zip.zip",
-                            checksum: "a2"
-                         ),
-                         path: workspace.artifactsDir.appending(components: "root", "A2", "A2.xcframework")
+            result.check(
+                packageIdentity: .plain("root"),
+                targetName: "A2",
+                source: .remote(
+                    url: "https://a.com/a2.zip.zip",
+                    checksum: "a2"
+                ),
+                path: workspace.artifactsDir.appending(components: "root", "A2", "A2.xcframework")
             )
         }
     }
@@ -8035,7 +8508,6 @@ final class WorkspaceTests: XCTestCase {
     func testLoadRootPackageWithBinaryDependencies() throws {
         let sandbox = AbsolutePath(path: "/tmp/ws/")
         let fs = InMemoryFileSystem()
-
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
@@ -8061,10 +8533,10 @@ final class WorkspaceTests: XCTestCase {
                             type: .binary,
                             url: "https://a.com/a2.zip.zip",
                             checksum: "a3"
-                        )
+                        ),
                     ],
                     products: []
-                )
+                ),
             ]
         )
 
@@ -8110,7 +8582,7 @@ final class WorkspaceTests: XCTestCase {
                     }
                 ]
             }
-            """
+            """,
         ]
 
         let checksumAlgorithm = MockHashAlgorithm() // used in tests
@@ -8118,7 +8590,7 @@ final class WorkspaceTests: XCTestCase {
 
         // returns a dummy file for the requested artifact
         let httpClient = LegacyHTTPClient(handler: { request, _, completion in
-            switch request.kind  {
+            switch request.kind {
             case .generic:
                 do {
                     let contents: String
@@ -8177,7 +8649,8 @@ final class WorkspaceTests: XCTestCase {
                     throw StringError("unexpected archivePath \(archivePath)")
                 }
                 try createDummyArtifactBundle(fileSystem: fs, path: destinationPath, name: name)
-                archiver.extractions.append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
+                archiver.extractions
+                    .append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
                 completion(.success(()))
             } catch {
                 completion(.failure(error))
@@ -8194,7 +8667,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo", dependencies: [
                             .product(name: "A1", package: "A"),
                             .product(name: "A2", package: "A"),
-                            "B"
+                            "B",
                         ]),
                     ],
                     products: [],
@@ -8219,11 +8692,11 @@ final class WorkspaceTests: XCTestCase {
                             type: .binary,
                             url: "https://a.com/a2.artifactbundleindex",
                             checksum: ariFilesChecksums[1]
-                        )
+                        ),
                     ],
                     products: [
                         MockProduct(name: "A1", targets: ["A1"]),
-                        MockProduct(name: "A2", targets: ["A2"])
+                        MockProduct(name: "A2", targets: ["A2"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -8250,69 +8723,79 @@ final class WorkspaceTests: XCTestCase {
             checksumAlgorithm: checksumAlgorithm
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             XCTAssert(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/a")))
             XCTAssert(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/b")))
-            XCTAssertEqual(downloads.map { $0.key.absoluteString }.sorted(), [
+            XCTAssertEqual(downloads.map(\.key.absoluteString).sorted(), [
                 "https://a.com/a1.zip",
                 "https://a.com/a2/a2.zip",
                 "https://b.com/b.zip",
             ])
-            XCTAssertEqual(checksumAlgorithm.hashes.map{ $0.hexadecimalRepresentation }.sorted(),
+            XCTAssertEqual(
+                checksumAlgorithm.hashes.map(\.hexadecimalRepresentation).sorted(),
                 (
                     ariFiles.map(ByteString.init(encodingAsUTF8:)) +
-                    ariFiles.map(ByteString.init(encodingAsUTF8:)) +
-                    [
-                        ByteString([0xA1]),
-                        ByteString([0xA2]),
-                        ByteString([0xB0]),
-                    ]
-                ).map{ $0.hexadecimalRepresentation }.sorted()
+                        ariFiles.map(ByteString.init(encodingAsUTF8:)) +
+                        [
+                            ByteString([0xA1]),
+                            ByteString([0xA2]),
+                            ByteString([0xB0]),
+                        ]
+                ).map(\.hexadecimalRepresentation).sorted()
             )
-            XCTAssertEqual(archiver.extractions.map { $0.destinationPath.parentDirectory }.sorted(), [
+            XCTAssertEqual(archiver.extractions.map(\.destinationPath.parentDirectory).sorted(), [
                 AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A1"),
                 AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A2"),
                 AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/b/B"),
             ])
             XCTAssertEqual(
-                downloads.map { $0.value }.sorted(),
-                archiver.extractions.map { $0.archivePath }.sorted()
+                downloads.map(\.value).sorted(),
+                archiver.extractions.map(\.archivePath).sorted()
             )
         }
 
         workspace.checkManagedArtifacts { result in
-            result.check(packageIdentity: .plain("a"),
-                         targetName: "A1",
-                         source: .remote(
-                            url: "https://a.com/a1.zip",
-                            checksum: "a1"
-                         ),
-                         path: workspace.artifactsDir.appending(components: "a", "A1", "A1.artifactbundle")
+            result.check(
+                packageIdentity: .plain("a"),
+                targetName: "A1",
+                source: .remote(
+                    url: "https://a.com/a1.zip",
+                    checksum: "a1"
+                ),
+                path: workspace.artifactsDir.appending(components: "a", "A1", "A1.artifactbundle")
             )
-            result.check(packageIdentity: .plain("a"),
-                         targetName: "A2",
-                         source: .remote(
-                            url: "https://a.com/a2/a2.zip",
-                            checksum: "a2"
-                         ),
-                         path: workspace.artifactsDir.appending(components: "a", "A2", "A2.artifactbundle")
+            result.check(
+                packageIdentity: .plain("a"),
+                targetName: "A2",
+                source: .remote(
+                    url: "https://a.com/a2/a2.zip",
+                    checksum: "a2"
+                ),
+                path: workspace.artifactsDir.appending(components: "a", "A2", "A2.artifactbundle")
             )
-            result.check(packageIdentity: .plain("b"),
-                         targetName: "B",
-                         source: .remote(
-                            url: "https://b.com/b.zip",
-                            checksum: "b0"
-                         ),
-                         path: workspace.artifactsDir.appending(components: "b", "B", "B.artifactbundle")
+            result.check(
+                packageIdentity: .plain("b"),
+                targetName: "B",
+                source: .remote(
+                    url: "https://b.com/b.zip",
+                    checksum: "b0"
+                ),
+                path: workspace.artifactsDir.appending(components: "b", "B", "B.artifactbundle")
             )
         }
 
         XCTAssertMatch(workspace.delegate.events, ["downloading binary artifact package: https://a.com/a1.zip"])
         XCTAssertMatch(workspace.delegate.events, ["downloading binary artifact package: https://a.com/a2/a2.zip"])
         XCTAssertMatch(workspace.delegate.events, ["downloading binary artifact package: https://b.com/b.zip"])
-        XCTAssertMatch(workspace.delegate.events, ["finished downloading binary artifact package: https://a.com/a1.zip"])
-        XCTAssertMatch(workspace.delegate.events, ["finished downloading binary artifact package: https://a.com/a2/a2.zip"])
+        XCTAssertMatch(
+            workspace.delegate.events,
+            ["finished downloading binary artifact package: https://a.com/a1.zip"]
+        )
+        XCTAssertMatch(
+            workspace.delegate.events,
+            ["finished downloading binary artifact package: https://a.com/a2/a2.zip"]
+        )
         XCTAssertMatch(workspace.delegate.events, ["finished downloading binary artifact package: https://b.com/b.zip"])
     }
 
@@ -8321,7 +8804,7 @@ final class WorkspaceTests: XCTestCase {
         let fs = InMemoryFileSystem()
 
         // returns a dummy files for the requested artifact
-        let httpClient = LegacyHTTPClient(handler: { request, _, completion in
+        let httpClient = LegacyHTTPClient(handler: { _, _, completion in
             completion(.success(.serverError()))
         })
 
@@ -8332,9 +8815,14 @@ final class WorkspaceTests: XCTestCase {
                 MockPackage(
                     name: "Root",
                     targets: [
-                        MockTarget(name: "A", type: .binary, url: "https://a.com/a.artifactbundleindex", checksum: "does-not-matter"),
+                        MockTarget(
+                            name: "A",
+                            type: .binary,
+                            url: "https://a.com/a.artifactbundleindex",
+                            checksum: "does-not-matter"
+                        ),
                     ]
-                )
+                ),
             ],
             binaryArtifactsManager: .init(
                 httpClient: httpClient
@@ -8343,7 +8831,12 @@ final class WorkspaceTests: XCTestCase {
 
         workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
-                result.check(diagnostic: .contains("failed retrieving 'https://a.com/a.artifactbundleindex': badResponseStatusCode(500)"), severity: .error)
+                result.check(
+                    diagnostic: .contains(
+                        "failed retrieving 'https://a.com/a.artifactbundleindex': badResponseStatusCode(500)"
+                    ),
+                    severity: .error
+                )
             }
         }
     }
@@ -8391,9 +8884,14 @@ final class WorkspaceTests: XCTestCase {
                 MockPackage(
                     name: "Root",
                     targets: [
-                        MockTarget(name: "A", type: .binary, url: "https://a.com/a.artifactbundleindex", checksum: "incorrect"),
+                        MockTarget(
+                            name: "A",
+                            type: .binary,
+                            url: "https://a.com/a.artifactbundleindex",
+                            checksum: "incorrect"
+                        ),
                     ]
-                )
+                ),
             ],
             binaryArtifactsManager: .init(
                 httpClient: httpClient
@@ -8402,7 +8900,12 @@ final class WorkspaceTests: XCTestCase {
 
         workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
-                result.check(diagnostic: .contains("failed retrieving 'https://a.com/a.artifactbundleindex': checksum of downloaded artifact of binary target 'A' (\(ariChecksums)) does not match checksum specified by the manifest (incorrect)"), severity: .error)
+                result.check(
+                    diagnostic: .contains(
+                        "failed retrieving 'https://a.com/a.artifactbundleindex': checksum of downloaded artifact of binary target 'A' (\(ariChecksums)) does not match checksum specified by the manifest (incorrect)"
+                    ),
+                    severity: .error
+                )
             }
         }
     }
@@ -8418,9 +8921,14 @@ final class WorkspaceTests: XCTestCase {
                 MockPackage(
                     name: "Root",
                     targets: [
-                        MockTarget(name: "A", type: .binary, url: "https://a.com/a.artifactbundleindex", checksum: "new-checksum"),
+                        MockTarget(
+                            name: "A",
+                            type: .binary,
+                            url: "https://a.com/a.artifactbundleindex",
+                            checksum: "new-checksum"
+                        ),
                     ]
-                )
+                ),
             ]
         )
 
@@ -8444,7 +8952,10 @@ final class WorkspaceTests: XCTestCase {
 
         workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
-                result.check(diagnostic: .contains("artifact of binary target 'A' has changed checksum"), severity: .error)
+                result.check(
+                    diagnostic: .contains("artifact of binary target 'A' has changed checksum"),
+                    severity: .error
+                )
             }
         }
     }
@@ -8472,7 +8983,7 @@ final class WorkspaceTests: XCTestCase {
         // returns a dummy files for the requested artifact
         let httpClient = LegacyHTTPClient(handler: { request, _, completion in
             do {
-                switch request.kind  {
+                switch request.kind {
                 case .generic:
                     let contents: String
                     switch request.url.lastPathComponent {
@@ -8517,7 +9028,8 @@ final class WorkspaceTests: XCTestCase {
                     throw StringError("unexpected archivePath \(archivePath)")
                 }
                 try fs.createDirectory(destinationPath.appending(component: name), recursive: false)
-                archiver.extractions.append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
+                archiver.extractions
+                    .append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
                 completion(.success(()))
             } catch {
                 completion(.failure(error))
@@ -8531,9 +9043,14 @@ final class WorkspaceTests: XCTestCase {
                 MockPackage(
                     name: "Root",
                     targets: [
-                        MockTarget(name: "A", type: .binary, url: "https://a.com/a.artifactbundleindex", checksum: ariChecksums),
+                        MockTarget(
+                            name: "A",
+                            type: .binary,
+                            url: "https://a.com/a.artifactbundleindex",
+                            checksum: ariChecksums
+                        ),
                     ]
-                )
+                ),
             ],
             binaryArtifactsManager: .init(
                 httpClient: httpClient,
@@ -8543,7 +9060,12 @@ final class WorkspaceTests: XCTestCase {
 
         workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
-                result.check(diagnostic: .contains("checksum of downloaded artifact of binary target 'A' (42) does not match checksum specified by the manifest (a)"), severity: .error)
+                result.check(
+                    diagnostic: .contains(
+                        "checksum of downloaded artifact of binary target 'A' (42) does not match checksum specified by the manifest (a)"
+                    ),
+                    severity: .error
+                )
             }
         }
     }
@@ -8571,16 +9093,16 @@ final class WorkspaceTests: XCTestCase {
         // returns a dummy files for the requested artifact
         let httpClient = LegacyHTTPClient(handler: { request, _, completion in
             do {
-                switch request.kind  {
+                switch request.kind {
                 case .generic:
-                        let contents: String
-                        switch request.url.lastPathComponent {
-                        case "a.artifactbundleindex":
-                            contents = ari
-                        default:
-                            throw StringError("unexpected url \(request.url)")
-                        }
-                        completion(.success(.okay(body: contents)))
+                    let contents: String
+                    switch request.url.lastPathComponent {
+                    case "a.artifactbundleindex":
+                        contents = ari
+                    default:
+                        throw StringError("unexpected url \(request.url)")
+                    }
+                    completion(.success(.okay(body: contents)))
 
                 case .download:
                     completion(.success(.notFound()))
@@ -8597,9 +9119,14 @@ final class WorkspaceTests: XCTestCase {
                 MockPackage(
                     name: "Root",
                     targets: [
-                        MockTarget(name: "A", type: .binary, url: "https://a.com/a.artifactbundleindex", checksum: ariChecksums),
+                        MockTarget(
+                            name: "A",
+                            type: .binary,
+                            url: "https://a.com/a.artifactbundleindex",
+                            checksum: ariChecksums
+                        ),
                     ]
-                )
+                ),
             ],
             binaryArtifactsManager: .init(
                 httpClient: httpClient
@@ -8608,7 +9135,12 @@ final class WorkspaceTests: XCTestCase {
 
         workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
-                result.check(diagnostic: .contains("failed downloading 'https://a.com/not-found.zip' which is required by binary target 'A': badResponseStatusCode(404)"), severity: .error)
+                result.check(
+                    diagnostic: .contains(
+                        "failed downloading 'https://a.com/not-found.zip' which is required by binary target 'A': badResponseStatusCode(404)"
+                    ),
+                    severity: .error
+                )
             }
         }
     }
@@ -8659,9 +9191,14 @@ final class WorkspaceTests: XCTestCase {
                 MockPackage(
                     name: "Root",
                     targets: [
-                        MockTarget(name: "A", type: .binary, url: "https://a.com/a.artifactbundleindex", checksum: ariChecksum),
+                        MockTarget(
+                            name: "A",
+                            type: .binary,
+                            url: "https://a.com/a.artifactbundleindex",
+                            checksum: ariChecksum
+                        ),
                     ]
-                )
+                ),
             ],
             binaryArtifactsManager: .init(
                 httpClient: httpClient
@@ -8670,7 +9207,12 @@ final class WorkspaceTests: XCTestCase {
 
         workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
-                result.check(diagnostic: .contains("failed retrieving 'https://a.com/a.artifactbundleindex': No supported archive was found for '\(hostToolchain.triple.tripleString)'"), severity: .error)
+                result.check(
+                    diagnostic: .contains(
+                        "failed retrieving 'https://a.com/a.artifactbundleindex': No supported archive was found for '\(hostToolchain.triple.tripleString)'"
+                    ),
+                    severity: .error
+                )
             }
         }
     }
@@ -8688,13 +9230,21 @@ final class WorkspaceTests: XCTestCase {
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
                             .product(name: "FooProduct", package: "FooUtilityPackage"),
-                            .product(name: "BarProduct", package: "BarUtilityPackage")
+                            .product(name: "BarProduct", package: "BarUtilityPackage"),
                         ]),
                     ],
                     products: [],
                     dependencies: [
-                        .sourceControlWithDeprecatedName(name: "FooUtilityPackage", path: "foo/utility", requirement: .upToNextMajor(from: "1.0.0")),
-                        .sourceControlWithDeprecatedName(name: "BarUtilityPackage", path: "bar/utility", requirement: .upToNextMajor(from: "1.0.0")),
+                        .sourceControlWithDeprecatedName(
+                            name: "FooUtilityPackage",
+                            path: "foo/utility",
+                            requirement: .upToNextMajor(from: "1.0.0")
+                        ),
+                        .sourceControlWithDeprecatedName(
+                            name: "BarUtilityPackage",
+                            path: "bar/utility",
+                            requirement: .upToNextMajor(from: "1.0.0")
+                        ),
                     ],
                     toolsVersion: .v5
                 ),
@@ -8726,7 +9276,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: "'root' dependency on '\(sandbox.appending(components: "pkgs", "bar", "utility"))' conflicts with dependency on '\(sandbox.appending(components: "pkgs", "foo", "utility"))' which has the same identity 'utility'",
@@ -8749,7 +9299,7 @@ final class WorkspaceTests: XCTestCase {
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
                             .product(name: "FooProduct", package: "FooUtilityPackage"),
-                            .product(name: "BarProduct", package: "BarUtilityPackage")
+                            .product(name: "BarProduct", package: "BarUtilityPackage"),
                         ]),
                     ],
                     products: [],
@@ -8787,7 +9337,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: "'root' dependency on '\(sandbox.appending(components: "pkgs", "bar", "utility"))' conflicts with dependency on '\(sandbox.appending(components: "pkgs", "foo", "utility"))' which has the same identity 'utility'",
@@ -8810,13 +9360,21 @@ final class WorkspaceTests: XCTestCase {
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
                             .product(name: "FooProduct", package: "FooPackage"),
-                            .product(name: "BarProduct", package: "BarPackage")
+                            .product(name: "BarProduct", package: "BarPackage"),
                         ]),
                     ],
                     products: [],
                     dependencies: [
-                        .sourceControlWithDeprecatedName(name: "FooPackage", path: "foo", requirement: .upToNextMajor(from: "1.0.0")),
-                        .sourceControlWithDeprecatedName(name: "FooPackage", path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .sourceControlWithDeprecatedName(
+                            name: "FooPackage",
+                            path: "foo",
+                            requirement: .upToNextMajor(from: "1.0.0")
+                        ),
+                        .sourceControlWithDeprecatedName(
+                            name: "FooPackage",
+                            path: "bar",
+                            requirement: .upToNextMajor(from: "1.0.0")
+                        ),
                     ],
                     toolsVersion: .v5
                 ),
@@ -8848,7 +9406,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: "'root' dependency on '\(sandbox.appending(components: "pkgs", "bar"))' conflicts with dependency on '\(sandbox.appending(components: "pkgs", "foo"))' which has the same explicit name 'FooPackage'",
@@ -8871,7 +9429,7 @@ final class WorkspaceTests: XCTestCase {
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
                             "FooProduct",
-                            "BarProduct"
+                            "BarProduct",
                         ]),
                     ],
                     products: [],
@@ -8908,7 +9466,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
     }
@@ -8963,7 +9521,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
     }
@@ -8981,7 +9539,7 @@ final class WorkspaceTests: XCTestCase {
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
                             "FooProduct",
-                            "BarProduct"
+                            "BarProduct",
                         ]),
                     ],
                     products: [],
@@ -9018,7 +9576,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
     }
@@ -9036,7 +9594,7 @@ final class WorkspaceTests: XCTestCase {
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
                             "FooProduct",
-                            "BarProduct"
+                            "BarProduct",
                         ]),
                     ],
                     products: [],
@@ -9073,7 +9631,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: "dependency 'FooProduct' in target 'RootTarget' requires explicit declaration; reference the package in the target dependency with '.product(name: \"FooProduct\", package: \"foo\")'",
@@ -9137,7 +9695,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
     }
@@ -9155,13 +9713,17 @@ final class WorkspaceTests: XCTestCase {
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
                             "FooProduct",
-                            "BarProduct"
+                            "BarProduct",
                         ]),
                     ],
                     products: [],
                     dependencies: [
                         .sourceControl(path: "foo", requirement: .upToNextMajor(from: "1.0.0")),
-                        .sourceControlWithDeprecatedName(name: "foo", path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .sourceControlWithDeprecatedName(
+                            name: "foo",
+                            path: "bar",
+                            requirement: .upToNextMajor(from: "1.0.0")
+                        ),
                     ],
                     toolsVersion: .v5
                 ),
@@ -9192,7 +9754,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: "'root' dependency on '\(sandbox.appending(components: "pkgs", "bar"))' conflicts with dependency on '\(sandbox.appending(components: "pkgs", "foo"))' which has the same explicit name 'foo'",
@@ -9221,7 +9783,11 @@ final class WorkspaceTests: XCTestCase {
                     products: [],
                     dependencies: [
                         .sourceControl(path: "foo", requirement: .upToNextMajor(from: "1.0.0")),
-                        .sourceControlWithDeprecatedName(name: "foo", path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .sourceControlWithDeprecatedName(
+                            name: "foo",
+                            path: "bar",
+                            requirement: .upToNextMajor(from: "1.0.0")
+                        ),
                     ],
                     toolsVersion: .v5_3
                 ),
@@ -9252,7 +9818,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: "'root' dependency on '\(sandbox.appending(components: "pkgs", "bar"))' conflicts with dependency on '\(sandbox.appending(components: "pkgs", "foo"))' which has the same explicit name 'foo'",
@@ -9275,13 +9841,21 @@ final class WorkspaceTests: XCTestCase {
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
                             .product(name: "FooUtilityProduct", package: "FooUtilityPackage"),
-                            .product(name: "BarProduct", package: "BarPackage")
+                            .product(name: "BarProduct", package: "BarPackage"),
                         ]),
                     ],
                     products: [],
                     dependencies: [
-                        .sourceControlWithDeprecatedName(name: "FooUtilityPackage", path: "foo/utility", requirement: .upToNextMajor(from: "1.0.0")),
-                        .sourceControlWithDeprecatedName(name: "BarPackage", path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .sourceControlWithDeprecatedName(
+                            name: "FooUtilityPackage",
+                            path: "foo/utility",
+                            requirement: .upToNextMajor(from: "1.0.0")
+                        ),
+                        .sourceControlWithDeprecatedName(
+                            name: "BarPackage",
+                            path: "bar",
+                            requirement: .upToNextMajor(from: "1.0.0")
+                        ),
                     ],
                     toolsVersion: .v5
                 ),
@@ -9310,7 +9884,11 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "BarProduct", targets: ["BarTarget"]),
                     ],
                     dependencies: [
-                        .sourceControlWithDeprecatedName(name: "OtherUtilityPackage", path: "other/utility", requirement: .upToNextMajor(from: "1.0.0")),
+                        .sourceControlWithDeprecatedName(
+                            name: "OtherUtilityPackage",
+                            path: "other/utility",
+                            requirement: .upToNextMajor(from: "1.0.0")
+                        ),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -9329,7 +9907,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: "'bar' dependency on '\(sandbox.appending(components: "pkgs", "other", "utility"))' conflicts with dependency on '\(sandbox.appending(components: "pkgs", "foo", "utility"))' which has the same identity 'utility'",
@@ -9352,7 +9930,7 @@ final class WorkspaceTests: XCTestCase {
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
                             .product(name: "FooUtilityProduct", package: "utility"),
-                            .product(name: "BarProduct", package: "bar")
+                            .product(name: "BarProduct", package: "bar"),
                         ]),
                     ],
                     products: [],
@@ -9408,7 +9986,7 @@ final class WorkspaceTests: XCTestCase {
 
         // 9/2021 this is currently emitting a warning only to support backwards compatibility
         // we will escalate this to an error in a few versions to tighten up the validation
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: "'bar' dependency on '\(sandbox.appending(components: "pkgs", "other-foo", "utility"))' conflicts with dependency on '\(sandbox.appending(components: "pkgs", "foo", "utility"))' which has the same identity 'utility'. this will be escalated to an error in future versions of SwiftPM.",
@@ -9437,7 +10015,7 @@ final class WorkspaceTests: XCTestCase {
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
                             .product(name: "FooProduct", package: "foo"),
-                            .product(name: "BarProduct", package: "bar")
+                            .product(name: "BarProduct", package: "bar"),
                         ]),
                     ],
                     products: [],
@@ -9472,7 +10050,10 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "BarProduct", targets: ["BarTarget"]),
                     ],
                     dependencies: [
-                        .sourceControl(url: "https://github.com/foo/foo.git", requirement: .upToNextMajor(from: "1.0.0")),
+                        .sourceControl(
+                            url: "https://github.com/foo/foo.git",
+                            requirement: .upToNextMajor(from: "1.0.0")
+                        ),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -9491,7 +10072,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
     }
@@ -9509,12 +10090,15 @@ final class WorkspaceTests: XCTestCase {
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
                             .product(name: "FooProduct", package: "foo"),
-                            .product(name: "BarProduct", package: "bar")
+                            .product(name: "BarProduct", package: "bar"),
                         ]),
                     ],
                     products: [],
                     dependencies: [
-                        .sourceControl(url: "https://github.com/foo/foo.git", requirement: .upToNextMajor(from: "1.0.0")),
+                        .sourceControl(
+                            url: "https://github.com/foo/foo.git",
+                            requirement: .upToNextMajor(from: "1.0.0")
+                        ),
                         .sourceControl(path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     toolsVersion: .v5_6
@@ -9563,7 +10147,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
     }
@@ -9581,12 +10165,15 @@ final class WorkspaceTests: XCTestCase {
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
                             .product(name: "FooProduct", package: "foo"),
-                            .product(name: "BarProduct", package: "bar")
+                            .product(name: "BarProduct", package: "bar"),
                         ]),
                     ],
                     products: [],
                     dependencies: [
-                        .sourceControl(url: "https://github.com/foo/foo.git", requirement: .upToNextMajor(from: "1.0.0")),
+                        .sourceControl(
+                            url: "https://github.com/foo/foo.git",
+                            requirement: .upToNextMajor(from: "1.0.0")
+                        ),
                         .sourceControl(path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     toolsVersion: .v5_6
@@ -9635,7 +10222,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
     }
@@ -9653,12 +10240,15 @@ final class WorkspaceTests: XCTestCase {
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
                             .product(name: "FooProduct", package: "foo"),
-                            .product(name: "BarProduct", package: "bar")
+                            .product(name: "BarProduct", package: "bar"),
                         ]),
                     ],
                     products: [],
                     dependencies: [
-                        .sourceControl(url: "https://github.enterprise.com/foo/foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .sourceControl(
+                            url: "https://github.enterprise.com/foo/foo",
+                            requirement: .upToNextMajor(from: "1.0.0")
+                        ),
                         .sourceControl(path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     toolsVersion: .v5_6
@@ -9688,7 +10278,10 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "BarProduct", targets: ["BarTarget"]),
                     ],
                     dependencies: [
-                        .sourceControl(url: "git@github.enterprise.com:foo/foo.git", requirement: .upToNextMajor(from: "1.0.0")),
+                        .sourceControl(
+                            url: "git@github.enterprise.com:foo/foo.git",
+                            requirement: .upToNextMajor(from: "1.0.0")
+                        ),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -9707,7 +10300,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
     }
@@ -9725,12 +10318,15 @@ final class WorkspaceTests: XCTestCase {
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
                             .product(name: "FooProduct", package: "foo"),
-                            .product(name: "BarProduct", package: "bar")
+                            .product(name: "BarProduct", package: "bar"),
                         ]),
                     ],
                     products: [],
                     dependencies: [
-                        .sourceControl(url: "https://github.com/foo/foo.git", requirement: .upToNextMajor(from: "1.0.0")),
+                        .sourceControl(
+                            url: "https://github.com/foo/foo.git",
+                            requirement: .upToNextMajor(from: "1.0.0")
+                        ),
                         .sourceControl(path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     toolsVersion: .v5_6
@@ -9760,7 +10356,10 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "BarProduct", targets: ["BarTarget"]),
                     ],
                     dependencies: [
-                        .sourceControl(url: "https://github.com/foo-moved/foo.git", requirement: .upToNextMajor(from: "1.0.0")),
+                        .sourceControl(
+                            url: "https://github.com/foo-moved/foo.git",
+                            requirement: .upToNextMajor(from: "1.0.0")
+                        ),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -9781,7 +10380,7 @@ final class WorkspaceTests: XCTestCase {
 
         // 9/2021 this is currently emitting a warning only to support backwards compatibility
         // we will escalate this to an error in a few versions to tighten up the validation
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: "'bar' dependency on 'https://github.com/foo-moved/foo.git' conflicts with dependency on 'https://github.com/foo/foo.git' which has the same identity 'foo'. this will be escalated to an error in future versions of SwiftPM.",
@@ -9805,14 +10404,23 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "RootTarget", dependencies: [
                             .product(name: "FooProduct", package: "foo"),
                             .product(name: "BarProduct", package: "bar"),
-                            .product(name: "BazProduct", package: "baz")
+                            .product(name: "BazProduct", package: "baz"),
                         ]),
                     ],
                     products: [],
                     dependencies: [
-                        .sourceControl(url: "https://github.com/org/foo.git", requirement: .upToNextMajor(from: "1.0.0")),
-                        .sourceControl(url: "https://github.com/org/bar.git", requirement: .upToNextMajor(from: "1.0.0")),
-                        .sourceControl(url: "https://github.com/org/baz.git", requirement: .upToNextMajor(from: "1.0.0")),
+                        .sourceControl(
+                            url: "https://github.com/org/foo.git",
+                            requirement: .upToNextMajor(from: "1.0.0")
+                        ),
+                        .sourceControl(
+                            url: "https://github.com/org/bar.git",
+                            requirement: .upToNextMajor(from: "1.0.0")
+                        ),
+                        .sourceControl(
+                            url: "https://github.com/org/baz.git",
+                            requirement: .upToNextMajor(from: "1.0.0")
+                        ),
                     ],
                     toolsVersion: .v5_6
                 ),
@@ -9842,7 +10450,10 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "BarProduct", targets: ["BarTarget"]),
                     ],
                     dependencies: [
-                        .sourceControl(url: "https://github.com/ORG/Foo.git", requirement: .upToNextMajor(from: "1.0.0")),
+                        .sourceControl(
+                            url: "https://github.com/ORG/Foo.git",
+                            requirement: .upToNextMajor(from: "1.0.0")
+                        ),
                         .sourceControl(url: "https://github.com/org/baz", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0"]
@@ -9887,7 +10498,7 @@ final class WorkspaceTests: XCTestCase {
 
         // 9/2021 this is currently emitting a warning only to support backwards compatibility
         // we will escalate this to an error in a few versions to tighten up the validation
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             testDiagnostics(diagnostics, minSeverity: .info) { result in
                 result.checkUnordered(
                     diagnostic: "dependency on 'foo' is represented by similar locations ('https://github.com/org/foo.git' and 'https://github.com/ORG/Foo.git') which are treated as the same canonical location 'github.com/org/foo'.",
@@ -9913,12 +10524,16 @@ final class WorkspaceTests: XCTestCase {
                     name: "Root",
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
-                            .product(name: "FooUtilityProduct", package: "FooUtilityPackage")
+                            .product(name: "FooUtilityProduct", package: "FooUtilityPackage"),
                         ]),
                     ],
                     products: [],
                     dependencies: [
-                        .sourceControlWithDeprecatedName(name: "FooUtilityPackage", path: "foo/utility", requirement: .upToNextMajor(from: "1.0.0")),
+                        .sourceControlWithDeprecatedName(
+                            name: "FooUtilityPackage",
+                            path: "foo/utility",
+                            requirement: .upToNextMajor(from: "1.0.0")
+                        ),
                     ],
                     toolsVersion: .v5
                 ),
@@ -9929,14 +10544,18 @@ final class WorkspaceTests: XCTestCase {
                     path: "foo/utility",
                     targets: [
                         MockTarget(name: "FooUtilityTarget", dependencies: [
-                            .product(name: "BarProduct", package: "BarPackage")
+                            .product(name: "BarProduct", package: "BarPackage"),
                         ]),
                     ],
                     products: [
                         MockProduct(name: "FooUtilityProduct", targets: ["FooUtilityTarget"]),
                     ],
                     dependencies: [
-                        .sourceControlWithDeprecatedName(name: "BarPackage", path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .sourceControlWithDeprecatedName(
+                            name: "BarPackage",
+                            path: "bar",
+                            requirement: .upToNextMajor(from: "1.0.0")
+                        ),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -9952,7 +10571,11 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "BarProduct", targets: ["BarTarget"]),
                     ],
                     dependencies: [
-                        .sourceControlWithDeprecatedName(name: "OtherUtilityPackage", path: "other/utility", requirement: .upToNextMajor(from: "1.0.0")),
+                        .sourceControlWithDeprecatedName(
+                            name: "OtherUtilityPackage",
+                            path: "other/utility",
+                            requirement: .upToNextMajor(from: "1.0.0")
+                        ),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -9971,7 +10594,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
                 // FIXME: rdar://72940946
                 // we need to improve this situation or diagnostics when working on identity
@@ -9995,7 +10618,7 @@ final class WorkspaceTests: XCTestCase {
                     name: "Root",
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
-                            .product(name: "FooUtilityProduct", package: "FooUtilityPackage")
+                            .product(name: "FooUtilityProduct", package: "FooUtilityPackage"),
                         ]),
                     ],
                     products: [],
@@ -10011,7 +10634,7 @@ final class WorkspaceTests: XCTestCase {
                     path: "foo/utility",
                     targets: [
                         MockTarget(name: "FooUtilityTarget", dependencies: [
-                            .product(name: "BarProduct", package: "BarPackage")
+                            .product(name: "BarProduct", package: "BarPackage"),
                         ]),
                     ],
                     products: [
@@ -10055,7 +10678,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
                 // FIXME: rdar://72940946
                 // we need to improve this situation or diagnostics when working on identity
@@ -10080,12 +10703,16 @@ final class WorkspaceTests: XCTestCase {
                     path: "foo",
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
-                            .product(name: "BarProduct", package: "BarPackage")
+                            .product(name: "BarProduct", package: "BarPackage"),
                         ]),
                     ],
                     products: [],
                     dependencies: [
-                        .sourceControlWithDeprecatedName(name: "BarPackage", path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .sourceControlWithDeprecatedName(
+                            name: "BarPackage",
+                            path: "bar",
+                            requirement: .upToNextMajor(from: "1.0.0")
+                        ),
                     ],
                     toolsVersion: .v5
                 ),
@@ -10103,7 +10730,11 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "BarProduct", targets: ["BarTarget"]),
                     ],
                     dependencies: [
-                        .sourceControlWithDeprecatedName(name: "FooPackage", path: "foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .sourceControlWithDeprecatedName(
+                            name: "FooPackage",
+                            path: "foo",
+                            requirement: .upToNextMajor(from: "1.0.0")
+                        ),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -10122,7 +10753,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        try workspace.checkPackageGraph(roots: ["foo"]) { graph, diagnostics in
+        try workspace.checkPackageGraph(roots: ["foo"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
                 // FIXME: rdar://72940946
                 // we need to improve this situation or diagnostics when working on identity
@@ -10147,7 +10778,7 @@ final class WorkspaceTests: XCTestCase {
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
                             .product(name: "FooProduct", package: "foo"),
-                            .product(name: "BarProduct", package: "bar")
+                            .product(name: "BarProduct", package: "bar"),
                         ]),
                     ],
                     products: [],
@@ -10185,7 +10816,7 @@ final class WorkspaceTests: XCTestCase {
                         .sourceControl(url: "http://localhost/org/foo", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0"]
-                )
+                ),
             ]
         )
 
@@ -10249,7 +10880,7 @@ final class WorkspaceTests: XCTestCase {
         struct TestLoader: ManifestLoaderProtocol {
             let error: Error?
 
-            init (error: Error?) {
+            init(error: Error?) {
                 self.error = error
             }
 
@@ -10296,7 +10927,11 @@ final class WorkspaceTests: XCTestCase {
 
         // write a manifest
         try fs.writeFileContents(.root.appending(component: Manifest.filename), bytes: "")
-        try ToolsVersionSpecificationWriter.rewriteSpecification(manifestDirectory: .root, toolsVersion: .current, fileSystem: fs)
+        try ToolsVersionSpecificationWriter.rewriteSpecification(
+            manifestDirectory: .root,
+            toolsVersion: .current,
+            fileSystem: fs
+        )
 
         do {
             // no error
@@ -10349,13 +10984,15 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(
                             name: "MyTarget1",
                             dependencies: [
-                                .product(name: "Foo", package: "foo")
-                            ]),
+                                .product(name: "Foo", package: "foo"),
+                            ]
+                        ),
                         MockTarget(
                             name: "MyTarget2",
                             dependencies: [
-                                .product(name: "Bar", package: "bar")
-                            ]),
+                                .product(name: "Bar", package: "bar"),
+                            ]
+                        ),
                     ],
                     products: [
                         MockProduct(name: "MyProduct", targets: ["MyTarget1", "MyTarget2"]),
@@ -10371,7 +11008,7 @@ final class WorkspaceTests: XCTestCase {
                     name: "Foo",
                     url: "http://localhost/org/foo",
                     targets: [
-                        MockTarget(name: "Foo")
+                        MockTarget(name: "Foo"),
                     ],
                     products: [
                         MockProduct(name: "Foo", targets: ["Foo"]),
@@ -10382,7 +11019,7 @@ final class WorkspaceTests: XCTestCase {
                     name: "Bar",
                     url: "http://localhost/org/bar",
                     targets: [
-                        MockTarget(name: "Bar")
+                        MockTarget(name: "Bar"),
                     ],
                     products: [
                         MockProduct(name: "Bar", targets: ["Bar"]),
@@ -10409,12 +11046,34 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // Check the load-package callbacks.
-        XCTAssertMatch(workspace.delegate.events, ["will load manifest for root package: \(sandbox.appending(components: "roots", "MyPackage")) (identity: mypackage)"])
-        XCTAssertMatch(workspace.delegate.events, ["did load manifest for root package: \(sandbox.appending(components: "roots", "MyPackage")) (identity: mypackage)"])
-        XCTAssertMatch(workspace.delegate.events, ["will load manifest for remoteSourceControl package: http://localhost/org/foo (identity: foo)"])
-        XCTAssertMatch(workspace.delegate.events, ["did load manifest for remoteSourceControl package: http://localhost/org/foo (identity: foo)"])
-        XCTAssertMatch(workspace.delegate.events, ["will load manifest for remoteSourceControl package: http://localhost/org/bar (identity: bar)"])
-        XCTAssertMatch(workspace.delegate.events, ["did load manifest for remoteSourceControl package: http://localhost/org/bar (identity: bar)"])
+        XCTAssertMatch(
+            workspace.delegate.events,
+            [
+                "will load manifest for root package: \(sandbox.appending(components: "roots", "MyPackage")) (identity: mypackage)",
+            ]
+        )
+        XCTAssertMatch(
+            workspace.delegate.events,
+            [
+                "did load manifest for root package: \(sandbox.appending(components: "roots", "MyPackage")) (identity: mypackage)",
+            ]
+        )
+        XCTAssertMatch(
+            workspace.delegate.events,
+            ["will load manifest for remoteSourceControl package: http://localhost/org/foo (identity: foo)"]
+        )
+        XCTAssertMatch(
+            workspace.delegate.events,
+            ["did load manifest for remoteSourceControl package: http://localhost/org/foo (identity: foo)"]
+        )
+        XCTAssertMatch(
+            workspace.delegate.events,
+            ["will load manifest for remoteSourceControl package: http://localhost/org/bar (identity: bar)"]
+        )
+        XCTAssertMatch(
+            workspace.delegate.events,
+            ["did load manifest for remoteSourceControl package: http://localhost/org/bar (identity: bar)"]
+        )
     }
 
     func testBasicTransitiveResolutionFromSourceControl() throws {
@@ -10431,13 +11090,15 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(
                             name: "MyTarget1",
                             dependencies: [
-                                .product(name: "Foo", package: "foo")
-                            ]),
+                                .product(name: "Foo", package: "foo"),
+                            ]
+                        ),
                         MockTarget(
                             name: "MyTarget2",
                             dependencies: [
-                                .product(name: "Bar", package: "bar")
-                            ]),
+                                .product(name: "Bar", package: "bar"),
+                            ]
+                        ),
                     ],
                     products: [
                         MockProduct(name: "MyProduct", targets: ["MyTarget1", "MyTarget2"]),
@@ -10456,8 +11117,9 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(
                             name: "Foo",
                             dependencies: [
-                                .product(name: "Baz", package: "baz")
-                            ]),
+                                .product(name: "Baz", package: "baz"),
+                            ]
+                        ),
                     ],
                     products: [
                         MockProduct(name: "Foo", targets: ["Foo"]),
@@ -10474,8 +11136,9 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(
                             name: "Bar",
                             dependencies: [
-                                .product(name: "Baz", package: "baz")
-                            ]),
+                                .product(name: "Baz", package: "baz"),
+                            ]
+                        ),
                     ],
                     products: [
                         MockProduct(name: "Bar", targets: ["Bar"]),
@@ -10519,14 +11182,42 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // Check the load-package callbacks.
-        XCTAssertMatch(workspace.delegate.events, ["will load manifest for root package: \(sandbox.appending(components: "roots", "MyPackage")) (identity: mypackage)"])
-        XCTAssertMatch(workspace.delegate.events, ["did load manifest for root package: \(sandbox.appending(components: "roots", "MyPackage")) (identity: mypackage)"])
-        XCTAssertMatch(workspace.delegate.events, ["will load manifest for remoteSourceControl package: http://localhost/org/foo (identity: foo)"])
-        XCTAssertMatch(workspace.delegate.events, ["did load manifest for remoteSourceControl package: http://localhost/org/foo (identity: foo)"])
-        XCTAssertMatch(workspace.delegate.events, ["will load manifest for remoteSourceControl package: http://localhost/org/bar (identity: bar)"])
-        XCTAssertMatch(workspace.delegate.events, ["did load manifest for remoteSourceControl package: http://localhost/org/bar (identity: bar)"])
-        XCTAssertMatch(workspace.delegate.events, ["will load manifest for remoteSourceControl package: http://localhost/org/baz (identity: baz)"])
-        XCTAssertMatch(workspace.delegate.events, ["did load manifest for remoteSourceControl package: http://localhost/org/baz (identity: baz)"])
+        XCTAssertMatch(
+            workspace.delegate.events,
+            [
+                "will load manifest for root package: \(sandbox.appending(components: "roots", "MyPackage")) (identity: mypackage)",
+            ]
+        )
+        XCTAssertMatch(
+            workspace.delegate.events,
+            [
+                "did load manifest for root package: \(sandbox.appending(components: "roots", "MyPackage")) (identity: mypackage)",
+            ]
+        )
+        XCTAssertMatch(
+            workspace.delegate.events,
+            ["will load manifest for remoteSourceControl package: http://localhost/org/foo (identity: foo)"]
+        )
+        XCTAssertMatch(
+            workspace.delegate.events,
+            ["did load manifest for remoteSourceControl package: http://localhost/org/foo (identity: foo)"]
+        )
+        XCTAssertMatch(
+            workspace.delegate.events,
+            ["will load manifest for remoteSourceControl package: http://localhost/org/bar (identity: bar)"]
+        )
+        XCTAssertMatch(
+            workspace.delegate.events,
+            ["did load manifest for remoteSourceControl package: http://localhost/org/bar (identity: bar)"]
+        )
+        XCTAssertMatch(
+            workspace.delegate.events,
+            ["will load manifest for remoteSourceControl package: http://localhost/org/baz (identity: baz)"]
+        )
+        XCTAssertMatch(
+            workspace.delegate.events,
+            ["did load manifest for remoteSourceControl package: http://localhost/org/baz (identity: baz)"]
+        )
     }
 
     func testBasicResolutionFromRegistry() throws {
@@ -10543,13 +11234,15 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(
                             name: "MyTarget1",
                             dependencies: [
-                                .product(name: "Foo", package: "org.foo")
-                            ]),
+                                .product(name: "Foo", package: "org.foo"),
+                            ]
+                        ),
                         MockTarget(
                             name: "MyTarget2",
                             dependencies: [
-                                .product(name: "Bar", package: "org.bar")
-                            ]),
+                                .product(name: "Bar", package: "org.bar"),
+                            ]
+                        ),
                     ],
                     products: [
                         MockProduct(name: "MyProduct", targets: ["MyTarget1", "MyTarget2"]),
@@ -10603,12 +11296,34 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // Check the load-package callbacks.
-        XCTAssertMatch(workspace.delegate.events, ["will load manifest for root package: \(sandbox.appending(components: "roots", "MyPackage")) (identity: mypackage)"])
-        XCTAssertMatch(workspace.delegate.events, ["did load manifest for root package: \(sandbox.appending(components: "roots", "MyPackage")) (identity: mypackage)"])
-        XCTAssertMatch(workspace.delegate.events, ["will load manifest for registry package: org.foo (identity: org.foo)"])
-        XCTAssertMatch(workspace.delegate.events, ["did load manifest for registry package: org.foo (identity: org.foo)"])
-        XCTAssertMatch(workspace.delegate.events, ["will load manifest for registry package: org.bar (identity: org.bar)"])
-        XCTAssertMatch(workspace.delegate.events, ["did load manifest for registry package: org.bar (identity: org.bar)"])
+        XCTAssertMatch(
+            workspace.delegate.events,
+            [
+                "will load manifest for root package: \(sandbox.appending(components: "roots", "MyPackage")) (identity: mypackage)",
+            ]
+        )
+        XCTAssertMatch(
+            workspace.delegate.events,
+            [
+                "did load manifest for root package: \(sandbox.appending(components: "roots", "MyPackage")) (identity: mypackage)",
+            ]
+        )
+        XCTAssertMatch(
+            workspace.delegate.events,
+            ["will load manifest for registry package: org.foo (identity: org.foo)"]
+        )
+        XCTAssertMatch(
+            workspace.delegate.events,
+            ["did load manifest for registry package: org.foo (identity: org.foo)"]
+        )
+        XCTAssertMatch(
+            workspace.delegate.events,
+            ["will load manifest for registry package: org.bar (identity: org.bar)"]
+        )
+        XCTAssertMatch(
+            workspace.delegate.events,
+            ["did load manifest for registry package: org.bar (identity: org.bar)"]
+        )
     }
 
     func testBasicTransitiveResolutionFromRegistry() throws {
@@ -10625,13 +11340,15 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(
                             name: "MyTarget1",
                             dependencies: [
-                                .product(name: "Foo", package: "org.foo")
-                            ]),
+                                .product(name: "Foo", package: "org.foo"),
+                            ]
+                        ),
                         MockTarget(
                             name: "MyTarget2",
                             dependencies: [
-                                .product(name: "Bar", package: "org.bar")
-                            ]),
+                                .product(name: "Bar", package: "org.bar"),
+                            ]
+                        ),
                     ],
                     products: [
                         MockProduct(name: "MyProduct", targets: ["MyTarget1", "MyTarget2"]),
@@ -10650,8 +11367,9 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(
                             name: "Foo",
                             dependencies: [
-                                .product(name: "Baz", package: "org.baz")
-                            ]),
+                                .product(name: "Baz", package: "org.baz"),
+                            ]
+                        ),
                     ],
                     products: [
                         MockProduct(name: "Foo", targets: ["Foo"]),
@@ -10668,8 +11386,9 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(
                             name: "Bar",
                             dependencies: [
-                                .product(name: "Baz", package: "org.baz")
-                            ]),
+                                .product(name: "Baz", package: "org.baz"),
+                            ]
+                        ),
                     ],
                     products: [
                         MockProduct(name: "Bar", targets: ["Bar"]),
@@ -10713,14 +11432,42 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // Check the load-package callbacks.
-        XCTAssertMatch(workspace.delegate.events, ["will load manifest for root package: \(sandbox.appending(components: "roots", "MyPackage")) (identity: mypackage)"])
-        XCTAssertMatch(workspace.delegate.events, ["did load manifest for root package: \(sandbox.appending(components: "roots", "MyPackage")) (identity: mypackage)"])
-        XCTAssertMatch(workspace.delegate.events, ["will load manifest for registry package: org.foo (identity: org.foo)"])
-        XCTAssertMatch(workspace.delegate.events, ["did load manifest for registry package: org.foo (identity: org.foo)"])
-        XCTAssertMatch(workspace.delegate.events, ["will load manifest for registry package: org.bar (identity: org.bar)"])
-        XCTAssertMatch(workspace.delegate.events, ["did load manifest for registry package: org.bar (identity: org.bar)"])
-        XCTAssertMatch(workspace.delegate.events, ["will load manifest for registry package: org.baz (identity: org.baz)"])
-        XCTAssertMatch(workspace.delegate.events, ["did load manifest for registry package: org.baz (identity: org.baz)"])
+        XCTAssertMatch(
+            workspace.delegate.events,
+            [
+                "will load manifest for root package: \(sandbox.appending(components: "roots", "MyPackage")) (identity: mypackage)",
+            ]
+        )
+        XCTAssertMatch(
+            workspace.delegate.events,
+            [
+                "did load manifest for root package: \(sandbox.appending(components: "roots", "MyPackage")) (identity: mypackage)",
+            ]
+        )
+        XCTAssertMatch(
+            workspace.delegate.events,
+            ["will load manifest for registry package: org.foo (identity: org.foo)"]
+        )
+        XCTAssertMatch(
+            workspace.delegate.events,
+            ["did load manifest for registry package: org.foo (identity: org.foo)"]
+        )
+        XCTAssertMatch(
+            workspace.delegate.events,
+            ["will load manifest for registry package: org.bar (identity: org.bar)"]
+        )
+        XCTAssertMatch(
+            workspace.delegate.events,
+            ["did load manifest for registry package: org.bar (identity: org.bar)"]
+        )
+        XCTAssertMatch(
+            workspace.delegate.events,
+            ["will load manifest for registry package: org.baz (identity: org.baz)"]
+        )
+        XCTAssertMatch(
+            workspace.delegate.events,
+            ["did load manifest for registry package: org.baz (identity: org.baz)"]
+        )
     }
 
     // no dups
@@ -10738,7 +11485,7 @@ final class WorkspaceTests: XCTestCase {
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
                             .product(name: "FooProduct", package: "foo"),
-                            .product(name: "BarProduct", package: "org.bar")
+                            .product(name: "BarProduct", package: "org.bar"),
                         ]),
                     ],
                     products: [],
@@ -10783,7 +11530,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "FooProduct", targets: ["FooTarget"]),
                     ],
                     versions: ["1.0.0", "1.1.0", "1.2.0"]
-                )
+                ),
             ]
         )
 
@@ -10796,7 +11543,8 @@ final class WorkspaceTests: XCTestCase {
                     result.check(roots: "Root")
                     result.check(packages: "BarPackage", "FooPackage", "Root")
                     result.check(targets: "FooTarget", "BarTarget", "RootTarget")
-                    result.checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
+                    result
+                        .checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
                 }
             }
 
@@ -10818,7 +11566,8 @@ final class WorkspaceTests: XCTestCase {
                     result.check(roots: "Root")
                     result.check(packages: "BarPackage", "FooPackage", "Root")
                     result.check(targets: "FooTarget", "BarTarget", "RootTarget")
-                    result.checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
+                    result
+                        .checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
                 }
             }
 
@@ -10840,7 +11589,8 @@ final class WorkspaceTests: XCTestCase {
                     result.check(roots: "Root")
                     result.check(packages: "BarPackage", "FooPackage", "Root")
                     result.check(targets: "FooTarget", "BarTarget", "RootTarget")
-                    result.checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
+                    result
+                        .checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
                 }
             }
 
@@ -10865,7 +11615,7 @@ final class WorkspaceTests: XCTestCase {
                     path: "root",
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
-                            .product(name: "FooProduct", package: "foo")
+                            .product(name: "FooProduct", package: "foo"),
                         ]),
                     ],
                     products: [],
@@ -10906,7 +11656,7 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .disabled
 
-            XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+            XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic: .contains("""
@@ -10918,7 +11668,8 @@ final class WorkspaceTests: XCTestCase {
             }) { error in
                 var diagnosed = false
                 if let realError = error as? PackageGraphError,
-                    realError.description == "multiple products named 'FooProduct' in: 'foo', 'org.foo'" {
+                   realError.description == "multiple products named 'FooProduct' in: 'foo', 'org.foo'"
+                {
                     diagnosed = true
                 }
                 XCTAssertTrue(diagnosed)
@@ -10931,7 +11682,7 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .identity
 
-            try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+            try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic: "'root' dependency on 'org.foo' conflicts with dependency on 'https://git/org/foo' which has the same identity 'org.foo'",
@@ -10948,7 +11699,7 @@ final class WorkspaceTests: XCTestCase {
             workspace.sourceControlToRegistryDependencyTransformation = .swizzle
 
             // TODO: this error message should be improved
-            try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+            try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic: "'root' dependency on 'org.foo' conflicts with dependency on 'org.foo' which has the same identity 'org.foo'",
@@ -10958,7 +11709,6 @@ final class WorkspaceTests: XCTestCase {
             }
         }
     }
-
 
     // mixed graph root --> dep1 scm
     //                  --> dep2 scm --> dep1 registry
@@ -10976,7 +11726,7 @@ final class WorkspaceTests: XCTestCase {
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
                             .product(name: "FooProduct", package: "foo"),
-                            .product(name: "BarProduct", package: "bar")
+                            .product(name: "BarProduct", package: "bar"),
                         ]),
                     ],
                     products: [],
@@ -11004,7 +11754,7 @@ final class WorkspaceTests: XCTestCase {
                     url: "https://git/org/bar",
                     targets: [
                         MockTarget(name: "BarTarget", dependencies: [
-                            .product(name: "FooProduct", package: "org.foo")
+                            .product(name: "FooProduct", package: "org.foo"),
                         ]),
                     ],
                     products: [
@@ -11033,30 +11783,31 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .disabled
             if ToolsVersion.current < .v5_8 {
-                XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+                XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                     testDiagnostics(diagnostics) { result in
                         result.check(
                             diagnostic: .contains("""
-                        multiple targets named 'FooTarget' in: 'foo', 'org.foo'
-                        """),
+                            multiple targets named 'FooTarget' in: 'foo', 'org.foo'
+                            """),
                             severity: .error
                         )
                     }
                 }) { error in
                     var diagnosed = false
                     if let realError = error as? PackageGraphError,
-                       realError.description == "multiple products named 'FooProduct' in: 'foo', 'org.foo'" {
+                       realError.description == "multiple products named 'FooProduct' in: 'foo', 'org.foo'"
+                    {
                         diagnosed = true
                     }
                     XCTAssertTrue(diagnosed)
                 }
             } else {
-                XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+                XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                     testDiagnostics(diagnostics) { result in
                         result.check(
                             diagnostic: .contains("""
-                        multiple targets named 'FooTarget' in: 'foo', 'org.foo'
-                        """),
+                            multiple targets named 'FooTarget' in: 'foo', 'org.foo'
+                            """),
                             severity: .error
                         )
                     }
@@ -11084,7 +11835,8 @@ final class WorkspaceTests: XCTestCase {
                     result.check(roots: "Root")
                     result.check(packages: "BarPackage", "FooPackage", "Root")
                     result.check(targets: "FooTarget", "BarTarget", "RootTarget")
-                    result.checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
+                    result
+                        .checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
                 }
             }
 
@@ -11107,7 +11859,8 @@ final class WorkspaceTests: XCTestCase {
                     result.check(roots: "Root")
                     result.check(packages: "BarPackage", "FooPackage", "Root")
                     result.check(targets: "FooTarget", "BarTarget", "RootTarget")
-                    result.checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
+                    result
+                        .checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
                 }
             }
 
@@ -11129,7 +11882,8 @@ final class WorkspaceTests: XCTestCase {
                     result.check(roots: "Root")
                     result.check(packages: "BarPackage", "FooPackage", "Root")
                     result.check(targets: "FooTarget", "BarTarget", "RootTarget")
-                    result.checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
+                    result
+                        .checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
                 }
             }
 
@@ -11156,7 +11910,7 @@ final class WorkspaceTests: XCTestCase {
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
                             .product(name: "FooProduct", package: "foo"),
-                            .product(name: "BarProduct", package: "org.bar")
+                            .product(name: "BarProduct", package: "org.bar"),
                         ]),
                     ],
                     products: [],
@@ -11184,7 +11938,7 @@ final class WorkspaceTests: XCTestCase {
                     identity: "org.bar",
                     targets: [
                         MockTarget(name: "BarTarget", dependencies: [
-                            .product(name: "FooProduct", package: "org.foo")
+                            .product(name: "FooProduct", package: "org.foo"),
                         ]),
                     ],
                     products: [
@@ -11213,30 +11967,31 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .disabled
             if ToolsVersion.current < .v5_8 {
-                XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+                XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                     testDiagnostics(diagnostics) { result in
                         result.check(
                             diagnostic: .contains("""
-                        multiple targets named 'FooTarget' in: 'foo', 'org.foo'
-                        """),
+                            multiple targets named 'FooTarget' in: 'foo', 'org.foo'
+                            """),
                             severity: .error
                         )
                     }
                 }) { error in
                     var diagnosed = false
                     if let realError = error as? PackageGraphError,
-                       realError.description == "multiple products named 'FooProduct' in: 'foo', 'org.foo'" {
+                       realError.description == "multiple products named 'FooProduct' in: 'foo', 'org.foo'"
+                    {
                         diagnosed = true
                     }
                     XCTAssertTrue(diagnosed)
                 }
             } else {
-                XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+                XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                     testDiagnostics(diagnostics) { result in
                         result.check(
                             diagnostic: .contains("""
-                        multiple targets named 'FooTarget' in: 'foo', 'org.foo'
-                        """),
+                            multiple targets named 'FooTarget' in: 'foo', 'org.foo'
+                            """),
                             severity: .error
                         )
                     }
@@ -11263,7 +12018,8 @@ final class WorkspaceTests: XCTestCase {
                     result.check(roots: "Root")
                     result.check(packages: "BarPackage", "FooPackage", "Root")
                     result.check(targets: "FooTarget", "BarTarget", "RootTarget")
-                    result.checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
+                    result
+                        .checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
                 }
             }
 
@@ -11285,7 +12041,8 @@ final class WorkspaceTests: XCTestCase {
                     result.check(roots: "Root")
                     result.check(packages: "BarPackage", "FooPackage", "Root")
                     result.check(targets: "FooTarget", "BarTarget", "RootTarget")
-                    result.checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
+                    result
+                        .checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
                 }
             }
 
@@ -11312,7 +12069,7 @@ final class WorkspaceTests: XCTestCase {
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
                             .product(name: "FooProduct", package: "foo"),
-                            .product(name: "BarProduct", package: "bar")
+                            .product(name: "BarProduct", package: "bar"),
                         ]),
                     ],
                     products: [],
@@ -11340,7 +12097,7 @@ final class WorkspaceTests: XCTestCase {
                     url: "https://git/org/bar",
                     targets: [
                         MockTarget(name: "BarTarget", dependencies: [
-                            .product(name: "FooProduct", package: "org.foo")
+                            .product(name: "FooProduct", package: "org.foo"),
                         ]),
                     ],
                     products: [
@@ -11369,30 +12126,31 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .disabled
             if ToolsVersion.current < .v5_8 {
-                XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+                XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                     testDiagnostics(diagnostics) { result in
                         result.check(
                             diagnostic: .contains("""
-                        multiple targets named 'FooTarget' in: 'foo', 'org.foo'
-                        """),
+                            multiple targets named 'FooTarget' in: 'foo', 'org.foo'
+                            """),
                             severity: .error
                         )
                     }
                 }) { error in
                     var diagnosed = false
                     if let realError = error as? PackageGraphError,
-                       realError.description == "multiple products named 'FooProduct' in: 'foo', 'org.foo'" {
+                       realError.description == "multiple products named 'FooProduct' in: 'foo', 'org.foo'"
+                    {
                         diagnosed = true
                     }
                     XCTAssertTrue(diagnosed)
                 }
             } else {
-                XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+                XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                     testDiagnostics(diagnostics) { result in
                         result.check(
                             diagnostic: .contains("""
-                        multiple targets named 'FooTarget' in: 'foo', 'org.foo'
-                        """),
+                            multiple targets named 'FooTarget' in: 'foo', 'org.foo'
+                            """),
                             severity: .error
                         )
                     }
@@ -11406,7 +12164,7 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .identity
 
-            try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+            try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic:
@@ -11426,7 +12184,7 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .swizzle
 
-            try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+            try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic:
@@ -11457,7 +12215,7 @@ final class WorkspaceTests: XCTestCase {
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
                             .product(name: "FooProduct", package: "org.foo"),
-                            .product(name: "BarProduct", package: "org.bar")
+                            .product(name: "BarProduct", package: "org.bar"),
                         ]),
                     ],
                     products: [],
@@ -11486,7 +12244,7 @@ final class WorkspaceTests: XCTestCase {
                     identity: "org.bar",
                     targets: [
                         MockTarget(name: "BarTarget", dependencies: [
-                            .product(name: "FooProduct", package: "foo")
+                            .product(name: "FooProduct", package: "foo"),
                         ]),
                     ],
                     products: [
@@ -11514,30 +12272,31 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .disabled
             if ToolsVersion.current < .v5_8 {
-                XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+                XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                     testDiagnostics(diagnostics) { result in
                         result.check(
                             diagnostic: .contains("""
-                        multiple targets named 'FooTarget' in: 'foo', 'org.foo'
-                        """),
+                            multiple targets named 'FooTarget' in: 'foo', 'org.foo'
+                            """),
                             severity: .error
                         )
                     }
                 }) { error in
                     var diagnosed = false
                     if let realError = error as? PackageGraphError,
-                       realError.description == "multiple products named 'FooProduct' in: 'foo', 'org.foo'" {
+                       realError.description == "multiple products named 'FooProduct' in: 'foo', 'org.foo'"
+                    {
                         diagnosed = true
                     }
                     XCTAssertTrue(diagnosed)
                 }
             } else {
-                XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+                XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                     testDiagnostics(diagnostics) { result in
                         result.check(
                             diagnostic: .contains("""
-                        multiple targets named 'FooTarget' in: 'foo', 'org.foo'
-                        """),
+                            multiple targets named 'FooTarget' in: 'foo', 'org.foo'
+                            """),
                             severity: .error
                         )
                     }
@@ -11572,7 +12331,8 @@ final class WorkspaceTests: XCTestCase {
                     result.check(roots: "Root")
                     result.check(packages: "BarPackage", "FooPackage", "Root")
                     result.check(targets: "FooTarget", "BarTarget", "RootTarget")
-                    result.checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
+                    result
+                        .checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
                 }
             }
 
@@ -11594,7 +12354,8 @@ final class WorkspaceTests: XCTestCase {
                     result.check(roots: "Root")
                     result.check(packages: "BarPackage", "FooPackage", "Root")
                     result.check(targets: "FooTarget", "BarTarget", "RootTarget")
-                    result.checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
+                    result
+                        .checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
                 }
             }
 
@@ -11621,7 +12382,7 @@ final class WorkspaceTests: XCTestCase {
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
                             .product(name: "FooProduct", package: "org.foo"),
-                            .product(name: "BarProduct", package: "org.bar")
+                            .product(name: "BarProduct", package: "org.bar"),
                         ]),
                     ],
                     products: [],
@@ -11650,7 +12411,7 @@ final class WorkspaceTests: XCTestCase {
                     identity: "org.bar",
                     targets: [
                         MockTarget(name: "BarTarget", dependencies: [
-                            .product(name: "FooProduct", package: "foo")
+                            .product(name: "FooProduct", package: "foo"),
                         ]),
                     ],
                     products: [
@@ -11678,30 +12439,31 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .disabled
             if ToolsVersion.current < .v5_8 {
-                XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+                XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                     testDiagnostics(diagnostics) { result in
                         result.check(
                             diagnostic: .contains("""
-                        multiple targets named 'FooTarget' in: 'foo', 'org.foo'
-                        """),
+                            multiple targets named 'FooTarget' in: 'foo', 'org.foo'
+                            """),
                             severity: .error
                         )
                     }
                 }) { error in
                     var diagnosed = false
                     if let realError = error as? PackageGraphError,
-                       realError.description == "multiple products named 'FooProduct' in: 'foo', 'org.foo'" {
+                       realError.description == "multiple products named 'FooProduct' in: 'foo', 'org.foo'"
+                    {
                         diagnosed = true
                     }
                     XCTAssertTrue(diagnosed)
                 }
             } else {
-                XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+                XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                     testDiagnostics(diagnostics) { result in
                         result.check(
                             diagnostic: .contains("""
-                        multiple targets named 'FooTarget' in: 'foo', 'org.foo'
-                        """),
+                            multiple targets named 'FooTarget' in: 'foo', 'org.foo'
+                            """),
                             severity: .error
                         )
                     }
@@ -11715,7 +12477,7 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .identity
 
-            try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+            try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic:
@@ -11735,7 +12497,7 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .swizzle
 
-            try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+            try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic:
@@ -11766,7 +12528,7 @@ final class WorkspaceTests: XCTestCase {
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
                             .product(name: "FooProduct", package: "org.foo"),
-                            .product(name: "BarProduct", package: "org.bar")
+                            .product(name: "BarProduct", package: "org.bar"),
                         ]),
                     ],
                     products: [],
@@ -11783,7 +12545,7 @@ final class WorkspaceTests: XCTestCase {
                     identity: "org.foo",
                     targets: [
                         MockTarget(name: "FooTarget", dependencies: [
-                            .product(name: "BazProduct", package: "baz")
+                            .product(name: "BazProduct", package: "baz"),
                         ]),
                     ],
                     products: [
@@ -11799,7 +12561,7 @@ final class WorkspaceTests: XCTestCase {
                     identity: "org.bar",
                     targets: [
                         MockTarget(name: "BarTarget", dependencies: [
-                            .product(name: "BazProduct", package: "org.baz")
+                            .product(name: "BazProduct", package: "org.baz"),
                         ]),
                     ],
                     products: [
@@ -11839,30 +12601,31 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .disabled
             if ToolsVersion.current < .v5_8 {
-                XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+                XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                     testDiagnostics(diagnostics) { result in
                         result.check(
                             diagnostic: .contains("""
-                        multiple targets named 'BazTarget' in: 'baz', 'org.baz'
-                        """),
+                            multiple targets named 'BazTarget' in: 'baz', 'org.baz'
+                            """),
                             severity: .error
                         )
                     }
                 }) { error in
                     var diagnosed = false
                     if let realError = error as? PackageGraphError,
-                       realError.description == "multiple products named 'BazProduct' in: 'baz', 'org.baz'" {
+                       realError.description == "multiple products named 'BazProduct' in: 'baz', 'org.baz'"
+                    {
                         diagnosed = true
                     }
                     XCTAssertTrue(diagnosed)
                 }
             } else {
-                XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+                XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                     testDiagnostics(diagnostics) { result in
                         result.check(
                             diagnostic: .contains("""
-                    multiple targets named 'BazTarget' in: 'baz', 'org.baz'
-                    """),
+                            multiple targets named 'BazTarget' in: 'baz', 'org.baz'
+                            """),
                             severity: .error
                         )
                     }
@@ -11887,8 +12650,8 @@ final class WorkspaceTests: XCTestCase {
                     if ToolsVersion.current >= .v5_8 {
                         result.check(
                             diagnostic: .contains("""
-                        product 'BazProduct' required by package 'org.foo' target 'FooTarget' not found in package 'baz'.
-                        """),
+                            product 'BazProduct' required by package 'org.foo' target 'FooTarget' not found in package 'baz'.
+                            """),
                             severity: .error
                         )
                     }
@@ -11897,7 +12660,8 @@ final class WorkspaceTests: XCTestCase {
                     result.check(roots: "Root")
                     result.check(packages: "BarPackage", "BazPackage", "FooPackage", "Root")
                     result.check(targets: "FooTarget", "BarTarget", "BazTarget", "RootTarget")
-                    result.checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
+                    result
+                        .checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
                     if ToolsVersion.current < .v5_8 {
                         result.checkTarget("FooTarget") { result in result.check(dependencies: "BazProduct") }
                     }
@@ -11924,7 +12688,8 @@ final class WorkspaceTests: XCTestCase {
                     result.check(roots: "Root")
                     result.check(packages: "BarPackage", "BazPackage", "FooPackage", "Root")
                     result.check(targets: "FooTarget", "BarTarget", "BazTarget", "RootTarget")
-                    result.checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
+                    result
+                        .checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
                     result.checkTarget("FooTarget") { result in result.check(dependencies: "BazProduct") }
                     result.checkTarget("BarTarget") { result in result.check(dependencies: "BazProduct") }
                 }
@@ -11954,7 +12719,7 @@ final class WorkspaceTests: XCTestCase {
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
                             .product(name: "FooProduct", package: "org.foo"),
-                            .product(name: "BarProduct", package: "org.bar")
+                            .product(name: "BarProduct", package: "org.bar"),
                         ]),
                     ],
                     products: [],
@@ -11971,7 +12736,7 @@ final class WorkspaceTests: XCTestCase {
                     identity: "org.foo",
                     targets: [
                         MockTarget(name: "FooTarget", dependencies: [
-                            .product(name: "BazProduct", package: "baz")
+                            .product(name: "BazProduct", package: "baz"),
                         ]),
                     ],
                     products: [
@@ -11987,7 +12752,7 @@ final class WorkspaceTests: XCTestCase {
                     identity: "org.bar",
                     targets: [
                         MockTarget(name: "BarTarget", dependencies: [
-                            .product(name: "BazProduct", package: "org.baz")
+                            .product(name: "BazProduct", package: "org.baz"),
                         ]),
                     ],
                     products: [
@@ -12027,30 +12792,31 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .disabled
             if ToolsVersion.current < .v5_8 {
-                XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+                XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                     testDiagnostics(diagnostics) { result in
                         result.check(
                             diagnostic: .contains("""
-                        multiple targets named 'BazTarget' in: 'baz', 'org.baz'
-                        """),
+                            multiple targets named 'BazTarget' in: 'baz', 'org.baz'
+                            """),
                             severity: .error
                         )
                     }
                 }) { error in
                     var diagnosed = false
                     if let realError = error as? PackageGraphError,
-                       realError.description == "multiple products named 'BazProduct' in: 'baz', 'org.baz'" {
+                       realError.description == "multiple products named 'BazProduct' in: 'baz', 'org.baz'"
+                    {
                         diagnosed = true
                     }
                     XCTAssertTrue(diagnosed)
                 }
             } else {
-                XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+                XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                     testDiagnostics(diagnostics) { result in
                         result.check(
                             diagnostic: .contains("""
-                        multiple targets named 'BazTarget' in: 'baz', 'org.baz'
-                        """),
+                            multiple targets named 'BazTarget' in: 'baz', 'org.baz'
+                            """),
                             severity: .error
                         )
                     }
@@ -12064,7 +12830,7 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .identity
 
-            try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+            try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic: """
@@ -12084,7 +12850,7 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .swizzle
 
-            try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+            try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                 testDiagnostics(diagnostics) { result in
                     result.check(
                         diagnostic: """
@@ -12115,7 +12881,7 @@ final class WorkspaceTests: XCTestCase {
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
                             .product(name: "FooProduct", package: "foo"),
-                            .product(name: "BarProduct", package: "org.bar")
+                            .product(name: "BarProduct", package: "org.bar"),
                         ]),
                     ],
                     products: [],
@@ -12143,7 +12909,7 @@ final class WorkspaceTests: XCTestCase {
                     identity: "org.bar",
                     targets: [
                         MockTarget(name: "BarTarget", dependencies: [
-                            .product(name: "FooProduct", package: "org.foo")
+                            .product(name: "FooProduct", package: "org.foo"),
                         ]),
                     ],
                     products: [
@@ -12172,30 +12938,31 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .disabled
             if ToolsVersion.current < .v5_8 {
-                XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+                XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                     testDiagnostics(diagnostics) { result in
                         result.check(
                             diagnostic: .contains("""
-                        multiple targets named 'FooTarget' in: 'foo', 'org.foo'
-                        """),
+                            multiple targets named 'FooTarget' in: 'foo', 'org.foo'
+                            """),
                             severity: .error
                         )
                     }
                 }) { error in
                     var diagnosed = false
                     if let realError = error as? PackageGraphError,
-                       realError.description == "multiple products named 'FooProduct' in: 'foo', 'org.foo'" {
+                       realError.description == "multiple products named 'FooProduct' in: 'foo', 'org.foo'"
+                    {
                         diagnosed = true
                     }
                     XCTAssertTrue(diagnosed)
                 }
             } else {
-                XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+                XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
                     testDiagnostics(diagnostics) { result in
                         result.check(
                             diagnostic: .contains("""
-                        multiple targets named 'FooTarget' in: 'foo', 'org.foo'
-                        """),
+                            multiple targets named 'FooTarget' in: 'foo', 'org.foo'
+                            """),
                             severity: .error
                         )
                     }
@@ -12222,7 +12989,8 @@ final class WorkspaceTests: XCTestCase {
                     result.check(roots: "Root")
                     result.check(packages: "BarPackage", "FooPackage", "Root")
                     result.check(targets: "FooTarget", "BarTarget", "RootTarget")
-                    result.checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
+                    result
+                        .checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
                 }
             }
 
@@ -12251,12 +13019,17 @@ final class WorkspaceTests: XCTestCase {
                     result.check(roots: "Root")
                     result.check(packages: "BarPackage", "FooPackage", "Root")
                     result.check(targets: "FooTarget", "BarTarget", "RootTarget")
-                    result.checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
+                    result
+                        .checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
                 }
             }
 
             workspace.checkManagedDependencies { result in
-                result.check(dependency: "org.foo", at: .checkout(.branch("experiment"))) // we cannot swizzle branch based deps
+                result
+                    .check(
+                        dependency: "org.foo",
+                        at: .checkout(.branch("experiment"))
+                    ) // we cannot swizzle branch based deps
                 result.check(dependency: "org.bar", at: .registryDownload("1.0.0"))
             }
         }
@@ -12269,7 +13042,11 @@ final class WorkspaceTests: XCTestCase {
         let customFS = InMemoryFileSystem()
         // write a manifest
         try customFS.writeFileContents(.root.appending(component: Manifest.filename), bytes: "")
-        try ToolsVersionSpecificationWriter.rewriteSpecification(manifestDirectory: .root, toolsVersion: .current, fileSystem: customFS)
+        try ToolsVersionSpecificationWriter.rewriteSpecification(
+            manifestDirectory: .root,
+            toolsVersion: .current,
+            fileSystem: customFS
+        )
         // write the sources
         let sourcesDir = AbsolutePath(path: "/Sources")
         let targetDir = sourcesDir.appending(component: "Baz")
@@ -12277,8 +13054,16 @@ final class WorkspaceTests: XCTestCase {
         try customFS.writeFileContents(targetDir.appending(component: "file.swift"), bytes: "")
 
         let bazURL = URL("https://example.com/baz")
-        let bazPackageReference = PackageReference(identity: PackageIdentity(url: bazURL), kind: .remoteSourceControl(bazURL))
-        let bazContainer = MockPackageContainer(package: bazPackageReference, dependencies: ["1.0.0": []], fileSystem: customFS, customRetrievalPath: .root)
+        let bazPackageReference = PackageReference(
+            identity: PackageIdentity(url: bazURL),
+            kind: .remoteSourceControl(bazURL)
+        )
+        let bazContainer = MockPackageContainer(
+            package: bazPackageReference,
+            dependencies: ["1.0.0": []],
+            fileSystem: customFS,
+            customRetrievalPath: .root
+        )
 
         let fooPath = AbsolutePath(path: "/tmp/ws/Foo")
         let fooPackageReference = PackageReference(identity: PackageIdentity(path: fooPath), kind: .root(fooPath))
@@ -12360,8 +13145,9 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(
                             name: "MyTarget",
                             dependencies: [
-                                .product(name: "Foo", package: "org.foo")
-                            ]),
+                                .product(name: "Foo", package: "org.foo"),
+                            ]
+                        ),
                     ],
                     dependencies: [
                         .registry(identity: "org.foo", requirement: .upToNextMajor(from: "1.0.0")),
@@ -12379,7 +13165,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Foo", targets: ["Foo"]),
                     ],
                     versions: ["1.0.0"]
-                )
+                ),
             ],
             registryClient: registryClient
         )
@@ -12405,8 +13191,9 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(
                             name: "MyTarget",
                             dependencies: [
-                                .product(name: "Foo", package: "org.foo")
-                            ]),
+                                .product(name: "Foo", package: "org.foo"),
+                            ]
+                        ),
                     ],
                     dependencies: [
                         .registry(identity: "org.foo", requirement: .upToNextMajor(from: "1.0.0")),
@@ -12424,7 +13211,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Foo", targets: ["Foo"]),
                     ],
                     versions: ["1.0.0"]
-                )
+                ),
             ]
         )
 
@@ -12432,7 +13219,7 @@ final class WorkspaceTests: XCTestCase {
             let registryClient = try makeRegistryClient(
                 packageIdentity: .plain("org.foo"),
                 packageVersion: "1.0.0",
-                releasesRequestHandler: { _, _ , completion in
+                releasesRequestHandler: { _, _, completion in
                     completion(.failure(StringError("boom")))
                 },
                 fileSystem: fs
@@ -12442,7 +13229,10 @@ final class WorkspaceTests: XCTestCase {
             workspace.registryClient = registryClient
             workspace.checkPackageGraphFailure(roots: ["MyPackage"]) { diagnostics in
                 testDiagnostics(diagnostics) { result in
-                    result.check(diagnostic: .equal("failed fetching 'org.foo' releases list from 'http://localhost': boom"), severity: .error)
+                    result.check(
+                        diagnostic: .equal("failed fetching 'org.foo' releases list from 'http://localhost': boom"),
+                        severity: .error
+                    )
                 }
             }
         }
@@ -12451,7 +13241,7 @@ final class WorkspaceTests: XCTestCase {
             let registryClient = try makeRegistryClient(
                 packageIdentity: .plain("org.foo"),
                 packageVersion: "1.0.0",
-                releasesRequestHandler: { _, _ , completion in
+                releasesRequestHandler: { _, _, completion in
                     completion(.success(.serverError()))
                 },
                 fileSystem: fs
@@ -12461,7 +13251,12 @@ final class WorkspaceTests: XCTestCase {
             workspace.registryClient = registryClient
             workspace.checkPackageGraphFailure(roots: ["MyPackage"]) { diagnostics in
                 testDiagnostics(diagnostics) { result in
-                    result.check(diagnostic: .equal("failed fetching 'org.foo' releases list from 'http://localhost': server error 500: Internal Server Error"), severity: .error)
+                    result.check(
+                        diagnostic: .equal(
+                            "failed fetching 'org.foo' releases list from 'http://localhost': server error 500: Internal Server Error"
+                        ),
+                        severity: .error
+                    )
                 }
             }
         }
@@ -12481,8 +13276,9 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(
                             name: "MyTarget",
                             dependencies: [
-                                .product(name: "Foo", package: "org.foo")
-                            ]),
+                                .product(name: "Foo", package: "org.foo"),
+                            ]
+                        ),
                     ],
                     dependencies: [
                         .registry(identity: "org.foo", requirement: .upToNextMajor(from: "1.0.0")),
@@ -12500,7 +13296,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Foo", targets: ["Foo"]),
                     ],
                     versions: ["1.0.0"]
-                )
+                ),
             ]
         )
 
@@ -12508,7 +13304,7 @@ final class WorkspaceTests: XCTestCase {
             let registryClient = try makeRegistryClient(
                 packageIdentity: .plain("org.foo"),
                 packageVersion: "1.0.0",
-                versionMetadataRequestHandler: { _, _ , completion in
+                versionMetadataRequestHandler: { _, _, completion in
                     completion(.failure(StringError("boom")))
                 },
                 fileSystem: fs
@@ -12518,7 +13314,12 @@ final class WorkspaceTests: XCTestCase {
             workspace.registryClient = registryClient
             workspace.checkPackageGraphFailure(roots: ["MyPackage"]) { diagnostics in
                 testDiagnostics(diagnostics) { result in
-                    result.check(diagnostic: .equal("failed fetching 'org.foo@1.0.0' release information from 'http://localhost': boom"), severity: .error)
+                    result.check(
+                        diagnostic: .equal(
+                            "failed fetching 'org.foo@1.0.0' release information from 'http://localhost': boom"
+                        ),
+                        severity: .error
+                    )
                 }
             }
         }
@@ -12527,7 +13328,7 @@ final class WorkspaceTests: XCTestCase {
             let registryClient = try makeRegistryClient(
                 packageIdentity: .plain("org.foo"),
                 packageVersion: "1.0.0",
-                versionMetadataRequestHandler: { _, _ , completion in
+                versionMetadataRequestHandler: { _, _, completion in
                     completion(.success(.serverError()))
                 },
                 fileSystem: fs
@@ -12537,7 +13338,12 @@ final class WorkspaceTests: XCTestCase {
             workspace.registryClient = registryClient
             workspace.checkPackageGraphFailure(roots: ["MyPackage"]) { diagnostics in
                 testDiagnostics(diagnostics) { result in
-                    result.check(diagnostic: .equal("failed fetching 'org.foo@1.0.0' release information from 'http://localhost': server error 500: Internal Server Error"), severity: .error)
+                    result.check(
+                        diagnostic: .equal(
+                            "failed fetching 'org.foo@1.0.0' release information from 'http://localhost': server error 500: Internal Server Error"
+                        ),
+                        severity: .error
+                    )
                 }
             }
         }
@@ -12557,8 +13363,9 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(
                             name: "MyTarget",
                             dependencies: [
-                                .product(name: "Foo", package: "org.foo")
-                            ]),
+                                .product(name: "Foo", package: "org.foo"),
+                            ]
+                        ),
                     ],
                     dependencies: [
                         .registry(identity: "org.foo", requirement: .upToNextMajor(from: "1.0.0")),
@@ -12576,7 +13383,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Foo", targets: ["Foo"]),
                     ],
                     versions: ["1.0.0"]
-                )
+                ),
             ]
         )
 
@@ -12584,7 +13391,7 @@ final class WorkspaceTests: XCTestCase {
             let registryClient = try makeRegistryClient(
                 packageIdentity: .plain("org.foo"),
                 packageVersion: "1.0.0",
-                manifestRequestHandler: { _, _ , completion in
+                manifestRequestHandler: { _, _, completion in
                     completion(.failure(StringError("boom")))
                 },
                 fileSystem: fs
@@ -12594,7 +13401,10 @@ final class WorkspaceTests: XCTestCase {
             workspace.registryClient = registryClient
             workspace.checkPackageGraphFailure(roots: ["MyPackage"]) { diagnostics in
                 testDiagnostics(diagnostics) { result in
-                    result.check(diagnostic: .equal("failed retrieving 'org.foo@1.0.0' manifest from 'http://localhost': boom"), severity: .error)
+                    result.check(
+                        diagnostic: .equal("failed retrieving 'org.foo@1.0.0' manifest from 'http://localhost': boom"),
+                        severity: .error
+                    )
                 }
             }
         }
@@ -12603,7 +13413,7 @@ final class WorkspaceTests: XCTestCase {
             let registryClient = try makeRegistryClient(
                 packageIdentity: .plain("org.foo"),
                 packageVersion: "1.0.0",
-                manifestRequestHandler: { _, _ , completion in
+                manifestRequestHandler: { _, _, completion in
                     completion(.success(.serverError()))
                 },
                 fileSystem: fs
@@ -12613,7 +13423,12 @@ final class WorkspaceTests: XCTestCase {
             workspace.registryClient = registryClient
             workspace.checkPackageGraphFailure(roots: ["MyPackage"]) { diagnostics in
                 testDiagnostics(diagnostics) { result in
-                    result.check(diagnostic: .equal("failed retrieving 'org.foo@1.0.0' manifest from 'http://localhost': server error 500: Internal Server Error"), severity: .error)
+                    result.check(
+                        diagnostic: .equal(
+                            "failed retrieving 'org.foo@1.0.0' manifest from 'http://localhost': server error 500: Internal Server Error"
+                        ),
+                        severity: .error
+                    )
                 }
             }
         }
@@ -12633,8 +13448,9 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(
                             name: "MyTarget",
                             dependencies: [
-                                .product(name: "Foo", package: "org.foo")
-                            ]),
+                                .product(name: "Foo", package: "org.foo"),
+                            ]
+                        ),
                     ],
                     dependencies: [
                         .registry(identity: "org.foo", requirement: .upToNextMajor(from: "1.0.0")),
@@ -12652,7 +13468,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Foo", targets: ["Foo"]),
                     ],
                     versions: ["1.0.0"]
-                )
+                ),
             ]
         )
 
@@ -12660,7 +13476,7 @@ final class WorkspaceTests: XCTestCase {
             let registryClient = try makeRegistryClient(
                 packageIdentity: .plain("org.foo"),
                 packageVersion: "1.0.0",
-                downloadArchiveRequestHandler: { _, _ , completion in
+                downloadArchiveRequestHandler: { _, _, completion in
                     completion(.failure(StringError("boom")))
                 },
                 fileSystem: fs
@@ -12670,7 +13486,12 @@ final class WorkspaceTests: XCTestCase {
             workspace.registryClient = registryClient
             workspace.checkPackageGraphFailure(roots: ["MyPackage"]) { diagnostics in
                 testDiagnostics(diagnostics) { result in
-                    result.check(diagnostic: .equal("failed downloading 'org.foo@1.0.0' source archive from 'http://localhost': boom"), severity: .error)
+                    result.check(
+                        diagnostic: .equal(
+                            "failed downloading 'org.foo@1.0.0' source archive from 'http://localhost': boom"
+                        ),
+                        severity: .error
+                    )
                 }
             }
         }
@@ -12679,7 +13500,7 @@ final class WorkspaceTests: XCTestCase {
             let registryClient = try makeRegistryClient(
                 packageIdentity: .plain("org.foo"),
                 packageVersion: "1.0.0",
-                downloadArchiveRequestHandler: { _, _ , completion in
+                downloadArchiveRequestHandler: { _, _, completion in
                     completion(.success(.serverError()))
                 },
                 fileSystem: fs
@@ -12689,7 +13510,12 @@ final class WorkspaceTests: XCTestCase {
             workspace.registryClient = registryClient
             workspace.checkPackageGraphFailure(roots: ["MyPackage"]) { diagnostics in
                 testDiagnostics(diagnostics) { result in
-                    result.check(diagnostic: .equal("failed downloading 'org.foo@1.0.0' source archive from 'http://localhost': server error 500: Internal Server Error"), severity: .error)
+                    result.check(
+                        diagnostic: .equal(
+                            "failed downloading 'org.foo@1.0.0' source archive from 'http://localhost': server error 500: Internal Server Error"
+                        ),
+                        severity: .error
+                    )
                 }
             }
         }
@@ -12702,7 +13528,7 @@ final class WorkspaceTests: XCTestCase {
         let registryClient = try makeRegistryClient(
             packageIdentity: .plain("org.foo"),
             packageVersion: "1.0.0",
-            archiver: MockArchiver(handler: { archiver, from, to, completion in
+            archiver: MockArchiver(handler: { _, _, _, completion in
                 completion(.failure(StringError("boom")))
             }),
             fileSystem: fs
@@ -12718,8 +13544,9 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(
                             name: "MyTarget",
                             dependencies: [
-                                .product(name: "Foo", package: "org.foo")
-                            ]),
+                                .product(name: "Foo", package: "org.foo"),
+                            ]
+                        ),
                     ],
                     dependencies: [
                         .registry(identity: "org.foo", requirement: .upToNextMajor(from: "1.0.0")),
@@ -12737,7 +13564,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Foo", targets: ["Foo"]),
                     ],
                     versions: ["1.0.0"]
-                )
+                ),
             ],
             registryClient: registryClient
         )
@@ -12746,7 +13573,12 @@ final class WorkspaceTests: XCTestCase {
         workspace.registryClient = registryClient
         workspace.checkPackageGraphFailure(roots: ["MyPackage"]) { diagnostics in
             testDiagnostics(diagnostics) { result in
-                result.check(diagnostic: .regex("failed extracting '.*[\\\\/]registry[\\\\/]downloads[\\\\/]org[\\\\/]foo[\\\\/]1.0.0.zip' to '.*[\\\\/]registry[\\\\/]downloads[\\\\/]org[\\\\/]foo[\\\\/]1.0.0': boom"), severity: .error)
+                result.check(
+                    diagnostic: .regex(
+                        "failed extracting '.*[\\\\/]registry[\\\\/]downloads[\\\\/]org[\\\\/]foo[\\\\/]1.0.0.zip' to '.*[\\\\/]registry[\\\\/]downloads[\\\\/]org[\\\\/]foo[\\\\/]1.0.0': boom"
+                    ),
+                    severity: .error
+                )
             }
         }
     }
@@ -12780,14 +13612,15 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(
                             name: "MyTarget",
                             dependencies: [
-                                .product(name: "Foo", package: "org.foo")
-                            ])
+                                .product(name: "Foo", package: "org.foo"),
+                            ]
+                        ),
                     ],
                     products: [
                         MockProduct(name: "MyProduct", targets: ["MyTarget"]),
                     ],
                     dependencies: [
-                        .registry(identity: "org.foo", requirement: .upToNextMajor(from: "1.0.0"))
+                        .registry(identity: "org.foo", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -12799,18 +13632,17 @@ final class WorkspaceTests: XCTestCase {
         let defaultLocations = try Workspace.Location(forRootPackage: sandbox, fileSystem: fs)
         let packagePath = defaultLocations.registryDownloadDirectory.appending(components: ["org", "foo", "1.5.1"])
         workspace.manifestLoader.manifests[.init(url: "org.foo", version: "1.5.1")] =
-            Manifest(
+            Manifest.createManifest(
                 displayName: "Foo",
                 path: packagePath.appending(component: Manifest.filename),
                 packageKind: .registry("org.foo"),
                 packageLocation: "org.foo",
-                platforms: [],
                 toolsVersion: .current,
                 products: [
-                    try .init(name: "Foo", type: .library(.automatic), targets: ["Foo"])
+                    try .init(name: "Foo", type: .library(.automatic), targets: ["Foo"]),
                 ],
                 targets: [
-                    try .init(name: "Foo")
+                    try .init(name: "Foo"),
                 ]
             )
 
@@ -12864,23 +13696,23 @@ final class WorkspaceTests: XCTestCase {
             return configuration
         }()
 
-        let releasesRequestHandler = releasesRequestHandler ?? { request, _ , completion in
+        let releasesRequestHandler = releasesRequestHandler ?? { _, _, completion in
             let metadata = RegistryClient.Serialization.PackageMetadata(
-                releases: [packageVersion.description:  .init(url: .none, problem: .none)]
+                releases: [packageVersion.description: .init(url: .none, problem: .none)]
             )
             completion(.success(
                 HTTPClientResponse(
                     statusCode: 200,
                     headers: [
                         "Content-Version": "1",
-                        "Content-Type": "application/json"
+                        "Content-Type": "application/json",
                     ],
                     body: try! jsonEncoder.encode(metadata)
                 )
             ))
         }
 
-        let versionMetadataRequestHandler = versionMetadataRequestHandler ?? { request, _ , completion in
+        let versionMetadataRequestHandler = versionMetadataRequestHandler ?? { _, _, completion in
             let metadata = RegistryClient.Serialization.VersionMetadata(
                 id: packageIdentity.description,
                 version: packageVersion.description,
@@ -12890,7 +13722,7 @@ final class WorkspaceTests: XCTestCase {
                         type: "application/zip",
                         checksum: "",
                         signing: nil
-                    )
+                    ),
                 ],
                 metadata: .init(
                     description: "package \(identity) description",
@@ -12903,27 +13735,27 @@ final class WorkspaceTests: XCTestCase {
                     statusCode: 200,
                     headers: [
                         "Content-Version": "1",
-                        "Content-Type": "application/json"
+                        "Content-Type": "application/json",
                     ],
                     body: try! jsonEncoder.encode(metadata)
                 )
             ))
         }
 
-        let manifestRequestHandler = manifestRequestHandler ?? { request, _ , completion in
+        let manifestRequestHandler = manifestRequestHandler ?? { _, _, completion in
             completion(.success(
                 HTTPClientResponse(
                     statusCode: 200,
                     headers: [
                         "Content-Version": "1",
-                        "Content-Type": "text/x-swift"
+                        "Content-Type": "text/x-swift",
                     ],
                     body: "// swift-tools-version:\(ToolsVersion.current)".data(using: .utf8)
                 )
             ))
         }
 
-        let downloadArchiveRequestHandler = downloadArchiveRequestHandler ?? { request, _ , completion in
+        let downloadArchiveRequestHandler = downloadArchiveRequestHandler ?? { request, _, completion in
             switch request.kind {
             case .download(let fileSystem, let destination):
                 // creates a dummy zipfile which is required by the archiver step
@@ -12938,14 +13770,14 @@ final class WorkspaceTests: XCTestCase {
                     statusCode: 200,
                     headers: [
                         "Content-Version": "1",
-                        "Content-Type": "application/zip"
+                        "Content-Type": "application/zip",
                     ],
                     body: "".data(using: .utf8)
                 )
             ))
         }
 
-        let archiver = archiver ?? MockArchiver(handler: { archiver, from, to, completion in
+        let archiver = archiver ?? MockArchiver(handler: { _, _, to, completion in
             do {
                 let packagePath = to.appending(component: "top")
                 try fileSystem.createDirectory(packagePath, recursive: true)
@@ -12956,8 +13788,14 @@ final class WorkspaceTests: XCTestCase {
                     fileSystem: fileSystem
                 )
                 for target in targets {
-                    try fileSystem.createDirectory(packagePath.appending(components: "Sources", target), recursive: true)
-                    try fileSystem.writeFileContents(packagePath.appending(components: ["Sources", target, "file.swift"]), bytes: [])
+                    try fileSystem.createDirectory(
+                        packagePath.appending(components: "Sources", target),
+                        recursive: true
+                    )
+                    try fileSystem.writeFileContents(
+                        packagePath.appending(components: ["Sources", target, "file.swift"]),
+                        bytes: []
+                    )
                 }
                 completion(.success(()))
             } catch {
@@ -12974,7 +13812,7 @@ final class WorkspaceTests: XCTestCase {
             signingEntityStorage: signingEntityStorage,
             signingEntityCheckingMode: signingEntityCheckingMode,
             authorizationProvider: authorizationProvider,
-            customHTTPClient: LegacyHTTPClient(configuration: .init(), handler: { request, progress , completion in
+            customHTTPClient: LegacyHTTPClient(configuration: .init(), handler: { request, progress, completion in
                 switch request.url {
                 // request to get package releases
                 case "\(configuration.defaultRegistry!.url)/\(identity.scope)/\(identity.name)":
@@ -13003,19 +13841,19 @@ func createDummyXCFramework(fileSystem: FileSystem, path: AbsolutePath, name: St
     try fileSystem.writeFileContents(
         path.appending(component: "info.plist"),
         string: """
-            <?xml version="1.0" encoding="UTF-8"?>
-            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-            <plist version="1.0">
-            <dict>
-                <key>AvailableLibraries</key>
-                <array></array>
-                <key>CFBundlePackageType</key>
-                <string>XFWK</string>
-                <key>XCFrameworkFormatVersion</key>
-                <string>1.0</string>
-            </dict>
-            </plist>
-            """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>AvailableLibraries</key>
+            <array></array>
+            <key>CFBundlePackageType</key>
+            <string>XFWK</string>
+            <key>XCFrameworkFormatVersion</key>
+            <string>1.0</string>
+        </dict>
+        </plist>
+        """
     )
 }
 

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -43,7 +43,7 @@ class PIFBuilderTests: XCTestCase {
                 fileSystem: fs,
                 manifests: [
                     Manifest.createLocalSourceControlManifest(
-                        name: "B",
+                        displayName: "B",
                         path: .init(path: "/B"),
                         toolsVersion: .v5_2,
                         products: [
@@ -55,7 +55,7 @@ class PIFBuilderTests: XCTestCase {
                             .init(name: "B1", dependencies: ["B2"]),
                         ]),
                     Manifest.createRootManifest(
-                        name: "A",
+                        displayName: "A",
                         path: .init(path: "/A"),
                         toolsVersion: .v5_2,
                         dependencies: [
@@ -114,7 +114,7 @@ class PIFBuilderTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createManifest(
-                    name: "Foo",
+                    displayName: "Foo",
                     path: .init(path: "/Foo"),
                     packageKind: .root(.init(path: "/Foo")),
                     defaultLocalization: "fr",
@@ -127,7 +127,7 @@ class PIFBuilderTests: XCTestCase {
                         .init(name: "FooTests", type: .test),
                     ]),
                 Manifest.createLocalSourceControlManifest(
-                    name: "Bar",
+                    displayName: "Bar",
                     path: .init(path: "/Bar"),
                     platforms: [
                         PlatformDescription(name: "macos", version: "10.14"),
@@ -397,7 +397,7 @@ class PIFBuilderTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Foo",
+                    displayName: "Foo",
                     path: .init(path: "/Foo"),
                     toolsVersion: .v5_2,
                     swiftLanguageVersions: [.v4_2, .v5],
@@ -419,7 +419,7 @@ class PIFBuilderTests: XCTestCase {
                         ])
                     ]),
                 Manifest.createLocalSourceControlManifest(
-                    name: "Bar",
+                    displayName: "Bar",
                     path: .init(path: "/Bar"),
                     toolsVersion: .v4_2,
                     cLanguageStandard: "c11",
@@ -731,7 +731,7 @@ class PIFBuilderTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Foo",
+                    displayName: "Foo",
                     path: .init(path: "/Foo"),
                     toolsVersion: .v5_2,
                     swiftLanguageVersions: [.v4_2, .v5],
@@ -753,7 +753,7 @@ class PIFBuilderTests: XCTestCase {
                         ])
                     ]),
                 Manifest.createLocalSourceControlManifest(
-                    name: "Bar",
+                    displayName: "Bar",
                     path: .init(path: "/Bar"),
                     toolsVersion: .v4_2,
                     cLanguageStandard: "c11",
@@ -979,7 +979,7 @@ class PIFBuilderTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Foo",
+                    displayName: "Foo",
                     path: .init(path: "/Foo"),
                     toolsVersion: .v5_2,
                     swiftLanguageVersions: [.v4_2, .v5],
@@ -998,7 +998,7 @@ class PIFBuilderTests: XCTestCase {
                         .init(name: "SystemLib", type: .system, pkgConfig: "Foo"),
                     ]),
                 Manifest.createLocalSourceControlManifest(
-                    name: "Bar",
+                    displayName: "Bar",
                     path: .init(path: "/Bar"),
                     toolsVersion: .v4_2,
                     cLanguageStandard: "c11",
@@ -1181,7 +1181,7 @@ class PIFBuilderTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Foo",
+                    displayName: "Foo",
                     path: .init(path: "/Foo"),
                     toolsVersion: .v5_2,
                     cxxLanguageStandard: "c++14",
@@ -1197,7 +1197,7 @@ class PIFBuilderTests: XCTestCase {
                         .init(name: "SystemLib", type: .system, pkgConfig: "Foo"),
                     ]),
                 Manifest.createLocalSourceControlManifest(
-                    name: "Bar",
+                    displayName: "Bar",
                     path: .init(path: "/Bar"),
                     toolsVersion: .v4_2,
                     cLanguageStandard: "c11",
@@ -1479,7 +1479,7 @@ class PIFBuilderTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "App",
+                    displayName: "App",
                     path: .init(path: "/App"),
                     dependencies: [
                         .localSourceControl(path: .init(path: "/Bar"), requirement: .branch("main")),
@@ -1492,7 +1492,7 @@ class PIFBuilderTests: XCTestCase {
                         ]),
                     ]),
                 Manifest.createLocalSourceControlManifest(
-                    name: "Bar",
+                    displayName: "Bar",
                     path: .init(path: "/Bar"),
                     products: [
                         .init(name: "BarLib", type: .library(.dynamic), targets: ["Lib"]),
@@ -1702,7 +1702,7 @@ class PIFBuilderTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Bar",
+                    displayName: "Bar",
                     path: .init(path: "/Bar"),
                     toolsVersion: .v4_2,
                     cLanguageStandard: "c11",
@@ -1755,7 +1755,7 @@ class PIFBuilderTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createManifest(
-                    name: "Bar",
+                    displayName: "Bar",
                     path: .init(path: "/Bar"),
                     packageKind: .root(.init(path: "/Bar")),
                     toolsVersion: .v4_2,
@@ -1813,7 +1813,7 @@ class PIFBuilderTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Foo",
+                    displayName: "Foo",
                     path: .init(path: "/Foo"),
                     toolsVersion: .v5_2,
                     cxxLanguageStandard: "c++14",
@@ -1932,7 +1932,7 @@ class PIFBuilderTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Foo",
+                    displayName: "Foo",
                     path: .init(path: "/Foo"),
                     toolsVersion: .v5_3,
                     products: [
@@ -2006,7 +2006,7 @@ class PIFBuilderTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Foo",
+                    displayName: "Foo",
                     path: .init(path: "/Foo"),
                     toolsVersion: .v5_3,
                     products: [
@@ -2222,7 +2222,7 @@ class PIFBuilderTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Foo",
+                    displayName: "Foo",
                     path: .init(path: "/Foo"),
                     toolsVersion: .v5,
                     products: [
@@ -2436,7 +2436,7 @@ class PIFBuilderTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createManifest(
-                    name: "Foo",
+                    displayName: "Foo",
                     path: .init(path: "/Foo"),
                     packageKind: .root(.init(path: "/Foo")),
                     toolsVersion: .v5_3,
@@ -2505,7 +2505,7 @@ class PIFBuilderTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "Foo",
+                    displayName: "Foo",
                     path: .init(path: "/Foo"),
                     platforms: [
                         PlatformDescription(name: "macos", version: "10.14", options: ["best"]),
@@ -2555,7 +2555,7 @@ class PIFBuilderTests: XCTestCase {
             fileSystem: fs,
             manifests: [
                 Manifest.createRootManifest(
-                    name: "MyLib",
+                    displayName: "MyLib",
                     path: .init(path: "/MyLib"),
                     toolsVersion: .v5,
                     products: [


### PR DESCRIPTION
motivation: safer code

changes:
* remove nil defaults from manfiest constructor
* update tests to use the test oriented helpers that set the defaults for testing
