### PR TITLE
ListDestinations: use `print` instead of `emit(info:)` for output

### DIFF
--- a/Sources/CrossCompilationDestinationsTool/ListDestinations.swift
+++ b/Sources/CrossCompilationDestinationsTool/ListDestinations.swift
@@ -42,7 +42,7 @@ struct ListDestinations: DestinationCommand {
         )
 
         guard !validBundles.isEmpty else {
-            observabilityScope.emit(info: "No cross-compilation destinations are currently installed.")
+            print("No cross-compilation destinations are currently installed.")
             return
         }
 


### PR DESCRIPTION
This message is user-visible, so it shouldn't contain "info: " string prefix on each line that `emit(info:)` provides. Its initial use could've suggested that this is a debugging info message.
