### PR TITLE
Package manifest checksum TOFU

### DIFF
--- a/Sources/PackageFingerprint/Model.swift
+++ b/Sources/PackageFingerprint/Model.swift
@@ -65,6 +65,10 @@ extension Fingerprint {
         }
     }
 
+    /// Each package version has a dictionary of fingerprints identified by content type.
+    /// Fingerprints of content type `sourceCode` can come from registry (i.e., source archive checksum)
+    /// or git repo (commit hash). However, the current implementation only stores fingerprints for manifests
+    /// downloaded from registry. It doesn't not save fingerprints for manifests in git repo.
     public enum ContentType: Hashable, CustomStringConvertible {
         case sourceCode
         case manifest(ToolsVersion?)

--- a/Sources/PackageFingerprint/Model.swift
+++ b/Sources/PackageFingerprint/Model.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -12,25 +12,28 @@
 
 import struct Foundation.URL
 
+import PackageModel
 import struct TSCUtility.Version
 
 public struct Fingerprint: Equatable {
     public let origin: Origin
     public let value: String
+    public let contentType: ContentType
 
-    public init(origin: Origin, value: String) {
+    public init(origin: Origin, value: String, contentType: ContentType) {
         self.origin = origin
         self.value = value
+        self.contentType = contentType
     }
 }
 
-public extension Fingerprint {
-    enum Kind: String, Hashable {
+extension Fingerprint {
+    public enum Kind: String, Hashable {
         case sourceControl
         case registry
     }
 
-    enum Origin: Equatable, CustomStringConvertible {
+    public enum Origin: Equatable, CustomStringConvertible {
         case sourceControl(URL)
         case registry(URL)
 
@@ -61,9 +64,25 @@ public extension Fingerprint {
             }
         }
     }
+
+    public enum ContentType: Hashable, CustomStringConvertible {
+        case sourceCode
+        case manifest(ToolsVersion?)
+
+        public var description: String {
+            switch self {
+            case .sourceCode:
+                return "sourceCode"
+            case .manifest(.none):
+                return Manifest.filename
+            case .manifest(.some(let toolsVersion)):
+                return "Package@swift-\(toolsVersion).swift"
+            }
+        }
+    }
 }
 
-public typealias PackageFingerprints = [Version: [Fingerprint.Kind: Fingerprint]]
+public typealias PackageFingerprints = [Version: [Fingerprint.Kind: [Fingerprint.ContentType: Fingerprint]]]
 
 public enum FingerprintCheckingMode: String {
     case strict

--- a/Sources/PackageRegistry/RegistryDownloadsManager.swift
+++ b/Sources/PackageRegistry/RegistryDownloadsManager.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -26,7 +26,6 @@ public class RegistryDownloadsManager: Cancellable {
     private let path: AbsolutePath
     private let cachePath: AbsolutePath?
     private let registryClient: RegistryClient
-    private let checksumAlgorithm: HashAlgorithm
     private let delegate: Delegate?
 
     private var pendingLookups = [PackageIdentity: DispatchGroup]()
@@ -37,14 +36,12 @@ public class RegistryDownloadsManager: Cancellable {
         path: AbsolutePath,
         cachePath: AbsolutePath?,
         registryClient: RegistryClient,
-        checksumAlgorithm: HashAlgorithm,
         delegate: Delegate?
     ) {
         self.fileSystem = fileSystem
         self.path = path
         self.cachePath = cachePath
         self.registryClient = registryClient
-        self.checksumAlgorithm = checksumAlgorithm
         self.delegate = delegate
     }
 
@@ -174,7 +171,6 @@ public class RegistryDownloadsManager: Cancellable {
                             package: package,
                             version: version,
                             destinationPath: cachedPackagePath,
-                            checksumAlgorithm: self.checksumAlgorithm,
                             progressHandler: updateDownloadProgress,
                             fileSystem: self.fileSystem,
                             observabilityScope: observabilityScope,
@@ -202,7 +198,6 @@ public class RegistryDownloadsManager: Cancellable {
                     package: package,
                     version: version,
                     destinationPath: packagePath,
-                    checksumAlgorithm: self.checksumAlgorithm,
                     progressHandler: updateDownloadProgress,
                     fileSystem: self.fileSystem,
                     observabilityScope: observabilityScope,
@@ -219,7 +214,6 @@ public class RegistryDownloadsManager: Cancellable {
                 package: package,
                 version: version,
                 destinationPath: packagePath,
-                checksumAlgorithm: self.checksumAlgorithm,
                 progressHandler: updateDownloadProgress,
                 fileSystem: self.fileSystem,
                 observabilityScope: observabilityScope,

--- a/Sources/PackageRegistryTool/PackageRegistryTool+Auth.swift
+++ b/Sources/PackageRegistryTool/PackageRegistryTool+Auth.swift
@@ -198,7 +198,8 @@ extension SwiftPackageRegistryTool {
                 signingEntityStorage: .none,
                 signingEntityCheckingMode: .strict,
                 authorizationProvider: authorizationProvider,
-                delegate: .none
+                delegate: .none,
+                checksumAlgorithm: SHA256()
             )
 
             // Try logging in

--- a/Sources/PackageRegistryTool/PackageRegistryTool+Publish.swift
+++ b/Sources/PackageRegistryTool/PackageRegistryTool+Publish.swift
@@ -138,7 +138,8 @@ extension SwiftPackageRegistryTool {
                 signingEntityStorage: .none,
                 signingEntityCheckingMode: .strict,
                 authorizationProvider: authorizationProvider,
-                delegate: .none
+                delegate: .none,
+                checksumAlgorithm: SHA256()
             )
 
             // step 1: publishing configuration

--- a/Sources/SPMTestSupport/MockRegistry.swift
+++ b/Sources/SPMTestSupport/MockRegistry.swift
@@ -68,7 +68,8 @@ public class MockRegistry {
             authorizationProvider: .none,
             customHTTPClient: LegacyHTTPClient(handler: self.httpHandler),
             customArchiverProvider: { fileSystem in MockRegistryArchiver(fileSystem: fileSystem) },
-            delegate: .none
+            delegate: .none,
+            checksumAlgorithm: checksumAlgorithm
         )
     }
 

--- a/Sources/Workspace/SourceControlPackageContainer.swift
+++ b/Sources/Workspace/SourceControlPackageContainer.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2014-2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2014-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -168,13 +168,18 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
                     package: self.package,
                     version: version,
                     kind: .sourceControl,
+                    contentType: .sourceCode,
                     observabilityScope: self.observabilityScope,
                     callbackQueue: .sharedConcurrent,
                     callback: $0
                 )
             }
         } catch PackageFingerprintStorageError.notFound {
-            fingerprint = Fingerprint(origin: .sourceControl(sourceControlURL), value: revision.identifier)
+            fingerprint = Fingerprint(
+                origin: .sourceControl(sourceControlURL),
+                value: revision.identifier,
+                contentType: .sourceCode
+            )
             // Write to storage if fingerprint not yet recorded
             do {
                 try temp_await {

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -685,7 +685,8 @@ public class Workspace {
             signingEntityStorage: signingEntities,
             signingEntityCheckingMode: SigningEntityCheckingMode.map(configuration.signingEntityCheckingMode),
             authorizationProvider: registryAuthorizationProvider,
-            delegate: WorkspaceRegistryClientDelegate(workspaceDelegate: delegate)
+            delegate: WorkspaceRegistryClientDelegate(workspaceDelegate: delegate),
+            checksumAlgorithm: checksumAlgorithm
         )
 
         // set default registry if not already set by configuration
@@ -698,7 +699,6 @@ public class Workspace {
             path: location.registryDownloadDirectory,
             cachePath: configuration.sharedDependenciesCacheEnabled ? location.sharedRegistryDownloadsCacheDirectory : .none,
             registryClient: registryClient,
-            checksumAlgorithm: checksumAlgorithm,
             delegate: delegate.map(WorkspaceRegistryDownloadsManagerDelegate.init(workspaceDelegate:))
         )
         // register the registry dependencies downloader with the cancellation handler

--- a/Tests/PackageRegistryTests/RegistryDownloadsManagerTests.swift
+++ b/Tests/PackageRegistryTests/RegistryDownloadsManagerTests.swift
@@ -51,7 +51,6 @@ class RegistryDownloadsManagerTests: XCTestCase {
             path: downloadsPath,
             cachePath: .none, // cache disabled
             registryClient: registry.registryClient,
-            checksumAlgorithm: MockHashAlgorithm(),
             delegate: delegate
         )
 
@@ -184,7 +183,6 @@ class RegistryDownloadsManagerTests: XCTestCase {
             path: downloadsPath,
             cachePath: cachePath, // cache enabled
             registryClient: registry.registryClient,
-            checksumAlgorithm: MockHashAlgorithm(),
             delegate: delegate
         )
 
@@ -274,7 +272,6 @@ class RegistryDownloadsManagerTests: XCTestCase {
             path: downloadsPath,
             cachePath: .none, // cache disabled
             registryClient: registry.registryClient,
-            checksumAlgorithm: MockHashAlgorithm(),
             delegate: delegate
         )
 

--- a/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
@@ -468,7 +468,8 @@ class RegistryPackageContainerTests: XCTestCase {
                 }
             }),
             customArchiverProvider: { _ in archiver },
-            delegate: .none
+            delegate: .none,
+            checksumAlgorithm: MockHashAlgorithm()
         )
     }
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -13873,7 +13873,8 @@ final class WorkspaceTests: XCTestCase {
                 }
             }),
             customArchiverProvider: { _ in archiver },
-            delegate: .none
+            delegate: .none,
+            checksumAlgorithm: MockHashAlgorithm()
         )
     }
 }


### PR DESCRIPTION
Motivation:
Currently fingerprints are for source archive (checksum from registry) and source repo (git hash from SCM) only. Additional content types need to be supported if SwiftPM were to do TOFU for manifest files too.

Modifications:
- Modify fingerprint storage structure to store fingerprint by content type
- Modfiy fingerprint storage API to allow retrieving fingerprints by content type

