### PR TITLE
Plugin import scanner isn't passing in the library directory, making `canImport` not work

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1293,7 +1293,7 @@ extension Workspace {
         packageGraph: PackageGraph,
         completion: @escaping(Result<[PackageIdentity: [String: [String]]], Error>) -> Void) {
         let pluginTargets = packageGraph.allTargets.filter{$0.type == .plugin}
-        let scanner = SwiftcImportScanner(swiftCompilerEnvironment: hostToolchain.swiftCompilerEnvironment, swiftCompilerFlags: hostToolchain.swiftCompilerFlags, swiftCompilerPath: hostToolchain.swiftCompilerPath)
+        let scanner = SwiftcImportScanner(swiftCompilerEnvironment: hostToolchain.swiftCompilerEnvironment, swiftCompilerFlags: hostToolchain.swiftCompilerFlags + ["-I", hostToolchain.swiftPMLibrariesLocation.pluginLibraryPath.pathString], swiftCompilerPath: hostToolchain.swiftCompilerPath)
         var importList = [PackageIdentity: [String: [String]]]()
 
         for pluginTarget in pluginTargets {


### PR DESCRIPTION
The Workspace type has a facility for scanning package plugins for imports.  But since it's not passing in the actual plugin directory provided by the caller (whether it's SwiftPM or Xcode), any modules provided by an IDE aren't picked up if they are guarded by `#if canImport()`.  This includes `XcodeProjectPlugin`, which is one of the additional plugin modules provided by Xcode.  The same would be true for other IDEs.

Changes:
- `Workspace.loadPluginImports` now also passes the path of the plugin directory to the import scanning
- extended the `testScanImportsInPluginTargets` unit test to check for this case

rdar://106387043