### PR TITLE
Improve error handling for 'package-registry login' command

### DIFF
--- a/Sources/PackageRegistryTool/PackageRegistryTool+Auth.swift
+++ b/Sources/PackageRegistryTool/PackageRegistryTool+Auth.swift
@@ -88,6 +88,19 @@ extension SwiftPackageRegistryTool {
         private static let PLACEHOLDER_TOKEN_USER = "token"
 
         func run(_ swiftTool: SwiftTool) throws {
+            // We need to be able to read/write credentials
+            // Make sure credentials store is available before proceeding
+            let authorizationProvider: AuthorizationProvider?
+            do {
+                authorizationProvider = try swiftTool.getRegistryAuthorizationProvider()
+            } catch {
+                throw ValidationError.invalidCredentialStore(error)
+            }
+
+            guard let authorizationProvider = authorizationProvider else {
+                throw ValidationError.unknownCredentialStore
+            }
+
             let configuration = try getRegistriesConfig(swiftTool)
 
             // compute and validate registry URL
@@ -99,11 +112,6 @@ extension SwiftPackageRegistryTool {
 
             guard let host = registryURL.host?.lowercased() else {
                 throw ValidationError.invalidURL(registryURL)
-            }
-
-            // We need to be able to read/write credentials
-            guard let authorizationProvider = try swiftTool.getRegistryAuthorizationProvider() else {
-                throw ValidationError.unknownCredentialStore
             }
 
             let authenticationType: RegistryConfiguration.AuthenticationType

--- a/Sources/PackageRegistryTool/PackageRegistryTool.swift
+++ b/Sources/PackageRegistryTool/PackageRegistryTool.swift
@@ -27,7 +27,7 @@ public struct SwiftPackageRegistryTool: ParsableCommand {
         abstract: "Interact with package registry and manage related configuration",
         discussion: "SEE ALSO: swift package",
         version: SwiftVersion.current.completeDisplayString,
-        subcommands:[
+        subcommands: [
             Set.self,
             Unset.self,
             Login.self,
@@ -137,6 +137,7 @@ public struct SwiftPackageRegistryTool: ParsableCommand {
         case invalidPackageIdentity(PackageIdentity)
         case unknownRegistry
         case unknownCredentialStore
+        case invalidCredentialStore(Error)
     }
 
     static func getRegistriesConfig(_ swiftTool: SwiftTool) throws -> Workspace.Configuration.Registries {
@@ -172,13 +173,15 @@ extension SwiftPackageRegistryTool.ValidationError: CustomStringConvertible {
     var description: String {
         switch self {
         case .invalidURL(let url):
-            return "Invalid URL: \(url)"
+            return "invalid URL: \(url)"
         case .invalidPackageIdentity(let identity):
-            return "Invalid package identifier '\(identity)'"
+            return "invalid package identifier '\(identity)'"
         case .unknownRegistry:
-            return "Unknown registry, is one configured?"
+            return "unknown registry, is one configured?"
         case .unknownCredentialStore:
-            return "No credential store available"
+            return "no credential store available"
+        case .invalidCredentialStore(let error):
+            return "credential store is invalid: \(error)"
         }
     }
 }

--- a/Sources/Workspace/Workspace+Configuration.swift
+++ b/Sources/Workspace/Workspace+Configuration.swift
@@ -354,7 +354,7 @@ extension Workspace.Configuration {
             switch self.netrc {
             case .custom(let path):
                 guard fileSystem.exists(path) else {
-                    throw StringError("Did not find netrc file at \(path).")
+                    throw StringError("did not find netrc file at \(path)")
                 }
                 providers.append(try NetrcAuthorizationProvider(path: path, fileSystem: fileSystem))
             case .user:

--- a/Tests/CommandsTests/SwiftToolTests.swift
+++ b/Tests/CommandsTests/SwiftToolTests.swift
@@ -219,7 +219,7 @@ final class SwiftToolTests: CommandsTestCase {
                 // delete it
                 try localFileSystem.removeFileTree(customPath)
                 XCTAssertThrowsError(try tool.getRegistryAuthorizationProvider(), "error expected") { error in
-                    XCTAssertEqual(error as? StringError, StringError("did not find netrc file at \(customPath)."))
+                    XCTAssertEqual(error as? StringError, StringError("did not find netrc file at \(customPath)"))
                 }
                 #endif
             }

--- a/Tests/CommandsTests/SwiftToolTests.swift
+++ b/Tests/CommandsTests/SwiftToolTests.swift
@@ -219,7 +219,7 @@ final class SwiftToolTests: CommandsTestCase {
                 // delete it
                 try localFileSystem.removeFileTree(customPath)
                 XCTAssertThrowsError(try tool.getRegistryAuthorizationProvider(), "error expected") { error in
-                    XCTAssertEqual(error as? StringError, StringError("Did not find netrc file at \(customPath)."))
+                    XCTAssertEqual(error as? StringError, StringError("did not find netrc file at \(customPath)."))
                 }
                 #endif
             }

--- a/Tests/WorkspaceTests/AuthorizationProviderTests.swift
+++ b/Tests/WorkspaceTests/AuthorizationProviderTests.swift
@@ -106,7 +106,7 @@ final class AuthorizationProviderTests: XCTestCase {
             // delete it
             try fileSystem.removeFileTree(customPath)
             XCTAssertThrowsError(try configuration.makeRegistryAuthorizationProvider(fileSystem: fileSystem, observabilityScope: observability.topScope), "error expected") { error in
-                XCTAssertEqual(error as? StringError, StringError("Did not find netrc file at \(customPath)."))
+                XCTAssertEqual(error as? StringError, StringError("did not find netrc file at \(customPath)"))
             }
         }
 


### PR DESCRIPTION
Motivation:
When running `login` with `--netrc` and `--netrc-file` options and the custom netrc file doesn't exist, the command fails immediately with file not found error:

```
swift-package-registry --netrc --netrc-file ./netrc-test login
Error: Did not find netrc file at /Users/appleseed/netrc-test.
```

Which can be confusing.

Modifications:
Rearrange logic so that we initialize `AuthorizationProvider` first thing and display better error messages to user.

```
Error: credential store is invalid: did not find netrc file at /Users/appleseed/netrc-test
```