### PR TITLE
Workspace: fix `target_link_libraries`

### DIFF
--- a/Sources/Workspace/CMakeLists.txt
+++ b/Sources/Workspace/CMakeLists.txt
@@ -35,7 +35,7 @@ target_link_libraries(Workspace PUBLIC
   PackageRegistry
   PackageSigning
   SourceControl)
-target_link_libraries(PackageLoading PUBLIC
+target_link_libraries(Workspace PUBLIC
   $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(Workspace PROPERTIES


### PR DESCRIPTION
The target that was supposed to link against Foundation was Workspace. Because we changed a dependency, the transitive closure happened to make this work.