### PR TITLE
cleanup warnings and bring back tests

### DIFF
--- a/Tests/CommandsTests/PackageRegistryToolTests.swift
+++ b/Tests/CommandsTests/PackageRegistryToolTests.swift
@@ -80,13 +80,6 @@ final class PackageRegistryToolTests: CommandsTestCase {
     }
 
     func testLocalConfiguration() throws {
-        // Only run the test if the environment in which we're running actually supports Swift concurrency (which the
-        // plugin APIs require).
-        try XCTSkipIf(
-            !UserToolchain.default.supportsSwiftConcurrency(),
-            "skipping because test environment doesn't support concurrency"
-        )
-
         try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
             let packageRoot = fixturePath.appending("Bar")
             let configurationFilePath = AbsolutePath(
@@ -193,13 +186,6 @@ final class PackageRegistryToolTests: CommandsTestCase {
     // TODO: Test global configuration
 
     func testSetMissingURL() throws {
-        // Only run the test if the environment in which we're running actually supports Swift concurrency (which the
-        // plugin APIs require).
-        try XCTSkipIf(
-            !UserToolchain.default.supportsSwiftConcurrency(),
-            "skipping because test environment doesn't support concurrency"
-        )
-
         try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
             let packageRoot = fixturePath.appending("Bar")
             let configurationFilePath = AbsolutePath(
@@ -220,13 +206,6 @@ final class PackageRegistryToolTests: CommandsTestCase {
     }
 
     func testSetInvalidURL() throws {
-        // Only run the test if the environment in which we're running actually supports Swift concurrency (which the
-        // plugin APIs require).
-        try XCTSkipIf(
-            !UserToolchain.default.supportsSwiftConcurrency(),
-            "skipping because test environment doesn't support concurrency"
-        )
-
         try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
             let packageRoot = fixturePath.appending("Bar")
             let configurationFilePath = AbsolutePath(
@@ -247,13 +226,6 @@ final class PackageRegistryToolTests: CommandsTestCase {
     }
 
     func testSetInvalidScope() throws {
-        // Only run the test if the environment in which we're running actually supports Swift concurrency (which the
-        // plugin APIs require).
-        try XCTSkipIf(
-            !UserToolchain.default.supportsSwiftConcurrency(),
-            "skipping because test environment doesn't support concurrency"
-        )
-
         try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
             let packageRoot = fixturePath.appending("Bar")
             let configurationFilePath = AbsolutePath(
@@ -277,13 +249,6 @@ final class PackageRegistryToolTests: CommandsTestCase {
     }
 
     func testUnsetMissingEntry() throws {
-        // Only run the test if the environment in which we're running actually supports Swift concurrency (which the
-        // plugin APIs require).
-        try XCTSkipIf(
-            !UserToolchain.default.supportsSwiftConcurrency(),
-            "skipping because test environment doesn't support concurrency"
-        )
-
         try fixture(name: "DependencyResolution/External/Simple") { fixturePath in
             let packageRoot = fixturePath.appending("Bar")
             let configurationFilePath = AbsolutePath(
@@ -327,15 +292,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
 
     // TODO: Test example with login and password
 
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func testArchiving() throws {
-        // Only run the test if the environment in which we're running actually supports Swift concurrency (which the
-        // plugin APIs require).
-        try XCTSkipIf(
-            !UserToolchain.default.supportsSwiftConcurrency(),
-            "skipping because test environment doesn't support concurrency"
-        )
-
         #if os(Linux)
         // needed for archiving
         guard SPM_posix_spawn_file_actions_addchdir_np_supported() else {

--- a/Tests/PackageSigningTests/SigningTests.swift
+++ b/Tests/PackageSigningTests/SigningTests.swift
@@ -31,8 +31,8 @@ final class SigningTests: XCTestCase {
                 .PrivateKey(P256.Signing.PrivateKey(derRepresentation: keyAndCertChain.privateKey))
         )
         let content = Array("per aspera ad astra".utf8)
-        let signatureFormat = SignatureFormat.cms_1_0_0
 
+        let signatureFormat = SignatureFormat.cms_1_0_0
         let signature = try SignatureProvider.sign(
             content: content,
             identity: signingIdentity,


### PR DESCRIPTION
motivation: address warnings and restore tests that can now run due to not using concurrency

changes:
* remove redundant await in tests
* remove conditionals from tets that could not run in CI due to lack of concurrnecy and can now run

