### PR TITLE
Only write .recognized signing entity to storage

### DIFF
--- a/Sources/PackageSigning/SigningEntity/FilePackageSigningEntityStorage.swift
+++ b/Sources/PackageSigning/SigningEntity/FilePackageSigningEntityStorage.swift
@@ -77,7 +77,7 @@ public struct FilePackageSigningEntityStorage: PackageSigningEntityStorage {
                     )
                 }
 
-                self.add(
+                try self.add(
                     packageSigners: &packageSigners,
                     signingEntity: signingEntity,
                     origin: origin,
@@ -106,7 +106,7 @@ public struct FilePackageSigningEntityStorage: PackageSigningEntityStorage {
         do {
             try self.withLock {
                 var packageSigners = try self.loadFromDisk(package: package)
-                self.add(
+                try self.add(
                     packageSigners: &packageSigners,
                     signingEntity: signingEntity,
                     origin: origin,
@@ -135,7 +135,7 @@ public struct FilePackageSigningEntityStorage: PackageSigningEntityStorage {
             try self.withLock {
                 var packageSigners = try self.loadFromDisk(package: package)
                 packageSigners.expectedSigner = (signingEntity: signingEntity, fromVersion: version)
-                self.add(
+                try self.add(
                     packageSigners: &packageSigners,
                     signingEntity: signingEntity,
                     origin: origin,
@@ -166,7 +166,7 @@ public struct FilePackageSigningEntityStorage: PackageSigningEntityStorage {
                 packageSigners.expectedSigner = (signingEntity: signingEntity, fromVersion: version)
                 // Delete all other signers
                 packageSigners.signers = packageSigners.signers.filter { $0.key == signingEntity }
-                self.add(
+                try self.add(
                     packageSigners: &packageSigners,
                     signingEntity: signingEntity,
                     origin: origin,
@@ -185,7 +185,11 @@ public struct FilePackageSigningEntityStorage: PackageSigningEntityStorage {
         signingEntity: SigningEntity,
         origin: SigningEntity.Origin,
         version: Version
-    ) {
+    ) throws {
+        guard case .recognized = signingEntity else {
+            throw PackageSigningEntityStorageError.unrecognizedSigningEntity(signingEntity)
+        }
+
         if var existingSigner = packageSigners.signers.removeValue(forKey: signingEntity) {
             existingSigner.origins.insert(origin)
             existingSigner.versions.insert(version)

--- a/Sources/PackageSigning/SigningEntity/PackageSigningEntityStorage.swift
+++ b/Sources/PackageSigning/SigningEntity/PackageSigningEntityStorage.swift
@@ -157,11 +157,14 @@ public struct PackageSigners {
 
 public enum PackageSigningEntityStorageError: Error, Equatable, CustomStringConvertible {
     case conflict(package: PackageIdentity, version: Version, given: SigningEntity, existing: SigningEntity)
+    case unrecognizedSigningEntity(SigningEntity)
 
     public var description: String {
         switch self {
         case .conflict(let package, let version, let given, let existing):
             return "\(package) version \(version) was previously signed by '\(existing)', which is different from '\(given)'."
+        case .unrecognizedSigningEntity(let signingEntity):
+            return "'\(signingEntity)' is not recognized and therefore will not be saved."
         }
     }
 }

--- a/Sources/PackageSigning/SigningEntity/SigningEntity.swift
+++ b/Sources/PackageSigning/SigningEntity/SigningEntity.swift
@@ -23,7 +23,7 @@ public enum SigningEntity: Hashable, Codable, CustomStringConvertible {
         let name = certificate.subject.commonName
         let organizationalUnit = certificate.subject.organizationalUnitName
         let organization = certificate.subject.organizationName
-        
+
         if let type = certificate.signingEntityType {
             return .recognized(
                 type: type,

--- a/Tests/PackageRegistryTests/PackageSigningEntityTOFUTests.swift
+++ b/Tests/PackageRegistryTests/PackageSigningEntityTOFUTests.swift
@@ -1131,7 +1131,8 @@ private class WriteConflictSigningEntityStorage: PackageSigningEntityStorage {
         callbackQueue: DispatchQueue,
         callback: @escaping (Result<Void, Error>) -> Void
     ) {
-        let existing = SigningEntity.unrecognized(
+        let existing = SigningEntity.recognized(
+            type: .adp,
             name: "xxx-\(signingEntity.name ?? "")",
             organizationalUnit: nil,
             organization: nil


### PR DESCRIPTION
Motivation:
Signing entity TOFU is really meant for identities we can "trust"--i.e., if they are recognized.

Modifications:
Strictly speaking writing only recognized identities to storage is business logic, so that logic was kept out of `PackageSigningEntityStorage` in previous implementation. However, with the added APIs for writing to storage, the best way to ensure only recognized identities get saved is having the check in the storage implementation.
