### PR TITLE
Reduce errors from manifest signature validation

### DIFF
--- a/Sources/PackageLoading/ManifestSignatureParser.swift
+++ b/Sources/PackageLoading/ManifestSignatureParser.swift
@@ -128,8 +128,6 @@ public enum ManifestSignatureParser {
     public enum Error: Swift.Error {
         /// Package manifest file is inaccessible (missing, unreadable, etc).
         case inaccessibleManifest(path: AbsolutePath, reason: String)
-        /// Package manifest file's content can not be decoded as a UTF-8 string.
-        case nonUTF8EncodedManifest(path: AbsolutePath)
         /// Malformed manifest signature.
         case malformedManifestSignature
     }


### PR DESCRIPTION
Motivation:
Manifest signature validation works similarly as source archive signature validation, meaning user could see duplicate errors (e.g., source archive not signed).

Modifications:
- Change most error throwing to logging diagnostics for manifest signature validation
- Continue to prompt if that's what user has configured for unsigned packages or untrusted signers; cache responses in memory to prevent repeatedly prompting for manifest and source archive downloads for the same package version.
- Wire up publisher TOFU for manifest signing
- Adjust tests