### PR TITLE
Update equality check for SigningEntity

### DIFF
--- a/Sources/PackageSigning/SigningEntity/SigningEntity.swift
+++ b/Sources/PackageSigning/SigningEntity/SigningEntity.swift
@@ -40,6 +40,27 @@ public enum SigningEntity: Hashable, Codable, CustomStringConvertible {
         }
     }
 
+    public static func == (lhs: SigningEntity, rhs: SigningEntity) -> Bool {
+        switch (lhs, rhs) {
+        case (
+            .recognized(let lhsType, let lhsName, let lhsOrgUnit, let lhsOrg),
+            .recognized(let rhsType, let rhsName, let rhsOrgUnit, let rhsOrg)
+        ):
+            // For ADP type, only team ID (org unit) needs to match
+            if lhsType == .adp, rhsType == .adp {
+                return lhsOrgUnit == rhsOrgUnit
+            }
+            return lhsType == rhsType && lhsName == rhsName && lhsOrgUnit == rhsOrgUnit && lhsOrg == rhsOrg
+        case (
+            .unrecognized(let lhsName, let lhsOrgUnit, let lhsOrg),
+            .unrecognized(let rhsName, let rhsOrgUnit, let rhsOrg)
+        ):
+            return lhsName == rhsName && lhsOrgUnit == rhsOrgUnit && lhsOrg == rhsOrg
+        default:
+            return false
+        }
+    }
+
     public var description: String {
         switch self {
         case .recognized(let type, let name, let organizationalUnit, let organization):

--- a/Tests/PackageRegistryTests/PackageSigningEntityTOFUTests.swift
+++ b/Tests/PackageRegistryTests/PackageSigningEntityTOFUTests.swift
@@ -30,8 +30,8 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         let signingEntity = SigningEntity.recognized(
             type: .adp,
             name: "J. Appleseed",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "SwiftPM Test Unit",
+            organization: "SwiftPM Test"
         )
 
         let signingEntityStorage = MockPackageSigningEntityStorage()
@@ -151,8 +151,8 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         let signingEntity = SigningEntity.recognized(
             type: .adp,
             name: "J. Appleseed",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "SwiftPM Test Unit",
+            organization: "SwiftPM Test"
         )
 
         let signingEntityStorage = MockPackageSigningEntityStorage(
@@ -191,14 +191,14 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         let signingEntity = SigningEntity.recognized(
             type: .adp,
             name: "J. Appleseed",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "SwiftPM Test Unit 1",
+            organization: "SwiftPM Test"
         )
         let existingSigningEntity = SigningEntity.recognized(
             type: .adp,
             name: "J. Smith",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "SwiftPM Test Unit 2",
+            organization: "SwiftPM Test"
         )
 
         let signingEntityStorage = MockPackageSigningEntityStorage(
@@ -255,14 +255,14 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         let signingEntity = SigningEntity.recognized(
             type: .adp,
             name: "J. Appleseed",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "SwiftPM Test Unit 1",
+            organization: "SwiftPM Test"
         )
         let existingSigningEntity = SigningEntity.recognized(
             type: .adp,
             name: "J. Smith",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "SwiftPM Test Unit 2",
+            organization: "SwiftPM Test"
         )
 
         let signingEntityStorage = MockPackageSigningEntityStorage(
@@ -322,8 +322,8 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         let existingSigningEntity = SigningEntity.recognized(
             type: .adp,
             name: "J. Smith",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "SwiftPM Test Unit",
+            organization: "SwiftPM Test"
         )
 
         let signingEntityStorage = MockPackageSigningEntityStorage(
@@ -381,8 +381,8 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         let signingEntity = SigningEntity.recognized(
             type: .adp,
             name: "J. Appleseed",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "SwiftPM Test Unit",
+            organization: "SwiftPM Test"
         )
 
         let signingEntityStorage = MockPackageSigningEntityStorage(
@@ -434,14 +434,14 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         let signingEntity = SigningEntity.recognized(
             type: .adp,
             name: "J. Appleseed",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "SwiftPM Test Unit 1",
+            organization: "SwiftPM Test"
         )
         let existingSigningEntity = SigningEntity.recognized(
             type: .adp,
             name: "J. Smith",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "SwiftPM Test Unit 2",
+            organization: "SwiftPM Test"
         )
 
         let signingEntityStorage = MockPackageSigningEntityStorage(
@@ -507,14 +507,14 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         let signingEntity = SigningEntity.recognized(
             type: .adp,
             name: "J. Appleseed",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "SwiftPM Test Unit 1",
+            organization: "SwiftPM Test"
         )
         let existingSigningEntity = SigningEntity.recognized(
             type: .adp,
             name: "J. Smith",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "SwiftPM Test Unit 2",
+            organization: "SwiftPM Test"
         )
 
         let signingEntityStorage = MockPackageSigningEntityStorage(
@@ -575,8 +575,8 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         let existingSigningEntity = SigningEntity.recognized(
             type: .adp,
             name: "J. Smith",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "SwiftPM Test Unit",
+            organization: "SwiftPM Test"
         )
 
         let signingEntityStorage = MockPackageSigningEntityStorage(
@@ -629,8 +629,8 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         let existingSigningEntity = SigningEntity.recognized(
             type: .adp,
             name: "J. Smith",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "SwiftPM Test Unit",
+            organization: "SwiftPM Test"
         )
 
         let signingEntityStorage = MockPackageSigningEntityStorage(
@@ -697,8 +697,8 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         let existingSigningEntity = SigningEntity.recognized(
             type: .adp,
             name: "J. Smith",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "SwiftPM Test Unit",
+            organization: "SwiftPM Test"
         )
 
         let signingEntityStorage = MockPackageSigningEntityStorage(
@@ -760,8 +760,8 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         let existingSigningEntity = SigningEntity.recognized(
             type: .adp,
             name: "J. Smith",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "SwiftPM Test Unit",
+            organization: "SwiftPM Test"
         )
 
         let signingEntityStorage = MockPackageSigningEntityStorage(
@@ -815,8 +815,8 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         let expectedSigningEntity = SigningEntity.recognized(
             type: .adp,
             name: "J. Smith",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "SwiftPM Test Unit",
+            organization: "SwiftPM Test"
         )
         let expectedFromVersion = Version("1.5.0")
 
@@ -869,15 +869,15 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         let signingEntity = SigningEntity.recognized(
             type: .adp,
             name: "J. Appleseed",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "SwiftPM Test Unit 1",
+            organization: "SwiftPM Test"
         )
         let existingVersion = Version("2.2.0")
         let expectedSigningEntity = SigningEntity.recognized(
             type: .adp,
             name: "J. Smith",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "SwiftPM Test Unit 2",
+            organization: "SwiftPM Test"
         )
         let expectedFromVersion = Version("1.5.0")
 
@@ -939,15 +939,15 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         let signingEntity = SigningEntity.recognized(
             type: .adp,
             name: "J. Appleseed",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "SwiftPM Test Unit 1",
+            organization: "SwiftPM Test"
         )
         let existingVersion = Version("2.2.0")
         let expectedSigningEntity = SigningEntity.recognized(
             type: .adp,
             name: "J. Smith",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "SwiftPM Test Unit 2",
+            organization: "SwiftPM Test"
         )
         let expectedFromVersion = Version("1.5.0")
 
@@ -1023,8 +1023,8 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         let signingEntity = SigningEntity.recognized(
             type: .adp,
             name: "J. Appleseed",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "SwiftPM Test Unit",
+            organization: "SwiftPM Test"
         )
 
         let signingEntityStorage = WriteConflictSigningEntityStorage()
@@ -1057,8 +1057,8 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         let signingEntity = SigningEntity.recognized(
             type: .adp,
             name: "J. Appleseed",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "SwiftPM Test Unit",
+            organization: "SwiftPM Test"
         )
 
         let signingEntityStorage = WriteConflictSigningEntityStorage()
@@ -1134,8 +1134,8 @@ private class WriteConflictSigningEntityStorage: PackageSigningEntityStorage {
         let existing = SigningEntity.recognized(
             type: .adp,
             name: "xxx-\(signingEntity.name ?? "")",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "xxx-\(signingEntity.organizationalUnit ?? "")",
+            organization: "xxx-\(signingEntity.organization ?? "")"
         )
         callback(.failure(PackageSigningEntityStorageError.conflict(
             package: package,
@@ -1189,6 +1189,24 @@ extension SigningEntity {
             return name
         case .unrecognized(let name, _, _):
             return name
+        }
+    }
+
+    var organizationalUnit: String? {
+        switch self {
+        case .recognized(_, _, let organizationalUnit, _):
+            return organizationalUnit
+        case .unrecognized(_, let organizationalUnit, _):
+            return organizationalUnit
+        }
+    }
+
+    var organization: String? {
+        switch self {
+        case .recognized(_, _, _, let organization):
+            return organization
+        case .unrecognized(_, _, let organization):
+            return organization
         }
     }
 }

--- a/Tests/PackageSigningTests/FilePackageSigningEntityStorageTests.swift
+++ b/Tests/PackageSigningTests/FilePackageSigningEntityStorageTests.swift
@@ -32,14 +32,14 @@ final class FilePackageSigningEntityStorageTests: XCTestCase {
         let appleseed = SigningEntity.recognized(
             type: .adp,
             name: "J. Appleseed",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "SwiftPM Test Unit 1",
+            organization: "SwiftPM Test"
         )
         let davinci = SigningEntity.recognized(
             type: .adp,
             name: "L. da Vinci",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "SwiftPM Test Unit 2",
+            organization: "SwiftPM Test"
         )
         try storage.put(
             package: package,
@@ -107,14 +107,14 @@ final class FilePackageSigningEntityStorageTests: XCTestCase {
         let appleseed = SigningEntity.recognized(
             type: .adp,
             name: "J. Appleseed",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "SwiftPM Test Unit 1",
+            organization: "SwiftPM Test"
         )
         let davinci = SigningEntity.recognized(
             type: .adp,
             name: "L. da Vinci",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "SwiftPM Test Unit 2",
+            organization: "SwiftPM Test"
         )
         let version = Version("1.0.0")
         try storage.put(
@@ -146,8 +146,8 @@ final class FilePackageSigningEntityStorageTests: XCTestCase {
         let appleseed = SigningEntity.recognized(
             type: .adp,
             name: "J. Appleseed",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "SwiftPM Test Unit",
+            organization: "SwiftPM Test"
         )
         let version = Version("1.0.0")
         try storage.put(
@@ -205,14 +205,14 @@ final class FilePackageSigningEntityStorageTests: XCTestCase {
         let appleseed = SigningEntity.recognized(
             type: .adp,
             name: "J. Appleseed",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "SwiftPM Test Unit 1",
+            organization: "SwiftPM Test"
         )
         let davinci = SigningEntity.recognized(
             type: .adp,
             name: "L. da Vinci",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "SwiftPM Test Unit 2",
+            organization: "SwiftPM Test"
         )
         let version = Version("1.0.0")
         try storage.put(
@@ -250,8 +250,8 @@ final class FilePackageSigningEntityStorageTests: XCTestCase {
         let davinci = SigningEntity.recognized(
             type: .adp,
             name: "L. da Vinci",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "SwiftPM Test Unit",
+            organization: "SwiftPM Test"
         )
         let version = Version("1.0.0")
         try storage.put(
@@ -282,14 +282,14 @@ final class FilePackageSigningEntityStorageTests: XCTestCase {
         let appleseed = SigningEntity.recognized(
             type: .adp,
             name: "J. Appleseed",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "SwiftPM Test Unit 1",
+            organization: "SwiftPM Test"
         )
         let davinci = SigningEntity.recognized(
             type: .adp,
             name: "L. da Vinci",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "SwiftPM Test Unit 2",
+            organization: "SwiftPM Test"
         )
         try storage.put(
             package: package,
@@ -326,8 +326,8 @@ final class FilePackageSigningEntityStorageTests: XCTestCase {
         let davinci = SigningEntity.recognized(
             type: .adp,
             name: "L. da Vinci",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "SwiftPM Test Unit",
+            organization: "SwiftPM Test"
         )
         try storage.put(
             package: package,
@@ -357,14 +357,14 @@ final class FilePackageSigningEntityStorageTests: XCTestCase {
         let appleseed = SigningEntity.recognized(
             type: .adp,
             name: "J. Appleseed",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "SwiftPM Test Unit 1",
+            organization: "SwiftPM Test"
         )
         let davinci = SigningEntity.recognized(
             type: .adp,
             name: "L. da Vinci",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "SwiftPM Test Unit 2",
+            organization: "SwiftPM Test"
         )
         try storage.put(
             package: package,
@@ -405,8 +405,8 @@ final class FilePackageSigningEntityStorageTests: XCTestCase {
         let davinci = SigningEntity.recognized(
             type: .adp,
             name: "L. da Vinci",
-            organizationalUnit: nil,
-            organization: nil
+            organizationalUnit: "SwiftPM Test Unit",
+            organization: "SwiftPM Test"
         )
         try storage.put(
             package: package,

--- a/Tests/PackageSigningTests/SigningEntityTests.swift
+++ b/Tests/PackageSigningTests/SigningEntityTests.swift
@@ -18,6 +18,29 @@ import SPMTestSupport
 import X509
 
 final class SigningEntityTests: XCTestCase {
+    func testTwoADPSigningEntitiesAreEqualIfTeamIDEqual() {
+        let adp1 = SigningEntity.recognized(
+            type: .adp,
+            name: "A. Appleseed",
+            organizationalUnit: "SwiftPM Test Unit X",
+            organization: "A"
+        )
+        let adp2 = SigningEntity.recognized(
+            type: .adp,
+            name: "B. Appleseed",
+            organizationalUnit: "SwiftPM Test Unit X",
+            organization: "B"
+        )
+        let adp3 = SigningEntity.recognized(
+            type: .adp,
+            name: "C. Appleseed",
+            organizationalUnit: "SwiftPM Test Unit Y",
+            organization: "C"
+        )
+        XCTAssertEqual(adp1, adp2) // Only team ID (org unit) needs to match
+        XCTAssertNotEqual(adp1, adp3)
+    }
+
     func testFromECKeyCertificate() throws {
         try fixture(name: "Signing", createGitRepo: false) { fixturePath in
             let certificateBytes = try readFileContents(


### PR DESCRIPTION
Two ADP signers are equal as long as their team ID (org unit) matches.
