### PR TITLE
Updates to PackageSigningEntityStorage and signing entity TOFU errors

### DIFF
--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -809,7 +809,8 @@ public final class RegistryClient: Cancellable {
                                                     switch checksumResult {
                                                     case .success:
                                                         do {
-                                                            // validate that the destination does not already exist (again, as this
+                                                            // validate that the destination does not already exist
+                                                            // (again, as this
                                                             // is
                                                             // async)
                                                             guard !fileSystem.exists(destinationPath) else {
@@ -1344,12 +1345,20 @@ public enum RegistryError: Error, CustomStringConvertible {
     case signerNotTrusted(SigningEntity)
     case failedToValidateSignature(Error)
     case signingEntityForReleaseChanged(
+        registry: Registry,
         package: PackageIdentity,
         version: Version,
         latest: SigningEntity?,
         previous: SigningEntity
     )
-    case signingEntityForPackageChanged(package: PackageIdentity, latest: SigningEntity?, previous: SigningEntity)
+    case signingEntityForPackageChanged(
+        registry: Registry,
+        package: PackageIdentity,
+        version: Version,
+        latest: SigningEntity?,
+        previous: SigningEntity,
+        previousVersion: Version
+    )
 
     public var description: String {
         switch self {
@@ -1443,10 +1452,17 @@ public enum RegistryError: Error, CustomStringConvertible {
             return "the signer \(signingEntity) is not trusted"
         case .failedToValidateSignature(let error):
             return "failed to validate signature: \(error)"
-        case .signingEntityForReleaseChanged(let package, let version, let latest, let previous):
-            return "the signing entity '\(String(describing: latest))' for \(package) version \(version) is different from the previously recorded value '\(previous)'"
-        case .signingEntityForPackageChanged(let package, let latest, let previous):
-            return "the signing entity '\(String(describing: latest))' for \(package) is different from the previously recorded value '\(previous)'"
+        case .signingEntityForReleaseChanged(let registry, let package, let version, let latest, let previous):
+            return "the signing entity '\(String(describing: latest))' from \(registry) for \(package) version \(version) is different from the previously recorded value '\(previous)'"
+        case .signingEntityForPackageChanged(
+            let registry,
+            let package,
+            let version,
+            let latest,
+            let previous,
+            let previousVersion
+        ):
+            return "the signing entity '\(String(describing: latest))' from \(registry) for \(package) version \(version) is different from the previously recorded value '\(previous)' for version \(previousVersion)"
         }
     }
 }

--- a/Sources/PackageRegistry/SignatureValidation.swift
+++ b/Sources/PackageRegistry/SignatureValidation.swift
@@ -77,6 +77,7 @@ struct SignatureValidation {
                 // Always do signing entity TOFU check at the end,
                 // whether the package is signed or not.
                 self.signingEntityTOFU.validate(
+                    registry: registry,
                     package: package,
                     version: version,
                     signingEntity: signingEntity,

--- a/Sources/PackageSigning/SigningEntity/PackageSigningEntityStorage.swift
+++ b/Sources/PackageSigning/SigningEntity/PackageSigningEntityStorage.swift
@@ -108,27 +108,32 @@ public struct PackageSigner: Codable {
     public let signingEntity: SigningEntity
     public internal(set) var origins: Set<SigningEntity.Origin>
     public internal(set) var versions: Set<Version>
+
+    public init(
+        signingEntity: SigningEntity,
+        origins: Set<SigningEntity.Origin>,
+        versions: Set<Version>
+    ) {
+        self.signingEntity = signingEntity
+        self.origins = origins
+        self.versions = versions
+    }
 }
 
 public struct PackageSigners {
     public internal(set) var expectedSigner: (signingEntity: SigningEntity, fromVersion: Version)?
     public internal(set) var signers: [SigningEntity: PackageSigner]
 
-    public var isEmpty: Bool {
-        self.signers.isEmpty
-    }
-
-    init() {
-        self.expectedSigner = .none
-        self.signers = [:]
-    }
-
-    init(
-        expectedSigner: (signingEntity: SigningEntity, fromVersion: Version)?,
-        signers: [SigningEntity: PackageSigner]
+    public init(
+        expectedSigner: (signingEntity: SigningEntity, fromVersion: Version)? = .none,
+        signers: [SigningEntity: PackageSigner] = [:]
     ) {
         self.expectedSigner = expectedSigner
         self.signers = signers
+    }
+
+    public var isEmpty: Bool {
+        self.signers.isEmpty
     }
 
     public var versionSigningEntities: [Version: Set<SigningEntity>] {

--- a/Sources/SPMTestSupport/MockPackageSigningEntityStorage.swift
+++ b/Sources/SPMTestSupport/MockPackageSigningEntityStorage.swift
@@ -14,65 +14,67 @@ import Basics
 import Dispatch
 import class Foundation.NSLock
 import PackageModel
-import PackageSigning
+@testable import PackageSigning
 
 import struct TSCUtility.Version
 
 public class MockPackageSigningEntityStorage: PackageSigningEntityStorage {
-    private var packageSignedVersions: [PackageIdentity: [SigningEntity: Set<Version>]]
+    private var packageSigners: [PackageIdentity: PackageSigners]
     private let lock = NSLock()
 
-    public init(_ packageSignedVersions: [PackageIdentity: [SigningEntity: Set<Version>]] = [:]) {
-        self.packageSignedVersions = packageSignedVersions
+    public init(_ packageSigners: [PackageIdentity: PackageSigners] = [:]) {
+        self.packageSigners = packageSigners
     }
-    
+
     public func get(
         package: PackageIdentity,
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue,
-        callback: @escaping (Result<[SigningEntity: Set<Version>], Error>) -> Void
+        callback: @escaping (Result<PackageSigners, Error>) -> Void
     ) {
-        if let signedVersions = self.lock.withLock({ self.packageSignedVersions[package] }) {
+        if let packageSigners = self.lock.withLock({ self.packageSigners[package] }) {
             callbackQueue.async {
-                callback(.success(signedVersions))
+                callback(.success(packageSigners))
             }
         } else {
             callbackQueue.async {
-                callback(.success([:]))
+                callback(.success(.init()))
             }
         }
     }
 
-    public  func put(
+    public func put(
         package: PackageIdentity,
         version: Version,
         signingEntity: SigningEntity,
+        origin: SigningEntity.Origin,
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue,
         callback: @escaping (Result<Void, Error>) -> Void
     ) {
         do {
             try self.lock.withLock {
-                var signedVersions = self.packageSignedVersions[package] ?? [:]
+                var packageSigners: PackageSigners = self.packageSigners[package] ?? .init()
 
-                if let existing = signedVersions.signingEntity(of: version) {
-                    // Error if we try to write a different signing entity for a version
-                    guard signingEntity == existing else {
-                        throw PackageSigningEntityStorageError.conflict(
-                            package: package,
-                            version: version,
-                            given: signingEntity,
-                            existing: existing
-                        )
-                    }
-                    // Don't need to do anything if signing entities are the same
-                    return
+                let otherSigningEntities = packageSigners.signingEntities(of: version).filter { $0 != signingEntity }
+                // Error if we try to write a different signing entity for a version
+                guard otherSigningEntities.isEmpty else {
+                    throw PackageSigningEntityStorageError.conflict(
+                        package: package,
+                        version: version,
+                        given: signingEntity,
+                        existing: otherSigningEntities.first! // !-safe because otherSigningEntities is not empty
+                    )
                 }
-                
-                var versions = signedVersions.removeValue(forKey: signingEntity) ?? []
-                versions.insert(version)
-                signedVersions[signingEntity] = versions
-                self.packageSignedVersions[package] = signedVersions
+
+                self.add(
+                    packageSigners: &packageSigners,
+                    signingEntity: signingEntity,
+                    origin: origin,
+                    version: version
+                )
+
+                self.packageSigners[package] = packageSigners
             }
 
             callbackQueue.async {
@@ -82,6 +84,96 @@ public class MockPackageSigningEntityStorage: PackageSigningEntityStorage {
             callbackQueue.async {
                 callback(.failure(error))
             }
+        }
+    }
+
+    public func add(
+        package: PackageIdentity,
+        version: Version,
+        signingEntity: SigningEntity,
+        origin: SigningEntity.Origin,
+        observabilityScope: ObservabilityScope,
+        callbackQueue: DispatchQueue,
+        callback: @escaping (Result<Void, Error>) -> Void
+    ) {
+        self.lock.withLock {
+            var packageSigners: PackageSigners = self.packageSigners[package] ?? .init()
+            self.add(
+                packageSigners: &packageSigners,
+                signingEntity: signingEntity,
+                origin: origin,
+                version: version
+            )
+            self.packageSigners[package] = packageSigners
+        }
+        callback(.success(()))
+    }
+
+    public func changeSigningEntityFromVersion(
+        package: PackageIdentity,
+        version: Version,
+        signingEntity: SigningEntity,
+        origin: SigningEntity.Origin,
+        observabilityScope: ObservabilityScope,
+        callbackQueue: DispatchQueue,
+        callback: @escaping (Result<Void, Error>) -> Void
+    ) {
+        self.lock.withLock {
+            var packageSigners: PackageSigners = self.packageSigners[package] ?? .init()
+            packageSigners.expectedSigner = (signingEntity: signingEntity, fromVersion: version)
+            self.add(
+                packageSigners: &packageSigners,
+                signingEntity: signingEntity,
+                origin: origin,
+                version: version
+            )
+            self.packageSigners[package] = packageSigners
+        }
+        callback(.success(()))
+    }
+
+    public func changeSigningEntityForAllVersions(
+        package: PackageIdentity,
+        version: Version,
+        signingEntity: SigningEntity,
+        origin: SigningEntity.Origin,
+        observabilityScope: ObservabilityScope,
+        callbackQueue: DispatchQueue,
+        callback: @escaping (Result<Void, Error>) -> Void
+    ) {
+        self.lock.withLock {
+            var packageSigners: PackageSigners = self.packageSigners[package] ?? .init()
+            packageSigners.expectedSigner = (signingEntity: signingEntity, fromVersion: version)
+            // Delete all other signers
+            packageSigners.signers = packageSigners.signers.filter { $0.key == signingEntity }
+            self.add(
+                packageSigners: &packageSigners,
+                signingEntity: signingEntity,
+                origin: origin,
+                version: version
+            )
+            self.packageSigners[package] = packageSigners
+        }
+        callback(.success(()))
+    }
+
+    private func add(
+        packageSigners: inout PackageSigners,
+        signingEntity: SigningEntity,
+        origin: SigningEntity.Origin,
+        version: Version
+    ) {
+        if var existingSigner = packageSigners.signers.removeValue(forKey: signingEntity) {
+            existingSigner.origins.insert(origin)
+            existingSigner.versions.insert(version)
+            packageSigners.signers[signingEntity] = existingSigner
+        } else {
+            let signer = PackageSigner(
+                signingEntity: signingEntity,
+                origins: [origin],
+                versions: [version]
+            )
+            packageSigners.signers[signingEntity] = signer
         }
     }
 }

--- a/Tests/PackageSigningTests/FilePackageSigningEntityStorageTests.swift
+++ b/Tests/PackageSigningTests/FilePackageSigningEntityStorageTests.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Foundation
+
 import Basics
 import PackageModel
 @testable import PackageSigning
@@ -29,12 +31,32 @@ final class FilePackageSigningEntityStorageTests: XCTestCase {
         let package = PackageIdentity.plain("mona.LinkedList")
         let appleseed = SigningEntity.unrecognized(name: "J. Appleseed", organizationalUnit: nil, organization: nil)
         let davinci = SigningEntity.unrecognized(name: "L. da Vinci", organizationalUnit: nil, organization: nil)
-        try storage.put(package: package, version: Version("1.0.0"), signingEntity: davinci)
-        try storage.put(package: package, version: Version("1.1.0"), signingEntity: davinci)
-        try storage.put(package: package, version: Version("2.0.0"), signingEntity: appleseed)
+        try storage.put(
+            package: package,
+            version: Version("1.0.0"),
+            signingEntity: davinci,
+            origin: .registry(URL("http://foo.com"))
+        )
+        try storage.put(
+            package: package,
+            version: Version("1.1.0"),
+            signingEntity: davinci,
+            origin: .registry(URL("http://bar.com"))
+        )
+        try storage.put(
+            package: package,
+            version: Version("2.0.0"),
+            signingEntity: appleseed,
+            origin: .registry(URL("http://foo.com"))
+        )
         // Record signing entity for another package
         let otherPackage = PackageIdentity.plain("other.LinkedList")
-        try storage.put(package: otherPackage, version: Version("1.0.0"), signingEntity: appleseed)
+        try storage.put(
+            package: otherPackage,
+            version: Version("1.0.0"),
+            signingEntity: appleseed,
+            origin: .registry(URL("http://foo.com"))
+        )
 
         // A data file should have been created for each package
         XCTAssertTrue(mockFileSystem.exists(storage.directoryPath.appending(component: package.signedVersionsFilename)))
@@ -45,20 +67,28 @@ final class FilePackageSigningEntityStorageTests: XCTestCase {
 
         // Signed versions should be saved
         do {
-            let signedVersions = try storage.get(package: package)
-            XCTAssertEqual(signedVersions.count, 2)
-            XCTAssertEqual(signedVersions[davinci], [Version("1.0.0"), Version("1.1.0")])
-            XCTAssertEqual(signedVersions[appleseed], [Version("2.0.0")])
+            let packageSigners = try storage.get(package: package)
+            XCTAssertNil(packageSigners.expectedSigner)
+            XCTAssertEqual(packageSigners.signers.count, 2)
+            XCTAssertEqual(packageSigners.signers[davinci]?.versions, [Version("1.0.0"), Version("1.1.0")])
+            XCTAssertEqual(
+                packageSigners.signers[davinci]?.origins,
+                [.registry(URL("http://foo.com")), .registry(URL("http://bar.com"))]
+            )
+            XCTAssertEqual(packageSigners.signers[appleseed]?.versions, [Version("2.0.0")])
+            XCTAssertEqual(packageSigners.signers[appleseed]?.origins, [.registry(URL("http://foo.com"))])
         }
 
         do {
-            let signedVersions = try storage.get(package: otherPackage)
-            XCTAssertEqual(signedVersions.count, 1)
-            XCTAssertEqual(signedVersions[appleseed], [Version("1.0.0")])
+            let packageSigners = try storage.get(package: otherPackage)
+            XCTAssertNil(packageSigners.expectedSigner)
+            XCTAssertEqual(packageSigners.signers.count, 1)
+            XCTAssertEqual(packageSigners.signers[appleseed]?.versions, [Version("1.0.0")])
+            XCTAssertEqual(packageSigners.signers[appleseed]?.origins, [.registry(URL("http://foo.com"))])
         }
     }
 
-    func testSingleFingerprintPerKind() throws {
+    func testPutDifferentSigningEntityShouldConflict() throws {
         let mockFileSystem = InMemoryFileSystem()
         let directoryPath = AbsolutePath("/signing")
         let storage = FilePackageSigningEntityStorage(fileSystem: mockFileSystem, directoryPath: directoryPath)
@@ -67,19 +97,166 @@ final class FilePackageSigningEntityStorageTests: XCTestCase {
         let appleseed = SigningEntity.unrecognized(name: "J. Appleseed", organizationalUnit: nil, organization: nil)
         let davinci = SigningEntity.unrecognized(name: "L. da Vinci", organizationalUnit: nil, organization: nil)
         let version = Version("1.0.0")
-        try storage.put(package: package, version: version, signingEntity: davinci)
+        try storage.put(
+            package: package,
+            version: version,
+            signingEntity: davinci,
+            origin: .registry(URL("http://foo.com"))
+        )
 
         // Writing different signing entities for the same version should fail
-        XCTAssertThrowsError(try storage.put(package: package, version: version, signingEntity: appleseed)) { error in
+        XCTAssertThrowsError(try storage.put(
+            package: package,
+            version: version,
+            signingEntity: appleseed,
+            origin: .registry(URL("http://foo.com"))
+        )) { error in
             guard case PackageSigningEntityStorageError.conflict = error else {
                 return XCTFail("Expected PackageSigningEntityStorageError.conflict, got \(error)")
             }
         }
     }
+
+    func testPutSameSigningEntityShouldNotConflict() throws {
+        let mockFileSystem = InMemoryFileSystem()
+        let directoryPath = AbsolutePath("/signing")
+        let storage = FilePackageSigningEntityStorage(fileSystem: mockFileSystem, directoryPath: directoryPath)
+
+        let package = PackageIdentity.plain("mona.LinkedList")
+        let appleseed = SigningEntity.unrecognized(name: "J. Appleseed", organizationalUnit: nil, organization: nil)
+        let version = Version("1.0.0")
+        try storage.put(
+            package: package,
+            version: version,
+            signingEntity: appleseed,
+            origin: .registry(URL("http://foo.com"))
+        )
+
+        // Writing same signing entity for version should be ok
+        XCTAssertNoThrow(try storage.put(
+            package: package,
+            version: version,
+            signingEntity: appleseed,
+            origin: .registry(URL("http://bar.com")) // origin is different and should be added
+        ))
+
+        let packageSigners = try storage.get(package: package)
+        XCTAssertNil(packageSigners.expectedSigner)
+        XCTAssertEqual(packageSigners.signers.count, 1)
+        XCTAssertEqual(packageSigners.signers[appleseed]?.versions, [Version("1.0.0")])
+        XCTAssertEqual(
+            packageSigners.signers[appleseed]?.origins,
+            [.registry(URL("http://foo.com")), .registry(URL("http://bar.com"))]
+        )
+    }
+
+    func testAddDifferentSigningEntityShouldNotConflict() throws {
+        let mockFileSystem = InMemoryFileSystem()
+        let directoryPath = AbsolutePath("/signing")
+        let storage = FilePackageSigningEntityStorage(fileSystem: mockFileSystem, directoryPath: directoryPath)
+
+        let package = PackageIdentity.plain("mona.LinkedList")
+        let appleseed = SigningEntity.unrecognized(name: "J. Appleseed", organizationalUnit: nil, organization: nil)
+        let davinci = SigningEntity.unrecognized(name: "L. da Vinci", organizationalUnit: nil, organization: nil)
+        let version = Version("1.0.0")
+        try storage.put(
+            package: package,
+            version: version,
+            signingEntity: davinci,
+            origin: .registry(URL("http://foo.com"))
+        )
+
+        // Adding different signing entity for the same version should not fail
+        XCTAssertNoThrow(try storage.add(
+            package: package,
+            version: version,
+            signingEntity: appleseed,
+            origin: .registry(URL("http://bar.com"))
+        ))
+
+        let packageSigners = try storage.get(package: package)
+        XCTAssertNil(packageSigners.expectedSigner)
+        XCTAssertEqual(packageSigners.signers.count, 2)
+        XCTAssertEqual(packageSigners.signers[appleseed]?.versions, [Version("1.0.0")])
+        XCTAssertEqual(packageSigners.signers[appleseed]?.origins, [.registry(URL("http://bar.com"))])
+        XCTAssertEqual(packageSigners.signers[davinci]?.versions, [Version("1.0.0")])
+        XCTAssertEqual(packageSigners.signers[davinci]?.origins, [.registry(URL("http://foo.com"))])
+        XCTAssertEqual(packageSigners.signingEntities(of: Version("1.0.0")), [appleseed, davinci])
+    }
+
+    func testChangeSigningEntityFromVersion() throws {
+        let mockFileSystem = InMemoryFileSystem()
+        let directoryPath = AbsolutePath("/signing")
+        let storage = FilePackageSigningEntityStorage(fileSystem: mockFileSystem, directoryPath: directoryPath)
+
+        let package = PackageIdentity.plain("mona.LinkedList")
+        let appleseed = SigningEntity.unrecognized(name: "J. Appleseed", organizationalUnit: nil, organization: nil)
+        let davinci = SigningEntity.unrecognized(name: "L. da Vinci", organizationalUnit: nil, organization: nil)
+        try storage.put(
+            package: package,
+            version: Version("1.0.0"),
+            signingEntity: davinci,
+            origin: .registry(URL("http://foo.com"))
+        )
+
+        // Sets package's expectedSigner and add package version signer
+        XCTAssertNoThrow(try storage.changeSigningEntityFromVersion(
+            package: package,
+            version: Version("1.5.0"),
+            signingEntity: appleseed,
+            origin: .registry(URL("http://bar.com"))
+        ))
+
+        let packageSigners = try storage.get(package: package)
+        XCTAssertEqual(packageSigners.expectedSigner?.signingEntity, appleseed)
+        XCTAssertEqual(packageSigners.expectedSigner?.fromVersion, Version("1.5.0"))
+        XCTAssertEqual(packageSigners.signers.count, 2)
+        XCTAssertEqual(packageSigners.signers[appleseed]?.versions, [Version("1.5.0")])
+        XCTAssertEqual(packageSigners.signers[appleseed]?.origins, [.registry(URL("http://bar.com"))])
+        XCTAssertEqual(packageSigners.signers[davinci]?.versions, [Version("1.0.0")])
+        XCTAssertEqual(packageSigners.signers[davinci]?.origins, [.registry(URL("http://foo.com"))])
+    }
+
+    func testChangeSigningEntityForAllVersions() throws {
+        let mockFileSystem = InMemoryFileSystem()
+        let directoryPath = AbsolutePath("/signing")
+        let storage = FilePackageSigningEntityStorage(fileSystem: mockFileSystem, directoryPath: directoryPath)
+
+        let package = PackageIdentity.plain("mona.LinkedList")
+        let appleseed = SigningEntity.unrecognized(name: "J. Appleseed", organizationalUnit: nil, organization: nil)
+        let davinci = SigningEntity.unrecognized(name: "L. da Vinci", organizationalUnit: nil, organization: nil)
+        try storage.put(
+            package: package,
+            version: Version("1.0.0"),
+            signingEntity: davinci,
+            origin: .registry(URL("http://foo.com"))
+        )
+        try storage.put(
+            package: package,
+            version: Version("2.0.0"),
+            signingEntity: appleseed,
+            origin: .registry(URL("http://bar.com"))
+        )
+
+        // Sets package's expectedSigner and remove all other signers
+        XCTAssertNoThrow(try storage.changeSigningEntityForAllVersions(
+            package: package,
+            version: Version("1.5.0"),
+            signingEntity: appleseed,
+            origin: .registry(URL("http://bar.com"))
+        ))
+
+        let packageSigners = try storage.get(package: package)
+        XCTAssertEqual(packageSigners.expectedSigner?.signingEntity, appleseed)
+        XCTAssertEqual(packageSigners.expectedSigner?.fromVersion, Version("1.5.0"))
+        XCTAssertEqual(packageSigners.signers.count, 1)
+        XCTAssertEqual(packageSigners.signers[appleseed]?.versions, [Version("1.5.0"), Version("2.0.0")])
+        XCTAssertEqual(packageSigners.signers[appleseed]?.origins, [.registry(URL("http://bar.com"))])
+    }
 }
 
 extension PackageSigningEntityStorage {
-    fileprivate func get(package: PackageIdentity) throws -> [SigningEntity: Set<Version>] {
+    fileprivate func get(package: PackageIdentity) throws -> PackageSigners {
         try tsc_await {
             self.get(
                 package: package,
@@ -93,13 +270,72 @@ extension PackageSigningEntityStorage {
     fileprivate func put(
         package: PackageIdentity,
         version: Version,
-        signingEntity: SigningEntity
+        signingEntity: SigningEntity,
+        origin: SigningEntity.Origin
     ) throws {
         try tsc_await {
             self.put(
                 package: package,
                 version: version,
                 signingEntity: signingEntity,
+                origin: origin,
+                observabilityScope: ObservabilitySystem.NOOP,
+                callbackQueue: .sharedConcurrent,
+                callback: $0
+            )
+        }
+    }
+
+    fileprivate func add(
+        package: PackageIdentity,
+        version: Version,
+        signingEntity: SigningEntity,
+        origin: SigningEntity.Origin
+    ) throws {
+        try tsc_await {
+            self.add(
+                package: package,
+                version: version,
+                signingEntity: signingEntity,
+                origin: origin,
+                observabilityScope: ObservabilitySystem.NOOP,
+                callbackQueue: .sharedConcurrent,
+                callback: $0
+            )
+        }
+    }
+
+    fileprivate func changeSigningEntityFromVersion(
+        package: PackageIdentity,
+        version: Version,
+        signingEntity: SigningEntity,
+        origin: SigningEntity.Origin
+    ) throws {
+        try tsc_await {
+            self.changeSigningEntityFromVersion(
+                package: package,
+                version: version,
+                signingEntity: signingEntity,
+                origin: origin,
+                observabilityScope: ObservabilitySystem.NOOP,
+                callbackQueue: .sharedConcurrent,
+                callback: $0
+            )
+        }
+    }
+
+    fileprivate func changeSigningEntityForAllVersions(
+        package: PackageIdentity,
+        version: Version,
+        signingEntity: SigningEntity,
+        origin: SigningEntity.Origin
+    ) throws {
+        try tsc_await {
+            self.changeSigningEntityForAllVersions(
+                package: package,
+                version: version,
+                signingEntity: signingEntity,
+                origin: origin,
                 observabilityScope: ObservabilitySystem.NOOP,
                 callbackQueue: .sharedConcurrent,
                 callback: $0


### PR DESCRIPTION
- Storage now includes source entity origin (i.e., registry)
- Enhance storage data model to support more sophisticated use cases
- Add more details to `RegistryError.signingEntityForReleaseChanged` and `.signingEntityForPackageChanged`
