### PR TITLE
Destinations: fix missing `remove` command message

### DIFF
--- a/Sources/CrossCompilationDestinationsTool/RemoveDestination.swift
+++ b/Sources/CrossCompilationDestinationsTool/RemoveDestination.swift
@@ -39,15 +39,11 @@ struct RemoveDestination: DestinationCommand {
         let destinationsDirectory = try self.getOrCreateDestinationsDirectory()
         let artifactBundleDirectory = destinationsDirectory.appending(component: self.destinationIDOrBundleName)
 
+        let removedBundleDirectory: AbsolutePath
         if fileSystem.exists(artifactBundleDirectory) {
             try fileSystem.removeFileTree(artifactBundleDirectory)
 
-            print(
-                """
-                Destination artifact bundle at path `\(artifactBundleDirectory)` was successfully removed from the \
-                file system.
-                """
-            )
+            removedBundleDirectory = artifactBundleDirectory
         } else {
             let bundles = try DestinationBundle.getAllValidBundles(
                 destinationsDirectory: destinationsDirectory,
@@ -106,6 +102,14 @@ struct RemoveDestination: DestinationCommand {
             }
 
             try fileSystem.removeFileTree(matchingBundle.path)
+            removedBundleDirectory = matchingBundle.path
         }
+
+        print(
+            """
+            Destination artifact bundle at path `\(removedBundleDirectory)` was successfully removed from the \
+            file system.
+            """
+        )
     }
 }


### PR DESCRIPTION
The `experimental-destination remove` subcommand has two conditions: removing by bundle name or artifact ID. Previously, on successful removal a message was printed only in one of the conditions, which was wrong.

When removing a bundle by artifact ID absence of a printed message is confusing to the user and makes it unclear whether the command invocation had any effect.

rdar://107138636