### PR TITLE
LLBuildManifest: clean up bleeding whitespace (NFC)

### DIFF
--- a/Sources/LLBuildManifest/CMakeLists.txt
+++ b/Sources/LLBuildManifest/CMakeLists.txt
@@ -9,7 +9,7 @@
 add_library(LLBuildManifest STATIC
   BuildManifest.swift
   Command.swift
-  ManifestWriter.swift  
+  ManifestWriter.swift
   Node.swift
   Target.swift
   Tools.swift)


### PR DESCRIPTION
Clean up some bleeding whitespace.