### PR TITLE
prompt for unsigned or untrusted packages if needed

### DIFF
--- a/Sources/CoreCommands/SwiftTool.swift
+++ b/Sources/CoreCommands/SwiftTool.swift
@@ -65,7 +65,8 @@ public struct ToolWorkspaceConfiguration {
 public typealias WorkspaceDelegateProvider = (
     _ observabilityScope: ObservabilityScope,
     _ outputHandler: @escaping (String, Bool) -> Void,
-    _ progressHandler: @escaping (Int64, Int64, String?) -> Void
+    _ progressHandler: @escaping (Int64, Int64, String?) -> Void,
+    _ inputHandler: @escaping (String, (String?) -> Void) -> Void
 ) -> WorkspaceDelegate
 public typealias WorkspaceLoaderProvider = (_ fileSystem: FileSystem, _ observabilityScope: ObservabilityScope)
     -> WorkspaceLoader
@@ -437,7 +438,8 @@ public final class SwiftTool {
         let delegate = self.workspaceDelegateProvider(
             self.observabilityScope,
             self.observabilityHandler.print,
-            self.observabilityHandler.progress
+            self.observabilityHandler.progress,
+            self.observabilityHandler.prompt
         )
         let isXcodeBuildSystemEnabled = self.options.build.buildSystem == .xcode
         let workspace = try Workspace(

--- a/Sources/CoreCommands/SwiftToolObservabilityHandler.swift
+++ b/Sources/CoreCommands/SwiftToolObservabilityHandler.swift
@@ -48,6 +48,11 @@ public struct SwiftToolObservabilityHandler: ObservabilityHandlerProvider {
         self.outputHandler.outputStream
     }
 
+    // prompt for user input
+    func prompt(_ message: String, completion: (String?) -> Void) {
+        self.outputHandler.prompt(message: message, completion: completion)
+    }
+
     func wait(timeout: DispatchTime) {
         self.outputHandler.wait(timeout: timeout)
     }
@@ -118,6 +123,20 @@ public struct SwiftToolObservabilityHandler: ObservabilityHandlerProvider {
                     text: description ?? ""
                 )
             }
+        }
+
+        // to read input from user
+        func prompt(message: String, completion: (String?) -> Void) {
+            guard self.outputStream.isTTY else {
+                return completion(.none)
+            }
+            let answer = self.queue.sync {
+                self.progressAnimation.clear()
+                self.outputStream.write(message.utf8)
+                self.outputStream.flush()
+                return readLine(strippingNewline: true)
+            }
+            completion(answer)
         }
 
         func wait(timeout: DispatchTime) {

--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -65,7 +65,7 @@ public final class RegistryClient: Cancellable {
         authorizationProvider: AuthorizationProvider? = .none,
         customHTTPClient: LegacyHTTPClient? = .none,
         customArchiverProvider: ((FileSystem) -> Archiver)? = .none,
-        delegate: Delegate? = .none
+        delegate: Delegate?
     ) {
         self.configuration = configuration
 
@@ -1980,11 +1980,11 @@ private struct RegistryClientSignatureValidationDelegate: SignatureValidation.De
         completion: (Bool) -> Void
     ) {
         if let underlying = self.underlying {
-            // TODO: record the responses locally
             underlying.onUnsigned(registry: registry, package: package, version: version, completion: completion)
         } else {
-            // TODO: consider this to be false by default
-            completion(true)
+            // true == continue resolution
+            // false == stop dependency resolution
+            completion(false)
         }
     }
 
@@ -1995,11 +1995,11 @@ private struct RegistryClientSignatureValidationDelegate: SignatureValidation.De
         completion: (Bool) -> Void
     ) {
         if let underlying = self.underlying {
-            // TODO: record the responses locally
             underlying.onUntrusted(registry: registry, package: package, version: version, completion: completion)
         } else {
-            // TODO: consider this to be false by default
-            completion(true)
+            // true == continue resolution
+            // false == stop dependency resolution
+            completion(false)
         }
     }
 }

--- a/Sources/PackageRegistryTool/PackageRegistryTool+Auth.swift
+++ b/Sources/PackageRegistryTool/PackageRegistryTool+Auth.swift
@@ -188,7 +188,8 @@ extension SwiftPackageRegistryTool {
                 fingerprintCheckingMode: .strict,
                 signingEntityStorage: .none,
                 signingEntityCheckingMode: .strict,
-                authorizationProvider: authorizationProvider
+                authorizationProvider: authorizationProvider,
+                delegate: .none
             )
 
             // Try logging in

--- a/Sources/PackageRegistryTool/PackageRegistryTool+Publish.swift
+++ b/Sources/PackageRegistryTool/PackageRegistryTool+Publish.swift
@@ -128,7 +128,8 @@ extension SwiftPackageRegistryTool {
                 fingerprintCheckingMode: .strict,
                 signingEntityStorage: .none,
                 signingEntityCheckingMode: .strict,
-                authorizationProvider: authorizationProvider
+                authorizationProvider: authorizationProvider,
+                delegate: .none
             )
 
             // step 1: publishing configuration

--- a/Sources/SPMTestSupport/MockRegistry.swift
+++ b/Sources/SPMTestSupport/MockRegistry.swift
@@ -60,7 +60,8 @@ public class MockRegistry {
             signingEntityCheckingMode: .strict,
             authorizationProvider: .none,
             customHTTPClient: LegacyHTTPClient(handler: self.httpHandler),
-            customArchiverProvider: { fileSystem in MockRegistryArchiver(fileSystem: fileSystem) }
+            customArchiverProvider: { fileSystem in MockRegistryArchiver(fileSystem: fileSystem) },
+            delegate: .none
         )
     }
 

--- a/Tests/CommandsTests/SwiftToolTests.swift
+++ b/Tests/CommandsTests/SwiftToolTests.swift
@@ -239,10 +239,18 @@ extension SwiftTool {
             options: options,
             toolWorkspaceConfiguration: .init(),
             workspaceDelegateProvider: {
-                ToolWorkspaceDelegate(observabilityScope: $0, outputHandler: $1, progressHandler: $2)
+                ToolWorkspaceDelegate(
+                    observabilityScope: $0,
+                    outputHandler: $1,
+                    progressHandler: $2,
+                    inputHandler: $3
+                )
             },
             workspaceLoaderProvider: {
-                XcodeWorkspaceLoader(fileSystem: $0, observabilityScope: $1)
+                XcodeWorkspaceLoader(
+                    fileSystem: $0,
+                    observabilityScope: $1
+                )
             })
     }
 }

--- a/Tests/PackageRegistryTests/RegistryClientTests.swift
+++ b/Tests/PackageRegistryTests/RegistryClientTests.swift
@@ -903,7 +903,8 @@ final class RegistryClientTests: XCTestCase {
                     try fileSystem.writeFileContents(packagePath.appending(component: "Package.swift"), string: "")
                     callback(.success(()))
                 })
-            }
+            },
+            delegate: .none
         )
 
         let fileSystem = InMemoryFileSystem()
@@ -1034,7 +1035,8 @@ final class RegistryClientTests: XCTestCase {
                     try fileSystem.writeFileContents(packagePath.appending("Package.swift"), string: "")
                     callback(.success(()))
                 })
-            }
+            },
+            delegate: .none
         )
 
         let fileSystem = InMemoryFileSystem()
@@ -1158,7 +1160,8 @@ final class RegistryClientTests: XCTestCase {
                     try fileSystem.writeFileContents(packagePath.appending("Package.swift"), string: "")
                     callback(.success(()))
                 })
-            }
+            },
+            delegate: .none
         )
 
         let fileSystem = InMemoryFileSystem()
@@ -1288,7 +1291,8 @@ final class RegistryClientTests: XCTestCase {
                     try fileSystem.writeFileContents(packagePath.appending("Package.swift"), string: "")
                     callback(.success(()))
                 })
-            }
+            },
+            delegate: .none
         )
 
         let fileSystem = InMemoryFileSystem()
@@ -1408,7 +1412,8 @@ final class RegistryClientTests: XCTestCase {
                     try fileSystem.writeFileContents(packagePath.appending("Package.swift"), string: "")
                     callback(.success(()))
                 })
-            }
+            },
+            delegate: .none
         )
 
         let fileSystem = InMemoryFileSystem()
@@ -1534,7 +1539,8 @@ final class RegistryClientTests: XCTestCase {
                     try fileSystem.writeFileContents(packagePath.appending("Package.swift"), string: "")
                     callback(.success(()))
                 })
-            }
+            },
+            delegate: .none
         )
 
         let fileSystem = InMemoryFileSystem()
@@ -1606,7 +1612,8 @@ final class RegistryClientTests: XCTestCase {
             fingerprintCheckingMode: .strict,
             signingEntityStorage: .none,
             signingEntityCheckingMode: .strict,
-            customHTTPClient: httpClient
+            customHTTPClient: httpClient,
+            delegate: .none
         )
 
         let fileSystem = InMemoryFileSystem()
@@ -1686,6 +1693,7 @@ final class RegistryClientTests: XCTestCase {
             signingEntityStorage: .none,
             signingEntityCheckingMode: .strict,
             customHTTPClient: httpClient
+            ,delegate: .none
         )
 
         let fileSystem = InMemoryFileSystem()
@@ -1733,7 +1741,8 @@ final class RegistryClientTests: XCTestCase {
             fingerprintCheckingMode: .strict,
             signingEntityStorage: .none,
             signingEntityCheckingMode: .strict,
-            customHTTPClient: httpClient
+            customHTTPClient: httpClient,
+            delegate: .none
         )
 
         let fileSystem = InMemoryFileSystem()
@@ -2764,7 +2773,8 @@ func makeRegistryClient(
         signingEntityCheckingMode: signingEntityCheckingMode,
         authorizationProvider: authorizationProvider,
         customHTTPClient: httpClient,
-        customArchiverProvider: { _ in MockArchiver() }
+        customArchiverProvider: { _ in MockArchiver() },
+        delegate: .none
     )
 }
 

--- a/Tests/PackageRegistryTests/SignatureValidationTests.swift
+++ b/Tests/PackageRegistryTests/SignatureValidationTests.swift
@@ -22,7 +22,6 @@ import XCTest
 import struct TSCUtility.Version
 
 final class SignatureValidationTests: XCTestCase {
-    // TODO: add testUnsignedPackage_shouldPrompt
     // TODO: add tests for signed package
 
     func testUnsignedPackage_shouldError() throws {
@@ -311,7 +310,6 @@ final class SignatureValidationTests: XCTestCase {
             ) { error in
                 guard case RegistryError.sourceArchiveNotSigned = error else {
                     return XCTFail("Expected RegistryError.sourceArchiveNotSigned, got '\(error)'")
-
                 }
             }
         }
@@ -426,22 +424,42 @@ extension SignatureValidation {
     }
 }
 
-fileprivate struct RejectingSignatureValidationDelegate: SignatureValidation.Delegate {
-    func onUnsigned(registry: PackageRegistry.Registry, package: PackageModel.PackageIdentity, version: TSCUtility.Version, completion: (Bool) -> Void) {
+private struct RejectingSignatureValidationDelegate: SignatureValidation.Delegate {
+    func onUnsigned(
+        registry: PackageRegistry.Registry,
+        package: PackageModel.PackageIdentity,
+        version: TSCUtility.Version,
+        completion: (Bool) -> Void
+    ) {
         completion(false)
     }
 
-    func onUntrusted(registry: PackageRegistry.Registry, package: PackageModel.PackageIdentity, version: TSCUtility.Version, completion: (Bool) -> Void) {
+    func onUntrusted(
+        registry: PackageRegistry.Registry,
+        package: PackageModel.PackageIdentity,
+        version: TSCUtility.Version,
+        completion: (Bool) -> Void
+    ) {
         completion(false)
     }
 }
 
-fileprivate struct AcceptingSignatureValidationDelegate: SignatureValidation.Delegate {
-    func onUnsigned(registry: PackageRegistry.Registry, package: PackageModel.PackageIdentity, version: TSCUtility.Version, completion: (Bool) -> Void) {
+private struct AcceptingSignatureValidationDelegate: SignatureValidation.Delegate {
+    func onUnsigned(
+        registry: PackageRegistry.Registry,
+        package: PackageModel.PackageIdentity,
+        version: TSCUtility.Version,
+        completion: (Bool) -> Void
+    ) {
         completion(true)
     }
 
-    func onUntrusted(registry: PackageRegistry.Registry, package: PackageModel.PackageIdentity, version: TSCUtility.Version, completion: (Bool) -> Void) {
+    func onUntrusted(
+        registry: PackageRegistry.Registry,
+        package: PackageModel.PackageIdentity,
+        version: TSCUtility.Version,
+        completion: (Bool) -> Void
+    ) {
         completion(true)
     }
 }

--- a/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
@@ -466,7 +466,8 @@ class RegistryPackageContainerTests: XCTestCase {
                     completion(.failure(StringError("unexpected url \(request.url)")))
                 }
             }),
-            customArchiverProvider: { _ in archiver }
+            customArchiverProvider: { _ in archiver },
+            delegate: .none
         )
     }
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -13810,7 +13810,8 @@ final class WorkspaceTests: XCTestCase {
                     completion(.failure(StringError("unexpected url \(request.url)")))
                 }
             }),
-            customArchiverProvider: { _ in archiver }
+            customArchiverProvider: { _ in archiver },
+            delegate: .none
         )
     }
 }


### PR DESCRIPTION
motivation: support the prompt configuration for handling unsigned or untrusted packages

changes:
* handle prompt request via swift-tool delegate
* add input API to swift-tool observability handler
