### PR TITLE
Allow sources anywhere in ./Sources when only one target is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Swift Next
 Swift 5.9
 -----------
 
+* [#6294]
+
+  When a package contains a single target, sources may be distributed anywhere within the `./Sources` directory. If sources are placed in a subdirectory under `./Sources/<target>`, or there is more than one target, the existing expectation for sources apply.
+
 * [#6114]
 
   Added a new `allowNetworkConnections(scope:reason:)` for giving a command plugin permissions to access the network. Permissions can be scoped to Unix domain sockets in general or specifically for Docker, as well as local or remote IP connections which can be limited by port. For non-interactive use cases, there is also a `--allow-network-connections` commandline flag to allow network connections for a particular scope.

--- a/Sources/PackageLoading/Diagnostics.swift
+++ b/Sources/PackageLoading/Diagnostics.swift
@@ -15,8 +15,14 @@ import PackageModel
 import TSCBasic
 
 extension Basics.Diagnostic {
-    static func targetHasNoSources(targetPath: String, target: String) -> Self {
-        .warning("Source files for target \(target) should be located under \(targetPath)")
+    static func targetHasNoSources(name: String, type: TargetDescription.TargetType, shouldSuggestRelaxedSourceDir: Bool) -> Self {
+        let folderName = PackageBuilder.suggestedPredefinedSourceDirectory(type: type)
+        var clauses = ["Source files for target \(name) should be located under '\(folderName)/\(name)'"]
+        if shouldSuggestRelaxedSourceDir {
+            clauses.append("'\(folderName)'")
+        }
+        clauses.append("or a custom sources path can be set with the 'path' property in Package.swift")
+        return .warning(clauses.joined(separator: ", "))
     }
 
     static func targetNameHasIncorrectCase(target: String) -> Self {

--- a/Sources/PackageModel/Manifest/Manifest.swift
+++ b/Sources/PackageModel/Manifest/Manifest.swift
@@ -454,6 +454,26 @@ public final class Manifest: Sendable {
             return false
         }
     }
+
+    /// Returns a list of target descriptions whose root source directory is the same as that for the given type.
+    public func targetsWithCommonSourceRoot(type: TargetDescription.TargetType) -> [TargetDescription] {
+        switch type {
+        case .test:
+            return targets.filter { $0.type == .test }
+        case .plugin:
+            return targets.filter { $0.type == .plugin }
+        default:
+            return targets.filter { $0.type != .test && $0.type != .plugin }
+        }
+    }
+
+    /// Returns true if the tools version is >= 5.9 and the number of targets with a common source root is 1.
+    public func shouldSuggestRelaxedSourceDir(type: TargetDescription.TargetType) -> Bool {
+        guard toolsVersion >= .v5_9 else {
+            return false
+        }
+        return targetsWithCommonSourceRoot(type: type).count == 1
+    }
 }
 
 extension Manifest: Hashable {

--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -257,8 +257,7 @@ public final class InitPackage {
                 if packageType == .executable {
                     param += """
                             .executableTarget(
-                                name: "\(pkgname)",
-                                path: "Sources"),
+                                name: "\(pkgname)")
                         ]
                     """
                 } else if packageType == .tool {
@@ -267,8 +266,7 @@ public final class InitPackage {
                                 name: "\(pkgname)",
                                 dependencies: [
                                     .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                                ],
-                                path: "Sources"),
+                                ]),
                         ]
                     """
                 } else if packageType == .macro {
@@ -364,9 +362,13 @@ public final class InitPackage {
         progressReporter?("Creating \(sources.relative(to: destinationPath))/")
         try makeDirectories(sources)
 
-        let moduleDir = packageType == .executable || packageType == .tool
-          ? sources
-          : sources.appending("\(pkgname)")
+        let moduleDir: AbsolutePath
+        switch packageType {
+        case .executable, .tool:
+            moduleDir = sources
+        default:
+            moduleDir = sources.appending("\(pkgname)")
+        }
         try makeDirectories(moduleDir)
 
         let sourceFileName: String

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -516,7 +516,7 @@ class PackageGraphTests: XCTestCase {
 
         testDiagnostics(observability.diagnostics) { result in
             result.check(
-                diagnostic: "Source files for target Bar should be located under \(Bar.appending(components: "Sources", "Bar"))",
+                diagnostic: .contains("Source files for target Bar should be located under 'Sources/Bar'"),
                 severity: .warning
             )
             result.check(


### PR DESCRIPTION
After getting some feedback about the added `path` argument for executable packages generated with `swift package init` (#6144), this change allows a target's sources to occupy the entire sources directory when there is only one target in the package. All package types can benefit from this.

When there is more than one target in a package, the existing requirements for target sources still apply.

This change should be compatible with existing layouts as well. If there is only a single target in a package, then sources can of course continue to exist in `./Sources/<target>`.

Amend the `executable` template's generated manifest to not include the `path` argument anymore.

rdar://106829666