### PR TITLE
Destinations: add `configuration set` subcommand

### DIFF
--- a/Sources/CrossCompilationDestinationsTool/CMakeLists.txt
+++ b/Sources/CrossCompilationDestinationsTool/CMakeLists.txt
@@ -7,8 +7,10 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_library(CrossCompilationDestinationsTool
+  Configuration/ConfigurationCommand.swift
   Configuration/ConfigureDestination.swift
   Configuration/ResetConfiguration.swift
+  Configuration/SetConfiguration.swift
   Configuration/ShowConfiguration.swift
   DestinationCommand.swift
   InstallDestination.swift

--- a/Sources/CrossCompilationDestinationsTool/Configuration/ConfigurationCommand.swift
+++ b/Sources/CrossCompilationDestinationsTool/Configuration/ConfigurationCommand.swift
@@ -1,0 +1,80 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import Basics
+import PackageModel
+
+import struct TSCBasic.AbsolutePath
+
+protocol ConfigurationCommand: DestinationCommand {
+    /// An identifier of an already installed destination.
+    var destinationID: String { get }
+
+    /// A run-time triple of the destination specified by `destinationID` identifier string.
+    var runTimeTriple: String { get }
+
+    /// Run a command related to configuration of cross-compilation destinations, passing it required configuration
+    /// values.
+    /// - Parameters:
+    ///   - buildTimeTriple: triple of the machine this command is running on.
+    ///   - runTimeTriple: triple of the machine on which cross-compiled code will run on.
+    ///   - destination: destination configuration fetched that matches currently set `destinationID` and
+    ///   `runTimeTriple`.
+    ///   - configurationStore: storage for configuration properties that this command operates on.
+    ///   - destinationsDirectory: directory containing destination artifact bundles and their configuration.
+    ///   - observabilityScope: observability scope used for logging.
+    func run(
+        buildTimeTriple: Triple,
+        runTimeTriple: Triple,
+        _ destination: Destination,
+        _ configurationStore: DestinationConfigurationStore,
+        _ destinationsDirectory: AbsolutePath,
+        _ observabilityScope: ObservabilityScope
+    ) throws
+}
+
+extension ConfigurationCommand {
+    func run(
+        buildTimeTriple: Triple,
+        _ destinationsDirectory: AbsolutePath,
+        _ observabilityScope: ObservabilityScope
+    ) throws {
+        let configurationStore = try DestinationConfigurationStore(
+            buildTimeTriple: buildTimeTriple,
+            destinationsDirectoryPath: destinationsDirectory,
+            fileSystem: fileSystem,
+            observabilityScope: observabilityScope
+        )
+        let runTimeTriple = try Triple(self.runTimeTriple)
+
+        guard let destination = try configurationStore.readConfiguration(
+            destinationID: destinationID,
+            runTimeTriple: runTimeTriple
+        ) else {
+            throw DestinationError.destinationNotFound(
+                artifactID: destinationID,
+                builtTimeTriple: buildTimeTriple,
+                runTimeTriple: runTimeTriple
+            )
+        }
+
+        try run(
+            buildTimeTriple: buildTimeTriple,
+            runTimeTriple: runTimeTriple,
+            destination,
+            configurationStore,
+            destinationsDirectory,
+            observabilityScope
+        )
+    }
+}

--- a/Sources/CrossCompilationDestinationsTool/Configuration/ConfigureDestination.swift
+++ b/Sources/CrossCompilationDestinationsTool/Configuration/ConfigureDestination.swift
@@ -20,6 +20,7 @@ struct ConfigureDestination: ParsableCommand {
         """,
         subcommands: [
             ResetConfiguration.self,
+            SetConfiguration.self,
             ShowConfiguration.self,
         ]
     )

--- a/Sources/CrossCompilationDestinationsTool/Configuration/SetConfiguration.swift
+++ b/Sources/CrossCompilationDestinationsTool/Configuration/SetConfiguration.swift
@@ -1,0 +1,156 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import Basics
+import CoreCommands
+import PackageModel
+
+import struct TSCBasic.AbsolutePath
+
+struct SetConfiguration: ConfigurationCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "set",
+        abstract: """
+        Sets configuration options for installed cross-compilation destinations.
+        """
+    )
+    
+    @OptionGroup(visibility: .hidden)
+    var locations: LocationOptions
+    
+    @Option(help: "A path to a directory containing the SDK root.")
+    var sdkRootPath: String? = nil
+    
+    @Option(help: "A path to a directory containing Swift resources for dynamic linking.")
+    var swiftResourcesPath: String? = nil
+    
+    @Option(help: "A path to a directory containing Swift resources for static linking.")
+    var swiftStaticResourcesPath: String? = nil
+    
+    @Option(
+        parsing: .singleValue,
+        help: """
+        A path to a directory containing headers. Multiple paths can be specified by providing this option multiple \
+        times to the command.
+        """
+    )
+    var includeSearchPath: [String] = []
+    
+    @Option(
+        parsing: .singleValue,
+        help: """
+        "A path to a directory containing libraries. Multiple paths can be specified by providing this option multiple \
+        times to the command.
+        """
+    )
+    var librarySearchPath: [String] = []
+    
+    @Option(
+        parsing: .singleValue,
+        help: """
+        "A path to a toolset file. Multiple paths can be specified by providing this option multiple times to the command.
+        """
+    )
+    var toolsetPath: [String] = []
+    
+    @Argument(
+        help: """
+        An identifier of an already installed destination. Use the `list` subcommand to see all available \
+        identifiers.
+        """
+    )
+    var destinationID: String
+    
+    @Argument(help: "The run-time triple of the destination to configure.")
+    var runTimeTriple: String
+
+    func run(
+        buildTimeTriple: Triple,
+        runTimeTriple: Triple,
+        _ destination: Destination,
+        _ configurationStore: DestinationConfigurationStore,
+        _ destinationsDirectory: AbsolutePath,
+        _ observabilityScope: ObservabilityScope
+    ) throws {
+        var configuration = destination.pathsConfiguration
+        var updatedProperties = [String]()
+
+        let currentWorkingDirectory = fileSystem.currentWorkingDirectory
+
+        if let sdkRootPath = sdkRootPath {
+            configuration.sdkRootPath = try AbsolutePath(validating: sdkRootPath, relativeTo: currentWorkingDirectory)
+            updatedProperties.append(CodingKeys.sdkRootPath.stringValue)
+        }
+
+        if let swiftResourcesPath = swiftResourcesPath {
+            configuration.swiftResourcesPath =
+                try AbsolutePath(validating: swiftResourcesPath, relativeTo: currentWorkingDirectory)
+            updatedProperties.append(CodingKeys.swiftResourcesPath.stringValue)
+        }
+
+        if let swiftStaticResourcesPath = swiftStaticResourcesPath {
+            configuration.swiftResourcesPath =
+                try AbsolutePath(validating: swiftStaticResourcesPath, relativeTo: currentWorkingDirectory)
+            updatedProperties.append(CodingKeys.swiftStaticResourcesPath.stringValue)
+        }
+
+        if !includeSearchPath.isEmpty {
+            configuration.includeSearchPaths =
+                try includeSearchPath.map { try AbsolutePath(validating: $0, relativeTo: currentWorkingDirectory) }
+            updatedProperties.append(CodingKeys.includeSearchPath.stringValue)
+        }
+
+        if !librarySearchPath.isEmpty {
+            configuration.librarySearchPaths =
+                try librarySearchPath.map { try AbsolutePath(validating: $0, relativeTo: currentWorkingDirectory) }
+            updatedProperties.append(CodingKeys.librarySearchPath.stringValue)
+        }
+
+        if !toolsetPath.isEmpty {
+            configuration.toolsetPaths =
+                try toolsetPath.map { try AbsolutePath(validating: $0, relativeTo: currentWorkingDirectory) }
+            updatedProperties.append(CodingKeys.toolsetPath.stringValue)
+        }
+
+        guard !updatedProperties.isEmpty else {
+            observabilityScope.emit(
+                error: """
+                No properties of destination `\(destinationID) for run-time triple `\(runTimeTriple)` were updated \
+                since none were specified. Pass `--help` flag to see the list of all available properties.
+                """
+            )
+            return
+        }
+
+        var destination = destination
+        destination.pathsConfiguration = configuration
+        try configurationStore.updateConfiguration(destinationID: destinationID, destination: destination)
+
+        observabilityScope.emit(
+            info: """
+            These properties of destination `\(destinationID) for run-time triple \
+            `\(runTimeTriple)` were successfully updated: \(updatedProperties.joined(separator: ", ")).
+            """
+        )
+    }
+}
+
+extension AbsolutePath {
+    fileprivate init(validating string: String, relativeTo basePath: AbsolutePath?) throws {
+        if let basePath = basePath {
+            try self.init(validating: string, relativeTo: basePath)
+        } else {
+            try self.init(validating: string)
+        }
+    }
+}

--- a/Sources/CrossCompilationDestinationsTool/Configuration/SetConfiguration.swift
+++ b/Sources/CrossCompilationDestinationsTool/Configuration/SetConfiguration.swift
@@ -24,19 +24,19 @@ struct SetConfiguration: ConfigurationCommand {
         Sets configuration options for installed cross-compilation destinations.
         """
     )
-    
+
     @OptionGroup(visibility: .hidden)
     var locations: LocationOptions
-    
+
     @Option(help: "A path to a directory containing the SDK root.")
     var sdkRootPath: String? = nil
-    
+
     @Option(help: "A path to a directory containing Swift resources for dynamic linking.")
     var swiftResourcesPath: String? = nil
-    
+
     @Option(help: "A path to a directory containing Swift resources for static linking.")
     var swiftStaticResourcesPath: String? = nil
-    
+
     @Option(
         parsing: .singleValue,
         help: """
@@ -45,7 +45,7 @@ struct SetConfiguration: ConfigurationCommand {
         """
     )
     var includeSearchPath: [String] = []
-    
+
     @Option(
         parsing: .singleValue,
         help: """
@@ -54,7 +54,7 @@ struct SetConfiguration: ConfigurationCommand {
         """
     )
     var librarySearchPath: [String] = []
-    
+
     @Option(
         parsing: .singleValue,
         help: """
@@ -62,7 +62,7 @@ struct SetConfiguration: ConfigurationCommand {
         """
     )
     var toolsetPath: [String] = []
-    
+
     @Argument(
         help: """
         An identifier of an already installed destination. Use the `list` subcommand to see all available \
@@ -70,7 +70,7 @@ struct SetConfiguration: ConfigurationCommand {
         """
     )
     var destinationID: String
-    
+
     @Argument(help: "The run-time triple of the destination to configure.")
     var runTimeTriple: String
 

--- a/Sources/CrossCompilationDestinationsTool/Configuration/ShowConfiguration.swift
+++ b/Sources/CrossCompilationDestinationsTool/Configuration/ShowConfiguration.swift
@@ -17,7 +17,7 @@ import PackageModel
 
 import struct TSCBasic.AbsolutePath
 
-struct ShowConfiguration: DestinationCommand {
+struct ShowConfiguration: ConfigurationCommand {
     static let configuration = CommandConfiguration(
         commandName: "show",
         abstract: """
@@ -41,30 +41,13 @@ struct ShowConfiguration: DestinationCommand {
 
     func run(
         buildTimeTriple: Triple,
+        runTimeTriple: Triple,
+        _ destination: Destination,
+        _ configurationStore: DestinationConfigurationStore,
         _ destinationsDirectory: AbsolutePath,
         _ observabilityScope: ObservabilityScope
     ) throws {
-        let configurationStore = try DestinationConfigurationStore(
-            buildTimeTriple: buildTimeTriple,
-            destinationsDirectoryPath: destinationsDirectory,
-            fileSystem: fileSystem,
-            observabilityScope: observabilityScope
-        )
-
-        let triple = try Triple(runTimeTriple)
-
-        guard let configuration = try configurationStore.readConfiguration(
-            destinationID: destinationID,
-            runTimeTriple: triple
-        )?.pathsConfiguration else {
-            throw DestinationError.destinationNotFound(
-                artifactID: destinationID,
-                builtTimeTriple: buildTimeTriple,
-                runTimeTriple: triple
-            )
-        }
-
-        print(configuration)
+        print(destination.pathsConfiguration)
     }
 }
 

--- a/Sources/PackageModel/DestinationConfigurationStore.swift
+++ b/Sources/PackageModel/DestinationConfigurationStore.swift
@@ -16,6 +16,7 @@ import TSCBasic
 import class Foundation.JSONDecoder
 import class Foundation.JSONEncoder
 
+/// Storage for configuration properties of cross-compilation destinations.
 public final class DestinationConfigurationStore {
     /// Triple of the machine on which SwiftPM is running.
     private let buildTimeTriple: Triple


### PR DESCRIPTION
### Motivation:

To update destinations configuration we need a new subcommand to complement existing `configuration show` and `configuration reset` subcommands.

### Modifications:

Added new `SetConfiguration` type with the implementation. Additionally, new `ConfigurationCommand` protocol was added that inherits from and extends `DestinationCommand` protocol to provide configuration-specific properties and arguments. This new protocol allows reusing common configuration code.

Also improved logging in `ResetConfiguration` to make it clear which properties were reset.

### Result:

Users can run `swift experimental-destination configuration set` subcommand to customize properties of installed destinations.
