### PR TITLE
[NFC] PkgConfigTests: use `some FileSystem` instead of existentials

### DIFF
--- a/Tests/PackageLoadingTests/PkgConfigTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigTests.swift
@@ -30,7 +30,7 @@ extension SystemLibraryTarget {
 class PkgConfigTests: XCTestCase {
     let inputsDir = AbsolutePath(path: #file).parentDirectory.appending(components: "Inputs")
     let observability = ObservabilitySystem.makeForTesting()
-    let fs = localFileSystem
+    let fs: some FileSystem = localFileSystem
 
     func testBasics() throws {
         // No pkgConfig name.


### PR DESCRIPTION
This is a small optimization that avoids the use of boxing for existentials.
