### PR TITLE
Add caching to OCSP verifier and perform expiry check

### DIFF
--- a/Sources/PackageRegistry/SignatureValidation.swift
+++ b/Sources/PackageRegistry/SignatureValidation.swift
@@ -313,7 +313,7 @@ extension VerifierConfiguration {
             if let certificateExpiration = validationChecks.certificateExpiration {
                 switch certificateExpiration {
                 case .enabled:
-                    verifierConfiguration.certificateExpiration = .enabled(validationTime: nil)
+                    verifierConfiguration.certificateExpiration = .enabled(validationTime: .none)
                 case .disabled:
                     verifierConfiguration.certificateExpiration = .disabled
                 }
@@ -322,9 +322,9 @@ extension VerifierConfiguration {
             if let certificateRevocation = validationChecks.certificateRevocation {
                 switch certificateRevocation {
                 case .strict:
-                    verifierConfiguration.certificateRevocation = .strict
+                    verifierConfiguration.certificateRevocation = .strict(validationTime: .none)
                 case .allowSoftFail:
-                    verifierConfiguration.certificateRevocation = .allowSoftFail
+                    verifierConfiguration.certificateRevocation = .allowSoftFail(validationTime: .none)
                 case .disabled:
                     verifierConfiguration.certificateRevocation = .disabled
                 }

--- a/Tests/PackageSigningTests/SigningTests.swift
+++ b/Tests/PackageSigningTests/SigningTests.swift
@@ -418,8 +418,7 @@ final class SigningTests: XCTestCase {
                 trustedRoots: [keyAndCertChain.rootCertificate],
                 includeDefaultTrustStore: false,
                 certificateExpiration: .enabled(
-                    validationTime: signingIdentity.certificate.notValidBefore
-                        .addingTimeInterval(-60 * 60 * 24 * 3)
+                    validationTime: signingIdentity.certificate.notValidBefore - .days(3)
                 ),
                 certificateRevocation: .disabled
             )
@@ -442,8 +441,7 @@ final class SigningTests: XCTestCase {
                 trustedRoots: [keyAndCertChain.rootCertificate],
                 includeDefaultTrustStore: false,
                 certificateExpiration: .enabled(
-                    validationTime: signingIdentity.certificate.notValidAfter
-                        .addingTimeInterval(60 * 60 * 24 * 3)
+                    validationTime: signingIdentity.certificate.notValidAfter + .days(3)
                 ),
                 certificateRevocation: .disabled
             )
@@ -510,7 +508,9 @@ final class SigningTests: XCTestCase {
                 trustedRoots: [OCSPTestHelper.chainWithSingleCertWithOCSP[1].derEncodedBytes],
                 includeDefaultTrustStore: false,
                 certificateExpiration: .disabled,
-                certificateRevocation: .strict
+                certificateRevocation: .strict(
+                    validationTime: signingIdentity.certificate.notValidAfter - .days(3)
+                )
             )
 
             let status = try await cmsProvider.status(
@@ -531,7 +531,9 @@ final class SigningTests: XCTestCase {
                 trustedRoots: [OCSPTestHelper.chainWithSingleCertWithOCSP[1].derEncodedBytes],
                 includeDefaultTrustStore: false,
                 certificateExpiration: .disabled,
-                certificateRevocation: .allowSoftFail
+                certificateRevocation: .allowSoftFail(
+                    validationTime: signingIdentity.certificate.notValidAfter - .days(3)
+                )
             )
 
             let status = try await cmsProvider.status(
@@ -572,7 +574,7 @@ final class SigningTests: XCTestCase {
             trustedRoots: [keyAndCertChain.rootCertificate],
             includeDefaultTrustStore: true,
             certificateExpiration: .enabled(validationTime: nil),
-            certificateRevocation: .strict
+            certificateRevocation: .strict(validationTime: nil)
         )
 
         let status = try await cmsProvider.status(
@@ -640,7 +642,7 @@ final class SigningTests: XCTestCase {
             trustedRoots: [],
             includeDefaultTrustStore: true, // WWDR roots are in the default trust store
             certificateExpiration: .enabled(validationTime: nil),
-            certificateRevocation: .strict
+            certificateRevocation: .strict(validationTime: nil)
         )
 
         let status = try await SignatureProvider.status(
@@ -697,7 +699,7 @@ final class SigningTests: XCTestCase {
             trustedRoots: [],
             includeDefaultTrustStore: true, // WWDR roots are in the default trust store
             certificateExpiration: .enabled(validationTime: nil),
-            certificateRevocation: .strict
+            certificateRevocation: .strict(validationTime: nil)
         )
 
         let status = try await cmsProvider.status(
@@ -753,7 +755,7 @@ final class SigningTests: XCTestCase {
             trustedRoots: [],
             includeDefaultTrustStore: true, // WWDR roots are in the default trust store
             certificateExpiration: .enabled(validationTime: nil),
-            certificateRevocation: .strict
+            certificateRevocation: .strict(validationTime: nil)
         )
 
         let status = try await cmsProvider.status(


### PR DESCRIPTION
- OCSP check is done through HTTP requests, add caching to reduce network calls.
- OCSP responder might not be able to provide revocation checking beyond certificate expiration, so check that leaf certificate has not expired before making OCSP requests.
