### PR TITLE
Basics: make `Triple` parsing errors human-readable

### DIFF
--- a/Sources/Basics/Triple.swift
+++ b/Sources/Basics/Triple.swift
@@ -297,3 +297,16 @@ extension Triple.Error: CustomNSError {
         [NSLocalizedDescriptionKey: "\(self)"]
     }
 }
+
+extension Triple.Error: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .badFormat(let triple):
+            return "couldn't parse triple string \(triple)"
+        case .unknownArch(let arch):
+            return "unknown architecture \(arch)"
+        case .unknownOS(let os):
+            return "unknown OS \(os)"
+        }
+    }
+}


### PR DESCRIPTION
### Motivation:

Currently when a triple can't be parsed, the only error message the end user sees in the terminal is `Error: badFormat(triple: "ksjnfklsdn")`. This is quite confusing and unreadable.

### Modifications:

Add conformance to `CustomStringConvertible` on `Triple.error`.

### Result:

When a triple can't be parsed, the parsing error is surfaced to the end user in a human-readable form so that it's easier to address the error and find a root cause.
