### PR TITLE
Remove outdated compiler conditionals

### DIFF
--- a/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
+++ b/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
@@ -46,9 +46,7 @@ extension DispatchQueue {
     )
 }
 
-#if swift(<5.7)
-extension URL: UnsafeSendable {}
-#elseif !canImport(Darwin)
+#if !canImport(Darwin)
 // As of Swift 5.7 and 5.8 swift-corelibs-foundation doesn't have `Sendable` annotations yet.
 extension URL: @unchecked Sendable {}
 #endif

--- a/Sources/Basics/Concurrency/SendableBox.swift
+++ b/Sources/Basics/Concurrency/SendableBox.swift
@@ -10,8 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if swift(>=5.5.2)
-
 import struct Foundation.Date
 
 /// A `Sendable` storage that allows access from concurrently running tasks in 
@@ -44,5 +42,3 @@ extension SendableBox where Value == Date {
         value = Date()
     }
 }
-
-#endif

--- a/Sources/Basics/Concurrency/ThreadSafeArrayStore.swift
+++ b/Sources/Basics/Concurrency/ThreadSafeArrayStore.swift
@@ -83,8 +83,4 @@ public final class ThreadSafeArrayStore<Value> {
     }
 }
 
-#if swift(<5.7)
-extension ThreadSafeArrayStore: UnsafeSendable where Value: Sendable {}
-#else
 extension ThreadSafeArrayStore: @unchecked Sendable where Value: Sendable {}
-#endif

--- a/Sources/Basics/Concurrency/ThreadSafeBox.swift
+++ b/Sources/Basics/Concurrency/ThreadSafeBox.swift
@@ -100,8 +100,4 @@ extension ThreadSafeBox where Value == Int {
     }
 }
 
-#if swift(<5.7)
-extension ThreadSafeBox: UnsafeSendable where Value: Sendable {}
-#else
 extension ThreadSafeBox: @unchecked Sendable where Value: Sendable {}
-#endif

--- a/Sources/Basics/Concurrency/ThreadSafeKeyValueStore.swift
+++ b/Sources/Basics/Concurrency/ThreadSafeKeyValueStore.swift
@@ -93,8 +93,4 @@ public final class ThreadSafeKeyValueStore<Key, Value> where Key: Hashable {
     }
 }
 
-#if swift(<5.7)
-extension ThreadSafeKeyValueStore: UnsafeSendable where Key: Sendable, Value: Sendable {}
-#else
 extension ThreadSafeKeyValueStore: @unchecked Sendable where Key: Sendable, Value: Sendable {}
-#endif

--- a/Sources/Basics/Concurrency/TokenBucket.swift
+++ b/Sources/Basics/Concurrency/TokenBucket.swift
@@ -10,15 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if swift(>=5.5.2)
-
 import _Concurrency
 import DequeModule
-
-// This type is already marked as `Sendable` in Swift 5.6 and later
-#if swift(<5.6)
-extension CheckedContinuation: UnsafeSendable {}
-#endif
 
 /// Type modeled after a "token bucket" pattern, which is similar to a semaphore, but is built with
 /// Swift Concurrency primitives.
@@ -67,5 +60,3 @@ public actor TokenBucket {
         }
     }
 }
-
-#endif // swift(>=5.5.2)

--- a/Sources/Basics/FileSystem/AsyncFileSystem.swift
+++ b/Sources/Basics/FileSystem/AsyncFileSystem.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if swift(>=5.5.2)
 import _Concurrency
 
 import class TSCBasic.BufferedOutputByteStream
@@ -264,5 +263,3 @@ extension AsyncFileSystem {
         try self.removeFileTree(tempDirectory)
     }
 }
-
-#endif // swift(>=5.5.2)

--- a/Sources/Basics/FileSystem/TemporaryFile.swift
+++ b/Sources/Basics/FileSystem/TemporaryFile.swift
@@ -12,13 +12,7 @@
 
 import _Concurrency
 import Foundation
-#if swift(>=5.7)
 @preconcurrency import TSCBasic
-#else
-import TSCBasic
-#endif
-
-#if swift(>=5.5.2)
 
 /// Creates a temporary directory and evaluates a closure with the directory path as an argument.
 /// The temporary directory will live on disk while the closure is evaluated and will be deleted when
@@ -85,8 +79,6 @@ public func withTemporaryDirectory<Result>(
         return try await body(path)
     }
 }
-
-#endif
 
 private func createTemporaryDirectory(fileSystem: FileSystem, dir: AbsolutePath?, prefix: String) throws -> AbsolutePath {
     // This random generation is needed so that

--- a/Sources/Basics/HTTPClient/HTTPClient.swift
+++ b/Sources/Basics/HTTPClient/HTTPClient.swift
@@ -10,8 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if swift(>=5.5.2)
-
 import _Concurrency
 import Foundation
 import DequeModule
@@ -251,5 +249,3 @@ public extension HTTPClient {
         )
     }
 }
-
-#endif

--- a/Sources/Basics/HTTPClient/HTTPClientConfiguration.swift
+++ b/Sources/Basics/HTTPClient/HTTPClientConfiguration.swift
@@ -10,9 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// `Sendable` conformance on contained types requires Swift Concurrency back-deployment.
-#if swift(>=5.5.2)
-
 import Foundation
 
 public struct HTTPClientConfiguration: Sendable {
@@ -43,8 +40,6 @@ public struct HTTPClientConfiguration: Sendable {
     public var circuitBreakerStrategy: HTTPClientCircuitBreakerStrategy?
     public var maxConcurrentRequests: Int?
 }
-
-#endif
 
 public enum HTTPClientRetryStrategy: Sendable {
     case exponentialBackoff(maxAttempts: Int, baseDelay: SendableTimeInterval)

--- a/Sources/Basics/HTTPClient/HTTPClientRequest.swift
+++ b/Sources/Basics/HTTPClient/HTTPClientRequest.swift
@@ -10,9 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// `AsyncFileSystem` used by `HTTPClientRequest` requires Swift Concurrency back-deployment.
-#if swift(>=5.5.2)
-
 import Foundation
 
 import struct TSCBasic.AbsolutePath
@@ -101,5 +98,3 @@ public struct HTTPClientRequest: Sendable {
         }
     }
 }
-
-#endif

--- a/Sources/Basics/HTTPClient/HTTPClientResponse.swift
+++ b/Sources/Basics/HTTPClient/HTTPClientResponse.swift
@@ -12,10 +12,6 @@
 
 import Foundation
 
-#if swift(<5.7)
-extension Data: UnsafeSendable {}
-#endif
-
 public struct HTTPClientResponse : Sendable {
     public let statusCode: Int
     public let statusText: String?

--- a/Sources/Basics/HTTPClient/URLSessionHTTPClient.swift
+++ b/Sources/Basics/HTTPClient/URLSessionHTTPClient.swift
@@ -29,8 +29,6 @@ final class URLSessionHTTPClient {
         self.downloadTaskManager = DownloadTaskManager(configuration: configuration)
     }
 
-#if swift(>=5.5.2)
-
     @Sendable
     func execute(
         _ request: HTTPClient.Request,
@@ -61,8 +59,6 @@ final class URLSessionHTTPClient {
             task.resume()
         }
     }
-
-#endif
 
     public func execute(
         _ request: LegacyHTTPClient.Request,
@@ -350,8 +346,6 @@ extension URLRequest {
         }
     }
 
-// For `HTTPClient` to be available we need Swift Concurrency back-deployment.
-#if swift(>=5.5.2)
     init(_ request: HTTPClient.Request) {
         self.init(url: request.url)
         self.httpMethod = request.method.string
@@ -363,7 +357,6 @@ extension URLRequest {
             self.timeoutInterval = interval
         }
     }
-#endif
 }
 
 private extension HTTPURLResponse {

--- a/Sources/Basics/SQLite.swift
+++ b/Sources/Basics/SQLite.swift
@@ -299,11 +299,9 @@ public final class SQLite {
     }
 }
 
-#if swift(>=5.6)
 // Explicitly mark this class as non-Sendable
 @available(*, unavailable)
 extension SQLite: Sendable {}
-#endif
 
 private func sqlite_callback(
     _ ctx: UnsafeMutableRawPointer?,

--- a/Sources/PackageRegistry/SignatureValidation.swift
+++ b/Sources/PackageRegistry/SignatureValidation.swift
@@ -10,10 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if swift(>=5.5.2)
 import _Concurrency
-#endif
-
 import Dispatch
 import struct Foundation.Data
 
@@ -186,7 +183,6 @@ struct SignatureValidation {
         observabilityScope: ObservabilityScope,
         completion: @escaping (Result<SigningEntity?, Error>) -> Void
     ) {
-        #if swift(>=5.5.2)
         Task {
             do {
                 let signatureStatus = try await SignatureProvider.status(
@@ -234,8 +230,5 @@ struct SignatureValidation {
                 completion(.failure(RegistryError.failedToValidateSignature(error)))
             }
         }
-        #else
-        completion(.failure(InternalError("package signature validation not supported")))
-        #endif
     }
 }

--- a/Sources/SPMTestSupport/MockHashAlgorithm.swift
+++ b/Sources/SPMTestSupport/MockHashAlgorithm.swift
@@ -33,9 +33,4 @@ public final class MockHashAlgorithm {
     }
 }
 
-// Older compilers are unable to infer sendability for `Optional` closures even when those are `@Sendable`.
-#if swift(<5.6)
-extension MockHashAlgorithm: UnsafeSendable {}
-#endif
-
 extension MockHashAlgorithm: HashAlgorithm {}

--- a/Tests/BasicsTests/FileSystem/AsyncFileSystemTests.swift
+++ b/Tests/BasicsTests/FileSystem/AsyncFileSystemTests.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if swift(>=5.5.2)
 import _Concurrency
 
 @testable import Basics
@@ -107,5 +106,3 @@ final class AsyncFileSystemTests: XCTestCase {
         }
     }
 }
-
-#endif // swift(>=5.5.2)

--- a/Tests/BasicsTests/FileSystem/TemporaryFileTests.swift
+++ b/Tests/BasicsTests/FileSystem/TemporaryFileTests.swift
@@ -10,8 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if swift(>=5.5.2)
-
 import XCTest
 import TSCBasic
 
@@ -92,5 +90,3 @@ class TemporaryAsyncFileTests: XCTestCase {
         } catch {}
     }
 }
-
-#endif

--- a/Tests/BasicsTests/FileSystem/VFSTests.swift
+++ b/Tests/BasicsTests/FileSystem/VFSTests.swift
@@ -14,8 +14,6 @@ import Basics
 import TSCBasic
 import XCTest
 
-#if swift(>=5.5.2)
-
 func testWithTemporaryDirectory(
     function: StaticString = #function,
     body: @escaping (AbsolutePath) async throws -> Void
@@ -33,8 +31,6 @@ func testWithTemporaryDirectory(
         try await  body(tmpDirPath)
     }.value
 }
-
-#endif
 
 class VFSTests: XCTestCase {
     func testLocalBasics() throws {

--- a/Tests/BasicsTests/HTTPClientTests.swift
+++ b/Tests/BasicsTests/HTTPClientTests.swift
@@ -10,8 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if swift(>=5.5.2)
-
 @testable import Basics
 import SPMTestSupport
 import XCTest
@@ -428,5 +426,3 @@ private func assertRequestHeaders(_ headers: HTTPClientHeaders, expected: HTTPCl
 private func assertResponseHeaders(_ headers: HTTPClientHeaders, expected: HTTPClientHeaders) {
     XCTAssertEqual(headers, expected, "expected headers to match")
 }
-
-#endif

--- a/Tests/BasicsTests/URLSessionHTTPClientTests.swift
+++ b/Tests/BasicsTests/URLSessionHTTPClientTests.swift
@@ -570,7 +570,6 @@ final class URLSessionHTTPClientTest: XCTestCase {
     }
 
     // FIXME: remove this availability check when back-deployment is available on CI hosts.
-#if swift(>=5.5.2)
     func testAsyncHead() async throws {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [MockURLProtocol.self]
@@ -964,7 +963,6 @@ final class URLSessionHTTPClientTest: XCTestCase {
             }
         }
     }
-#endif // swift(>=5.5.2)
 }
 
 private class MockURLProtocol: URLProtocol {
@@ -977,11 +975,9 @@ private class MockURLProtocol: URLProtocol {
         self.onRequest(request.method.string, request.url, completion: completion)
     }
 
-#if swift(>=5.5.2)
     static func onRequest(_ request: HTTPClientRequest, completion: @escaping Action) {
         self.onRequest(request.method.string, request.url, completion: completion)
     }
-#endif
 
     static func onRequest(_ method: String, _ url: URL, completion: @escaping Action) {
         let key = Key(method, url)

--- a/Tests/FunctionalTests/ModuleAliasingFixtureTests.swift
+++ b/Tests/FunctionalTests/ModuleAliasingFixtureTests.swift
@@ -21,10 +21,6 @@ import XCTest
 class ModuleAliasingFixtureTests: XCTestCase {
 
     func testModuleDirectDeps1() throws {
-        #if swift(<5.7)
-        try XCTSkipIf(true, "Module aliasing is only supported on swift 5.7+")
-        #endif
-
         try fixture(name: "ModuleAliasing/DirectDeps1") { fixturePath in
             let pkgPath = fixturePath.appending(components: "AppPkg")
             let buildPath = pkgPath.appending(components: ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug")
@@ -39,10 +35,6 @@ class ModuleAliasingFixtureTests: XCTestCase {
     }
 
     func testModuleDirectDeps2() throws {
-        #if swift(<5.7)
-        try XCTSkipIf(true, "Module aliasing is only supported on swift 5.7+")
-        #endif
-
         try fixture(name: "ModuleAliasing/DirectDeps2") { fixturePath in
             let pkgPath = fixturePath.appending(components: "AppPkg")
             let buildPath = pkgPath.appending(components: ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug")

--- a/Tests/PackageSigningTests/SigningTests.swift
+++ b/Tests/PackageSigningTests/SigningTests.swift
@@ -20,7 +20,6 @@ import SPMTestSupport
 import func TSCBasic.tsc_await
 import X509
 
-#if swift(>=5.5.2)
 final class SigningTests: XCTestCase {
     func testCMS1_0_0EndToEnd() async throws {
         let keyAndCertChain = try tsc_await { self.ecTestKeyAndCertChain(callback: $0) }
@@ -413,4 +412,3 @@ final class SigningTests: XCTestCase {
         }
     }
 }
-#endif


### PR DESCRIPTION
SwiftPM now requires 5.7 tools as a minimum, so we can drop any conditionals needed for building with older compilers.
