### PR TITLE
Destinations: allow removing by artifact ID

### DIFF
--- a/Sources/CrossCompilationDestinationsTool/RemoveDestination.swift
+++ b/Sources/CrossCompilationDestinationsTool/RemoveDestination.swift
@@ -91,7 +91,8 @@ struct RemoveDestination: DestinationCommand {
                     .map { "`\($0)`" }
                     .joined(separator: ", ")
 
-                print("""
+                print(
+                    """
                     WARNING: the destination bundle containing artifact with ID \(self.destinationIDOrBundleName) \
                     also contains other artifacts: \(otherArtifactIDs).
                     """

--- a/Sources/PackageModel/Destination.swift
+++ b/Sources/PackageModel/Destination.swift
@@ -59,7 +59,7 @@ extension DestinationError: CustomStringConvertible {
         case .destinationNotFound(let artifactID, let buildTimeTriple, let runTimeTriple):
             return """
             destination with ID \(artifactID), build-time triple \(buildTimeTriple), and run-time triple \
-            \(runTimeTriple) is not currently installed.SB
+            \(runTimeTriple) is not currently installed.
             """
         }
     }

--- a/Sources/PackageModel/DestinationBundle.swift
+++ b/Sources/PackageModel/DestinationBundle.swift
@@ -20,10 +20,14 @@ public struct DestinationBundle {
         let destinations: [Destination]
     }
 
-    let path: AbsolutePath
+    // Path to the bundle root directory.
+    public let path: AbsolutePath
 
     /// Mapping of artifact IDs to variants available for a corresponding artifact.
     public fileprivate(set) var artifacts = [String: [Variant]]()
+
+    /// Name of the destination bundle that can be used to distinguish it from other bundles.
+    public var name: String { path.basename }
 
     /// Lists all valid cross-compilation destination bundles in a given directory.
     /// - Parameters:


### PR DESCRIPTION
### Motivation:

Currently only removing by bundle name is allowed, but this is confusing since `swift experimental-destination list` doesn't provide bundle names, only destination/artifact IDs. Let's allow removing bundles by providing destination IDs. An appropriate check is done if multiple artifacts are available in a bundle.

### Modifications:

Added new logic to `RemoveDestination.swift`, renamed its `bundleName` property to `destinationIDOrBundleName`. Also modified `DestinationBundle.swift` to provide destination name when needed.

### Result:

Users can now pass artifact ID from `swift experimental-destination list` to `swift experimental-destination remove`.
