### PR TITLE
use relative path in artifact bundles

### DIFF
--- a/Sources/PackageModel/ArtifactsArchiveMetadata.swift
+++ b/Sources/PackageModel/ArtifactsArchiveMetadata.swift
@@ -47,10 +47,10 @@ public struct ArtifactsArchiveMetadata: Equatable {
     }
 
     public struct Variant: Equatable {
-        public let path: String
+        public let path: RelativePath
         public let supportedTriples: [Triple]
 
-        public init(path: String, supportedTriples: [Triple]) {
+        public init(path: RelativePath, supportedTriples: [Triple]) {
             self.path = path
             self.supportedTriples = supportedTriples
         }
@@ -77,7 +77,9 @@ extension ArtifactsArchiveMetadata {
             case (1, 1), (1, 0):
                 return decodedMetadata
             default:
-                throw StringError("invalid `schemaVersion` of bundle manifest at `\(path)`: \(decodedMetadata.schemaVersion)")
+                throw StringError(
+                    "invalid `schemaVersion` of bundle manifest at `\(path)`: \(decodedMetadata.schemaVersion)"
+                )
             }
 
         } catch {
@@ -117,6 +119,6 @@ extension ArtifactsArchiveMetadata.Variant: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.supportedTriples = try container.decode([String].self, forKey: .supportedTriples).map { try Triple($0) }
-        self.path = try container.decode(String.self, forKey: .path)
+        self.path = try RelativePath(validating: container.decode(String.self, forKey: .path))
     }
 }

--- a/Sources/PackageModel/DestinationBundle.swift
+++ b/Sources/PackageModel/DestinationBundle.swift
@@ -156,8 +156,8 @@ extension ArtifactsArchiveMetadata {
             var variants = [DestinationBundle.Variant]()
 
             for variantMetadata in artifactMetadata.variants {
-                let destinationJSONPath = try bundlePath
-                    .appending(RelativePath(validating: variantMetadata.path))
+                let destinationJSONPath = bundlePath
+                    .appending(variantMetadata.path)
                     .appending("destination.json")
 
                 guard fileSystem.exists(destinationJSONPath) else {
@@ -253,7 +253,7 @@ extension Array where Element == DestinationBundle {
                                     multiple destinations match ID `\(artifactID)` and host triple \(
                                         hostTriple.tripleString
                                     ), selected one at \(
-                                        matchedByID.path.appending(component: matchedByID.variant.metadata.path)
+                                        matchedByID.path.appending(matchedByID.variant.metadata.path)
                                     )
                                     """
                                 )
@@ -270,7 +270,7 @@ extension Array where Element == DestinationBundle {
                                     multiple destinations match target triple `\(selector)` and host triple \(
                                         hostTriple.tripleString
                                     ), selected one at \(
-                                        matchedByTriple.path.appending(component: matchedByTriple.variant.metadata.path)
+                                        matchedByTriple.path.appending(matchedByTriple.variant.metadata.path)
                                     )
                                     """
                                 )
@@ -289,7 +289,7 @@ extension Array where Element == DestinationBundle {
                 """
                 multiple destinations match the query `\(selector)` and host triple \(
                     hostTriple.tripleString
-                ), selected one at \(matchedByID.path.appending(component: matchedByID.variant.metadata.path))
+                ), selected one at \(matchedByID.path.appending(matchedByID.variant.metadata.path))
                 """
             )
         }

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -2968,7 +2968,7 @@ final class WorkspaceTests: XCTestCase {
                 initializationWarningHandler: { _ in }
             )
             externalState.dependencies.remove(fooState.packageRef.identity)
-            externalState.dependencies.add(try fooState.edited(subpath: .init("foo"), unmanagedPath: fooEditPath))
+            externalState.dependencies.add(try fooState.edited(subpath: "foo", unmanagedPath: fooEditPath))
             try externalState.save()
         }
 


### PR DESCRIPTION
motivation: type safety

changes:
* artifact bundle path is suppose to be relative, use the right type for that
* add extensions for test to use strings as realtive path via ExpressibleByStringLiteral
* update call sites
