### PR TITLE
The warning "dependency '<name>' is not used by any target" should have package metadata

### DIFF
--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -193,11 +193,14 @@ private func checkAllDependenciesAreUsed(_ rootPackages: [ResolvedPackage], obse
             if dependency.products.contains(where: \.isCommandPlugin) {
                 continue
             }
+            
+            // Make sure that any diagnostics we emit below are associated with the package.
+            let packageDiagnosticsScope = observabilityScope.makeChildScope(description: "Package Dependency Validation", metadata: package.underlyingPackage.diagnosticsMetadata)
 
             // Otherwise emit a warning if none of the dependency package's products are used.
             let dependencyIsUsed = dependency.products.contains(where: productDependencies.contains)
             if !dependencyIsUsed && !observabilityScope.errorsReportedInAnyScope {
-                observabilityScope.emit(.unusedDependency(dependency.identity.description))
+                packageDiagnosticsScope.emit(.unusedDependency(dependency.identity.description))
             }
         }
     }

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -892,7 +892,9 @@ class PackageGraphTests: XCTestCase {
         )
 
         testDiagnostics(observability.diagnostics) { result in
-            result.check(diagnostic: "dependency 'baz' is not used by any target", severity: .warning)
+            let diagnostic = result.check(diagnostic: "dependency 'baz' is not used by any target", severity: .warning)
+            XCTAssertEqual(diagnostic?.metadata?.packageIdentity, "foo")
+            XCTAssertEqual(diagnostic?.metadata?.packageKind?.isRoot, true)
             #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
             result.check(diagnostic: "dependency 'biz' is not used by any target", severity: .warning)
             #endif


### PR DESCRIPTION
### Motivation:

Like other diagnostics, the warning "dependency '\<name\>' is not used by any target" should be associated with a package (by specifying the package in its metadata). This allows it to show up in the right place in a package resolution log in IDEs that show such things.

### Modifications:

- set the metadata on the diagnostics scope
- extend a unit test to check this metadata

rdar://106678793
