### PR TITLE
Workspace: remove extraneous dependency

### DIFF
--- a/Sources/Workspace/CMakeLists.txt
+++ b/Sources/Workspace/CMakeLists.txt
@@ -28,7 +28,6 @@ target_link_libraries(Workspace PUBLIC
   TSCUtility
   Basics
   SPMBuildCore
-  PackageFingerprint
   PackageGraph
   PackageLoading
   PackageModel


### PR DESCRIPTION
Clean up the build graph by removing a dependency.