### PR TITLE
Add build setting for enabling the builtin module

### DIFF
--- a/Sources/PackageDescription/BuildSettings.swift
+++ b/Sources/PackageDescription/BuildSettings.swift
@@ -389,8 +389,9 @@ public struct SwiftSetting {
     }
 
     @available(_PackageDescription, introduced: 5.9)
-    public static var _enableBuiltinModule: SwiftSetting {
-        SwiftSetting(name: "_enableBuiltinModule", value: [], condition: nil)
+    @_spi(FrontendOptions)
+    public static var enableBuiltinModule: SwiftSetting {
+        SwiftSetting(name: "enableBuiltinModule", value: [], condition: nil)
     }
 }
 

--- a/Sources/PackageLoading/ManifestJSONParser.swift
+++ b/Sources/PackageLoading/ManifestJSONParser.swift
@@ -704,8 +704,8 @@ extension TargetBuildSettingDescription.Kind {
             return .enableExperimentalFeature(value)
         case "unsafeFlags":
             return .unsafeFlags(values)
-        case "_enableBuiltinModule":
-            return ._enableBuiltinModule
+        case "enableBuiltinModule":
+            return .enableBuiltinModule
         default:
             throw InternalError("invalid build setting \(name)")
         }

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -1039,7 +1039,7 @@ public final class PackageBuilder {
 
                 values = ["-enable-experimental-feature", value]
 
-            case ._enableBuiltinModule:
+            case .enableBuiltinModule:
                 switch setting.tool {
                 case .c, .cxx, .linker:
                     throw InternalError(
@@ -1049,7 +1049,7 @@ public final class PackageBuilder {
                     decl = .OTHER_SWIFT_FLAGS
                 }
 
-                values = ["-Xfrontend", "-enable-builtin-module"]
+                values = ["-enable-builtin-module"]
             }
 
             // Create an assignment for this setting.

--- a/Sources/PackageModel/Manifest/TargetBuildSettingDescription.swift
+++ b/Sources/PackageModel/Manifest/TargetBuildSettingDescription.swift
@@ -40,14 +40,14 @@ public enum TargetBuildSettingDescription {
 
         case unsafeFlags([String])
 
-        case _enableBuiltinModule
+        case enableBuiltinModule
 
         public var isUnsafeFlags: Bool {
             switch self {
             case .unsafeFlags(let flags):
                 // If `.unsafeFlags` is used, but doesn't specify any flags, we treat it the same way as not specifying it.
                 return !flags.isEmpty
-            case .headerSearchPath, .define, .linkedLibrary, .linkedFramework, .interoperabilityMode, .enableUpcomingFeature, .enableExperimentalFeature, ._enableBuiltinModule:
+            case .headerSearchPath, .define, .linkedLibrary, .linkedFramework, .interoperabilityMode, .enableUpcomingFeature, .enableExperimentalFeature, .enableBuiltinModule:
                 return false
             }
         }

--- a/Sources/PackageModel/ManifestSourceGeneration.swift
+++ b/Sources/PackageModel/ManifestSourceGeneration.swift
@@ -526,7 +526,7 @@ fileprivate extension SourceCodeFragment {
                 params.append(SourceCodeFragment(from: condition))
             }
             self.init(enum: setting.kind.name, subnodes: params)
-        case ._enableBuiltinModule:
+        case .enableBuiltinModule:
             self.init(enum: setting.kind.name)
         }
     }
@@ -680,8 +680,8 @@ extension TargetBuildSettingDescription.Kind {
             return "enableUpcomingFeature"
         case .enableExperimentalFeature:
             return "enableExperimentalFeature"
-        case ._enableBuiltinModule:
-            return "_enableBuiltinModule"
+        case .enableBuiltinModule:
+            return "enableBuiltinModule"
         }
     }
 }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -3246,7 +3246,7 @@ final class BuildPlanTests: XCTestCase {
                         .init(tool: .swift, kind: .interoperabilityMode(.Cxx, "swift-6.0"), condition: .init(platformNames: ["macos"])),
                         .init(tool: .swift, kind: .enableUpcomingFeature("BestFeature")),
                         .init(tool: .swift, kind: .enableUpcomingFeature("WorstFeature"), condition: .init(platformNames: ["macos"], config: "debug")),
-                        .init(tool: .swift, kind: ._enableBuiltinModule)
+                        .init(tool: .swift, kind: .enableBuiltinModule)
                     ]
                 ),
                 try TargetDescription(
@@ -3312,7 +3312,7 @@ final class BuildPlanTests: XCTestCase {
             XCTAssertMatch(cbar, [.anySequence, "-DCCC=2", "-I\(A.appending(components: "Sources", "cbar", "Sources", "headers"))", "-I\(A.appending(components: "Sources", "cbar", "Sources", "cppheaders"))", "-Icfoo", "-L", "cbar", "-Icxxfoo", "-L", "cxxbar", .end])
 
             let bar = try result.target(for: "bar").swiftTarget().compileArguments()
-            XCTAssertMatch(bar, [.anySequence, "-DLINUX", "-Isfoo", "-L", "sbar", "-cxx-interoperability-mode=swift-5.9", "-enable-upcoming-feature", "BestFeature", "-Xfrontend", "-enable-builtin-module", .end])
+            XCTAssertMatch(bar, [.anySequence, "-DLINUX", "-Isfoo", "-L", "sbar", "-cxx-interoperability-mode=swift-5.9", "-enable-upcoming-feature", "BestFeature", "-enable-builtin-module", .end])
 
             let exe = try result.target(for: "exe").swiftTarget().compileArguments()
             XCTAssertMatch(exe, [.anySequence, "-DFOO", .end])
@@ -3328,7 +3328,7 @@ final class BuildPlanTests: XCTestCase {
             XCTAssertMatch(cbar, [.anySequence, "-DCCC=2", "-I\(A.appending(components: "Sources", "cbar", "Sources", "headers"))", "-I\(A.appending(components: "Sources", "cbar", "Sources", "cppheaders"))", "-Icfoo", "-L", "cbar", "-Icxxfoo", "-L", "cxxbar", .end])
 
             let bar = try result.target(for: "bar").swiftTarget().compileArguments()
-            XCTAssertMatch(bar, [.anySequence, "-DDMACOS", "-Isfoo", "-L", "sbar", "-cxx-interoperability-mode=swift-6.0", "-enable-upcoming-feature", "BestFeature", "-enable-upcoming-feature", "WorstFeature", "-Xfrontend", "-enable-builtin-module", .end])
+            XCTAssertMatch(bar, [.anySequence, "-DDMACOS", "-Isfoo", "-L", "sbar", "-cxx-interoperability-mode=swift-6.0", "-enable-upcoming-feature", "BestFeature", "-enable-upcoming-feature", "WorstFeature", "-enable-builtin-module", .end])
 
             let exe = try result.target(for: "exe").swiftTarget().compileArguments()
             XCTAssertMatch(exe, [.anySequence, "-DFOO", .end])

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -528,26 +528,6 @@ class ManifestSourceGenerationTests: XCTestCase {
         try testManifestWritingRoundTrip(manifestContents: manifestContents, toolsVersion: .v5_8)
     }
 
-    func testEnableBuiltinModule() throws {
-        let manifestContents = """
-            // swift-tools-version:5.9
-            import PackageDescription
-
-            let package = Package(
-                name: "EnableBuiltinModule",
-                targets: [
-                    .target(
-                        name: "MyTool",
-                        swiftSettings: [
-                            ._enableBuiltinModule
-                        ]
-                    )
-                ]
-            )
-            """
-        try testManifestWritingRoundTrip(manifestContents: manifestContents, toolsVersion: .v5_9)
-    }
-
     func testPluginNetworkingPermissionGeneration() throws {
         let manifest = Manifest.createRootManifest(
             displayName: "thisPkg",


### PR DESCRIPTION
This adds an underscored build setting to enable the `Builtin` module in packages. This is useful for some of the packages the standard library team plans to create/make use of to allow usage of these things without using `unsafeFlags`.