### PR TITLE
better diagnostics when potentially duplicate packages are found

### DIFF
--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -505,7 +505,7 @@ private func createResolvedPackages(
                         throw InternalError("dependency reference for \(product.packageBuilder.package.manifest.packageLocation) not found")
                     }
                     let referencedPackageName = referencedPackageDependency.nameForTargetDependencyResolutionOnly
-                    if productRef.name !=  referencedPackageName {
+                    if productRef.name != referencedPackageName {
                         let error = PackageGraphError.productDependencyMissingPackage(
                             productName: productRef.name,
                             targetName: targetBuilder.target.name,
@@ -522,15 +522,79 @@ private func createResolvedPackages(
 
     // If a target with similar name was encountered before, we emit a diagnostic.
     if foundDuplicateTarget {
+        var duplicateTargets = [String: [Package]]()
         for targetName in allTargetNames.sorted() {
-            // Find the packages this target is present in.
             let packages = packageBuilders
                 .filter({ $0.targets.contains(where: { $0.target.name == targetName }) })
-                .map{ $0.package.identity.description }
-                .sorted()
+                .map{ $0.package }
             if packages.count > 1 {
-                observabilityScope.emit(ModuleError.duplicateModule(targetName, packages))
+                duplicateTargets[targetName, default: []].append(contentsOf: packages)
             }
+        }
+
+        struct Pair: Hashable {
+            let package1: Package
+            let package2: Package
+
+            static func == (lhs: Pair, rhs: Pair) -> Bool {
+                return lhs.package1.identity == rhs.package1.identity &&
+                    lhs.package2.identity == rhs.package2.identity
+            }
+
+            public func hash(into hasher: inout Hasher) {
+                hasher.combine(self.package1.identity)
+                hasher.combine(self.package2.identity)
+            }
+        }
+
+        var potentiallyDuplicatePackages = [Pair: [String]]()
+        for entry in duplicateTargets {
+            // the duplicate is across exactly two packages
+            if entry.value.count == 2 {
+                potentiallyDuplicatePackages[Pair(package1: entry.value[0], package2: entry.value[1]), default: []].append(entry.key)
+            }
+        }
+
+        var duplicateTargetsAddressed = [String]()
+        for potentiallyDuplicatePackage in potentiallyDuplicatePackages {
+            // more than three target matches, or all targets in the package match
+            if potentiallyDuplicatePackage.value.count > 3 || potentiallyDuplicatePackage.value.sorted() == potentiallyDuplicatePackage.key.package1.targets.map({ $0.name }).sorted() {
+                switch (potentiallyDuplicatePackage.key.package1.identity.registry, potentiallyDuplicatePackage.key.package2.identity.registry) {
+                case (.some(let registryIdentity), .none):
+                    observabilityScope.emit(
+                        ModuleError.duplicateModulesScmAndRegistry(
+                            regsitryPackage: registryIdentity,
+                            scmPackage: potentiallyDuplicatePackage.key.package2.identity,
+                            targets: potentiallyDuplicatePackage.value
+                        )
+                    )
+                case (.none, .some(let registryIdentity)):
+                    observabilityScope.emit(
+                        ModuleError.duplicateModulesScmAndRegistry(
+                            regsitryPackage: registryIdentity,
+                            scmPackage: potentiallyDuplicatePackage.key.package1.identity,
+                            targets: potentiallyDuplicatePackage.value
+                        )
+                    )
+                default:
+                    observabilityScope.emit(
+                        ModuleError.duplicateModules(
+                            package: potentiallyDuplicatePackage.key.package1.identity,
+                            otherPackage: potentiallyDuplicatePackage.key.package2.identity,
+                            targets: potentiallyDuplicatePackage.value
+                        )
+                    )
+                }
+                duplicateTargetsAddressed += potentiallyDuplicatePackage.value
+            }
+        }
+
+        for entry in duplicateTargets.filter({ !duplicateTargetsAddressed.contains($0.key) }) {
+            observabilityScope.emit(
+                ModuleError.duplicateModule(
+                    targetName: entry.key,
+                    packages: entry.value.map{ $0.identity })
+            )
         }
     }
 

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -558,7 +558,11 @@ private func createResolvedPackages(
         var duplicateTargetsAddressed = [String]()
         for potentiallyDuplicatePackage in potentiallyDuplicatePackages {
             // more than three target matches, or all targets in the package match
-            if potentiallyDuplicatePackage.value.count > 3 || potentiallyDuplicatePackage.value.sorted() == potentiallyDuplicatePackage.key.package1.targets.map({ $0.name }).sorted() {
+            if potentiallyDuplicatePackage.value.count > 3 ||
+                (potentiallyDuplicatePackage.value.sorted() == potentiallyDuplicatePackage.key.package1.targets.map({ $0.name }).sorted()
+                &&
+                potentiallyDuplicatePackage.value.sorted() == potentiallyDuplicatePackage.key.package2.targets.map({ $0.name }).sorted())
+            {
                 switch (potentiallyDuplicatePackage.key.package1.identity.registry, potentiallyDuplicatePackage.key.package2.identity.registry) {
                 case (.some(let registryIdentity), .none):
                     observabilityScope.emit(

--- a/Sources/SPMTestSupport/ManifestExtensions.swift
+++ b/Sources/SPMTestSupport/ManifestExtensions.swift
@@ -161,6 +161,43 @@ extension Manifest {
         )
     }
 
+    public static func createRegistryManifest(
+        displayName: String,
+        identity: PackageIdentity,
+        path: AbsolutePath = .root,
+        defaultLocalization: String? = nil,
+        platforms: [PlatformDescription] = [],
+        version: TSCUtility.Version? = nil,
+        toolsVersion: ToolsVersion = .v4,
+        pkgConfig: String? = nil,
+        providers: [SystemPackageProviderDescription]? = nil,
+        cLanguageStandard: String? = nil,
+        cxxLanguageStandard: String? = nil,
+        swiftLanguageVersions: [SwiftLanguageVersion]? = nil,
+        dependencies: [PackageDependency] = [],
+        products: [ProductDescription] = [],
+        targets: [TargetDescription] = []
+    ) -> Manifest {
+        Self.createManifest(
+            displayName: displayName,
+            path: path,
+            packageKind: .registry(identity),
+            packageLocation: identity.description,
+            defaultLocalization: defaultLocalization,
+            platforms: platforms,
+            version: version,
+            toolsVersion: toolsVersion,
+            pkgConfig: pkgConfig,
+            providers: providers,
+            cLanguageStandard: cLanguageStandard,
+            cxxLanguageStandard: cxxLanguageStandard,
+            swiftLanguageVersions: swiftLanguageVersions,
+            dependencies: dependencies,
+            products: products,
+            targets: targets
+        )
+    }
+
     public static func createManifest(
         displayName: String,
         path: AbsolutePath = .root,
@@ -181,7 +218,7 @@ extension Manifest {
     ) -> Manifest {
         return Manifest(
             displayName: displayName,
-            path: path.basename == Manifest.filename ? path : path.appending(component: Manifest.filename) ,
+            path: path.basename == Manifest.filename ? path : path.appending(component: Manifest.filename),
             packageKind: packageKind,
             packageLocation: packageLocation ?? path.pathString,
             defaultLocalization: defaultLocalization,

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -263,8 +263,10 @@ class PackageGraphTests: XCTestCase {
 
     func testDuplicateModules() throws {
         let fs = InMemoryFileSystem(emptyFiles:
+            "/Foo/Sources/Foo/source.swift",
             "/Foo/Sources/Bar/source.swift",
-            "/Bar/Sources/Bar/source.swift"
+            "/Bar/Sources/Bar/source.swift",
+            "/Bar/Sources/Baz/source.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -278,6 +280,7 @@ class PackageGraphTests: XCTestCase {
                         .localSourceControl(path: .init(path: "/Bar"), requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     targets: [
+                        TargetDescription(name: "Foo"),
                         TargetDescription(name: "Bar"),
                     ]),
                 Manifest.createRootManifest(
@@ -285,6 +288,7 @@ class PackageGraphTests: XCTestCase {
                     path: .init(path: "/Bar"),
                     targets: [
                         TargetDescription(name: "Bar"),
+                        TargetDescription(name: "Baz"),
                     ]),
             ],
             observabilityScope: observability.topScope
@@ -356,9 +360,13 @@ class PackageGraphTests: XCTestCase {
 
     func testSeveralDuplicateModules() throws {
         let fs = InMemoryFileSystem(emptyFiles:
+            "/Fourth/Sources/Fourth/source.swift",
             "/Fourth/Sources/Bar/source.swift",
+            "/Third/Sources/Third/source.swift",
             "/Third/Sources/Bar/source.swift",
+            "/Second/Sources/Second/source.swift",
             "/Second/Sources/Foo/source.swift",
+            "/First/Sources/First/source.swift",
             "/First/Sources/Foo/source.swift"
         )
 
@@ -370,27 +378,30 @@ class PackageGraphTests: XCTestCase {
                     displayName: "Fourth",
                     path: .init(path: "/Fourth"),
                     products: [
-                        ProductDescription(name: "Fourth", type: .library(.automatic), targets: ["Bar"])
+                        ProductDescription(name: "Fourth", type: .library(.automatic), targets: ["Fourth", "Bar"])
                     ],
                     targets: [
+                        TargetDescription(name: "Fourth"),
                         TargetDescription(name: "Bar"),
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "Third",
                     path: .init(path: "/Third"),
                     products: [
-                        ProductDescription(name: "Third", type: .library(.automatic), targets: ["Bar"])
+                        ProductDescription(name: "Third", type: .library(.automatic), targets: ["Third", "Bar"])
                     ],
                     targets: [
+                        TargetDescription(name: "Third"),
                         TargetDescription(name: "Bar"),
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "Second",
                     path: .init(path: "/Second"),
                     products: [
-                        ProductDescription(name: "Second", type: .library(.automatic), targets: ["Foo"])
+                        ProductDescription(name: "Second", type: .library(.automatic), targets: ["Second", "Foo"])
                     ],
                     targets: [
+                        TargetDescription(name: "Second"),
                         TargetDescription(name: "Foo"),
                     ]),
                 Manifest.createRootManifest(
@@ -401,7 +412,11 @@ class PackageGraphTests: XCTestCase {
                         .localSourceControl(path: .init(path: "/Third"), requirement: .upToNextMajor(from: "1.0.0")),
                         .localSourceControl(path: .init(path: "/Fourth"), requirement: .upToNextMajor(from: "1.0.0")),
                     ],
+                    products: [
+                        ProductDescription(name: "First", type: .library(.automatic), targets: ["First", "Foo"])
+                    ],
                     targets: [
+                        TargetDescription(name: "First"),
                         TargetDescription(name: "Foo", dependencies: ["Second", "Third", "Fourth"]),
                     ]),
             ],
@@ -409,14 +424,15 @@ class PackageGraphTests: XCTestCase {
         )
 
         testDiagnostics(observability.diagnostics) { result in
-            result.check(diagnostic: "multiple targets named 'Bar' in: 'fourth', 'third'; consider using the `moduleAliases` parameter in manifest to provide unique names", severity: .error)
-            result.check(diagnostic: "multiple targets named 'Foo' in: 'first', 'second'; consider using the `moduleAliases` parameter in manifest to provide unique names", severity: .error)
+            result.checkUnordered(diagnostic: "multiple targets named 'Bar' in: 'fourth', 'third'; consider using the `moduleAliases` parameter in manifest to provide unique names", severity: .error)
+            result.checkUnordered(diagnostic: "multiple targets named 'Foo' in: 'first', 'second'; consider using the `moduleAliases` parameter in manifest to provide unique names", severity: .error)
         }
     }
 
     func testNestedDuplicateModules() throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/Fourth/Sources/First/source.swift",
+            "/Fourth/Sources/Fourth/source.swift",
             "/Third/Sources/Third/source.swift",
             "/Second/Sources/Second/source.swift",
             "/First/Sources/First/source.swift"
@@ -430,9 +446,10 @@ class PackageGraphTests: XCTestCase {
                     displayName: "Fourth",
                     path: .init(path: "/Fourth"),
                     products: [
-                        ProductDescription(name: "Fourth", type: .library(.automatic), targets: ["First"])
+                        ProductDescription(name: "Fourth", type: .library(.automatic), targets: ["Fourth", "First"])
                     ],
                     targets: [
+                        TargetDescription(name: "Fourth"),
                         TargetDescription(name: "First"),
                     ]),
                 Manifest.createFileSystemManifest(
@@ -477,6 +494,151 @@ class PackageGraphTests: XCTestCase {
 
         testDiagnostics(observability.diagnostics) { result in
             result.check(diagnostic: "multiple targets named 'First' in: 'first', 'fourth'; consider using the `moduleAliases` parameter in manifest to provide unique names", severity: .error)
+        }
+    }
+
+    func testPotentiallyDuplicatePackages() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/First/Sources/Foo/source.swift",
+            "/First/Sources/Bar/source.swift",
+            "/Second/Sources/Foo/source.swift",
+            "/Second/Sources/Bar/source.swift"
+        )
+
+        let observability = ObservabilitySystem.makeForTesting()
+        _ = try loadPackageGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "First",
+                    path: .init(path: "/First"),
+                    dependencies: [
+                        .localSourceControl(path: .init(path: "/Second"), requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    products: [
+                        ProductDescription(name: "First", type: .library(.automatic), targets: ["Foo", "Bar"])
+                    ],
+                    targets: [
+                        TargetDescription(name: "Foo"),
+                        TargetDescription(name: "Bar"),
+                    ]),
+                Manifest.createLocalSourceControlManifest(
+                    displayName: "Second",
+                    path: .init(path: "/Second"),
+                    products: [
+                        ProductDescription(name: "Second", type: .library(.automatic), targets: ["Foo", "Bar"])
+                    ],
+                    targets: [
+                        TargetDescription(name: "Foo"),
+                        TargetDescription(name: "Bar"),
+                    ]),
+            ],
+            observabilityScope: observability.topScope
+        )
+
+        testDiagnostics(observability.diagnostics) { result in
+            result.check(diagnostic: .contains("multiple similar targets 'Bar', 'Foo' appear in package 'first' and 'second'"), severity: .error)
+        }
+    }
+
+    func testPotentiallyDuplicatePackagesManyTargets() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/First/Sources/Foo/source.swift",
+            "/First/Sources/Bar/source.swift",
+            "/First/Sources/Baz/source.swift",
+            "/First/Sources/Qux/source.swift",
+            "/First/Sources/Quux/source.swift",
+            "/Second/Sources/Foo/source.swift",
+            "/Second/Sources/Bar/source.swift",
+            "/Second/Sources/Baz/source.swift",
+            "/Second/Sources/Qux/source.swift",
+            "/Second/Sources/Quux/source.swift"
+        )
+
+        let observability = ObservabilitySystem.makeForTesting()
+        _ = try loadPackageGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "First",
+                    path: .init(path: "/First"),
+                    dependencies: [
+                        .localSourceControl(path: .init(path: "/Second"), requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    products: [
+                        ProductDescription(name: "First", type: .library(.automatic), targets: ["Foo", "Bar", "Baz", "Qux", "Quux"])
+                    ],
+                    targets: [
+                        TargetDescription(name: "Foo"),
+                        TargetDescription(name: "Bar"),
+                        TargetDescription(name: "Baz"),
+                        TargetDescription(name: "Qux"),
+                        TargetDescription(name: "Quux"),
+                    ]),
+                Manifest.createLocalSourceControlManifest(
+                    displayName: "Second",
+                    path: .init(path: "/Second"),
+                    products: [
+                        ProductDescription(name: "Second", type: .library(.automatic), targets: ["Foo", "Bar", "Baz", "Qux", "Quux"])
+                    ],
+                    targets: [
+                        TargetDescription(name: "Foo"),
+                        TargetDescription(name: "Bar"),
+                        TargetDescription(name: "Baz"),
+                        TargetDescription(name: "Qux"),
+                        TargetDescription(name: "Quux"),
+                    ]),
+            ],
+            observabilityScope: observability.topScope
+        )
+
+        testDiagnostics(observability.diagnostics) { result in
+            result.check(diagnostic: .contains("multiple similar targets 'Bar', 'Baz', 'Foo' and 2 others appear in package 'first' and 'second'"), severity: .error)
+        }
+    }
+
+    func testPotentiallyDuplicatePackagesRegistrySCM() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/First/Sources/Foo/source.swift",
+            "/First/Sources/Bar/source.swift",
+            "/Second/Sources/Foo/source.swift",
+            "/Second/Sources/Bar/source.swift"
+        )
+
+        let observability = ObservabilitySystem.makeForTesting()
+        _ = try loadPackageGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "First",
+                    path: .init(path: "/First"),
+                    dependencies: [
+                        .registry(identity: "test.second", requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    products: [
+                        ProductDescription(name: "First", type: .library(.automatic), targets: ["Foo", "Bar"])
+                    ],
+                    targets: [
+                        TargetDescription(name: "Foo"),
+                        TargetDescription(name: "Bar"),
+                    ]),
+                Manifest.createRegistryManifest(
+                    displayName: "Second",
+                    identity: .plain("test.second"),
+                    path: .init(path: "/Second"),
+                    products: [
+                        ProductDescription(name: "Second", type: .library(.automatic), targets: ["Foo", "Bar"])
+                    ],
+                    targets: [
+                        TargetDescription(name: "Foo"),
+                        TargetDescription(name: "Bar"),
+                    ]),
+            ],
+            observabilityScope: observability.topScope
+        )
+
+        testDiagnostics(observability.diagnostics) { result in
+            result.check(diagnostic: .contains("multiple similar targets 'Bar', 'Foo' appear in registry package 'test.second' and source control package 'first'"), severity: .error)
         }
     }
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -11786,7 +11786,7 @@ final class WorkspaceTests: XCTestCase {
                     testDiagnostics(diagnostics) { result in
                         result.check(
                             diagnostic: .contains("""
-                            multiple targets named 'FooTarget' in: 'foo', 'org.foo'
+                            multiple similar targets 'FooTarget' appear in registry package 'org.foo' and source control package 'foo'
                             """),
                             severity: .error
                         )
@@ -11970,7 +11970,7 @@ final class WorkspaceTests: XCTestCase {
                     testDiagnostics(diagnostics) { result in
                         result.check(
                             diagnostic: .contains("""
-                            multiple targets named 'FooTarget' in: 'foo', 'org.foo'
+                            multiple similar targets 'FooTarget' appear in registry package 'org.foo' and source control package 'foo'
                             """),
                             severity: .error
                         )
@@ -12129,7 +12129,7 @@ final class WorkspaceTests: XCTestCase {
                     testDiagnostics(diagnostics) { result in
                         result.check(
                             diagnostic: .contains("""
-                            multiple targets named 'FooTarget' in: 'foo', 'org.foo'
+                            multiple similar targets 'FooTarget' appear in registry package 'org.foo' and source control package 'foo'
                             """),
                             severity: .error
                         )
@@ -12275,7 +12275,7 @@ final class WorkspaceTests: XCTestCase {
                     testDiagnostics(diagnostics) { result in
                         result.check(
                             diagnostic: .contains("""
-                            multiple targets named 'FooTarget' in: 'foo', 'org.foo'
+                            multiple similar targets 'FooTarget' appear in registry package 'org.foo' and source control package 'foo'
                             """),
                             severity: .error
                         )
@@ -12442,7 +12442,7 @@ final class WorkspaceTests: XCTestCase {
                     testDiagnostics(diagnostics) { result in
                         result.check(
                             diagnostic: .contains("""
-                            multiple targets named 'FooTarget' in: 'foo', 'org.foo'
+                            multiple similar targets 'FooTarget' appear in registry package 'org.foo' and source control package 'foo'
                             """),
                             severity: .error
                         )
@@ -12604,7 +12604,7 @@ final class WorkspaceTests: XCTestCase {
                     testDiagnostics(diagnostics) { result in
                         result.check(
                             diagnostic: .contains("""
-                            multiple targets named 'BazTarget' in: 'baz', 'org.baz'
+                            multiple similar targets 'BazTarget' appear in registry package 'org.baz' and source control package 'baz'
                             """),
                             severity: .error
                         )
@@ -12795,7 +12795,7 @@ final class WorkspaceTests: XCTestCase {
                     testDiagnostics(diagnostics) { result in
                         result.check(
                             diagnostic: .contains("""
-                            multiple targets named 'BazTarget' in: 'baz', 'org.baz'
+                            multiple similar targets 'BazTarget' appear in registry package 'org.baz' and source control package 'baz'
                             """),
                             severity: .error
                         )
@@ -12941,7 +12941,7 @@ final class WorkspaceTests: XCTestCase {
                     testDiagnostics(diagnostics) { result in
                         result.check(
                             diagnostic: .contains("""
-                            multiple targets named 'FooTarget' in: 'foo', 'org.foo'
+                            multiple similar targets 'FooTarget' appear in registry package 'org.foo' and source control package 'foo'
                             """),
                             severity: .error
                         )


### PR DESCRIPTION
motivation: with the intriduction of the regsitry, there is a higher likelyhood of running into duplicate packages

changes: perform a heuristics to try and determine if the packages are duplicate and provide a better diagnostics instead of the standard "duplicate target" one
