### PR TITLE
build: stop exporting a couple of targets

### DIFF
--- a/Sources/Build/CMakeLists.txt
+++ b/Sources/Build/CMakeLists.txt
@@ -21,12 +21,14 @@ target_link_libraries(Build PUBLIC
   TSCBasic
   Basics
   PackageGraph
-  LLBuildManifest
-  SPMBuildCore
-  SPMLLBuild)
+  SPMBuildCore)
 target_link_libraries(Build PRIVATE
   DriverSupport
+  LLBuildManifest
+  SPMLLBuild
   SwiftDriver)
+target_link_libraries(Build INTERFACE
+  llbuildSwift)
 
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(Build PROPERTIES

--- a/Sources/LLBuildManifest/CMakeLists.txt
+++ b/Sources/LLBuildManifest/CMakeLists.txt
@@ -20,5 +20,3 @@ target_link_libraries(LLBuildManifest PUBLIC
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(LLBuildManifest PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
-
-set_property(GLOBAL APPEND PROPERTY SwiftPM_EXPORTS LLBuildManifest)

--- a/Sources/PackageFingerprint/CMakeLists.txt
+++ b/Sources/PackageFingerprint/CMakeLists.txt
@@ -18,5 +18,3 @@ target_link_libraries(PackageFingerprint PUBLIC
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(PackageFingerprint PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
-
-set_property(GLOBAL APPEND PROPERTY SwiftPM_EXPORTS PackageFingerprint)

--- a/Sources/PackageGraph/CMakeLists.txt
+++ b/Sources/PackageGraph/CMakeLists.txt
@@ -39,8 +39,9 @@ target_link_libraries(PackageGraph PUBLIC
   Basics
   PackageLoading
   PackageModel
-  SourceControl
   TSCUtility)
+target_link_libraries(PackageGraph PRIVATE
+  SourceControl)
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(PackageGraph PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})

--- a/Sources/PackageLoading/CMakeLists.txt
+++ b/Sources/PackageLoading/CMakeLists.txt
@@ -29,6 +29,8 @@ target_link_libraries(PackageLoading PUBLIC
   TSCUtility)
 target_link_libraries(PackageLoading PUBLIC
   $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)
+target_link_libraries(PackageLoading PRIVATE
+  SourceControl)
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(PackageLoading PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})

--- a/Sources/PackageRegistry/CMakeLists.txt
+++ b/Sources/PackageRegistry/CMakeLists.txt
@@ -24,5 +24,3 @@ target_link_libraries(PackageRegistry PUBLIC
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(PackageRegistry PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
-
-set_property(GLOBAL APPEND PROPERTY SwiftPM_EXPORTS PackageRegistry)

--- a/Sources/SPMLLBuild/CMakeLists.txt
+++ b/Sources/SPMLLBuild/CMakeLists.txt
@@ -16,5 +16,3 @@ target_link_libraries(SPMLLBuild PUBLIC
   TSCBasic
   TSCUtility
   llbuildSwift)
-
-set_property(GLOBAL APPEND PROPERTY SwiftPM_EXPORTS SPMLLBuild)

--- a/Sources/SourceControl/CMakeLists.txt
+++ b/Sources/SourceControl/CMakeLists.txt
@@ -20,5 +20,3 @@ target_link_libraries(SourceControl PUBLIC
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(SourceControl PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
-
-set_property(GLOBAL APPEND PROPERTY SwiftPM_EXPORTS SourceControl)


### PR DESCRIPTION
Reduce the overall exported set of libraries.  These are internal to SPM and do not need to be exposed to consumers.