### PR TITLE
Skip other paths under target if target declares sources

### DIFF
--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -379,7 +379,7 @@ public struct TargetSourcesBuilder {
     /// ones that should be copied as-is.
     public func computeContents() -> [AbsolutePath] {
         var contents: [AbsolutePath] = []
-        var queue: [AbsolutePath] = [targetPath]
+        var queue: [AbsolutePath] = declaredSources ?? [targetPath]
 
         // Ignore xcodeproj and playground directories.
         var ignoredDirectoryExtensions = ["xcodeproj", "playground", "xcworkspace"]


### PR DESCRIPTION
### Motivation:

Some large Swift packages like Firebase make Xcode and SPM very slow at resolving package graph. It seems to be largely due to (their dependencies) containing large amounts of unrelated files which SPM checks each anyway.

Quoting my [post on Swift Forums](https://forums.swift.org/t/spm-how-to-prevent-resolve-packages-from-stymying-developer-productivity-local-packages/63363/3),

> Tracing `swift-package` with the File Activity instruments further reveals that SPM is indeed hitting a lot of files under Firebase and its dependencies. The biggest of those libraries consist of over 20,000 files, most of them (excluded code, tests and test data) irrelevant to the Swift package. `TargetSourcesBuilder` starts by finding all files reachable under the target's directory. But that becomes a problem if a package is making [deliberate use](https://github.com/grpc/grpc-ios/blob/main/Package.swift#L34-L76) of `.target(... path: exclude: sources: )`.

### Modifications:

Don't include *every file* under `targetPath` for those targets which declare their own `sources` explicitly. Instead, only traverse the file and directory paths included in `declaredSources`.

### Result:

> If this change is right to do (it breaks some potentially obsolete unit tests!), it could provide up to a further 4.5x speedup, evaluating show-dependencies for me in just 2.324s/0.767s/0.561s.

This change currently breaks some seemingly obsolete unit tests, which assert a package structure foreign to today's conventions. Should this PR move forward, I need assistance from maintainers resolving what to do with those tests and which new test cases to add.