### PR TITLE
serialize registry metadata and cache it so it can be exposed to clients

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -233,7 +233,8 @@ let package = Package(
             name: "PackageLoading",
             dependencies: [
                 "Basics",
-                "PackageModel"
+                "PackageModel",
+                "PackageSigning"
             ],
             exclude: ["CMakeLists.txt", "README.md"]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -233,8 +233,7 @@ let package = Package(
             name: "PackageLoading",
             dependencies: [
                 "Basics",
-                "PackageModel",
-                "PackageSigning"
+                "PackageModel"
             ],
             exclude: ["CMakeLists.txt", "README.md"]
         ),

--- a/Sources/PackageGraph/ResolvedPackage.swift
+++ b/Sources/PackageGraph/ResolvedPackage.swift
@@ -58,7 +58,7 @@ public final class ResolvedPackage {
         dependencies: [ResolvedPackage],
         targets: [ResolvedTarget],
         products: [ResolvedProduct],
-        registryMetadata: RegistryReleaseMetadata? = nil
+        registryMetadata: RegistryReleaseMetadata?
     ) {
         self.underlyingPackage = package
         self.defaultLocalization = defaultLocalization

--- a/Sources/PackageLoading/CMakeLists.txt
+++ b/Sources/PackageLoading/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(PackageLoading
   ManifestJSONParser.swift
   Platform.swift
   PkgConfig.swift
+  RegistryReleaseMetadataSerialization.swift
   Target+PkgConfig.swift
   TargetSourcesBuilder.swift
   ToolsVersionParser.swift)
@@ -24,7 +25,7 @@ target_link_libraries(PackageLoading PUBLIC
   TSCBasic
   Basics
   PackageModel
-  SourceControl
+  PackageSigning
   TSCUtility)
 target_link_libraries(PackageLoading PUBLIC
   $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)

--- a/Sources/PackageLoading/CMakeLists.txt
+++ b/Sources/PackageLoading/CMakeLists.txt
@@ -25,7 +25,6 @@ target_link_libraries(PackageLoading PUBLIC
   TSCBasic
   Basics
   PackageModel
-  PackageSigning
   TSCUtility)
 target_link_libraries(PackageLoading PUBLIC
   $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)

--- a/Sources/PackageLoading/RegistryReleaseMetadataSerialization.swift
+++ b/Sources/PackageLoading/RegistryReleaseMetadataSerialization.swift
@@ -1,0 +1,173 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+@_implementationOnly import Foundation
+import PackageModel
+import PackageSigning
+import TSCBasic
+
+public enum RegistryReleaseMetadataStorage {
+    public static let fileName = ".registry-metadata"
+
+    private static let encoder = JSONEncoder.makeWithDefaults()
+    private static let decoder = JSONDecoder.makeWithDefaults()
+
+    public static func save(_ metadata: RegistryReleaseMetadata, to path: AbsolutePath, fileSystem: FileSystem) throws {
+        let codableMetadata = CodableRegistryReleaseMetadata(metadata)
+        let data = try Self.encoder.encode(codableMetadata)
+        try fileSystem.writeFileContents(path, data: data)
+    }
+
+    public static func load(from path: AbsolutePath, fileSystem: FileSystem) throws -> RegistryReleaseMetadata {
+        let codableMetadata = try Self.decoder.decode(
+            path: path,
+            fileSystem: fileSystem,
+            as: CodableRegistryReleaseMetadata.self
+        )
+        return try RegistryReleaseMetadata(codableMetadata)
+    }
+}
+
+private struct CodableRegistryReleaseMetadata: Codable {
+    public let registry: URL
+    public let signature: Signature?
+    public let author: Author?
+    public let description: String?
+    public let licenseURL: URL?
+    public let readmeURL: URL?
+    public let scmRepositoryURLs: [URL]?
+
+    init(_ seed: RegistryReleaseMetadata) {
+        switch seed.source {
+        case .registry(let url):
+            self.registry = url
+        }
+        self.signature = seed.signature.map { signature in
+            .init(
+                signedBy: signature.signedBy.flatMap {
+                    switch $0 {
+                    case .recognized(let type, let commonName, let organization, let identity):
+                        return .recognized(
+                            type: type,
+                            commonName: commonName,
+                            organization: organization,
+                            identity: identity
+                        )
+                    case .unrecognized(let commonName, let organization):
+                        return .unrecognized(commonName: commonName, organization: organization)
+                    }
+                },
+                format: signature.format,
+                base64: Data(signature.value).base64EncodedString()
+            )
+        }
+        self.author = seed.metadata.author.map {
+            .init(
+                name: $0.name,
+                emailAddress: $0.emailAddress,
+                description: $0.description,
+                url: $0.url,
+                organization: $0.organization.map {
+                    .init(
+                        name: $0.name,
+                        emailAddress: $0.emailAddress,
+                        description: $0.description,
+                        url: $0.url
+                    )
+                }
+            )
+        }
+        self.description = seed.metadata.description
+        self.licenseURL = seed.metadata.licenseURL
+        self.readmeURL = seed.metadata.readmeURL
+        self.scmRepositoryURLs = seed.metadata.scmRepositoryURLs
+    }
+
+    public struct Signature: Codable {
+        let signedBy: SigningEntity?
+        let format: String
+        let base64: String
+    }
+
+    public enum SigningEntity: Codable {
+        case recognized(type: String?, commonName: String?, organization: String?, identity: String?)
+        case unrecognized(commonName: String?, organization: String?)
+    }
+
+    public struct Author: Codable {
+        let name: String
+        let emailAddress: String?
+        let description: String?
+        let url: URL?
+        let organization: Organization?
+    }
+
+    struct Organization: Codable {
+        let name: String
+        let emailAddress: String?
+        let description: String?
+        let url: URL?
+    }
+}
+
+extension RegistryReleaseMetadata {
+    fileprivate init(_ seed: CodableRegistryReleaseMetadata) throws {
+        self.init(
+            source: .registry(seed.registry),
+            metadata: .init(
+                author: seed.author.flatMap {
+                    .init(
+                        name: $0.name,
+                        emailAddress: $0.emailAddress,
+                        description: $0.description,
+                        url: $0.url,
+                        organization: $0.organization.flatMap {
+                            .init(
+                                name: $0.name,
+                                emailAddress: $0.emailAddress,
+                                description: $0.description,
+                                url: $0.url
+                            )
+                        }
+                    )
+                },
+                description: seed.description,
+                licenseURL: seed.licenseURL,
+                readmeURL: seed.readmeURL,
+                scmRepositoryURLs: seed.scmRepositoryURLs
+            ),
+            signature: try seed.signature.flatMap { signature in
+                guard let signatureData = Data(base64Encoded: signature.base64) else {
+                    throw StringError("invalid base64 signature")
+                }
+                return .init(
+                    signedBy: signature.signedBy.flatMap {
+                        switch $0 {
+                        case .recognized(let type, let commonName, let organization, let identity):
+                            return .recognized(
+                                type: type,
+                                commonName: commonName,
+                                organization: organization,
+                                identity: identity
+                            )
+                        case .unrecognized(let commonName, let organization):
+                            return .unrecognized(commonName: commonName, organization: organization)
+                        }
+                    },
+                    format: signature.format,
+                    value: Array(signatureData)
+                )
+            }
+        )
+    }
+}

--- a/Sources/PackageLoading/RegistryReleaseMetadataSerialization.swift
+++ b/Sources/PackageLoading/RegistryReleaseMetadataSerialization.swift
@@ -13,7 +13,6 @@
 import Basics
 @_implementationOnly import Foundation
 import PackageModel
-import PackageSigning
 import TSCBasic
 
 public enum RegistryReleaseMetadataStorage {
@@ -100,7 +99,7 @@ private struct CodableRegistryReleaseMetadata: Codable {
     }
 
     public enum SigningEntity: Codable {
-        case recognized(type: String?, commonName: String?, organization: String?, identity: String?)
+        case recognized(type: String, commonName: String?, organization: String?, identity: String?)
         case unrecognized(commonName: String?, organization: String?)
     }
 

--- a/Sources/PackageModel/RegistryReleaseMetadata.swift
+++ b/Sources/PackageModel/RegistryReleaseMetadata.swift
@@ -106,7 +106,7 @@ public struct RegistryReleaseMetadata {
     }
 
     public enum SigningEntity: Codable {
-        case recognized(type: String?, commonName: String?, organization: String?, identity: String?)
+        case recognized(type: String, commonName: String?, organization: String?, identity: String?)
         case unrecognized(commonName: String?, organization: String?)
     }
     

--- a/Sources/PackageModel/RegistryReleaseMetadata.swift
+++ b/Sources/PackageModel/RegistryReleaseMetadata.swift
@@ -13,22 +13,64 @@
 import struct Foundation.URL
 import struct TSCUtility.Version
 
+
 public struct RegistryReleaseMetadata {
-    /// Information from the signing certificate.
-    public enum Certificate {
-        case trusted(commonName: String, organization: String, identity: String?)
-        case untrusted(commonName: String, organization: String)
-        case none
+    public let source: Source
+    public let metadata: Metadata
+    public let signature: RegistrySignature?
+
+    public init(
+        source: RegistryReleaseMetadata.Source,
+        metadata: RegistryReleaseMetadata.Metadata,
+        signature: RegistrySignature?
+    ) {
+        self.source = source
+        self.metadata = metadata
+        self.signature = signature
     }
 
     /// Metadata of the given release, provided by the registry.
     public struct Metadata {
+        public let author: Author?
+        public let description: String?
+        public let licenseURL: URL?
+        public let readmeURL: URL?
+        public let scmRepositoryURLs: [URL]?
+
+        public init(
+            author: RegistryReleaseMetadata.Metadata.Author? = nil,
+            description: String? = nil,
+            licenseURL: URL? = nil,
+            readmeURL: URL? = nil,
+            scmRepositoryURLs: [URL]?
+        ) {
+            self.author = author
+            self.description = description
+            self.licenseURL = licenseURL
+            self.readmeURL = readmeURL
+            self.scmRepositoryURLs = scmRepositoryURLs
+        }
+
         public struct Author {
             public let name: String
             public let emailAddress: String?
             public let description: String?
             public let url: URL?
-            public let organization: Organization
+            public let organization: Organization?
+
+            public init(
+                name: String,
+                emailAddress: String? = nil,
+                description: String? = nil,
+                url: URL? = nil,
+                organization: RegistryReleaseMetadata.Metadata.Organization?
+            ) {
+                self.name = name
+                self.emailAddress = emailAddress
+                self.description = description
+                self.url = url
+                self.organization = organization
+            }
         }
 
         public struct Organization {
@@ -36,22 +78,40 @@ public struct RegistryReleaseMetadata {
             public let emailAddress: String?
             public let description: String?
             public let url: URL?
-        }
 
-        public let author: Author?
-        public let description: String?
-        public let licenseURL: URL?
-        public let readmeURL: URL?
-        public let scmRepositoryURLs: [URL]
-        public let version: Version
+            public init(name: String, emailAddress: String? = nil, description: String? = nil, url: URL? = nil) {
+                self.name = name
+                self.emailAddress = emailAddress
+                self.description = description
+                self.url = url
+            }
+        }
     }
 
+    /// Information from the signing certificate.
+    public struct RegistrySignature: Codable {
+        public let signedBy: SigningEntity?
+        public let format: String
+        public let value: [UInt8]
+
+        public init(
+            signedBy: SigningEntity?,
+            format: String,
+            value: [UInt8]
+        ) {
+            self.signedBy = signedBy
+            self.format = format
+            self.value = value
+        }
+    }
+
+    public enum SigningEntity: Codable {
+        case recognized(type: String?, commonName: String?, organization: String?, identity: String?)
+        case unrecognized(commonName: String?, organization: String?)
+    }
+    
     /// Information about the source of the release.
-    public enum Source {
+    public enum Source: Equatable {
         case registry(URL)
     }
-
-    public let certificate: Certificate
-    public let metadata: Metadata
-    public let source: Source
 }

--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -1920,14 +1920,15 @@ extension RegistryReleaseMetadata {
                 }
                 return RegistrySignature(
                     signedBy: signingEntity.flatMap {
-                        if $0.isRecognized {
+                        switch $0.type {
+                        case .adp:
                             return .recognized(
-                                type: $0.type?.rawValue,
+                                type: "adp",
                                 commonName: $0.name,
                                 organization: $0.organization,
                                 identity: $0.organizationalUnit
                             )
-                        } else {
+                        case .none:
                             return .unrecognized(commonName: $0.name, organization: $0.organization)
                         }
                     },

--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -784,7 +784,7 @@ public final class RegistryClient: Cancellable {
                                             callbackQueue: callbackQueue
                                         ) { signatureResult in
                                             switch signatureResult {
-                                            case .success:
+                                            case .success(let signingEntity):
                                                 checksumTOFU.validate(
                                                     registry: registry,
                                                     package: package,
@@ -822,6 +822,18 @@ public final class RegistryClient: Cancellable {
                                                                         // strip first level component
                                                                         try fileSystem
                                                                             .stripFirstLevel(of: destinationPath)
+                                                                        // write down copy of version metadata
+                                                                        let registryMetadataPath = destinationPath
+                                                                            .appending(
+                                                                                component: RegistryReleaseMetadataStorage
+                                                                                    .fileName
+                                                                            )
+                                                                        try RegistryReleaseMetadataStorage.save(
+                                                                            metadata: versionMetadata,
+                                                                            signingEntity: signingEntity,
+                                                                            to: registryMetadataPath,
+                                                                            fileSystem: fileSystem
+                                                                        )
                                                                     }.mapError { error in
                                                                         StringError(
                                                                             "failed extracting '\(downloadPath)' to '\(destinationPath)': \(error)"
@@ -1853,6 +1865,77 @@ extension RegistryClient {
                 self.identifiers = identifiers
             }
         }
+    }
+}
+
+// MARK: - RegistryReleaseMetadata serialization helpers
+
+extension RegistryReleaseMetadataStorage {
+    fileprivate static func save(
+        metadata: RegistryClient.PackageVersionMetadata,
+        signingEntity: SigningEntity?,
+        to path: AbsolutePath,
+        fileSystem: FileSystem
+    ) throws {
+        let registryMetadata = try RegistryReleaseMetadata(
+            metadata: metadata,
+            signingEntity: signingEntity
+        )
+        try self.save(registryMetadata, to: path, fileSystem: fileSystem)
+    }
+}
+
+extension RegistryReleaseMetadata {
+    fileprivate init(
+        metadata: RegistryClient.PackageVersionMetadata,
+        signingEntity: PackageSigning.SigningEntity?
+    ) throws {
+        self.init(
+            source: .registry(metadata.registry.url),
+            metadata: .init(
+                author: metadata.author.flatMap {
+                    .init(
+                        name: $0.name,
+                        emailAddress: $0.email,
+                        description: $0.description,
+                        url: $0.url,
+                        organization: $0.organization.flatMap {
+                            .init(
+                                name: $0.name,
+                                emailAddress: $0.email,
+                                description: $0.description,
+                                url: $0.url
+                            )
+                        }
+                    )
+                },
+                description: metadata.description,
+                licenseURL: metadata.licenseURL,
+                readmeURL: metadata.readmeURL,
+                scmRepositoryURLs: metadata.repositoryURLs
+            ),
+            signature: try metadata.sourceArchive?.signing.flatMap {
+                guard let signatureData = Data(base64Encoded: $0.signatureBase64Encoded) else {
+                    throw StringError("invalid based64 encoded signature")
+                }
+                return RegistrySignature(
+                    signedBy: signingEntity.flatMap {
+                        if $0.isRecognized {
+                            return .recognized(
+                                type: $0.type?.rawValue,
+                                commonName: $0.name,
+                                organization: $0.organization,
+                                identity: $0.organizationalUnit
+                            )
+                        } else {
+                            return .unrecognized(commonName: $0.name, organization: $0.organization)
+                        }
+                    },
+                    format: $0.signatureFormat,
+                    value: Array(signatureData)
+                )
+            }
+        )
     }
 }
 

--- a/Sources/PackageRegistry/SignatureValidation.swift
+++ b/Sources/PackageRegistry/SignatureValidation.swift
@@ -50,7 +50,7 @@ struct SignatureValidation {
         timeout: DispatchTimeInterval?,
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue,
-        completion: @escaping (Result<Void, Error>) -> Void
+        completion: @escaping (Result<SigningEntity?, Error>) -> Void
     ) {
         self.getAndValidateSignature(
             registry: registry,
@@ -71,9 +71,10 @@ struct SignatureValidation {
                     version: version,
                     signingEntity: signingEntity,
                     observabilityScope: observabilityScope,
-                    callbackQueue: callbackQueue,
-                    completion: completion
-                )
+                    callbackQueue: callbackQueue
+                ) { _ in
+                    completion(.success(signingEntity))
+                }
             case .failure(let error):
                 completion(.failure(error))
             }

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -134,7 +134,14 @@ public final class MockWorkspace {
                 if let containerProvider = customPackageContainerProvider {
                     let observability = ObservabilitySystem.makeForTesting()
                     let packageRef = PackageReference(identity: PackageIdentity(url: url), kind: .remoteSourceControl(url))
-                    let container = try temp_await { containerProvider.getContainer(for: packageRef, skipUpdate: true, observabilityScope: observability.topScope, on: .sharedConcurrent, completion: $0) }
+                    let container = try temp_await {
+                        containerProvider.getContainer(
+                            for: packageRef,
+                            skipUpdate: true,
+                            observabilityScope: observability.topScope,
+                            on: .sharedConcurrent, completion: $0
+                        )
+                    }
                     guard let customContainer = container as? CustomPackageContainer else {
                         throw StringError("invalid custom container: \(container)")
                     }

--- a/Sources/SPMTestSupport/PackageGraphTester.swift
+++ b/Sources/SPMTestSupport/PackageGraphTester.swift
@@ -124,6 +124,10 @@ public final class PackageGraphResult {
         return graph.allProducts.first(where: { $0.name == product })
     }
 
+    public func find(package: PackageIdentity) -> ResolvedPackage? {
+        return graph.packages.first(where: { $0.identity == package })
+    }
+
     private func reachableBuildTargets(in environment: BuildEnvironment) throws -> Set<ResolvedTarget> {
         let inputTargets = graph.inputPackages.lazy.flatMap { $0.targets }
         let recursiveBuildTargetDependencies = try inputTargets

--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -285,3 +285,17 @@ extension URL: ExpressibleByStringInterpolation {
         self.init(string: value)!
     }
 }
+
+extension PackageIdentity: ExpressibleByStringLiteral {}
+
+extension PackageIdentity: ExpressibleByStringInterpolation {
+    public init(stringLiteral value: String) {
+        self = Self.plain(value)
+    }
+}
+
+extension PackageIdentity {
+    public static func registry(_ value: String) -> RegistryIdentity {
+        Self.plain(value).registry!
+    }
+}

--- a/Tests/PackageRegistryTests/SignatureValidationTests.swift
+++ b/Tests/PackageRegistryTests/SignatureValidationTests.swift
@@ -287,7 +287,7 @@ extension SignatureValidation {
         content: Data,
         configuration: RegistryConfiguration.Security.Signing,
         observabilityScope: ObservabilityScope? = nil
-    ) throws {
+    ) throws -> SigningEntity? {
         try tsc_await {
             self.validate(
                 registry: registry,


### PR DESCRIPTION
motivation: clients of SwiftPM may be interested in the registry metadata for presentation

changes: serialize the metadata when downloading registry based  packages and deserializae it when construting the graph

