### PR TITLE
[5.9] Turn development mode back on

### DIFF
--- a/Sources/Basics/SwiftVersion.swift
+++ b/Sources/Basics/SwiftVersion.swift
@@ -55,7 +55,7 @@ extension SwiftVersion {
     /// The current version of the package manager.
     public static let current = SwiftVersion(
         version: (5, 9, 0),
-        isDevelopment: false,
+        isDevelopment: true,
         buildIdentifier: getBuildIdentifier()
     )
 }


### PR DESCRIPTION
It seems like we were a little too quick with this. We do want users to be able to try out macros with the 5.9 toolchain, but they are still a pre-release feature.
