### PR TITLE
Mark types conforming to `FileSystem` as `Sendable`

### DIFF
--- a/Sources/Basics/FileSystem/TemporaryFile.swift
+++ b/Sources/Basics/FileSystem/TemporaryFile.swift
@@ -12,7 +12,7 @@
 
 import _Concurrency
 import Foundation
-@preconcurrency import TSCBasic
+import TSCBasic
 
 /// Creates a temporary directory and evaluates a closure with the directory path as an argument.
 /// The temporary directory will live on disk while the closure is evaluated and will be deleted when

--- a/Sources/Basics/FileSystem/VirtualFileSystem.swift
+++ b/Sources/Basics/FileSystem/VirtualFileSystem.swift
@@ -178,7 +178,7 @@ public class VirtualFileSystem: FileSystem {
         return node.children.map { $0.name }
     }
 
-    public var currentWorkingDirectory: AbsolutePath? = nil
+    public let currentWorkingDirectory: AbsolutePath? = nil
 
     public func changeCurrentWorkingDirectory(to path: AbsolutePath) throws {
         throw Errors.readOnlyFileSystem
@@ -246,3 +246,6 @@ public class VirtualFileSystem: FileSystem {
         return FileInfo(attrs)
     }
 }
+
+// `VirtualFileSystem` is read-only, so it can be marked as `Sendable`.
+extension VirtualFileSystem: @unchecked Sendable {}

--- a/Sources/PackageRegistry/SignatureValidation.swift
+++ b/Sources/PackageRegistry/SignatureValidation.swift
@@ -63,7 +63,7 @@ struct SignatureValidation {
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue,
-        completion: @escaping (Result<SigningEntity?, Error>) -> Void
+        completion: @Sendable @escaping (Result<SigningEntity?, Error>) -> Void
     ) {
         guard !self.skipSignatureValidation else {
             return completion(.success(.none))
@@ -110,7 +110,7 @@ struct SignatureValidation {
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue,
-        completion: @escaping (Result<SigningEntity?, Error>) -> Void
+        completion: @Sendable @escaping (Result<SigningEntity?, Error>) -> Void
     ) {
         do {
             let versionMetadata = try self.versionMetadataProvider(package, version)
@@ -212,7 +212,7 @@ struct SignatureValidation {
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue,
-        completion: @escaping (Result<SigningEntity?, Error>) -> Void
+        completion: @Sendable @escaping (Result<SigningEntity?, Error>) -> Void
     ) {
         guard !self.skipSignatureValidation else {
             return completion(.success(.none))
@@ -245,7 +245,7 @@ struct SignatureValidation {
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue,
-        completion: @escaping (Result<SigningEntity?, Error>) -> Void
+        completion: @Sendable @escaping (Result<SigningEntity?, Error>) -> Void
     ) {
         do {
             let versionMetadata = try self.versionMetadataProvider(package, version)
@@ -352,7 +352,7 @@ struct SignatureValidation {
         configuration: RegistryConfiguration.Security.Signing,
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope,
-        completion: @escaping (Result<SigningEntity?, Error>) -> Void
+        completion: @Sendable @escaping (Result<SigningEntity?, Error>) -> Void
     ) {
         Task {
             do {

--- a/Sources/SPMTestSupport/InMemoryGitRepository.swift
+++ b/Sources/SPMTestSupport/InMemoryGitRepository.swift
@@ -388,6 +388,9 @@ extension InMemoryGitRepository: WorkingCheckout {
     }
 }
 
+// Public mutation of `InMemoryGitRepository` is protected with a lock.
+extension InMemoryGitRepository: @unchecked Sendable {}
+
 /// This class implement provider for in memory git repository.
 public final class InMemoryGitRepositoryProvider: RepositoryProvider {
     /// Contains the repository added to this provider.

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -974,6 +974,9 @@ private class GitFileSystemView: FileSystem {
     }
 }
 
+// State of `GitFileSystemView` is protected with `ThreadSafeKeyValueStore`.
+extension GitFileSystemView: @unchecked Sendable {}
+
 // MARK: - Errors
 
 private struct GitShellError: Error {

--- a/Tests/BasicsTests/URLSessionHTTPClientTests.swift
+++ b/Tests/BasicsTests/URLSessionHTTPClientTests.swift
@@ -1129,7 +1129,7 @@ private class MockURLProtocol: URLProtocol {
     }
 }
 
-class FailingFileSystem: FileSystem {
+final class FailingFileSystem: FileSystem {
     var currentWorkingDirectory: AbsolutePath? {
         fatalError("unexpected call")
     }


### PR DESCRIPTION
None of these types store internal mutable state, so this should be safe. This resolves some of the sendability warnings that we currently have.