### PR TITLE
Update Swift version to 5.7 in `.swiftformat`

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,6 +1,6 @@
 ## File options
 
---swiftversion 5.5
+--swiftversion 5.7
 --exclude .build
 
 ## Formatting options


### PR DESCRIPTION
Since we have `swift-tools-version:5.7` in `Package.swift`, it makes sense to align `.swiftformat` with that version.
