### PR TITLE
PackageRegistry: mark PackageVersionMetadata Sendable

### DIFF
--- a/Sources/PackageModel/PackageIdentity.swift
+++ b/Sources/PackageModel/PackageIdentity.swift
@@ -74,7 +74,7 @@ public struct PackageIdentity: CustomStringConvertible, Sendable {
         self.registry != nil
     }
 
-    public struct RegistryIdentity: Hashable, CustomStringConvertible {
+    public struct RegistryIdentity: Hashable, CustomStringConvertible, Sendable {
         public let scope: PackageIdentity.Scope
         public let name: PackageIdentity.Name
         public let underlying: PackageIdentity

--- a/Sources/PackageModel/Registry.swift
+++ b/Sources/PackageModel/Registry.swift
@@ -13,7 +13,7 @@
 import Basics
 import struct Foundation.URL
 
-public struct Registry: Hashable, CustomStringConvertible {
+public struct Registry: Hashable, CustomStringConvertible, Sendable {
     public var url: URL
     public var supportsAvailability: Bool
 

--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -1745,7 +1745,7 @@ extension RegistryClient {
         public let alternateLocations: [URL]?
     }
 
-    public struct PackageVersionMetadata {
+    public struct PackageVersionMetadata: Sendable {
         public let registry: Registry
         public let licenseURL: URL?
         public let readmeURL: URL?
@@ -1758,7 +1758,7 @@ extension RegistryClient {
             self.resources.first(where: { $0.name == "source-archive" })
         }
 
-        public struct Resource {
+        public struct Resource: Sendable {
             public let name: String
             public let type: String
             public let checksum: String?
@@ -1772,12 +1772,12 @@ extension RegistryClient {
             }
         }
 
-        public struct Signing {
+        public struct Signing: Sendable {
             public let signatureBase64Encoded: String
             public let signatureFormat: String
         }
 
-        public struct Author {
+        public struct Author: Sendable {
             public let name: String
             public let email: String?
             public let description: String?
@@ -1785,7 +1785,7 @@ extension RegistryClient {
             public let url: URL?
         }
 
-        public struct Organization {
+        public struct Organization: Sendable {
             public let name: String
             public let email: String?
             public let description: String?


### PR DESCRIPTION
This allows capturing `PackageVersionMetadata` in `@Sendable` closures. We still have a couple of warnings related to such closures, but this change is a first step towards resolving those in the future. Also marked `RegistryIdentity` as `Sendable` for the same reason.