### PR TITLE
print compiler output when precompiling plugins

### DIFF
--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -335,7 +335,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
             }
             func didCompilePlugin(result: PluginCompilationResult) {
                 if !result.description.isEmpty {
-                    self.buildSystemDelegate?.preparationStepHadOutput(preparationStepName, output: result.description)
+                    self.buildSystemDelegate?.preparationStepHadOutput(preparationStepName, output: result.description, verboseOnly: result.succeeded)
                 }
                 self.buildSystemDelegate?.preparationStepFinished(preparationStepName, result: (result.succeeded ? .succeeded : .failed))
             }
@@ -343,7 +343,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
                 // Historically we have emitted log info about cached plugins that are used. We should reconsider whether this is the right thing to do.
                 self.buildSystemDelegate?.preparationStepStarted(preparationStepName)
                 if !cachedResult.description.isEmpty {
-                    self.buildSystemDelegate?.preparationStepHadOutput(preparationStepName, output: cachedResult.description)
+                    self.buildSystemDelegate?.preparationStepHadOutput(preparationStepName, output: cachedResult.description, verboseOnly: true)
                 }
                 self.buildSystemDelegate?.preparationStepFinished(preparationStepName, result: (cachedResult.succeeded ? .succeeded : .failed))
             }

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -334,16 +334,29 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
                 self.buildSystemDelegate?.preparationStepStarted(preparationStepName)
             }
             func didCompilePlugin(result: PluginCompilationResult) {
-                if !result.description.isEmpty {
-                    self.buildSystemDelegate?.preparationStepHadOutput(preparationStepName, output: result.description, verboseOnly: result.succeeded)
+                self.buildSystemDelegate?.preparationStepHadOutput(
+                    preparationStepName,
+                    output: result.commandLine.joined(separator: " "),
+                    verboseOnly: true
+                )
+                if !result.compilerOutput.isEmpty {
+                    self.buildSystemDelegate?.preparationStepHadOutput(
+                        preparationStepName,
+                        output: result.compilerOutput,
+                        verboseOnly: false
+                    )
                 }
                 self.buildSystemDelegate?.preparationStepFinished(preparationStepName, result: (result.succeeded ? .succeeded : .failed))
             }
             func skippedCompilingPlugin(cachedResult: PluginCompilationResult) {
                 // Historically we have emitted log info about cached plugins that are used. We should reconsider whether this is the right thing to do.
                 self.buildSystemDelegate?.preparationStepStarted(preparationStepName)
-                if !cachedResult.description.isEmpty {
-                    self.buildSystemDelegate?.preparationStepHadOutput(preparationStepName, output: cachedResult.description, verboseOnly: true)
+                if !cachedResult.compilerOutput.isEmpty {
+                    self.buildSystemDelegate?.preparationStepHadOutput(
+                        preparationStepName,
+                        output: cachedResult.compilerOutput,
+                        verboseOnly: false
+                    )
                 }
                 self.buildSystemDelegate?.preparationStepFinished(preparationStepName, result: (cachedResult.succeeded ? .succeeded : .failed))
             }

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -757,10 +757,10 @@ final class BuildOperationBuildSystemDelegateHandler: LLBuildBuildSystemDelegate
     }
 
     /// Invoked when an action taken before building emits output.
-    func preparationStepHadOutput(_ name: String, output: String) {
+    func preparationStepHadOutput(_ name: String, output: String, verboseOnly: Bool) {
         queue.async {
             self.progressAnimation.clear()
-            if self.logLevel.isVerbose {
+            if !verboseOnly || self.logLevel.isVerbose {
                 self.outputStream <<< output.spm_chomp() <<< "\n"
                 self.outputStream.flush()
             }

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -757,6 +757,7 @@ final class BuildOperationBuildSystemDelegateHandler: LLBuildBuildSystemDelegate
     }
 
     /// Invoked when an action taken before building emits output.
+    /// when verboseOnly is set to true, the output will only be printed in verbose logging mode
     func preparationStepHadOutput(_ name: String, output: String, verboseOnly: Bool) {
         queue.async {
             self.progressAnimation.clear()

--- a/Sources/SPMBuildCore/PluginScriptRunner.swift
+++ b/Sources/SPMBuildCore/PluginScriptRunner.swift
@@ -98,7 +98,7 @@ public struct PluginCompilationResult: Equatable {
     public var diagnosticsFile: AbsolutePath
     
     /// Any output emitted by the compiler (stdout and stderr combined).
-    public var compilerOutput: String
+    public var rawCompilerOutput: String
     
     /// Whether the compilation result came from the cache (false means that the compiler did run).
     public var cached: Bool
@@ -108,21 +108,21 @@ public struct PluginCompilationResult: Equatable {
         commandLine: [String],
         executableFile: AbsolutePath,
         diagnosticsFile: AbsolutePath,
-        compilerOutput: String,
+        compilerOutput rawCompilerOutput: String,
         cached: Bool
     ) {
         self.succeeded = succeeded
         self.commandLine = commandLine
         self.executableFile = executableFile
         self.diagnosticsFile = diagnosticsFile
-        self.compilerOutput = compilerOutput
+        self.rawCompilerOutput = rawCompilerOutput
         self.cached = cached
     }
 }
 
-extension PluginCompilationResult: CustomStringConvertible {
-    public var description: String {
-        let output = compilerOutput.spm_chomp()
+extension PluginCompilationResult {
+    public var compilerOutput: String {
+        let output = self.rawCompilerOutput.spm_chomp()
         return output + (output.isEmpty || output.hasSuffix("\n") ? "" : "\n")
     }
 }

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -2878,9 +2878,7 @@ final class PackageToolTests: CommandsTestCase {
                 XCTAssertNotEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
                 XCTAssertMatch(output, .contains("Compiling plugin MyBuildToolPlugin"))
                 XCTAssertMatch(output, .contains("Compiling plugin MyCommandPlugin"))
-                #if false // sometimes this line isn't emitted; being investigated in https://bugs.swift.org/browse/SR-15831
-                    XCTAssertMatch(output, .contains("MyCommandPlugin/plugin.swift:7:19: error: consecutive statements on a line must be separated by ';'"))
-                #endif
+                XCTAssertMatch(output, .contains("error: consecutive statements on a line must be separated by ';'"))
                 XCTAssertNoMatch(output, .contains("Building for debugging..."))
             }
         }


### PR DESCRIPTION
motivation: surface any plugins compiler errors to users

changes:
* always print compiler output when failing to compile plugins
* restore testPluginCompilationBeforeBuilding test
