### PR TITLE
do not use fatalError in Triple.getHostTriple

### DIFF
--- a/Sources/Basics/Triple.swift
+++ b/Sources/Basics/Triple.swift
@@ -194,7 +194,7 @@ public struct Triple: Encodable, Equatable, Sendable {
     public static let macOS = try! Triple("x86_64-apple-macosx")
 
     /// Determine the versioned host triple using the Swift compiler.
-    public static func getHostTriple(usingSwiftCompiler swiftCompiler: AbsolutePath) -> Triple {
+    public static func getHostTriple(usingSwiftCompiler swiftCompiler: AbsolutePath) throws -> Triple {
         // Call the compiler to get the target info JSON.
         let compilerOutput: String
         do {
@@ -206,7 +206,7 @@ public struct Triple: Encodable, Equatable, Sendable {
             #if os(macOS)
             return .macOS
             #else
-            fatalError("Failed to get target info (\(error))")
+            throw InternalError("Failed to get target info (\(error))")
             #endif
         }
         // Parse the compiler's JSON output.
@@ -214,20 +214,20 @@ public struct Triple: Encodable, Equatable, Sendable {
         do {
             parsedTargetInfo = try JSON(string: compilerOutput)
         } catch {
-            fatalError("Failed to parse target info (\(error)).\nRaw compiler output: \(compilerOutput)")
+            throw InternalError("Failed to parse target info (\(error)).\nRaw compiler output: \(compilerOutput)")
         }
         // Get the triple string from the parsed JSON.
         let tripleString: String
         do {
             tripleString = try parsedTargetInfo.get("target").get("triple")
         } catch {
-            fatalError("Target info does not contain a triple string (\(error)).\nTarget info: \(parsedTargetInfo)")
+            throw InternalError("Target info does not contain a triple string (\(error)).\nTarget info: \(parsedTargetInfo)")
         }
         // Parse the triple string.
         do {
             return try Triple(tripleString)
         } catch {
-            fatalError("Failed to parse triple string (\(error)).\nTriple string: \(tripleString)")
+            throw InternalError("Failed to parse triple string (\(error)).\nTriple string: \(tripleString)")
         }
     }
 

--- a/Sources/CoreCommands/SwiftTool.swift
+++ b/Sources/CoreCommands/SwiftTool.swift
@@ -720,7 +720,7 @@ public final class SwiftTool {
             let dataPath = self.scratchDirectory.appending(
                 component: destinationTriple.platformBuildPathComponent(buildSystem: options.build.buildSystem)
             )
-            return BuildParameters(
+            return try BuildParameters(
                 dataPath: dataPath,
                 configuration: options.build.configuration,
                 toolchain: destinationToolchain,
@@ -757,7 +757,7 @@ public final class SwiftTool {
         do {
             let hostToolchain = try _hostToolchain.get()
             hostDestination = hostToolchain.destination
-            let hostTriple = Triple.getHostTriple(usingSwiftCompiler: hostToolchain.swiftCompilerPath)
+            let hostTriple = try Triple.getHostTriple(usingSwiftCompiler: hostToolchain.swiftCompilerPath)
 
             // Create custom toolchain if present.
             if let customDestination = options.locations.customCompileDestination {

--- a/Sources/CrossCompilationDestinationsTool/DestinationCommand.swift
+++ b/Sources/CrossCompilationDestinationsTool/DestinationCommand.swift
@@ -69,7 +69,7 @@ extension DestinationCommand {
         let destinationsDirectory = try self.getOrCreateDestinationsDirectory()
 
         let hostToolchain = try UserToolchain(destination: Destination.hostDestination())
-        let triple = Triple.getHostTriple(usingSwiftCompiler: hostToolchain.swiftCompilerPath)
+        let triple = try Triple.getHostTriple(usingSwiftCompiler: hostToolchain.swiftCompilerPath)
 
         var commandError: Error? = nil
         do {

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -453,7 +453,7 @@ public final class UserToolchain: Toolchain {
         self.architectures = destination.architectures
 
         // Use the triple from destination or compute the host triple using swiftc.
-        var triple = destination.targetTriple ?? Triple.getHostTriple(usingSwiftCompiler: swiftCompilers.compile)
+        var triple = try destination.targetTriple ?? Triple.getHostTriple(usingSwiftCompiler: swiftCompilers.compile)
 
         // Change the triple to the specified arch if there's exactly one of them.
         // The Triple property is only looked at by the native build system currently.

--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -251,13 +251,13 @@ public struct BuildParameters: Encodable {
         linkerDeadStrip: Bool = true,
         colorizedOutput: Bool = false,
         verboseOutput: Bool = false
-    ) {
-        let triple = destinationTriple ?? .getHostTriple(usingSwiftCompiler: toolchain.swiftCompilerPath)
+    ) throws {
+        let triple = try destinationTriple ?? .getHostTriple(usingSwiftCompiler: toolchain.swiftCompilerPath)
 
         self.dataPath = dataPath
         self.configuration = configuration
         self._toolchain = _Toolchain(toolchain: toolchain)
-        self.hostTriple = hostTriple ?? .getHostTriple(usingSwiftCompiler: toolchain.swiftCompilerPath)
+        self.hostTriple = try hostTriple ?? .getHostTriple(usingSwiftCompiler: toolchain.swiftCompilerPath)
         self.triple = triple
         self.flags = flags
         self.pkgConfigDirectories = pkgConfigDirectories
@@ -305,7 +305,7 @@ public struct BuildParameters: Encodable {
             testEntryPointPath = nil
         }
 
-        return .init(
+        return try .init(
             dataPath: self.dataPath.parentDirectory.appending(components: ["plugins", "tools"]),
             configuration: self.configuration,
             toolchain: try UserToolchain(destination: Destination.hostDestination()),

--- a/Sources/swift-bootstrap/main.swift
+++ b/Sources/swift-bootstrap/main.swift
@@ -250,7 +250,7 @@ struct SwiftBootstrapBuildTool: ParsableCommand {
                 component: self.destinationToolchain.triple.platformBuildPathComponent(buildSystem: buildSystem)
             )
 
-            let buildParameters = BuildParameters(
+            let buildParameters = try BuildParameters(
                 dataPath: dataPath,
                 configuration: configuration,
                 toolchain: self.destinationToolchain,

--- a/Tests/BuildTests/MockBuildTestHelper.swift
+++ b/Tests/BuildTests/MockBuildTestHelper.swift
@@ -76,7 +76,7 @@ func mockBuildParameters(
     useExplicitModuleBuild: Bool = false,
     linkerDeadStrip: Bool = true
 ) -> BuildParameters {
-    return BuildParameters(
+    return try! BuildParameters(
         dataPath: buildPath,
         configuration: config,
         toolchain: toolchain,


### PR DESCRIPTION
motivation: avoid crashes, use structured error handling

changes:
* make Triple.getHostTriple throwable and remove use of fatalError
* update call sites

rdar://90317112
