### PR TITLE
NFC: add utilities for AbsolutePath

### DIFF
--- a/Sources/Basics/CMakeLists.txt
+++ b/Sources/Basics/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(Basics
   Errors.swift
   FileSystem/AsyncFileSystem.swift
   FileSystem/FileSystem+Extensions.swift
+  FileSystem/Path+Extensions.swift
   FileSystem/VFSOverlay.swift
   HTTPClient/HTTPClient.swift
   HTTPClient/HTTPClientConfiguration.swift

--- a/Sources/Basics/FileSystem/AsyncFileSystem.swift
+++ b/Sources/Basics/FileSystem/AsyncFileSystem.swift
@@ -246,19 +246,19 @@ extension AsyncFileSystem {
 extension AsyncFileSystem {
     public func stripFirstLevel(of path: AbsolutePath) throws {
         let topLevelDirectories = try self.getDirectoryContents(path)
-            .map{ path.appending(component: $0) }
+            .map{ path.appending($0) }
             .filter{ self.isDirectory($0) }
 
         guard topLevelDirectories.count == 1, let rootDirectory = topLevelDirectories.first else {
             throw StringError("stripFirstLevel requires single top level directory")
         }
 
-        let tempDirectory = path.parentDirectory.appending(component: UUID().uuidString)
+        let tempDirectory = path.parentDirectory.appending(UUID().uuidString)
         try self.move(from: rootDirectory, to: tempDirectory)
 
         let rootContents = try self.getDirectoryContents(tempDirectory)
         for entry in rootContents {
-            try self.move(from: tempDirectory.appending(component: entry), to: path.appending(component: entry))
+            try self.move(from: tempDirectory.appending(entry), to: path.appending(entry))
         }
 
         try self.removeFileTree(tempDirectory)

--- a/Sources/Basics/FileSystem/FileSystem+Extensions.swift
+++ b/Sources/Basics/FileSystem/FileSystem+Extensions.swift
@@ -22,13 +22,13 @@ extension FileSystem {
     /// SwiftPM directory under user's home directory (~/.swiftpm)
     public var dotSwiftPM: AbsolutePath {
         get throws {
-            return try self.homeDirectory.appending(component: ".swiftpm")
+            return try self.homeDirectory.appending(".swiftpm")
         }
     }
 
     fileprivate var idiomaticSwiftPMDirectory: AbsolutePath? {
         get throws {
-            return try FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first.flatMap { try AbsolutePath(validating: $0.path) }?.appending(component: "org.swift.swiftpm")
+            return try FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first.flatMap { try AbsolutePath(validating: $0.path) }?.appending("org.swift.swiftpm")
         }
     }
 }
@@ -45,7 +45,7 @@ extension FileSystem {
     public var swiftPMCacheDirectory: AbsolutePath {
         get throws {
             if let path = self.idiomaticUserCacheDirectory {
-                return path.appending(component: "org.swift.swiftpm")
+                return path.appending("org.swift.swiftpm")
             } else {
                 return try self.dotSwiftPMCachesDirectory
             }
@@ -54,7 +54,7 @@ extension FileSystem {
 
     fileprivate var dotSwiftPMCachesDirectory: AbsolutePath {
         get throws {
-            return try self.dotSwiftPM.appending(component: "cache")
+            return try self.dotSwiftPM.appending("cache")
         }
     }
 }
@@ -88,7 +88,7 @@ extension FileSystem {
     public var swiftPMConfigurationDirectory: AbsolutePath {
         get throws {
             if let path = try self.idiomaticSwiftPMDirectory {
-                return path.appending(component: "configuration")
+                return path.appending("configuration")
             } else {
                 return try self.dotSwiftPMConfigurationDirectory
             }
@@ -97,7 +97,7 @@ extension FileSystem {
 
     fileprivate var dotSwiftPMConfigurationDirectory: AbsolutePath {
         get throws {
-            return try self.dotSwiftPM.appending(component: "configuration")
+            return try self.dotSwiftPM.appending("configuration")
         }
     }
 }
@@ -142,7 +142,7 @@ extension FileSystem {
         } else {
             // copy the configuration files from old location (~/.swiftpm/config) to new one (~/.swiftpm/configuration)
             // but leave them there for backwards compatibility (eg older toolchain)
-            let oldConfigDirectory = try self.dotSwiftPM.appending(component: "config")
+            let oldConfigDirectory = try self.dotSwiftPM.appending("config")
             if self.exists(oldConfigDirectory, followSymlink: false) && self.isDirectory(oldConfigDirectory) {
                 let configurationFiles = try self.getDirectoryContents(oldConfigDirectory)
                     .map{ oldConfigDirectory.appending(component: $0) }
@@ -179,7 +179,7 @@ extension FileSystem {
     public var swiftPMSecurityDirectory: AbsolutePath {
         get throws {
             if let path = try self.idiomaticSwiftPMDirectory {
-                return path.appending(component: "security")
+                return path.appending("security")
             } else {
                 return try self.dotSwiftPMSecurityDirectory
             }
@@ -188,7 +188,7 @@ extension FileSystem {
 
     fileprivate var dotSwiftPMSecurityDirectory: AbsolutePath {
         get throws {
-            return try self.dotSwiftPM.appending(component: "security")
+            return try self.dotSwiftPM.appending("security")
         }
     }
 }

--- a/Sources/Basics/FileSystem/Path+Extensions.swift
+++ b/Sources/Basics/FileSystem/Path+Extensions.swift
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import struct TSCBasic.AbsolutePath
+
+extension AbsolutePath {
+    public func appending(_ component: String) -> AbsolutePath {
+        self.appending(component: component)
+    }
+
+    public func appending(_ components: String...) -> AbsolutePath {
+        self.appending(components: components)
+    }
+
+    public func appending(extension: String) -> AbsolutePath {
+        guard !self.isRoot else { return self }
+        let `extension` = `extension`.spm_dropPrefix(".")
+        return self.parentDirectory.appending("\(basename).\(`extension`)")
+    }
+
+    public func basenameWithoutAnyExtension() -> String {
+        var basename = self.basename
+        if let index = basename.firstIndex(of: ".") {
+            basename.removeSubrange(index ..< basename.endIndex)
+        }
+        return String(basename)
+    }
+
+    public func escapedPathString() -> String {
+        return self.pathString.replacingOccurrences(of: "\\", with: "\\\\")
+    }
+}

--- a/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
@@ -100,7 +100,7 @@ public final class ClangTargetBuildDescription {
         self.toolsVersion = toolsVersion
         self.buildParameters = buildParameters
         self.tempsPath = buildParameters.buildPath.appending(component: target.c99name + ".build")
-        self.derivedSources = Sources(paths: [], root: tempsPath.appending(component: "DerivedSources"))
+        self.derivedSources = Sources(paths: [], root: tempsPath.appending("DerivedSources"))
 
         // Try computing modulemap path for a C library.  This also creates the file in the file system, if needed.
         if target.type == .library {
@@ -127,7 +127,7 @@ public final class ClangTargetBuildDescription {
         if bundlePath != nil {
             try self.generateResourceAccessor()
 
-            let infoPlistPath = tempsPath.appending(component: "Info.plist")
+            let infoPlistPath = tempsPath.appending("Info.plist")
             if try generateResourceInfoPlist(fileSystem: fileSystem, target: target, path: infoPlistPath) {
                 resourceBundleInfoPlistPath = infoPlistPath
             }
@@ -353,7 +353,7 @@ public final class ClangTargetBuildDescription {
         }
         #endif
         """
-        let headerFile = derivedSources.root.appending(component: "resource_bundle_accessor.h")
+        let headerFile = derivedSources.root.appending("resource_bundle_accessor.h")
         self.resourceAccessorHeaderFile = headerFile
 
         try fileSystem.writeIfChanged(

--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -64,7 +64,7 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
 
     /// Path to the link filelist file.
     var linkFileListPath: AbsolutePath {
-        self.tempsPath.appending(component: "Objects.LinkFileList")
+        self.tempsPath.appending("Objects.LinkFileList")
     }
 
     /// File system reference.
@@ -276,8 +276,8 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
                 let backDeployedStdlib = try buildParameters.toolchain.macosSwiftStdlib
                     .parentDirectory
                     .parentDirectory
-                    .appending(component: "swift-5.5")
-                    .appending(component: "macosx")
+                    .appending("swift-5.5")
+                    .appending("macosx")
                 args += ["-Xlinker", "-rpath", "-Xlinker", backDeployedStdlib.pathString]
             }
         }

--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -249,7 +249,7 @@ public final class SwiftTargetBuildDescription {
         }
         self.fileSystem = fileSystem
         self.tempsPath = buildParameters.buildPath.appending(component: target.c99name + ".build")
-        self.derivedSources = Sources(paths: [], root: self.tempsPath.appending(component: "DerivedSources"))
+        self.derivedSources = Sources(paths: [], root: self.tempsPath.appending("DerivedSources"))
         self.pluginDerivedSources = Sources(paths: [], root: buildParameters.dataPath)
         self.buildToolPluginInvocationResults = buildToolPluginInvocationResults
         self.prebuildCommandResults = prebuildCommandResults
@@ -295,7 +295,7 @@ public final class SwiftTargetBuildDescription {
         if self.bundlePath != nil {
             try self.generateResourceAccessor()
 
-            let infoPlistPath = self.tempsPath.appending(component: "Info.plist")
+            let infoPlistPath = self.tempsPath.appending("Info.plist")
             if try generateResourceInfoPlist(fileSystem: self.fileSystem, target: target, path: infoPlistPath) {
                 self.resourceBundleInfoPlistPath = infoPlistPath
             }
@@ -664,12 +664,12 @@ public final class SwiftTargetBuildDescription {
     }
 
     private func writeOutputFileMap() throws -> AbsolutePath {
-        let path = self.tempsPath.appending(component: "output-file-map.json")
+        let path = self.tempsPath.appending("output-file-map.json")
         let stream = BufferedOutputByteStream()
 
         stream <<< "{\n"
 
-        let masterDepsPath = self.tempsPath.appending(component: "master.swiftdeps")
+        let masterDepsPath = self.tempsPath.appending("master.swiftdeps")
         stream <<< "  \"\": {\n"
         if self.buildParameters.useWholeModuleOptimization {
             let moduleName = self.target.c99name
@@ -739,7 +739,7 @@ public final class SwiftTargetBuildDescription {
 
     /// Returns the path to the ObjC compatibility header for this Swift target.
     var objCompatibilityHeaderPath: AbsolutePath {
-        self.tempsPath.appending(component: "\(self.target.name)-Swift.h")
+        self.tempsPath.appending("\(self.target.name)-Swift.h")
     }
 
     /// Returns the build flags from the declared build settings.

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -398,7 +398,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         if let pluginConfiguration = self.pluginConfiguration  {
             let buildOperationForPluginDependencies = try BuildOperation(buildParameters: self.buildParameters.withDestination(self.buildParameters.hostTriple), cacheBuildManifest: false, packageGraphLoader: { return graph }, additionalFileRules: self.additionalFileRules, pkgConfigDirectories: self.pkgConfigDirectories, outputStream: self.outputStream, logLevel: self.logLevel, fileSystem: self.fileSystem, observabilityScope: self.observabilityScope)
             buildToolPluginInvocationResults = try graph.invokeBuildToolPlugins(
-                outputDir: pluginConfiguration.workDirectory.appending(component: "outputs"),
+                outputDir: pluginConfiguration.workDirectory.appending("outputs"),
                 builtToolsDir: self.buildParameters.buildPath,
                 buildEnvironment: self.buildParameters.buildEnvironment,
                 toolSearchDirectories: [self.buildParameters.toolchain.swiftCompilerPath.parentDirectory],
@@ -543,7 +543,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         )
         self.buildSystemDelegate = buildSystemDelegate
 
-        let databasePath = buildParameters.dataPath.appending(component: "build.db").pathString
+        let databasePath = buildParameters.dataPath.appending("build.db").pathString
         let buildSystem = SPMLLBuild.BuildSystem(
             buildFile: buildParameters.llbuildManifest.pathString,
             databaseFile: databasePath,

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -444,11 +444,11 @@ public final class BuildExecutionContext {
                 // search, preferring `IndexStore.dll` over `libIndexStore.dll`.
                 let indexStoreLib = buildParameters.toolchain.swiftCompilerPath
                     .parentDirectory
-                    .appending(component: "libIndexStore.dll")
+                    .appending("libIndexStore.dll")
                 #else
                 let ext = buildParameters.hostTriple.dynamicLibraryExtension
                 let indexStoreLib = try buildParameters.toolchain.toolchainLibDir
-                    .appending(component: "libIndexStore" + ext)
+                    .appending("libIndexStore" + ext)
                 #endif
                 return try .success(IndexStoreAPI(dylib: indexStoreLib))
             } catch {

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -52,7 +52,7 @@ extension BuildParameters {
             if let path = ProcessEnv.vars["SWIFTPM_TESTS_MODULECACHE"] {
                 return try AbsolutePath(validating: path)
             }
-            return buildPath.appending(component: "ModuleCache")
+            return buildPath.appending("ModuleCache")
         }
     }
 

--- a/Sources/Build/LLBuildManifestBuilder.swift
+++ b/Sources/Build/LLBuildManifestBuilder.swift
@@ -125,7 +125,7 @@ extension LLBuildManifestBuilder {
             inputs.append(file: package.manifest.path)
 
             // FIXME: This won't be the location of Package.resolved for multiroot packages.
-            inputs.append(file: package.path.appending(component: "Package.resolved"))
+            inputs.append(file: package.path.appending("Package.resolved"))
 
             // FIXME: Add config file as an input
 

--- a/Sources/Commands/PackageTools/APIDiff.swift
+++ b/Sources/Commands/PackageTools/APIDiff.swift
@@ -118,7 +118,7 @@ struct APIDiff: SwiftCommand {
         var skippedModules: Set<String> = []
 
         for module in modulesToDiff {
-            let moduleBaselinePath = baselineDir.appending(component: "\(module).json")
+            let moduleBaselinePath = baselineDir.appending("\(module).json")
             guard swiftTool.fileSystem.exists(moduleBaselinePath) else {
                 print("\nSkipping \(module) because it does not exist in the baseline")
                 skippedModules.insert(module)

--- a/Sources/Commands/PackageTools/ArchiveSource.swift
+++ b/Sources/Commands/PackageTools/ArchiveSource.swift
@@ -41,7 +41,7 @@ extension SwiftPackageTool {
             } else {
                 let graph = try swiftTool.loadPackageGraph()
                 let packageName = graph.rootPackages[0].manifest.displayName // TODO: use identity instead?
-                archivePath = packageDirectory.appending(component: "\(packageName).zip")
+                archivePath = packageDirectory.appending("\(packageName).zip")
             }
 
             try SwiftPackageTool.archiveSource(

--- a/Sources/Commands/PackageTools/DumpCommands.swift
+++ b/Sources/Commands/PackageTools/DumpCommands.swift
@@ -65,7 +65,7 @@ struct DumpSymbolGraph: SwiftCommand {
 
         // Run the tool once for every library and executable target in the root package.
         let buildPlan = try buildSystem.buildPlan
-        let symbolGraphDirectory = buildPlan.buildParameters.dataPath.appending(component: "symbolgraph")
+        let symbolGraphDirectory = buildPlan.buildParameters.dataPath.appending("symbolgraph")
         let targets = try buildSystem.getPackageGraph().rootPackages.flatMap{ $0.targets }.filter{ $0.type == .library || $0.type == .executable }
         for target in targets {
             print("-- Emitting symbol graph for", target.name)

--- a/Sources/Commands/PackageTools/Learn.swift
+++ b/Sources/Commands/PackageTools/Learn.swift
@@ -50,7 +50,7 @@ extension SwiftPackageTool {
         }
 
         func loadSnippetsAndSnippetGroups(fileSystem: FileSystem, from package: ResolvedPackage) throws -> [SnippetGroup] {
-            let snippetsDirectory = package.path.appending(component: "Snippets")
+            let snippetsDirectory = package.path.appending("Snippets")
             guard fileSystem.isDirectory(snippetsDirectory) else {
                 return []
             }
@@ -68,7 +68,7 @@ extension SwiftPackageTool {
                     let snippets = try files(fileSystem: fileSystem, in: subdirectory, fileExtension: "swift")
                         .map { try Snippet(parsing: $0) }
 
-                    let explanationFile = subdirectory.appending(component: "Explanation.md")
+                    let explanationFile = subdirectory.appending("Explanation.md")
 
                     let snippetGroupExplanation: String
                     if fileSystem.isFile(explanationFile) {

--- a/Sources/Commands/PackageTools/PluginCommand.swift
+++ b/Sources/Commands/PackageTools/PluginCommand.swift
@@ -164,7 +164,7 @@ struct PluginCommand: SwiftCommand {
         )
 
         // The `outputs` directory contains subdirectories for each combination of package and command plugin. Each usage of a plugin has an output directory that is writable by the plugin, where it can write additional files, and to which it can configure tools to write their outputs, etc.
-        let outputDir = pluginsDir.appending(component: "outputs")
+        let outputDir = pluginsDir.appending("outputs")
 
         var allowNetworkConnections = [SandboxNetworkPermission(options.allowNetworkConnections)]
         // Determine the set of directories under which plugins are allowed to write. We always include the output directory.

--- a/Sources/Commands/Utilities/APIDigester.swift
+++ b/Sources/Commands/Utilities/APIDigester.swift
@@ -87,7 +87,7 @@ struct APIDigesterBaselineDumper {
         }
 
         // Setup a temporary directory where we can checkout and build the baseline treeish.
-        let baselinePackageRoot = apiDiffDir.appending(component: "\(baselineRevision.identifier)-checkout")
+        let baselinePackageRoot = apiDiffDir.appending("\(baselineRevision.identifier)-checkout")
         if swiftTool.fileSystem.exists(baselinePackageRoot) {
             try swiftTool.fileSystem.removeFileTree(baselinePackageRoot)
         }
@@ -297,7 +297,7 @@ extension SwiftAPIDigester {
 extension BuildParameters {
     /// The directory containing artifacts for API diffing operations.
     var apiDiff: AbsolutePath {
-        dataPath.appending(component: "apidiff")
+        dataPath.appending("apidiff")
     }
 }
 

--- a/Sources/Commands/Utilities/GenerateLinuxMain.swift
+++ b/Sources/Commands/Utilities/GenerateLinuxMain.swift
@@ -61,7 +61,7 @@ final class LinuxMainGenerator {
             assert(target.type == .test, "Unexpected target type \(target.type) for \(target)")
 
             // Write the manifest file for this module.
-            let testManifest = target.sources.root.appending(component: "XCTestManifests.swift")
+            let testManifest = target.sources.root.appending("XCTestManifests.swift")
             let stream = try LocalFileOutputByteStream(testManifest)
 
             stream <<< "#if !canImport(ObjectiveC)" <<< "\n"

--- a/Sources/Commands/Utilities/MultiRootSupport.swift
+++ b/Sources/Commands/Utilities/MultiRootSupport.swift
@@ -46,7 +46,7 @@ public struct XcodeWorkspaceLoader: WorkspaceLoader {
 
     /// Load the given workspace and return the file ref paths from it.
     public func load(workspace: AbsolutePath) throws -> [AbsolutePath] {
-        let path = workspace.appending(component: "contents.xcworkspacedata")
+        let path = workspace.appending("contents.xcworkspacedata")
         let contents: Data = try self.fileSystem.readFileContents(path)
 
         let delegate = ParserDelegate(observabilityScope: self.observabilityScope)

--- a/Sources/CoreCommands/SwiftTool.swift
+++ b/Sources/CoreCommands/SwiftTool.swift
@@ -372,7 +372,7 @@ public final class SwiftTool {
         self.scratchDirectory =
             try BuildSystemUtilities.getEnvBuildPath(workingDir: cwd) ??
             options.locations.scratchDirectory ??
-            (packageRoot ?? cwd).appending(component: ".build")
+            (packageRoot ?? cwd).appending(".build")
 
         // make sure common directories are created
         self.sharedSecurityDirectory = try getSharedSecurityDirectory(options: options, fileSystem: fileSystem)
@@ -481,7 +481,7 @@ public final class SwiftTool {
     private func getEditsDirectory() throws -> AbsolutePath {
         // TODO: replace multiroot-data-file with explicit overrides
         if let multiRootPackageDataFile = options.locations.multirootPackageDataFile {
-            return multiRootPackageDataFile.appending(component: "Packages")
+            return multiRootPackageDataFile.appending("Packages")
         }
         return try Workspace.DefaultLocations.editsDirectory(forRootPackage: self.getPackageRoot())
     }
@@ -614,7 +614,7 @@ public final class SwiftTool {
 
     public func getPluginScriptRunner(customPluginsDir: AbsolutePath? = .none) throws -> PluginScriptRunner {
         let pluginsDir = try customPluginsDir ?? self.getActiveWorkspace().location.pluginWorkingDirectory
-        let cacheDir = pluginsDir.appending(component: "cache")
+        let cacheDir = pluginsDir.appending("cache")
         let pluginScriptRunner = try DefaultPluginScriptRunner(
             fileSystem: self.fileSystem,
             cacheDir: cacheDir,

--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -57,7 +57,7 @@ public struct PackageCollections: PackageCollectionsProtocol, Closable {
         let storage = Storage(
             sources: FilePackageCollectionsSourcesStorage(
                 fileSystem: fileSystem,
-                path: configuration.configurationDirectory?.appending(component: "collections.json")
+                path: configuration.configurationDirectory?.appending("collections.json")
             ),
             collections: SQLitePackageCollectionsStorage(
                 location: configuration.cacheDirectory.map { .path($0.appending(components: "package-collection.db")) },

--- a/Sources/PackageCollections/PackageIndex.swift
+++ b/Sources/PackageCollections/PackageIndex.swift
@@ -48,7 +48,7 @@ struct PackageIndex: PackageIndexProtocol, Closable {
             cacheConfig.maxSizeInMegabytes = configuration.cacheMaxSizeInMegabytes
             self.cache = SQLiteBackedCache<CacheValue>(
                 tableName: "package_index_cache",
-                path: configuration.cacheDirectory.appending(component: "index-package-metadata.db"),
+                path: configuration.cacheDirectory.appending("index-package-metadata.db"),
                 configuration: cacheConfig
             )
         } else {

--- a/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
@@ -42,7 +42,7 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider, Closable {
             cacheConfig.maxSizeInMegabytes = configuration.cacheSizeInMegabytes
             self.cache = SQLiteBackedCache<CacheValue>(
                 tableName: "github_cache",
-                path: configuration.cacheDir.appending(component: "package-metadata.db"),
+                path: configuration.cacheDir.appending("package-metadata.db"),
                 configuration: cacheConfig
             )
         } else {

--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -62,7 +62,7 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
         self.observabilityScope = observabilityScope
         self.httpClient = customHTTPClient ?? Self.makeDefaultHTTPClient()
         self.signatureValidator = customSignatureValidator ?? PackageCollectionSigning(
-            trustedRootCertsDir: configuration.trustedRootCertsDir ?? (try? fileSystem.swiftPMConfigurationDirectory.appending(component: "trust-root-certs").asURL) ?? AbsolutePath.root.asURL,
+            trustedRootCertsDir: configuration.trustedRootCertsDir ?? (try? fileSystem.swiftPMConfigurationDirectory.appending("trust-root-certs").asURL) ?? AbsolutePath.root.asURL,
             additionalTrustedRootCerts: sourceCertPolicy.allRootCerts.map { Array($0) },
             observabilityScope: observabilityScope,
             callbackQueue: .sharedConcurrent

--- a/Sources/PackageCollections/Storage/FilePackageCollectionsSourcesStorage.swift
+++ b/Sources/PackageCollections/Storage/FilePackageCollectionsSourcesStorage.swift
@@ -28,7 +28,7 @@ struct FilePackageCollectionsSourcesStorage: PackageCollectionsSourcesStorage {
     init(fileSystem: FileSystem, path: AbsolutePath? = nil) {
         self.fileSystem = fileSystem
 
-        self.path = path ?? (try? fileSystem.swiftPMConfigurationDirectory.appending(component: "collections.json")) ?? .root
+        self.path = path ?? (try? fileSystem.swiftPMConfigurationDirectory.appending("collections.json")) ?? .root
         self.encoder = JSONEncoder.makeWithDefaults()
         self.decoder = JSONDecoder.makeWithDefaults()
     }

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -519,7 +519,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 
         do {
             try withTemporaryDirectory { tempDir, cleanupTempDir in
-                let manifestTempFilePath = tempDir.appending(component: "manifest.swift")
+                let manifestTempFilePath = tempDir.appending("manifest.swift")
                 try localFileSystem.writeFileContents(manifestTempFilePath, bytes: ByteString(manifestPreamble.contents + manifestContents))
 
                 #if os(Windows)
@@ -528,7 +528,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                 let vfsOverlayTempFilePath: AbsolutePath? = nil
                 #else
                 let effectiveManifestPath = manifestPath
-                let vfsOverlayTempFilePath = tempDir.appending(component: "vfs.yaml")
+                let vfsOverlayTempFilePath = tempDir.appending("vfs.yaml")
                 try VFSOverlay(roots: [
                     VFSOverlay.File(name: manifestPath.pathString, externalContents: manifestTempFilePath.pathString)
                 ]).write(to: vfsOverlayTempFilePath, fileSystem: localFileSystem)
@@ -646,8 +646,8 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 
         // Add the arguments for emitting serialized diagnostics, if requested.
         if self.serializedDiagnostics, let databaseCacheDir = self.databaseCacheDir {
-            let diaDir = databaseCacheDir.appending(component: "ManifestLoading")
-            let diagnosticFile = diaDir.appending(component: "\(packageIdentity).dia")
+            let diaDir = databaseCacheDir.appending("ManifestLoading")
+            let diagnosticFile = diaDir.appending("\(packageIdentity).dia")
             do {
                 try localFileSystem.createDirectory(diaDir, recursive: true)
                 cmd += ["-Xfrontend", "-serialize-diagnostics-path", "-Xfrontend", diagnosticFile.pathString]
@@ -682,7 +682,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                     #else
                     let executableSuffix = ""
                     #endif
-                    let compiledManifestFile = tmpDir.appending(component: "\(packageIdentity)-manifest\(executableSuffix)")
+                    let compiledManifestFile = tmpDir.appending("\(packageIdentity)-manifest\(executableSuffix)")
                     cmd += ["-o", compiledManifestFile.pathString]
 
                     evaluationResult.compilerCommandLine = cmd
@@ -708,7 +708,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                         }
 
                         // Pass an open file descriptor of a file to which the JSON representation of the manifest will be written.
-                        let jsonOutputFile = tmpDir.appending(component: "\(packageIdentity)-output.json")
+                        let jsonOutputFile = tmpDir.appending("\(packageIdentity)-output.json")
                         guard let jsonOutputFileDesc = fopen(jsonOutputFile.pathString, "w") else {
                             return completion(.failure(StringError("couldn't create the manifest's JSON output file")))
                         }
@@ -840,7 +840,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 
     /// Returns path to the manifest database inside the given cache directory.
     private static func manifestCacheDBPath(_ cacheDir: AbsolutePath) -> AbsolutePath {
-        return cacheDir.appending(component: "manifest.db")
+        return cacheDir.appending("manifest.db")
     }
 
     /// reset internal cache

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -1464,7 +1464,7 @@ extension Target.Dependency {
 
 extension PackageBuilder {
     fileprivate func createSnippetTargets(dependencies: [Target.Dependency]) throws -> [Target] {
-        let snippetsDirectory = packagePath.appending(component: "Snippets")
+        let snippetsDirectory = packagePath.appending("Snippets")
         guard fileSystem.isDirectory(snippetsDirectory) else {
             return []
         }

--- a/Sources/PackageModel/ArtifactsArchiveMetadata.swift
+++ b/Sources/PackageModel/ArtifactsArchiveMetadata.swift
@@ -59,7 +59,7 @@ public struct ArtifactsArchiveMetadata: Equatable {
 
 extension ArtifactsArchiveMetadata {
     public static func parse(fileSystem: FileSystem, rootPath: AbsolutePath) throws -> ArtifactsArchiveMetadata {
-        let path = rootPath.appending(component: "info.json")
+        let path = rootPath.appending("info.json")
         guard fileSystem.exists(path) else {
             throw StringError("ArtifactsArchive info.json not found at '\(rootPath)'")
         }

--- a/Sources/PackageModel/DestinationBundle.swift
+++ b/Sources/PackageModel/DestinationBundle.swift
@@ -159,7 +159,7 @@ extension ArtifactsArchiveMetadata {
             for variantMetadata in artifactMetadata.variants {
                 let destinationJSONPath = try bundlePath
                     .appending(RelativePath(validating: variantMetadata.path))
-                    .appending(component: "destination.json")
+                    .appending("destination.json")
 
                 guard fileSystem.exists(destinationJSONPath) else {
                     observabilityScope.emit(

--- a/Sources/PackageModel/ToolchainConfiguration.swift
+++ b/Sources/PackageModel/ToolchainConfiguration.swift
@@ -108,9 +108,9 @@ extension ToolchainConfiguration {
 
         public init(root: AbsolutePath, manifestLibraryMinimumDeploymentTarget: PlatformVersion? = nil, pluginLibraryMinimumDeploymentTarget: PlatformVersion? = nil) {
             self.init(
-                manifestLibraryPath: root.appending(component: "ManifestAPI"),
+                manifestLibraryPath: root.appending("ManifestAPI"),
                 manifestLibraryMinimumDeploymentTarget: manifestLibraryMinimumDeploymentTarget,
-                pluginLibraryPath: root.appending(component: "PluginAPI"),
+                pluginLibraryPath: root.appending("PluginAPI"),
                 pluginLibraryMinimumDeploymentTarget: pluginLibraryMinimumDeploymentTarget
             )
         }
@@ -130,10 +130,10 @@ extension ToolchainConfiguration {
 
         private static func macOSManifestLibraryPath(for manifestAPI: AbsolutePath) -> AbsolutePath {
             if manifestAPI.extension == "framework" {
-                return manifestAPI.appending(component: "PackageDescription")
+                return manifestAPI.appending("PackageDescription")
             } else {
                 // note: this is not correct for all platforms, but we only actually use it on macOS.
-                return manifestAPI.appending(component: "libPackageDescription.dylib")
+                return manifestAPI.appending("libPackageDescription.dylib")
             }
         }
 
@@ -145,10 +145,10 @@ extension ToolchainConfiguration {
             // if runtimePath is set to "PackageFrameworks" that means we could be developing SwiftPM in Xcode
             // which produces a framework for dynamic package products.
             if pluginAPI.extension == "framework" {
-                return pluginAPI.appending(component: "PackagePlugin")
+                return pluginAPI.appending("PackagePlugin")
             } else {
                 // note: this is not correct for all platforms, but we only actually use it on macOS.
-                return pluginAPI.appending(component: "libPackagePlugin.dylib")
+                return pluginAPI.appending("libPackagePlugin.dylib")
             }
         }
 

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -39,7 +39,7 @@ public final class UserToolchain: Toolchain {
 
     /// Path of the `swift` interpreter.
     public var swiftInterpreterPath: AbsolutePath {
-        self.swiftCompilerPath.parentDirectory.appending(component: "swift" + hostExecutableSuffix)
+        self.swiftCompilerPath.parentDirectory.appending("swift" + hostExecutableSuffix)
     }
 
     /// The compilation destination object.
@@ -326,7 +326,7 @@ public final class UserToolchain: Toolchain {
                     var extraSwiftCFlags: [String] = []
 
                     if let settings = WindowsSDKSettings(
-                        reading: sdkroot.appending(component: "SDKSettings.plist"),
+                        reading: sdkroot.appending("SDKSettings.plist"),
                         diagnostics: nil,
                         filesystem: localFileSystem
                     ) {
@@ -351,14 +351,14 @@ public final class UserToolchain: Toolchain {
                     let platform = sdkroot.parentDirectory.parentDirectory.parentDirectory
 
                     if let info = WindowsPlatformInfo(
-                        reading: platform.appending(component: "Info.plist"),
+                        reading: platform.appending("Info.plist"),
                         diagnostics: nil,
                         filesystem: localFileSystem
                     ) {
                         let installation: AbsolutePath =
-                            platform.appending(component: "Developer")
-                                .appending(component: "Library")
-                                .appending(component: "XCTest-\(info.defaults.xctestVersion)")
+                            platform.appending("Developer")
+                                .appending("Library")
+                                .appending("XCTest-\(info.defaults.xctestVersion)")
 
                         xctest = try [
                             "-I",
@@ -495,7 +495,7 @@ public final class UserToolchain: Toolchain {
         if triple.isWindows() {
             if let SDKROOT = environment["SDKROOT"], let root = try? AbsolutePath(validating: SDKROOT) {
                 if let settings = WindowsSDKSettings(
-                    reading: root.appending(component: "SDKSettings.plist"),
+                    reading: root.appending("SDKSettings.plist"),
                     diagnostics: nil,
                     filesystem: localFileSystem
                 ) {
@@ -614,7 +614,7 @@ public final class UserToolchain: Toolchain {
             }
 
             // this tests if we are debugging / testing SwiftPM with SwiftPM
-            if localFileSystem.exists(applicationPath.appending(component: "swift-package")) {
+            if localFileSystem.exists(applicationPath.appending("swift-package")) {
                 return .init(
                     manifestLibraryPath: applicationPath,
                     pluginLibraryPath: applicationPath
@@ -660,14 +660,14 @@ public final class UserToolchain: Toolchain {
             let platform = sdkRoot.parentDirectory.parentDirectory.parentDirectory
 
             if let info = WindowsPlatformInfo(
-                reading: platform.appending(component: "Info.plist"),
+                reading: platform.appending("Info.plist"),
                 diagnostics: nil,
                 filesystem: localFileSystem
             ) {
                 let xctest: AbsolutePath =
-                    platform.appending(component: "Developer")
-                        .appending(component: "Library")
-                        .appending(component: "XCTest-\(info.defaults.xctestVersion)")
+                    platform.appending("Developer")
+                        .appending("Library")
+                        .appending("XCTest-\(info.defaults.xctestVersion)")
 
                 // Migration Path
                 //
@@ -680,32 +680,32 @@ public final class UserToolchain: Toolchain {
                 switch triple.arch {
                 case .x86_64, .x86_64h:
                     let path: AbsolutePath =
-                        xctest.appending(component: "usr")
-                            .appending(component: "bin64")
+                        xctest.appending("usr")
+                            .appending("bin64")
                     if localFileSystem.exists(path) {
                         return path
                     }
 
                 case .i686:
                     let path: AbsolutePath =
-                        xctest.appending(component: "usr")
-                            .appending(component: "bin32")
+                        xctest.appending("usr")
+                            .appending("bin32")
                     if localFileSystem.exists(path) {
                         return path
                     }
 
                 case .armv7:
                     let path: AbsolutePath =
-                        xctest.appending(component: "usr")
-                            .appending(component: "bin32a")
+                        xctest.appending("usr")
+                            .appending("bin32a")
                     if localFileSystem.exists(path) {
                         return path
                     }
 
                 case .arm64:
                     let path: AbsolutePath =
-                        xctest.appending(component: "usr")
-                            .appending(component: "bin64a")
+                        xctest.appending("usr")
+                            .appending("bin64a")
                     if localFileSystem.exists(path) {
                         return path
                     }
@@ -718,8 +718,8 @@ public final class UserToolchain: Toolchain {
                 }
 
                 // Assume that we are in the old-style layout.
-                return xctest.appending(component: "usr")
-                    .appending(component: "bin")
+                return xctest.appending("usr")
+                    .appending("bin")
             }
         }
         return .none

--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -717,7 +717,7 @@ public final class RegistryClient: Cancellable {
                 }
 
                 // prepare target download locations
-                let downloadPath = destinationPath.withExtension("zip")
+                let downloadPath = destinationPath.appending(extension: "zip")
                 do {
                     // prepare directories
                     if !fileSystem.exists(downloadPath.parentDirectory) {
@@ -1942,13 +1942,6 @@ extension RegistryReleaseMetadata {
 
 // MARK: - Utilities
 
-extension AbsolutePath {
-    fileprivate func withExtension(_ extension: String) -> AbsolutePath {
-        guard !self.isRoot else { return self }
-        let `extension` = `extension`.spm_dropPrefix(".")
-        return self.parentDirectory.appending(component: "\(basename).\(`extension`)")
-    }
-}
 
 extension URLComponents {
     fileprivate mutating func appendPathComponents(_ components: String...) {

--- a/Sources/PackageRegistryTool/PackageRegistryTool+Publish.swift
+++ b/Sources/PackageRegistryTool/PackageRegistryTool+Publish.swift
@@ -183,7 +183,7 @@ extension SwiftPackageRegistryTool {
 
                 swiftTool.observabilityScope.emit(info: "signing the archive at '\(archivePath)'")
                 let signaturePath = workingDirectory
-                    .appending(component: "\(self.packageIdentity)-\(self.packageVersion).sig")
+                    .appending("\(self.packageIdentity)-\(self.packageVersion).sig")
                 signature = try await PackageArchiveSigner.sign(
                     archivePath: archivePath,
                     signaturePath: signaturePath,
@@ -237,7 +237,7 @@ extension SwiftPackageRegistryTool {
             cancellator: Cancellator?,
             observabilityScope: ObservabilityScope
         ) throws -> AbsolutePath {
-            let archivePath = workingDirectory.appending(component: "\(packageIdentity)-\(packageVersion).zip")
+            let archivePath = workingDirectory.appending("\(packageIdentity)-\(packageVersion).zip")
 
             // create temp location for sources
             let sourceDirectory = workingDirectory.appending(components: "source", "\(packageIdentity)")

--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -354,12 +354,12 @@ public struct BuildParameters: Encodable {
 
     /// The path to the code coverage directory.
     public var codeCovPath: AbsolutePath {
-        return buildPath.appending(component: "codecov")
+        return buildPath.appending("codecov")
     }
 
     /// The path to the code coverage profdata file.
     public var codeCovDataFile: AbsolutePath {
-        return codeCovPath.appending(component: "default.profdata")
+        return codeCovPath.appending("default.profdata")
     }
 
     public var llbuildManifest: AbsolutePath {

--- a/Sources/SPMBuildCore/XCFrameworkMetadata.swift
+++ b/Sources/SPMBuildCore/XCFrameworkMetadata.swift
@@ -48,7 +48,7 @@ public struct XCFrameworkMetadata: Equatable {
 
 extension XCFrameworkMetadata {
     public static func parse(fileSystem: FileSystem, rootPath: AbsolutePath) throws -> XCFrameworkMetadata {
-        let path = rootPath.appending(component: "Info.plist")
+        let path = rootPath.appending("Info.plist")
         guard fileSystem.exists(path) else {
             throw StringError("XCFramework Info.plist not found at '\(rootPath)'")
         }

--- a/Sources/SPMTestSupport/InMemoryGitRepository.swift
+++ b/Sources/SPMTestSupport/InMemoryGitRepository.swift
@@ -247,7 +247,7 @@ extension InMemoryGitRepository: FileSystem {
     }
 
     public var currentWorkingDirectory: AbsolutePath? {
-        return AbsolutePath(path: "/")
+        return AbsolutePath("/")
     }
 
     public func changeCurrentWorkingDirectory(to path: AbsolutePath) throws {

--- a/Sources/SPMTestSupport/MockRegistry.swift
+++ b/Sources/SPMTestSupport/MockRegistry.swift
@@ -356,11 +356,11 @@ public struct InMemoryRegistryPackageSource {
 
     public func writePackageContent(targets: [String] = [], toolsVersion: ToolsVersion = .current) throws {
         try self.fileSystem.createDirectory(self.path, recursive: true)
-        let sourcesDir = self.path.appending(component: "Sources")
+        let sourcesDir = self.path.appending("Sources")
         for target in targets {
             let targetDir = sourcesDir.appending(component: target)
             try self.fileSystem.createDirectory(targetDir, recursive: true)
-            try self.fileSystem.writeFileContents(targetDir.appending(component: "file.swift"), bytes: "")
+            try self.fileSystem.writeFileContents(targetDir.appending("file.swift"), bytes: "")
         }
         let manifestPath = self.path.appending(component: Manifest.filename)
         try self.fileSystem.writeFileContents(manifestPath, string: "// swift-tools-version:\(toolsVersion)")
@@ -407,7 +407,7 @@ private struct MockRegistryArchiver: Archiver {
                 let relativePath = String(path.dropFirst(rootPath.count + 1))
                 let targetPath = try AbsolutePath(
                     validating: relativePath,
-                    relativeTo: destinationPath.appending(component: "package")
+                    relativeTo: destinationPath.appending("package")
                 )
                 if !self.fileSystem.exists(targetPath.parentDirectory) {
                     try self.fileSystem.createDirectory(targetPath.parentDirectory, recursive: true)

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -95,11 +95,11 @@ public final class MockWorkspace {
     }
 
     public var rootsDir: AbsolutePath {
-        return self.sandbox.appending(component: "roots")
+        return self.sandbox.appending("roots")
     }
 
     public var packagesDir: AbsolutePath {
-        return self.sandbox.appending(component: "pkgs")
+        return self.sandbox.appending("pkgs")
     }
 
     public var artifactsDir: AbsolutePath {
@@ -228,11 +228,11 @@ public final class MockWorkspace {
             }
 
             func writePackageContent(fileSystem: FileSystem, root: AbsolutePath, toolsVersion: ToolsVersion) throws {
-                let sourcesDir = root.appending(component: "Sources")
+                let sourcesDir = root.appending("Sources")
                 for target in package.targets {
                     let targetDir = sourcesDir.appending(component: target.name)
                     try fileSystem.createDirectory(targetDir, recursive: true)
-                    try fileSystem.writeFileContents(targetDir.appending(component: "file.swift"), bytes: "")
+                    try fileSystem.writeFileContents(targetDir.appending("file.swift"), bytes: "")
                 }
                 let manifestPath = root.appending(component: Manifest.filename)
                 try fileSystem.writeFileContents(manifestPath, bytes: "")
@@ -265,9 +265,9 @@ public final class MockWorkspace {
         let workspace = try Workspace._init(
             fileSystem: self.fileSystem,
             location: .init(
-                scratchDirectory: self.sandbox.appending(component: ".build"),
-                editsDirectory: self.sandbox.appending(component: "edits"),
-                resolvedVersionsFile: self.sandbox.appending(component: "Package.resolved"),
+                scratchDirectory: self.sandbox.appending(".build"),
+                editsDirectory: self.sandbox.appending("edits"),
+                resolvedVersionsFile: self.sandbox.appending("Package.resolved"),
                 localConfigurationDirectory: Workspace.DefaultLocations.configurationDirectory(forRootPackage: self.sandbox),
                 sharedConfigurationDirectory: self.fileSystem.swiftPMConfigurationDirectory,
                 sharedSecurityDirectory: self.fileSystem.swiftPMSecurityDirectory,

--- a/Sources/SPMTestSupport/Toolchain.swift
+++ b/Sources/SPMTestSupport/Toolchain.swift
@@ -62,9 +62,9 @@ extension UserToolchain {
             // On macOS 11 and earlier, we don't know if concurrency actually works because not all SDKs and toolchains have the right bits.  We could examine the SDK and the various libraries, but the most accurate test is to just try to compile and run a snippet of code that requires async/await support.  It doesn't have to actually do anything, it's enough that all the libraries can be found (but because the library reference is weak we do need the linkage reference to `_swift_task_create` and the like).
             do {
                 try testWithTemporaryDirectory { tmpPath in
-                    let inputPath = tmpPath.appending(component: "foo.swift")
+                    let inputPath = tmpPath.appending("foo.swift")
                     try localFileSystem.writeFileContents(inputPath, string: "public func foo() async {}\nTask { await foo() }")
-                    let outputPath = tmpPath.appending(component: "foo")
+                    let outputPath = tmpPath.appending("foo")
                     let toolchainPath = self.swiftCompilerPath.parentDirectory.parentDirectory
                     let backDeploymentLibPath = toolchainPath.appending(components: "lib", "swift-5.5", "macosx")
                     try Process.checkNonZeroExit(arguments: ["/usr/bin/xcrun", "--toolchain", toolchainPath.pathString, "swiftc", inputPath.pathString, "-Xlinker", "-rpath", "-Xlinker", backDeploymentLibPath.pathString, "-o", outputPath.pathString])
@@ -87,10 +87,10 @@ extension UserToolchain {
     public func supportsSerializedDiagnostics(otherSwiftFlags: [String] = []) -> Bool {
         do {
             try testWithTemporaryDirectory { tmpPath in
-                let inputPath = tmpPath.appending(component: "best.swift")
+                let inputPath = tmpPath.appending("best.swift")
                 try localFileSystem.writeFileContents(inputPath, string: "func foo() -> Bool {\nvar unused: Int\nreturn true\n}\n")
-                let outputPath = tmpPath.appending(component: "foo")
-                let serializedDiagnosticsPath = tmpPath.appending(component: "out.dia")
+                let outputPath = tmpPath.appending("foo")
+                let serializedDiagnosticsPath = tmpPath.appending("out.dia")
                 let toolchainPath = self.swiftCompilerPath.parentDirectory.parentDirectory
                 try Process.checkNonZeroExit(arguments: ["/usr/bin/xcrun", "--toolchain", toolchainPath.pathString, "swiftc", inputPath.pathString, "-Xfrontend", "-serialize-diagnostics-path", "-Xfrontend", serializedDiagnosticsPath.pathString, "-g", "-o", outputPath.pathString] + otherSwiftFlags)
                 try Process.checkNonZeroExit(arguments: [outputPath.pathString])

--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -59,7 +59,7 @@ public func fixture(
 
             // Construct the expected path of the fixture.
             // FIXME: This seems quite hacky; we should provide some control over where fixtures are found.
-            let fixtureDir = AbsolutePath(path: "../../../Fixtures", relativeTo: AbsolutePath(path: #file)).appending(fixtureSubpath)
+            let fixtureDir = AbsolutePath("../../../Fixtures", relativeTo: AbsolutePath(path: #file)).appending(fixtureSubpath)
 
             // Check that the fixture is really there.
             guard localFileSystem.isDirectory(fixtureDir) else {
@@ -68,7 +68,7 @@ public func fixture(
             }
 
             // The fixture contains either a checkout or just a Git directory.
-            if localFileSystem.isFile(fixtureDir.appending(component: "Package.swift")) {
+            if localFileSystem.isFile(fixtureDir.appending("Package.swift")) {
                 // It's a single package, so copy the whole directory as-is.
                 let dstDir = tmpDirPath.appending(component: copyName)
                 try systemQuietly("cp", "-R", "-H", fixtureDir.pathString, dstDir.pathString)
@@ -121,7 +121,7 @@ public func initGitRepo(
 ) {
     do {
         if addFile {
-            let file = dir.appending(component: "file.swift")
+            let file = dir.appending("file.swift")
             try localFileSystem.writeFileContents(file, bytes: "")
         }
 
@@ -258,20 +258,22 @@ public func loadPackageGraph(
 
 public let emptyZipFile = ByteString([0x80, 0x75, 0x05, 0x06] + [UInt8](repeating: 0x00, count: 18))
 
- extension AbsolutePath {
-     public init(path: StaticString) {
-        let pathString = path.withUTF8Buffer {
-            String(decoding: $0, as: UTF8.self)
-        }
-        try! self.init(validating: pathString)
+extension AbsolutePath: ExpressibleByStringLiteral {
+    public init(_ value: StringLiteralType) {
+        try! self.init(validating: value)
     }
+}
 
-     public init(path: StaticString, relativeTo basePath: AbsolutePath) {
-        let pathString = path.withUTF8Buffer {
-            String(decoding: $0, as: UTF8.self)
-        }
-        try! self.init(validating: pathString, relativeTo: basePath)
+extension AbsolutePath: ExpressibleByStringInterpolation {
+    public init(stringLiteral value: String) {
+        try! self.init(validating: value)
     }
+}
+
+extension AbsolutePath {
+    public init(_ path: StringLiteralType, relativeTo basePath: AbsolutePath) {
+       try! self.init(validating: path, relativeTo: basePath)
+   }
 }
 
 extension URL: ExpressibleByStringLiteral {

--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -253,7 +253,7 @@ public final class InitPackage {
         guard packageType != .empty else {
             return
         }
-        let gitignore = destinationPath.appending(component: ".gitignore")
+        let gitignore = destinationPath.appending(".gitignore")
         guard self.fileSystem.exists(gitignore) == false else {
             return
         }
@@ -278,7 +278,7 @@ public final class InitPackage {
             return
         }
 
-        let sources = destinationPath.appending(component: "Sources")
+        let sources = destinationPath.appending("Sources")
         guard self.fileSystem.exists(sources) == false else {
             return
         }
@@ -287,7 +287,7 @@ public final class InitPackage {
 
         let moduleDir = packageType == .executable || packageType == .tool
           ? sources
-          : sources.appending(component: "\(pkgname)")
+          : sources.appending("\(pkgname)")
         try makeDirectories(moduleDir)
 
         let sourceFileName: String
@@ -345,7 +345,7 @@ public final class InitPackage {
         case .empty, .executable, .tool, .`extension`: return
             default: break
         }
-        let tests = destinationPath.appending(component: "Tests")
+        let tests = destinationPath.appending("Tests")
         guard self.fileSystem.exists(tests) == false else {
             return
         }

--- a/Sources/Workspace/Workspace+BinaryArtifacts.swift
+++ b/Sources/Workspace/Workspace+BinaryArtifacts.swift
@@ -571,13 +571,3 @@ extension FileSystem {
             .first{ $0.extension.map { acceptableExtensions.contains($0) } ?? false } != nil
     }
 }
-
-extension AbsolutePath {
-    fileprivate func basenameWithoutAnyExtension() -> String {
-        var basename = self.basename
-        if let index = basename.firstIndex(of: ".") {
-            basename.removeSubrange(index ..< basename.endIndex)
-        }
-        return String(basename)
-    }
-}

--- a/Sources/Workspace/Workspace+Configuration.swift
+++ b/Sources/Workspace/Workspace+Configuration.swift
@@ -58,12 +58,12 @@ extension Workspace {
 
         /// Path to the repositories clones.
         public var repositoriesDirectory: AbsolutePath {
-            self.scratchDirectory.appending(component: "repositories")
+            self.scratchDirectory.appending("repositories")
         }
 
         /// Path to the repository checkouts.
         public var repositoriesCheckoutsDirectory: AbsolutePath {
-            self.scratchDirectory.appending(component: "checkouts")
+            self.scratchDirectory.appending("checkouts")
         }
 
         /// Path to the registry downloads.
@@ -73,12 +73,12 @@ extension Workspace {
 
         /// Path to the downloaded binary artifacts.
         public var artifactsDirectory: AbsolutePath {
-            self.scratchDirectory.appending(component: "artifacts")
+            self.scratchDirectory.appending("artifacts")
         }
 
         // Path to temporary files related to running plugins in the workspace
         public var pluginWorkingDirectory: AbsolutePath {
-            self.scratchDirectory.appending(component: "plugins")
+            self.scratchDirectory.appending("plugins")
         }
 
         // config locations
@@ -113,17 +113,17 @@ extension Workspace {
 
         /// Path to the shared fingerprints directory.
         public var sharedFingerprintsDirectory: AbsolutePath? {
-            self.sharedSecurityDirectory.map { $0.appending(component: "fingerprints") }
+            self.sharedSecurityDirectory.map { $0.appending("fingerprints") }
         }
         
         /// Path to the shared directory where package signing records are kept.
         public var sharedSigningEntitiesDirectory: AbsolutePath? {
-            self.sharedSecurityDirectory.map { $0.appending(component: "signing-entities") }
+            self.sharedSecurityDirectory.map { $0.appending("signing-entities") }
         }
 
         /// Path to the shared trusted root certificates directory.
         public var sharedTrustedRootCertificatesDirectory: AbsolutePath? {
-            self.sharedSecurityDirectory.map { $0.appending(component: "trusted-root-certs") }
+            self.sharedSecurityDirectory.map { $0.appending("trusted-root-certs") }
         }
         
         // cache locations
@@ -135,7 +135,7 @@ extension Workspace {
 
         /// Path to the shared repositories cache.
         public var sharedRepositoriesCacheDirectory: AbsolutePath? {
-            self.sharedCacheDirectory.map { $0.appending(component: "repositories") }
+            self.sharedCacheDirectory.map { $0.appending("repositories") }
         }
 
         /// Path to the shared registry download cache.
@@ -196,15 +196,15 @@ extension Workspace {
     /// Workspace default locations utilities
     public struct DefaultLocations {
         public static func scratchDirectory(forRootPackage rootPath: AbsolutePath) -> AbsolutePath {
-            rootPath.appending(component: ".build")
+            rootPath.appending(".build")
         }
 
         public static func editsDirectory(forRootPackage rootPath: AbsolutePath) -> AbsolutePath {
-            rootPath.appending(component: "Packages")
+            rootPath.appending("Packages")
         }
 
         public static func resolvedVersionsFile(forRootPackage rootPath: AbsolutePath) -> AbsolutePath {
-            rootPath.appending(component: "Package.resolved")
+            rootPath.appending("Package.resolved")
         }
 
         public static func configurationDirectory(forRootPackage rootPath: AbsolutePath) -> AbsolutePath {
@@ -216,7 +216,7 @@ extension Workspace {
         }
 
         public static func mirrorsConfigurationFile(at path: AbsolutePath) -> AbsolutePath {
-            path.appending(component: "mirrors.json")
+            path.appending("mirrors.json")
         }
 
         public static func registriesConfigurationFile(forRootPackage rootPath: AbsolutePath) -> AbsolutePath {
@@ -224,11 +224,11 @@ extension Workspace {
         }
 
         public static func registriesConfigurationFile(at path: AbsolutePath) -> AbsolutePath {
-            path.appending(component: "registries.json")
+            path.appending("registries.json")
         }
 
         public static func manifestsDirectory(at path: AbsolutePath) -> AbsolutePath {
-            path.appending(component: "manifests")
+            path.appending("manifests")
         }
     }
 
@@ -282,7 +282,7 @@ extension Workspace.Configuration {
                 providers.append(try NetrcAuthorizationProvider(path: path, fileSystem: fileSystem))
             case .user:
                 // user .netrc file (most typical)
-                let userHomePath = try fileSystem.homeDirectory.appending(component: ".netrc")
+                let userHomePath = try fileSystem.homeDirectory.appending(".netrc")
 
                 // user didn't tell us to explicitly use these .netrc files so be more lenient with errors
                 if let userHomeProvider = self.loadOptionalNetrc(fileSystem: fileSystem, path: userHomePath, observabilityScope: observabilityScope) {
@@ -331,7 +331,7 @@ extension Workspace.Configuration {
                 }
                 providers.append(try NetrcAuthorizationProvider(path: path, fileSystem: fileSystem))
             case .user:
-                let userHomePath = try fileSystem.homeDirectory.appending(component: ".netrc")
+                let userHomePath = try fileSystem.homeDirectory.appending(".netrc")
                 // Add user .netrc file unless we don't have access
                 if let userHomeProvider = try? NetrcAuthorizationProvider(path: userHomePath, fileSystem: fileSystem) {
                     providers.append(userHomeProvider)

--- a/Sources/Workspace/Workspace+State.swift
+++ b/Sources/Workspace/Workspace+State.swift
@@ -38,7 +38,7 @@ public final class WorkspaceState {
         storageDirectory: AbsolutePath,
         initializationWarningHandler: (String) -> Void
     ) {
-        self.storagePath = storageDirectory.appending(component: "workspace-state.json")
+        self.storagePath = storageDirectory.appending("workspace-state.json")
         self.storage = WorkspaceStateStorage(path: self.storagePath, fileSystem: fileSystem)
 
         // Load the state from disk, if possible.

--- a/Sources/swift-bootstrap/main.swift
+++ b/Sources/swift-bootstrap/main.swift
@@ -160,7 +160,7 @@ struct SwiftBootstrapBuildTool: ParsableCommand {
             let scratchDirectory =
                 try BuildSystemUtilities.getEnvBuildPath(workingDir: cwd) ??
                 self.scratchDirectory ??
-                packagePath.appending(component: ".build")
+                packagePath.appending(".build")
 
             let builder = try Builder(
                 fileSystem: localFileSystem,

--- a/Tests/BasicsTests/AuthorizationProviderTests.swift
+++ b/Tests/BasicsTests/AuthorizationProviderTests.swift
@@ -28,7 +28,7 @@ final class AuthorizationProviderTests: XCTestCase {
 
     func testNetrc() throws {
         try testWithTemporaryDirectory { tmpPath in
-            let netrcPath = tmpPath.appending(component: ".netrc")
+            let netrcPath = tmpPath.appending(".netrc")
 
             let provider = try NetrcAuthorizationProvider(path: netrcPath, fileSystem: localFileSystem)
 

--- a/Tests/BasicsTests/CancellatorTests.swift
+++ b/Tests/BasicsTests/CancellatorTests.swift
@@ -46,7 +46,7 @@ final class CancellatorTests: XCTestCase {
     func testTSCProcess() throws {
 #if os(macOS)
         try withTemporaryDirectory { temporaryDirectory in
-            let scriptPath = temporaryDirectory.appending(component: "script")
+            let scriptPath = temporaryDirectory.appending("script")
             try localFileSystem.writeFileContents(scriptPath) {
                 """
                 set -e
@@ -104,7 +104,7 @@ final class CancellatorTests: XCTestCase {
     func testTSCProcessForceKill() throws {
 #if os(macOS)
         try withTemporaryDirectory { temporaryDirectory in
-            let scriptPath = temporaryDirectory.appending(component: "script")
+            let scriptPath = temporaryDirectory.appending("script")
             try localFileSystem.writeFileContents(scriptPath) {
                 """
                 set -e
@@ -170,7 +170,7 @@ final class CancellatorTests: XCTestCase {
     func testFoundationProcess() throws {
 #if os(macOS)
         try withTemporaryDirectory { temporaryDirectory in
-            let scriptPath = temporaryDirectory.appending(component: "script")
+            let scriptPath = temporaryDirectory.appending("script")
             try localFileSystem.writeFileContents(scriptPath) {
                 """
                 set -e
@@ -232,7 +232,7 @@ final class CancellatorTests: XCTestCase {
     func testFoundationProcessForceKill() throws {
 #if os(macOS)
         try withTemporaryDirectory { temporaryDirectory in
-            let scriptPath = temporaryDirectory.appending(component: "script")
+            let scriptPath = temporaryDirectory.appending("script")
             try localFileSystem.writeFileContents(scriptPath) {
                 """
                 set -e

--- a/Tests/BasicsTests/FileSystem/AsyncFileSystemTests.swift
+++ b/Tests/BasicsTests/FileSystem/AsyncFileSystemTests.swift
@@ -22,18 +22,18 @@ final class AsyncFileSystemTests: XCTestCase {
     func testStripFirstLevelComponent() async throws {
         let fileSystem = AsyncFileSystem { InMemoryFileSystem() }
 
-        let rootPath = AbsolutePath(path: "/root")
+        let rootPath = AbsolutePath("/root")
         try await fileSystem.createDirectory(rootPath)
 
         let totalDirectories = Int.random(in: 0 ..< 100)
         for index in 0 ..< totalDirectories {
-            let path = rootPath.appending(component: "dir\(index)")
+            let path = rootPath.appending("dir\(index)")
             try await fileSystem.createDirectory(path, recursive: false)
         }
 
         let totalFiles = Int.random(in: 0 ..< 100)
         for index in 0 ..< totalFiles {
-            let path = rootPath.appending(component: "file\(index)")
+            let path = rootPath.appending("file\(index)")
             try await fileSystem.writeFileContents(path, string: "\(index)")
         }
 
@@ -71,7 +71,7 @@ final class AsyncFileSystemTests: XCTestCase {
         do {
             let fileSystem = AsyncFileSystem { InMemoryFileSystem() }
             for index in 0 ..< 3 {
-                let path = AbsolutePath.root.appending(component: "dir\(index)")
+                let path = AbsolutePath.root.appending("dir\(index)")
                 try await fileSystem.createDirectory(path, recursive: false)
             }
             do {
@@ -85,7 +85,7 @@ final class AsyncFileSystemTests: XCTestCase {
         do {
             let fileSystem = AsyncFileSystem { InMemoryFileSystem() }
             for index in 0 ..< 3 {
-                let path = AbsolutePath.root.appending(component: "file\(index)")
+                let path = AbsolutePath.root.appending("file\(index)")
                 try await fileSystem.writeFileContents(path, string: "\(index)")
             }
             do {
@@ -98,7 +98,7 @@ final class AsyncFileSystemTests: XCTestCase {
 
         do {
             let fileSystem = AsyncFileSystem { InMemoryFileSystem() }
-            let path = AbsolutePath.root.appending(component: "file")
+            let path = AbsolutePath.root.appending("file")
             try await fileSystem.writeFileContents(path, string: "")
             try await fileSystem.stripFirstLevel(of: .root)
             XCTFail("expected error")

--- a/Tests/BasicsTests/FileSystem/FileSystemTests.swift
+++ b/Tests/BasicsTests/FileSystem/FileSystemTests.swift
@@ -20,18 +20,18 @@ final class FileSystemTests: XCTestCase {
     func testStripFirstLevelComponent() throws {
         let fileSystem = InMemoryFileSystem()
 
-        let rootPath = AbsolutePath(path: "/root")
+        let rootPath = AbsolutePath("/root")
         try fileSystem.createDirectory(rootPath)
 
         let totalDirectories = Int.random(in: 0 ..< 100)
         for index in 0 ..< totalDirectories {
-            let path = rootPath.appending(component: "dir\(index)")
+            let path = rootPath.appending("dir\(index)")
             try fileSystem.createDirectory(path, recursive: false)
         }
 
         let totalFiles = Int.random(in: 0 ..< 100)
         for index in 0 ..< totalFiles {
-            let path = rootPath.appending(component: "file\(index)")
+            let path = rootPath.appending("file\(index)")
             try fileSystem.writeFileContents(path, string: "\(index)")
         }
 
@@ -66,7 +66,7 @@ final class FileSystemTests: XCTestCase {
         do {
             let fileSystem = InMemoryFileSystem()
             for index in 0 ..< 3 {
-                let path = AbsolutePath.root.appending(component: "dir\(index)")
+                let path = AbsolutePath.root.appending("dir\(index)")
                 try fileSystem.createDirectory(path, recursive: false)
             }
             XCTAssertThrowsError(try fileSystem.stripFirstLevel(of: .root), "expected error") { error in
@@ -77,7 +77,7 @@ final class FileSystemTests: XCTestCase {
         do {
             let fileSystem = InMemoryFileSystem()
             for index in 0 ..< 3 {
-                let path = AbsolutePath.root.appending(component: "file\(index)")
+                let path = AbsolutePath.root.appending("file\(index)")
                 try fileSystem.writeFileContents(path, string: "\(index)")
             }
             XCTAssertThrowsError(try fileSystem.stripFirstLevel(of: .root), "expected error") { error in
@@ -87,7 +87,7 @@ final class FileSystemTests: XCTestCase {
 
         do {
             let fileSystem = InMemoryFileSystem()
-            let path = AbsolutePath.root.appending(component: "file")
+            let path = AbsolutePath.root.appending("file")
             try fileSystem.writeFileContents(path, string: "")
             XCTAssertThrowsError(try fileSystem.stripFirstLevel(of: .root), "expected error") { error in
                 XCTAssertMatch((error as? StringError)?.description, .contains("requires single top level directory"))

--- a/Tests/BasicsTests/FileSystem/TemporaryFileTests.swift
+++ b/Tests/BasicsTests/FileSystem/TemporaryFileTests.swift
@@ -33,7 +33,7 @@ class TemporaryAsyncFileTests: XCTestCase {
         let path2: AbsolutePath = try await withTemporaryDirectory { tempDirPath in
             XCTAssertTrue(localFileSystem.isDirectory(tempDirPath))
             // Create a file inside the temp directory.
-            let filePath = tempDirPath.appending(component: "somefile")
+            let filePath = tempDirPath.appending("somefile")
             // Do some async task
             try await Task.sleep(nanoseconds: 1_000)
             
@@ -48,7 +48,7 @@ class TemporaryAsyncFileTests: XCTestCase {
         // Test temp directory is removed when its not empty and removeTreeOnDeinit is enabled.
         let path3: AbsolutePath = try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDirPath in
             XCTAssertTrue(localFileSystem.isDirectory(tempDirPath))
-            let filePath = tempDirPath.appending(component: "somefile")
+            let filePath = tempDirPath.appending("somefile")
             // Do some async task
             try await Task.sleep(nanoseconds: 1_000)
             

--- a/Tests/BasicsTests/FileSystem/VFSTests.swift
+++ b/Tests/BasicsTests/FileSystem/VFSTests.swift
@@ -54,22 +54,22 @@ class VFSTests: XCTestCase {
         let fs = TSCBasic.localFileSystem
         try withTemporaryFile { [contents] vfsPath in
             try withTemporaryDirectory(removeTreeOnDeinit: true) { [contents] tempDirPath in
-                let file = tempDirPath.appending(component: "best")
+                let file = tempDirPath.appending("best")
                 try fs.writeFileContents(file, string: "best")
 
-                let sym = tempDirPath.appending(component: "hello")
+                let sym = tempDirPath.appending("hello")
                 try fs.createSymbolicLink(sym, pointingAt: file, relative: false)
 
-                let executable = tempDirPath.appending(component: "exec-foo")
+                let executable = tempDirPath.appending("exec-foo")
                 try fs.writeFileContents(executable, bytes: ByteString(contents))
 #if !os(Windows)
                 try fs.chmod(.executable, path: executable, options: [])
 #endif
 
-                let executableSym = tempDirPath.appending(component: "exec-sym")
+                let executableSym = tempDirPath.appending("exec-sym")
                 try fs.createSymbolicLink(executableSym, pointingAt: executable, relative: false)
 
-                try fs.createDirectory(tempDirPath.appending(component: "dir"))
+                try fs.createDirectory(tempDirPath.appending("dir"))
                 try fs.writeFileContents(tempDirPath.appending(components: ["dir", "file"]), body: { _ in })
 
                 try VirtualFileSystem.serializeDirectoryTree(tempDirPath, into: vfsPath.path, fs: fs, includeContents: [executable])
@@ -78,62 +78,62 @@ class VFSTests: XCTestCase {
             let vfs = try VirtualFileSystem(path: vfsPath.path, fs: fs)
 
             // exists()
-            XCTAssertTrue(vfs.exists(AbsolutePath(path: "/")))
-            XCTAssertFalse(vfs.exists(AbsolutePath(path: "/does-not-exist")))
+            XCTAssertTrue(vfs.exists(AbsolutePath("/")))
+            XCTAssertFalse(vfs.exists(AbsolutePath("/does-not-exist")))
 
             // isFile()
-            let filePath = AbsolutePath(path: "/best")
+            let filePath = AbsolutePath("/best")
             XCTAssertTrue(vfs.exists(filePath))
             XCTAssertTrue(vfs.isFile(filePath))
             XCTAssertEqual(try vfs.getFileInfo(filePath).fileType, .typeRegular)
             XCTAssertFalse(vfs.isDirectory(filePath))
-            XCTAssertFalse(vfs.isFile(AbsolutePath(path: "/does-not-exist")))
-            XCTAssertFalse(vfs.isSymlink(AbsolutePath(path: "/does-not-exist")))
-            XCTAssertThrowsError(try vfs.getFileInfo(AbsolutePath(path: "/does-not-exist")))
+            XCTAssertFalse(vfs.isFile(AbsolutePath("/does-not-exist")))
+            XCTAssertFalse(vfs.isSymlink(AbsolutePath("/does-not-exist")))
+            XCTAssertThrowsError(try vfs.getFileInfo(AbsolutePath("/does-not-exist")))
 
             // isSymlink()
-            let symPath = AbsolutePath(path: "/hello")
+            let symPath = AbsolutePath("/hello")
             XCTAssertTrue(vfs.isSymlink(symPath))
             XCTAssertTrue(vfs.isFile(symPath))
             XCTAssertEqual(try vfs.getFileInfo(symPath).fileType, .typeSymbolicLink)
             XCTAssertFalse(vfs.isDirectory(symPath))
 
             // isExecutableFile
-            let executablePath = AbsolutePath(path: "/exec-foo")
-            let executableSymPath = AbsolutePath(path: "/exec-sym")
+            let executablePath = AbsolutePath("/exec-foo")
+            let executableSymPath = AbsolutePath("/exec-sym")
             XCTAssertTrue(vfs.isExecutableFile(executablePath))
             XCTAssertTrue(vfs.isExecutableFile(executableSymPath))
             XCTAssertTrue(vfs.isSymlink(executableSymPath))
             XCTAssertFalse(vfs.isExecutableFile(symPath))
             XCTAssertFalse(vfs.isExecutableFile(filePath))
-            XCTAssertFalse(vfs.isExecutableFile(AbsolutePath(path: "/does-not-exist")))
-            XCTAssertFalse(vfs.isExecutableFile(AbsolutePath(path: "/")))
+            XCTAssertFalse(vfs.isExecutableFile(AbsolutePath("/does-not-exist")))
+            XCTAssertFalse(vfs.isExecutableFile(AbsolutePath("/")))
 
             // readFileContents
             let execFileContents = try vfs.readFileContents(executablePath)
             XCTAssertEqual(execFileContents, ByteString(contents))
 
             // isDirectory()
-            XCTAssertTrue(vfs.isDirectory(AbsolutePath(path: "/")))
-            XCTAssertFalse(vfs.isDirectory(AbsolutePath(path: "/does-not-exist")))
+            XCTAssertTrue(vfs.isDirectory(AbsolutePath("/")))
+            XCTAssertFalse(vfs.isDirectory(AbsolutePath("/does-not-exist")))
 
             // getDirectoryContents()
             do {
-                _ = try vfs.getDirectoryContents(AbsolutePath(path: "/does-not-exist"))
+                _ = try vfs.getDirectoryContents(AbsolutePath("/does-not-exist"))
                 XCTFail("Unexpected success")
             } catch {
-                XCTAssertEqual(error.localizedDescription, "no such file or directory: \(AbsolutePath(path: "/does-not-exist"))")
+                XCTAssertEqual(error.localizedDescription, "no such file or directory: \(AbsolutePath("/does-not-exist"))")
             }
 
-            let thisDirectoryContents = try vfs.getDirectoryContents(AbsolutePath(path: "/"))
+            let thisDirectoryContents = try vfs.getDirectoryContents(AbsolutePath("/"))
             XCTAssertFalse(thisDirectoryContents.contains(where: { $0 == "." }))
             XCTAssertFalse(thisDirectoryContents.contains(where: { $0 == ".." }))
             XCTAssertEqual(thisDirectoryContents.sorted(), ["best", "dir", "exec-foo", "exec-sym", "hello"])
 
-            let contents = try vfs.getDirectoryContents(AbsolutePath(path: "/dir"))
+            let contents = try vfs.getDirectoryContents(AbsolutePath("/dir"))
             XCTAssertEqual(contents, ["file"])
 
-            let fileContents = try vfs.readFileContents(AbsolutePath(path: "/dir/file"))
+            let fileContents = try vfs.readFileContents(AbsolutePath("/dir/file"))
             XCTAssertEqual(fileContents, "")
         }
     }

--- a/Tests/BasicsTests/SQLiteBackedCacheTests.swift
+++ b/Tests/BasicsTests/SQLiteBackedCacheTests.swift
@@ -19,7 +19,7 @@ import XCTest
 final class SQLiteBackedCacheTests: XCTestCase {
     func testHappyCase() throws {
         try testWithTemporaryDirectory { tmpPath in
-            let path = tmpPath.appending(component: "test.db")
+            let path = tmpPath.appending("test.db")
             let cache = SQLiteBackedCache<String>(tableName: "SQLiteBackedCacheTest", path: path)
             defer { XCTAssertNoThrow(try cache.close()) }
 
@@ -59,7 +59,7 @@ final class SQLiteBackedCacheTests: XCTestCase {
         try XCTSkipIf(is_tsan_enabled())
 
         try testWithTemporaryDirectory { tmpPath in
-            let path = tmpPath.appending(component: "test.db")
+            let path = tmpPath.appending("test.db")
             let cache = SQLiteBackedCache<String>(tableName: "SQLiteBackedCacheTest", path: path)
             defer { XCTAssertNoThrow(try cache.close()) }
 
@@ -101,7 +101,7 @@ final class SQLiteBackedCacheTests: XCTestCase {
         try XCTSkipIf(is_tsan_enabled())
 
         try testWithTemporaryDirectory { tmpPath in
-            let path = tmpPath.appending(component: "test.db")
+            let path = tmpPath.appending("test.db")
             let cache = SQLiteBackedCache<String>(tableName: "SQLiteBackedCacheTest", path: path)
             defer { XCTAssertNoThrow(try cache.close()) }
 
@@ -136,7 +136,7 @@ final class SQLiteBackedCacheTests: XCTestCase {
 
     func testMaxSizeNotHandled() throws {
         try testWithTemporaryDirectory { tmpPath in
-            let path = tmpPath.appending(component: "test.db")
+            let path = tmpPath.appending("test.db")
             var configuration = SQLiteBackedCacheConfiguration()
             configuration.maxSizeInBytes = 1024 * 3
             configuration.truncateWhenFull = false
@@ -158,7 +158,7 @@ final class SQLiteBackedCacheTests: XCTestCase {
 
     func testMaxSizeHandled() throws {
         try testWithTemporaryDirectory { tmpPath in
-            let path = tmpPath.appending(component: "test.db")
+            let path = tmpPath.appending("test.db")
             var configuration = SQLiteBackedCacheConfiguration()
             configuration.maxSizeInBytes = 1024 * 3
             configuration.truncateWhenFull = true

--- a/Tests/BasicsTests/SandboxTests.swift
+++ b/Tests/BasicsTests/SandboxTests.swift
@@ -143,13 +143,13 @@ final class SandboxTest: XCTestCase {
 
         try withTemporaryDirectory { tmpDir in
             // Check that we can write into the temporary directory, but not into a read-only directory underneath it.
-            let writableDir = tmpDir.appending(component: "ShouldBeWritable")
+            let writableDir = tmpDir.appending("ShouldBeWritable")
             try localFileSystem.createDirectory(writableDir)
             let allowedCommand = try Sandbox.apply(command: ["touch", writableDir.pathString], strictness: .default, writableDirectories: [writableDir])
             XCTAssertNoThrow(try TSCBasic.Process.checkNonZeroExit(arguments: allowedCommand))
 
             // Check that we cannot write into a read-only directory inside a writable temporary directory.
-            let readOnlyDir = writableDir.appending(component: "ShouldBeReadOnly")
+            let readOnlyDir = writableDir.appending("ShouldBeReadOnly")
             try localFileSystem.createDirectory(readOnlyDir)
             let deniedCommand = try Sandbox.apply(command: ["touch", readOnlyDir.pathString], strictness: .writableTemporaryDirectory, readOnlyDirectories: [readOnlyDir])
             XCTAssertThrowsError(try TSCBasic.Process.checkNonZeroExit(arguments: deniedCommand)) { error in
@@ -168,7 +168,7 @@ final class SandboxTest: XCTestCase {
 
          try withTemporaryDirectory { tmpDir in
              // Check that we cannot write into a read-only directory, but into a writable directory underneath it.
-             let readOnlyDir = tmpDir.appending(component: "ShouldBeReadOnly")
+             let readOnlyDir = tmpDir.appending("ShouldBeReadOnly")
              try localFileSystem.createDirectory(readOnlyDir)
              let deniedCommand = try Sandbox.apply(command: ["touch", readOnlyDir.pathString], strictness: .writableTemporaryDirectory, readOnlyDirectories: [readOnlyDir])
              XCTAssertThrowsError(try TSCBasic.Process.checkNonZeroExit(arguments: deniedCommand)) { error in
@@ -179,7 +179,7 @@ final class SandboxTest: XCTestCase {
              }
 
              // Check that we can write into a writable directory underneath it.
-             let writableDir = readOnlyDir.appending(component: "ShouldBeWritable")
+             let writableDir = readOnlyDir.appending("ShouldBeWritable")
              try localFileSystem.createDirectory(writableDir)
              let allowedCommand = try Sandbox.apply(command: ["touch", writableDir.pathString], strictness: .default, writableDirectories:[writableDir], readOnlyDirectories: [readOnlyDir])
              XCTAssertNoThrow(try TSCBasic.Process.checkNonZeroExit(arguments: allowedCommand))

--- a/Tests/BasicsTests/URLSessionHTTPClientTests.swift
+++ b/Tests/BasicsTests/URLSessionHTTPClientTests.swift
@@ -231,7 +231,7 @@ final class URLSessionHTTPClientTest: XCTestCase {
             let completionExpectation = XCTestExpectation(description: "completion")
 
             let url = URL("https://downloader-tests.com/testBasics.zip")
-            let destination = temporaryDirectory.appending(component: "download")
+            let destination = temporaryDirectory.appending("download")
             let request = LegacyHTTPClient.Request.download(url: url, fileSystem: localFileSystem, destination: destination)
             httpClient.execute(
                 request,
@@ -299,7 +299,7 @@ final class URLSessionHTTPClientTest: XCTestCase {
             let completionExpectation = XCTestExpectation(description: "completion")
 
             let url = URL("https://protected.downloader-tests.com/testBasics.zip")
-            let destination = temporaryDirectory.appending(component: "download")
+            let destination = temporaryDirectory.appending("download")
             var request = LegacyHTTPClient.Request.download(url: url, fileSystem: localFileSystem, destination: destination)
             request.options.authorizationProvider = netrc.httpAuthorizationHeader(for:)
 
@@ -370,7 +370,7 @@ final class URLSessionHTTPClientTest: XCTestCase {
             let completionExpectation = XCTestExpectation(description: "completion")
 
             let url = URL("https://restricted.downloader-tests.com/testBasics.zip")
-            let destination = temporaryDirectory.appending(component: "download")
+            let destination = temporaryDirectory.appending("download")
             var request = LegacyHTTPClient.Request.download(url: url, fileSystem: localFileSystem, destination: destination)
             request.options.authorizationProvider = netrc.httpAuthorizationHeader(for:)
 
@@ -436,7 +436,7 @@ final class URLSessionHTTPClientTest: XCTestCase {
 
             let clientError = StringError("boom")
             let url = URL("https://downloader-tests.com/testClientError.zip")
-            let request = LegacyHTTPClient.Request.download(url: url, fileSystem: localFileSystem, destination: temporaryDirectory.appending(component: "download"))
+            let request = LegacyHTTPClient.Request.download(url: url, fileSystem: localFileSystem, destination: temporaryDirectory.appending("download"))
             httpClient.execute(
                 request,
                 progress: { bytesDownloaded, totalBytesToDownload in
@@ -497,7 +497,7 @@ final class URLSessionHTTPClientTest: XCTestCase {
             let completionExpectation = XCTestExpectation(description: "completion")
 
             let url = URL("https://downloader-tests.com/testServerError.zip")
-            var request = LegacyHTTPClient.Request.download(url: url, fileSystem: localFileSystem, destination: temporaryDirectory.appending(component: "download"))
+            var request = LegacyHTTPClient.Request.download(url: url, fileSystem: localFileSystem, destination: temporaryDirectory.appending("download"))
             request.options.validResponseCodes = [200]
 
             httpClient.execute(
@@ -545,7 +545,7 @@ final class URLSessionHTTPClientTest: XCTestCase {
             let completionExpectation = XCTestExpectation(description: "error")
 
             let url = URL("https://downloader-tests.com/testFileSystemError.zip")
-            let request = LegacyHTTPClient.Request.download(url: url, fileSystem: FailingFileSystem(), destination: temporaryDirectory.appending(component: "download"))
+            let request = LegacyHTTPClient.Request.download(url: url, fileSystem: FailingFileSystem(), destination: temporaryDirectory.appending("download"))
             httpClient.execute(request, progress: { _, _ in }, completion: { result in
                 switch result {
                 case .success:
@@ -717,7 +717,7 @@ final class URLSessionHTTPClientTest: XCTestCase {
 
         try await testWithTemporaryDirectory { temporaryDirectory in
             let url = URL("https://async-downloader-tests.com/testBasics.zip")
-            let destination = temporaryDirectory.appending(component: "download")
+            let destination = temporaryDirectory.appending("download")
             let request = HTTPClient.Request.download(
                 url: url,
                 fileSystem: AsyncFileSystem { localFileSystem },
@@ -771,7 +771,7 @@ final class URLSessionHTTPClientTest: XCTestCase {
 
         try await testWithTemporaryDirectory { temporaryDirectory in
             let url = URL("https://async-protected.downloader-tests.com/testBasics.zip")
-            let destination = temporaryDirectory.appending(component: "download")
+            let destination = temporaryDirectory.appending("download")
             var options = HTTPClientRequest.Options()
             options.authorizationProvider = netrc.httpAuthorizationHeader(for:)
             let request = HTTPClient.Request.download(
@@ -829,7 +829,7 @@ final class URLSessionHTTPClientTest: XCTestCase {
 
         try await testWithTemporaryDirectory { temporaryDirectory in
             let url = URL("https://async-restricted.downloader-tests.com/testBasics.zip")
-            let destination = temporaryDirectory.appending(component: "download")
+            let destination = temporaryDirectory.appending("download")
 
             var options = HTTPClientRequest.Options()
             options.authorizationProvider = netrc.httpAuthorizationHeader(for:)
@@ -887,7 +887,7 @@ final class URLSessionHTTPClientTest: XCTestCase {
             let request = HTTPClient.Request.download(
                 url: url,
                 fileSystem: AsyncFileSystem { localFileSystem },
-                destination: temporaryDirectory.appending(component: "download")
+                destination: temporaryDirectory.appending("download")
             )
 
             MockURLProtocol.onRequest(request) { request in
@@ -943,7 +943,7 @@ final class URLSessionHTTPClientTest: XCTestCase {
                 url: url,
                 options: options,
                 fileSystem: AsyncFileSystem { localFileSystem },
-                destination: temporaryDirectory.appending(component: "download")
+                destination: temporaryDirectory.appending("download")
             )
 
             MockURLProtocol.onRequest(request) { request in

--- a/Tests/BasicsTests/ZipArchiverTests.swift
+++ b/Tests/BasicsTests/ZipArchiverTests.swift
@@ -22,7 +22,7 @@ class ZipArchiverTests: XCTestCase {
             let archiver = ZipArchiver(fileSystem: localFileSystem)
             let inputArchivePath = AbsolutePath(path: #file).parentDirectory.appending(components: "Inputs", "archive.zip")
             try archiver.extract(from: inputArchivePath, to: tmpdir)
-            let content = tmpdir.appending(component: "file")
+            let content = tmpdir.appending("file")
             XCTAssert(localFileSystem.exists(content))
             XCTAssertEqual((try? localFileSystem.readFileContents(content))?.cString, "Hello World!")
         }
@@ -31,8 +31,8 @@ class ZipArchiverTests: XCTestCase {
     func testZipArchiverArchiveDoesntExist() {
         let fileSystem = InMemoryFileSystem()
         let archiver = ZipArchiver(fileSystem: fileSystem)
-        let archive = AbsolutePath(path: "/archive.zip")
-        XCTAssertThrowsError(try archiver.extract(from: archive, to: AbsolutePath(path: "/"))) { error in
+        let archive = AbsolutePath("/archive.zip")
+        XCTAssertThrowsError(try archiver.extract(from: archive, to: "/")) { error in
             XCTAssertEqual(error as? FileSystemError, FileSystemError(.noEntry, archive))
         }
     }
@@ -40,8 +40,8 @@ class ZipArchiverTests: XCTestCase {
     func testZipArchiverDestinationDoesntExist() throws {
         let fileSystem = InMemoryFileSystem(emptyFiles: "/archive.zip")
         let archiver = ZipArchiver(fileSystem: fileSystem)
-        let destination = AbsolutePath(path: "/destination")
-        XCTAssertThrowsError(try archiver.extract(from: AbsolutePath(path: "/archive.zip"), to: destination)) { error in
+        let destination = AbsolutePath("/destination")
+        XCTAssertThrowsError(try archiver.extract(from: "/archive.zip", to: destination)) { error in
             XCTAssertEqual(error as? FileSystemError, FileSystemError(.notDirectory, destination))
         }
     }
@@ -49,8 +49,8 @@ class ZipArchiverTests: XCTestCase {
     func testZipArchiverDestinationIsFile() throws {
         let fileSystem = InMemoryFileSystem(emptyFiles: "/archive.zip", "/destination")
         let archiver = ZipArchiver(fileSystem: fileSystem)
-        let destination = AbsolutePath(path: "/destination")
-        XCTAssertThrowsError(try archiver.extract(from: AbsolutePath(path: "/archive.zip"), to: destination)) { error in
+        let destination = AbsolutePath("/destination")
+        XCTAssertThrowsError(try archiver.extract(from: "/archive.zip", to: destination)) { error in
             XCTAssertEqual(error as? FileSystemError, FileSystemError(.notDirectory, destination))
         }
     }
@@ -88,7 +88,7 @@ class ZipArchiverTests: XCTestCase {
         // error
         try testWithTemporaryDirectory { tmpdir in
             let archiver = ZipArchiver(fileSystem: localFileSystem)
-            let path = AbsolutePath.root.appending(component: "does_not_exist.zip")
+            let path = AbsolutePath.root.appending("does_not_exist.zip")
             XCTAssertThrowsError(try archiver.validate(path: path)) { error in
                 XCTAssertEqual(error as? FileSystemError, FileSystemError(.noEntry, path))
             }
@@ -107,16 +107,16 @@ class ZipArchiverTests: XCTestCase {
 
              let rootDir = tmpdir.appending(component: UUID().uuidString)
              try localFileSystem.createDirectory(rootDir)
-             try localFileSystem.writeFileContents(rootDir.appending(component: "file1.txt"), string: "Hello World!")
+             try localFileSystem.writeFileContents(rootDir.appending("file1.txt"), string: "Hello World!")
 
-             let dir1 = rootDir.appending(component: "dir1")
+             let dir1 = rootDir.appending("dir1")
              try localFileSystem.createDirectory(dir1)
-             try localFileSystem.writeFileContents(dir1.appending(component: "file2.txt"), string: "Hello World 2!")
+             try localFileSystem.writeFileContents(dir1.appending("file2.txt"), string: "Hello World 2!")
 
-             let dir2 = dir1.appending(component: "dir2")
+             let dir2 = dir1.appending("dir2")
              try localFileSystem.createDirectory(dir2)
-             try localFileSystem.writeFileContents(dir2.appending(component: "file3.txt"), string: "Hello World 3!")
-             try localFileSystem.writeFileContents(dir2.appending(component: "file4.txt"), string: "Hello World 4!")
+             try localFileSystem.writeFileContents(dir2.appending("file3.txt"), string: "Hello World 3!")
+             try localFileSystem.writeFileContents(dir2.appending("file4.txt"), string: "Hello World 4!")
 
              let archivePath = tmpdir.appending(component: UUID().uuidString + ".zip")
              try archiver.compress(directory: rootDir, to: archivePath)
@@ -127,30 +127,30 @@ class ZipArchiverTests: XCTestCase {
              try archiver.extract(from: archivePath, to: extractRootDir)
              try localFileSystem.stripFirstLevel(of: extractRootDir)
 
-             XCTAssertFileExists(extractRootDir.appending(component: "file1.txt"))
+             XCTAssertFileExists(extractRootDir.appending("file1.txt"))
              XCTAssertEqual(
-                 try? localFileSystem.readFileContents(extractRootDir.appending(component: "file1.txt")),
+                 try? localFileSystem.readFileContents(extractRootDir.appending("file1.txt")),
                  "Hello World!"
              )
 
-             let extractedDir1 = extractRootDir.appending(component: "dir1")
+             let extractedDir1 = extractRootDir.appending("dir1")
              XCTAssertDirectoryExists(extractedDir1)
-             XCTAssertFileExists(extractedDir1.appending(component: "file2.txt"))
+             XCTAssertFileExists(extractedDir1.appending("file2.txt"))
              XCTAssertEqual(
-                 try? localFileSystem.readFileContents(extractedDir1.appending(component: "file2.txt")),
+                 try? localFileSystem.readFileContents(extractedDir1.appending("file2.txt")),
                  "Hello World 2!"
              )
 
-             let extractedDir2 = extractedDir1.appending(component: "dir2")
+             let extractedDir2 = extractedDir1.appending("dir2")
              XCTAssertDirectoryExists(extractedDir2)
-             XCTAssertFileExists(extractedDir2.appending(component: "file3.txt"))
+             XCTAssertFileExists(extractedDir2.appending("file3.txt"))
              XCTAssertEqual(
-                 try? localFileSystem.readFileContents(extractedDir2.appending(component: "file3.txt")),
+                 try? localFileSystem.readFileContents(extractedDir2.appending("file3.txt")),
                  "Hello World 3!"
              )
-             XCTAssertFileExists(extractedDir2.appending(component: "file4.txt"))
+             XCTAssertFileExists(extractedDir2.appending("file4.txt"))
              XCTAssertEqual(
-                 try? localFileSystem.readFileContents(extractedDir2.appending(component: "file4.txt")),
+                 try? localFileSystem.readFileContents(extractedDir2.appending("file4.txt")),
                  "Hello World 4!"
              )
          }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -540,7 +540,7 @@ final class BuildPlanTests: XCTestCase {
     func testPackageNameFlag() throws {
         let isFlagSupportedInDriver = try driverSupport.checkToolchainDriverFlags(flags: ["package-name"], toolchain: UserToolchain.default, fileSystem: localFileSystem)
         try fixture(name: "Miscellaneous/PackageNameFlag") { fixturePath in
-            let (stdout, _) = try executeSwiftBuild(fixturePath.appending(component: "appPkg"), extraArgs: ["-v"])
+            let (stdout, _) = try executeSwiftBuild(fixturePath.appending("appPkg"), extraArgs: ["-v"])
             XCTAssertMatch(stdout, .contains("-module-name Foo"))
             XCTAssertMatch(stdout, .contains("-module-name Zoo"))
             XCTAssertMatch(stdout, .contains("-module-name Bar"))
@@ -657,22 +657,22 @@ final class BuildPlanTests: XCTestCase {
             // A -> B -> C
             let fs = localFileSystem
             try fs.changeCurrentWorkingDirectory(to: path)
-            let testDirPath = path.appending(component: "ExplicitTest")
-            let buildDirPath = path.appending(component: ".build")
-            let sourcesPath = testDirPath.appending(component: "Sources")
-            let aPath = sourcesPath.appending(component: "A")
-            let bPath = sourcesPath.appending(component: "B")
-            let cPath = sourcesPath.appending(component: "C")
+            let testDirPath = path.appending("ExplicitTest")
+            let buildDirPath = path.appending(".build")
+            let sourcesPath = testDirPath.appending("Sources")
+            let aPath = sourcesPath.appending("A")
+            let bPath = sourcesPath.appending("B")
+            let cPath = sourcesPath.appending("C")
             try fs.createDirectory(testDirPath)
             try fs.createDirectory(buildDirPath)
             try fs.createDirectory(sourcesPath)
             try fs.createDirectory(aPath)
             try fs.createDirectory(bPath)
             try fs.createDirectory(cPath)
-            let main = aPath.appending(component: "main.swift")
-            let aSwift = aPath.appending(component: "A.swift")
-            let bSwift = bPath.appending(component: "B.swift")
-            let cSwift = cPath.appending(component: "C.swift")
+            let main = aPath.appending("main.swift")
+            let aSwift = aPath.appending("A.swift")
+            let bSwift = bPath.appending("B.swift")
+            let cSwift = cPath.appending("C.swift")
             try localFileSystem.writeFileContents(main) {
               $0 <<< "baz();"
             }
@@ -721,7 +721,7 @@ final class BuildPlanTests: XCTestCase {
                 )
 
 
-                let yaml = buildDirPath.appending(component: "release.yaml")
+                let yaml = buildDirPath.appending("release.yaml")
                 let llbuild = LLBuildManifestBuilder(plan, fileSystem: localFileSystem, observabilityScope: observability.topScope)
                 try llbuild.generateManifest(at: yaml)
                 let contents: String = try localFileSystem.readFileContents(yaml)
@@ -744,7 +744,7 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testSwiftConditionalDependency() throws {
-        let Pkg: AbsolutePath = AbsolutePath(path: "/Pkg")
+        let Pkg: AbsolutePath = AbsolutePath("/Pkg")
 
         let fs = InMemoryFileSystem(emptyFiles:
             Pkg.appending(components: "Sources", "exe", "main.swift").pathString,
@@ -822,7 +822,7 @@ final class BuildPlanTests: XCTestCase {
 
             let buildPath: AbsolutePath = plan.buildParameters.dataPath.appending(components: "release")
 
-            let linkedFileList: String = try fs.readFileContents(AbsolutePath(path: "/path/to/build/release/exe.product/Objects.LinkFileList"))
+            let linkedFileList: String = try fs.readFileContents("/path/to/build/release/exe.product/Objects.LinkFileList")
             XCTAssertMatch(linkedFileList, .contains("PkgLib"))
             XCTAssertNoMatch(linkedFileList, .contains("ExtLib"))
 
@@ -848,7 +848,7 @@ final class BuildPlanTests: XCTestCase {
                 observabilityScope: observability.topScope
             )
 
-            let linkedFileList: String = try fs.readFileContents(AbsolutePath(path: "/path/to/build/debug/exe.product/Objects.LinkFileList"))
+            let linkedFileList: String = try fs.readFileContents("/path/to/build/debug/exe.product/Objects.LinkFileList")
             XCTAssertNoMatch(linkedFileList, .contains("PkgLib"))
             XCTAssertNoMatch(linkedFileList, .contains("ExtLib"))
 
@@ -1072,8 +1072,8 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testBasicClangPackage() throws {
-        let Pkg: AbsolutePath = AbsolutePath(path: "/Pkg")
-        let ExtPkg: AbsolutePath = AbsolutePath(path: "/ExtPkg")
+        let Pkg: AbsolutePath = AbsolutePath("/Pkg")
+        let ExtPkg: AbsolutePath = AbsolutePath("/ExtPkg")
 
         let fs = InMemoryFileSystem(emptyFiles:
             Pkg.appending(components: "Sources", "exe", "main.c").pathString,
@@ -1314,7 +1314,7 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testCLanguageStandard() throws {
-        let Pkg: AbsolutePath = AbsolutePath(path: "/Pkg")
+        let Pkg: AbsolutePath = AbsolutePath("/Pkg")
 
         let fs = InMemoryFileSystem(emptyFiles:
             Pkg.appending(components: "Sources", "exe", "main.cpp").pathString,
@@ -1403,7 +1403,7 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testSwiftCMixed() throws {
-        let Pkg: AbsolutePath = AbsolutePath(path: "/Pkg")
+        let Pkg: AbsolutePath = AbsolutePath("/Pkg")
 
         let fs = InMemoryFileSystem(emptyFiles:
             Pkg.appending(components: "Sources", "exe", "main.swift").pathString,
@@ -1540,13 +1540,13 @@ final class BuildPlanTests: XCTestCase {
 
         let lib = try result.target(for: "lib").clangTarget()
         XCTAssertEqual(try lib.objects, [
-            AbsolutePath(path: "/path/to/build/debug/lib.build/lib.S.o"),
-            AbsolutePath(path: "/path/to/build/debug/lib.build/lib.c.o")
+            AbsolutePath("/path/to/build/debug/lib.build/lib.S.o"),
+            AbsolutePath("/path/to/build/debug/lib.build/lib.c.o")
         ])
     }
 
     func testREPLArguments() throws {
-        let Dep: AbsolutePath = AbsolutePath(path: "/Dep")
+        let Dep = AbsolutePath("/Dep")
         let fs = InMemoryFileSystem(emptyFiles:
             "/Pkg/Sources/exe/main.swift",
             "/Pkg/Sources/swiftlib/lib.swift",
@@ -1781,7 +1781,7 @@ final class BuildPlanTests: XCTestCase {
             "/Pkg/Snippets/AtMainSnippet.swift"
         )
 
-        try fs.writeFileContents(AbsolutePath(path: "/Pkg/Sources/exe3/foo.swift")) {
+        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe3/foo.swift")) {
             """
             @main
             struct Runner {
@@ -1792,7 +1792,7 @@ final class BuildPlanTests: XCTestCase {
             """
         }
 
-        try fs.writeFileContents(AbsolutePath(path: "/Pkg/Sources/exe4/main.swift")) {
+        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe4/main.swift")) {
             """
             @main
             struct Runner {
@@ -1803,21 +1803,21 @@ final class BuildPlanTests: XCTestCase {
             """
         }
 
-        try fs.writeFileContents(AbsolutePath(path: "/Pkg/Sources/exe5/comments.swift")) {
+        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe5/comments.swift")) {
             """
             // @main in comment
             print("hello world")
             """
         }
 
-        try fs.writeFileContents(AbsolutePath(path: "/Pkg/Sources/exe6/comments.swift")) {
+        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe6/comments.swift")) {
             """
             /* @main in comment */
             print("hello world")
             """
         }
 
-        try fs.writeFileContents(AbsolutePath(path: "/Pkg/Sources/exe7/comments.swift")) {
+        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe7/comments.swift")) {
             """
             /*
             @main in comment
@@ -1826,7 +1826,7 @@ final class BuildPlanTests: XCTestCase {
             """
         }
 
-        try fs.writeFileContents(AbsolutePath(path: "/Pkg/Sources/exe8/comments.swift")) {
+        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe8/comments.swift")) {
             """
             /*
             @main
@@ -1840,7 +1840,7 @@ final class BuildPlanTests: XCTestCase {
             """
         }
 
-        try fs.writeFileContents(AbsolutePath(path: "/Pkg/Sources/exe9/comments.swift")) {
+        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe9/comments.swift")) {
             """
             /*@main
             struct Runner {
@@ -1851,7 +1851,7 @@ final class BuildPlanTests: XCTestCase {
             """
         }
 
-        try fs.writeFileContents(AbsolutePath(path: "/Pkg/Sources/exe10/comments.swift")) {
+        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe10/comments.swift")) {
             """
             // @main in comment
             @main
@@ -1863,7 +1863,7 @@ final class BuildPlanTests: XCTestCase {
             """
         }
 
-        try fs.writeFileContents(AbsolutePath(path: "/Pkg/Sources/exe11/comments.swift")) {
+        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe11/comments.swift")) {
             """
             /* @main in comment */
             @main
@@ -1875,7 +1875,7 @@ final class BuildPlanTests: XCTestCase {
             """
         }
 
-        try fs.writeFileContents(AbsolutePath(path: "/Pkg/Sources/exe12/comments.swift")) {
+        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe12/comments.swift")) {
             """
             /*
             @main
@@ -1893,7 +1893,7 @@ final class BuildPlanTests: XCTestCase {
             """
         }
 
-        try fs.writeFileContents(AbsolutePath(path: "/Pkg/Snippets/TopLevelCodeSnippet.swift")) {
+        try fs.writeFileContents("/Pkg/Snippets/TopLevelCodeSnippet.swift") {
             """
             struct Foo {
               init() {}
@@ -1904,7 +1904,7 @@ final class BuildPlanTests: XCTestCase {
             """
         }
 
-        try fs.writeFileContents(AbsolutePath(path: "/Pkg/Snippets/AtMainSnippet.swift")) {
+        try fs.writeFileContents("/Pkg/Snippets/AtMainSnippet.swift") {
             """
             @main
             struct Runner {
@@ -2017,7 +2017,7 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testCModule() throws {
-        let Clibgit: AbsolutePath = AbsolutePath(path: "/Clibgit")
+        let Clibgit = AbsolutePath("/Clibgit")
 
         let fs = InMemoryFileSystem(emptyFiles:
             "/Pkg/Sources/exe/main.swift",
@@ -2352,7 +2352,7 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testClangTargets() throws {
-        let Pkg: AbsolutePath = AbsolutePath(path: "/Pkg")
+        let Pkg: AbsolutePath = AbsolutePath("/Pkg")
 
         let fs = InMemoryFileSystem(emptyFiles:
             Pkg.appending(components: "Sources", "exe", "main.c").pathString,
@@ -2824,7 +2824,7 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testWindowsTarget() throws {
-        let Pkg: AbsolutePath = AbsolutePath(path: "/Pkg")
+        let Pkg: AbsolutePath = AbsolutePath("/Pkg")
         let fs = InMemoryFileSystem(emptyFiles:
             Pkg.appending(components: "Sources", "exe", "main.swift").pathString,
             Pkg.appending(components: "Sources", "lib", "lib.c").pathString,
@@ -2884,7 +2884,7 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testWASITarget() throws {
-        let Pkg: AbsolutePath = AbsolutePath(path: "/Pkg")
+        let Pkg: AbsolutePath = AbsolutePath("/Pkg")
 
         let fs = InMemoryFileSystem(emptyFiles:
             Pkg.appending(components: "Sources", "app", "main.swift").pathString,
@@ -3202,7 +3202,7 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testBuildSettings() throws {
-        let A: AbsolutePath = AbsolutePath(path: "/A")
+        let A = AbsolutePath("/A")
 
         let fs = InMemoryFileSystem(emptyFiles:
             "/A/Sources/exe/main.swift",
@@ -3336,7 +3336,7 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testExtraBuildFlags() throws {
-        let libpath: AbsolutePath = AbsolutePath(path: "/fake/path/lib")
+        let libpath = AbsolutePath("/fake/path/lib")
 
         let fs = InMemoryFileSystem(emptyFiles:
             "/A/Sources/exe/main.swift",
@@ -3405,7 +3405,7 @@ final class BuildPlanTests: XCTestCase {
                 ],
                 rootPaths: try UserToolchain.default.destination.toolset.rootPaths
             ),
-            pathsConfiguration: .init(sdkRootPath: AbsolutePath(path: "/fake/sdk"))
+            pathsConfiguration: .init(sdkRootPath: "/fake/sdk")
         )
         let mockToolchain = try UserToolchain(destination: userDestination)
         let extraBuildParameters = mockBuildParameters(toolchain: mockToolchain,
@@ -3436,7 +3436,7 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testExecBuildTimeDependency() throws {
-        let PkgA: AbsolutePath = AbsolutePath(path: "/PkgA")
+        let PkgA = AbsolutePath("/PkgA")
 
         let fs = InMemoryFileSystem(emptyFiles:
             PkgA.appending(components: "Sources", "exe", "main.swift").pathString,
@@ -3502,7 +3502,7 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testObjCHeader1() throws {
-        let PkgA: AbsolutePath = AbsolutePath(path: "/PkgA")
+        let PkgA = AbsolutePath("/PkgA")
 
         // This has a Swift and ObjC target in the same package.
         let fs = InMemoryFileSystem(emptyFiles:
@@ -3565,7 +3565,7 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testObjCHeader2() throws {
-        let PkgA: AbsolutePath = AbsolutePath(path: "/PkgA")
+        let PkgA = AbsolutePath("/PkgA")
 
         // This has a Swift and ObjC target in different packages with automatic product type.
         let fs = InMemoryFileSystem(emptyFiles:
@@ -3639,7 +3639,7 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testObjCHeader3() throws {
-        let PkgA: AbsolutePath = AbsolutePath(path: "/PkgA")
+        let PkgA = AbsolutePath("/PkgA")
 
         // This has a Swift and ObjC target in different packages with dynamic product type.
         let fs = InMemoryFileSystem(emptyFiles:
@@ -4024,7 +4024,7 @@ final class BuildPlanTests: XCTestCase {
         )
         let result = try BuildPlanResult(plan: plan)
 
-        let buildPath: AbsolutePath = result.plan.buildParameters.dataPath.appending(component: "debug")
+        let buildPath: AbsolutePath = result.plan.buildParameters.dataPath.appending("debug")
 
         let fooTarget = try result.target(for: "Foo").clangTarget()
         XCTAssertEqual(try fooTarget.objects.map(\.pathString).sorted(), [
@@ -4039,7 +4039,7 @@ final class BuildPlanTests: XCTestCase {
         )
 
         let resourceAccessorHeader = resourceAccessorDirectory
-            .appending(component: "resource_bundle_accessor.h")
+            .appending("resource_bundle_accessor.h")
         let headerContents: String = try fs.readFileContents(resourceAccessorHeader)
         XCTAssertMatch(
             headerContents,
@@ -4047,7 +4047,7 @@ final class BuildPlanTests: XCTestCase {
         )
 
         let resourceAccessorImpl = resourceAccessorDirectory
-            .appending(component: "resource_bundle_accessor.m")
+            .appending("resource_bundle_accessor.m")
         let implContents: String = try fs.readFileContents(resourceAccessorImpl)
         XCTAssertMatch(
             implContents,
@@ -4096,7 +4096,7 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testXCFrameworkBinaryTargets(platform: String, arch: String, destinationTriple: TSCUtility.Triple) throws {
-        let Pkg: AbsolutePath = AbsolutePath(path: "/Pkg")
+        let Pkg: AbsolutePath = AbsolutePath("/Pkg")
 
         let fs = InMemoryFileSystem(emptyFiles:
             Pkg.appending(components: "Sources", "exe", "main.swift").pathString,
@@ -4105,9 +4105,9 @@ final class BuildPlanTests: XCTestCase {
             Pkg.appending(components: "Sources", "CLibrary", "include", "library.h").pathString
         )
 
-        try! fs.createDirectory(AbsolutePath(path: "/Pkg/Framework.xcframework"), recursive: true)
+        try! fs.createDirectory("/Pkg/Framework.xcframework", recursive: true)
         try! fs.writeFileContents(
-            AbsolutePath(path: "/Pkg/Framework.xcframework/Info.plist"),
+            "/Pkg/Framework.xcframework/Info.plist",
             bytes: ByteString(encodingAsUTF8: """
                 <?xml version="1.0" encoding="UTF-8"?>
                 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -4136,9 +4136,9 @@ final class BuildPlanTests: XCTestCase {
                 </plist>
                 """))
 
-        try! fs.createDirectory(AbsolutePath(path: "/Pkg/StaticLibrary.xcframework"), recursive: true)
+        try! fs.createDirectory("/Pkg/StaticLibrary.xcframework", recursive: true)
         try! fs.writeFileContents(
-            AbsolutePath(path: "/Pkg/StaticLibrary.xcframework/Info.plist"),
+            "/Pkg/StaticLibrary.xcframework/Info.plist",
             bytes: ByteString(encodingAsUTF8: """
                 <?xml version="1.0" encoding="UTF-8"?>
                 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -4193,8 +4193,8 @@ final class BuildPlanTests: XCTestCase {
             ],
             binaryArtifacts: [
                 .plain("pkg"): [
-                    "Framework": .init(kind: .xcframework, originURL: nil, path: AbsolutePath(path: "/Pkg/Framework.xcframework")),
-                    "StaticLibrary": .init(kind: .xcframework, originURL: nil, path: AbsolutePath(path: "/Pkg/StaticLibrary.xcframework"))
+                    "Framework": .init(kind: .xcframework, originURL: nil, path: "/Pkg/Framework.xcframework"),
+                    "StaticLibrary": .init(kind: .xcframework, originURL: nil, path: "/Pkg/StaticLibrary.xcframework")
                 ]
             ],
             observabilityScope: observability.topScope
@@ -4261,11 +4261,11 @@ final class BuildPlanTests: XCTestCase {
         let fs = InMemoryFileSystem(emptyFiles: "/Pkg/Sources/exe/main.swift")
 
         let artifactName = "my-tool"
-        let toolPath = AbsolutePath(path: "/Pkg/MyTool.artifactbundle")
+        let toolPath = AbsolutePath("/Pkg/MyTool.artifactbundle")
         try fs.createDirectory(toolPath, recursive: true)
 
         try fs.writeFileContents(
-            toolPath.appending(component: "info.json"),
+            toolPath.appending("info.json"),
             bytes: ByteString(encodingAsUTF8: """
                 {
                     "schemaVersion": "1.0",
@@ -4360,7 +4360,7 @@ final class BuildPlanTests: XCTestCase {
             "/Pkg/Snippets/ASnippet.swift",
             "/Pkg/.build/release.yaml"
         )
-        let buildPath = AbsolutePath(path: "/Pkg/.build")
+        let buildPath = AbsolutePath("/Pkg/.build")
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(
             fileSystem: fs,
@@ -4393,7 +4393,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "ASnippet" && $0.target.type == .snippet })
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "Lib" })
 
-        let yaml = buildPath.appending(component: "release.yaml")
+        let yaml = buildPath.appending("release.yaml")
         let llbuild = LLBuildManifestBuilder(plan, fileSystem: fs, observabilityScope: observability.topScope)
         try llbuild.generateManifest(at: yaml)
 

--- a/Tests/BuildTests/LLBuildManifestTests.swift
+++ b/Tests/BuildTests/LLBuildManifestTests.swift
@@ -20,7 +20,7 @@ final class LLBuildManifestTests: XCTestCase {
     func testBasics() throws {
         var manifest = BuildManifest()
 
-        let root: AbsolutePath = AbsolutePath(path: "/some")
+        let root: AbsolutePath = AbsolutePath("/some")
 
         manifest.defaultTarget = "main"
         manifest.addPhonyCmd(
@@ -36,7 +36,7 @@ final class LLBuildManifestTests: XCTestCase {
         manifest.addNode(.virtual("Foo"), toTarget: "main")
 
         let fs = InMemoryFileSystem()
-        try ManifestWriter(fileSystem: fs).write(manifest, at: AbsolutePath(path: "/manifest.yaml"))
+        try ManifestWriter(fileSystem: fs).write(manifest, at: "/manifest.yaml")
 
         let contents: String = try fs.readFileContents(AbsolutePath(path: "/manifest.yaml"))
 
@@ -92,7 +92,7 @@ final class LLBuildManifestTests: XCTestCase {
         manifest.addNode(.file(AbsolutePath(path: "/file.out")), toTarget: "main")
 
         let fs = InMemoryFileSystem()
-        try ManifestWriter(fileSystem: fs).write(manifest, at: AbsolutePath(path: "/manifest.yaml"))
+        try ManifestWriter(fileSystem: fs).write(manifest, at: "/manifest.yaml")
 
         let contents: String = try fs.readFileContents(AbsolutePath(path: "/manifest.yaml"))
 

--- a/Tests/BuildTests/MockBuildTestHelper.swift
+++ b/Tests/BuildTests/MockBuildTestHelper.swift
@@ -20,15 +20,15 @@ import XCTest
 
 struct MockToolchain: PackageModel.Toolchain {
 #if os(Windows)
-    let librarianPath = AbsolutePath(path: "/fake/path/to/link.exe")
+    let librarianPath = AbsolutePath("/fake/path/to/link.exe")
 #elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    let librarianPath = AbsolutePath(path: "/fake/path/to/libtool")
+    let librarianPath = AbsolutePath("/fake/path/to/libtool")
 #elseif os(Android)
-    let librarianPath = AbsolutePath(path: "/fake/path/to/llvm-ar")
+    let librarianPath = AbsolutePath("/fake/path/to/llvm-ar")
 #else
-    let librarianPath = AbsolutePath(path: "/fake/path/to/ar")
+    let librarianPath = AbsolutePath("/fake/path/to/ar")
 #endif
-    let swiftCompilerPath = AbsolutePath(path: "/fake/path/to/swiftc")
+    let swiftCompilerPath = AbsolutePath("/fake/path/to/swiftc")
     
     #if os(macOS)
     let extraFlags = BuildFlags(cxxCompilerFlags: ["-lc++"])
@@ -57,12 +57,6 @@ extension TSCUtility.Triple {
     static let wasi = try! Triple("wasm32-unknown-wasi")
 }
 
-extension AbsolutePath {
-    func escapedPathString() -> String {
-        return self.pathString.replacingOccurrences(of: "\\", with: "\\\\")
-    }
-}
-
 let hostTriple = try! UserToolchain.default.triple
 #if os(macOS)
     let defaultTargetTriple: String = hostTriple.tripleString(forPlatformVersion: "10.13")
@@ -71,7 +65,7 @@ let hostTriple = try! UserToolchain.default.triple
 #endif
 
 func mockBuildParameters(
-    buildPath: AbsolutePath = AbsolutePath(path: "/path/to/build"),
+    buildPath: AbsolutePath = AbsolutePath("/path/to/build"),
     config: BuildConfiguration = .debug,
     toolchain: PackageModel.Toolchain = MockToolchain(),
     flags: PackageModel.BuildFlags = PackageModel.BuildFlags(),

--- a/Tests/CommandsTests/APIDiffTests.swift
+++ b/Tests/CommandsTests/APIDiffTests.swift
@@ -63,9 +63,9 @@ final class APIDiffTests: CommandsTestCase {
     func testInvokeAPIDiffDigester() throws {
         try skipIfApiDigesterUnsupported()
         try fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
-            let packageRoot = fixturePath.appending(component: "Foo")
+            let packageRoot = fixturePath.appending("Foo")
             // Overwrite the existing decl.
-            try localFileSystem.writeFileContents(packageRoot.appending(component: "Foo.swift")) {
+            try localFileSystem.writeFileContents(packageRoot.appending("Foo.swift")) {
                 $0 <<< "public let foo = 42"
             }
             XCTAssertThrowsCommandExecutionError(try execute(["diagnose-api-breaking-changes", "1.2.3"], packagePath: packageRoot)) { error in
@@ -77,9 +77,9 @@ final class APIDiffTests: CommandsTestCase {
     func testSimpleAPIDiff() throws {
         try skipIfApiDigesterUnsupportedOrUnset()
         try fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
-            let packageRoot = fixturePath.appending(component: "Foo")
+            let packageRoot = fixturePath.appending("Foo")
             // Overwrite the existing decl.
-            try localFileSystem.writeFileContents(packageRoot.appending(component: "Foo.swift")) {
+            try localFileSystem.writeFileContents(packageRoot.appending("Foo.swift")) {
                 $0 <<< "public let foo = 42"
             }
             XCTAssertThrowsCommandExecutionError(try execute(["diagnose-api-breaking-changes", "1.2.3"], packagePath: packageRoot)) { error in
@@ -92,7 +92,7 @@ final class APIDiffTests: CommandsTestCase {
     func testMultiTargetAPIDiff() throws {
         try skipIfApiDigesterUnsupportedOrUnset()
         try fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
-            let packageRoot = fixturePath.appending(component: "Bar")
+            let packageRoot = fixturePath.appending("Bar")
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Baz", "Baz.swift")) {
                 $0 <<< "public func baz() -> String { \"hello, world!\" }"
             }
@@ -112,7 +112,7 @@ final class APIDiffTests: CommandsTestCase {
     func testBreakageAllowlist() throws {
         try skipIfApiDigesterUnsupportedOrUnset()
         try fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
-            let packageRoot = fixturePath.appending(component: "Bar")
+            let packageRoot = fixturePath.appending("Bar")
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Baz", "Baz.swift")) {
                 $0 <<< "public func baz() -> String { \"hello, world!\" }"
             }
@@ -140,7 +140,7 @@ final class APIDiffTests: CommandsTestCase {
     func testCheckVendedModulesOnly() throws {
         try skipIfApiDigesterUnsupportedOrUnset()
         try fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
-            let packageRoot = fixturePath.appending(component: "NonAPILibraryTargets")
+            let packageRoot = fixturePath.appending("NonAPILibraryTargets")
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Foo", "Foo.swift")) {
                 $0 <<< "public func baz() -> String { \"hello, world!\" }"
             }
@@ -173,7 +173,7 @@ final class APIDiffTests: CommandsTestCase {
     func testFilters() throws {
         try skipIfApiDigesterUnsupportedOrUnset()
         try fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
-            let packageRoot = fixturePath.appending(component: "NonAPILibraryTargets")
+            let packageRoot = fixturePath.appending("NonAPILibraryTargets")
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Foo", "Foo.swift")) {
                 $0 <<< "public func baz() -> String { \"hello, world!\" }"
             }
@@ -234,7 +234,7 @@ final class APIDiffTests: CommandsTestCase {
     func testAPIDiffOfModuleWithCDependency() throws {
         try skipIfApiDigesterUnsupportedOrUnset()
         try fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
-            let packageRoot = fixturePath.appending(component: "CTargetDep")
+            let packageRoot = fixturePath.appending("CTargetDep")
             // Overwrite the existing decl.
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Bar", "Bar.swift")) {
                 $0 <<< """
@@ -261,7 +261,7 @@ final class APIDiffTests: CommandsTestCase {
     func testNoBreakingChanges() throws {
         try skipIfApiDigesterUnsupportedOrUnset()
         try fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
-            let packageRoot = fixturePath.appending(component: "Bar")
+            let packageRoot = fixturePath.appending("Bar")
             // Introduce an API-compatible change
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Baz", "Baz.swift")) {
                 $0 <<< "public func bar() -> Int { 100 }"
@@ -275,12 +275,12 @@ final class APIDiffTests: CommandsTestCase {
     func testAPIDiffAfterAddingNewTarget() throws {
         try skipIfApiDigesterUnsupportedOrUnset()
         try fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
-            let packageRoot = fixturePath.appending(component: "Bar")
+            let packageRoot = fixturePath.appending("Bar")
             try localFileSystem.createDirectory(packageRoot.appending(components: "Sources", "Foo"))
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Foo", "Foo.swift")) {
                 $0 <<< "public let foo = \"All new module!\""
             }
-            try localFileSystem.writeFileContents(packageRoot.appending(component: "Package.swift")) {
+            try localFileSystem.writeFileContents(packageRoot.appending("Package.swift")) {
                 $0 <<< """
                 // swift-tools-version:4.2
                 import PackageDescription
@@ -309,7 +309,7 @@ final class APIDiffTests: CommandsTestCase {
     func testBadTreeish() throws {
         try skipIfApiDigesterUnsupportedOrUnset()
         try fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
-            let packageRoot = fixturePath.appending(component: "Foo")
+            let packageRoot = fixturePath.appending("Foo")
             XCTAssertThrowsCommandExecutionError(try execute(["diagnose-api-breaking-changes", "7.8.9"], packagePath: packageRoot)) { error in
                 XCTAssertMatch(error.stderr, .contains("error: Couldn’t get revision"))
             }
@@ -320,11 +320,11 @@ final class APIDiffTests: CommandsTestCase {
         try skipIfApiDigesterUnsupportedOrUnset()
         try withTemporaryDirectory { baselineDir in
             try fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
-                let packageRoot = fixturePath.appending(component: "Foo")
+                let packageRoot = fixturePath.appending("Foo")
                 let repo = GitRepository(path: packageRoot)
                 try repo.checkout(newBranch: "feature")
                 // Overwrite the existing decl.
-                try localFileSystem.writeFileContents(packageRoot.appending(component: "Foo.swift")) {
+                try localFileSystem.writeFileContents(packageRoot.appending("Foo.swift")) {
                     $0 <<< "public let foo = 42"
                 }
                 try repo.stage(file: "Foo.swift")
@@ -340,7 +340,7 @@ final class APIDiffTests: CommandsTestCase {
 
                 // Update `main` and ensure the baseline is regenerated.
                 try repo.checkout(revision: .init(identifier: "main"))
-                try localFileSystem.writeFileContents(packageRoot.appending(component: "Foo.swift")) {
+                try localFileSystem.writeFileContents(packageRoot.appending("Foo.swift")) {
                     $0 <<< "public let foo = 42"
                 }
                 try repo.stage(file: "Foo.swift")
@@ -356,13 +356,13 @@ final class APIDiffTests: CommandsTestCase {
     func testBaselineDirOverride() throws {
         try skipIfApiDigesterUnsupportedOrUnset()
         try fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
-            let packageRoot = fixturePath.appending(component: "Foo")
+            let packageRoot = fixturePath.appending("Foo")
             // Overwrite the existing decl.
-            try localFileSystem.writeFileContents(packageRoot.appending(component: "Foo.swift")) {
+            try localFileSystem.writeFileContents(packageRoot.appending("Foo.swift")) {
                 $0 <<< "public let foo = 42"
             }
 
-            let baselineDir = fixturePath.appending(component: "Baselines")
+            let baselineDir = fixturePath.appending("Baselines")
             let repo = GitRepository(path: packageRoot)
             let revision = try repo.resolveRevision(identifier: "1.2.3")
 
@@ -379,16 +379,16 @@ final class APIDiffTests: CommandsTestCase {
     func testRegenerateBaseline() throws {
        try skipIfApiDigesterUnsupportedOrUnset()
         try fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
-            let packageRoot = fixturePath.appending(component: "Foo")
+            let packageRoot = fixturePath.appending("Foo")
             // Overwrite the existing decl.
-            try localFileSystem.writeFileContents(packageRoot.appending(component: "Foo.swift")) {
+            try localFileSystem.writeFileContents(packageRoot.appending("Foo.swift")) {
                 $0 <<< "public let foo = 42"
             }
 
             let repo = GitRepository(path: packageRoot)
             let revision = try repo.resolveRevision(identifier: "1.2.3")
 
-            let baselineDir = fixturePath.appending(component: "Baselines")
+            let baselineDir = fixturePath.appending("Baselines")
             let fooBaselinePath = baselineDir.appending(components: revision.identifier, "Foo.json")
 
             try localFileSystem.createDirectory(fooBaselinePath.parentDirectory, recursive: true)
@@ -420,7 +420,7 @@ final class APIDiffTests: CommandsTestCase {
     func testBrokenAPIDiff() throws {
         try skipIfApiDigesterUnsupportedOrUnset()
         try fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
-            let packageRoot = fixturePath.appending(component: "BrokenPkg")
+            let packageRoot = fixturePath.appending("BrokenPkg")
             XCTAssertThrowsCommandExecutionError(try execute(["diagnose-api-breaking-changes", "1.2.3"], packagePath: packageRoot)) { error in
                 XCTAssertMatch(error.stderr, .contains("baseline for Swift2 contains no symbols, swift-api-digester output"))
             }

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -116,9 +116,9 @@ final class BuildToolTests: CommandsTestCase {
             let targetPath = fullPath.appending(components: ".build", try UserToolchain.default.triple.platformBuildPathComponent())
             let xcbuildTargetPath = fullPath.appending(components: ".build", "apple")
             XCTAssertEqual(try execute(["--show-bin-path"], packagePath: fullPath).stdout,
-                           "\(targetPath.appending(component: "debug").pathString)\n")
+                           "\(targetPath.appending("debug").pathString)\n")
             XCTAssertEqual(try execute(["-c", "release", "--show-bin-path"], packagePath: fullPath).stdout,
-                           "\(targetPath.appending(component: "release").pathString)\n")
+                           "\(targetPath.appending("release").pathString)\n")
 
             // Print correct path when building with XCBuild.
             let xcodeDebugOutput = try execute(["--build-system", "xcode", "--show-bin-path"], packagePath: fullPath).stdout
@@ -127,17 +127,17 @@ final class BuildToolTests: CommandsTestCase {
             XCTAssertEqual(xcodeDebugOutput, "\(xcbuildTargetPath.appending(components: "Products", "Debug").pathString)\n")
             XCTAssertEqual(xcodeReleaseOutput, "\(xcbuildTargetPath.appending(components: "Products", "Release").pathString)\n")
           #else
-            XCTAssertEqual(xcodeDebugOutput, "\(targetPath.appending(component: "debug").pathString)\n")
-            XCTAssertEqual(xcodeReleaseOutput, "\(targetPath.appending(component: "release").pathString)\n")
+            XCTAssertEqual(xcodeDebugOutput, "\(targetPath.appending("debug").pathString)\n")
+            XCTAssertEqual(xcodeReleaseOutput, "\(targetPath.appending("release").pathString)\n")
           #endif
 
             // Test symlink.
             _ = try execute([], packagePath: fullPath)
             XCTAssertEqual(try resolveSymlinks(fullPath.appending(components: ".build", "debug")),
-                           targetPath.appending(component: "debug"))
+                           targetPath.appending("debug"))
             _ = try execute(["-c", "release"], packagePath: fullPath)
             XCTAssertEqual(try resolveSymlinks(fullPath.appending(components: ".build", "release")),
-                           targetPath.appending(component: "release"))
+                           targetPath.appending("release"))
         }
     }
 
@@ -212,7 +212,7 @@ final class BuildToolTests: CommandsTestCase {
 
     func testNonReachableProductsAndTargetsFunctional() throws {
         try fixture(name: "Miscellaneous/UnreachableTargets") { fixturePath in
-            let aPath = fixturePath.appending(component: "A")
+            let aPath = fixturePath.appending("A")
 
             do {
                 let result = try build([], packagePath: aPath)
@@ -233,7 +233,7 @@ final class BuildToolTests: CommandsTestCase {
                 XCTAssertNoMatch(result.binContents, ["BLibrary.a"])
 
                 // FIXME: We create the modulemap during build planning, hence this uglyness.
-                let bTargetBuildDir = ((try? localFileSystem.getDirectoryContents(result.binPath.appending(component: "BTarget1.build"))) ?? []).filter{ $0 != moduleMapFilename }
+                let bTargetBuildDir = ((try? localFileSystem.getDirectoryContents(result.binPath.appending("BTarget1.build"))) ?? []).filter{ $0 != moduleMapFilename }
                 XCTAssertTrue(bTargetBuildDir.isEmpty, "bTargetBuildDir should be empty")
 
                 XCTAssertNoMatch(result.binContents, ["cexec"])

--- a/Tests/CommandsTests/MultiRootSupportTests.swift
+++ b/Tests/CommandsTests/MultiRootSupportTests.swift
@@ -24,8 +24,8 @@ final class MultiRootSupportTests: CommandsTestCase {
             "/tmp/test/dep/Package.swift",
             "/tmp/test/local/Package.swift",
         ])
-        let path = AbsolutePath(path: "/tmp/test/Workspace.xcworkspace")
-        try fs.writeFileContents(path.appending(component: "contents.xcworkspacedata")) {
+        let path = AbsolutePath("/tmp/test/Workspace.xcworkspace")
+        try fs.writeFileContents(path.appending("contents.xcworkspacedata")) {
             $0 <<< """
                 <?xml version="1.0" encoding="UTF-8"?>
                 <Workspace

--- a/Tests/CommandsTests/PackageRegistryToolTests.swift
+++ b/Tests/CommandsTests/PackageRegistryToolTests.swift
@@ -71,7 +71,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
 
         try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
-            let packageRoot = fixturePath.appending(component: "Bar")
+            let packageRoot = fixturePath.appending("Bar")
             let configurationFilePath = AbsolutePath(
                 path: ".swiftpm/configuration/registries.json",
                 relativeTo: packageRoot
@@ -180,7 +180,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
 
         try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
-            let packageRoot = fixturePath.appending(component: "Bar")
+            let packageRoot = fixturePath.appending("Bar")
             let configurationFilePath = AbsolutePath(
                 path: ".swiftpm/configuration/registries.json",
                 relativeTo: packageRoot
@@ -203,7 +203,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
 
         try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
-            let packageRoot = fixturePath.appending(component: "Bar")
+            let packageRoot = fixturePath.appending("Bar")
             let configurationFilePath = AbsolutePath(
                 path: ".swiftpm/configuration/registries.json",
                 relativeTo: packageRoot
@@ -226,7 +226,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
 
         try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
-            let packageRoot = fixturePath.appending(component: "Bar")
+            let packageRoot = fixturePath.appending("Bar")
             let configurationFilePath = AbsolutePath(
                 path: ".swiftpm/configuration/registries.json",
                 relativeTo: packageRoot
@@ -252,7 +252,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
 
         try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
-            let packageRoot = fixturePath.appending(component: "Bar")
+            let packageRoot = fixturePath.appending("Bar")
             let configurationFilePath = AbsolutePath(
                 path: ".swiftpm/configuration/registries.json",
                 relativeTo: packageRoot
@@ -314,7 +314,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
 
         // git repo
         try withTemporaryDirectory { temporaryDirectory in
-            let packageDirectory = temporaryDirectory.appending(component: "MyPackage")
+            let packageDirectory = temporaryDirectory.appending("MyPackage")
             try localFileSystem.createDirectory(packageDirectory)
 
             let initPackage = try InitPackage(
@@ -324,7 +324,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
                 fileSystem: localFileSystem
             )
             try initPackage.writePackageStructure()
-            XCTAssertFileExists(packageDirectory.appending(component: "Package.swift"))
+            XCTAssertFileExists(packageDirectory.appending("Package.swift"))
 
             initGitRepo(packageDirectory)
 
@@ -345,7 +345,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
 
         // not a git repo
         try withTemporaryDirectory { temporaryDirectory in
-            let packageDirectory = temporaryDirectory.appending(component: "MyPackage")
+            let packageDirectory = temporaryDirectory.appending("MyPackage")
             try localFileSystem.createDirectory(packageDirectory)
 
             let initPackage = try InitPackage(
@@ -355,7 +355,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
                 fileSystem: localFileSystem
             )
             try initPackage.writePackageStructure()
-            XCTAssertFileExists(packageDirectory.appending(component: "Package.swift"))
+            XCTAssertFileExists(packageDirectory.appending("Package.swift"))
 
             let workingDirectory = temporaryDirectory.appending(component: UUID().uuidString)
 
@@ -373,7 +373,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
 
         // canonical metadata location
         try withTemporaryDirectory { temporaryDirectory in
-            let packageDirectory = temporaryDirectory.appending(component: "MyPackage")
+            let packageDirectory = temporaryDirectory.appending("MyPackage")
             try localFileSystem.createDirectory(packageDirectory)
 
             let initPackage = try InitPackage(
@@ -383,7 +383,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
                 fileSystem: localFileSystem
             )
             try initPackage.writePackageStructure()
-            XCTAssertFileExists(packageDirectory.appending(component: "Package.swift"))
+            XCTAssertFileExists(packageDirectory.appending("Package.swift"))
 
             // metadata file
             try localFileSystem.writeFileContents(
@@ -414,7 +414,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
             try localFileSystem.createDirectory(extractPath)
             try tsc_await { archiver.extract(from: archivePath, to: extractPath, completion: $0) }
             try localFileSystem.stripFirstLevel(of: extractPath)
-            XCTAssertFileExists(extractPath.appending(component: "Package.swift"))
+            XCTAssertFileExists(extractPath.appending("Package.swift"))
             return extractPath
         }
     }
@@ -430,15 +430,15 @@ final class PackageRegistryToolTests: CommandsTestCase {
         // certificate and private key
         /*
         try await withTemporaryDirectory { temporaryDirectory in
-            let archivePath = temporaryDirectory.appending(component: "fake.zip")
+            let archivePath = temporaryDirectory.appending("fake.zip")
             try localFileSystem.writeFileContents(archivePath, string: "test")
 
-            let privateKeyPath = temporaryDirectory.appending(component: "private-key")
+            let privateKeyPath = temporaryDirectory.appending("private-key")
             // TODO: write the private key
-            let certificatePath = temporaryDirectory.appending(component: "certificate")
+            let certificatePath = temporaryDirectory.appending("certificate")
             // TODO: write the cert
 
-            let signaturePath = temporaryDirectory.appending(component: "signature")
+            let signaturePath = temporaryDirectory.appending("signature")
 
             let signature = try await PackageArchiveSigner.sign(
                 archivePath: archivePath,
@@ -456,10 +456,10 @@ final class PackageRegistryToolTests: CommandsTestCase {
 
         // basic validation
         try withTemporaryDirectory { temporaryDirectory in
-            let archivePath = temporaryDirectory.appending(component: "fake.zip")
+            let archivePath = temporaryDirectory.appending("fake.zip")
             try localFileSystem.writeFileContents(archivePath, bytes: [])
 
-            let signaturePath = temporaryDirectory.appending(component: "signature")
+            let signaturePath = temporaryDirectory.appending("signature")
 
             let result = try SwiftPMProduct.SwiftPackageRegistry.executeProcess(
                 [

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -117,7 +117,7 @@ final class PackageToolTests: CommandsTestCase {
     func testNetrcFile() throws {
         try fixture(name: "DependencyResolution/External/XCFramework") { fixturePath in
             let fs = localFileSystem
-            let netrcPath = fixturePath.appending(component: ".netrc")
+            let netrcPath = fixturePath.appending(".netrc")
             try fs.writeFileContents(netrcPath) { stream in
                 stream <<< "machine mymachine.labkey.org login user@labkey.org password mypassword"
             }
@@ -150,10 +150,10 @@ final class PackageToolTests: CommandsTestCase {
 
     func testEnableDisableCache() throws {
         try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
-            let packageRoot = fixturePath.appending(component: "Bar")
+            let packageRoot = fixturePath.appending("Bar")
             let repositoriesPath = packageRoot.appending(components: ".build", "repositories")
-            let cachePath = fixturePath.appending(component: "cache")
-            let repositoriesCachePath = cachePath.appending(component: "repositories")
+            let cachePath = fixturePath.appending("cache")
+            let repositoriesCachePath = cachePath.appending("repositories")
 
             do {
                 // Remove .build and cache folder
@@ -243,7 +243,7 @@ final class PackageToolTests: CommandsTestCase {
 
     func testResolve() throws {
         try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
-            let packageRoot = fixturePath.appending(component: "Bar")
+            let packageRoot = fixturePath.appending("Bar")
 
             // Check that `resolve` works.
             _ = try execute(["resolve"], packagePath: packageRoot)
@@ -254,7 +254,7 @@ final class PackageToolTests: CommandsTestCase {
 
     func testUpdate() throws {
         try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
-            let packageRoot = fixturePath.appending(component: "Bar")
+            let packageRoot = fixturePath.appending("Bar")
 
             // Perform an initial fetch.
             _ = try execute(["resolve"], packagePath: packageRoot)
@@ -262,7 +262,7 @@ final class PackageToolTests: CommandsTestCase {
             XCTAssertEqual(try GitRepository(path: path).getTags(), ["1.2.3"])
 
             // Retag the dependency, and update.
-            let repo = GitRepository(path: fixturePath.appending(component: "Foo"))
+            let repo = GitRepository(path: fixturePath.appending("Foo"))
             try repo.tag(name: "1.2.4")
             _ = try execute(["update"], packagePath: packageRoot)
 
@@ -274,10 +274,10 @@ final class PackageToolTests: CommandsTestCase {
 
     func testCache() throws {
         try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
-            let packageRoot = fixturePath.appending(component: "Bar")
+            let packageRoot = fixturePath.appending("Bar")
             let repositoriesPath = packageRoot.appending(components: ".build", "repositories")
-            let cachePath = fixturePath.appending(component: "cache")
-            let repositoriesCachePath = cachePath.appending(component: "repositories")
+            let cachePath = fixturePath.appending("cache")
+            let repositoriesCachePath = cachePath.appending("repositories")
 
             // Perform an initial fetch and populate the cache
             _ = try execute(["resolve", "--cache-path", cachePath.pathString], packagePath: packageRoot)
@@ -439,7 +439,7 @@ final class PackageToolTests: CommandsTestCase {
 
     func testDumpPackage() throws {
         try fixture(name: "DependencyResolution/External/Complex") { fixturePath in
-            let packageRoot = fixturePath.appending(component: "app")
+            let packageRoot = fixturePath.appending("app")
             let (dumpOutput, _) = try execute(["dump-package"], packagePath: packageRoot)
             let json = try JSON(bytes: ByteString(encodingAsUTF8: dumpOutput))
             guard case let .dictionary(contents) = json else { XCTFail("unexpected result"); return }
@@ -519,7 +519,7 @@ final class PackageToolTests: CommandsTestCase {
 
     func testShowDependencies() throws {
         try fixture(name: "DependencyResolution/External/Complex") { fixturePath in
-            let packageRoot = fixturePath.appending(component: "app")
+            let packageRoot = fixturePath.appending("app")
             let textOutput = try SwiftPMProduct.SwiftPackage.executeProcess(["show-dependencies", "--format=text"], packagePath: packageRoot).utf8Output()
             XCTAssert(textOutput.contains("FisherYates@1.2.3"))
 
@@ -648,7 +648,7 @@ final class PackageToolTests: CommandsTestCase {
 
             // Create root package.
             try fs.writeFileContents(root.appending(components: "Sources", "root", "main.swift")) { $0 <<< "" }
-            try fs.writeFileContents(root.appending(component: "Package.swift")) {
+            try fs.writeFileContents(root.appending("Package.swift")) {
                 $0 <<< """
                 // swift-tools-version:4.2
                 import PackageDescription
@@ -662,7 +662,7 @@ final class PackageToolTests: CommandsTestCase {
 
             // Create dependency.
             try fs.writeFileContents(dep.appending(components: "Sources", "dep", "lib.swift")) { $0 <<< "" }
-            try fs.writeFileContents(dep.appending(component: "Package.swift")) {
+            try fs.writeFileContents(dep.appending("Package.swift")) {
                 $0 <<< """
                 // swift-tools-version:4.2
                 import PackageDescription
@@ -681,7 +681,7 @@ final class PackageToolTests: CommandsTestCase {
                 try depGit.tag(name: "1.0.0")
             }
 
-            let resultPath = root.appending(component: "result.json")
+            let resultPath = root.appending("result.json")
             _ = try execute(["show-dependencies", "--format", "json", "--output-path", resultPath.pathString ], packagePath: root)
 
             XCTAssertFileExists(resultPath)
@@ -696,66 +696,66 @@ final class PackageToolTests: CommandsTestCase {
     func testInitEmpty() throws {
         try testWithTemporaryDirectory { tmpPath in
             let fs = localFileSystem
-            let path = tmpPath.appending(component: "Foo")
+            let path = tmpPath.appending("Foo")
             try fs.createDirectory(path)
             _ = try execute(["init", "--type", "empty"], packagePath: path)
 
-            XCTAssertFileExists(path.appending(component: "Package.swift"))
+            XCTAssertFileExists(path.appending("Package.swift"))
         }
     }
 
     func testInitExecutable() throws {
         try testWithTemporaryDirectory { tmpPath in
             let fs = localFileSystem
-            let path = tmpPath.appending(component: "Foo")
+            let path = tmpPath.appending("Foo")
             try fs.createDirectory(path)
             _ = try execute(["init", "--type", "executable"], packagePath: path)
 
-            let manifest = path.appending(component: "Package.swift")
+            let manifest = path.appending("Package.swift")
             let contents: String = try localFileSystem.readFileContents(manifest)
             let version = InitPackage.newPackageToolsVersion
             let versionSpecifier = "\(version.major).\(version.minor)"
             XCTAssertMatch(contents, .prefix("// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"))
 
             XCTAssertFileExists(manifest)
-            XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources")), ["main.swift"])
+            XCTAssertEqual(try fs.getDirectoryContents(path.appending("Sources")), ["main.swift"])
         }
     }
 
     func testInitLibrary() throws {
         try testWithTemporaryDirectory { tmpPath in
             let fs = localFileSystem
-            let path = tmpPath.appending(component: "Foo")
+            let path = tmpPath.appending("Foo")
             try fs.createDirectory(path)
             _ = try execute(["init"], packagePath: path)
 
-            XCTAssertFileExists(path.appending(component: "Package.swift"))
-            XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources").appending(component: "Foo")), ["Foo.swift"])
-            XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Tests")).sorted(), ["FooTests"])
+            XCTAssertFileExists(path.appending("Package.swift"))
+            XCTAssertEqual(try fs.getDirectoryContents(path.appending("Sources").appending("Foo")), ["Foo.swift"])
+            XCTAssertEqual(try fs.getDirectoryContents(path.appending("Tests")).sorted(), ["FooTests"])
         }
     }
 
     func testInitCustomNameExecutable() throws {
         try testWithTemporaryDirectory { tmpPath in
             let fs = localFileSystem
-            let path = tmpPath.appending(component: "Foo")
+            let path = tmpPath.appending("Foo")
             try fs.createDirectory(path)
             _ = try execute(["init", "--name", "CustomName", "--type", "executable"], packagePath: path)
 
-            let manifest = path.appending(component: "Package.swift")
+            let manifest = path.appending("Package.swift")
             let contents: String = try localFileSystem.readFileContents(manifest)
             let version = InitPackage.newPackageToolsVersion
             let versionSpecifier = "\(version.major).\(version.minor)"
             XCTAssertMatch(contents, .prefix("// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"))
 
             XCTAssertFileExists(manifest)
-            XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources")), ["main.swift"])
+            XCTAssertEqual(try fs.getDirectoryContents(path.appending("Sources")), ["main.swift"])
         }
     }
 
     func testPackageEditAndUnedit() throws {
         try fixture(name: "Miscellaneous/PackageEdit") { fixturePath in
-            let fooPath = fixturePath.appending(component: "foo")
+            let fooPath = fixturePath.appending("foo")
             func build() throws -> (stdout: String, stderr: String) {
                 return try SwiftPMProduct.SwiftBuild.execute([], packagePath: fooPath)
             }
@@ -809,13 +809,13 @@ final class PackageToolTests: CommandsTestCase {
             _ = try SwiftPMProduct.SwiftPackage.execute(["unedit", "bar"], packagePath: fooPath)
 
             // Test editing with a path i.e. ToT development.
-            let bazTot = fixturePath.appending(component: "tot")
+            let bazTot = fixturePath.appending("tot")
             try SwiftPMProduct.SwiftPackage.execute(["edit", "baz", "--path", bazTot.pathString], packagePath: fooPath)
             XCTAssertTrue(localFileSystem.exists(bazTot))
             XCTAssertTrue(localFileSystem.isSymlink(bazEditsPath))
 
             // Edit a file in baz ToT checkout.
-            let bazTotPackageFile = bazTot.appending(component: "Package.swift")
+            let bazTotPackageFile = bazTot.appending("Package.swift")
             let stream = BufferedOutputByteStream()
             stream <<< (try localFileSystem.readFileContents(bazTotPackageFile)) <<< "\n// Edited."
             try localFileSystem.writeFileContents(bazTotPackageFile, bytes: stream.bytes)
@@ -834,11 +834,11 @@ final class PackageToolTests: CommandsTestCase {
 
     func testPackageClean() throws {
         try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
-            let packageRoot = fixturePath.appending(component: "Bar")
+            let packageRoot = fixturePath.appending("Bar")
 
             // Build it.
             XCTAssertBuilds(packageRoot)
-            let buildPath = packageRoot.appending(component: ".build")
+            let buildPath = packageRoot.appending(".build")
             let binFile = buildPath.appending(components: try UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Bar")
             XCTAssertFileExists(binFile)
             XCTAssert(localFileSystem.isDirectory(buildPath))
@@ -853,11 +853,11 @@ final class PackageToolTests: CommandsTestCase {
 
     func testPackageReset() throws {
         try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
-            let packageRoot = fixturePath.appending(component: "Bar")
+            let packageRoot = fixturePath.appending("Bar")
 
             // Build it.
             XCTAssertBuilds(packageRoot)
-            let buildPath = packageRoot.appending(component: ".build")
+            let buildPath = packageRoot.appending(".build")
             let binFile = buildPath.appending(components: try UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Bar")
             XCTAssertFileExists(binFile)
             XCTAssert(localFileSystem.isDirectory(buildPath))
@@ -865,7 +865,7 @@ final class PackageToolTests: CommandsTestCase {
 
             _ = try execute(["clean"], packagePath: packageRoot)
             XCTAssertNoSuchPath(binFile)
-            XCTAssertFalse(try localFileSystem.getDirectoryContents(buildPath.appending(component: "repositories")).isEmpty)
+            XCTAssertFalse(try localFileSystem.getDirectoryContents(buildPath.appending("repositories")).isEmpty)
 
             // Fully clean.
             _ = try execute(["reset"], packagePath: packageRoot)
@@ -878,7 +878,7 @@ final class PackageToolTests: CommandsTestCase {
 
     func testPinningBranchAndRevision() throws {
         try fixture(name: "Miscellaneous/PackageEdit") { fixturePath in
-            let fooPath = fixturePath.appending(component: "foo")
+            let fooPath = fixturePath.appending("foo")
 
             @discardableResult
             func execute(_ args: String..., printError: Bool = true) throws -> String {
@@ -887,11 +887,11 @@ final class PackageToolTests: CommandsTestCase {
 
             try execute("update")
 
-            let pinsFile = fooPath.appending(component: "Package.resolved")
+            let pinsFile = fooPath.appending("Package.resolved")
             XCTAssertFileExists(pinsFile)
 
             // Update bar repo.
-            let barPath = fixturePath.appending(component: "bar")
+            let barPath = fixturePath.appending("bar")
             let barRepo = GitRepository(path: barPath)
             try barRepo.checkout(newBranch: "YOLO")
             let yoloRevision = try barRepo.getCurrentRevision()
@@ -924,7 +924,7 @@ final class PackageToolTests: CommandsTestCase {
 
     func testPinning() throws {
         try fixture(name: "Miscellaneous/PackageEdit") { fixturePath in
-            let fooPath = fixturePath.appending(component: "foo")
+            let fooPath = fixturePath.appending("foo")
             func build() throws -> String {
                 return try SwiftPMProduct.SwiftBuild.execute([], packagePath: fooPath).stdout
             }
@@ -944,7 +944,7 @@ final class PackageToolTests: CommandsTestCase {
             }
 
             // We should see a pin file now.
-            let pinsFile = fooPath.appending(component: "Package.resolved")
+            let pinsFile = fooPath.appending("Package.resolved")
             XCTAssertFileExists(pinsFile)
 
             // Test pins file.
@@ -987,7 +987,7 @@ final class PackageToolTests: CommandsTestCase {
 
             // Update bar repo.
             do {
-                let barPath = fixturePath.appending(component: "bar")
+                let barPath = fixturePath.appending("bar")
                 let barRepo = GitRepository(path: barPath)
                 try localFileSystem.writeFileContents(barPath.appending(components: "Sources", "bar.swift"), bytes: "public let theValue = 6\n")
                 try barRepo.stageEverything()
@@ -1028,7 +1028,7 @@ final class PackageToolTests: CommandsTestCase {
 
     func testOnlyUseVersionsFromResolvedFileFetchesWithExistingState() throws {
         func writeResolvedFile(packageDir: AbsolutePath, repositoryURL: String, revision: String, version: String) throws {
-            try localFileSystem.writeFileContents(packageDir.appending(component: "Package.resolved")) {
+            try localFileSystem.writeFileContents(packageDir.appending("Package.resolved")) {
                 $0 <<< """
                     {
                       "object": {
@@ -1052,7 +1052,7 @@ final class PackageToolTests: CommandsTestCase {
 
         try testWithTemporaryDirectory { tmpPath in
             let packageDir = tmpPath.appending(components: "library")
-            try localFileSystem.writeFileContents(packageDir.appending(component: "Package.swift")) {
+            try localFileSystem.writeFileContents(packageDir.appending("Package.swift")) {
                 $0 <<< """
                 // swift-tools-version:5.0
                 import PackageDescription
@@ -1079,7 +1079,7 @@ final class PackageToolTests: CommandsTestCase {
             let repositoryURL = "file://\(packageDir.pathString)"
 
             let clientDir = tmpPath.appending(components: "client")
-            try localFileSystem.writeFileContents(clientDir.appending(component: "Package.swift")) {
+            try localFileSystem.writeFileContents(clientDir.appending("Package.swift")) {
                 $0 <<< """
                 // swift-tools-version:5.0
                 import PackageDescription
@@ -1126,7 +1126,7 @@ final class PackageToolTests: CommandsTestCase {
 
             // Create root package.
             try fs.writeFileContents(root.appending(components: "Sources", "root", "main.swift")) { $0 <<< "" }
-            try fs.writeFileContents(root.appending(component: "Package.swift")) {
+            try fs.writeFileContents(root.appending("Package.swift")) {
                 $0 <<< """
                 // swift-tools-version:4.2
                 import PackageDescription
@@ -1141,7 +1141,7 @@ final class PackageToolTests: CommandsTestCase {
 
             // Create dependency.
             try fs.writeFileContents(dep.appending(components: "Sources", "dep", "lib.swift")) { $0 <<< "" }
-            try fs.writeFileContents(dep.appending(component: "Package.swift")) {
+            try fs.writeFileContents(dep.appending("Package.swift")) {
                 $0 <<< """
                 // swift-tools-version:4.2
                 import PackageDescription
@@ -1170,8 +1170,8 @@ final class PackageToolTests: CommandsTestCase {
     func testMirrorConfig() throws {
         try testWithTemporaryDirectory { fixturePath in
             let fs = localFileSystem
-            let packageRoot = fixturePath.appending(component: "Foo")
-            let configOverride = fixturePath.appending(component: "configoverride")
+            let packageRoot = fixturePath.appending("Foo")
+            let configOverride = fixturePath.appending("configoverride")
             let configFile = Workspace.DefaultLocations.mirrorsConfigurationFile(forRootPackage: packageRoot)
 
             fs.createEmptyFiles(at: packageRoot, files:
@@ -1231,7 +1231,7 @@ final class PackageToolTests: CommandsTestCase {
     func testMirrorSimple() throws {
         try testWithTemporaryDirectory { fixturePath in
             let fs = localFileSystem
-            let packageRoot = fixturePath.appending(component: "MyPackage")
+            let packageRoot = fixturePath.appending("MyPackage")
             let configFile = Workspace.DefaultLocations.mirrorsConfigurationFile(forRootPackage: packageRoot)
 
             fs.createEmptyFiles(
@@ -1242,7 +1242,7 @@ final class PackageToolTests: CommandsTestCase {
                 "/Package.swift"
             )
 
-            try fs.writeFileContents(packageRoot.appending(component: "Package.swift"), string:
+            try fs.writeFileContents(packageRoot.appending("Package.swift"), string:
                 """
                 // swift-tools-version: 5.7
                 import PackageDescription
@@ -1276,7 +1276,7 @@ final class PackageToolTests: CommandsTestCase {
     func testMirrorURLToRegistry() throws {
         try testWithTemporaryDirectory { fixturePath in
             let fs = localFileSystem
-            let packageRoot = fixturePath.appending(component: "MyPackage")
+            let packageRoot = fixturePath.appending("MyPackage")
             let configFile = Workspace.DefaultLocations.mirrorsConfigurationFile(forRootPackage: packageRoot)
 
             fs.createEmptyFiles(
@@ -1287,7 +1287,7 @@ final class PackageToolTests: CommandsTestCase {
                 "/Package.swift"
             )
 
-            try fs.writeFileContents(packageRoot.appending(component: "Package.swift"), string:
+            try fs.writeFileContents(packageRoot.appending("Package.swift"), string:
                 """
                 // swift-tools-version: 5.7
                 import PackageDescription
@@ -1321,7 +1321,7 @@ final class PackageToolTests: CommandsTestCase {
     func testMirrorRegistryToURL() throws {
         try testWithTemporaryDirectory { fixturePath in
             let fs = localFileSystem
-            let packageRoot = fixturePath.appending(component: "MyPackage")
+            let packageRoot = fixturePath.appending("MyPackage")
             let configFile = Workspace.DefaultLocations.mirrorsConfigurationFile(forRootPackage: packageRoot)
 
             fs.createEmptyFiles(
@@ -1332,7 +1332,7 @@ final class PackageToolTests: CommandsTestCase {
                 "/Package.swift"
             )
 
-            try fs.writeFileContents(packageRoot.appending(component: "Package.swift"), string:
+            try fs.writeFileContents(packageRoot.appending("Package.swift"), string:
                 """
                 // swift-tools-version: 5.7
                 import PackageDescription
@@ -1385,7 +1385,7 @@ final class PackageToolTests: CommandsTestCase {
                 }
 
                 // Invoke `swift-package`, passing in the overriding `PATH` environment variable.
-                let packageRoot = fixturePath.appending(component: "Library")
+                let packageRoot = fixturePath.appending("Library")
                 let patchedPATH = fakeBinDir.pathString + ":" + ProcessInfo.processInfo.environment["PATH"]!
                 let result = try SwiftPMProduct.SwiftPackage.executeProcess(["dump-package"], packagePath: packageRoot, env: ["PATH": patchedPATH])
                 let textOutput = try result.utf8Output() + result.utf8stderrOutput()
@@ -1404,7 +1404,7 @@ final class PackageToolTests: CommandsTestCase {
         try testWithTemporaryDirectory { tmpPath in
             // Create a sample package with a library target and a plugin.
             let packageDir = tmpPath.appending(components: "MyPackage")
-            try localFileSystem.writeFileContents(packageDir.appending(component: "Package.swift")) {
+            try localFileSystem.writeFileContents(packageDir.appending("Package.swift")) {
                 $0 <<< """
                 // swift-tools-version: 5.5
                 import PackageDescription
@@ -1492,7 +1492,7 @@ final class PackageToolTests: CommandsTestCase {
             // Create a sample package with a library target and a plugin.
             let packageDir = tmpPath.appending(components: "MyPackage")
             try localFileSystem.createDirectory(packageDir, recursive: true)
-            try localFileSystem.writeFileContents(packageDir.appending(component: "Package.swift"), string: """
+            try localFileSystem.writeFileContents(packageDir.appending("Package.swift"), string: """
                 // swift-tools-version: 5.6
                 import PackageDescription
                 let package = Package(
@@ -1514,13 +1514,13 @@ final class PackageToolTests: CommandsTestCase {
             )
             let myLibraryTargetDir = packageDir.appending(components: "Sources", "MyLibrary")
             try localFileSystem.createDirectory(myLibraryTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(myLibraryTargetDir.appending(component: "library.swift"), string: """
+            try localFileSystem.writeFileContents(myLibraryTargetDir.appending("library.swift"), string: """
                 public func Foo() { }
                 """
             )
             let myPluginTargetDir = packageDir.appending(components: "Plugins", "MyPlugin")
             try localFileSystem.createDirectory(myPluginTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(myPluginTargetDir.appending(component: "plugin.swift"), string: """
+            try localFileSystem.writeFileContents(myPluginTargetDir.appending("plugin.swift"), string: """
                 import PackagePlugin
                 import Foundation
                 @main
@@ -1551,7 +1551,7 @@ final class PackageToolTests: CommandsTestCase {
 
     func testArchiveSource() throws {
         try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
-            let packageRoot = fixturePath.appending(component: "Bar")
+            let packageRoot = fixturePath.appending("Bar")
 
             // Running without arguments or options
             do {
@@ -1573,7 +1573,7 @@ final class PackageToolTests: CommandsTestCase {
 
             // Running with output as absolute path within package root
             do {
-                let destination = packageRoot.appending(component: "Bar-1.2.3.zip")
+                let destination = packageRoot.appending("Bar-1.2.3.zip")
                 let result = try SwiftPMProduct.SwiftPackage.executeProcess(["archive-source", "--output", destination.pathString], packagePath: packageRoot)
                 XCTAssertEqual(result.exitStatus, .terminated(code: 0))
 
@@ -1583,7 +1583,7 @@ final class PackageToolTests: CommandsTestCase {
 
             // Running with output is outside the package root
             try withTemporaryDirectory { tempDirectory in
-                let destination = tempDirectory.appending(component: "Bar-1.2.3.zip")
+                let destination = tempDirectory.appending("Bar-1.2.3.zip")
                 let result = try SwiftPMProduct.SwiftPackage.executeProcess(["archive-source", "--output", destination.pathString], packagePath: packageRoot)
                 XCTAssertEqual(result.exitStatus, .terminated(code: 0))
 
@@ -2287,7 +2287,7 @@ final class PackageToolTests: CommandsTestCase {
             )
             let myPluginTargetDir = packageDir.appending(components: "Plugins", "MyPlugin")
             try localFileSystem.createDirectory(myPluginTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(myPluginTargetDir.appending(component: "plugin.swift"), string: """
+            try localFileSystem.writeFileContents(myPluginTargetDir.appending("plugin.swift"), string: """
                 import PackagePlugin
                 @main
                 struct MyCommandPlugin: CommandPlugin {
@@ -2334,13 +2334,13 @@ final class PackageToolTests: CommandsTestCase {
             )
             let myLibraryTargetDir = packageDir.appending(components: "Sources", "MyLibrary")
             try localFileSystem.createDirectory(myLibraryTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(myLibraryTargetDir.appending(component: "library.swift"), string: """
+            try localFileSystem.writeFileContents(myLibraryTargetDir.appending("library.swift"), string: """
                 public func GetGreeting() -> String { return "Hello" }
                 """
             )
             let myExecutableTargetDir = packageDir.appending(components: "Sources", "MyExecutable")
             try localFileSystem.createDirectory(myExecutableTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(myExecutableTargetDir.appending(component: "main.swift"), string: """
+            try localFileSystem.writeFileContents(myExecutableTargetDir.appending("main.swift"), string: """
                 import MyLibrary
                 print("\\(GetGreeting()), World!")
                 """
@@ -2444,7 +2444,7 @@ final class PackageToolTests: CommandsTestCase {
             )
             let myPluginTargetDir = packageDir.appending(components: "Plugins", "MyPlugin")
             try localFileSystem.createDirectory(myPluginTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(myPluginTargetDir.appending(component: "plugin.swift"), string: """
+            try localFileSystem.writeFileContents(myPluginTargetDir.appending("plugin.swift"), string: """
                 import PackagePlugin
                 @main
                 struct MyCommandPlugin: CommandPlugin {
@@ -2479,13 +2479,13 @@ final class PackageToolTests: CommandsTestCase {
             )
             let myLibraryTargetDir = packageDir.appending(components: "Sources", "MyLibrary")
             try localFileSystem.createDirectory(myLibraryTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(myLibraryTargetDir.appending(component: "library.swift"), string: """
+            try localFileSystem.writeFileContents(myLibraryTargetDir.appending("library.swift"), string: """
                 public func Foo() { }
                 """
             )
             let myBasicTestsTargetDir = packageDir.appending(components: "Tests", "MyBasicTests")
             try localFileSystem.createDirectory(myBasicTestsTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(myBasicTestsTargetDir.appending(component: "Test1.swift"), string: """
+            try localFileSystem.writeFileContents(myBasicTestsTargetDir.appending("Test1.swift"), string: """
                 import XCTest
                 class TestSuite1: XCTestCase {
                     func testBooleanInvariants() throws {
@@ -2497,7 +2497,7 @@ final class PackageToolTests: CommandsTestCase {
                 }
                 """
             )
-            try localFileSystem.writeFileContents(myBasicTestsTargetDir.appending(component: "Test2.swift"), string: """
+            try localFileSystem.writeFileContents(myBasicTestsTargetDir.appending("Test2.swift"), string: """
                 import XCTest
                 class TestSuite2: XCTestCase {
                     func testStringInvariants() throws {
@@ -2508,7 +2508,7 @@ final class PackageToolTests: CommandsTestCase {
             )
             let myExtendedTestsTargetDir = packageDir.appending(components: "Tests", "MyExtendedTests")
             try localFileSystem.createDirectory(myExtendedTestsTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(myExtendedTestsTargetDir.appending(component: "Test3.swift"), string: """
+            try localFileSystem.writeFileContents(myExtendedTestsTargetDir.appending("Test3.swift"), string: """
                 import XCTest
                 class TestSuite3: XCTestCase {
                     func testArrayInvariants() throws {
@@ -2541,7 +2541,7 @@ final class PackageToolTests: CommandsTestCase {
             // Create a sample package with a plugin to test various parts of the API.
             let packageDir = tmpPath.appending(components: "MyPackage")
             try localFileSystem.createDirectory(packageDir, recursive: true)
-            try localFileSystem.writeFileContents(packageDir.appending(component: "Package.swift"), string: """
+            try localFileSystem.writeFileContents(packageDir.appending("Package.swift"), string: """
                 // swift-tools-version: 5.6
                 import PackageDescription
                 let package = Package(
@@ -2600,31 +2600,31 @@ final class PackageToolTests: CommandsTestCase {
 
             let firstTargetDir = packageDir.appending(components: "Sources", "FirstTarget")
             try localFileSystem.createDirectory(firstTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(firstTargetDir.appending(component: "library.swift"), string: """
+            try localFileSystem.writeFileContents(firstTargetDir.appending("library.swift"), string: """
                 public func FirstFunc() { }
                 """)
 
             let secondTargetDir = packageDir.appending(components: "Sources", "SecondTarget")
             try localFileSystem.createDirectory(secondTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(secondTargetDir.appending(component: "library.swift"), string: """
+            try localFileSystem.writeFileContents(secondTargetDir.appending("library.swift"), string: """
                 public func SecondFunc() { }
                 """)
 
             let thirdTargetDir = packageDir.appending(components: "Sources", "ThirdTarget")
             try localFileSystem.createDirectory(thirdTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(thirdTargetDir.appending(component: "library.swift"), string: """
+            try localFileSystem.writeFileContents(thirdTargetDir.appending("library.swift"), string: """
                 public func ThirdFunc() { }
                 """)
 
             let fourthTargetDir = packageDir.appending(components: "Sources", "FourthTarget")
             try localFileSystem.createDirectory(fourthTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(fourthTargetDir.appending(component: "library.swift"), string: """
+            try localFileSystem.writeFileContents(fourthTargetDir.appending("library.swift"), string: """
                 public func FourthFunc() { }
                 """)
 
             let fifthTargetDir = packageDir.appending(components: "Sources", "FifthTarget")
             try localFileSystem.createDirectory(fifthTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(fifthTargetDir.appending(component: "main.swift"), string: """
+            try localFileSystem.writeFileContents(fifthTargetDir.appending("main.swift"), string: """
                 @main struct MyExec {
                     func run() throws {}
                 }
@@ -2632,7 +2632,7 @@ final class PackageToolTests: CommandsTestCase {
 
             let testTargetDir = packageDir.appending(components: "Tests", "TestTarget")
             try localFileSystem.createDirectory(testTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(testTargetDir.appending(component: "tests.swift"), string: """
+            try localFileSystem.writeFileContents(testTargetDir.appending("tests.swift"), string: """
                 import XCTest
                 class MyTestCase: XCTestCase {
                 }
@@ -2640,7 +2640,7 @@ final class PackageToolTests: CommandsTestCase {
 
             let pluginTargetTargetDir = packageDir.appending(components: "Plugins", "PrintTargetDependencies")
             try localFileSystem.createDirectory(pluginTargetTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(pluginTargetTargetDir.appending(component: "plugin.swift"), string: """
+            try localFileSystem.writeFileContents(pluginTargetTargetDir.appending("plugin.swift"), string: """
                 import PackagePlugin
                 @main struct PrintTargetDependencies: CommandPlugin {
                     func performCommand(
@@ -2680,7 +2680,7 @@ final class PackageToolTests: CommandsTestCase {
             // Create a separate vendored package so that we can test dependencies across products in other packages.
             let helperPackageDir = packageDir.appending(components: "VendoredDependencies", "HelperPackage")
             try localFileSystem.createDirectory(helperPackageDir, recursive: true)
-            try localFileSystem.writeFileContents(helperPackageDir.appending(component: "Package.swift"), string: """
+            try localFileSystem.writeFileContents(helperPackageDir.appending("Package.swift"), string: """
                 // swift-tools-version: 5.6
                 import PackageDescription
                 let package = Package(
@@ -2697,7 +2697,7 @@ final class PackageToolTests: CommandsTestCase {
                     ]
                 )
                 """)
-            try localFileSystem.writeFileContents(helperPackageDir.appending(component: "library.swift"), string: """
+            try localFileSystem.writeFileContents(helperPackageDir.appending("library.swift"), string: """
                 public func Foo() { }
                 """)
 
@@ -2797,20 +2797,20 @@ final class PackageToolTests: CommandsTestCase {
             )
             let myLibraryTargetDir = packageDir.appending(components: "Sources", "MyLibrary")
             try localFileSystem.createDirectory(myLibraryTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(myLibraryTargetDir.appending(component: "library.swift"), string: """
+            try localFileSystem.writeFileContents(myLibraryTargetDir.appending("library.swift"), string: """
                 public func GetGreeting() -> String { return "Hello" }
                 """
             )
             let myExecutableTargetDir = packageDir.appending(components: "Sources", "MyExecutable")
             try localFileSystem.createDirectory(myExecutableTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(myExecutableTargetDir.appending(component: "main.swift"), string: """
+            try localFileSystem.writeFileContents(myExecutableTargetDir.appending("main.swift"), string: """
                 import MyLibrary
                 print("\\(GetGreeting()), World!")
                 """
             )
             let myBuildToolPluginTargetDir = packageDir.appending(components: "Plugins", "MyBuildToolPlugin")
             try localFileSystem.createDirectory(myBuildToolPluginTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(myBuildToolPluginTargetDir.appending(component: "plugin.swift"), string: """
+            try localFileSystem.writeFileContents(myBuildToolPluginTargetDir.appending("plugin.swift"), string: """
                 import PackagePlugin
                 @main struct MyBuildToolPlugin: BuildToolPlugin {
                     func createBuildCommands(
@@ -2824,7 +2824,7 @@ final class PackageToolTests: CommandsTestCase {
             )
             let myCommandPluginTargetDir = packageDir.appending(components: "Plugins", "MyCommandPlugin")
             try localFileSystem.createDirectory(myCommandPluginTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(myCommandPluginTargetDir.appending(component: "plugin.swift"), string: """
+            try localFileSystem.writeFileContents(myCommandPluginTargetDir.appending("plugin.swift"), string: """
                 import PackagePlugin
                 @main struct MyCommandPlugin: CommandPlugin {
                     func performCommand(
@@ -2857,7 +2857,7 @@ final class PackageToolTests: CommandsTestCase {
             }
 
             // Deliberately break the command plugin.
-            try localFileSystem.writeFileContents(myCommandPluginTargetDir.appending(component: "plugin.swift"), string: """
+            try localFileSystem.writeFileContents(myCommandPluginTargetDir.appending("plugin.swift"), string: """
                 import PackagePlugin
                 @main struct MyCommandPlugin: CommandPlugin {
                     func performCommand(
@@ -2894,7 +2894,7 @@ final class PackageToolTests: CommandsTestCase {
             // Create a sample package with a library target and a plugin.
             let packageDir = tmpPath.appending(components: "MyPackage")
             try localFileSystem.createDirectory(packageDir, recursive: true)
-            try localFileSystem.writeFileContents(packageDir.appending(component: "Package.swift"), string: """
+            try localFileSystem.writeFileContents(packageDir.appending("Package.swift"), string: """
                    // swift-tools-version: 5.7
                    import PackageDescription
                    let package = Package(
@@ -2918,7 +2918,7 @@ final class PackageToolTests: CommandsTestCase {
 
             let myPluginTargetDir = packageDir.appending(components: "Plugins", "Foo")
             try localFileSystem.createDirectory(myPluginTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(myPluginTargetDir.appending(component: "plugin.swift"), string: """
+            try localFileSystem.writeFileContents(myPluginTargetDir.appending("plugin.swift"), string: """
                      import PackagePlugin
                      @main struct FooPlugin: BuildToolPlugin {
                          func createBuildCommands(

--- a/Tests/CommandsTests/RunToolTests.swift
+++ b/Tests/CommandsTests/RunToolTests.swift
@@ -77,7 +77,7 @@ final class RunToolTests: CommandsTestCase {
 
     func testUnreachableExecutable() throws {
         try fixture(name: "Miscellaneous/UnreachableTargets") { fixturePath in
-            let (output, _) = try execute(["bexec"], packagePath: fixturePath.appending(component: "A"))
+            let (output, _) = try execute(["bexec"], packagePath: fixturePath.appending("A"))
             let outputLines = output.split(separator: "\n")
             XCTAssertMatch(String(outputLines[0]), .contains("BTarget2"))
         }
@@ -104,7 +104,7 @@ final class RunToolTests: CommandsTestCase {
     func testSwiftRunSIGINT() throws {
         try XCTSkipIfCI()
         try fixture(name: "Miscellaneous/SwiftRun") { fixturePath in
-            let mainFilePath = fixturePath.appending(component: "main.swift")
+            let mainFilePath = fixturePath.appending("main.swift")
             try localFileSystem.removeFileTree(mainFilePath)
             try localFileSystem.writeFileContents(mainFilePath) {
                 """

--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -105,7 +105,7 @@ final class TestToolTests: CommandsTestCase {
             }
 
             do {
-                let xUnitOutput = fixturePath.appending(component: "result.xml")
+                let xUnitOutput = fixturePath.appending("result.xml")
                 // Run tests in parallel with verbose output.
                 XCTAssertThrowsCommandExecutionError(
                     try SwiftPMProduct.SwiftTest.execute(["--parallel", "--verbose", "--xunit-output", xUnitOutput.pathString], packagePath: fixturePath)

--- a/Tests/FunctionalTests/CFamilyTargetTests.swift
+++ b/Tests/FunctionalTests/CFamilyTargetTests.swift
@@ -47,7 +47,7 @@ class CFamilyTargetTestCase: XCTestCase {
 
     func testCUsingCAndSwiftDep() throws {
         try fixture(name: "DependencyResolution/External/CUsingCDep") { fixturePath in
-            let packageRoot = fixturePath.appending(component: "Bar")
+            let packageRoot = fixturePath.appending("Bar")
             XCTAssertBuilds(packageRoot)
             let debugPath = fixturePath.appending(components: "Bar", ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Sea.c.o")

--- a/Tests/FunctionalTests/DependencyResolutionTests.swift
+++ b/Tests/FunctionalTests/DependencyResolutionTests.swift
@@ -52,7 +52,7 @@ class DependencyResolutionTests: XCTestCase {
                 try repo.tag(name: tag)
             }
 
-            let packageRoot = fixturePath.appending(component: "Bar")
+            let packageRoot = fixturePath.appending("Bar")
             XCTAssertBuilds(packageRoot)
             XCTAssertFileExists(fixturePath.appending(components: "Bar", ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Bar"))
             let path = try SwiftPMProduct.packagePath(for: "Foo", packageRoot: packageRoot)
@@ -62,7 +62,7 @@ class DependencyResolutionTests: XCTestCase {
 
     func testExternalComplex() throws {
         try fixture(name: "DependencyResolution/External/Complex") { fixturePath in
-            XCTAssertBuilds(fixturePath.appending(component: "app"))
+            XCTAssertBuilds(fixturePath.appending("app"))
             let output = try Process.checkNonZeroExit(args: fixturePath.appending(components: "app", ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Dealer").pathString)
             XCTAssertEqual(output, "♣︎K\n♣︎Q\n♣︎J\n♣︎10\n♣︎9\n♣︎8\n♣︎7\n♣︎6\n♣︎5\n♣︎4\n")
         }
@@ -71,7 +71,7 @@ class DependencyResolutionTests: XCTestCase {
     func testConvenienceBranchInit() throws {
         try fixture(name: "DependencyResolution/External/Branch") { fixturePath in
             // Tests the convenience init .package(url: , branch: )
-            let app = fixturePath.appending(component: "Bar")
+            let app = fixturePath.appending("Bar")
             let result = try SwiftPMProduct.SwiftBuild.executeProcess([], packagePath: app)
             XCTAssertEqual(result.exitStatus, .terminated(code: 0))
         }
@@ -80,8 +80,8 @@ class DependencyResolutionTests: XCTestCase {
     func testMirrors() throws {
         try fixture(name: "DependencyResolution/External/Mirror") { fixturePath in
             let prefix = try resolveSymlinks(fixturePath)
-            let appPath = prefix.appending(component: "App")
-            let appPinsPath = appPath.appending(component: "Package.resolved")
+            let appPath = prefix.appending("App")
+            let appPinsPath = appPath.appending("Package.resolved")
 
             // prepare the dependencies as git repos
             try ["Foo", "Bar", "BarMirror"].forEach { directory in
@@ -108,13 +108,13 @@ class DependencyResolutionTests: XCTestCase {
             }
 
             // clean
-            try localFileSystem.removeFileTree(appPath.appending(component: ".build"))
+            try localFileSystem.removeFileTree(appPath.appending(".build"))
             try localFileSystem.removeFileTree(appPinsPath)
 
             // set mirror
             _ = try executeSwiftPackage(appPath, extraArgs: ["config", "set-mirror",
-                                                              "--original-url", prefix.appending(component: "Bar").pathString,
-                                                              "--mirror-url", prefix.appending(component: "BarMirror").pathString])
+                                                              "--original-url", prefix.appending("Bar").pathString,
+                                                              "--mirror-url", prefix.appending("BarMirror").pathString])
 
             // run with mirror
             do {
@@ -141,7 +141,7 @@ class DependencyResolutionTests: XCTestCase {
 
     func testPackageLookupCaseInsensitive() throws {
         try fixture(name: "DependencyResolution/External/PackageLookupCaseInsensitive") { fixturePath in
-            let result = try SwiftPMProduct.SwiftPackage.executeProcess(["update"], packagePath: fixturePath.appending(component: "pkg"))
+            let result = try SwiftPMProduct.SwiftPackage.executeProcess(["update"], packagePath: fixturePath.appending("pkg"))
             XCTAssert(result.exitStatus == .terminated(code: 0), try! result.utf8Output() + result.utf8stderrOutput())
         }
     }

--- a/Tests/FunctionalTests/MacroTests.swift
+++ b/Tests/FunctionalTests/MacroTests.swift
@@ -23,11 +23,11 @@ class MacroTests: XCTestCase {
         try XCTSkipIf(!DriverSupport.checkSupportedFrontendFlags(flags: ["load-plugin-library"], toolchain: UserToolchain.default, fileSystem: localFileSystem), "test needs `-load-plugin-library`")
 
         // Check for presence of `libSwiftSyntaxMacros`.
-        let libSwiftSyntaxMacrosPath = try UserToolchain.default.hostLibDir.appending(component: "libSwiftSyntaxMacros.dylib")
+        let libSwiftSyntaxMacrosPath = try UserToolchain.default.hostLibDir.appending("libSwiftSyntaxMacros.dylib")
         try XCTSkipIf(!localFileSystem.exists(libSwiftSyntaxMacrosPath), "test need `libSwiftSyntaxMacros` to exist in the host toolchain")
 
         try fixture(name: "Macros") { fixturePath in
-            let (stdout, _) = try executeSwiftBuild(fixturePath.appending(component: "MacroPackage"), configuration: .Debug)
+            let (stdout, _) = try executeSwiftBuild(fixturePath.appending("MacroPackage"), configuration: .Debug)
             XCTAssert(stdout.contains("@__swiftmacro_11MacroClient11fontLiteralfMf_.swift as Font"), "stdout:\n\(stdout)")
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -28,7 +28,7 @@ class MiscellaneousTestCase: XCTestCase {
         // the selected version of the package
 
         try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
-            let (stdout, stderr) = try executeSwiftBuild(fixturePath.appending(component: "Bar"))
+            let (stdout, stderr) = try executeSwiftBuild(fixturePath.appending("Bar"))
             // package resolution output goes to stderr
             XCTAssertMatch(stderr, .regex("Computed .* at 1\\.2\\.3"))
             // in "swift build" build output goes to stdout
@@ -49,11 +49,11 @@ class MiscellaneousTestCase: XCTestCase {
         // are not passed into the build-command.
 
         try fixture(name: "Miscellaneous/ExactDependencies") { fixturePath in
-            XCTAssertBuilds(fixturePath.appending(component: "app"))
+            XCTAssertBuilds(fixturePath.appending("app"))
             let buildDir = fixturePath.appending(components: "app", ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug")
-            XCTAssertFileExists(buildDir.appending(component: "FooExec"))
-            XCTAssertFileExists(buildDir.appending(component: "FooLib1.swiftmodule"))
-            XCTAssertFileExists(buildDir.appending(component: "FooLib2.swiftmodule"))
+            XCTAssertFileExists(buildDir.appending("FooExec"))
+            XCTAssertFileExists(buildDir.appending("FooLib1.swiftmodule"))
+            XCTAssertFileExists(buildDir.appending("FooLib2.swiftmodule"))
         }
     }
 
@@ -64,9 +64,9 @@ class MiscellaneousTestCase: XCTestCase {
         // should immediately exit with exit-status: `0`
 
         try fixture(name: "DependencyResolution/External/Complex") { fixturePath in
-            XCTAssertBuilds(fixturePath.appending(component: "app"))
-            XCTAssertBuilds(fixturePath.appending(component: "app"))
-            XCTAssertBuilds(fixturePath.appending(component: "app"))
+            XCTAssertBuilds(fixturePath.appending("app"))
+            XCTAssertBuilds(fixturePath.appending("app"))
+            XCTAssertBuilds(fixturePath.appending("app"))
         }
     }
 
@@ -131,7 +131,7 @@ class MiscellaneousTestCase: XCTestCase {
         try fixture(name: "DependencyResolution/External/Complex") { fixturePath in
             let execpath = fixturePath.appending(components: "app", ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Dealer").pathString
 
-            let packageRoot = fixturePath.appending(component: "app")
+            let packageRoot = fixturePath.appending("app")
             XCTAssertBuilds(packageRoot)
             var output = try Process.checkNonZeroExit(args: execpath)
             XCTAssertEqual(output, "♣︎K\n♣︎Q\n♣︎J\n♣︎10\n♣︎9\n♣︎8\n♣︎7\n♣︎6\n♣︎5\n♣︎4\n")
@@ -144,7 +144,7 @@ class MiscellaneousTestCase: XCTestCase {
             try localFileSystem.chmod(.userWritable, path: path, options: [.recursive])
             try localFileSystem.writeFileContents(path.appending(components: "src", "Fisher-Yates_Shuffle.swift"), bytes: "public extension Collection{ func shuffle() -> [Iterator.Element] {return []} }\n\npublic extension MutableCollection where Index == Int { mutating func shuffleInPlace() { for (i, _) in enumerated() { self[i] = self[0] } }}\n\npublic let shuffle = true")
 
-            XCTAssertBuilds(fixturePath.appending(component: "app"))
+            XCTAssertBuilds(fixturePath.appending("app"))
             output = try Process.checkNonZeroExit(args: execpath)
             XCTAssertEqual(output, "♠︎A\n♠︎A\n♠︎A\n♠︎A\n♠︎A\n♠︎A\n♠︎A\n♠︎A\n♠︎A\n♠︎A\n")
         }
@@ -158,8 +158,8 @@ class MiscellaneousTestCase: XCTestCase {
         try fixture(name: "Miscellaneous/DependencyEdges/External") { fixturePath in
             let execpath = [fixturePath.appending(components: "root", ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug", "dep2").pathString]
 
-            let packageRoot = fixturePath.appending(component: "root")
-            XCTAssertBuilds(fixturePath.appending(component: "root"))
+            let packageRoot = fixturePath.appending("root")
+            XCTAssertBuilds(fixturePath.appending("root"))
             var output = try Process.checkNonZeroExit(arguments: execpath)
             XCTAssertEqual(output, "Hello\n")
 
@@ -171,7 +171,7 @@ class MiscellaneousTestCase: XCTestCase {
             try localFileSystem.chmod(.userWritable, path: path, options: [.recursive])
             try localFileSystem.writeFileContents(path.appending(components: "Foo.swift"), bytes: "public let foo = \"Goodbye\"")
 
-            XCTAssertBuilds(fixturePath.appending(component: "root"))
+            XCTAssertBuilds(fixturePath.appending("root"))
             output = try Process.checkNonZeroExit(arguments: execpath)
             XCTAssertEqual(output, "Goodbye\n")
         }
@@ -209,14 +209,14 @@ class MiscellaneousTestCase: XCTestCase {
 
     func testPkgConfigCFamilyTargets() throws {
         try fixture(name: "Miscellaneous/PkgConfig") { fixturePath in
-            let systemModule = fixturePath.appending(component: "SystemModule")
+            let systemModule = fixturePath.appending("SystemModule")
             // Create a shared library.
             let input = systemModule.appending(components: "Sources", "SystemModule.c")
             let triple = try UserToolchain.default.triple
-            let output =  systemModule.appending(component: "libSystemModule\(triple.dynamicLibraryExtension)")
+            let output =  systemModule.appending("libSystemModule\(triple.dynamicLibraryExtension)")
             try systemQuietly(["clang", "-shared", input.pathString, "-o", output.pathString])
 
-            let pcFile = fixturePath.appending(component: "libSystemModule.pc")
+            let pcFile = fixturePath.appending("libSystemModule.pc")
 
             let stream = BufferedOutputByteStream()
             stream <<< """
@@ -234,7 +234,7 @@ class MiscellaneousTestCase: XCTestCase {
                 """
             try localFileSystem.writeFileContents(pcFile, bytes: stream.bytes)
 
-            let moduleUser = fixturePath.appending(component: "SystemModuleUserClang")
+            let moduleUser = fixturePath.appending("SystemModuleUserClang")
             let env = ["PKG_CONFIG_PATH": fixturePath.pathString]
             _ = try executeSwiftBuild(moduleUser, env: env)
 
@@ -283,7 +283,7 @@ class MiscellaneousTestCase: XCTestCase {
             }
 
             // Launch swift-build.
-            let app = fixturePath.appending(component: "Bar")
+            let app = fixturePath.appending("Bar")
             let process = Process(args: SwiftPMProduct.SwiftBuild.path.pathString, "--package-path", app.pathString, environment: env)
             try process.launch()
 
@@ -311,7 +311,7 @@ class MiscellaneousTestCase: XCTestCase {
             // dependency to induce a failure.
 
             // Launch swift-build.
-            let app = fixturePath.appending(component: "Bar")
+            let app = fixturePath.appending("Bar")
 
             let result = try SwiftPMProduct.SwiftBuild.executeProcess([], packagePath: app)
 
@@ -327,7 +327,7 @@ class MiscellaneousTestCase: XCTestCase {
         try fixture(name: "Miscellaneous/LocalPackageAsURL", createGitRepo: false) { fixturePath in
             // This fixture has a setup that is trying to use a local package
             // as a url that hasn't been initialized as a repo
-            let result = try SwiftPMProduct.SwiftBuild.executeProcess([], packagePath: fixturePath.appending(component: "Bar"))
+            let result = try SwiftPMProduct.SwiftBuild.executeProcess([], packagePath: fixturePath.appending("Bar"))
             XCTAssert(result.exitStatus != .terminated(code: 0))
             let output = try result.utf8stderrOutput()
             XCTAssert(output.contains("cannot clone from local directory"), "Didn't find expected output: \(output)")
@@ -337,13 +337,13 @@ class MiscellaneousTestCase: XCTestCase {
     func testInvalidRefsValidation() throws {
         try fixture(name: "Miscellaneous/InvalidRefs", createGitRepo: false) { fixturePath in
             do {
-                let result = try SwiftPMProduct.SwiftBuild.executeProcess([], packagePath: fixturePath.appending(component: "InvalidBranch"))
+                let result = try SwiftPMProduct.SwiftBuild.executeProcess([], packagePath: fixturePath.appending("InvalidBranch"))
                 XCTAssert(result.exitStatus != .terminated(code: 0))
                 let output = try result.utf8stderrOutput()
                 XCTAssert(output.contains("invalid branch name: "), "Didn't find expected output: \(output)")
             }
             do {
-                let result = try SwiftPMProduct.SwiftBuild.executeProcess([], packagePath: fixturePath.appending(component: "InvalidRevision"))
+                let result = try SwiftPMProduct.SwiftBuild.executeProcess([], packagePath: fixturePath.appending("InvalidRevision"))
                 XCTAssert(result.exitStatus != .terminated(code: 0))
                 let output = try result.utf8stderrOutput()
                 XCTAssert(output.contains("invalid revision: "), "Didn't find expected output: \(output)")
@@ -364,8 +364,8 @@ class MiscellaneousTestCase: XCTestCase {
             // ••••• Set up dependency.
             let dependencyName = "UnicodeDependency‐\(complicatedString)"
             let dependencyOrigin = AbsolutePath(path: #file).parentDirectory.parentDirectory.parentDirectory
-                .appending(component: "Fixtures")
-                .appending(component: "Miscellaneous")
+                .appending("Fixtures")
+                .appending("Miscellaneous")
                 .appending(component: dependencyName)
             let dependencyDestination = fixturePath.parentDirectory.appending(component: dependencyName)
             try? FileManager.default.removeItem(atPath: dependencyDestination.pathString)
@@ -446,7 +446,7 @@ class MiscellaneousTestCase: XCTestCase {
     func testEditModeEndToEnd() throws {
         try fixture(name: "Miscellaneous/Edit") { fixturePath in
             let prefix = try resolveSymlinks(fixturePath)
-            let appPath = fixturePath.appending(component: "App")
+            let appPath = fixturePath.appending("App")
 
             // prepare the dependencies as git repos
             try ["Foo", "Bar"].forEach { directory in
@@ -581,13 +581,13 @@ class MiscellaneousTestCase: XCTestCase {
         try fixture(name: "Miscellaneous/FlatPackage") { package in
             // First build, make sure we got the `.build` directory where we expect it, and that there is no JSON output (by looking for known output).
             let (stdout1, stderr1) = try SwiftPMProduct.SwiftBuild.execute([], packagePath: package)
-            XCTAssertDirectoryExists(package.appending(component: ".build"))
+            XCTAssertDirectoryExists(package.appending(".build"))
             XCTAssertNoMatch(stdout1, .contains("command_arguments"))
             XCTAssertNoMatch(stderr1, .contains("command_arguments"))
             
             // Now test, make sure we got the `.build` directory where we expect it, and that there is no JSON output (by looking for known output).
             let (stdout2, stderr2) = try SwiftPMProduct.SwiftTest.execute([], packagePath: package)
-            XCTAssertDirectoryExists(package.appending(component: ".build"))
+            XCTAssertDirectoryExists(package.appending(".build"))
             XCTAssertNoMatch(stdout2, .contains("command_arguments"))
             XCTAssertNoMatch(stderr2, .contains("command_arguments"))
         }
@@ -596,14 +596,14 @@ class MiscellaneousTestCase: XCTestCase {
     func testNoWarningFromRemoteDependencies() throws {
         try fixture(name: "Miscellaneous/DependenciesWarnings") { path in
             // prepare the deps as git sources
-            let dependency1Path = path.appending(component: "dep1")
+            let dependency1Path = path.appending("dep1")
             initGitRepo(dependency1Path, tag: "1.0.0")
-            let dependency2Path = path.appending(component: "dep2")
+            let dependency2Path = path.appending("dep2")
             initGitRepo(dependency2Path, tag: "1.0.0")
 
-            let appPath = path.appending(component: "app")
+            let appPath = path.appending("app")
             let (stdout, stderr) = try SwiftPMProduct.SwiftBuild.execute([], packagePath: appPath)
-            XCTAssertDirectoryExists(appPath.appending(component: ".build"))
+            XCTAssertDirectoryExists(appPath.appending(".build"))
             XCTAssertMatch(stdout + stderr, .contains("'DeprecatedApp' is deprecated"))
             XCTAssertNoMatch(stdout + stderr, .contains("'Deprecated1' is deprecated"))
             XCTAssertNoMatch(stdout + stderr, .contains("'Deprecated2' is deprecated"))
@@ -613,14 +613,14 @@ class MiscellaneousTestCase: XCTestCase {
     func testNoWarningFromRemoteDependenciesWithWarningsAsErrors() throws {
         try fixture(name: "Miscellaneous/DependenciesWarnings2") { path in
             // prepare the deps as git sources
-            let dependency1Path = path.appending(component: "dep1")
+            let dependency1Path = path.appending("dep1")
             initGitRepo(dependency1Path, tag: "1.0.0")
-            let dependency2Path = path.appending(component: "dep2")
+            let dependency2Path = path.appending("dep2")
             initGitRepo(dependency2Path, tag: "1.0.0")
 
-            let appPath = path.appending(component: "app")
+            let appPath = path.appending("app")
             let (stdout, stderr) = try SwiftPMProduct.SwiftBuild.execute(["-Xswiftc", "-warnings-as-errors"], packagePath: appPath)
-            XCTAssertDirectoryExists(appPath.appending(component: ".build"))
+            XCTAssertDirectoryExists(appPath.appending(".build"))
             XCTAssertNoMatch(stdout + stderr, .contains("'Deprecated1' is deprecated"))
             XCTAssertNoMatch(stdout + stderr, .contains("'Deprecated2' is deprecated"))
         }

--- a/Tests/FunctionalTests/ModuleMapTests.swift
+++ b/Tests/FunctionalTests/ModuleMapTests.swift
@@ -25,7 +25,7 @@ class ModuleMapsTestCase: XCTestCase {
             let triple = try UserToolchain.default.triple
             let outdir = fixturePath.appending(components: rootpkg, ".build", triple.platformBuildPathComponent(), "debug")
             try makeDirectories(outdir)
-            let output = outdir.appending(component: "libfoo\(triple.dynamicLibraryExtension)")
+            let output = outdir.appending("libfoo\(triple.dynamicLibraryExtension)")
             try systemQuietly(["clang", "-shared", input.pathString, "-o", output.pathString])
 
             var Xld = ["-L", outdir.pathString]
@@ -40,7 +40,7 @@ class ModuleMapsTestCase: XCTestCase {
     func testDirectDependency() throws {
         try fixture(name: "ModuleMaps/Direct", cModuleName: "CFoo", rootpkg: "App") { fixturePath, Xld in
 
-            XCTAssertBuilds(fixturePath.appending(component: "App"), Xld: Xld)
+            XCTAssertBuilds(fixturePath.appending("App"), Xld: Xld)
 
             let triple = try UserToolchain.default.triple
             let targetPath = fixturePath.appending(components: "App", ".build", triple.platformBuildPathComponent())
@@ -54,7 +54,7 @@ class ModuleMapsTestCase: XCTestCase {
     func testTransitiveDependency() throws {
         try fixture(name: "ModuleMaps/Transitive", cModuleName: "packageD", rootpkg: "packageA") { fixturePath, Xld in
 
-            XCTAssertBuilds(fixturePath.appending(component: "packageA"), Xld: Xld)
+            XCTAssertBuilds(fixturePath.appending("packageA"), Xld: Xld)
 
             func verify(_ conf: String) throws {
                 let triple = try UserToolchain.default.triple

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -27,7 +27,7 @@ class PluginTests: XCTestCase {
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
 
         try fixture(name: "Miscellaneous/Plugins") { fixturePath in
-            let (stdout, _) = try executeSwiftBuild(fixturePath.appending(component: "MySourceGenPlugin"), configuration: .Debug, extraArgs: ["--product", "MyLocalTool"])
+            let (stdout, _) = try executeSwiftBuild(fixturePath.appending("MySourceGenPlugin"), configuration: .Debug, extraArgs: ["--product", "MyLocalTool"])
             XCTAssert(stdout.contains("Linking MySourceGenBuildTool"), "stdout:\n\(stdout)")
             XCTAssert(stdout.contains("Generating foo.swift from foo.dat"), "stdout:\n\(stdout)")
             XCTAssert(stdout.contains("Linking MyLocalTool"), "stdout:\n\(stdout)")
@@ -40,7 +40,7 @@ class PluginTests: XCTestCase {
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
 
         try fixture(name: "Miscellaneous/Plugins") { fixturePath in
-            let (stdout, _) = try executeSwiftBuild(fixturePath.appending(component: "MySourceGenClient"), configuration: .Debug, extraArgs: ["--product", "MyTool"])
+            let (stdout, _) = try executeSwiftBuild(fixturePath.appending("MySourceGenClient"), configuration: .Debug, extraArgs: ["--product", "MyTool"])
             XCTAssert(stdout.contains("Linking MySourceGenBuildTool"), "stdout:\n\(stdout)")
             XCTAssert(stdout.contains("Generating foo.swift from foo.dat"), "stdout:\n\(stdout)")
             XCTAssert(stdout.contains("Linking MyTool"), "stdout:\n\(stdout)")
@@ -53,7 +53,7 @@ class PluginTests: XCTestCase {
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
 
         try fixture(name: "Miscellaneous/Plugins") { fixturePath in
-            let (stdout, _) = try executeSwiftBuild(fixturePath.appending(component: "MySourceGenPlugin"), configuration: .Debug, extraArgs: ["--product", "MyOtherLocalTool"])
+            let (stdout, _) = try executeSwiftBuild(fixturePath.appending("MySourceGenPlugin"), configuration: .Debug, extraArgs: ["--product", "MyOtherLocalTool"])
             XCTAssert(stdout.contains("Compiling MyOtherLocalTool bar.swift"), "stdout:\n\(stdout)")
             XCTAssert(stdout.contains("Compiling MyOtherLocalTool baz.swift"), "stdout:\n\(stdout)")
             XCTAssert(stdout.contains("Linking MyOtherLocalTool"), "stdout:\n\(stdout)")
@@ -66,7 +66,7 @@ class PluginTests: XCTestCase {
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
         
         try fixture(name: "Miscellaneous/Plugins") { fixturePath in
-            let (stdout, _) = try executeSwiftBuild(fixturePath.appending(component: "ClientOfPluginWithInternalExecutable"))
+            let (stdout, _) = try executeSwiftBuild(fixturePath.appending("ClientOfPluginWithInternalExecutable"))
             XCTAssert(stdout.contains("Compiling PluginExecutable main.swift"), "stdout:\n\(stdout)")
             XCTAssert(stdout.contains("Linking PluginExecutable"), "stdout:\n\(stdout)")
             XCTAssert(stdout.contains("Generating foo.swift from foo.dat"), "stdout:\n\(stdout)")
@@ -81,7 +81,7 @@ class PluginTests: XCTestCase {
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
 
         try fixture(name: "Miscellaneous/Plugins") { fixturePath in
-            XCTAssertThrowsCommandExecutionError(try executeSwiftBuild(fixturePath.appending(component: "InvalidUseOfInternalPluginExecutable")), "Illegally used internal executable") { error in
+            XCTAssertThrowsCommandExecutionError(try executeSwiftBuild(fixturePath.appending("InvalidUseOfInternalPluginExecutable")), "Illegally used internal executable") { error in
                 XCTAssert(
                     error.stderr.contains("product 'PluginExecutable' required by package 'invaliduseofinternalpluginexecutable' target 'RootTarget' not found in package 'PluginWithInternalExecutable'."), "stderr:\n\(error.stderr)"
                 )
@@ -94,7 +94,7 @@ class PluginTests: XCTestCase {
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
         
         try fixture(name: "Miscellaneous/Plugins") { fixturePath in
-            let (stdout, _) = try executeSwiftBuild(fixturePath.appending(component: "LibraryWithLocalBuildToolPluginUsingRemoteTool"))
+            let (stdout, _) = try executeSwiftBuild(fixturePath.appending("LibraryWithLocalBuildToolPluginUsingRemoteTool"))
             XCTAssert(stdout.contains("Compiling MySourceGenBuildTool main.swift"), "stdout:\n\(stdout)")
             XCTAssert(stdout.contains("Linking MySourceGenBuildTool"), "stdout:\n\(stdout)")
             XCTAssert(stdout.contains("Generating generated.swift from generated.dat"), "stdout:\n\(stdout)")
@@ -108,7 +108,7 @@ class PluginTests: XCTestCase {
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
         
         try fixture(name: "Miscellaneous/Plugins") { fixturePath in
-            let (stdout, _) = try executeSwiftBuild(fixturePath.appending(component: "MyBuildToolPluginDependencies"))
+            let (stdout, _) = try executeSwiftBuild(fixturePath.appending("MyBuildToolPluginDependencies"))
             XCTAssert(stdout.contains("Compiling MySourceGenBuildTool main.swift"), "stdout:\n\(stdout)")
             XCTAssert(stdout.contains("Linking MySourceGenBuildTool"), "stdout:\n\(stdout)")
             XCTAssert(stdout.contains("Generating foo.swift from foo.dat"), "stdout:\n\(stdout)")
@@ -122,7 +122,7 @@ class PluginTests: XCTestCase {
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
 
         try fixture(name: "Miscellaneous/Plugins") { fixturePath in
-            let (stdout, _) = try executeSwiftBuild(fixturePath.appending(component: "ContrivedTestPlugin"), configuration: .Debug, extraArgs: ["--product", "MyLocalTool"])
+            let (stdout, _) = try executeSwiftBuild(fixturePath.appending("ContrivedTestPlugin"), configuration: .Debug, extraArgs: ["--product", "MyLocalTool"])
             XCTAssert(stdout.contains("Linking MySourceGenBuildTool"), "stdout:\n\(stdout)")
             XCTAssert(stdout.contains("Generating foo.swift from foo.dat"), "stdout:\n\(stdout)")
             XCTAssert(stdout.contains("Linking MyLocalTool"), "stdout:\n\(stdout)")
@@ -137,7 +137,7 @@ class PluginTests: XCTestCase {
         // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
         try fixture(name: "Miscellaneous/Plugins") { fixturePath in
-            let (stdout, _) = try executeSwiftBuild(fixturePath.appending(component: "SandboxTesterPlugin"), configuration: .Debug, extraArgs: ["--product", "MyLocalTool"])
+            let (stdout, _) = try executeSwiftBuild(fixturePath.appending("SandboxTesterPlugin"), configuration: .Debug, extraArgs: ["--product", "MyLocalTool"])
             XCTAssert(stdout.contains("Linking MyLocalTool"), "stdout:\n\(stdout)")
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
@@ -150,7 +150,7 @@ class PluginTests: XCTestCase {
         // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
         try fixture(name: "Miscellaneous/Plugins") { fixturePath in
-            let (stdout, _) = try executeSwiftBuild(fixturePath.appending(component: "MyBinaryToolPlugin"), configuration: .Debug, extraArgs: ["--product", "MyLocalTool"])
+            let (stdout, _) = try executeSwiftBuild(fixturePath.appending("MyBinaryToolPlugin"), configuration: .Debug, extraArgs: ["--product", "MyLocalTool"])
             XCTAssert(stdout.contains("Linking MyLocalTool"), "stdout:\n\(stdout)")
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
@@ -163,7 +163,7 @@ class PluginTests: XCTestCase {
         // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
         try fixture(name: "Miscellaneous/Plugins") { fixturePath in
-            let (stdout, _) = try executeSwiftBuild(fixturePath.appending(component: "BinaryToolProductPlugin"), configuration: .Debug, extraArgs: ["--product", "MyLocalTool"])
+            let (stdout, _) = try executeSwiftBuild(fixturePath.appending("BinaryToolProductPlugin"), configuration: .Debug, extraArgs: ["--product", "MyLocalTool"])
             XCTAssert(stdout.contains("Linking MyLocalTool"), "stdout:\n\(stdout)")
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
@@ -177,7 +177,7 @@ class PluginTests: XCTestCase {
         try testWithTemporaryDirectory { tmpPath in
             // Create a sample package with a library target and a plugin. It depends on a sample package.
             let packageDir = tmpPath.appending(components: "MyPackage")
-            let manifestFile = packageDir.appending(component: "Package.swift")
+            let manifestFile = packageDir.appending("Package.swift")
             try localFileSystem.createDirectory(manifestFile.parentDirectory, recursive: true)
             try localFileSystem.writeFileContents(manifestFile) {
                 """
@@ -448,7 +448,7 @@ class PluginTests: XCTestCase {
                 do {
                     let scriptRunner = DefaultPluginScriptRunner(
                         fileSystem: localFileSystem,
-                        cacheDir: pluginDir.appending(component: "cache"),
+                        cacheDir: pluginDir.appending("cache"),
                         toolchain: try UserToolchain.default
                     )
 
@@ -458,10 +458,10 @@ class PluginTests: XCTestCase {
                         buildEnvironment: BuildEnvironment(platform: .macOS, configuration: .debug),
                         scriptRunner: scriptRunner,
                         workingDirectory: package.path,
-                        outputDirectory: pluginDir.appending(component: "output"),
+                        outputDirectory: pluginDir.appending("output"),
                         toolSearchDirectories: toolSearchDirectories,
                         accessibleTools: [:],
-                        writableDirectories: [pluginDir.appending(component: "output")],
+                        writableDirectories: [pluginDir.appending("output")],
                         readOnlyDirectories: [package.path],
                         pkgConfigDirectories: [],
                         fileSystem: localFileSystem,
@@ -512,7 +512,7 @@ class PluginTests: XCTestCase {
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
 
         try fixture(name: "Miscellaneous/Plugins/PluginUsingLocalAndRemoteTool") { path in
-            let (stdout, stderr) = try executeSwiftPackage(path.appending(component: "MyLibrary"), configuration: .Debug, extraArgs: ["plugin", "my-plugin"])
+            let (stdout, stderr) = try executeSwiftPackage(path.appending("MyLibrary"), configuration: .Debug, extraArgs: ["plugin", "my-plugin"])
             XCTAssert(stderr.contains("Linking RemoteTool"), "stdout:\n\(stderr)\n\(stdout)")
             XCTAssert(stderr.contains("Linking LocalTool"), "stdout:\n\(stderr)\n\(stdout)")
             XCTAssert(stderr.contains("Linking ImpliedLocalTool"), "stdout:\n\(stderr)\n\(stdout)")
@@ -595,14 +595,14 @@ class PluginTests: XCTestCase {
             }
             let myLibraryTargetDir = packageDir.appending(components: "Sources", "MyLibrary")
             try localFileSystem.createDirectory(myLibraryTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(myLibraryTargetDir.appending(component: "library.swift")) {
+            try localFileSystem.writeFileContents(myLibraryTargetDir.appending("library.swift")) {
                 """
                 public func GetGreeting() -> String { return "Hello" }
                 """
             }
             let neverendingPluginTargetDir = packageDir.appending(components: "Plugins", "NeverendingPlugin")
             try localFileSystem.createDirectory(neverendingPluginTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(neverendingPluginTargetDir.appending(component: "plugin.swift")) {
+            try localFileSystem.writeFileContents(neverendingPluginTargetDir.appending("plugin.swift")) {
                 """
                 import PackagePlugin
                 import Foundation
@@ -714,7 +714,7 @@ class PluginTests: XCTestCase {
             let pluginDir = tmpPath.appending(components: package.identity.description, plugin.name)
             let scriptRunner = DefaultPluginScriptRunner(
                 fileSystem: localFileSystem,
-                cacheDir: pluginDir.appending(component: "cache"),
+                cacheDir: pluginDir.appending("cache"),
                 toolchain: try UserToolchain.default
             )
             let delegate = PluginDelegate(delegateQueue: delegateQueue)
@@ -724,10 +724,10 @@ class PluginTests: XCTestCase {
                 buildEnvironment: BuildEnvironment(platform: .macOS, configuration: .debug),
                 scriptRunner: scriptRunner,
                 workingDirectory: package.path,
-                outputDirectory: pluginDir.appending(component: "output"),
+                outputDirectory: pluginDir.appending("output"),
                 toolSearchDirectories: [try UserToolchain.default.swiftCompilerPath.parentDirectory],
                 accessibleTools: [:],
-                writableDirectories: [pluginDir.appending(component: "output")],
+                writableDirectories: [pluginDir.appending("output")],
                 readOnlyDirectories: [package.path],
                 pkgConfigDirectories: [],
                 fileSystem: localFileSystem,
@@ -777,7 +777,7 @@ class PluginTests: XCTestCase {
             // Create a sample package that uses three packages that vend plugins.
             let packageDir = tmpPath.appending(components: "MyPackage")
             try localFileSystem.createDirectory(packageDir, recursive: true)
-            try localFileSystem.writeFileContents(packageDir.appending(component: "Package.swift")) {
+            try localFileSystem.writeFileContents(packageDir.appending("Package.swift")) {
                 """
                 // swift-tools-version: 5.6
                 import PackageDescription
@@ -800,7 +800,7 @@ class PluginTests: XCTestCase {
                 )
                 """
             }
-            try localFileSystem.writeFileContents(packageDir.appending(component: "Library.swift")) {
+            try localFileSystem.writeFileContents(packageDir.appending("Library.swift")) {
                 """
                 public var Foo: String
                 """
@@ -809,7 +809,7 @@ class PluginTests: XCTestCase {
             // Create the depended-upon package that vends a build tool plugin that is used by the main package.
             let buildToolPluginPackageDir = packageDir.appending(components: "VendoredDependencies", "BuildToolPluginPackage")
             try localFileSystem.createDirectory(buildToolPluginPackageDir, recursive: true)
-            try localFileSystem.writeFileContents(buildToolPluginPackageDir.appending(component: "Package.swift")) {
+            try localFileSystem.writeFileContents(buildToolPluginPackageDir.appending("Package.swift")) {
                 """
                 // swift-tools-version: 5.6
                 import PackageDescription
@@ -829,7 +829,7 @@ class PluginTests: XCTestCase {
                 )
                 """
             }
-            try localFileSystem.writeFileContents(buildToolPluginPackageDir.appending(component: "Plugin.swift")) {
+            try localFileSystem.writeFileContents(buildToolPluginPackageDir.appending("Plugin.swift")) {
                 """
                 import PackagePlugin
                 @main struct MyPlugin: BuildToolPlugin {
@@ -843,7 +843,7 @@ class PluginTests: XCTestCase {
             // Create the depended-upon package that vends a build tool plugin that is not used by the main package.
             let unusedBuildToolPluginPackageDir = packageDir.appending(components: "VendoredDependencies", "UnusedBuildToolPluginPackage")
             try localFileSystem.createDirectory(unusedBuildToolPluginPackageDir, recursive: true)
-            try localFileSystem.writeFileContents(unusedBuildToolPluginPackageDir.appending(component: "Package.swift")) {
+            try localFileSystem.writeFileContents(unusedBuildToolPluginPackageDir.appending("Package.swift")) {
                 """
                 // swift-tools-version: 5.6
                 import PackageDescription
@@ -863,7 +863,7 @@ class PluginTests: XCTestCase {
                 )
                 """
             }
-            try localFileSystem.writeFileContents(unusedBuildToolPluginPackageDir.appending(component: "Plugin.swift")) {
+            try localFileSystem.writeFileContents(unusedBuildToolPluginPackageDir.appending("Plugin.swift")) {
                 """
                 import PackagePlugin
                 @main struct MyPlugin: BuildToolPlugin {
@@ -877,7 +877,7 @@ class PluginTests: XCTestCase {
             // Create the depended-upon package that vends a command plugin.
             let commandPluginPackageDir = packageDir.appending(components: "VendoredDependencies", "CommandPluginPackage")
             try localFileSystem.createDirectory(commandPluginPackageDir, recursive: true)
-            try localFileSystem.writeFileContents(commandPluginPackageDir.appending(component: "Package.swift")) {
+            try localFileSystem.writeFileContents(commandPluginPackageDir.appending("Package.swift")) {
                 """
                 // swift-tools-version: 5.6
                 import PackageDescription
@@ -897,7 +897,7 @@ class PluginTests: XCTestCase {
                 )
                 """
             }
-            try localFileSystem.writeFileContents(commandPluginPackageDir.appending(component: "Plugin.swift")) {
+            try localFileSystem.writeFileContents(commandPluginPackageDir.appending("Plugin.swift")) {
                 """
                 import PackagePlugin
                 @main struct MyPlugin: CommandPlugin {
@@ -944,7 +944,7 @@ class PluginTests: XCTestCase {
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
 
         try fixture(name: "Miscellaneous/Plugins") { path in
-            let (stdout, stderr) = try executeSwiftPackage(path.appending(component: "PluginsAndSnippets"), configuration: .Debug, extraArgs: ["do-something"])
+            let (stdout, stderr) = try executeSwiftPackage(path.appending("PluginsAndSnippets"), configuration: .Debug, extraArgs: ["do-something"])
             XCTAssert(stdout.contains("type of snippet target: snippet"), "output:\n\(stderr)\n\(stdout)")
         }
     }
@@ -959,14 +959,14 @@ class PluginTests: XCTestCase {
 
         // Check that the build fails with a sandbox violation by default.
         try fixture(name: "Miscellaneous/Plugins/SandboxViolatingBuildToolPluginCommands") { path in
-            XCTAssertThrowsError(try executeSwiftBuild(path.appending(component: "MyLibrary"), configuration: .Debug)) { error in
+            XCTAssertThrowsError(try executeSwiftBuild(path.appending("MyLibrary"), configuration: .Debug)) { error in
                 XCTAssertMatch("\(error)", .contains("You don’t have permission to save the file “generated” in the folder “MyLibrary”."))
             }
         }
 
         // Check that the build succeeds if we disable the sandbox.
         try fixture(name: "Miscellaneous/Plugins/SandboxViolatingBuildToolPluginCommands") { path in
-            let (stdout, stderr) = try executeSwiftBuild(path.appending(component: "MyLibrary"), configuration: .Debug, extraArgs: ["--disable-sandbox"])
+            let (stdout, stderr) = try executeSwiftBuild(path.appending("MyLibrary"), configuration: .Debug, extraArgs: ["--disable-sandbox"])
             XCTAssert(stdout.contains("Compiling MyLibrary foo.swift"), "[STDOUT]\n\(stdout)\n[STDERR]\n\(stderr)\n")
         }
 
@@ -977,7 +977,7 @@ class PluginTests: XCTestCase {
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
 
         try fixture(name: "Miscellaneous/Plugins") { fixturePath in
-            let (stdout, _) = try executeSwiftBuild(fixturePath.appending(component: "TransitivePluginOnlyDependency"))
+            let (stdout, _) = try executeSwiftBuild(fixturePath.appending("TransitivePluginOnlyDependency"))
             XCTAssert(stdout.contains("Compiling plugin MyPlugin"), "stdout:\n\(stdout)")
             XCTAssert(stdout.contains("Compiling Library Library.swift"), "stdout:\n\(stdout)")
             XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
@@ -990,7 +990,7 @@ class PluginTests: XCTestCase {
 
         try fixture(name: "Miscellaneous/Plugins") { fixturePath in
             do {
-                try executeSwiftBuild(fixturePath.appending(component: "MissingPlugin"))
+                try executeSwiftBuild(fixturePath.appending("MissingPlugin"))
             } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
                 XCTAssert(stderr.contains("error: 'missingplugin': no plugin named 'NonExistingPlugin' found"), "stderr:\n\(stderr)")
             }
@@ -1002,7 +1002,7 @@ class PluginTests: XCTestCase {
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
 
         try fixture(name: "Miscellaneous/Plugins") { fixturePath in
-            let (stdout, _) = try executeSwiftBuild(fixturePath.appending(component: "PluginCanBeReferencedByProductName"))
+            let (stdout, _) = try executeSwiftBuild(fixturePath.appending("PluginCanBeReferencedByProductName"))
             XCTAssert(stdout.contains("Compiling plugin MyPlugin"), "stdout:\n\(stdout)")
             XCTAssert(stdout.contains("Compiling PluginCanBeReferencedByProductName gen.swift"), "stdout:\n\(stdout)")
             XCTAssert(stdout.contains("Compiling PluginCanBeReferencedByProductName PluginCanBeReferencedByProductName.swift"), "stdout:\n\(stdout)")

--- a/Tests/FunctionalTests/ResourcesTests.swift
+++ b/Tests/FunctionalTests/ResourcesTests.swift
@@ -37,7 +37,7 @@ class ResourcesTests: XCTestCase {
         try fixture(name: "Resources/Localized") { fixturePath in
             try executeSwiftBuild(fixturePath)
 
-            let exec = AbsolutePath(path: ".build/debug/exe", relativeTo: fixturePath)
+            let exec = AbsolutePath(".build/debug/exe", relativeTo: fixturePath)
             // Note: <rdar://problem/59738569> Source from LANG and -AppleLanguages on command line for Linux resources
             let output = try Process.checkNonZeroExit(args: exec.pathString, "-AppleLanguages", "(en_US)")
             XCTAssertEqual(output, """

--- a/Tests/FunctionalTests/SwiftPMXCTestHelperTests.swift
+++ b/Tests/FunctionalTests/SwiftPMXCTestHelperTests.swift
@@ -50,7 +50,7 @@ class SwiftPMXCTestHelperTests: XCTestCase {
     func XCTAssertXCTestHelper(_ bundlePath: AbsolutePath, testCases: NSDictionary) throws {
         #if os(macOS)
         let env = ["DYLD_FRAMEWORK_PATH": try Destination.sdkPlatformFrameworkPaths().fwk.pathString]
-        let outputFile = bundlePath.parentDirectory.appending(component: "tests.txt")
+        let outputFile = bundlePath.parentDirectory.appending("tests.txt")
         let _ = try SwiftPMProduct.XCTestHelper.execute([bundlePath.pathString, outputFile.pathString], env: env)
         guard let data = NSData(contentsOfFile: outputFile.pathString) else {
             XCTFail("No output found in : \(outputFile)"); return;

--- a/Tests/FunctionalTests/ToolsVersionTests.swift
+++ b/Tests/FunctionalTests/ToolsVersionTests.swift
@@ -26,12 +26,12 @@ class ToolsVersionTests: XCTestCase {
             let fs = localFileSystem
 
             // Create a repo for the dependency to test against.
-            let depPath = path.appending(component: "Dep")
+            let depPath = path.appending("Dep")
             try fs.createDirectory(depPath)
             initGitRepo(depPath)
             let repo = GitRepository(path: depPath)
 
-            try fs.writeFileContents(depPath.appending(component: "Package.swift")) {
+            try fs.writeFileContents(depPath.appending("Package.swift")) {
                 $0 <<< """
                     // swift-tools-version:5.0
                     import PackageDescription
@@ -46,7 +46,7 @@ class ToolsVersionTests: XCTestCase {
                     )
                     """
             }
-            try fs.writeFileContents(depPath.appending(component: "foo.swift")) {
+            try fs.writeFileContents(depPath.appending("foo.swift")) {
                 $0 <<< """
                     public func foo() { print("foo@1.0") }
                     """
@@ -59,7 +59,7 @@ class ToolsVersionTests: XCTestCase {
             // v1.0.1
             _ = try SwiftPMProduct.SwiftPackage.execute(
                 ["tools-version", "--set", "10000.1"], packagePath: depPath)
-            try fs.writeFileContents(depPath.appending(component: "foo.swift")) {
+            try fs.writeFileContents(depPath.appending("foo.swift")) {
                 $0 <<< """
                     public func foo() { print("foo@1.0.1") }
                     """
@@ -69,8 +69,8 @@ class ToolsVersionTests: XCTestCase {
             try repo.tag(name: "1.0.1")
 
             // Create the primary repository.
-            let primaryPath = path.appending(component: "Primary")
-            try fs.writeFileContents(primaryPath.appending(component: "Package.swift")) {
+            let primaryPath = path.appending("Primary")
+            try fs.writeFileContents(primaryPath.appending("Package.swift")) {
                 $0 <<< """
                     import PackageDescription
                     let package = Package(
@@ -81,7 +81,7 @@ class ToolsVersionTests: XCTestCase {
                     """
             }
             // Create a file.
-            try fs.writeFileContents(primaryPath.appending(component: "main.swift")) {
+            try fs.writeFileContents(primaryPath.appending("main.swift")) {
                 $0 <<< """
                     import Dep
                     Dep.foo()
@@ -105,7 +105,7 @@ class ToolsVersionTests: XCTestCase {
             }
 
             // Write the manifest with incompatible sources.
-            try fs.writeFileContents(primaryPath.appending(component: "Package.swift")) {
+            try fs.writeFileContents(primaryPath.appending("Package.swift")) {
                 $0 <<< """
                     import PackageDescription
                     let package = Package(
@@ -122,7 +122,7 @@ class ToolsVersionTests: XCTestCase {
                 XCTAssertTrue(error.stderr.contains("package 'primary' requires minimum Swift language version 1000 which is not supported by the current tools version (\(ToolsVersion.current))"), error.stderr)
             }
 
-             try fs.writeFileContents(primaryPath.appending(component: "Package.swift")) {
+             try fs.writeFileContents(primaryPath.appending("Package.swift")) {
                 $0 <<< """
                     import PackageDescription
                     let package = Package(

--- a/Tests/FunctionalTests/VersionSpecificTests.swift
+++ b/Tests/FunctionalTests/VersionSpecificTests.swift
@@ -23,13 +23,13 @@ class VersionSpecificTests: XCTestCase {
             let fs = localFileSystem
 
             // Create a repo for the dependency to test against.
-            let depPath = path.appending(component: "Dep")
+            let depPath = path.appending("Dep")
             try fs.createDirectory(depPath)
             initGitRepo(depPath)
             let repo = GitRepository(path: depPath)
 
             // Create the initial commit.
-            try fs.writeFileContents(depPath.appending(component: "Package.swift")) {
+            try fs.writeFileContents(depPath.appending("Package.swift")) {
                 $0 <<< """
                     // swift-tools-version:4.2
                     import PackageDescription
@@ -49,14 +49,14 @@ class VersionSpecificTests: XCTestCase {
             try repo.tag(name: "1.0.0")
 
             // Create the version to test against.
-            try fs.writeFileContents(depPath.appending(component: "Package.swift")) {
+            try fs.writeFileContents(depPath.appending("Package.swift")) {
                 // FIXME: We end up filtering this manifest if it has an invalid
                 // tools version as they're assumed to be v3 manifests. Should we
                 // do something better?
                 $0 <<< "// swift-tools-version:4.2\n"
                 $0 <<< "NOT_A_VALID_PACKAGE"
             }
-            try fs.writeFileContents(depPath.appending(component: "foo.swift")) {
+            try fs.writeFileContents(depPath.appending("foo.swift")) {
                 $0 <<< """
                     public func foo() { print("foo\\n") }
                     """
@@ -67,8 +67,8 @@ class VersionSpecificTests: XCTestCase {
             try repo.tag(name: "1.1.0")
 
             // Create the primary repository.
-            let primaryPath = path.appending(component: "Primary")
-            try fs.writeFileContents(primaryPath.appending(component: "Package.swift")) {
+            let primaryPath = path.appending("Primary")
+            try fs.writeFileContents(primaryPath.appending("Package.swift")) {
                 $0 <<< """
                     // swift-tools-version:4.2
                     import PackageDescription
@@ -87,7 +87,7 @@ class VersionSpecificTests: XCTestCase {
             XCTAssertBuildFails(primaryPath)
 
             // Create a file which requires a version 1.1.0 resolution.
-            try fs.writeFileContents(primaryPath.appending(component: "main.swift")) {
+            try fs.writeFileContents(primaryPath.appending("main.swift")) {
                 $0 <<< """
                     import Dep
                     Dep.foo()
@@ -95,7 +95,7 @@ class VersionSpecificTests: XCTestCase {
             }
 
             // Create a version-specific tag, which should work.
-            try fs.writeFileContents(depPath.appending(component: "Package.swift")) {
+            try fs.writeFileContents(depPath.appending("Package.swift")) {
                 $0 <<< """
                     // swift-tools-version:4.2
                     import PackageDescription

--- a/Tests/PackageCollectionsTests/PackageCollectionsSourcesStorageTest.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsSourcesStorageTest.swift
@@ -30,7 +30,7 @@ final class PackageCollectionsSourcesStorageTest: XCTestCase {
     func testRealFile() throws {
         try testWithTemporaryDirectory { tmpPath in
             let fileSystem = localFileSystem
-            let path = tmpPath.appending(component: "test.json")
+            let path = tmpPath.appending("test.json")
             let storage = FilePackageCollectionsSourcesStorage(fileSystem: fileSystem, path: path)
 
             try assertHappyCase(storage: storage)

--- a/Tests/PackageCollectionsTests/PackageCollectionsStorageTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsStorageTests.swift
@@ -20,7 +20,7 @@ import XCTest
 class PackageCollectionsStorageTests: XCTestCase {
     func testHappyCase() throws {
         try testWithTemporaryDirectory { tmpPath in
-            let path = tmpPath.appending(component: "test.db")
+            let path = tmpPath.appending("test.db")
             let storage = SQLitePackageCollectionsStorage(path: path)
             defer { XCTAssertNoThrow(try storage.close()) }
 
@@ -77,7 +77,7 @@ class PackageCollectionsStorageTests: XCTestCase {
         try XCTSkipIf(is_tsan_enabled())
 
         try testWithTemporaryDirectory { tmpPath in
-            let path = tmpPath.appending(component: "test.db")
+            let path = tmpPath.appending("test.db")
             let storage = SQLitePackageCollectionsStorage(path: path)
             defer { XCTAssertNoThrow(try storage.close()) }
 
@@ -119,7 +119,7 @@ class PackageCollectionsStorageTests: XCTestCase {
         try XCTSkipIf(is_tsan_enabled())
 
         try testWithTemporaryDirectory { tmpPath in
-            let path = tmpPath.appending(component: "test.db")
+            let path = tmpPath.appending("test.db")
             let storage = SQLitePackageCollectionsStorage(path: path)
             defer { XCTAssertNoThrow(try storage.close()) }
 
@@ -220,7 +220,7 @@ class PackageCollectionsStorageTests: XCTestCase {
 
     func testPopulateTargetTrie() throws {
         try testWithTemporaryDirectory { tmpPath in
-            let path = tmpPath.appending(component: "test.db")
+            let path = tmpPath.appending("test.db")
             let storage = SQLitePackageCollectionsStorage(path: path)
             defer { XCTAssertNoThrow(try storage.close()) }
 

--- a/Tests/PackageCollectionsTests/PackageIndexConfigurationTests.swift
+++ b/Tests/PackageCollectionsTests/PackageIndexConfigurationTests.swift
@@ -20,7 +20,7 @@ class PackageIndexConfigurationTests: XCTestCase {
         let configuration = PackageIndexConfiguration(url: url)
         
         let fileSystem = InMemoryFileSystem()
-        let storage = PackageIndexConfigurationStorage(path: try fileSystem.swiftPMConfigurationDirectory.appending(component: "index.json"), fileSystem: fileSystem)
+        let storage = PackageIndexConfigurationStorage(path: try fileSystem.swiftPMConfigurationDirectory.appending("index.json"), fileSystem: fileSystem)
         try storage.save(configuration)
         
         let loadedConfiguration = try storage.load()
@@ -29,7 +29,7 @@ class PackageIndexConfigurationTests: XCTestCase {
     
     func testLoad_fileDoesNotExist() throws {
         let fileSystem = InMemoryFileSystem()
-        let storage = PackageIndexConfigurationStorage(path: try fileSystem.swiftPMConfigurationDirectory.appending(component: "index.json"), fileSystem: fileSystem)
+        let storage = PackageIndexConfigurationStorage(path: try fileSystem.swiftPMConfigurationDirectory.appending("index.json"), fileSystem: fileSystem)
         let configuration = try storage.load()
         XCTAssertNil(configuration.url)
     }
@@ -45,7 +45,7 @@ class PackageIndexConfigurationTests: XCTestCase {
         """
         
         let fileSystem = InMemoryFileSystem()
-        let configPath = try fileSystem.swiftPMConfigurationDirectory.appending(component: "index.json")
+        let configPath = try fileSystem.swiftPMConfigurationDirectory.appending("index.json")
         if !fileSystem.exists(configPath.parentDirectory, followSymlink: false) {
             try fileSystem.createDirectory(configPath.parentDirectory, recursive: true)
         }

--- a/Tests/PackageFingerprintTests/FilePackageFingerprintStorageTests.swift
+++ b/Tests/PackageFingerprintTests/FilePackageFingerprintStorageTests.swift
@@ -23,7 +23,7 @@ import struct TSCUtility.Version
 final class FilePackageFingerprintStorageTests: XCTestCase {
     func testHappyCase() throws {
         let mockFileSystem = InMemoryFileSystem()
-        let directoryPath = AbsolutePath(path: "/fingerprints")
+        let directoryPath = AbsolutePath("/fingerprints")
         let storage = FilePackageFingerprintStorage(fileSystem: mockFileSystem, directoryPath: directoryPath)
         let registryURL = URL("https://example.packages.com")
         let sourceControlURL = URL("https://example.com/mona/LinkedList.git")
@@ -72,7 +72,7 @@ final class FilePackageFingerprintStorageTests: XCTestCase {
 
     func testNotFound() throws {
         let mockFileSystem = InMemoryFileSystem()
-        let directoryPath = AbsolutePath(path: "/fingerprints")
+        let directoryPath = AbsolutePath("/fingerprints")
         let storage = FilePackageFingerprintStorage(fileSystem: mockFileSystem, directoryPath: directoryPath)
         let registryURL = URL("https://example.packages.com")
 
@@ -97,7 +97,7 @@ final class FilePackageFingerprintStorageTests: XCTestCase {
 
     func testSingleFingerprintPerKind() throws {
         let mockFileSystem = InMemoryFileSystem()
-        let directoryPath = AbsolutePath(path: "/fingerprints")
+        let directoryPath = AbsolutePath("/fingerprints")
         let storage = FilePackageFingerprintStorage(fileSystem: mockFileSystem, directoryPath: directoryPath)
         let registryURL = URL("https://example.packages.com")
 
@@ -120,7 +120,7 @@ final class FilePackageFingerprintStorageTests: XCTestCase {
 
     func testHappyCase_PackageReferenceAPI() throws {
         let mockFileSystem = InMemoryFileSystem()
-        let directoryPath = AbsolutePath(path: "/fingerprints")
+        let directoryPath = AbsolutePath("/fingerprints")
         let storage = FilePackageFingerprintStorage(fileSystem: mockFileSystem, directoryPath: directoryPath)
         let sourceControlURL = URL("https://example.com/mona/LinkedList.git")
         let packageRef = PackageReference.remoteSourceControl(identity: PackageIdentity(url: sourceControlURL), url: sourceControlURL)
@@ -138,7 +138,7 @@ final class FilePackageFingerprintStorageTests: XCTestCase {
 
     func testDifferentRepoURLsThatHaveSameIdentity() throws {
         let mockFileSystem = InMemoryFileSystem()
-        let directoryPath = AbsolutePath(path: "/fingerprints")
+        let directoryPath = AbsolutePath("/fingerprints")
         let storage = FilePackageFingerprintStorage(fileSystem: mockFileSystem, directoryPath: directoryPath)
         let fooURL = URL("https://example.com/foo/LinkedList.git")
         let barURL = URL("https://example.com/bar/LinkedList.git")

--- a/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
@@ -78,7 +78,7 @@ class DependencyResolverRealWorldPerfTests: XCTestCasePerf {
     }
 
     func mockGraph(for name: String) throws -> MockDependencyGraph {
-        let input = AbsolutePath(path: #file).parentDirectory.appending(component: "Inputs").appending(component: name)
+        let input = AbsolutePath(path: #file).parentDirectory.appending("Inputs").appending(component: name)
         let jsonString: Data = try localFileSystem.readFileContents(input)
         let json = try JSON(data: jsonString)
         return MockDependencyGraph(json)

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -481,7 +481,7 @@ class PackageGraphTests: XCTestCase {
     }
 
     func testEmptyDependency() throws {
-        let Bar: AbsolutePath = AbsolutePath(path: "/Bar")
+        let Bar: AbsolutePath = AbsolutePath("/Bar")
 
         let fs = InMemoryFileSystem(emptyFiles:
             "/Foo/Sources/Foo/foo.swift",
@@ -1304,7 +1304,7 @@ class PackageGraphTests: XCTestCase {
         let fs = InMemoryFileSystem(files: ["/pins": ByteString(encodingAsUTF8: json)])
 
         XCTAssertThrows(StringError("Package.resolved file is corrupted or malformed; fix or delete the file to continue: duplicated entry for package \"yams\""), {
-            _ = try PinsStore(pinsFile: AbsolutePath(path: "/pins"), workingDirectory: .root, fileSystem: fs, mirrors: .init())
+            _ = try PinsStore(pinsFile: "/pins", workingDirectory: .root, fileSystem: fs, mirrors: .init())
         })
     }
 

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -1614,10 +1614,10 @@ final class PubgrubTests: XCTestCase {
                 ]),
             pinsMap: PinsStore.PinsMap()
         )
-        let rootLocation = AbsolutePath(path: "/Root")
-        let otherLocation = AbsolutePath(path: "/Other")
-        let dependencyALocation = AbsolutePath(path: "/DependencyA")
-        let dependencyBLocation = AbsolutePath(path: "/DependencyB")
+        let rootLocation = AbsolutePath("/Root")
+        let otherLocation = AbsolutePath("/Other")
+        let dependencyALocation = AbsolutePath("/DependencyA")
+        let dependencyBLocation = AbsolutePath("/DependencyB")
         let root = PackageReference(identity: PackageIdentity(path: rootLocation), kind: .fileSystem(rootLocation))
         let other = PackageReference.localSourceControl(identity: .init(path: otherLocation), path: otherLocation)
         let dependencyA = PackageReference.localSourceControl(identity: .init(path: dependencyALocation), path: dependencyALocation)
@@ -3118,7 +3118,7 @@ class DependencyGraphBuilder {
     /// Creates a pins store with the given pins.
     func create(pinsStore pins: [String: (PinsStore.PinState, ProductFilter)]) throws -> PinsStore {
         let fs = InMemoryFileSystem()
-        let store = try! PinsStore(pinsFile: AbsolutePath(path: "/tmp/Package.resolved"), workingDirectory: .root, fileSystem: fs, mirrors: .init())
+        let store = try! PinsStore(pinsFile: "/tmp/Package.resolved", workingDirectory: .root, fileSystem: fs, mirrors: .init())
 
         for (package, pin) in pins {
             store.pin(packageRef: try reference(for: package), state: pin.0)

--- a/Tests/PackageGraphTests/TargetTests.swift
+++ b/Tests/PackageGraphTests/TargetTests.swift
@@ -23,7 +23,7 @@ private extension ResolvedTarget {
                 name: name,
                 type: .library,
                 path: .root,
-                sources: Sources(paths: [], root: AbsolutePath(path: "/")),
+                sources: Sources(paths: [], root: "/"),
                 dependencies: [],
                 swiftVersion: .v4,
                 usesUnsafeFlags: false

--- a/Tests/PackageLoadingPerformanceTests/ManifestLoadingTests.swift
+++ b/Tests/PackageLoadingPerformanceTests/ManifestLoadingTests.swift
@@ -22,7 +22,7 @@ class ManifestLoadingPerfTests: XCTestCasePerf {
 
     func write(_ bytes: ByteString, body: (AbsolutePath) -> ()) throws {
         try testWithTemporaryDirectory { tmpdir in
-            let manifestFile = tmpdir.appending(component: "Package.swift")
+            let manifestFile = tmpdir.appending("Package.swift")
             try localFileSystem.writeFileContents(manifestFile, bytes: bytes)
             body(tmpdir)
         }

--- a/Tests/PackageLoadingTests/ManifestLoaderSQLiteCacheTests.swift
+++ b/Tests/PackageLoadingTests/ManifestLoaderSQLiteCacheTests.swift
@@ -20,7 +20,7 @@ import XCTest
 class ManifestLoaderSQLiteCacheTests: XCTestCase {
     func testHappyCase() throws {
         try testWithTemporaryDirectory { tmpPath in
-            let path = tmpPath.appending(component: "test.db")
+            let path = tmpPath.appending("test.db")
             let storage = SQLiteBackedCache<ManifestLoader.EvaluationResult>(tableName: "manifests", path: path)
             defer { XCTAssertNoThrow(try storage.close()) }
 

--- a/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
+++ b/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
@@ -144,7 +144,7 @@ class ModuleMapGeneration: XCTestCase {
     }
 
     func testUnsupportedLayouts() throws {
-        let include: AbsolutePath = AbsolutePath(path: "/include")
+        let include: AbsolutePath = AbsolutePath("/include")
 
         var fs = InMemoryFileSystem(emptyFiles:
             include.appending(components: "Foo", "Foo.h").pathString,

--- a/Tests/PackageLoadingTests/PD_4_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_0_LoadingTests.swift
@@ -17,11 +17,6 @@ import SPMTestSupport
 import TSCBasic
 import XCTest
 
-extension AbsolutePath {
-    fileprivate func escapedPathString() -> String {
-        return self.pathString.replacingOccurrences(of: "\\", with: "\\\\")
-    }
-}
 
 class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
     override var toolsVersion: ToolsVersion {

--- a/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
@@ -18,12 +18,6 @@ import SPMTestSupport
 import TSCBasic
 import XCTest
 
-extension AbsolutePath {
-    fileprivate func escapedPathString() -> String {
-        return self.pathString.replacingOccurrences(of: "\\", with: "\\\\")
-    }
-}
-
 class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
     override var toolsVersion: ToolsVersion {
         .v4_2

--- a/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
@@ -586,8 +586,8 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
         try testWithTemporaryDirectory { path in
             let fs = localFileSystem
 
-            let packagePath = path.appending(component: "pkg")
-            let manifestPath = packagePath.appending(component: "Package.swift")
+            let packagePath = path.appending("pkg")
+            let manifestPath = packagePath.appending("Package.swift")
             try fs.writeFileContents(manifestPath) { stream in
                 stream <<< """
                 // swift-tools-version:5
@@ -604,7 +604,7 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
                 """
             }
 
-            let moduleTraceFilePath = path.appending(component: "swift-module-trace")
+            let moduleTraceFilePath = path.appending("swift-module-trace")
             var env = EnvironmentVariables.process()
             env["SWIFT_LOADED_MODULE_TRACE_FILE"] = moduleTraceFilePath.pathString
             let toolchain = try UserToolchain(destination: Destination.default, environment: env)

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -41,7 +41,7 @@ class PackageBuilderTests: XCTestCase {
     }
 
     func testMixedSources() throws {
-        let foo: AbsolutePath = AbsolutePath(path: "/Sources/foo")
+        let foo: AbsolutePath = AbsolutePath("/Sources/foo")
 
         let fs = InMemoryFileSystem(emptyFiles:
             foo.appending(components: "main.swift").pathString,
@@ -226,7 +226,7 @@ class PackageBuilderTests: XCTestCase {
     }
 
     func testPublicIncludeDirMixedWithSources() throws {
-        let Sources: AbsolutePath = AbsolutePath(path: "/Sources")
+        let Sources: AbsolutePath = AbsolutePath("/Sources")
 
         let fs = InMemoryFileSystem(emptyFiles:
             Sources.appending(components: "clib", "nested", "nested.h").pathString,
@@ -566,7 +566,7 @@ class PackageBuilderTests: XCTestCase {
                 ),
             ]
         )
-        PackageBuilderTester(manifest, path: AbsolutePath(path: "/pkg"), in: fs) { package, _ in
+        PackageBuilderTester(manifest, path: "/pkg", in: fs) { package, _ in
             package.checkModule("exe") { _ in }
             package.checkModule("tests") { _ in }
 
@@ -597,7 +597,7 @@ class PackageBuilderTests: XCTestCase {
 
     func testMultipleTestEntryPointsError() throws {
         let name = SwiftTarget.defaultTestEntryPointName
-        let swift: AbsolutePath = AbsolutePath(path: "/swift")
+        let swift: AbsolutePath = AbsolutePath("/swift")
 
         let fs = InMemoryFileSystem(emptyFiles:
             AbsolutePath.root.appending(components: name).pathString,
@@ -621,9 +621,9 @@ class PackageBuilderTests: XCTestCase {
     }
 
     func testCustomTargetPaths() throws {
-        let Sources: AbsolutePath = AbsolutePath(path: "/Sources")
+        let Sources: AbsolutePath = AbsolutePath("/Sources")
         let swift: RelativePath = RelativePath("swift")
-        let bar: AbsolutePath = AbsolutePath(path: "/bar")
+        let bar: AbsolutePath = AbsolutePath("/bar")
 
         let fs = InMemoryFileSystem(emptyFiles:
             "/mah/target/exe/swift/exe/main.swift",
@@ -659,7 +659,7 @@ class PackageBuilderTests: XCTestCase {
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, _ in
-            package.checkPredefinedPaths(target: Sources.pathString, testTarget: AbsolutePath(path: "/Tests").pathString)
+            package.checkPredefinedPaths(target: Sources, testTarget: "/Tests")
 
             package.checkModule("exe") { module in
                 module.check(c99name: "exe", type: .executable)
@@ -687,7 +687,7 @@ class PackageBuilderTests: XCTestCase {
     }
 
     func testCustomTargetPathsOverlap() throws {
-        let bar: AbsolutePath = AbsolutePath(path: "/target/bar")
+        let bar: AbsolutePath = AbsolutePath("/target/bar")
 
         let fs = InMemoryFileSystem(emptyFiles:
             bar.appending(components: "bar.swift").pathString,
@@ -724,7 +724,7 @@ class PackageBuilderTests: XCTestCase {
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, _ in
-            package.checkPredefinedPaths(target: AbsolutePath(path: "/Sources").pathString, testTarget: AbsolutePath(path: "/Tests").pathString)
+            package.checkPredefinedPaths(target: "/Sources", testTarget: "/Tests")
 
             package.checkModule("bar") { module in
                 module.check(c99name: "bar", type: .library)
@@ -741,8 +741,8 @@ class PackageBuilderTests: XCTestCase {
     }
 
     func testPublicHeadersPath() throws {
-        let Sources: AbsolutePath = AbsolutePath(path: "/Sources")
-        let Tests: AbsolutePath = AbsolutePath(path: "/Tests")
+        let Sources: AbsolutePath = AbsolutePath("/Sources")
+        let Tests: AbsolutePath = AbsolutePath("/Tests")
 
         let fs = InMemoryFileSystem(emptyFiles:
             Sources.appending(components: "Foo", "inc", "module.modulemap").pathString,
@@ -766,7 +766,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         PackageBuilderTester(manifest, in: fs) { package, _ in
-            package.checkPredefinedPaths(target: Sources.pathString, testTarget: Tests.pathString)
+            package.checkPredefinedPaths(target: Sources, testTarget: Tests)
 
             package.checkModule("Foo") { module in
                 let clangTarget = module.target as? ClangTarget
@@ -813,7 +813,7 @@ class PackageBuilderTests: XCTestCase {
     }
 
     func testTestsLayoutsv4() throws {
-        let Sources: AbsolutePath = AbsolutePath(path: "/Sources")
+        let Sources: AbsolutePath = AbsolutePath("/Sources")
 
         let fs = InMemoryFileSystem(emptyFiles:
             Sources.appending(components: "A", "main.swift").pathString,
@@ -832,7 +832,7 @@ class PackageBuilderTests: XCTestCase {
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, _ in
-            package.checkPredefinedPaths(target: Sources.pathString, testTarget: AbsolutePath(path: "/Tests").pathString)
+            package.checkPredefinedPaths(target: Sources, testTarget: "/Tests")
 
             package.checkModule("A") { module in
                 module.check(c99name: "A", type: .executable)
@@ -960,7 +960,7 @@ class PackageBuilderTests: XCTestCase {
     }
 
     func testTargetDependencies() throws {
-        let Sources: AbsolutePath = AbsolutePath(path: "/Sources")
+        let Sources: AbsolutePath = AbsolutePath("/Sources")
 
         let fs = InMemoryFileSystem(emptyFiles:
             Sources.appending(components: "Foo", "Foo.swift").pathString,
@@ -980,7 +980,7 @@ class PackageBuilderTests: XCTestCase {
         )
         PackageBuilderTester(manifest, in: fs) { package, _ in
 
-            package.checkPredefinedPaths(target: Sources.pathString, testTarget: AbsolutePath(path: "/Tests").pathString)
+            package.checkPredefinedPaths(target: Sources, testTarget: "/Tests")
 
             package.checkModule("Foo") { module in
                 module.check(c99name: "Foo", type: .library)
@@ -1089,8 +1089,8 @@ class PackageBuilderTests: XCTestCase {
             try fs.writeFileContents(AbsolutePath(path: "/foo2.zip"), bytes: "")
 
             let binaryArtifacts = [
-                "foo": BinaryArtifact(kind: .xcframework, originURL: "https://foo.com/foo.zip", path: AbsolutePath(path: "/foo.xcframework")),
-                "foo2": BinaryArtifact(kind: .xcframework, originURL: nil, path: AbsolutePath(path: "/foo2.xcframework"))
+                "foo": BinaryArtifact(kind: .xcframework, originURL: "https://foo.com/foo.zip", path: "/foo.xcframework"),
+                "foo2": BinaryArtifact(kind: .xcframework, originURL: nil, path: "/foo2.xcframework")
             ]
             PackageBuilderTester(manifest, binaryArtifacts: binaryArtifacts, in: fs) { package, _ in
                 package.checkModule("foo")
@@ -1131,7 +1131,7 @@ class PackageBuilderTests: XCTestCase {
         }
 
         do {
-            let pkg2: AbsolutePath = AbsolutePath(path: "/Sources/pkg2")
+            let pkg2: AbsolutePath = AbsolutePath("/Sources/pkg2")
 
             // Reference a target which doesn't have sources.
             let fs = InMemoryFileSystem(emptyFiles:
@@ -1196,7 +1196,7 @@ class PackageBuilderTests: XCTestCase {
                     try TargetDescription(name: "Foo", path: "../foo"),
                 ]
             )
-            PackageBuilderTester(manifest, path: AbsolutePath(path: "/pkg"), in: fs) { package, diagnostics in
+            PackageBuilderTester(manifest, path: "/pkg", in: fs) { package, diagnostics in
                 diagnostics.check(diagnostic: "target 'Foo' in package '\(package.packageIdentity)' is outside the package root", severity: .error)
             }
         }
@@ -1211,7 +1211,7 @@ class PackageBuilderTests: XCTestCase {
                     try TargetDescription(name: "Foo", path: "/foo"),
                 ]
             )
-            PackageBuilderTester(manifest, path: AbsolutePath(path: "/pkg"), in: fs) { _, diagnostics in
+            PackageBuilderTester(manifest, path: "/pkg", in: fs) { _, diagnostics in
                 diagnostics.check(diagnostic: "target path \'/foo\' is not supported; it should be relative to package root", severity: .error)
             }
         }
@@ -1227,7 +1227,7 @@ class PackageBuilderTests: XCTestCase {
                     try TargetDescription(name: "Foo", path: "~/foo"),
                 ]
             )
-            PackageBuilderTester(manifest, path: AbsolutePath(path: "/pkg"), in: fs) { _, diagnostics in
+            PackageBuilderTester(manifest, path: "/pkg", in: fs) { _, diagnostics in
                 diagnostics.check(diagnostic: "target path \'~/foo\' is not supported; it should be relative to package root", severity: .error)
             }
         }
@@ -1441,7 +1441,7 @@ class PackageBuilderTests: XCTestCase {
     }
 
     func testSpecialTargetDir() throws {
-        let src: AbsolutePath = AbsolutePath(path: "/src")
+        let src: AbsolutePath = AbsolutePath("/src")
         // Special directory should be src because both target and test target are under it.
         let fs = InMemoryFileSystem(emptyFiles:
             src.appending(components: "A", "Foo.swift").pathString,
@@ -1457,7 +1457,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         PackageBuilderTester(manifest, in: fs) { package, _ in
-            package.checkPredefinedPaths(target: src.pathString, testTarget: src.pathString)
+            package.checkPredefinedPaths(target: src, testTarget: src)
 
             package.checkModule("A") { module in
                 module.check(c99name: "A", type: .library)
@@ -1592,7 +1592,7 @@ class PackageBuilderTests: XCTestCase {
     }
 
     func testSystemLibraryTargetDiagnostics() throws {
-        let Sources: AbsolutePath = AbsolutePath(path: "/Sources")
+        let Sources: AbsolutePath = AbsolutePath("/Sources")
 
         let fs = InMemoryFileSystem(emptyFiles:
             Sources.appending(components: "foo", "module.modulemap").pathString,
@@ -1811,7 +1811,7 @@ class PackageBuilderTests: XCTestCase {
     }
 
     func testUnknownSourceFilesUnderDeclaredSourcesIgnoredInV5_2Manifest() throws {
-        let lib: AbsolutePath = AbsolutePath(path: "/Sources/lib")
+        let lib: AbsolutePath = AbsolutePath("/Sources/lib")
 
         // Files with unknown suffixes under declared sources are not considered valid sources in 5.2 manifest.
         let fs = InMemoryFileSystem(emptyFiles:
@@ -1838,7 +1838,7 @@ class PackageBuilderTests: XCTestCase {
     }
 
     func testUnknownSourceFilesUnderDeclaredSourcesCompiledInV5_3Manifest() throws {
-        let lib: AbsolutePath = AbsolutePath(path: "/Sources/lib")
+        let lib: AbsolutePath = AbsolutePath("/Sources/lib")
 
         // Files with unknown suffixes under declared sources are treated as compilable in 5.3 manifest.
         let fs = InMemoryFileSystem(emptyFiles:
@@ -2070,7 +2070,7 @@ class PackageBuilderTests: XCTestCase {
             ]
         )
 
-        PackageBuilderTester(manifest1, path: AbsolutePath(path: "/pkg"), in: fs) { package, diagnostics in
+        PackageBuilderTester(manifest1, path: "/pkg", in: fs) { package, diagnostics in
             diagnostics.check(diagnostic: "invalid relative path '/Sources/headers'; relative path should not begin with '\(AbsolutePath.root)' or '~'", severity: .error)
         }
 
@@ -2087,7 +2087,7 @@ class PackageBuilderTests: XCTestCase {
             ]
         )
 
-        PackageBuilderTester(manifest2, path: AbsolutePath(path: "/pkg"), in: fs) { _, diagnostics in
+        PackageBuilderTester(manifest2, path: "/pkg", in: fs) { _, diagnostics in
             diagnostics.check(diagnostic: "invalid header search path '../../..'; header search path should not be outside the package root", severity: .error)
         }
     }
@@ -2139,7 +2139,7 @@ class PackageBuilderTests: XCTestCase {
             ]
         )
 
-        PackageBuilderTester(manifest, path: AbsolutePath(path: "/Foo"), in: fs) { package, diagnostics in
+        PackageBuilderTester(manifest, path: "/Foo", in: fs) { package, diagnostics in
             package.checkModule("Foo")
             package.checkModule("Foo2")
             package.checkModule("Foo3")
@@ -2244,13 +2244,13 @@ class PackageBuilderTests: XCTestCase {
             ]
         )
 
-        PackageBuilderTester(manifest, path: AbsolutePath(path: "/Foo"), in: fs) { _, diagnostics in
+        PackageBuilderTester(manifest, path: "/Foo", in: fs) { _, diagnostics in
             diagnostics.check(diagnostic: "manifest property 'defaultLocalization' not set; it is required in the presence of localized resources", severity: .error)
         }
     }
 
     func testXcodeResources() throws {
-        let root: AbsolutePath = AbsolutePath(path: "/Foo")
+        let root: AbsolutePath = AbsolutePath("/Foo")
         let Foo: AbsolutePath = root.appending(components: "Sources", "Foo")
 
         let fs = InMemoryFileSystem(emptyFiles:
@@ -2283,14 +2283,14 @@ class PackageBuilderTests: XCTestCase {
     }
     
     func testSnippetsLinkProductLibraries() throws {
-        let root = AbsolutePath(path: "/Foo")
+        let root = AbsolutePath("/Foo")
         let internalSourcesDir = root.appending(components: "Sources", "Internal")
         let productSourcesDir = root.appending(components: "Sources", "Product")
         let snippetsDir = root.appending(components: "Snippets")
         let fs = InMemoryFileSystem(emptyFiles:
-                                        internalSourcesDir.appending(component: "Internal.swift").pathString,
-            productSourcesDir.appending(component: "Product.swift").pathString,
-            snippetsDir.appending(component: "ASnippet.swift").pathString)
+                                        internalSourcesDir.appending("Internal.swift").pathString,
+            productSourcesDir.appending("Product.swift").pathString,
+            snippetsDir.appending("ASnippet.swift").pathString)
         
         let manifest = Manifest.createRootManifest(
             displayName: "Foo", toolsVersion: .v5_7,
@@ -2397,12 +2397,12 @@ final class PackageBuilderTester {
         }
     }
 
-    func checkPredefinedPaths(target: String, testTarget: String, file: StaticString = #file, line: UInt = #line) {
+    func checkPredefinedPaths(target: AbsolutePath, testTarget: AbsolutePath, file: StaticString = #file, line: UInt = #line) {
         guard case .package(let package) = result else {
             return XCTFail("Expected package did not load \(self)", file: file, line: line)
         }
-        XCTAssertEqual(target, package.targetSearchPath.pathString, file: file, line: line)
-        XCTAssertEqual(testTarget, package.testTargetSearchPath.pathString, file: file, line: line)
+        XCTAssertEqual(target, package.targetSearchPath, file: file, line: line)
+        XCTAssertEqual(testTarget, package.testTargetSearchPath, file: file, line: line)
     }
 
     func checkModule(_ name: String, file: StaticString = #file, line: UInt = #line, _ body: ((ModuleResult) -> Void)? = nil) {

--- a/Tests/PackageLoadingTests/PkgConfigParserTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigParserTests.swift
@@ -225,7 +225,7 @@ final class PkgConfigParserTests: XCTestCase {
             try PkgConfig(
                 name: "gobject-2.0",
                 additionalSearchPaths: [AbsolutePath(path: "/usr/local/opt/glib/lib/pkgconfig")],
-                brewPrefix: AbsolutePath(path: "/usr/local"),
+                brewPrefix: "/usr/local",
                 fileSystem: fileSystem,
                 observabilityScope: observability.topScope
             )

--- a/Tests/PackageLoadingTests/PkgConfigTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigTests.swift
@@ -21,7 +21,7 @@ extension SystemLibraryTarget {
     convenience init(pkgConfig: String, providers: [SystemPackageProviderDescription] = []) {
         self.init(
             name: "Foo",
-            path: AbsolutePath(path: "/fake"),
+            path: "/fake",
             pkgConfig: pkgConfig.isEmpty ? nil : pkgConfig,
             providers: providers.isEmpty ? nil : providers)
     }

--- a/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
+++ b/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
@@ -591,15 +591,15 @@ class TargetSourcesBuilderTests: XCTestCase {
 
         build(target: target, defaultLocalization: "fr", toolsVersion: .v5_3, fs: fs) { _, resources, _,  _, _, _, _, diagnostics in
             XCTAssertEqual(resources.sorted(by: { $0.path < $1.path }), [
-                Resource(rule: .process(localization: .none), path: AbsolutePath(path: "/Processed/foo.txt")),
-                Resource(rule: .process(localization: "en-us"), path: AbsolutePath(path: "/Processed/En-uS.lproj/Localizable.stringsdict")),
-                Resource(rule: .process(localization: "en-us"), path: AbsolutePath(path: "/Processed/en-US.lproj/Localizable.strings")),
-                Resource(rule: .process(localization: "fr"), path: AbsolutePath(path: "/Processed/fr.lproj/Localizable.strings")),
-                Resource(rule: .process(localization: "fr"), path: AbsolutePath(path: "/Processed/fr.lproj/Localizable.stringsdict")),
-                Resource(rule: .process(localization: "Base"), path: AbsolutePath(path: "/Processed/Base.lproj/Storyboard.storyboard")),
-                Resource(rule: .copy, path: AbsolutePath(path: "/Copied")),
-                Resource(rule: .process(localization: "Base"), path: AbsolutePath(path: "/Other/Launch.storyboard")),
-                Resource(rule: .process(localization: "fr"), path: AbsolutePath(path: "/Other/Image.png")),
+                Resource(rule: .process(localization: .none), path: "/Processed/foo.txt"),
+                Resource(rule: .process(localization: "en-us"), path: "/Processed/En-uS.lproj/Localizable.stringsdict"),
+                Resource(rule: .process(localization: "en-us"), path: "/Processed/en-US.lproj/Localizable.strings"),
+                Resource(rule: .process(localization: "fr"), path: "/Processed/fr.lproj/Localizable.strings"),
+                Resource(rule: .process(localization: "fr"), path: "/Processed/fr.lproj/Localizable.stringsdict"),
+                Resource(rule: .process(localization: "Base"), path: "/Processed/Base.lproj/Storyboard.storyboard"),
+                Resource(rule: .copy, path: "/Copied"),
+                Resource(rule: .process(localization: "Base"), path: "/Other/Launch.storyboard"),
+                Resource(rule: .process(localization: "fr"), path: "/Other/Image.png"),
             ].sorted(by: { $0.path < $1.path }))
         }
     }
@@ -612,8 +612,8 @@ class TargetSourcesBuilderTests: XCTestCase {
 
         build(target: try TargetDescription(name: "Foo"), defaultLocalization: "fr", toolsVersion: .v5_3, fs: fs) { _, resources, _, _, _, _, _, diagnostics in
             XCTAssertEqual(resources.sorted(by: { $0.path < $1.path }), [
-                Resource(rule: .process(localization: "fr"), path: AbsolutePath(path: "/Foo/fr.lproj/Image.png")),
-                Resource(rule: .process(localization: "es"), path: AbsolutePath(path: "/Foo/es.lproj/Image.png")),
+                Resource(rule: .process(localization: "fr"), path: "/Foo/fr.lproj/Image.png"),
+                Resource(rule: .process(localization: "es"), path: "/Foo/es.lproj/Image.png"),
             ].sorted(by: { $0.path < $1.path }))
         }
     }

--- a/Tests/PackageLoadingTests/ToolsVersionParserTests.swift
+++ b/Tests/PackageLoadingTests/ToolsVersionParserTests.swift
@@ -140,10 +140,10 @@ class ToolsVersionParserTests: XCTestCase {
     func testEmptyManifest() throws {
         let fs = InMemoryFileSystem()
 
-		let packageRoot = AbsolutePath(path: "/lorem/ipsum/dolor")
+		let packageRoot = AbsolutePath("/lorem/ipsum/dolor")
 		try fs.createDirectory(packageRoot, recursive: true)
 
-		let manifestPath = packageRoot.appending(component: "Package.swift")
+		let manifestPath = packageRoot.appending("Package.swift")
         try fs.writeFileContents(manifestPath, bytes: "")
 
         XCTAssertThrowsError(
@@ -678,7 +678,7 @@ class ToolsVersionParserTests: XCTestCase {
 
     func testVersionSpecificManifest() throws {
         let fs = InMemoryFileSystem()
-        let root = AbsolutePath(path: "/pkg")
+        let root = AbsolutePath("/pkg")
         try fs.createDirectory(root, recursive: true)
 
         /// Loads the tools version of root pkg.
@@ -688,7 +688,7 @@ class ToolsVersionParserTests: XCTestCase {
         }
 
         // Test default manifest.
-        try fs.writeFileContents(root.appending(component: "Package.swift"), bytes: "// swift-tools-version:3.1.1\n")
+        try fs.writeFileContents(root.appending("Package.swift"), bytes: "// swift-tools-version:3.1.1\n")
         try parse { version in
             XCTAssertEqual(version.description, "3.1.1")
         }
@@ -700,19 +700,19 @@ class ToolsVersionParserTests: XCTestCase {
         XCTAssertEqual(keys.count, 3)
 
         // Test the last key.
-        try fs.writeFileContents(root.appending(component: "Package\(keys[2]).swift"), bytes: "// swift-tools-version:3.4.1\n")
+        try fs.writeFileContents(root.appending("Package\(keys[2]).swift"), bytes: "// swift-tools-version:3.4.1\n")
         try parse { version in
             XCTAssertEqual(version.description, "3.4.1")
         }
 
         // Test the second last key.
-        try fs.writeFileContents(root.appending(component: "Package\(keys[1]).swift"), bytes: "// swift-tools-version:3.4.0\n")
+        try fs.writeFileContents(root.appending("Package\(keys[1]).swift"), bytes: "// swift-tools-version:3.4.0\n")
         try parse { version in
             XCTAssertEqual(version.description, "3.4.0")
         }
 
         // Test the first key.
-        try fs.writeFileContents(root.appending(component: "Package\(keys[0]).swift"), bytes: "// swift-tools-version:3.4.5\n")
+        try fs.writeFileContents(root.appending("Package\(keys[0]).swift"), bytes: "// swift-tools-version:3.4.5\n")
         try parse { version in
             XCTAssertEqual(version.description, "3.4.5")
         }
@@ -722,18 +722,18 @@ class ToolsVersionParserTests: XCTestCase {
         let fs = InMemoryFileSystem(emptyFiles:
             "/pkg/foo"
         )
-        let root = AbsolutePath(path: "/pkg")
+        let root = AbsolutePath("/pkg")
 
         func parse(currentToolsVersion: ToolsVersion, _ body: (ToolsVersion) -> Void) throws {
             let manifestPath = try ManifestLoader.findManifest(packagePath: root, fileSystem: fs, currentToolsVersion: currentToolsVersion)
             body(try ToolsVersionParser.parse(manifestPath: manifestPath, fileSystem: fs))
         }
 
-        try fs.writeFileContents(root.appending(component: "Package.swift"), bytes: "// swift-tools-version:1.0.0\n")
-        try fs.writeFileContents(root.appending(component: "Package@swift-4.2.swift"), bytes: "// swift-tools-version:3.4.5\n")
-        try fs.writeFileContents(root.appending(component: "Package@swift-15.1.swift"), bytes: "// swift-tools-version:3.4.6\n")
-        try fs.writeFileContents(root.appending(component: "Package@swift-15.2.swift"), bytes: "// swift-tools-version:3.4.7\n")
-        try fs.writeFileContents(root.appending(component: "Package@swift-15.3.swift"), bytes: "// swift-tools-version:3.4.8\n")
+        try fs.writeFileContents(root.appending("Package.swift"), bytes: "// swift-tools-version:1.0.0\n")
+        try fs.writeFileContents(root.appending("Package@swift-4.2.swift"), bytes: "// swift-tools-version:3.4.5\n")
+        try fs.writeFileContents(root.appending("Package@swift-15.1.swift"), bytes: "// swift-tools-version:3.4.6\n")
+        try fs.writeFileContents(root.appending("Package@swift-15.2.swift"), bytes: "// swift-tools-version:3.4.7\n")
+        try fs.writeFileContents(root.appending("Package@swift-15.3.swift"), bytes: "// swift-tools-version:3.4.8\n")
 
         try parse(currentToolsVersion: ToolsVersion(version: "15.1.1")) { version in
             XCTAssertEqual(version.description, "3.4.6")

--- a/Tests/PackageModelTests/PackageModelTests.swift
+++ b/Tests/PackageModelTests/PackageModelTests.swift
@@ -57,8 +57,8 @@ class PackageModelTests: XCTestCase {
 
     func testAndroidCompilerFlags() throws {
         let triple = try Triple("x86_64-unknown-linux-android")
-        let sdkDir = AbsolutePath(path: "/some/path/to/an/SDK.sdk")
-        let toolchainPath = AbsolutePath(path: "/some/path/to/a/toolchain.xctoolchain")
+        let sdkDir = AbsolutePath("/some/path/to/an/SDK.sdk")
+        let toolchainPath = AbsolutePath("/some/path/to/a/toolchain.xctoolchain")
 
         let destination = Destination(
             targetTriple: triple,
@@ -100,13 +100,13 @@ class PackageModelTests: XCTestCase {
 
         try withTemporaryFile { [contents] _ in
             try withTemporaryDirectory(removeTreeOnDeinit: true) { [contents] tmp in
-                let bin = tmp.appending(component: "bin")
+                let bin = tmp.appending("bin")
                 try fs.createDirectory(bin)
 
-                let lld = bin.appending(component: "lld-link\(suffix)")
+                let lld = bin.appending("lld-link\(suffix)")
                 try fs.writeFileContents(lld, bytes: ByteString(contents))
 
-                let not = bin.appending(component: "not-link\(suffix)")
+                let not = bin.appending("not-link\(suffix)")
                 try fs.writeFileContents(not, bytes: ByteString(contents))
 
                 #if !os(Windows)

--- a/Tests/PackageModelTests/SnippetTests.swift
+++ b/Tests/PackageModelTests/SnippetTests.swift
@@ -15,7 +15,7 @@ import TSCBasic
 import XCTest
 
 class SnippetTests: XCTestCase {
-    let fakeSourceFilePath = AbsolutePath(path: "/fake/path/to/test.swift")
+    let fakeSourceFilePath = AbsolutePath("/fake/path/to/test.swift")
 
     /// Test the contents of the ``Snippet`` model when parsing an empty file.
     /// Currently, no errors are emitted and most things are either nil or empty.

--- a/Tests/PackageRegistryTests/RegistryClientTests.swift
+++ b/Tests/PackageRegistryTests/RegistryClientTests.swift
@@ -1029,16 +1029,16 @@ final class RegistryClientTests: XCTestCase {
                     let data = try fileSystem.readFileContents(from)
                     XCTAssertEqual(data, emptyZipFile)
 
-                    let packagePath = to.appending(component: "package")
+                    let packagePath = to.appending("package")
                     try fileSystem.createDirectory(packagePath, recursive: true)
-                    try fileSystem.writeFileContents(packagePath.appending(component: "Package.swift"), string: "")
+                    try fileSystem.writeFileContents(packagePath.appending("Package.swift"), string: "")
                     callback(.success(()))
                 })
             }
         )
 
         let fileSystem = InMemoryFileSystem()
-        let path = AbsolutePath(path: "/LinkedList-1.1.1")
+        let path = AbsolutePath("/LinkedList-1.1.1")
 
         try registryClient.downloadSourceArchive(
             package: identity,
@@ -1153,16 +1153,16 @@ final class RegistryClientTests: XCTestCase {
                     let data = try fileSystem.readFileContents(from)
                     XCTAssertEqual(data, emptyZipFile)
 
-                    let packagePath = to.appending(component: "package")
+                    let packagePath = to.appending("package")
                     try fileSystem.createDirectory(packagePath, recursive: true)
-                    try fileSystem.writeFileContents(packagePath.appending(component: "Package.swift"), string: "")
+                    try fileSystem.writeFileContents(packagePath.appending("Package.swift"), string: "")
                     callback(.success(()))
                 })
             }
         )
 
         let fileSystem = InMemoryFileSystem()
-        let path = AbsolutePath(path: "/LinkedList-1.1.1")
+        let path = AbsolutePath("/LinkedList-1.1.1")
 
         XCTAssertThrowsError(
             try registryClient.downloadSourceArchive(
@@ -1283,16 +1283,16 @@ final class RegistryClientTests: XCTestCase {
                     let data = try fileSystem.readFileContents(from)
                     XCTAssertEqual(data, emptyZipFile)
 
-                    let packagePath = to.appending(component: "package")
+                    let packagePath = to.appending("package")
                     try fileSystem.createDirectory(packagePath, recursive: true)
-                    try fileSystem.writeFileContents(packagePath.appending(component: "Package.swift"), string: "")
+                    try fileSystem.writeFileContents(packagePath.appending("Package.swift"), string: "")
                     callback(.success(()))
                 })
             }
         )
 
         let fileSystem = InMemoryFileSystem()
-        let path = AbsolutePath(path: "/LinkedList-1.1.1")
+        let path = AbsolutePath("/LinkedList-1.1.1")
         let observability = ObservabilitySystem.makeForTesting()
 
         // The checksum differs from that in storage, but error is not thrown
@@ -1403,16 +1403,16 @@ final class RegistryClientTests: XCTestCase {
                     let data = try fileSystem.readFileContents(from)
                     XCTAssertEqual(data, emptyZipFile)
 
-                    let packagePath = to.appending(component: "package")
+                    let packagePath = to.appending("package")
                     try fileSystem.createDirectory(packagePath, recursive: true)
-                    try fileSystem.writeFileContents(packagePath.appending(component: "Package.swift"), string: "")
+                    try fileSystem.writeFileContents(packagePath.appending("Package.swift"), string: "")
                     callback(.success(()))
                 })
             }
         )
 
         let fileSystem = InMemoryFileSystem()
-        let path = AbsolutePath(path: "/LinkedList-1.1.1")
+        let path = AbsolutePath("/LinkedList-1.1.1")
 
         try registryClient.downloadSourceArchive(
             package: identity,
@@ -1529,16 +1529,16 @@ final class RegistryClientTests: XCTestCase {
                     let data = try fileSystem.readFileContents(from)
                     XCTAssertEqual(data, emptyZipFile)
 
-                    let packagePath = to.appending(component: "package")
+                    let packagePath = to.appending("package")
                     try fileSystem.createDirectory(packagePath, recursive: true)
-                    try fileSystem.writeFileContents(packagePath.appending(component: "Package.swift"), string: "")
+                    try fileSystem.writeFileContents(packagePath.appending("Package.swift"), string: "")
                     callback(.success(()))
                 })
             }
         )
 
         let fileSystem = InMemoryFileSystem()
-        let path = AbsolutePath(path: "/LinkedList-1.1.1")
+        let path = AbsolutePath("/LinkedList-1.1.1")
 
         try registryClient.downloadSourceArchive(
             package: identity,
@@ -1610,7 +1610,7 @@ final class RegistryClientTests: XCTestCase {
         )
 
         let fileSystem = InMemoryFileSystem()
-        let path = AbsolutePath(path: "/LinkedList-1.1.1")
+        let path = AbsolutePath("/LinkedList-1.1.1")
 
         XCTAssertThrowsError(try registryClient.downloadSourceArchive(
             package: identity,
@@ -1689,7 +1689,7 @@ final class RegistryClientTests: XCTestCase {
         )
 
         let fileSystem = InMemoryFileSystem()
-        let path = AbsolutePath(path: "/LinkedList-1.1.1")
+        let path = AbsolutePath("/LinkedList-1.1.1")
 
         XCTAssertThrowsError(try registryClient.downloadSourceArchive(
             package: identity,
@@ -1737,7 +1737,7 @@ final class RegistryClientTests: XCTestCase {
         )
 
         let fileSystem = InMemoryFileSystem()
-        let path = AbsolutePath(path: "/LinkedList-1.1.1")
+        let path = AbsolutePath("/LinkedList-1.1.1")
 
         XCTAssertThrowsError(try registryClient.downloadSourceArchive(
             package: identity,
@@ -2130,10 +2130,10 @@ final class RegistryClientTests: XCTestCase {
         }
 
         try withTemporaryDirectory { temporaryDirectory in
-            let archivePath = temporaryDirectory.appending(component: "\(identity)-\(version).zip")
+            let archivePath = temporaryDirectory.appending("\(identity)-\(version).zip")
             try localFileSystem.writeFileContents(archivePath, string: archiveContent)
 
-            let metadataPath = temporaryDirectory.appending(component: "\(identity)-\(version)-metadata.json")
+            let metadataPath = temporaryDirectory.appending("\(identity)-\(version)-metadata.json")
             try localFileSystem.writeFileContents(metadataPath, string: metadataContent)
 
             let httpClient = LegacyHTTPClient(handler: handler)
@@ -2195,10 +2195,10 @@ final class RegistryClientTests: XCTestCase {
         }
 
         try withTemporaryDirectory { temporaryDirectory in
-            let archivePath = temporaryDirectory.appending(component: "\(identity)-\(version).zip")
+            let archivePath = temporaryDirectory.appending("\(identity)-\(version).zip")
             try localFileSystem.writeFileContents(archivePath, string: archiveContent)
 
-            let metadataPath = temporaryDirectory.appending(component: "\(identity)-\(version)-metadata.json")
+            let metadataPath = temporaryDirectory.appending("\(identity)-\(version)-metadata.json")
             try localFileSystem.writeFileContents(metadataPath, string: metadataContent)
 
             let httpClient = LegacyHTTPClient(handler: handler)
@@ -2237,10 +2237,10 @@ final class RegistryClientTests: XCTestCase {
         )
 
         try withTemporaryDirectory { temporaryDirectory in
-            let archivePath = temporaryDirectory.appending(component: "\(identity)-\(version).zip")
+            let archivePath = temporaryDirectory.appending("\(identity)-\(version).zip")
             try localFileSystem.writeFileContents(archivePath, bytes: [])
 
-            let metadataPath = temporaryDirectory.appending(component: "\(identity)-\(version)-metadata.json")
+            let metadataPath = temporaryDirectory.appending("\(identity)-\(version)-metadata.json")
             try localFileSystem.writeFileContents(metadataPath, bytes: [])
 
             let httpClient = LegacyHTTPClient(handler: serverErrorHandler.handle)
@@ -2285,10 +2285,10 @@ final class RegistryClientTests: XCTestCase {
         }
 
         try withTemporaryDirectory { temporaryDirectory in
-            let archivePath = temporaryDirectory.appending(component: "\(identity)-\(version).zip")
+            let archivePath = temporaryDirectory.appending("\(identity)-\(version).zip")
             // try localFileSystem.writeFileContents(archivePath, bytes: [])
 
-            let metadataPath = temporaryDirectory.appending(component: "\(identity)-\(version)-metadata.json")
+            let metadataPath = temporaryDirectory.appending("\(identity)-\(version)-metadata.json")
 
             let httpClient = LegacyHTTPClient(handler: handler)
             httpClient.configuration.circuitBreakerStrategy = .none
@@ -2324,10 +2324,10 @@ final class RegistryClientTests: XCTestCase {
         }
 
         try withTemporaryDirectory { temporaryDirectory in
-            let archivePath = temporaryDirectory.appending(component: "\(identity)-\(version).zip")
+            let archivePath = temporaryDirectory.appending("\(identity)-\(version).zip")
             try localFileSystem.writeFileContents(archivePath, bytes: [])
 
-            let metadataPath = temporaryDirectory.appending(component: "\(identity)-\(version)-metadata.json")
+            let metadataPath = temporaryDirectory.appending("\(identity)-\(version)-metadata.json")
 
             let httpClient = LegacyHTTPClient(handler: handler)
             httpClient.configuration.circuitBreakerStrategy = .none

--- a/Tests/PackageSigningTests/FilePackageSigningEntityStorageTests.swift
+++ b/Tests/PackageSigningTests/FilePackageSigningEntityStorageTests.swift
@@ -22,7 +22,7 @@ import struct TSCUtility.Version
 final class FilePackageSigningEntityStorageTests: XCTestCase {
     func testHappyCase() throws {
         let mockFileSystem = InMemoryFileSystem()
-        let directoryPath = AbsolutePath(path: "/signing")
+        let directoryPath = AbsolutePath("/signing")
         let storage = FilePackageSigningEntityStorage(fileSystem: mockFileSystem, directoryPath: directoryPath)
 
         // Record signing entities for mona.LinkedList
@@ -60,7 +60,7 @@ final class FilePackageSigningEntityStorageTests: XCTestCase {
 
     func testSingleFingerprintPerKind() throws {
         let mockFileSystem = InMemoryFileSystem()
-        let directoryPath = AbsolutePath(path: "/signing")
+        let directoryPath = AbsolutePath("/signing")
         let storage = FilePackageSigningEntityStorage(fileSystem: mockFileSystem, directoryPath: directoryPath)
 
         let package = PackageIdentity.plain("mona.LinkedList")

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -187,8 +187,8 @@ class PluginInvocationTests: XCTestCase {
         }
 
         // Construct a canned input and run plugins using our MockPluginScriptRunner().
-        let outputDir = AbsolutePath(path: "/Foo/.build")
-        let builtToolsDir = AbsolutePath(path: "/Foo/.build/debug")
+        let outputDir = AbsolutePath("/Foo/.build")
+        let builtToolsDir = AbsolutePath("/Foo/.build/debug")
         let pluginRunner = MockPluginScriptRunner()
         let results = try graph.invokeBuildToolPlugins(
             outputDir: outputDir,
@@ -213,11 +213,11 @@ class PluginInvocationTests: XCTestCase {
         XCTAssertEqual(evalFirstResult.buildCommands.count, 1)
         let evalFirstCommand = try XCTUnwrap(evalFirstResult.buildCommands.first)
         XCTAssertEqual(evalFirstCommand.configuration.displayName, "Do something")
-        XCTAssertEqual(evalFirstCommand.configuration.executable, AbsolutePath(path: "/bin/FooTool"))
+        XCTAssertEqual(evalFirstCommand.configuration.executable, AbsolutePath("/bin/FooTool"))
         XCTAssertEqual(evalFirstCommand.configuration.arguments, ["-c", "/Foo/Sources/Foo/SomeFile.abc"])
         XCTAssertEqual(evalFirstCommand.configuration.environment, ["X": "Y"])
-        XCTAssertEqual(evalFirstCommand.configuration.workingDirectory, AbsolutePath(path: "/Foo/Sources/Foo"))
-        XCTAssertEqual(evalFirstCommand.inputFiles, [builtToolsDir.appending(component: "FooTool")])
+        XCTAssertEqual(evalFirstCommand.configuration.workingDirectory, AbsolutePath("/Foo/Sources/Foo"))
+        XCTAssertEqual(evalFirstCommand.inputFiles, [builtToolsDir.appending("FooTool")])
         XCTAssertEqual(evalFirstCommand.outputFiles, [])
 
         XCTAssertEqual(evalFirstResult.diagnostics.count, 1)
@@ -234,7 +234,7 @@ class PluginInvocationTests: XCTestCase {
             // Create a sample package with a library target and a plugin.
             let packageDir = tmpPath.appending(components: "MyPackage")
             try localFileSystem.createDirectory(packageDir, recursive: true)
-            try localFileSystem.writeFileContents(packageDir.appending(component: "Package.swift"), string: """
+            try localFileSystem.writeFileContents(packageDir.appending("Package.swift"), string: """
                 // swift-tools-version: 5.6
                 import PackageDescription
                 let package = Package(
@@ -256,13 +256,13 @@ class PluginInvocationTests: XCTestCase {
             
             let myLibraryTargetDir = packageDir.appending(components: "Sources", "MyLibrary")
             try localFileSystem.createDirectory(myLibraryTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(myLibraryTargetDir.appending(component: "library.swift"), string: """
+            try localFileSystem.writeFileContents(myLibraryTargetDir.appending("library.swift"), string: """
                 public func Foo() { }
                 """)
             
             let myPluginTargetDir = packageDir.appending(components: "Plugins", "MyPlugin")
             try localFileSystem.createDirectory(myPluginTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(myPluginTargetDir.appending(component: "plugin.swift"), string: """
+            try localFileSystem.writeFileContents(myPluginTargetDir.appending("plugin.swift"), string: """
                 import PackagePlugin
                 @main struct MyBuildToolPlugin: BuildToolPlugin {
                     func createBuildCommands(
@@ -305,7 +305,7 @@ class PluginInvocationTests: XCTestCase {
             XCTAssertEqual(buildToolPlugin.capability, .buildTool)
 
             // Create a plugin script runner for the duration of the test.
-            let pluginCacheDir = tmpPath.appending(component: "plugin-cache")
+            let pluginCacheDir = tmpPath.appending("plugin-cache")
             let pluginScriptRunner = DefaultPluginScriptRunner(
                 fileSystem: localFileSystem,
                 cacheDir: pluginCacheDir,
@@ -372,7 +372,7 @@ class PluginInvocationTests: XCTestCase {
             }
 
             // Now replace the plugin script source with syntactically valid contents that still produces a warning.
-            try localFileSystem.writeFileContents(myPluginTargetDir.appending(component: "plugin.swift"), string: """
+            try localFileSystem.writeFileContents(myPluginTargetDir.appending("plugin.swift"), string: """
                 import PackagePlugin
                 @main struct MyBuildToolPlugin: BuildToolPlugin {
                     func createBuildCommands(
@@ -484,7 +484,7 @@ class PluginInvocationTests: XCTestCase {
             }
 
             // Now replace the plugin script source with syntactically valid contents that no longer produces a warning.
-            try localFileSystem.writeFileContents(myPluginTargetDir.appending(component: "plugin.swift"), string: """
+            try localFileSystem.writeFileContents(myPluginTargetDir.appending("plugin.swift"), string: """
                 import PackagePlugin
                 @main struct MyBuildToolPlugin: BuildToolPlugin {
                     func createBuildCommands(
@@ -540,7 +540,7 @@ class PluginInvocationTests: XCTestCase {
             }
 
             // Now replace the plugin script source with a broken one again.
-            try localFileSystem.writeFileContents(myPluginTargetDir.appending(component: "plugin.swift"), string: """
+            try localFileSystem.writeFileContents(myPluginTargetDir.appending("plugin.swift"), string: """
                 import PackagePlugin
                 @main struct MyBuildToolPlugin: BuildToolPlugin {
                     func createBuildCommands(
@@ -601,7 +601,7 @@ class PluginInvocationTests: XCTestCase {
             // Create a sample package with a library product and a plugin.
             let packageDir = tmpPath.appending(components: "MyPackage")
             try localFileSystem.createDirectory(packageDir, recursive: true)
-            try localFileSystem.writeFileContents(packageDir.appending(component: "Package.swift"), string: """
+            try localFileSystem.writeFileContents(packageDir.appending("Package.swift"), string: """
             // swift-tools-version: 5.7
             import PackageDescription
             let package = Package(
@@ -623,7 +623,7 @@ class PluginInvocationTests: XCTestCase {
 
             let myPluginTargetDir = packageDir.appending(components: "Plugins", "MyPlugin")
             try localFileSystem.createDirectory(myPluginTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(myPluginTargetDir.appending(component: "plugin.swift"), string: """
+            try localFileSystem.writeFileContents(myPluginTargetDir.appending("plugin.swift"), string: """
                   import PackagePlugin
                   import Foo
                   @main struct MyBuildToolPlugin: BuildToolPlugin {
@@ -636,7 +636,7 @@ class PluginInvocationTests: XCTestCase {
 
             let fooPkgDir = tmpPath.appending(components: "FooPackage")
             try localFileSystem.createDirectory(fooPkgDir, recursive: true)
-            try localFileSystem.writeFileContents(fooPkgDir.appending(component: "Package.swift"), string: """
+            try localFileSystem.writeFileContents(fooPkgDir.appending("Package.swift"), string: """
                 // swift-tools-version: 5.7
                 import PackageDescription
                 let package = Package(
@@ -655,7 +655,7 @@ class PluginInvocationTests: XCTestCase {
                 """)
             let fooTargetDir = fooPkgDir.appending(components: "Sources", "Foo")
             try localFileSystem.createDirectory(fooTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(fooTargetDir.appending(component: "file.swift"), string: """
+            try localFileSystem.writeFileContents(fooTargetDir.appending("file.swift"), string: """
                   public func foo() { }
                   """)
 
@@ -699,7 +699,7 @@ class PluginInvocationTests: XCTestCase {
             // Create a sample package with a library target and a plugin.
             let packageDir = tmpPath.appending(components: "MyPackage")
             try localFileSystem.createDirectory(packageDir, recursive: true)
-            try localFileSystem.writeFileContents(packageDir.appending(component: "Package.swift"), string: """
+            try localFileSystem.writeFileContents(packageDir.appending("Package.swift"), string: """
                 // swift-tools-version: 5.7
                 import PackageDescription
                 let package = Package(
@@ -722,12 +722,12 @@ class PluginInvocationTests: XCTestCase {
 
             let myLibraryTargetDir = packageDir.appending(components: "Sources", "MyLibrary")
             try localFileSystem.createDirectory(myLibraryTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(myLibraryTargetDir.appending(component: "library.swift"), string: """
+            try localFileSystem.writeFileContents(myLibraryTargetDir.appending("library.swift"), string: """
                     public func hello() { }
                     """)
             let myPluginTargetDir = packageDir.appending(components: "Plugins", "MyPlugin")
             try localFileSystem.createDirectory(myPluginTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(myPluginTargetDir.appending(component: "plugin.swift"), string: """
+            try localFileSystem.writeFileContents(myPluginTargetDir.appending("plugin.swift"), string: """
                   import PackagePlugin
                   import MyLibrary
                   @main struct MyBuildToolPlugin: BuildToolPlugin {
@@ -778,7 +778,7 @@ class PluginInvocationTests: XCTestCase {
             // Create a sample package with a library target and a plugin.
             let packageDir = tmpPath.appending(components: "mypkg")
             try localFileSystem.createDirectory(packageDir, recursive: true)
-            try localFileSystem.writeFileContents(packageDir.appending(component: "Package.swift"), string: """
+            try localFileSystem.writeFileContents(packageDir.appending("Package.swift"), string: """
                 // swift-tools-version:5.7
 
                 import PackageDescription
@@ -810,7 +810,7 @@ class PluginInvocationTests: XCTestCase {
 
             let libTargetDir = packageDir.appending(components: "Sources", "MyLib")
             try localFileSystem.createDirectory(libTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(libTargetDir.appending(component: "file.swift"), string: """
+            try localFileSystem.writeFileContents(libTargetDir.appending("file.swift"), string: """
                 public struct MyUtilLib {
                     public let strings: [String]
                     public init(args: [String]) {
@@ -821,7 +821,7 @@ class PluginInvocationTests: XCTestCase {
 
             let depTargetDir = packageDir.appending(components: "Sources", "Y")
             try localFileSystem.createDirectory(depTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(depTargetDir.appending(component: "main.swift"), string: """
+            try localFileSystem.writeFileContents(depTargetDir.appending("main.swift"), string: """
                 struct Y {
                     func run() {
                         print("You passed us two arguments, argumentOne, and argumentTwo")
@@ -832,7 +832,7 @@ class PluginInvocationTests: XCTestCase {
 
             let pluginTargetDir = packageDir.appending(components: "Plugins", "X")
             try localFileSystem.createDirectory(pluginTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(pluginTargetDir.appending(component: "plugin.swift"), string: """
+            try localFileSystem.writeFileContents(pluginTargetDir.appending("plugin.swift"), string: """
                   import PackagePlugin
                   @main struct X: BuildToolPlugin {
                       func createBuildCommands(context: PluginContext, target: Target) async throws -> [Command] {
@@ -879,7 +879,7 @@ class PluginInvocationTests: XCTestCase {
             XCTAssertEqual(buildToolPlugin.capability, .buildTool)
 
             // Create a plugin script runner for the duration of the test.
-            let pluginCacheDir = tmpPath.appending(component: "plugin-cache")
+            let pluginCacheDir = tmpPath.appending("plugin-cache")
             let pluginScriptRunner = DefaultPluginScriptRunner(
                 fileSystem: localFileSystem,
                 cacheDir: pluginCacheDir,
@@ -888,8 +888,8 @@ class PluginInvocationTests: XCTestCase {
 
             // Invoke build tool plugin
             do {
-                let outputDir = packageDir.appending(component: ".build")
-                let builtToolsDir = outputDir.appending(component: "debug")
+                let outputDir = packageDir.appending(".build")
+                let builtToolsDir = outputDir.appending("debug")
                 let result = try packageGraph.invokeBuildToolPlugins(
                     outputDir: outputDir,
                     builtToolsDir: builtToolsDir,
@@ -918,7 +918,7 @@ class PluginInvocationTests: XCTestCase {
             // Create a sample package with a library target and a plugin.
             let packageDir = tmpPath.appending(components: "MyPackage")
             try localFileSystem.createDirectory(packageDir, recursive: true)
-            try localFileSystem.writeFileContents(packageDir.appending(component: "Package.swift"), string: """
+            try localFileSystem.writeFileContents(packageDir.appending("Package.swift"), string: """
                 // swift-tools-version: 5.7
                 import PackageDescription
                 let package = Package(
@@ -948,12 +948,12 @@ class PluginInvocationTests: XCTestCase {
 
             let myLibraryTargetDir = packageDir.appending(components: "Sources", "MyLibrary")
             try localFileSystem.createDirectory(myLibraryTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(myLibraryTargetDir.appending(component: "library.swift"), string: """
+            try localFileSystem.writeFileContents(myLibraryTargetDir.appending("library.swift"), string: """
                     public func hello() { }
                     """)
             let xPluginTargetDir = packageDir.appending(components: "Plugins", "XPlugin")
             try localFileSystem.createDirectory(xPluginTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(xPluginTargetDir.appending(component: "plugin.swift"), string: """
+            try localFileSystem.writeFileContents(xPluginTargetDir.appending("plugin.swift"), string: """
                   import PackagePlugin
                   import XcodeProjectPlugin
                   @main struct XBuildToolPlugin: BuildToolPlugin {
@@ -965,7 +965,7 @@ class PluginInvocationTests: XCTestCase {
                   """)
             let yPluginTargetDir = packageDir.appending(components: "Plugins", "YPlugin")
             try localFileSystem.createDirectory(yPluginTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(yPluginTargetDir.appending(component: "plugin.swift"), string: """
+            try localFileSystem.writeFileContents(yPluginTargetDir.appending("plugin.swift"), string: """
                      import PackagePlugin
                      import Foundation
                      @main struct YPlugin: BuildToolPlugin {
@@ -981,7 +981,7 @@ class PluginInvocationTests: XCTestCase {
 
             let otherPackageDir = tmpPath.appending(components: "OtherPackage")
             try localFileSystem.createDirectory(otherPackageDir, recursive: true)
-            try localFileSystem.writeFileContents(otherPackageDir.appending(component: "Package.swift"), string: """
+            try localFileSystem.writeFileContents(otherPackageDir.appending("Package.swift"), string: """
                 // swift-tools-version: 5.7
                 import PackageDescription
                 let package = Package(
@@ -1009,7 +1009,7 @@ class PluginInvocationTests: XCTestCase {
 
             let qPluginTargetDir = otherPackageDir.appending(components: "Plugins", "QPlugin")
             try localFileSystem.createDirectory(qPluginTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(qPluginTargetDir.appending(component: "plugin.swift"), string: """
+            try localFileSystem.writeFileContents(qPluginTargetDir.appending("plugin.swift"), string: """
                   import PackagePlugin
                   import XcodeProjectPlugin
                   @main struct QBuildToolPlugin: BuildToolPlugin {
@@ -1085,7 +1085,7 @@ class PluginInvocationTests: XCTestCase {
             // Create a sample package with a library target and a plugin.
             let packageDir = tmpPath.appending(components: "MyPackage")
             try localFileSystem.createDirectory(packageDir, recursive: true)
-            try localFileSystem.writeFileContents(packageDir.appending(component: "Package.swift"), string: """
+            try localFileSystem.writeFileContents(packageDir.appending("Package.swift"), string: """
                    // swift-tools-version: 5.7
                    import PackageDescription
                    let package = Package(
@@ -1138,7 +1138,7 @@ class PluginInvocationTests: XCTestCase {
                     }
                  }
             """
-            try localFileSystem.writeFileContents(myPluginTargetDir.appending(component: "plugin.swift"), string: content)
+            try localFileSystem.writeFileContents(myPluginTargetDir.appending("plugin.swift"), string: content)
             let artifactVariants = artifactSupportedTriples.map {
                 """
                 { "path": "LocalBinaryTool\($0.tripleString).sh", "supportedTriples": ["\($0.tripleString)"] }
@@ -1204,7 +1204,7 @@ class PluginInvocationTests: XCTestCase {
             )
 
             // Create a plugin script runner for the duration of the test.
-            let pluginCacheDir = tmpPath.appending(component: "plugin-cache")
+            let pluginCacheDir = tmpPath.appending("plugin-cache")
             let pluginScriptRunner = DefaultPluginScriptRunner(
                 fileSystem: localFileSystem,
                 cacheDir: pluginCacheDir,
@@ -1212,8 +1212,8 @@ class PluginInvocationTests: XCTestCase {
             )
 
             // Invoke build tool plugin
-            let outputDir = packageDir.appending(component: ".build")
-            let builtToolsDir = outputDir.appending(component: "debug")
+            let outputDir = packageDir.appending(".build")
+            let builtToolsDir = outputDir.appending("debug")
             let result = try packageGraph.invokeBuildToolPlugins(
                 outputDir: outputDir,
                 builtToolsDir: builtToolsDir,

--- a/Tests/SourceControlTests/GitRepositoryProviderTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryProviderTests.swift
@@ -21,22 +21,22 @@ class GitRepositoryProviderTests: XCTestCase {
             let provider = GitRepositoryProvider()
 
             // standard repository
-            let repositoryPath = sandbox.appending(component: "test")
+            let repositoryPath = sandbox.appending("test")
             try localFileSystem.createDirectory(repositoryPath)
             initGitRepo(repositoryPath)
             XCTAssertTrue(provider.repositoryExists(at: repositoryPath))
 
             // no-checkout bare repository
-            let noCheckoutRepositoryPath = sandbox.appending(component: "test-no-checkout")
-            try localFileSystem.copy(from: repositoryPath.appending(component: ".git"), to: noCheckoutRepositoryPath)
+            let noCheckoutRepositoryPath = sandbox.appending("test-no-checkout")
+            try localFileSystem.copy(from: repositoryPath.appending(".git"), to: noCheckoutRepositoryPath)
             XCTAssertTrue(provider.repositoryExists(at: noCheckoutRepositoryPath))
 
             // non-git directory
-            let notGitPath = sandbox.appending(component: "test-not-git")
+            let notGitPath = sandbox.appending("test-not-git")
             XCTAssertFalse(provider.repositoryExists(at: notGitPath))
 
             // non-git child directory of a git directory
-            let notGitChildPath = repositoryPath.appending(component: "test-not-git")
+            let notGitChildPath = repositoryPath.appending("test-not-git")
             XCTAssertFalse(provider.repositoryExists(at: notGitChildPath))
         }
     }

--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -60,12 +60,12 @@ class GitRepositoryTests: XCTestCase {
     /// Test the basic provider functions.
     func testProvider() throws {
         try testWithTemporaryDirectory { path in
-            let testRepoPath = path.appending(component: "test-repo")
+            let testRepoPath = path.appending("test-repo")
             try! makeDirectories(testRepoPath)
             initGitRepo(testRepoPath, tag: "1.2.3")
 
             // Test the provider.
-            let testCheckoutPath = path.appending(component: "checkout")
+            let testCheckoutPath = path.appending("checkout")
             let provider = GitRepositoryProvider()
             XCTAssertTrue(try provider.workingCopyExists(at: testRepoPath))
             let repoSpec = RepositorySpecifier(path: testRepoPath)
@@ -134,7 +134,7 @@ class GitRepositoryTests: XCTestCase {
 #else
             try systemQuietly(["tar", "-x", "-v", "-C", path.pathString, "-f", inputArchivePath.pathString])
 #endif
-            let testRepoPath = path.appending(component: "TestRepo")
+            let testRepoPath = path.appending("TestRepo")
 
             // Check hash resolution.
             let repo = GitRepository(path: testRepoPath)
@@ -185,11 +185,11 @@ class GitRepositoryTests: XCTestCase {
 
     func testSubmoduleRead() throws {
         try testWithTemporaryDirectory { path in
-            let testRepoPath = path.appending(component: "test-repo")
+            let testRepoPath = path.appending("test-repo")
             try makeDirectories(testRepoPath)
             initGitRepo(testRepoPath)
 
-            let repoPath = path.appending(component: "repo")
+            let repoPath = path.appending("repo")
             try makeDirectories(repoPath)
             initGitRepo(repoPath)
 
@@ -208,7 +208,7 @@ class GitRepositoryTests: XCTestCase {
     /// Test the Git file system view.
     func testGitFileView() throws {
         try testWithTemporaryDirectory { path in
-            let testRepoPath = path.appending(component: "test-repo")
+            let testRepoPath = path.appending("test-repo")
             try makeDirectories(testRepoPath)
             initGitRepo(testRepoPath)
 
@@ -220,18 +220,18 @@ class GitRepositoryTests: XCTestCase {
                 set -e
                 exit 0
                 """
-            try localFileSystem.writeFileContents(testRepoPath.appending(component: "test-file-1.txt"), bytes: test1FileContents)
-            try localFileSystem.createDirectory(testRepoPath.appending(component: "subdir"))
+            try localFileSystem.writeFileContents(testRepoPath.appending("test-file-1.txt"), bytes: test1FileContents)
+            try localFileSystem.createDirectory(testRepoPath.appending("subdir"))
             try localFileSystem.writeFileContents(testRepoPath.appending(components: "subdir", "test-file-2.txt"), bytes: test2FileContents)
-            try localFileSystem.writeFileContents(testRepoPath.appending(component: "test-file-3.sh"), bytes: test3FileContents)
-            try localFileSystem.chmod(.executable, path: testRepoPath.appending(component: "test-file-3.sh"), options: [])
+            try localFileSystem.writeFileContents(testRepoPath.appending("test-file-3.sh"), bytes: test3FileContents)
+            try localFileSystem.chmod(.executable, path: testRepoPath.appending("test-file-3.sh"), options: [])
             let testRepo = GitRepository(path: testRepoPath)
             try testRepo.stage(files: "test-file-1.txt", "subdir/test-file-2.txt", "test-file-3.sh")
             try testRepo.commit()
             try testRepo.tag(name: "test-tag")
 
             // Get the the repository via the provider. the provider.
-            let testClonePath = path.appending(component: "clone")
+            let testClonePath = path.appending("clone")
             let provider = GitRepositoryProvider()
             let repoSpec = RepositorySpecifier(path: testRepoPath)
             try provider.fetch(repository: repoSpec, to: testClonePath)
@@ -254,7 +254,7 @@ class GitRepositoryTests: XCTestCase {
 #endif
 
             // Check read of a directory.
-            let subdirPath = AbsolutePath(path: "/subdir")
+            let subdirPath = AbsolutePath("/subdir")
             XCTAssertEqual(try view.getDirectoryContents(AbsolutePath(path: "/")).sorted(), ["file.swift", "subdir", "test-file-1.txt", "test-file-3.sh"])
             XCTAssertEqual(try view.getDirectoryContents(subdirPath).sorted(), ["test-file-2.txt"])
             XCTAssertThrows(FileSystemError(.isDirectory, subdirPath)) {
@@ -267,21 +267,21 @@ class GitRepositoryTests: XCTestCase {
             }
 
             // Check read through a non-directory.
-            let notDirectoryPath1 = AbsolutePath(path: "/test-file-1.txt")
+            let notDirectoryPath1 = AbsolutePath("/test-file-1.txt")
             XCTAssertThrows(FileSystemError(.notDirectory, notDirectoryPath1)) {
                 _ = try view.getDirectoryContents(notDirectoryPath1)
             }
-            let notDirectoryPath2 = AbsolutePath(path: "/test-file-1.txt/thing")
+            let notDirectoryPath2 = AbsolutePath("/test-file-1.txt/thing")
             XCTAssertThrows(FileSystemError(.notDirectory, notDirectoryPath2)) {
                 _ = try view.readFileContents(notDirectoryPath2)
             }
 
             // Check read/write into a missing directory.
-            let noEntryPath1 = AbsolutePath(path: "/does-not-exist")
+            let noEntryPath1 = AbsolutePath("/does-not-exist")
             XCTAssertThrows(FileSystemError(.noEntry, noEntryPath1)) {
                 _ = try view.getDirectoryContents(noEntryPath1)
             }
-            let noEntryPath2 = AbsolutePath(path: "/does/not/exist")
+            let noEntryPath2 = AbsolutePath("/does/not/exist")
             XCTAssertThrows(FileSystemError(.noEntry, noEntryPath2)) {
                 _ = try view.readFileContents(noEntryPath2)
             }
@@ -296,13 +296,13 @@ class GitRepositoryTests: XCTestCase {
     func testCheckouts() throws {
         try testWithTemporaryDirectory { path in
             // Create a test repository.
-            let testRepoPath = path.appending(component: "test-repo")
+            let testRepoPath = path.appending("test-repo")
             try makeDirectories(testRepoPath)
             initGitRepo(testRepoPath, tag: "initial")
             let initialRevision = try GitRepository(path: testRepoPath).getCurrentRevision()
 
             // Add a couple files and a directory.
-            try localFileSystem.writeFileContents(testRepoPath.appending(component: "test.txt"), bytes: "Hi")
+            try localFileSystem.writeFileContents(testRepoPath.appending("test.txt"), bytes: "Hi")
             let testRepo = GitRepository(path: testRepoPath)
             try testRepo.stage(file: "test.txt")
             try testRepo.commit()
@@ -310,18 +310,18 @@ class GitRepositoryTests: XCTestCase {
             let currentRevision = try GitRepository(path: testRepoPath).getCurrentRevision()
 
             // Fetch the repository using the provider.
-            let testClonePath = path.appending(component: "clone")
+            let testClonePath = path.appending("clone")
             let provider = GitRepositoryProvider()
             let repoSpec = RepositorySpecifier(path: testRepoPath)
             try provider.fetch(repository: repoSpec, to: testClonePath)
 
             // Clone off a checkout.
-            let checkoutPath = path.appending(component: "checkout")
+            let checkoutPath = path.appending("checkout")
             _ = try provider.createWorkingCopy(repository: repoSpec, sourcePath: testClonePath, at: checkoutPath, editable: false)
             // The remote of this checkout should point to the clone.
             XCTAssertEqual(try GitRepository(path: checkoutPath).remotes()[0].url, testClonePath.pathString)
 
-            let editsPath = path.appending(component: "edit")
+            let editsPath = path.appending("edit")
             _ = try provider.createWorkingCopy(repository: repoSpec, sourcePath: testClonePath, at: editsPath, editable: true)
             // The remote of this checkout should point to the original repo.
             XCTAssertEqual(try GitRepository(path: editsPath).remotes()[0].url, testRepoPath.pathString)
@@ -331,10 +331,10 @@ class GitRepositoryTests: XCTestCase {
                 let workingCopy = try provider.openWorkingCopy(at: path)
                 try workingCopy.checkout(tag: "test-tag")
                 XCTAssertEqual(try workingCopy.getCurrentRevision(), currentRevision)
-                XCTAssertFileExists(path.appending(component: "test.txt"))
+                XCTAssertFileExists(path.appending("test.txt"))
                 try workingCopy.checkout(tag: "initial")
                 XCTAssertEqual(try workingCopy.getCurrentRevision(), initialRevision)
-                XCTAssertNoSuchPath(path.appending(component: "test.txt"))
+                XCTAssertNoSuchPath(path.appending("test.txt"))
             }
         }
     }
@@ -342,14 +342,14 @@ class GitRepositoryTests: XCTestCase {
     func testFetch() throws {
         try testWithTemporaryDirectory { path in
             // Create a repo.
-            let testRepoPath = path.appending(component: "test-repo")
+            let testRepoPath = path.appending("test-repo")
             try makeDirectories(testRepoPath)
             initGitRepo(testRepoPath, tag: "1.2.3")
             let repo = GitRepository(path: testRepoPath)
             XCTAssertEqual(try repo.getTags(), ["1.2.3"])
 
             // Clone it somewhere.
-            let testClonePath = path.appending(component: "clone")
+            let testClonePath = path.appending("clone")
             let provider = GitRepositoryProvider()
             let repoSpec = RepositorySpecifier(path: testRepoPath)
             try provider.fetch(repository: repoSpec, to: testClonePath)
@@ -357,12 +357,12 @@ class GitRepositoryTests: XCTestCase {
             XCTAssertEqual(try clonedRepo.getTags(), ["1.2.3"])
 
             // Clone off a checkout.
-            let checkoutPath = path.appending(component: "checkout")
+            let checkoutPath = path.appending("checkout")
             let checkoutRepo = try provider.createWorkingCopy(repository: repoSpec, sourcePath: testClonePath, at: checkoutPath, editable: false)
             XCTAssertEqual(try checkoutRepo.getTags(), ["1.2.3"])
 
             // Add a new file to original repo.
-            try localFileSystem.writeFileContents(testRepoPath.appending(component: "test.txt"), bytes: "Hi")
+            try localFileSystem.writeFileContents(testRepoPath.appending("test.txt"), bytes: "Hi")
             let testRepo = GitRepository(path: testRepoPath)
             try testRepo.stage(file: "test.txt")
             try testRepo.commit()
@@ -381,27 +381,27 @@ class GitRepositoryTests: XCTestCase {
     func testHasUnpushedCommits() throws {
         try testWithTemporaryDirectory { path in
             // Create a repo.
-            let testRepoPath = path.appending(component: "test-repo")
+            let testRepoPath = path.appending("test-repo")
             try makeDirectories(testRepoPath)
             initGitRepo(testRepoPath)
 
             // Create a bare clone it somewhere because we want to later push into the repo.
-            let testBareRepoPath = path.appending(component: "test-repo-bare")
+            let testBareRepoPath = path.appending("test-repo-bare")
             try systemQuietly([Git.tool, "clone", "--bare", testRepoPath.pathString, testBareRepoPath.pathString])
 
             // Clone it somewhere.
-            let testClonePath = path.appending(component: "clone")
+            let testClonePath = path.appending("clone")
             let provider = GitRepositoryProvider()
             let repoSpec = RepositorySpecifier(path: testBareRepoPath)
             try provider.fetch(repository: repoSpec, to: testClonePath)
 
             // Clone off a checkout.
-            let checkoutPath = path.appending(component: "checkout")
+            let checkoutPath = path.appending("checkout")
             let checkoutRepo = try provider.createWorkingCopy(repository: repoSpec, sourcePath: testClonePath, at: checkoutPath, editable: true)
 
             XCTAssertFalse(try checkoutRepo.hasUnpushedCommits())
             // Add a new file to checkout.
-            try localFileSystem.writeFileContents(checkoutPath.appending(component: "test.txt"), bytes: "Hi")
+            try localFileSystem.writeFileContents(checkoutPath.appending("test.txt"), bytes: "Hi")
             let checkoutTestRepo = GitRepository(path: checkoutPath)
             try checkoutTestRepo.stage(file: "test.txt")
             try checkoutTestRepo.commit()
@@ -417,7 +417,7 @@ class GitRepositoryTests: XCTestCase {
     func testSetRemote() throws {
         try testWithTemporaryDirectory { path in
             // Create a repo.
-            let testRepoPath = path.appending(component: "test-repo")
+            let testRepoPath = path.appending("test-repo")
             try makeDirectories(testRepoPath)
             initGitRepo(testRepoPath)
             let repo = GitRepository(path: testRepoPath)
@@ -447,12 +447,12 @@ class GitRepositoryTests: XCTestCase {
     func testUncommitedChanges() throws {
         try testWithTemporaryDirectory { path in
             // Create a repo.
-            let testRepoPath = path.appending(component: "test-repo")
+            let testRepoPath = path.appending("test-repo")
             try makeDirectories(testRepoPath)
             initGitRepo(testRepoPath)
 
             // Create a file (which we will modify later).
-            try localFileSystem.writeFileContents(testRepoPath.appending(component: "test.txt"), bytes: "Hi")
+            try localFileSystem.writeFileContents(testRepoPath.appending("test.txt"), bytes: "Hi")
             let repo = GitRepository(path: testRepoPath)
 
             XCTAssert(repo.hasUncommittedChanges())
@@ -466,7 +466,7 @@ class GitRepositoryTests: XCTestCase {
             XCTAssertFalse(repo.hasUncommittedChanges())
 
             // Modify the file in the repo.
-            try localFileSystem.writeFileContents(repo.path.appending(component: "test.txt"), bytes: "Hello")
+            try localFileSystem.writeFileContents(repo.path.appending("test.txt"), bytes: "Hello")
             XCTAssert(repo.hasUncommittedChanges())
         }
     }
@@ -474,7 +474,7 @@ class GitRepositoryTests: XCTestCase {
     func testBranchOperations() throws {
         try testWithTemporaryDirectory { path in
             // Create a repo.
-            let testRepoPath = path.appending(component: "test-repo")
+            let testRepoPath = path.appending("test-repo")
             try makeDirectories(testRepoPath)
             initGitRepo(testRepoPath)
 
@@ -504,13 +504,13 @@ class GitRepositoryTests: XCTestCase {
     func testCheckoutRevision() throws {
         try testWithTemporaryDirectory { path in
             // Create a repo.
-            let testRepoPath = path.appending(component: "test-repo")
+            let testRepoPath = path.appending("test-repo")
             try makeDirectories(testRepoPath)
             initGitRepo(testRepoPath)
             let repo = GitRepository(path: testRepoPath)
 
             func createAndStageTestFile() throws {
-                try localFileSystem.writeFileContents(testRepoPath.appending(component: "test.txt"), bytes: "Hi")
+                try localFileSystem.writeFileContents(testRepoPath.appending("test.txt"), bytes: "Hi")
                 try repo.stage(file: "test.txt")
             }
 
@@ -550,17 +550,17 @@ class GitRepositoryTests: XCTestCase {
 
             // Create repos: foo and bar, foo will have bar as submodule and then later
             // the submodule ref will be updated in foo.
-            let fooPath = path.appending(component: "foo-original")
+            let fooPath = path.appending("foo-original")
             let fooSpecifier = RepositorySpecifier(path: fooPath)
-            let fooRepoPath = path.appending(component: "foo-repo")
-            let fooWorkingPath = path.appending(component: "foo-working")
-            let barPath = path.appending(component: "bar-original")
-            let bazPath = path.appending(component: "baz-original")
+            let fooRepoPath = path.appending("foo-repo")
+            let fooWorkingPath = path.appending("foo-working")
+            let barPath = path.appending("bar-original")
+            let bazPath = path.appending("baz-original")
             // Create the repos and add a file.
             for path in [fooPath, barPath, bazPath] {
                 try makeDirectories(path)
                 initGitRepo(path)
-                try localFileSystem.writeFileContents(path.appending(component: "hello.txt"), bytes: "hello")
+                try localFileSystem.writeFileContents(path.appending("hello.txt"), bytes: "hello")
                 let repo = GitRepository(path: path)
                 try repo.stageEverything()
                 try repo.commit()
@@ -579,7 +579,7 @@ class GitRepositoryTests: XCTestCase {
 
             // Checkout the first tag which doesn't has submodule.
             try fooWorkingRepo.checkout(tag: "1.0.0")
-            XCTAssertNoSuchPath(fooWorkingPath.appending(component: "bar"))
+            XCTAssertNoSuchPath(fooWorkingPath.appending("bar"))
 
             // Add submodule to foo and tag it as 1.0.1
             try foo.checkout(newBranch: "submodule")
@@ -603,7 +603,7 @@ class GitRepositoryTests: XCTestCase {
             XCTAssertNoSuchPath(fooWorkingPath.appending(components: "bar"))
 
             // Add something to bar.
-            try localFileSystem.writeFileContents(barPath.appending(component: "bar.txt"), bytes: "hello")
+            try localFileSystem.writeFileContents(barPath.appending("bar.txt"), bytes: "hello")
             // Add a submodule too to check for recursive submodules.
             try Process.checkNonZeroExit(
                 args: Git.tool, "-C", barPath.pathString, "submodule", "add", bazPath.pathString, "baz",
@@ -614,7 +614,7 @@ class GitRepositoryTests: XCTestCase {
             try bar.commit()
 
             // Update the ref of bar in foo and tag as 1.0.2
-            try systemQuietly([Git.tool, "-C", fooPath.appending(component: "bar").pathString, "pull"])
+            try systemQuietly([Git.tool, "-C", fooPath.appending("bar").pathString, "pull"])
             try foo.stageEverything()
             try foo.commit()
             try foo.tag(name: "1.0.2")
@@ -636,14 +636,14 @@ class GitRepositoryTests: XCTestCase {
     func testAlternativeObjectStoreValidation() throws {
         try testWithTemporaryDirectory { path in
             // Create a repo.
-            let testRepoPath = path.appending(component: "test-repo")
+            let testRepoPath = path.appending("test-repo")
             try makeDirectories(testRepoPath)
             initGitRepo(testRepoPath, tag: "1.2.3")
             let repo = GitRepository(path: testRepoPath)
             XCTAssertEqual(try repo.getTags(), ["1.2.3"])
 
             // Clone it somewhere.
-            let testClonePath = path.appending(component: "clone")
+            let testClonePath = path.appending("clone")
             let provider = GitRepositoryProvider()
             let repoSpec = RepositorySpecifier(path: testRepoPath)
             try provider.fetch(repository: repoSpec, to: testClonePath)
@@ -651,7 +651,7 @@ class GitRepositoryTests: XCTestCase {
             XCTAssertEqual(try clonedRepo.getTags(), ["1.2.3"])
 
             // Clone off a checkout.
-            let checkoutPath = path.appending(component: "checkout")
+            let checkoutPath = path.appending("checkout")
             let checkoutRepo = try provider.createWorkingCopy(repository: repoSpec, sourcePath: testClonePath, at: checkoutPath, editable: false)
 
             // The object store should be valid.
@@ -666,20 +666,20 @@ class GitRepositoryTests: XCTestCase {
     func testAreIgnored() throws {
         try testWithTemporaryDirectory { path in
             // Create a repo.
-            let testRepoPath = path.appending(component: "test_repo")
+            let testRepoPath = path.appending("test_repo")
             try makeDirectories(testRepoPath)
             initGitRepo(testRepoPath)
             let repo = GitRepository(path: testRepoPath)
 
             // Add a .gitignore
-            try localFileSystem.writeFileContents(testRepoPath.appending(component: ".gitignore"), bytes: "ignored_file1\nignored file2")
+            try localFileSystem.writeFileContents(testRepoPath.appending(".gitignore"), bytes: "ignored_file1\nignored file2")
 
-            let ignored = try repo.areIgnored([testRepoPath.appending(component: "ignored_file1"), testRepoPath.appending(component: "ignored file2"), testRepoPath.appending(component: "not ignored")])
+            let ignored = try repo.areIgnored([testRepoPath.appending("ignored_file1"), testRepoPath.appending("ignored file2"), testRepoPath.appending("not ignored")])
             XCTAssertTrue(ignored[0])
             XCTAssertTrue(ignored[1])
             XCTAssertFalse(ignored[2])
 
-            let notIgnored = try repo.areIgnored([testRepoPath.appending(component: "not_ignored")])
+            let notIgnored = try repo.areIgnored([testRepoPath.appending("not_ignored")])
             XCTAssertFalse(notIgnored[0])
         }
     }
@@ -687,15 +687,15 @@ class GitRepositoryTests: XCTestCase {
     func testAreIgnoredWithSpaceInRepoPath() throws {
         try testWithTemporaryDirectory { path in
             // Create a repo.
-            let testRepoPath = path.appending(component: "test repo")
+            let testRepoPath = path.appending("test repo")
             try makeDirectories(testRepoPath)
             initGitRepo(testRepoPath)
             let repo = GitRepository(path: testRepoPath)
 
             // Add a .gitignore
-            try localFileSystem.writeFileContents(testRepoPath.appending(component: ".gitignore"), bytes: "ignored_file1")
+            try localFileSystem.writeFileContents(testRepoPath.appending(".gitignore"), bytes: "ignored_file1")
 
-            let ignored = try repo.areIgnored([testRepoPath.appending(component: "ignored_file1")])
+            let ignored = try repo.areIgnored([testRepoPath.appending("ignored_file1")])
             XCTAssertTrue(ignored[0])
         }
     }
@@ -703,7 +703,7 @@ class GitRepositoryTests: XCTestCase {
     func testMissingDefaultBranch() throws {
         try testWithTemporaryDirectory { path in
             // Create a repository.
-            let testRepoPath = path.appending(component: "test-repo")
+            let testRepoPath = path.appending("test-repo")
             try makeDirectories(testRepoPath)
             initGitRepo(testRepoPath)
             let repo = GitRepository(path: testRepoPath)
@@ -716,7 +716,7 @@ class GitRepositoryTests: XCTestCase {
             try systemQuietly([Git.tool, "-C", testRepoPath.pathString, "symbolic-ref", "HEAD", "refs/heads/_non_existent_branch_"])
 
             // Clone it somewhere.
-            let testClonePath = path.appending(component: "clone")
+            let testClonePath = path.appending("clone")
             let provider = GitRepositoryProvider()
             let repoSpec = RepositorySpecifier(path: testRepoPath)
             try provider.fetch(repository: repoSpec, to: testClonePath)
@@ -724,13 +724,13 @@ class GitRepositoryTests: XCTestCase {
             XCTAssertEqual(try clonedRepo.getTags(), [])
 
             // Clone off a checkout.
-            let checkoutPath = path.appending(component: "checkout")
+            let checkoutPath = path.appending("checkout")
             let checkoutRepo = try provider.createWorkingCopy(repository: repoSpec, sourcePath: testClonePath, at: checkoutPath, editable: false)
-            XCTAssertNoSuchPath(checkoutPath.appending(component: "file.swift"))
+            XCTAssertNoSuchPath(checkoutPath.appending("file.swift"))
 
             // Try to check out the `main` branch.
             try checkoutRepo.checkout(revision: Revision(identifier: "newMain"))
-            XCTAssertFileExists(checkoutPath.appending(component: "file.swift"))
+            XCTAssertFileExists(checkoutPath.appending("file.swift"))
 
             // The following will throw if HEAD was set incorrectly and we didn't do a no-checkout clone.
             XCTAssertNoThrow(try checkoutRepo.getCurrentRevision())

--- a/Tests/SourceControlTests/InMemoryGitRepositoryTests.swift
+++ b/Tests/SourceControlTests/InMemoryGitRepositoryTests.swift
@@ -24,7 +24,7 @@ class InMemoryGitRepositoryTests: XCTestCase {
 
         try repo.createDirectory(AbsolutePath(path: "/new-dir/subdir"), recursive: true)
         XCTAssertTrue(!repo.hasUncommittedChanges())
-        let filePath = AbsolutePath(path: "/new-dir/subdir").appending(component: "new-file.txt")
+        let filePath = AbsolutePath("/new-dir/subdir").appending("new-file.txt")
 
         try repo.writeFileContents(filePath, bytes: "one")
         XCTAssertEqual(try repo.readFileContents(filePath), "one")
@@ -80,7 +80,7 @@ class InMemoryGitRepositoryTests: XCTestCase {
 
         let specifier = RepositorySpecifier(path: .init(path: "/foo"))
         try repo.createDirectory(AbsolutePath(path: "/new-dir/subdir"), recursive: true)
-        let filePath = AbsolutePath(path: "/new-dir/subdir").appending(component: "new-file.txt")
+        let filePath = AbsolutePath("/new-dir/subdir").appending("new-file.txt")
         try repo.writeFileContents(filePath, bytes: "one")
         try repo.commit()
         try repo.tag(name: v1)
@@ -91,7 +91,7 @@ class InMemoryGitRepositoryTests: XCTestCase {
         let provider = InMemoryGitRepositoryProvider()
         provider.add(specifier: specifier, repository: repo)
 
-        let fooRepoPath = AbsolutePath(path: "/fooRepo")
+        let fooRepoPath = AbsolutePath("/fooRepo")
         try provider.fetch(repository: specifier, to: fooRepoPath)
         let fooRepo = try provider.open(repository: specifier, at: fooRepoPath)
 
@@ -100,7 +100,7 @@ class InMemoryGitRepositoryTests: XCTestCase {
         XCTAssertEqual(try fooRepo.getTags().sorted(), [v1, v2])
         XCTAssert(fooRepo.exists(revision: try fooRepo.resolveRevision(tag: v1)))
 
-        let fooCheckoutPath = AbsolutePath(path: "/fooCheckout")
+        let fooCheckoutPath = AbsolutePath("/fooCheckout")
         XCTAssertFalse(try provider.workingCopyExists(at: fooCheckoutPath))
         _ = try provider.createWorkingCopy(repository: specifier, sourcePath: fooRepoPath, at: fooCheckoutPath, editable: false)
         XCTAssertTrue(try provider.workingCopyExists(at: fooCheckoutPath))

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -52,11 +52,11 @@ class RepositoryManagerTests: XCTestCase {
                 XCTAssertEqual(try! repository.getTags(), ["1.0.0"])
 
                 // Create a checkout of the repository.
-                let checkoutPath = path.appending(component: "checkout")
+                let checkoutPath = path.appending("checkout")
                 _ = try! handle.createWorkingCopy(at: checkoutPath, editable: false)
 
                 XCTAssertDirectoryExists(checkoutPath)
-                XCTAssertFileExists(checkoutPath.appending(component: "README.txt"))
+                XCTAssertFileExists(checkoutPath.appending("README.txt"))
 
                 try delegate.wait(timeout: .now() + 2)
                 XCTAssertEqual(delegate.willFetch.map { $0.repository }, [dummyRepo])
@@ -102,7 +102,7 @@ class RepositoryManagerTests: XCTestCase {
 
                 // Check removing the repo updates the persistent file.
                 /*do {
-                    let checkoutsStateFile = path.appending(component: "checkouts-state.json")
+                    let checkoutsStateFile = path.appending("checkouts-state.json")
                     let jsonData = try JSON(bytes: localFileSystem.readFileContents(checkoutsStateFile))
                     XCTAssertEqual(jsonData.dictionary?["object"]?.dictionary?["repositories"]?.dictionary?[dummyRepo.location.description], nil)
                 }*/
@@ -136,9 +136,9 @@ class RepositoryManagerTests: XCTestCase {
         let observability = ObservabilitySystem.makeForTesting()
 
         try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
-            let cachePath = fixturePath.appending(component: "cache")
-            let repositoriesPath = fixturePath.appending(component: "repositories")
-            let repo = RepositorySpecifier(path: fixturePath.appending(component: "Foo"))
+            let cachePath = fixturePath.appending("cache")
+            let repositoriesPath = fixturePath.appending("repositories")
+            let repo = RepositorySpecifier(path: fixturePath.appending("Foo"))
 
             let provider = GitRepositoryProvider()
             let delegate = DummyRepositoryManagerDelegate()
@@ -209,7 +209,7 @@ class RepositoryManagerTests: XCTestCase {
         let observability = ObservabilitySystem.makeForTesting()
 
         try testWithTemporaryDirectory { path in
-            let repos = path.appending(component: "repo")
+            let repos = path.appending("repo")
             let provider = DummyRepositoryProvider(fileSystem: fs)
             let delegate = DummyRepositoryManagerDelegate()
 
@@ -387,7 +387,7 @@ class RepositoryManagerTests: XCTestCase {
         let observability = ObservabilitySystem.makeForTesting()
 
         try testWithTemporaryDirectory { path in
-            let repos = path.appending(component: "repo")
+            let repos = path.appending("repo")
             let provider = DummyRepositoryProvider(fileSystem: fs)
             let delegate = DummyRepositoryManagerDelegate()
 
@@ -665,7 +665,7 @@ private class DummyRepositoryProvider: RepositoryProvider {
     func fetch(repository: RepositorySpecifier, to path: AbsolutePath, progressHandler: FetchProgress.Handler? = nil) throws {
         assert(!self.fileSystem.exists(path))
         try self.fileSystem.createDirectory(path, recursive: true)
-        try self.fileSystem.writeFileContents(path.appending(component: "readme.md"), bytes: ByteString(encodingAsUTF8: repository.location.description))
+        try self.fileSystem.writeFileContents(path.appending("readme.md"), bytes: ByteString(encodingAsUTF8: repository.location.description))
 
         self.lock.withLock {
             self._numClones += 1
@@ -702,7 +702,7 @@ private class DummyRepositoryProvider: RepositoryProvider {
 
     func createWorkingCopy(repository: RepositorySpecifier, sourcePath: AbsolutePath, at destinationPath: AbsolutePath, editable: Bool) throws -> WorkingCheckout  {
         try self.fileSystem.createDirectory(destinationPath)
-        try self.fileSystem.writeFileContents(destinationPath.appending(component: "README.txt"), bytes: "Hi")
+        try self.fileSystem.writeFileContents(destinationPath.appending("README.txt"), bytes: "Hi")
         return try self.openWorkingCopy(at: destinationPath)
     }
 

--- a/Tests/WorkspaceTests/AuthorizationProviderTests.swift
+++ b/Tests/WorkspaceTests/AuthorizationProviderTests.swift
@@ -53,7 +53,7 @@ final class AuthorizationProviderTests: XCTestCase {
         do {
             let fileSystem = InMemoryFileSystem()
 
-            let userPath = try fileSystem.homeDirectory.appending(component: ".netrc")
+            let userPath = try fileSystem.homeDirectory.appending(".netrc")
             try fileSystem.createDirectory(userPath.parentDirectory, recursive: true)
             try fileSystem.writeFileContents(userPath) {
                 "machine mymachine.labkey.org login user@labkey.org password user"
@@ -115,7 +115,7 @@ final class AuthorizationProviderTests: XCTestCase {
         do {
             let fileSystem = InMemoryFileSystem()
 
-            let userPath = try fileSystem.homeDirectory.appending(component: ".netrc")
+            let userPath = try fileSystem.homeDirectory.appending(".netrc")
             try fileSystem.createDirectory(userPath.parentDirectory, recursive: true)
             try fileSystem.writeFileContents(userPath) {
                 "machine mymachine.labkey.org login user@labkey.org password user"

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -23,7 +23,7 @@ class InitTests: XCTestCase {
     func testInitPackageEmpty() throws {
         try testWithTemporaryDirectory { tmpPath in
             let fs = localFileSystem
-            let path = tmpPath.appending(component: "Foo")
+            let path = tmpPath.appending("Foo")
             let name = path.basename
             try fs.createDirectory(path)
             
@@ -44,7 +44,7 @@ class InitTests: XCTestCase {
             XCTAssertGreaterThan(progressMessages.count, 0)
 
             // Verify basic file system content that we expect in the package
-            let manifest = path.appending(component: "Package.swift")
+            let manifest = path.appending("Package.swift")
             XCTAssertFileExists(manifest)
             let manifestContents: String = try localFileSystem.readFileContents(manifest)
             let version = InitPackage.newPackageToolsVersion
@@ -57,7 +57,7 @@ class InitTests: XCTestCase {
     func testInitPackageExecutable() throws {
         try testWithTemporaryDirectory { tmpPath in
             let fs = localFileSystem
-            let path = tmpPath.appending(component: "Foo")
+            let path = tmpPath.appending("Foo")
             let name = path.basename
             try fs.createDirectory(path)
 
@@ -78,21 +78,21 @@ class InitTests: XCTestCase {
             XCTAssertGreaterThan(progressMessages.count, 0)
             
             // Verify basic file system content that we expect in the package
-            let manifest = path.appending(component: "Package.swift")
+            let manifest = path.appending("Package.swift")
             XCTAssertFileExists(manifest)
             let manifestContents: String = try localFileSystem.readFileContents(manifest)
             let version = InitPackage.newPackageToolsVersion
             let versionSpecifier = "\(version.major).\(version.minor)"
             XCTAssertMatch(manifestContents, .prefix("// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"))
 
-            XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources")), ["main.swift"])
+            XCTAssertEqual(try fs.getDirectoryContents(path.appending("Sources")), ["main.swift"])
             XCTAssertBuilds(path)
             let triple = try UserToolchain.default.triple
             let binPath = path.appending(components: ".build", triple.platformBuildPathComponent(), "debug")
 #if os(Windows)
-            XCTAssertFileExists(binPath.appending(component: "Foo.exe"))
+            XCTAssertFileExists(binPath.appending("Foo.exe"))
 #else
-            XCTAssertFileExists(binPath.appending(component: "Foo"))
+            XCTAssertFileExists(binPath.appending("Foo"))
 #endif
             XCTAssertFileExists(binPath.appending(components: "Foo.swiftmodule"))
         }
@@ -101,7 +101,7 @@ class InitTests: XCTestCase {
     func testInitPackageLibrary() throws {
         try testWithTemporaryDirectory { tmpPath in
             let fs = localFileSystem
-            let path = tmpPath.appending(component: "Foo")
+            let path = tmpPath.appending("Foo")
             let name = path.basename
             try fs.createDirectory(path)
 
@@ -122,19 +122,19 @@ class InitTests: XCTestCase {
             XCTAssertGreaterThan(progressMessages.count, 0)
 
             // Verify basic file system content that we expect in the package
-            let manifest = path.appending(component: "Package.swift")
+            let manifest = path.appending("Package.swift")
             XCTAssertFileExists(manifest)
             let manifestContents: String = try localFileSystem.readFileContents(manifest)
             let version = InitPackage.newPackageToolsVersion
             let versionSpecifier = "\(version.major).\(version.minor)"
             XCTAssertMatch(manifestContents, .prefix("// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"))
 
-            XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources").appending(component: "Foo")), ["Foo.swift"])
+            XCTAssertEqual(try fs.getDirectoryContents(path.appending("Sources").appending("Foo")), ["Foo.swift"])
 
-            let tests = path.appending(component: "Tests")
+            let tests = path.appending("Tests")
             XCTAssertEqual(try fs.getDirectoryContents(tests).sorted(), ["FooTests"])
 
-            let testFile = tests.appending(component: "FooTests").appending(component: "FooTests.swift")
+            let testFile = tests.appending("FooTests").appending("FooTests.swift")
             let testFileContents: String = try localFileSystem.readFileContents(testFile)
             XCTAssertTrue(testFileContents.hasPrefix("import XCTest"), """
                           Validates formatting of XCTest source file, in particular that it does not contain leading whitespace:
@@ -156,7 +156,7 @@ class InitTests: XCTestCase {
             XCTAssertDirectoryExists(tempDirPath)
             
             // Create a directory with non c99name.
-            let packageRoot = tempDirPath.appending(component: "some-package")
+            let packageRoot = tempDirPath.appending("some-package")
             let packageName = packageRoot.basename
             try localFileSystem.createDirectory(packageRoot)
             XCTAssertDirectoryExists(packageRoot)
@@ -184,7 +184,7 @@ class InitTests: XCTestCase {
         try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDirPath in
             XCTAssertDirectoryExists(tempDirPath)
             
-            let packageRoot = tempDirPath.appending(component: "Foo")
+            let packageRoot = tempDirPath.appending("Foo")
             try localFileSystem.createDirectory(packageRoot)
             XCTAssertDirectoryExists(packageRoot)
             
@@ -215,7 +215,7 @@ class InitTests: XCTestCase {
                 .init(platform: .tvOS, version: PlatformVersion("999")),
             ]
 
-            let packageRoot = tempDirPath.appending(component: "Foo")
+            let packageRoot = tempDirPath.appending("Foo")
             try localFileSystem.removeFileTree(packageRoot)
             try localFileSystem.createDirectory(packageRoot)
 
@@ -227,7 +227,7 @@ class InitTests: XCTestCase {
             )
             try initPackage.writePackageStructure()
 
-            let contents: String = try localFileSystem.readFileContents(packageRoot.appending(component: "Package.swift"))
+            let contents: String = try localFileSystem.readFileContents(packageRoot.appending("Package.swift"))
             XCTAssertMatch(contents, .contains(#"platforms: [.macOS(.v10_15), .iOS(.v12), .watchOS("2.1"), .tvOS("999.0")],"#))
         }
     }

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -425,10 +425,10 @@ class ManifestSourceGenerationTests: XCTestCase {
 
     func testCustomProductSourceGeneration() throws {
         // Create a manifest containing a product for which we'd like to do custom source fragment generation.
-        let packageDir = AbsolutePath(path: "/tmp/MyLibrary")
+        let packageDir = AbsolutePath("/tmp/MyLibrary")
         let manifest = Manifest.createManifest(
             displayName: "MyLibrary",
-            path: packageDir.appending(component: "Package.swift"),
+            path: packageDir.appending("Package.swift"),
             packageKind: .root(AbsolutePath(path: "/tmp/MyLibrary")),
             packageLocation: packageDir.pathString,
             platforms: [],

--- a/Tests/WorkspaceTests/MirrorsConfigurationTests.swift
+++ b/Tests/WorkspaceTests/MirrorsConfigurationTests.swift
@@ -18,7 +18,7 @@ import XCTest
 final class MirrorsConfigurationTests: XCTestCase {
     func testLoadingSchema1() throws {
         let fs = InMemoryFileSystem()
-        let configFile = AbsolutePath(path: "/config/mirrors.json")
+        let configFile = AbsolutePath("/config/mirrors.json")
 
         let originalURL = "https://github.com/apple/swift-argument-parser.git"
         let mirrorURL = "https://github.com/mona/swift-argument-parser.git"
@@ -46,7 +46,7 @@ final class MirrorsConfigurationTests: XCTestCase {
 
     func testThrowsWhenNotFound() throws {
         let fs = InMemoryFileSystem()
-        let configFile = AbsolutePath(path: "/config/mirrors.json")
+        let configFile = AbsolutePath("/config/mirrors.json")
 
         let config = Workspace.Configuration.MirrorsStorage(path: configFile, fileSystem: fs, deleteWhenEmpty: true)
         let mirrors = try config.get()
@@ -58,7 +58,7 @@ final class MirrorsConfigurationTests: XCTestCase {
 
     func testDeleteWhenEmpty() throws {
         let fs = InMemoryFileSystem()
-        let configFile = AbsolutePath(path: "/config/mirrors.json")
+        let configFile = AbsolutePath("/config/mirrors.json")
 
         let config = Workspace.Configuration.MirrorsStorage(path: configFile, fileSystem: fs, deleteWhenEmpty: true)
 
@@ -81,7 +81,7 @@ final class MirrorsConfigurationTests: XCTestCase {
 
     func testDontDeleteWhenEmpty() throws {
         let fs = InMemoryFileSystem()
-        let configFile = AbsolutePath(path: "/config/mirrors.json")
+        let configFile = AbsolutePath("/config/mirrors.json")
 
         let config = Workspace.Configuration.MirrorsStorage(path: configFile, fileSystem: fs, deleteWhenEmpty: false)
 
@@ -105,8 +105,8 @@ final class MirrorsConfigurationTests: XCTestCase {
 
     func testLocalAndShared() throws {
         let fs = InMemoryFileSystem()
-        let localConfigFile = AbsolutePath(path: "/config/local-mirrors.json")
-        let sharedConfigFile = AbsolutePath(path: "/config/shared-mirrors.json")
+        let localConfigFile = AbsolutePath("/config/local-mirrors.json")
+        let sharedConfigFile = AbsolutePath("/config/shared-mirrors.json")
 
         let config = try Workspace.Configuration.Mirrors(
             fileSystem: fs,

--- a/Tests/WorkspaceTests/PinsStoreTests.swift
+++ b/Tests/WorkspaceTests/PinsStoreTests.swift
@@ -27,14 +27,14 @@ final class PinsStoreTests: XCTestCase {
 
     func testBasics() throws {
         let fs = InMemoryFileSystem()
-        let pinsFile = AbsolutePath(path: "/pinsfile.txt")
+        let pinsFile = AbsolutePath("/pinsfile.txt")
 
         do {
-            let fooPath = AbsolutePath(path: "/foo")
+            let fooPath = AbsolutePath("/foo")
             let foo = PackageIdentity(path: fooPath)
             let fooRef = PackageReference.localSourceControl(identity: foo, path: fooPath)
 
-            let barPath = AbsolutePath(path: "/bar")
+            let barPath = AbsolutePath("/bar")
             let bar = PackageIdentity(path: barPath)
             let barRef = PackageReference.localSourceControl(identity: bar, path: barPath)
 
@@ -80,7 +80,7 @@ final class PinsStoreTests: XCTestCase {
         // Test source control version pin.
 
         do {
-            let path = AbsolutePath(path: "/foo")
+            let path = AbsolutePath("/foo")
             let identity = PackageIdentity(path: path)
             let revision = UUID().uuidString
 
@@ -100,7 +100,7 @@ final class PinsStoreTests: XCTestCase {
         // Test source control branch pin.
 
         do {
-            let path = AbsolutePath(path: "/foo")
+            let path = AbsolutePath("/foo")
             let identity = PackageIdentity(path: path)
             let revision = UUID().uuidString
 
@@ -120,7 +120,7 @@ final class PinsStoreTests: XCTestCase {
         // Test source control revision pin.
 
         do {
-            let path = AbsolutePath(path: "/foo")
+            let path = AbsolutePath("/foo")
             let identity = PackageIdentity(path: path)
             let revision = UUID().uuidString
 
@@ -158,7 +158,7 @@ final class PinsStoreTests: XCTestCase {
 
     func testLoadingSchema1() throws {
         let fs = InMemoryFileSystem()
-        let pinsFile = AbsolutePath(path: "/pinsfile.txt")
+        let pinsFile = AbsolutePath("/pinsfile.txt")
 
         try fs.writeFileContents(pinsFile, string:
             """
@@ -196,7 +196,7 @@ final class PinsStoreTests: XCTestCase {
 
     func testLoadingSchema2() throws {
         let fs = InMemoryFileSystem()
-        let pinsFile = AbsolutePath(path: "/pinsfile.txt")
+        let pinsFile = AbsolutePath("/pinsfile.txt")
 
         try fs.writeFileContents(pinsFile, string:
             """
@@ -240,7 +240,7 @@ final class PinsStoreTests: XCTestCase {
 
     func testLoadingUnknownSchemaVersion() throws {
         let fs = InMemoryFileSystem()
-        let pinsFile = AbsolutePath(path: "/pinsfile.txt")
+        let pinsFile = AbsolutePath("/pinsfile.txt")
 
         let version = -1
         try fs.writeFileContents(pinsFile, string: "{ \"version\": \(version) }");
@@ -253,7 +253,7 @@ final class PinsStoreTests: XCTestCase {
 
     func testLoadingBadFormat() throws {
         let fs = InMemoryFileSystem()
-        let pinsFile = AbsolutePath(path: "/pinsfile.txt")
+        let pinsFile = AbsolutePath("/pinsfile.txt")
 
         try fs.writeFileContents(pinsFile, string: "boom")
 
@@ -264,13 +264,13 @@ final class PinsStoreTests: XCTestCase {
 
     func testEmptyPins() throws {
         let fs = InMemoryFileSystem()
-        let pinsFile = AbsolutePath(path: "/pinsfile.txt")
+        let pinsFile = AbsolutePath("/pinsfile.txt")
         let store = try PinsStore(pinsFile: pinsFile, workingDirectory: .root, fileSystem: fs, mirrors: .init())
 
         try store.saveState(toolsVersion: ToolsVersion.current)
         XCTAssertFalse(fs.exists(pinsFile))
 
-        let fooPath = AbsolutePath(path: "/foo")
+        let fooPath = AbsolutePath("/foo")
         let foo = PackageIdentity(path: fooPath)
         let fooRef = PackageReference.localSourceControl(identity: foo, path: fooPath)
         let revision = "81513c8fd220cf1ed1452b98060cd80d3725c5b7"
@@ -304,7 +304,7 @@ final class PinsStoreTests: XCTestCase {
         mirrors.set(mirrorURL: barMirroredURL.absoluteString, forURL: barURL.absoluteString)
 
         let fileSystem = InMemoryFileSystem()
-        let pinsFile = AbsolutePath(path: "/pins.txt")
+        let pinsFile = AbsolutePath("/pins.txt")
 
         let store = try PinsStore(pinsFile: pinsFile, workingDirectory: .root, fileSystem: fileSystem, mirrors: mirrors)
 
@@ -356,7 +356,7 @@ final class PinsStoreTests: XCTestCase {
         mirrors.set(mirrorURL: fooMirroredURL.absoluteString, forURL: fooURL4.absoluteString)
 
         let fileSystem = InMemoryFileSystem()
-        let pinsFile = AbsolutePath(path: "/pins.txt")
+        let pinsFile = AbsolutePath("/pins.txt")
 
         let store1 = try PinsStore(pinsFile: pinsFile, workingDirectory: .root, fileSystem: fileSystem, mirrors: mirrors)
         store1.pin(

--- a/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
@@ -406,7 +406,7 @@ class RegistryPackageContainerTests: XCTestCase {
             // meh
             let path = packagePath
                 .appending(components: ".build", "registry", "downloads", registryIdentity.scope.description, registryIdentity.name.description)
-                .appending(component: "\(packageVersion).zip")
+                .appending("\(packageVersion).zip")
             try! fileSystem.createDirectory(path.parentDirectory, recursive: true)
             try! fileSystem.writeFileContents(path, string: "")
 
@@ -424,7 +424,7 @@ class RegistryPackageContainerTests: XCTestCase {
 
         let archiver = archiver ?? MockArchiver(handler: { archiver, from, to, completion in
             do {
-                try fileSystem.createDirectory(to.appending(component: "top"), recursive: true)
+                try fileSystem.createDirectory(to.appending("top"), recursive: true)
                 completion(.success(()))
             } catch {
                 completion(.failure(error))

--- a/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
@@ -185,7 +185,7 @@ class SourceControlPackageContainerTests: XCTestCase {
         let fs = InMemoryFileSystem()
 
         let repoPath = AbsolutePath.root
-        let filePath = repoPath.appending(component: "Package.swift")
+        let filePath = repoPath.appending("Package.swift")
 
         let specifier = RepositorySpecifier(path: repoPath)
         let repo = InMemoryGitRepository(path: repoPath, fs: fs)
@@ -201,7 +201,7 @@ class SourceControlPackageContainerTests: XCTestCase {
         let inMemRepoProvider = InMemoryGitRepositoryProvider()
         inMemRepoProvider.add(specifier: specifier, repository: repo)
 
-        let p = AbsolutePath.root.appending(component: "repoManager")
+        let p = AbsolutePath.root.appending("repoManager")
         try fs.createDirectory(p, recursive: true)
         let repositoryManager = RepositoryManager(
             fileSystem: fs,
@@ -227,7 +227,7 @@ class SourceControlPackageContainerTests: XCTestCase {
         let fs = InMemoryFileSystem()
 
         let repoPath = AbsolutePath.root
-        let filePath = repoPath.appending(component: "Package.swift")
+        let filePath = repoPath.appending("Package.swift")
 
         let specifier = RepositorySpecifier(path: repoPath)
         let repo = InMemoryGitRepository(path: repoPath, fs: fs)
@@ -253,7 +253,7 @@ class SourceControlPackageContainerTests: XCTestCase {
         let inMemRepoProvider = InMemoryGitRepositoryProvider()
         inMemRepoProvider.add(specifier: specifier, repository: repo)
 
-        let p = AbsolutePath.root.appending(component: "repoManager")
+        let p = AbsolutePath.root.appending("repoManager")
         try fs.createDirectory(p, recursive: true)
         let repositoryManager = RepositoryManager(
             fileSystem: fs,
@@ -320,7 +320,7 @@ class SourceControlPackageContainerTests: XCTestCase {
         let fs = InMemoryFileSystem()
 
         let repoPath = AbsolutePath.root
-        let filePath = repoPath.appending(component: "Package.swift")
+        let filePath = repoPath.appending("Package.swift")
 
         let specifier = RepositorySpecifier(path: repoPath)
         let repo = InMemoryGitRepository(path: repoPath, fs: fs)
@@ -338,7 +338,7 @@ class SourceControlPackageContainerTests: XCTestCase {
         let inMemRepoProvider = InMemoryGitRepositoryProvider()
         inMemRepoProvider.add(specifier: specifier, repository: repo)
 
-        let p = AbsolutePath.root.appending(component: "repoManager")
+        let p = AbsolutePath.root.appending("repoManager")
         try fs.createDirectory(p, recursive: true)
         let repositoryManager = RepositoryManager(
             fileSystem: fs,
@@ -364,7 +364,7 @@ class SourceControlPackageContainerTests: XCTestCase {
         let fs = InMemoryFileSystem()
 
         let repoPath = AbsolutePath.root
-        let filePath = repoPath.appending(component: "Package.swift")
+        let filePath = repoPath.appending("Package.swift")
 
         let specifier = RepositorySpecifier(path: repoPath)
         let repo = InMemoryGitRepository(path: repoPath, fs: fs)
@@ -387,7 +387,7 @@ class SourceControlPackageContainerTests: XCTestCase {
         let inMemRepoProvider = InMemoryGitRepositoryProvider()
         inMemRepoProvider.add(specifier: specifier, repository: repo)
 
-        let p = AbsolutePath.root.appending(component: "repoManager")
+        let p = AbsolutePath.root.appending("repoManager")
         try fs.createDirectory(p, recursive: true)
         let repositoryManager = RepositoryManager(
             fileSystem: fs,
@@ -546,13 +546,13 @@ class SourceControlPackageContainerTests: XCTestCase {
     func testMissingBranchDiagnostics() throws {
         try testWithTemporaryDirectory { tmpDir in
             // Create a repository.
-            let packageDir = tmpDir.appending(component: "SomePackage")
+            let packageDir = tmpDir.appending("SomePackage")
             try localFileSystem.createDirectory(packageDir)
             initGitRepo(packageDir)
             let packageRepo = GitRepository(path: packageDir)
 
             // Create a package manifest in it (it only needs the `swift-tools-version` part, because we'll supply the manifest later).
-            let manifestFile = packageDir.appending(component: "Package.swift")
+            let manifestFile = packageDir.appending("Package.swift")
             try localFileSystem.writeFileContents(manifestFile, bytes: ByteString("// swift-tools-version:4.2"))
 
             // Commit it and tag it.
@@ -617,12 +617,12 @@ class SourceControlPackageContainerTests: XCTestCase {
     // This lead to corrupt graph states.
     func testRepositoryPackageContainerCache() throws {
         try testWithTemporaryDirectory { temporaryDirectory in
-            let packageDirectory = temporaryDirectory.appending(component: "Package")
+            let packageDirectory = temporaryDirectory.appending("Package")
             try localFileSystem.createDirectory(packageDirectory)
             initGitRepo(packageDirectory)
             let packageRepository = GitRepository(path: packageDirectory)
 
-            let manifestFile = packageDirectory.appending(component: "Package.swift")
+            let manifestFile = packageDirectory.appending("Package.swift")
             try localFileSystem.writeFileContents(manifestFile, bytes: ByteString("// swift-tools-version:5.2"))
 
             try packageRepository.stage(file: "Package.swift")

--- a/Tests/WorkspaceTests/ToolsVersionSpecificationRewriterTests.swift
+++ b/Tests/WorkspaceTests/ToolsVersionSpecificationRewriterTests.swift
@@ -113,7 +113,7 @@ class ToolsVersionSpecificationRewriterTests: XCTestCase {
         let toolsVersion = ToolsVersion.v5_3
         
         let inMemoryFileSystem = InMemoryFileSystem()
-        let manifestFilePath = AbsolutePath(path: "/pkg/Package.swift/Package.swift")
+        let manifestFilePath = AbsolutePath("/pkg/Package.swift/Package.swift")
         try inMemoryFileSystem.createDirectory(manifestFilePath.parentDirectory, recursive: true) // /pkg/Package.swift/
         
         // Test `ManifestAccessError.Kind.isADirectory`
@@ -189,7 +189,7 @@ class ToolsVersionSpecificationRewriterTests: XCTestCase {
         do {
             let inMemoryFileSystem = InMemoryFileSystem()
 
-            let manifestFilePath = AbsolutePath(path: "/pkg/Package.swift")
+            let manifestFilePath = AbsolutePath("/pkg/Package.swift")
 
             try inMemoryFileSystem.createDirectory(manifestFilePath.parentDirectory, recursive: true)
             try inMemoryFileSystem.writeFileContents(manifestFilePath, bytes: stream.bytes)

--- a/Tests/WorkspaceTests/WorkspaceStateTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceStateTests.swift
@@ -19,10 +19,10 @@ final class WorkspaceStateTests: XCTestCase {
     func testV4Format() throws {
         let fs = InMemoryFileSystem()
 
-        let buildDir = AbsolutePath(path: "/.build")
+        let buildDir = AbsolutePath("/.build")
         try fs.createDirectory(buildDir, recursive: true)
 
-        let statePath = buildDir.appending(component: "workspace-state.json")
+        let statePath = buildDir.appending("workspace-state.json")
         try fs.writeFileContents(statePath) {
             """
             {
@@ -93,10 +93,10 @@ final class WorkspaceStateTests: XCTestCase {
     func testV4FormatWithPath() throws {
         let fs = InMemoryFileSystem()
 
-        let buildDir = AbsolutePath(path: "/.build")
+        let buildDir = AbsolutePath("/.build")
         try fs.createDirectory(buildDir, recursive: true)
 
-        let statePath = buildDir.appending(component: "workspace-state.json")
+        let statePath = buildDir.appending("workspace-state.json")
         try fs.writeFileContents(statePath) {
             """
             {
@@ -167,10 +167,10 @@ final class WorkspaceStateTests: XCTestCase {
     func testV5Format() throws {
         let fs = InMemoryFileSystem()
 
-        let buildDir = AbsolutePath(path: "/.build")
+        let buildDir = AbsolutePath("/.build")
         try fs.createDirectory(buildDir, recursive: true)
 
-        let statePath = buildDir.appending(component: "workspace-state.json")
+        let statePath = buildDir.appending("workspace-state.json")
         try fs.writeFileContents(statePath) {
             """
             {
@@ -241,10 +241,10 @@ final class WorkspaceStateTests: XCTestCase {
     func testSavedDependenciesAreSorted() throws {
         let fs = InMemoryFileSystem()
 
-        let buildDir = AbsolutePath(path: "/.build")
+        let buildDir = AbsolutePath("/.build")
         try fs.createDirectory(buildDir, recursive: true)
 
-        let statePath = buildDir.appending(component: "workspace-state.json")
+        let statePath = buildDir.appending("workspace-state.json")
         try fs.writeFileContents(statePath) {
             """
             {
@@ -306,10 +306,10 @@ final class WorkspaceStateTests: XCTestCase {
     func testArtifacts() throws {
         let fs = InMemoryFileSystem()
 
-        let buildDir = AbsolutePath(path: "/.build")
+        let buildDir = AbsolutePath("/.build")
         try fs.createDirectory(buildDir, recursive: true)
 
-        let statePath = buildDir.appending(component: "workspace-state.json")
+        let statePath = buildDir.appending("workspace-state.json")
         try fs.writeFileContents(statePath) {
             """
             {
@@ -378,10 +378,10 @@ final class WorkspaceStateTests: XCTestCase {
     func testDuplicateDependenciesDoNotCrash() throws {
         let fs = InMemoryFileSystem()
 
-        let buildDir = AbsolutePath(path: "/.build")
+        let buildDir = AbsolutePath("/.build")
         try fs.createDirectory(buildDir, recursive: true)
 
-        let statePath = buildDir.appending(component: "workspace-state.json")
+        let statePath = buildDir.appending("workspace-state.json")
         try fs.writeFileContents(statePath) {
             """
             {
@@ -439,10 +439,10 @@ final class WorkspaceStateTests: XCTestCase {
     func testDuplicateArtifactsDoNotCrash() throws {
         let fs = InMemoryFileSystem()
 
-        let buildDir = AbsolutePath(path: "/.build")
+        let buildDir = AbsolutePath("/.build")
         try fs.createDirectory(buildDir, recursive: true)
 
-        let statePath = buildDir.appending(component: "workspace-state.json")
+        let statePath = buildDir.appending("workspace-state.json")
         try fs.writeFileContents(statePath) {
             """
             {

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -30,7 +30,7 @@ import struct TSCUtility.Version
 
 final class WorkspaceTests: XCTestCase {
     func testBasics() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -159,16 +159,16 @@ final class WorkspaceTests: XCTestCase {
         let fs = localFileSystem
 
         try testWithTemporaryDirectory { path in
-            let foo = path.appending(component: "foo")
+            let foo = path.appending("foo")
 
             func createWorkspace(withManifest manifest: (OutputByteStream) -> Void) throws -> Workspace {
-                try fs.writeFileContents(foo.appending(component: "Package.swift")) {
+                try fs.writeFileContents(foo.appending("Package.swift")) {
                     manifest($0)
                 }
 
                 let manifestLoader = ManifestLoader(toolchain: try UserToolchain.default)
 
-                let sandbox = path.appending(component: "ws")
+                let sandbox = path.appending("ws")
                 return try Workspace(
                     fileSystem: fs,
                     forRootPackage: sandbox,
@@ -213,8 +213,8 @@ final class WorkspaceTests: XCTestCase {
         let observability = ObservabilitySystem.makeForTesting()
 
         try testWithTemporaryDirectory { path in
-            let pkgDir = path.appending(component: "MyPkg")
-            try localFileSystem.writeFileContents(pkgDir.appending(component: "Package.swift")) {
+            let pkgDir = path.appending("MyPkg")
+            try localFileSystem.writeFileContents(pkgDir.appending("Package.swift")) {
                 $0 <<<
                     """
                     // swift-tools-version:4.0
@@ -256,7 +256,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testMultipleRootPackages() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -313,7 +313,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testRootPackagesOverride() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -375,7 +375,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDuplicateRootPackages() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -412,7 +412,7 @@ final class WorkspaceTests: XCTestCase {
 
     /// Test that the explicit name given to a package is not used as its identity.
     func testExplicitPackageNameIsNotUsedAsPackageIdentity() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -485,7 +485,7 @@ final class WorkspaceTests: XCTestCase {
 
     /// Test that the remote repository is not resolved when a root package with same name is already present.
     func testRootAsDependency1() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -546,7 +546,7 @@ final class WorkspaceTests: XCTestCase {
 
     /// Test that a root package can be used as a dependency when the remote version was resolved previously.
     func testRootAsDependency2() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -633,7 +633,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testGraphRootDependencies() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -669,12 +669,12 @@ final class WorkspaceTests: XCTestCase {
 
         let dependencies: [PackageDependency] = [
             .localSourceControl(
-                path: workspace.packagesDir.appending(component: "Bar"),
+                path: workspace.packagesDir.appending("Bar"),
                 requirement: .upToNextMajor(from: "1.0.0"),
                 productFilter: .specific(["Bar"])
             ),
             .localSourceControl(
-                path: workspace.packagesDir.appending(component: "Foo"),
+                path: workspace.packagesDir.appending("Foo"),
                 requirement: .upToNextMajor(from: "1.0.0"),
                 productFilter: .specific(["Foo"])
             ),
@@ -695,7 +695,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testCanResolveWithIncompatiblePins() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -797,7 +797,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testResolverCanHaveError() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -858,7 +858,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testPrecomputeResolution_empty() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
         let v1_5 = CheckoutState.version("1.0.5", revision: Revision(identifier: "hello"))
@@ -904,7 +904,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testPrecomputeResolution_newPackages() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
         let v1Requirement: SourceControlRequirement = .range("1.0.0" ..< "2.0.0")
@@ -966,7 +966,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testPrecomputeResolution_requirementChange_versionToBranch() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
         let cPath = RelativePath("C")
@@ -1035,7 +1035,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testPrecomputeResolution_requirementChange_versionToRevision() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let cPath = RelativePath("C")
         let v1_5 = CheckoutState.version("1.0.5", revision: Revision(identifier: "hello"))
@@ -1087,7 +1087,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testPrecomputeResolution_requirementChange_localToBranch() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
         let v1Requirement: SourceControlRequirement = .range("1.0.0" ..< "2.0.0")
@@ -1155,7 +1155,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testPrecomputeResolution_requirementChange_versionToLocal() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
         let cPath = RelativePath("C")
@@ -1223,7 +1223,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testPrecomputeResolution_requirementChange_branchToLocal() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
         let cPath = RelativePath("C")
@@ -1292,7 +1292,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testPrecomputeResolution_other() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
         let cPath = RelativePath("C")
@@ -1364,7 +1364,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testPrecomputeResolution_notRequired() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
         let cPath = RelativePath("C")
@@ -1430,7 +1430,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testLoadingRootManifests() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -1454,7 +1454,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testUpdate() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -1555,7 +1555,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testUpdateDryRun() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -1626,7 +1626,7 @@ final class WorkspaceTests: XCTestCase {
                 .updated(.init(requirement: .version(Version("1.5.0")), products: .everything))
             #endif
 
-            let path = AbsolutePath(path: "/tmp/ws/pkgs/Foo")
+            let path = AbsolutePath("/tmp/ws/pkgs/Foo")
             let expectedChange = (
                 PackageReference.localSourceControl(identity: PackageIdentity(path: path), path: path),
                 stateChange
@@ -1650,7 +1650,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testPartialUpdate() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -1754,7 +1754,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testCleanAndReset() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -1795,7 +1795,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Drop a build artifact in data directory.
         let ws = try workspace.getOrCreateWorkspace()
-        let buildArtifact = ws.location.scratchDirectory.appending(component: "test.o")
+        let buildArtifact = ws.location.scratchDirectory.appending("test.o")
         try fs.writeFileContents(buildArtifact, bytes: "Hi")
 
         // Double checks.
@@ -1833,7 +1833,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDependencyManifestLoading() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -1912,7 +1912,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDependencyManifestsOrder() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -1981,7 +1981,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testBranchAndRevision() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -2045,7 +2045,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testResolve() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -2118,7 +2118,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDeletedCheckoutDirectory() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -2164,7 +2164,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testMinimumRequiredToolsVersionInDependencyResolution() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -2205,7 +2205,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testToolsVersionRootPackages() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -2238,7 +2238,7 @@ final class WorkspaceTests: XCTestCase {
             toolsVersion: .v4
         )
 
-        let roots = try workspace.rootPaths(for: ["Foo", "Bar", "Baz"]).map { $0.appending(component: "Package.swift") }
+        let roots = try workspace.rootPaths(for: ["Foo", "Bar", "Baz"]).map { $0.appending("Package.swift") }
 
         try fs.writeFileContents(roots[0], bytes: "// swift-tools-version:4.0")
         try fs.writeFileContents(roots[1], bytes: "// swift-tools-version:4.1.0")
@@ -2284,7 +2284,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testEditDependency() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -2337,7 +2337,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // Edit foo.
-        let fooPath = try workspace.getOrCreateWorkspace().location.editsDirectory.appending(component: "Foo")
+        let fooPath = try workspace.getOrCreateWorkspace().location.editsDirectory.appending("Foo")
         workspace.checkEdit(packageName: "Foo") { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
@@ -2370,7 +2370,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // Edit bar at a custom path and branch (ToT).
-        let barPath = AbsolutePath(path: "/tmp/ws/custom/bar")
+        let barPath = AbsolutePath("/tmp/ws/custom/bar")
         workspace.checkEdit(packageName: "Bar", path: barPath, checkoutBranch: "dev") { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
@@ -2392,7 +2392,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testMissingEditCanRestoreOriginalCheckout() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -2428,7 +2428,7 @@ final class WorkspaceTests: XCTestCase {
         try workspace.checkPackageGraph(roots: ["Root"]) { _, _ in }
 
         // Edit foo.
-        let fooPath = try workspace.getOrCreateWorkspace().location.editsDirectory.appending(component: "Foo")
+        let fooPath = try workspace.getOrCreateWorkspace().location.editsDirectory.appending("Foo")
         workspace.checkEdit(packageName: "Foo") { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
@@ -2455,7 +2455,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testCanUneditRemovedDependencies() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -2529,7 +2529,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDependencyResolutionWithEdit() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -2650,7 +2650,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testPrefetchingWithOverridenPackage() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -2735,7 +2735,7 @@ final class WorkspaceTests: XCTestCase {
 
     // Test that changing a particular dependency re-resolves the graph.
     func testChangeOneDependency() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -2820,7 +2820,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testResolutionFailureWithEditedDependency() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -2900,7 +2900,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testStateModified() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -2960,10 +2960,7 @@ final class WorkspaceTests: XCTestCase {
         // mimic external process putting a dependency into edit mode
         do {
             try fs.createDirectory(fooEditPath, recursive: true)
-            try fs.writeFileContents(
-                fooEditPath.appending(component: "Package.swift"),
-                bytes: "// swift-tools-version: 5.6"
-            )
+            try fs.writeFileContents(fooEditPath.appending("Package.swift"), bytes: "// swift-tools-version: 5.6")
 
             let fooState = underlying.state.dependencies[.plain("foo")]!
             let externalState = WorkspaceState(
@@ -2995,7 +2992,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testSkipUpdate() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -3044,7 +3041,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testLocalDependencyBasics() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -3122,7 +3119,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testLocalDependencyTransitive() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -3184,7 +3181,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testLocalDependencyWithPackageUpdate() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -3248,7 +3245,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testMissingLocalDependencyDiagnostic() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -3288,7 +3285,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testRevisionVersionSwitch() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -3357,7 +3354,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testLocalVersionSwitch() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -3426,7 +3423,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testLocalLocalSwitch() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -3498,7 +3495,7 @@ final class WorkspaceTests: XCTestCase {
     // Test that switching between two same local packages placed at
     // different locations works correctly.
     func testDependencySwitchLocalWithSameIdentity() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -3575,7 +3572,7 @@ final class WorkspaceTests: XCTestCase {
     // Test that switching between two remote packages at
     // different locations works correctly.
     func testDependencySwitchRemoteWithSameIdentity() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -3651,7 +3648,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testResolvedFileUpdate() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -3713,7 +3710,7 @@ final class WorkspaceTests: XCTestCase {
             (ToolsVersion.v5_6, ToolsVersion.v5_6),
             (ToolsVersion.v5_2, ToolsVersion.v5_6),
         ] {
-            let sandbox = AbsolutePath(path: "/tmp/ws/")
+            let sandbox = AbsolutePath("/tmp/ws/")
             let workspace = try MockWorkspace(
                 sandbox: sandbox,
                 fileSystem: fs,
@@ -3774,7 +3771,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testResolvedFileStableCanonicalLocation() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -3891,7 +3888,7 @@ final class WorkspaceTests: XCTestCase {
 
         // reset state, excluding the resolved file
         try workspace.closeWorkspace()
-        XCTAssertTrue(fs.exists(sandbox.appending(component: "Package.resolved")))
+        XCTAssertTrue(fs.exists(sandbox.appending("Package.resolved")))
         // run update
         try workspace.checkUpdate(roots: ["Root"], deps: deps) { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
@@ -3926,7 +3923,7 @@ final class WorkspaceTests: XCTestCase {
         ]
         // reset state, excluding the resolved file
         try workspace.closeWorkspace()
-        XCTAssertTrue(fs.exists(sandbox.appending(component: "Package.resolved")))
+        XCTAssertTrue(fs.exists(sandbox.appending("Package.resolved")))
         // run update
         try workspace.checkUpdate(roots: ["Root"], deps: deps) { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
@@ -3964,8 +3961,8 @@ final class WorkspaceTests: XCTestCase {
         ]
         // reset state, including the resolved file
         workspace.checkReset { XCTAssertNoDiagnostics($0) }
-        try fs.removeFileTree(sandbox.appending(component: "Package.resolved"))
-        XCTAssertFalse(fs.exists(sandbox.appending(component: "Package.resolved")))
+        try fs.removeFileTree(sandbox.appending("Package.resolved"))
+        XCTAssertFalse(fs.exists(sandbox.appending("Package.resolved")))
         // run update
         try workspace.checkUpdate(roots: ["Root"], deps: deps) { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
@@ -4000,7 +3997,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testPackageSimpleMirrorPath() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let mirrors = DependencyMirrors()
@@ -4092,7 +4089,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testPackageMirrorPath() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let mirrors = DependencyMirrors()
@@ -4195,7 +4192,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testPackageSimpleMirrorURL() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let mirrors = DependencyMirrors()
@@ -4284,7 +4281,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testPackageMirrorURL() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let mirrors = DependencyMirrors()
@@ -4389,7 +4386,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testPackageMirrorURLToRegistry() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let mirrors = DependencyMirrors()
@@ -4459,7 +4456,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testPackageMirrorRegistryToURL() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let mirrors = DependencyMirrors()
@@ -4532,7 +4529,7 @@ final class WorkspaceTests: XCTestCase {
     // file for a transitive dependency whose URL is later changed to
     // something else, while keeping the same package identity.
     func testTransitiveDependencySwitchWithSameIdentity() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         // Use the same revision (hash) for "foo" to indicate they are the same
@@ -4679,7 +4676,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testForceResolveToResolvedVersions() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -4802,7 +4799,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testForceResolveToResolvedVersionsDuplicateLocalDependency() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -4853,7 +4850,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testForceResolveWithNoResolvedFile() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -4910,7 +4907,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testForceResolveToResolvedVersionsLocalPackage() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -4956,7 +4953,7 @@ final class WorkspaceTests: XCTestCase {
 
         try testWithTemporaryDirectory { path in
             // Create a temporary package as a test case.
-            let packagePath = path.appending(component: "MyPkg")
+            let packagePath = path.appending("MyPkg")
             let initPackage = try InitPackage(
                 name: packagePath.basename,
                 packageType: .executable,
@@ -5017,7 +5014,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testRevisionDepOnLocal() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -5075,7 +5072,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testRootPackagesOverrideBasenameMismatch() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -5125,7 +5122,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testManagedDependenciesNotCaseSensitive() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -5219,7 +5216,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testUnsafeFlags() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -5299,7 +5296,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testEditDependencyHadOverridableConstraints() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -5369,7 +5366,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // Edit foo.
-        let fooPath = try workspace.getOrCreateWorkspace().location.editsDirectory.appending(component: "Foo")
+        let fooPath = try workspace.getOrCreateWorkspace().location.editsDirectory.appending("Foo")
         workspace.checkEdit(packageName: "Foo") { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
@@ -5400,7 +5397,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testTargetBasedDependency() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let barProducts: [MockProduct]
@@ -5507,7 +5504,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testLocalArchivedArtifactExtractionHappyPath() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         // create dummy xcframework and artifactbundle directories from the request archive
@@ -5593,35 +5590,35 @@ final class WorkspaceTests: XCTestCase {
         // Create dummy xcframework/artifactbundle zip files
         let aPath = workspace.packagesDir.appending(components: "A")
 
-        let aFrameworksPath = aPath.appending(component: "XCFrameworks")
-        let a1FrameworkArchivePath = aFrameworksPath.appending(component: "A1.zip")
+        let aFrameworksPath = aPath.appending("XCFrameworks")
+        let a1FrameworkArchivePath = aFrameworksPath.appending("A1.zip")
         try fs.createDirectory(aFrameworksPath, recursive: true)
         try fs.writeFileContents(a1FrameworkArchivePath, bytes: ByteString([0xA1]))
 
-        let aArtifactBundlesPath = aPath.appending(component: "ArtifactBundles")
-        let a2ArtifactBundleArchivePath = aArtifactBundlesPath.appending(component: "A2.zip")
+        let aArtifactBundlesPath = aPath.appending("ArtifactBundles")
+        let a2ArtifactBundleArchivePath = aArtifactBundlesPath.appending("A2.zip")
         try fs.createDirectory(aArtifactBundlesPath, recursive: true)
         try fs.writeFileContents(a2ArtifactBundleArchivePath, bytes: ByteString([0xA2]))
 
         let bPath = workspace.packagesDir.appending(components: "B")
 
-        let bFrameworksPath = bPath.appending(component: "XCFrameworks")
-        let bFrameworkArchivePath = bFrameworksPath.appending(component: "B.zip")
+        let bFrameworksPath = bPath.appending("XCFrameworks")
+        let bFrameworkArchivePath = bFrameworksPath.appending("B.zip")
         try fs.createDirectory(bFrameworksPath, recursive: true)
         try fs.writeFileContents(bFrameworkArchivePath, bytes: ByteString([0xB0]))
 
         // Ensure that the artifacts do not exist yet
-        XCTAssertFalse(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/A/A1.xcframework")))
-        XCTAssertFalse(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/A/A2.artifactbundle")))
-        XCTAssertFalse(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/B/B.xcframework")))
+        XCTAssertFalse(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/A/A1.xcframework")))
+        XCTAssertFalse(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/A/A2.artifactbundle")))
+        XCTAssertFalse(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/B/B.xcframework")))
 
         try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
 
             // Ensure that the artifacts have been properly extracted
-            XCTAssertTrue(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/a/A1/A1.xcframework")))
-            XCTAssertTrue(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/a/A2/A2.artifactbundle")))
-            XCTAssertTrue(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/b/B/B.xcframework")))
+            XCTAssertTrue(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/a/A1/A1.xcframework")))
+            XCTAssertTrue(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/a/A2/A2.artifactbundle")))
+            XCTAssertTrue(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/b/B/B.xcframework")))
 
             // Ensure that the original archives have been untouched
             XCTAssertTrue(fs.exists(a1FrameworkArchivePath))
@@ -5630,24 +5627,15 @@ final class WorkspaceTests: XCTestCase {
 
             // Ensure that the temporary folders have been properly created
             XCTAssertEqual(archiver.extractions.map(\.destinationPath.parentDirectory).sorted(), [
-                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A1"),
-                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A2"),
-                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/b/B"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A1"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A2"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/b/B"),
             ])
 
             // Ensure that the temporary directories have been removed
-            XCTAssertTrue(
-                try! fs.getDirectoryContents(AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A1"))
-                    .isEmpty
-            )
-            XCTAssertTrue(
-                try! fs.getDirectoryContents(AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A2"))
-                    .isEmpty
-            )
-            XCTAssertTrue(
-                try! fs.getDirectoryContents(AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/b/B"))
-                    .isEmpty
-            )
+            XCTAssertTrue(try! fs.getDirectoryContents(AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A1")).isEmpty)
+            XCTAssertTrue(try! fs.getDirectoryContents(AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A2")).isEmpty)
+            XCTAssertTrue(try! fs.getDirectoryContents(AbsolutePath("/tmp/ws/.build/artifacts/extract/b/B")).isEmpty)
         }
 
         workspace.checkManagedArtifacts { result in
@@ -5686,7 +5674,7 @@ final class WorkspaceTests: XCTestCase {
     // It ensures that all the appropriate clean-up operations are executed, and the workspace
     // contains the correct set of managed artifacts after the transition.
     func testLocalArchivedArtifactSourceTransitionPermutations() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let a1FrameworkName = "A1.xcframework"
@@ -5821,19 +5809,19 @@ final class WorkspaceTests: XCTestCase {
         try fs.createDirectory(aFrameworksPath, recursive: true)
 
         let a1FrameworkPath = aFrameworksPath.appending(component: a1FrameworkName)
-        let a1FrameworkArchivePath = aFrameworksPath.appending(component: "A1.zip")
+        let a1FrameworkArchivePath = aFrameworksPath.appending("A1.zip")
         try fs.createDirectory(a1FrameworkPath, recursive: true)
         try fs.writeFileContents(a1FrameworkArchivePath, bytes: ByteString([0xA1]))
 
         let a2FrameworkPath = aFrameworksPath.appending(component: a2FrameworkName)
-        let a2FrameworkArchivePath = aFrameworksPath.appending(component: "A2.zip")
+        let a2FrameworkArchivePath = aFrameworksPath.appending("A2.zip")
         try createDummyXCFramework(fileSystem: fs, path: a2FrameworkPath.parentDirectory, name: "A2")
         try fs.writeFileContents(a2FrameworkArchivePath, bytes: ByteString([0xA2]))
 
-        let a3FrameworkArchivePath = aFrameworksPath.appending(component: "A3.zip")
+        let a3FrameworkArchivePath = aFrameworksPath.appending("A3.zip")
         try fs.writeFileContents(a3FrameworkArchivePath, bytes: ByteString([0xA3]))
 
-        let a4FrameworkArchivePath = aFrameworksPath.appending(component: "A4.zip")
+        let a4FrameworkArchivePath = aFrameworksPath.appending("A4.zip")
         try fs.writeFileContents(a4FrameworkArchivePath, bytes: ByteString([0xA4]))
 
         // Pin A to 1.0.0, Checkout B to 1.0.0
@@ -5961,7 +5949,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testLocalArchivedArtifactNameDoesNotMatchTargetName() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         // create a dummy xcframework directory from the request archive
@@ -6007,10 +5995,10 @@ final class WorkspaceTests: XCTestCase {
 
         // Create dummy zip files
         let rootPath = try workspace.pathToRoot(withName: "Root")
-        let frameworksPath = rootPath.appending(component: "XCFrameworks")
+        let frameworksPath = rootPath.appending("XCFrameworks")
         try fs.createDirectory(frameworksPath, recursive: true)
         try fs.writeFileContents(
-            frameworksPath.appending(component: "archived-does-not-match-target-name.zip"),
+            frameworksPath.appending("archived-does-not-match-target-name.zip"),
             bytes: ByteString([0xA1])
         )
 
@@ -6020,7 +6008,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testLocalArchivedArtifactExtractionError() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let archiver = MockArchiver(handler: { _, _, _, completion in
@@ -6071,7 +6059,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testLocalArchiveDoesNotMatchTargetName() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         // create dummy xcframework and artifactbundle directories from the request archive
@@ -6117,13 +6105,13 @@ final class WorkspaceTests: XCTestCase {
 
         // Create dummy zip files
         let rootPath = try workspace.pathToRoot(withName: "Root")
-        let frameworksPath = rootPath.appending(component: "XCFrameworks")
+        let frameworksPath = rootPath.appending("XCFrameworks")
         try fs.createDirectory(frameworksPath, recursive: true)
-        try fs.writeFileContents(frameworksPath.appending(component: "A1.zip"), bytes: ByteString([0xA1]))
+        try fs.writeFileContents(frameworksPath.appending("A1.zip"), bytes: ByteString([0xA1]))
 
-        let aArtifactBundlesPath = rootPath.appending(component: "ArtifactBundles")
+        let aArtifactBundlesPath = rootPath.appending("ArtifactBundles")
         try fs.createDirectory(aArtifactBundlesPath, recursive: true)
-        try fs.writeFileContents(aArtifactBundlesPath.appending(component: "A2.zip"), bytes: ByteString([0xA2]))
+        try fs.writeFileContents(aArtifactBundlesPath.appending("A2.zip"), bytes: ByteString([0xA2]))
 
         try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
@@ -6146,7 +6134,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testLocalArchivedArtifactChecksumChange() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         // create dummy xcframework directories from the request archive
@@ -6220,16 +6208,16 @@ final class WorkspaceTests: XCTestCase {
         let frameworksPath = rootPath.appending(components: "XCFrameworks")
         try fs.createDirectory(frameworksPath, recursive: true)
 
-        let a1FrameworkArchivePath = frameworksPath.appending(component: "A1.zip")
+        let a1FrameworkArchivePath = frameworksPath.appending("A1.zip")
         try fs.writeFileContents(a1FrameworkArchivePath, bytes: ByteString([0xA1]))
 
-        let a2FrameworkArchivePath = frameworksPath.appending(component: "A2.zip")
+        let a2FrameworkArchivePath = frameworksPath.appending("A2.zip")
         try fs.writeFileContents(a2FrameworkArchivePath, bytes: ByteString([0xA2]))
 
         try workspace.checkPackageGraph(roots: ["Root"]) { _, _ in
             // Ensure that only the artifact archive with the changed checksum has been extracted
             XCTAssertEqual(archiver.extractions.map(\.destinationPath.parentDirectory).sorted(), [
-                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/A1"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/root/A1"),
             ])
         }
 
@@ -6250,7 +6238,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testLocalArchivedArtifactStripFirstComponent() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         // create a dummy xcframework directory from the request archive
@@ -6260,16 +6248,16 @@ final class WorkspaceTests: XCTestCase {
                 case "flat.zip":
                     try createDummyXCFramework(fileSystem: fs, path: destinationPath, name: "flat")
                 case "nested.zip":
-                    let nestedPath = destinationPath.appending(component: "root")
+                    let nestedPath = destinationPath.appending("root")
                     try fs.createDirectory(nestedPath, recursive: true)
                     try createDummyXCFramework(fileSystem: fs, path: nestedPath, name: "nested")
                 case "nested2.zip":
-                    let nestedPath = destinationPath.appending(component: "root")
+                    let nestedPath = destinationPath.appending("root")
                     try fs.createDirectory(nestedPath, recursive: true)
                     try createDummyXCFramework(fileSystem: fs, path: destinationPath, name: "nested2")
                     try fs
                         .writeFileContents(
-                            nestedPath.appending(component: ".DS_Store"),
+                            nestedPath.appending(".DS_Store"),
                             bytes: []
                         ) // add a file next to the directory
                 default:
@@ -6318,22 +6306,22 @@ final class WorkspaceTests: XCTestCase {
         let rootPath = try workspace.pathToRoot(withName: "Root")
         let archivesPath = rootPath.appending(components: "frameworks")
         try fs.createDirectory(archivesPath, recursive: true)
-        try fs.writeFileContents(archivesPath.appending(component: "flat.zip"), bytes: ByteString([0x1]))
-        try fs.writeFileContents(archivesPath.appending(component: "nested.zip"), bytes: ByteString([0x2]))
-        try fs.writeFileContents(archivesPath.appending(component: "nested2.zip"), bytes: ByteString([0x3]))
+        try fs.writeFileContents(archivesPath.appending("flat.zip"), bytes: ByteString([0x1]))
+        try fs.writeFileContents(archivesPath.appending("nested.zip"), bytes: ByteString([0x2]))
+        try fs.writeFileContents(archivesPath.appending("nested2.zip"), bytes: ByteString([0x3]))
 
         // ensure that the artifacts do not exist yet
-        XCTAssertFalse(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/root/flat/flat.xcframework")))
-        XCTAssertFalse(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/root/nested/nested.artifactbundle")))
-        XCTAssertFalse(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/root/nested2/nested2.xcframework")))
+        XCTAssertFalse(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/root/flat/flat.xcframework")))
+        XCTAssertFalse(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/root/nested/nested.artifactbundle")))
+        XCTAssertFalse(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/root/nested2/nested2.xcframework")))
 
         try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            XCTAssert(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/root")))
+            XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/root")))
             XCTAssertEqual(archiver.extractions.map(\.destinationPath.parentDirectory).sorted(), [
-                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/flat"),
-                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/nested"),
-                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/nested2"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/root/flat"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/root/nested"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/root/nested2"),
             ])
         }
 
@@ -6360,7 +6348,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testLocalArtifactHappyPath() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -6388,12 +6376,8 @@ final class WorkspaceTests: XCTestCase {
         let rootPath = try workspace.pathToRoot(withName: "Root")
 
         // make sure the directory exist in their destined location
-        try createDummyXCFramework(fileSystem: fs, path: rootPath.appending(component: "XCFrameworks"), name: "A1")
-        try createDummyArtifactBundle(
-            fileSystem: fs,
-            path: rootPath.appending(component: "ArtifactBundles"),
-            name: "A2"
-        )
+        try createDummyXCFramework(fileSystem: fs, path: rootPath.appending("XCFrameworks"), name: "A1")
+        try createDummyArtifactBundle(fileSystem: fs, path: rootPath.appending("ArtifactBundles"), name: "A2")
 
         try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
@@ -6416,7 +6400,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testLocalArtifactDoesNotExist() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -6445,13 +6429,13 @@ final class WorkspaceTests: XCTestCase {
             testDiagnostics(diagnostics) { result in
                 result.checkUnordered(
                     diagnostic: .contains(
-                        "local binary target 'A1' at '\(AbsolutePath(path: "/tmp/ws/roots/Root/XCFrameworks/incorrect.xcframework"))' does not contain a binary artifact."
+                        "local binary target 'A1' at '\(AbsolutePath("/tmp/ws/roots/Root/XCFrameworks/incorrect.xcframework"))' does not contain a binary artifact."
                     ),
                     severity: .error
                 )
                 result.checkUnordered(
                     diagnostic: .contains(
-                        "local binary target 'A2' at '\(AbsolutePath(path: "/tmp/ws/roots/Root/ArtifactBundles/incorrect.artifactbundle"))' does not contain a binary artifact."
+                        "local binary target 'A2' at '\(AbsolutePath("/tmp/ws/roots/Root/ArtifactBundles/incorrect.artifactbundle"))' does not contain a binary artifact."
                     ),
                     severity: .error
                 )
@@ -6460,7 +6444,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testArtifactDownloadHappyPath() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let downloads = ThreadSafeKeyValueStore<URL, AbsolutePath>()
 
@@ -6584,8 +6568,8 @@ final class WorkspaceTests: XCTestCase {
 
         try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            XCTAssert(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/a")))
-            XCTAssert(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/b")))
+            XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/a")))
+            XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/b")))
             XCTAssertEqual(downloads.map(\.key.absoluteString).sorted(), [
                 "https://a.com/a1.zip",
                 "https://a.com/a2.zip",
@@ -6597,9 +6581,9 @@ final class WorkspaceTests: XCTestCase {
                 ByteString([0xB0]).hexadecimalRepresentation,
             ])
             XCTAssertEqual(archiver.extractions.map(\.destinationPath.parentDirectory).sorted(), [
-                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A1"),
-                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A2"),
-                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/b/B"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A1"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A2"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/b/B"),
             ])
             XCTAssertEqual(
                 downloads.map(\.value).sorted(),
@@ -6652,7 +6636,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testArtifactDownloadWithPreviousState() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let downloads = ThreadSafeKeyValueStore<URL, AbsolutePath>()
 
@@ -6882,14 +6866,14 @@ final class WorkspaceTests: XCTestCase {
                     severity: .error
                 )
             }
-            XCTAssert(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/b")))
-            XCTAssert(fs.exists(AbsolutePath(path: "/tmp/ws/.build/artifacts/a/A1/A1.xcframework")))
-            XCTAssert(fs.exists(AbsolutePath(path: "/tmp/ws/.build/artifacts/a/A2/A2.xcframework")))
-            XCTAssert(!fs.exists(AbsolutePath(path: "/tmp/ws/.build/artifacts/a/A3/A3.xcframework")))
-            XCTAssert(!fs.exists(AbsolutePath(path: "/tmp/ws/.build/artifacts/a/A4/A4.xcframework")))
-            XCTAssert(!fs.exists(AbsolutePath(path: "/tmp/ws/.build/artifacts/a/A5/A5.xcframework")))
-            XCTAssert(fs.exists(AbsolutePath(path: "/tmp/ws/pkgs/a/XCFrameworks/A7.xcframework")))
-            XCTAssert(!fs.exists(AbsolutePath(path: "/tmp/ws/.build/artifacts/Foo")))
+            XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/b")))
+            XCTAssert(fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/a/A1/A1.xcframework")))
+            XCTAssert(fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/a/A2/A2.xcframework")))
+            XCTAssert(!fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/a/A3/A3.xcframework")))
+            XCTAssert(!fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/a/A4/A4.xcframework")))
+            XCTAssert(!fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/a/A5/A5.xcframework")))
+            XCTAssert(fs.exists(AbsolutePath("/tmp/ws/pkgs/a/XCFrameworks/A7.xcframework")))
+            XCTAssert(!fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/Foo")))
             XCTAssertEqual(downloads.map(\.key.absoluteString).sorted(), [
                 "https://a.com/a2.zip",
                 "https://a.com/a3.zip",
@@ -6903,10 +6887,10 @@ final class WorkspaceTests: XCTestCase {
                 ByteString([0xB0]).hexadecimalRepresentation,
             ])
             XCTAssertEqual(archiver.extractions.map(\.destinationPath.parentDirectory).sorted(), [
-                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A2"),
-                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A3"),
-                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A7"),
-                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/b/B"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A2"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A3"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A7"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/b/B"),
             ])
             XCTAssertEqual(
                 downloads.map(\.value).sorted(),
@@ -6963,7 +6947,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testArtifactDownloadTwice() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let downloads = ThreadSafeArrayStore<(URL, AbsolutePath)>()
 
@@ -7042,7 +7026,7 @@ final class WorkspaceTests: XCTestCase {
 
         try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            XCTAssert(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/root")))
+            XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/root")))
             XCTAssertEqual(workspace.checksumAlgorithm.hashes.map(\.hexadecimalRepresentation).sorted(), [
                 ByteString([0xA1]).hexadecimalRepresentation,
             ])
@@ -7052,7 +7036,7 @@ final class WorkspaceTests: XCTestCase {
             "https://a.com/a1.zip",
         ])
         XCTAssertEqual(archiver.extractions.map(\.destinationPath.parentDirectory).sorted(), [
-            AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/A1"),
+            AbsolutePath("/tmp/ws/.build/artifacts/extract/root/A1"),
         ])
         XCTAssertEqual(
             downloads.map(\.1).sorted(),
@@ -7067,7 +7051,7 @@ final class WorkspaceTests: XCTestCase {
 
         try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            XCTAssert(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/root")))
+            XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/root")))
 
             XCTAssertEqual(workspace.checksumAlgorithm.hashes.map(\.hexadecimalRepresentation).sorted(), [
                 ByteString([0xA1]).hexadecimalRepresentation, ByteString([0xA1]).hexadecimalRepresentation,
@@ -7078,8 +7062,8 @@ final class WorkspaceTests: XCTestCase {
             "https://a.com/a1.zip", "https://a.com/a1.zip",
         ])
         XCTAssertEqual(archiver.extractions.map(\.destinationPath.parentDirectory).sorted(), [
-            AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/A1"),
-            AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/A1"),
+            AbsolutePath("/tmp/ws/.build/artifacts/extract/root/A1"),
+            AbsolutePath("/tmp/ws/.build/artifacts/extract/root/A1"),
         ])
         XCTAssertEqual(
             downloads.map(\.1).sorted(),
@@ -7089,7 +7073,7 @@ final class WorkspaceTests: XCTestCase {
 
     func testArtifactDownloadServerError() throws {
         let fs = InMemoryFileSystem()
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         try fs.createDirectory(sandbox, recursive: true)
 
         let httpClient = LegacyHTTPClient(handler: { request, _, completion in
@@ -7144,12 +7128,12 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // make sure artifact downloaded is deleted
-        XCTAssertTrue(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/root")))
-        XCTAssertFalse(fs.exists(AbsolutePath(path: "/tmp/ws/.build/artifacts/root/a.zip")))
+        XCTAssertTrue(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/root")))
+        XCTAssertFalse(fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/root/a.zip")))
     }
 
     func testArtifactDownloaderOrArchiverError() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         // returns a dummy zipfile for the requested artifact
@@ -7177,10 +7161,7 @@ final class WorkspaceTests: XCTestCase {
         })
 
         let archiver = MockArchiver(handler: { _, _, destinationPath, completion in
-            XCTAssertEqual(
-                destinationPath.parentDirectory,
-                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/A2")
-            )
+            XCTAssertEqual(destinationPath.parentDirectory, AbsolutePath("/tmp/ws/.build/artifacts/extract/root/A2"))
             completion(.failure(DummyError()))
         })
 
@@ -7243,7 +7224,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDownloadedArtifactNotAnArchiveError() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         // returns a dummy zipfile for the requested artifact
@@ -7355,7 +7336,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDownloadedArtifactInvalid() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         // returns a dummy zipfile for the requested artifact
@@ -7430,7 +7411,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDownloadedArtifactDoesNotMatchTargetName() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         // returns a dummy zipfile for the requested artifact
@@ -7510,7 +7491,7 @@ final class WorkspaceTests: XCTestCase {
 
     func testArtifactChecksum() throws {
         let fs = InMemoryFileSystem()
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         try fs.createDirectory(sandbox, recursive: true)
 
         let checksumAlgorithm = MockHashAlgorithm()
@@ -7526,7 +7507,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Checks the valid case.
         do {
-            let binaryPath = sandbox.appending(component: "binary.zip")
+            let binaryPath = sandbox.appending("binary.zip")
             try fs.writeFileContents(binaryPath, bytes: ByteString([0xAA, 0xBB, 0xCC]))
 
             let checksum = try binaryArtifactsManager.checksum(forBinaryArtifactAt: binaryPath)
@@ -7536,7 +7517,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Checks an unsupported extension.
         do {
-            let unknownPath = sandbox.appending(component: "unknown")
+            let unknownPath = sandbox.appending("unknown")
             XCTAssertThrowsError(
                 try binaryArtifactsManager.checksum(forBinaryArtifactAt: unknownPath),
                 "error expected"
@@ -7550,21 +7531,21 @@ final class WorkspaceTests: XCTestCase {
 
         // Checks a supported extension that is not a file (does not exist).
         do {
-            let unknownPath = sandbox.appending(component: "missingFile.zip")
+            let unknownPath = sandbox.appending("missingFile.zip")
             XCTAssertThrowsError(
                 try binaryArtifactsManager.checksum(forBinaryArtifactAt: unknownPath),
                 "error expected"
             ) { error in
                 XCTAssertEqual(
                     error as? StringError,
-                    StringError("file not found at path: \(sandbox.appending(component: "missingFile.zip"))")
+                    StringError("file not found at path: \(sandbox.appending("missingFile.zip"))")
                 )
             }
         }
 
         // Checks a supported extension that is a directory instead of a file.
         do {
-            let unknownPath = sandbox.appending(component: "aDirectory.zip")
+            let unknownPath = sandbox.appending("aDirectory.zip")
             try fs.createDirectory(unknownPath)
             XCTAssertThrowsError(
                 try binaryArtifactsManager.checksum(forBinaryArtifactAt: unknownPath),
@@ -7572,14 +7553,14 @@ final class WorkspaceTests: XCTestCase {
             ) { error in
                 XCTAssertEqual(
                     error as? StringError,
-                    StringError("file not found at path: \(sandbox.appending(component: "aDirectory.zip"))")
+                    StringError("file not found at path: \(sandbox.appending("aDirectory.zip"))")
                 )
             }
         }
     }
 
     func testDownloadedArtifactChecksumChange() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let httpClient = LegacyHTTPClient(handler: { _, _, _ in
@@ -7631,7 +7612,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDownloadedArtifactChecksumChangeURLChange() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let httpClient = LegacyHTTPClient(handler: { request, _, completion in
@@ -7726,7 +7707,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testArtifactDownloadAddsAcceptHeader() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let downloads = ThreadSafeKeyValueStore<URL, AbsolutePath>()
         var acceptHeaders: [String] = []
@@ -7808,7 +7789,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDownloadedArtifactTransitive() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let downloads = ThreadSafeKeyValueStore<URL, AbsolutePath>()
 
@@ -7951,7 +7932,7 @@ final class WorkspaceTests: XCTestCase {
 
         try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            XCTAssert(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/a")))
+            XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/a")))
             XCTAssertEqual(downloads.map(\.key.absoluteString).sorted(), [
                 "https://a.com/a.zip",
             ])
@@ -7959,7 +7940,7 @@ final class WorkspaceTests: XCTestCase {
                 ByteString([0xA]).hexadecimalRepresentation,
             ])
             XCTAssertEqual(archiver.extractions.map(\.destinationPath.parentDirectory).sorted(), [
-                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A"),
             ])
             XCTAssertEqual(
                 downloads.map(\.value).sorted(),
@@ -7981,7 +7962,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDownloadedArtifactArchiveExists() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         // this relies on internal knowledge of the destination path construction
         let expectedDownloadDestination = sandbox.appending(
@@ -8095,7 +8076,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDownloadedArtifactConcurrency() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let maxConcurrentRequests = 2
@@ -8216,7 +8197,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDownloadedArtifactStripFirstComponent() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let downloads = ThreadSafeKeyValueStore<URL, AbsolutePath>()
 
@@ -8261,18 +8242,18 @@ final class WorkspaceTests: XCTestCase {
                     archiver.extractions
                         .append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
                 case "nested.zip":
-                    let nestedPath = destinationPath.appending(component: "root")
+                    let nestedPath = destinationPath.appending("root")
                     try fs.createDirectory(nestedPath)
                     try createDummyXCFramework(fileSystem: fs, path: nestedPath, name: "nested")
                     archiver.extractions
                         .append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
                 case "nested2.zip":
-                    let nestedPath = destinationPath.appending(component: "root")
+                    let nestedPath = destinationPath.appending("root")
                     try fs.createDirectory(nestedPath)
                     try createDummyXCFramework(fileSystem: fs, path: nestedPath, name: "nested2")
                     try fs
                         .writeFileContents(
-                            nestedPath.appending(component: ".DS_Store"),
+                            nestedPath.appending(".DS_Store"),
                             bytes: []
                         ) // add a file next to the directory
 
@@ -8325,7 +8306,7 @@ final class WorkspaceTests: XCTestCase {
 
         try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            XCTAssert(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/root")))
+            XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/root")))
             XCTAssertEqual(downloads.map(\.key.absoluteString).sorted(), [
                 "https://a.com/flat.zip",
                 "https://a.com/nested.zip",
@@ -8337,9 +8318,9 @@ final class WorkspaceTests: XCTestCase {
                 ByteString([0x03]).hexadecimalRepresentation,
             ])
             XCTAssertEqual(archiver.extractions.map(\.destinationPath.parentDirectory).sorted(), [
-                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/flat"),
-                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/nested"),
-                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/nested2"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/root/flat"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/root/nested"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/root/nested2"),
             ])
             XCTAssertEqual(
                 downloads.map(\.value).sorted(),
@@ -8379,7 +8360,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testArtifactMultipleExtensions() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let downloads = ThreadSafeKeyValueStore<URL, AbsolutePath>()
 
@@ -8474,8 +8455,8 @@ final class WorkspaceTests: XCTestCase {
                 ByteString([0xA2]).hexadecimalRepresentation,
             ])
             XCTAssertEqual(archiver.extractions.map(\.destinationPath.parentDirectory).sorted(), [
-                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/A1"),
-                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/root/A2"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/root/A1"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/root/A2"),
             ])
             XCTAssertEqual(
                 downloads.map(\.value).sorted(),
@@ -8506,7 +8487,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testLoadRootPackageWithBinaryDependencies() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -8544,7 +8525,7 @@ final class WorkspaceTests: XCTestCase {
         let wks = try workspace.getOrCreateWorkspace()
         XCTAssertNoThrow(try tsc_await {
             wks.loadRootPackage(
-                at: workspace.rootsDir.appending(component: "Root"),
+                at: workspace.rootsDir.appending("Root"),
                 observabilityScope: observability.topScope,
                 completion: $0
             )
@@ -8553,7 +8534,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDownloadArchiveIndexFilesHappyPath() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let downloads = ThreadSafeKeyValueStore<URL, AbsolutePath>()
         let hostToolchain = try UserToolchain(destination: .hostDestination())
@@ -8725,8 +8706,8 @@ final class WorkspaceTests: XCTestCase {
 
         try workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            XCTAssert(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/a")))
-            XCTAssert(fs.isDirectory(AbsolutePath(path: "/tmp/ws/.build/artifacts/b")))
+            XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/a")))
+            XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/b")))
             XCTAssertEqual(downloads.map(\.key.absoluteString).sorted(), [
                 "https://a.com/a1.zip",
                 "https://a.com/a2/a2.zip",
@@ -8745,9 +8726,9 @@ final class WorkspaceTests: XCTestCase {
                 ).map(\.hexadecimalRepresentation).sorted()
             )
             XCTAssertEqual(archiver.extractions.map(\.destinationPath.parentDirectory).sorted(), [
-                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A1"),
-                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/a/A2"),
-                AbsolutePath(path: "/tmp/ws/.build/artifacts/extract/b/B"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A1"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/a/A2"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/b/B"),
             ])
             XCTAssertEqual(
                 downloads.map(\.value).sorted(),
@@ -8800,7 +8781,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDownloadArchiveIndexServerError() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         // returns a dummy files for the requested artifact
@@ -8842,7 +8823,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDownloadArchiveIndexFileBadChecksum() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let hostToolchain = try UserToolchain(destination: .hostDestination())
 
@@ -8911,7 +8892,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDownloadArchiveIndexFileChecksumChanges() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -8961,7 +8942,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDownloadArchiveIndexFileBadArchivesChecksum() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let hostToolchain = try UserToolchain(destination: .hostDestination())
 
@@ -9071,7 +9052,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDownloadArchiveIndexFileArchiveNotFound() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let hostToolchain = try UserToolchain(destination: .hostDestination())
 
@@ -9146,7 +9127,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDownloadArchiveIndexTripleNotFound() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let hostToolchain = try UserToolchain(destination: .hostDestination())
@@ -9218,7 +9199,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDuplicateDependencyIdentityWithNameAtRoot() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -9287,7 +9268,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDuplicateDependencyIdentityWithoutNameAtRoot() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -9348,7 +9329,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDuplicateExplicitDependencyName_AtRoot() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -9417,7 +9398,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDuplicateManifestNameAtRoot() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -9472,7 +9453,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDuplicateManifestName_ExplicitProductPackage_AtRoot() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -9527,7 +9508,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testManifestNameAndIdentityConflict_AtRoot_Pre52() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -9582,7 +9563,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testManifestNameAndIdentityConflict_AtRoot_Post52_Incorrect() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -9646,7 +9627,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testManifestNameAndIdentityConflict_AtRoot_Post52_Correct() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -9701,7 +9682,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testManifestNameAndIdentityConflict_ExplicitDependencyNames_AtRoot() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -9765,7 +9746,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testManifestNameAndIdentityConflict_ExplicitDependencyNames_ExplicitProductPackage_AtRoot() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -9829,7 +9810,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDuplicateTransitiveIdentityWithNames() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -9918,7 +9899,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDuplicateTransitiveIdentityWithoutNames() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -10003,7 +9984,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDuplicateTransitiveIdentitySimilarURLs1() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -10078,7 +10059,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDuplicateTransitiveIdentitySimilarURLs2() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -10153,7 +10134,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDuplicateTransitiveIdentityGitHubURLs1() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -10228,7 +10209,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDuplicateTransitiveIdentityGitHubURLs2() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -10306,7 +10287,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDuplicateTransitiveIdentityUnfamiliarURLs() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -10391,7 +10372,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDuplicateTransitiveIdentityWithSimilarURLs() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -10513,7 +10494,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDuplicateNestedTransitiveIdentityWithNames() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -10607,7 +10588,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testDuplicateNestedTransitiveIdentityWithoutNames() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -10691,7 +10672,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testRootPathConflictsWithTransitiveIdentity() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -10766,7 +10747,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testResolutionBranchAndVersion() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -10841,9 +10822,9 @@ final class WorkspaceTests: XCTestCase {
             let fs = localFileSystem
             let observability = ObservabilitySystem.makeForTesting()
 
-            let foo = path.appending(component: "foo")
+            let foo = path.appending("foo")
 
-            try fs.writeFileContents(foo.appending(component: "Package.swift")) {
+            try fs.writeFileContents(foo.appending("Package.swift")) {
                 $0 <<<
                     """
                     // swift-tools-version:5.3
@@ -10858,7 +10839,7 @@ final class WorkspaceTests: XCTestCase {
             }
 
             let manifestLoader = try ManifestLoader(toolchain: UserToolchain.default)
-            let sandbox = path.appending(component: "ws")
+            let sandbox = path.appending("ws")
             let workspace = try Workspace(
                 fileSystem: fs,
                 forRootPackage: sandbox,
@@ -10971,7 +10952,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testBasicResolutionFromSourceControl() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -11077,7 +11058,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testBasicTransitiveResolutionFromSourceControl() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -11221,7 +11202,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testBasicResolutionFromRegistry() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -11327,7 +11308,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testBasicTransitiveResolutionFromRegistry() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -11472,7 +11453,7 @@ final class WorkspaceTests: XCTestCase {
 
     // no dups
     func testResolutionMixedRegistryAndSourceControl1() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -11603,7 +11584,7 @@ final class WorkspaceTests: XCTestCase {
 
     // duplicate package at root level
     func testResolutionMixedRegistryAndSourceControl2() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -11713,7 +11694,7 @@ final class WorkspaceTests: XCTestCase {
     // mixed graph root --> dep1 scm
     //                  --> dep2 scm --> dep1 registry
     func testResolutionMixedRegistryAndSourceControl3() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -11897,7 +11878,7 @@ final class WorkspaceTests: XCTestCase {
     // mixed graph root --> dep1 scm
     //                  --> dep2 registry --> dep1 registry
     func testResolutionMixedRegistryAndSourceControl4() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -12056,7 +12037,7 @@ final class WorkspaceTests: XCTestCase {
     // mixed graph root --> dep1 scm
     //                  --> dep2 scm --> dep1 registry incompatible version
     func testResolutionMixedRegistryAndSourceControl5() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -12202,7 +12183,7 @@ final class WorkspaceTests: XCTestCase {
     // mixed graph root --> dep1 registry
     //                  --> dep2 registry --> dep1 scm
     func testResolutionMixedRegistryAndSourceControl6() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -12369,7 +12350,7 @@ final class WorkspaceTests: XCTestCase {
     // mixed graph root --> dep1 registry
     //                  --> dep2 registry --> dep1 scm incompatible version
     func testResolutionMixedRegistryAndSourceControl7() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -12515,7 +12496,7 @@ final class WorkspaceTests: XCTestCase {
     // mixed graph root --> dep1 registry --> dep3 scm
     //                  --> dep2 registry --> dep3 registry
     func testResolutionMixedRegistryAndSourceControl8() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -12706,7 +12687,7 @@ final class WorkspaceTests: XCTestCase {
     // mixed graph root --> dep1 registry --> dep3 scm
     //                  --> dep2 registry --> dep3 registry incompatible version
     func testResolutionMixedRegistryAndSourceControl9() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -12868,7 +12849,7 @@ final class WorkspaceTests: XCTestCase {
     // mixed graph root --> dep1 scm branch
     //                  --> dep2 registry --> dep1 registry
     func testResolutionMixedRegistryAndSourceControl10() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -13036,7 +13017,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testCustomPackageContainerProvider() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let customFS = InMemoryFileSystem()
@@ -13048,10 +13029,10 @@ final class WorkspaceTests: XCTestCase {
             fileSystem: customFS
         )
         // write the sources
-        let sourcesDir = AbsolutePath(path: "/Sources")
-        let targetDir = sourcesDir.appending(component: "Baz")
+        let sourcesDir = AbsolutePath("/Sources")
+        let targetDir = sourcesDir.appending("Baz")
         try customFS.createDirectory(targetDir, recursive: true)
-        try customFS.writeFileContents(targetDir.appending(component: "file.swift"), bytes: "")
+        try customFS.writeFileContents(targetDir.appending("file.swift"), bytes: "")
 
         let bazURL = URL("https://example.com/baz")
         let bazPackageReference = PackageReference(
@@ -13065,7 +13046,7 @@ final class WorkspaceTests: XCTestCase {
             customRetrievalPath: .root
         )
 
-        let fooPath = AbsolutePath(path: "/tmp/ws/Foo")
+        let fooPath = AbsolutePath("/tmp/ws/Foo")
         let fooPackageReference = PackageReference(identity: PackageIdentity(path: fooPath), kind: .root(fooPath))
         let fooContainer = MockPackageContainer(package: fooPackageReference)
 
@@ -13125,7 +13106,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testRegistryMissingConfigurationErrors() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let registryClient = try makeRegistryClient(
@@ -13178,7 +13159,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testRegistryReleasesServerErrors() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -13263,7 +13244,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testRegistryReleaseChecksumServerErrors() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -13350,7 +13331,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testRegistryManifestServerErrors() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -13435,7 +13416,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testRegistryDownloadServerErrors() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let workspace = try MockWorkspace(
@@ -13522,7 +13503,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testRegistryArchiveErrors() throws {
-        let sandbox = AbsolutePath(path: "/tmp/ws/")
+        let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
         let registryClient = try makeRegistryClient(
@@ -13779,7 +13760,7 @@ final class WorkspaceTests: XCTestCase {
 
         let archiver = archiver ?? MockArchiver(handler: { _, _, to, completion in
             do {
-                let packagePath = to.appending(component: "top")
+                let packagePath = to.appending("top")
                 try fileSystem.createDirectory(packagePath, recursive: true)
                 try fileSystem.writeFileContents(packagePath.appending(component: Manifest.filename), bytes: [])
                 try ToolsVersionSpecificationWriter.rewriteSpecification(
@@ -13836,10 +13817,10 @@ final class WorkspaceTests: XCTestCase {
 }
 
 func createDummyXCFramework(fileSystem: FileSystem, path: AbsolutePath, name: String) throws {
-    let path = path.appending(component: "\(name).xcframework")
+    let path = path.appending("\(name).xcframework")
     try fileSystem.createDirectory(path, recursive: true)
     try fileSystem.writeFileContents(
-        path.appending(component: "info.plist"),
+        path.appending("info.plist"),
         string: """
         <?xml version="1.0" encoding="UTF-8"?>
         <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -13858,10 +13839,10 @@ func createDummyXCFramework(fileSystem: FileSystem, path: AbsolutePath, name: St
 }
 
 func createDummyArtifactBundle(fileSystem: FileSystem, path: AbsolutePath, name: String) throws {
-    let path = path.appending(component: "\(name).artifactbundle")
+    let path = path.appending("\(name).artifactbundle")
     try fileSystem.createDirectory(path, recursive: true)
     try fileSystem.writeFileContents(
-        path.appending(component: "info.json"),
+        path.appending("info.json"),
         string: """
         {
             "schemaVersion": "1.0",

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -723,7 +723,7 @@ class PIFBuilderTests: XCTestCase {
                                     "/Bar/Sources/BarTests/BarTests.swift",
                                     "/Bar/Sources/CBarTests/CBarTests.m",
                                     "/Bar/Sources/BarLib/lib.swift",
-                                    inputsDir.appending(component: "Foo.pc").pathString
+                                    inputsDir.appending("Foo.pc").pathString
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -1947,7 +1947,7 @@ class PIFBuilderTests: XCTestCase {
             ],
             binaryArtifacts: [
                 .plain("foo"): [
-                    "BinaryLibrary": .init(kind: .xcframework, originURL: nil, path: AbsolutePath(path: "/Foo/BinaryLibrary.xcframework"))
+                    "BinaryLibrary": .init(kind: .xcframework, originURL: nil, path: "/Foo/BinaryLibrary.xcframework")
                 ]
             ],
             shouldCreateMultipleTestProducts: true,
@@ -2614,8 +2614,8 @@ extension PIFBuilderParameters {
         PIFBuilderParameters(
             enableTestability: false,
             shouldCreateDylibForDynamicProducts: shouldCreateDylibForDynamicProducts,
-            toolchainLibDir: AbsolutePath(path: "/toolchain/lib"),
-            pkgConfigDirectories: [AbsolutePath(path: "/pkg-config")]
+            toolchainLibDir: "/toolchain/lib",
+            pkgConfigDirectories: ["/pkg-config"]
         )
     }
 }

--- a/Tests/XCBuildSupportTests/PIFTests.swift
+++ b/Tests/XCBuildSupportTests/PIFTests.swift
@@ -23,13 +23,13 @@ class PIFTests: XCTestCase {
         PIF.Workspace(
             guid: "workspace",
             name: "MyWorkspace",
-            path: AbsolutePath(path: "/path/to/workspace"),
+            path: "/path/to/workspace",
             projects: [
                 PIF.Project(
                     guid: "project",
                     name: "MyProject",
-                    path: AbsolutePath(path: "/path/to/workspace/project"),
-                    projectDirectory: AbsolutePath(path: "/path/to/workspace/project"),
+                    path: "/path/to/workspace/project",
+                    projectDirectory: "/path/to/workspace/project",
                     developmentRegion: "fr",
                     buildConfigurations: [
                         PIF.BuildConfiguration(
@@ -275,14 +275,14 @@ class PIFTests: XCTestCase {
 
         XCTAssertEqual(workspace["type"]?.string, "workspace")
         XCTAssertEqual(workspaceContents["guid"]?.string, "workspace@11")
-        XCTAssertEqual(workspaceContents["path"]?.string, AbsolutePath(path: "/path/to/workspace").pathString)
+        XCTAssertEqual(workspaceContents["path"]?.string, AbsolutePath("/path/to/workspace").pathString)
         XCTAssertEqual(workspaceContents["name"]?.string, "MyWorkspace")
         XCTAssertEqual(workspaceContents["projects"]?.array, [project["signature"]!])
 
         XCTAssertEqual(project["type"]?.string, "project")
         XCTAssertEqual(projectContents["guid"]?.string, "project@11")
-        XCTAssertEqual(projectContents["path"]?.string, AbsolutePath(path: "/path/to/workspace/project").pathString)
-        XCTAssertEqual(projectContents["projectDirectory"]?.string, AbsolutePath(path: "/path/to/workspace/project").pathString)
+        XCTAssertEqual(projectContents["path"]?.string, AbsolutePath("/path/to/workspace/project").pathString)
+        XCTAssertEqual(projectContents["projectDirectory"]?.string, AbsolutePath("/path/to/workspace/project").pathString)
         XCTAssertEqual(projectContents["projectName"]?.string, "MyProject")
         XCTAssertEqual(projectContents["projectIsPackage"]?.string, "true")
         XCTAssertEqual(projectContents["developmentRegion"]?.string, "fr")


### PR DESCRIPTION
motivation: clean up common patterns incode

changes:
* add extension to AbsolutePath for common patterns in code so we can simplift the call sites
* conform AbsolutePath to ExpressibleByStringLiteral and ExpressibleByStringInterpolation in test helpers to clean up test code
* update call sites
