### PR TITLE
Basics: vendor `Triple`, reduce dependency on TSC

### DIFF
--- a/Sources/Basics/CMakeLists.txt
+++ b/Sources/Basics/CMakeLists.txt
@@ -48,6 +48,7 @@ add_library(Basics
   String+Extensions.swift
   SwiftVersion.swift
   SQLiteBackedCache.swift
+  Triple.swift
   Version+Extensions.swift
   WritableByteStream+Extensions.swift)
 target_link_libraries(Basics PUBLIC

--- a/Sources/Basics/Triple.swift
+++ b/Sources/Basics/Triple.swift
@@ -1,0 +1,299 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2014-2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import protocol Foundation.CustomNSError
+import var Foundation.NSLocalizedDescriptionKey
+import TSCBasic
+
+/// Triple - Helper class for working with Destination.target values
+///
+/// Used for parsing values such as x86_64-apple-macosx10.10 into
+/// set of enums. For os/arch/abi based conditions in build plan.
+///
+/// @see Destination.target
+/// @see https://github.com/apple/swift-llvm/blob/stable/include/llvm/ADT/Triple.h
+///
+public struct Triple: Encodable, Equatable, Sendable {
+    public let tripleString: String
+
+    public let arch: Arch
+    public let vendor: Vendor
+    public let os: OS
+    public let abi: ABI
+    public let osVersion: String?
+    public let abiVersion: String?
+
+    public enum Error: Swift.Error {
+        case badFormat(triple: String)
+        case unknownArch(arch: String)
+        case unknownOS(os: String)
+    }
+
+    public enum Arch: String, Encodable, Sendable {
+        case x86_64
+        case x86_64h
+        case i686
+        case powerpc
+        case powerpc64le
+        case s390x
+        case aarch64
+        case amd64
+        case armv7
+        case armv6
+        case armv5
+        case arm
+        case arm64
+        case arm64e
+        case wasm32
+        case riscv64
+        case mips
+        case mipsel
+        case mips64
+        case mips64el
+    }
+
+    public enum Vendor: String, Encodable, Sendable {
+        case unknown
+        case apple
+    }
+
+    public enum OS: String, Encodable, CaseIterable, Sendable {
+        case darwin
+        case macOS = "macosx"
+        case linux
+        case windows
+        case wasi
+        case openbsd
+    }
+
+    public enum ABI: Encodable, Equatable, RawRepresentable, Sendable {
+        case unknown
+        case android
+        case other(name: String)
+
+        public init?(rawValue: String) {
+            if rawValue.hasPrefix(ABI.android.rawValue) {
+                self = .android
+            } else if let version = rawValue.firstIndex(where: { $0.isNumber }) {
+                self = .other(name: String(rawValue[..<version]))
+            } else {
+                self = .other(name: rawValue)
+            }
+        }
+
+        public var rawValue: String {
+            switch self {
+            case .android: return "android"
+            case .other(let name): return name
+            case .unknown: return "unknown"
+            }
+        }
+
+        public static func == (lhs: ABI, rhs: ABI) -> Bool {
+            switch (lhs, rhs) {
+            case (.unknown, .unknown):
+                return true
+            case (.android, .android):
+                return true
+            case (.other(let lhsName), .other(let rhsName)):
+                return lhsName == rhsName
+            default:
+                return false
+            }
+        }
+    }
+
+    public init(_ string: String) throws {
+        let components = string.split(separator: "-").map(String.init)
+
+        guard components.count == 3 || components.count == 4 else {
+            throw Error.badFormat(triple: string)
+        }
+
+        guard let arch = Arch(rawValue: components[0]) else {
+            throw Error.unknownArch(arch: components[0])
+        }
+
+        let vendor = Vendor(rawValue: components[1]) ?? .unknown
+
+        guard let os = Triple.parseOS(components[2]) else {
+            throw Error.unknownOS(os: components[2])
+        }
+
+        let osVersion = Triple.parseVersion(components[2])
+
+        let abi = components.count > 3 ? Triple.ABI(rawValue: components[3]) : nil
+        let abiVersion = components.count > 3 ? Triple.parseVersion(components[3]) : nil
+
+        self.tripleString = string
+        self.arch = arch
+        self.vendor = vendor
+        self.os = os
+        self.osVersion = osVersion
+        self.abi = abi ?? .unknown
+        self.abiVersion = abiVersion
+    }
+
+    fileprivate static func parseOS(_ string: String) -> OS? {
+        var candidates = OS.allCases.map { (name: $0.rawValue, value: $0) }
+        // LLVM target triples support this alternate spelling as well.
+        candidates.append((name: "macos", value: .macOS))
+        return candidates.first(where: { string.hasPrefix($0.name) })?.value
+    }
+
+    fileprivate static func parseVersion(_ string: String) -> String? {
+        let candidate = String(string.drop(while: { $0.isLetter }))
+        if candidate != string && !candidate.isEmpty {
+            return candidate
+        }
+
+        return nil
+    }
+
+    public func isAndroid() -> Bool {
+        os == .linux && abi == .android
+    }
+
+    public func isDarwin() -> Bool {
+        vendor == .apple || os == .macOS || os == .darwin
+    }
+
+    public func isLinux() -> Bool {
+        os == .linux
+    }
+
+    public func isWindows() -> Bool {
+        os == .windows
+    }
+
+    public func isWASI() -> Bool {
+        os == .wasi
+    }
+
+    public func isOpenBSD() -> Bool {
+        os == .openbsd
+    }
+
+    /// Returns the triple string for the given platform version.
+    ///
+    /// This is currently meant for Apple platforms only.
+    public func tripleString(forPlatformVersion version: String) -> String {
+        precondition(isDarwin())
+        return String(self.tripleString.dropLast(self.osVersion?.count ?? 0)) + version
+    }
+
+    public static let macOS = try! Triple("x86_64-apple-macosx")
+
+    /// Determine the versioned host triple using the Swift compiler.
+    public static func getHostTriple(usingSwiftCompiler swiftCompiler: AbsolutePath) -> Triple {
+        // Call the compiler to get the target info JSON.
+        let compilerOutput: String
+        do {
+            let result = try Process.popen(args: swiftCompiler.pathString, "-print-target-info")
+            compilerOutput = try result.utf8Output().spm_chomp()
+        } catch {
+            // FIXME: Remove the macOS special-casing once the latest version of Xcode comes with
+            // a Swift compiler that supports -print-target-info.
+            #if os(macOS)
+            return .macOS
+            #else
+            fatalError("Failed to get target info (\(error))")
+            #endif
+        }
+        // Parse the compiler's JSON output.
+        let parsedTargetInfo: JSON
+        do {
+            parsedTargetInfo = try JSON(string: compilerOutput)
+        } catch {
+            fatalError("Failed to parse target info (\(error)).\nRaw compiler output: \(compilerOutput)")
+        }
+        // Get the triple string from the parsed JSON.
+        let tripleString: String
+        do {
+            tripleString = try parsedTargetInfo.get("target").get("triple")
+        } catch {
+            fatalError("Target info does not contain a triple string (\(error)).\nTarget info: \(parsedTargetInfo)")
+        }
+        // Parse the triple string.
+        do {
+            return try Triple(tripleString)
+        } catch {
+            fatalError("Failed to parse triple string (\(error)).\nTriple string: \(tripleString)")
+        }
+    }
+
+    public static func == (lhs: Triple, rhs: Triple) -> Bool {
+        lhs.arch == rhs.arch && lhs.vendor == rhs.vendor && lhs.os == rhs.os && lhs.abi == rhs.abi && lhs
+            .osVersion == rhs.osVersion && lhs.abiVersion == rhs.abiVersion
+    }
+}
+
+extension Triple {
+    /// The file prefix for dynamic libraries
+    public var dynamicLibraryPrefix: String {
+        switch os {
+        case .windows:
+            return ""
+        default:
+            return "lib"
+        }
+    }
+
+    /// The file extension for dynamic libraries (eg. `.dll`, `.so`, or `.dylib`)
+    public var dynamicLibraryExtension: String {
+        switch os {
+        case .darwin, .macOS:
+            return ".dylib"
+        case .linux, .openbsd:
+            return ".so"
+        case .windows:
+            return ".dll"
+        case .wasi:
+            return ".wasm"
+        }
+    }
+
+    public var executableExtension: String {
+        switch os {
+        case .darwin, .macOS:
+            return ""
+        case .linux, .openbsd:
+            return ""
+        case .wasi:
+            return ".wasm"
+        case .windows:
+            return ".exe"
+        }
+    }
+
+    /// The file extension for static libraries.
+    public var staticLibraryExtension: String {
+        ".a"
+    }
+
+    /// The file extension for Foundation-style bundle.
+    public var nsbundleExtension: String {
+        switch os {
+        case .darwin, .macOS:
+            return ".bundle"
+        default:
+            // See: https://github.com/apple/swift-corelibs-foundation/blob/master/Docs/FHS%20Bundles.md
+            return ".resources"
+        }
+    }
+}
+
+extension Triple.Error: CustomNSError {
+    public var errorUserInfo: [String: Any] {
+        [NSLocalizedDescriptionKey: "\(self)"]
+    }
+}

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -22,7 +22,6 @@ import SPMBuildCore
 import TSCBasic
 
 import enum TSCUtility.Diagnostics
-import struct TSCUtility.Triple
 import var TSCUtility.verbosity
 
 extension String {
@@ -1092,7 +1091,7 @@ func generateResourceInfoPlist(
     return true
 }
 
-extension TSCUtility.Triple {
+extension Basics.Triple {
     var isSupportingStaticStdlib: Bool {
         isLinux() || arch == .wasm32
     }

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -12,6 +12,8 @@
 
 import ArgumentParser
 
+import struct Basics.Triple
+
 import struct Foundation.URL
 
 import enum PackageModel.BuildConfiguration
@@ -26,7 +28,6 @@ import struct TSCBasic.AbsolutePath
 import var TSCBasic.localFileSystem
 import struct TSCBasic.StringError
 
-import struct TSCUtility.Triple
 import struct TSCUtility.Version
 
 import struct Workspace.WorkspaceConfiguration
@@ -188,9 +189,11 @@ public struct SecurityOptions: ParsableArguments {
     /// Whether to load netrc files for authenticating with remote servers
     /// when downloading binary artifacts. This has no effects on registry
     /// communications.
-    @Flag(inversion: .prefixedEnableDisable,
-          exclusivity: .exclusive,
-          help: "Load credentials from a netrc file")
+    @Flag(
+        inversion: .prefixedEnableDisable,
+        exclusivity: .exclusive,
+        help: "Load credentials from a netrc file"
+    )
     public var netrc: Bool = true
 
     /// The path to the netrc file used when `netrc` is `true`.
@@ -205,14 +208,18 @@ public struct SecurityOptions: ParsableArguments {
     /// when downloading binary artifacts. This has no effects on registry
     /// communications.
     #if canImport(Security)
-    @Flag(inversion: .prefixedEnableDisable,
-          exclusivity: .exclusive,
-          help: "Search credentials in macOS keychain")
+    @Flag(
+        inversion: .prefixedEnableDisable,
+        exclusivity: .exclusive,
+        help: "Search credentials in macOS keychain"
+    )
     public var keychain: Bool = true
     #else
-    @Flag(inversion: .prefixedEnableDisable,
-          exclusivity: .exclusive,
-          help: .hidden)
+    @Flag(
+        inversion: .prefixedEnableDisable,
+        exclusivity: .exclusive,
+        help: .hidden
+    )
     public var keychain: Bool = false
     #endif
 
@@ -281,38 +288,52 @@ public struct BuildOptions: ParsableArguments {
     @Option(name: .shortAndLong, help: "Build with configuration")
     public var configuration: BuildConfiguration = .debug
 
-    @Option(name: .customLong("Xcc", withSingleDash: true),
-            parsing: .unconditionalSingleValue,
-            help: "Pass flag through to all C compiler invocations")
+    @Option(
+        name: .customLong("Xcc", withSingleDash: true),
+        parsing: .unconditionalSingleValue,
+        help: "Pass flag through to all C compiler invocations"
+    )
     var cCompilerFlags: [String] = []
 
-    @Option(name: .customLong("Xswiftc", withSingleDash: true),
-            parsing: .unconditionalSingleValue,
-            help: "Pass flag through to all Swift compiler invocations")
+    @Option(
+        name: .customLong("Xswiftc", withSingleDash: true),
+        parsing: .unconditionalSingleValue,
+        help: "Pass flag through to all Swift compiler invocations"
+    )
     var swiftCompilerFlags: [String] = []
 
-    @Option(name: .customLong("Xlinker", withSingleDash: true),
-            parsing: .unconditionalSingleValue,
-            help: "Pass flag through to all linker invocations")
+    @Option(
+        name: .customLong("Xlinker", withSingleDash: true),
+        parsing: .unconditionalSingleValue,
+        help: "Pass flag through to all linker invocations"
+    )
     var linkerFlags: [String] = []
 
-    @Option(name: .customLong("Xcxx", withSingleDash: true),
-            parsing: .unconditionalSingleValue,
-            help: "Pass flag through to all C++ compiler invocations")
+    @Option(
+        name: .customLong("Xcxx", withSingleDash: true),
+        parsing: .unconditionalSingleValue,
+        help: "Pass flag through to all C++ compiler invocations"
+    )
     var cxxCompilerFlags: [String] = []
 
-    @Option(name: .customLong("Xxcbuild", withSingleDash: true),
-            parsing: .unconditionalSingleValue,
-            help: ArgumentHelp(
-                "Pass flag through to the Xcode build system invocations",
-                visibility: .hidden
-            ))
+    @Option(
+        name: .customLong("Xxcbuild", withSingleDash: true),
+        parsing: .unconditionalSingleValue,
+        help: ArgumentHelp(
+            "Pass flag through to the Xcode build system invocations",
+            visibility: .hidden
+        )
+    )
     public var xcbuildFlags: [String] = []
 
-    @Option(name: .customLong("Xmanifest", withSingleDash: true),
-            parsing: .unconditionalSingleValue,
-            help: ArgumentHelp("Pass flag to the manifest build invocation",
-                               visibility: .hidden))
+    @Option(
+        name: .customLong("Xmanifest", withSingleDash: true),
+        parsing: .unconditionalSingleValue,
+        help: ArgumentHelp(
+            "Pass flag to the manifest build invocation",
+            visibility: .hidden
+        )
+    )
     var manifestFlags: [String] = []
 
     public var buildFlags: BuildFlags {
@@ -409,10 +430,13 @@ public struct BuildOptions: ParsableArguments {
     @Flag(help: .hidden)
     public var enableTestDiscovery: Bool = false
 
-    /// Path of test entry point file to use, instead of synthesizing one or using `XCTMain.swift` in the package (if present).
+    /// Path of test entry point file to use, instead of synthesizing one or using `XCTMain.swift` in the package (if
+    /// present).
     /// This implies `--enable-test-discovery`
-    @Option(name: .customLong("experimental-test-entry-point-path"),
-            help: .hidden)
+    @Option(
+        name: .customLong("experimental-test-entry-point-path"),
+        help: .hidden
+    )
     public var testEntryPointPath: AbsolutePath?
 
     // @Flag works best when there is a default value present

--- a/Sources/CoreCommands/SwiftTool.swift
+++ b/Sources/CoreCommands/SwiftTool.swift
@@ -45,7 +45,6 @@ import class TSCUtility.MultiLineNinjaProgressAnimation
 import class TSCUtility.NinjaProgressAnimation
 import class TSCUtility.PercentProgressAnimation
 import protocol TSCUtility.ProgressAnimationProtocol
-import struct TSCUtility.Triple
 import var TSCUtility.verbosity
 
 typealias Diagnostic = Basics.Diagnostic

--- a/Sources/PackageModel/ArtifactsArchiveMetadata.swift
+++ b/Sources/PackageModel/ArtifactsArchiveMetadata.swift
@@ -10,10 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Basics
 import Foundation
 import TSCBasic
 
-import struct TSCUtility.Triple
 import struct TSCUtility.Version
 
 public struct ArtifactsArchiveMetadata: Equatable {

--- a/Sources/PackageModel/Destination.swift
+++ b/Sources/PackageModel/Destination.swift
@@ -14,7 +14,6 @@ import Basics
 import Foundation
 import TSCBasic
 
-import struct TSCUtility.Triple
 import struct TSCUtility.Version
 
 public enum DestinationError: Swift.Error {

--- a/Sources/PackageModel/DestinationBundle.swift
+++ b/Sources/PackageModel/DestinationBundle.swift
@@ -12,7 +12,6 @@
 
 import Basics
 import TSCBasic
-import TSCUtility
 
 /// Represents an `.artifactbundle` on the filesystem that contains cross-compilation destinations.
 public struct DestinationBundle {

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -14,7 +14,6 @@ import Basics
 import Foundation
 import TSCBasic
 
-import struct TSCUtility.Triple
 #if os(Windows)
 private let hostExecutableSuffix = ".exe"
 #else

--- a/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
+++ b/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
@@ -16,8 +16,6 @@ import PackageModel
 import PackageGraph
 import TSCBasic
 
-import struct TSCUtility.Triple
-
 /// Information about a library from a binary dependency.
 public struct LibraryInfo: Equatable {
     /// The path to the binary.

--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -16,7 +16,7 @@ import TSCBasic
 import PackageModel
 import PackageGraph
 
-import struct TSCUtility.Triple
+import struct Basics.Triple
 
 public struct BuildParameters: Encodable {
     /// Mode for the indexing-while-building feature.

--- a/Sources/SPMBuildCore/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/PluginInvocation.swift
@@ -17,8 +17,6 @@ import PackageLoading
 import PackageGraph
 import TSCBasic
 
-import struct TSCUtility.Triple
-
 public enum PluginAction {
     case createBuildToolCommands(package: ResolvedPackage, target: ResolvedTarget)
     case performCommand(package: ResolvedPackage, arguments: [String])

--- a/Sources/SPMBuildCore/PluginScriptRunner.swift
+++ b/Sources/SPMBuildCore/PluginScriptRunner.swift
@@ -16,7 +16,6 @@ import PackageModel
 import PackageLoading
 import PackageGraph
 import TSCBasic
-import struct TSCUtility.Triple
 
 /// Implements the mechanics of running and communicating with a plugin (implemented as a set of Swift source files). In most environments this is done by compiling the code to an executable, invoking it as a sandboxed subprocess, and communicating with it using pipes. Specific implementations are free to implement things differently, however.
 public protocol PluginScriptRunner {

--- a/Sources/SPMBuildCore/Triple+Extensions.swift
+++ b/Sources/SPMBuildCore/Triple+Extensions.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import struct TSCUtility.Triple
+import struct Basics.Triple
 
 extension Triple {
     public func platformBuildPathComponent() -> String {

--- a/Sources/SPMBuildCore/XCFrameworkMetadata.swift
+++ b/Sources/SPMBuildCore/XCFrameworkMetadata.swift
@@ -14,7 +14,7 @@ import Foundation
 import PackageModel
 import TSCBasic
 
-import struct TSCUtility.Triple
+import struct Basics.Triple
 
 public struct XCFrameworkMetadata: Equatable {
     public struct Library: Equatable {

--- a/Sources/Workspace/DefaultPluginScriptRunner.swift
+++ b/Sources/Workspace/DefaultPluginScriptRunner.swift
@@ -18,7 +18,6 @@ import SPMBuildCore
 import TSCBasic
 
 import struct TSCUtility.SerializedDiagnostics
-import struct TSCUtility.Triple
 
 /// A plugin script runner that compiles the plugin source files as an executable binary for the host platform, and invokes it as a subprocess.
 public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {

--- a/Sources/Workspace/Workspace+BinaryArtifacts.swift
+++ b/Sources/Workspace/Workspace+BinaryArtifacts.swift
@@ -17,7 +17,6 @@ import SPMBuildCore
 import TSCBasic
 
 import enum TSCUtility.Diagnostics
-import struct TSCUtility.Triple
 import PackageLoading
 
 extension Workspace {

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -25,7 +25,6 @@ import TSCBasic
 
 import enum TSCUtility.Diagnostics
 import enum TSCUtility.SignpostName
-import struct TSCUtility.Triple
 import struct TSCUtility.Version
 
 public typealias Diagnostic = TSCBasic.Diagnostic

--- a/Sources/swift-bootstrap/main.swift
+++ b/Sources/swift-bootstrap/main.swift
@@ -25,7 +25,6 @@ import XCBuildSupport
 
 import enum TSCUtility.Diagnostics
 import struct TSCUtility.Version
-import struct TSCUtility.Triple
 
 SwiftBootstrapBuildTool.main()
 

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -22,7 +22,6 @@ import TSCBasic
 import Workspace
 import XCTest
 import enum TSCUtility.Diagnostics
-import struct TSCUtility.Triple
 @_implementationOnly import DriverSupport
 
 final class BuildPlanTests: XCTestCase {
@@ -3002,7 +3001,7 @@ final class BuildPlanTests: XCTestCase {
             observabilityScope: observability.topScope
         )
 
-        func createResult(for triple: TSCUtility.Triple) throws -> BuildPlanResult {
+        func createResult(for triple: Basics.Triple) throws -> BuildPlanResult {
             try BuildPlanResult(plan: BuildPlan(
                 buildParameters: mockBuildParameters(canRenameEntrypointFunctionName: true, destinationTriple: triple),
                 graph: graph,
@@ -3010,7 +3009,7 @@ final class BuildPlanTests: XCTestCase {
                 observabilityScope: observability.topScope
             ))
         }
-        let supportingTriples: [TSCUtility.Triple] = [.x86_64Linux, .macOS]
+        let supportingTriples: [Basics.Triple] = [.x86_64Linux, .macOS]
         for triple in supportingTriples {
             let result = try createResult(for: triple)
             let exe = try result.target(for: "exe").swiftTarget().compileArguments()
@@ -3019,7 +3018,7 @@ final class BuildPlanTests: XCTestCase {
             XCTAssertMatch(linkExe, [.contains("exe_main")])
         }
 
-        let unsupportingTriples: [TSCUtility.Triple] = [.wasi, .windows]
+        let unsupportingTriples: [Basics.Triple] = [.wasi, .windows]
         for triple in unsupportingTriples {
             let result = try createResult(for: triple)
             let exe = try result.target(for: "exe").swiftTarget().compileArguments()
@@ -3290,7 +3289,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        func createResult(for dest: TSCUtility.Triple) throws -> BuildPlanResult {
+        func createResult(for dest: Basics.Triple) throws -> BuildPlanResult {
             return try BuildPlanResult(plan: BuildPlan(
                 buildParameters: mockBuildParameters(destinationTriple: dest),
                 graph: graph,
@@ -4077,7 +4076,7 @@ final class BuildPlanTests: XCTestCase {
             observabilityScope: observability.topScope
         )
 
-        let supportingTriples: [TSCUtility.Triple] = [.x86_64Linux, .arm64Linux, .wasi]
+        let supportingTriples: [Basics.Triple] = [.x86_64Linux, .arm64Linux, .wasi]
         for triple in supportingTriples {
             let result = try BuildPlanResult(plan: BuildPlan(
                 buildParameters: mockBuildParameters(shouldLinkStaticSwiftStdlib: true, destinationTriple: triple),
@@ -4095,7 +4094,7 @@ final class BuildPlanTests: XCTestCase {
         }
     }
 
-    func testXCFrameworkBinaryTargets(platform: String, arch: String, destinationTriple: TSCUtility.Triple) throws {
+    func testXCFrameworkBinaryTargets(platform: String, arch: String, destinationTriple: Basics.Triple) throws {
         let Pkg: AbsolutePath = AbsolutePath("/Pkg")
 
         let fs = InMemoryFileSystem(emptyFiles:
@@ -4250,14 +4249,14 @@ final class BuildPlanTests: XCTestCase {
     func testXCFrameworkBinaryTargets() throws {
         try testXCFrameworkBinaryTargets(platform: "macos", arch: "x86_64", destinationTriple: .macOS)
 
-        let arm64Triple = try TSCUtility.Triple("arm64-apple-macosx")
+        let arm64Triple = try Basics.Triple("arm64-apple-macosx")
         try testXCFrameworkBinaryTargets(platform: "macos", arch: "arm64", destinationTriple: arm64Triple)
 
-        let arm64eTriple = try TSCUtility.Triple("arm64e-apple-macosx")
+        let arm64eTriple = try Basics.Triple("arm64e-apple-macosx")
         try testXCFrameworkBinaryTargets(platform: "macos", arch: "arm64e", destinationTriple: arm64eTriple)
     }
 
-    func testArtifactsArchiveBinaryTargets(artifactTriples:[TSCUtility.Triple], destinationTriple: TSCUtility.Triple) throws -> Bool {
+    func testArtifactsArchiveBinaryTargets(artifactTriples:[Basics.Triple], destinationTriple: Basics.Triple) throws -> Bool {
         let fs = InMemoryFileSystem(emptyFiles: "/Pkg/Sources/exe/main.swift")
 
         let artifactName = "my-tool"
@@ -4328,12 +4327,12 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertTrue(try testArtifactsArchiveBinaryTargets(artifactTriples: [.macOS], destinationTriple: .macOS))
 
         do {
-            let triples = try ["arm64-apple-macosx",  "x86_64-apple-macosx", "x86_64-unknown-linux-gnu"].map(TSCUtility.Triple.init)
+            let triples = try ["arm64-apple-macosx",  "x86_64-apple-macosx", "x86_64-unknown-linux-gnu"].map(Basics.Triple.init)
             XCTAssertTrue(try testArtifactsArchiveBinaryTargets(artifactTriples: triples, destinationTriple: triples.first!))
         }
 
         do {
-            let triples = try ["x86_64-unknown-linux-gnu"].map(TSCUtility.Triple.init)
+            let triples = try ["x86_64-unknown-linux-gnu"].map(Basics.Triple.init)
             XCTAssertFalse(try testArtifactsArchiveBinaryTargets(artifactTriples: triples, destinationTriple: .macOS))
         }
     }

--- a/Tests/BuildTests/MockBuildTestHelper.swift
+++ b/Tests/BuildTests/MockBuildTestHelper.swift
@@ -49,12 +49,12 @@ struct MockToolchain: PackageModel.Toolchain {
 }
 
 
-extension TSCUtility.Triple {
-    static let x86_64Linux = try! Triple("x86_64-unknown-linux-gnu")
-    static let arm64Linux = try! Triple("aarch64-unknown-linux-gnu")
-    static let arm64Android = try! Triple("aarch64-unknown-linux-android")
-    static let windows = try! Triple("x86_64-unknown-windows-msvc")
-    static let wasi = try! Triple("wasm32-unknown-wasi")
+extension Basics.Triple {
+    static let x86_64Linux = try! Self("x86_64-unknown-linux-gnu")
+    static let arm64Linux = try! Self("aarch64-unknown-linux-gnu")
+    static let arm64Android = try! Self("aarch64-unknown-linux-android")
+    static let windows = try! Self("x86_64-unknown-windows-msvc")
+    static let wasi = try! Self("wasm32-unknown-wasi")
 }
 
 let hostTriple = try! UserToolchain.default.triple
@@ -71,7 +71,7 @@ func mockBuildParameters(
     flags: PackageModel.BuildFlags = PackageModel.BuildFlags(),
     shouldLinkStaticSwiftStdlib: Bool = false,
     canRenameEntrypointFunctionName: Bool = false,
-    destinationTriple: TSCUtility.Triple = hostTriple,
+    destinationTriple: Basics.Triple = hostTriple,
     indexStoreMode: BuildParameters.IndexStoreMode = .off,
     useExplicitModuleBuild: Bool = false,
     linkerDeadStrip: Bool = true
@@ -94,7 +94,7 @@ func mockBuildParameters(
 }
 
 func mockBuildParameters(environment: BuildEnvironment) -> BuildParameters {
-    let triple: TSCUtility.Triple
+    let triple: Basics.Triple
     switch environment.platform {
     case .macOS:
         triple = Triple.macOS

--- a/Tests/PackageModelTests/DestinationTests.swift
+++ b/Tests/PackageModelTests/DestinationTests.swift
@@ -14,7 +14,6 @@ import Basics
 @testable import PackageModel
 @testable import SPMBuildCore
 import TSCBasic
-import TSCUtility
 import XCTest
 
 private let bundleRootPath = try! AbsolutePath(validating: "/tmp/cross-toolchain")

--- a/Tests/PackageModelTests/PackageModelTests.swift
+++ b/Tests/PackageModelTests/PackageModelTests.swift
@@ -13,7 +13,6 @@
 import Basics
 @testable import PackageModel
 import TSCBasic
-import TSCUtility
 import XCTest
 
 class PackageModelTests: XCTestCase {

--- a/Tests/SPMBuildCoreTests/ArtifactsArchiveMetadataTests.swift
+++ b/Tests/SPMBuildCoreTests/ArtifactsArchiveMetadataTests.swift
@@ -14,7 +14,7 @@ import PackageModel
 import TSCBasic
 import XCTest
 
-import struct TSCUtility.Triple
+import struct Basics.Triple
 
 final class ArtifactsArchiveMetadataTests: XCTestCase {
     func testParseMetadata() throws {

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -21,7 +21,6 @@ import Workspace
 import XCTest
 
 import struct TSCUtility.SerializedDiagnostics
-import struct TSCUtility.Triple
 
 class PluginInvocationTests: XCTestCase {
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -25,7 +25,6 @@ import TSCBasic
 import XCTest
 
 import enum TSCUtility.Diagnostics
-import struct TSCUtility.Triple
 import struct TSCUtility.Version
 
 final class WorkspaceTests: XCTestCase {


### PR DESCRIPTION
As we want to reduce our dependency on TSC, it makes sense to move `Triple` to our codebase and deprecate it in TSC.