### PR TITLE
[Macro package init] Use triple-slash documentation comments

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -415,12 +415,12 @@ public final class InitPackage {
             // The Swift Programming Language
             // https://docs.swift.org/swift-book
 
-            // A macro that produces both a value and a string containing the
-            // source code that generated the value. For example,
-            //
-            //     #stringify(x + y)
-            //
-            // produces a tuple `(x + y, "x + y")`.
+            /// A macro that produces both a value and a string containing the
+            /// source code that generated the value. For example,
+            ///
+            ///     #stringify(x + y)
+            ///
+            /// produces a tuple `(x + y, "x + y")`.
             @freestanding(expression)
             public macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "\(moduleName)Macros", type: "StringifyMacro")
             """


### PR DESCRIPTION
In the generated `stringify` macro declaration, use triple-slash documentation comments rather than double-slash comments, so we get better documentation.
