### PR TITLE
Basics: clean up `DiagnosticsEngine` in `Observability`

### DIFF
--- a/Sources/Basics/Observability.swift
+++ b/Sources/Basics/Observability.swift
@@ -12,10 +12,13 @@
 
 import Dispatch
 import Foundation
-import TSCBasic
 
+import class TSCBasic.UnknownLocation
 import enum TSCUtility.Diagnostics
+import protocol TSCBasic.DiagnosticData
+import protocol TSCBasic.DiagnosticLocation
 import protocol TSCUtility.DiagnosticDataConvertible
+import struct TSCBasic.Diagnostic
 
 // this could become a struct when we remove the "errorsReported" pattern
 
@@ -527,14 +530,13 @@ extension ObservabilityMetadata {
 
 // MARK: - Compatibility with TSC Diagnostics APIs
 
-@available(*, deprecated, message: "temporary for transition DiagnosticsEngine -> DiagnosticsEmitter")
 extension ObservabilityScope {
-    public func makeDiagnosticsEngine() -> DiagnosticsEngine {
-        return .init(handlers: [{ Diagnostic($0).map{ self.diagnosticsHandler.handleDiagnostic(scope: self, diagnostic: $0) } }])
+    public func makeDiagnosticsHandler() -> (TSCBasic.Diagnostic) -> Void {
+        { Diagnostic($0).map { self.diagnosticsHandler.handleDiagnostic(scope: self, diagnostic: $0) } }
     }
 }
 
-@available(*, deprecated, message: "temporary for transition DiagnosticsEngine -> DiagnosticsEmitter")
+@available(*, deprecated, message: "temporary for transition TSCBasic.Diagnostic -> SwiftDriver.Diagnostic")
 extension Diagnostic {
     init?(_ diagnostic: TSCBasic.Diagnostic) {
         var metadata = ObservabilityMetadata()
@@ -558,7 +560,7 @@ extension Diagnostic {
     }
 }
 
-@available(*, deprecated, message: "temporary for transition DiagnosticsEngine -> DiagnosticsEmitter")
+@available(*, deprecated, message: "temporary for transition TSCBasic.Diagnostic -> SwiftDriver.Diagnostic")
 extension ObservabilityMetadata {
     public var legacyDiagnosticLocation: DiagnosticLocationWrapper? {
         get {
@@ -586,7 +588,7 @@ extension ObservabilityMetadata {
     }
 }
 
-@available(*, deprecated, message: "temporary for transition DiagnosticsEngine -> DiagnosticsEmitter")
+@available(*, deprecated, message: "temporary for transition TSCBasic.Diagnostic -> SwiftDriver.Diagnostic")
 extension ObservabilityMetadata {
     var legacyDiagnosticData: DiagnosticDataWrapper? {
         get {

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -197,7 +197,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
 
                 let consumeDiagnostics: DiagnosticsEngine = DiagnosticsEngine(handlers: [])
                 var driver = try Driver(args: commandLine,
-                                        diagnosticsEngine: consumeDiagnostics,
+                                        diagnosticsOutput: .engine(consumeDiagnostics),
                                         fileSystem: localFileSystem,
                                         executor: executor)
                 guard !consumeDiagnostics.hasErrors else {

--- a/Sources/Build/LLBuildManifestBuilder.swift
+++ b/Sources/Build/LLBuildManifestBuilder.swift
@@ -262,7 +262,7 @@ extension LLBuildManifestBuilder {
         )
         var driver = try Driver(
             args: commandLine,
-            diagnosticsEngine: self.observabilityScope.makeDiagnosticsEngine(),
+            diagnosticsOutput: .handler(self.observabilityScope.makeDiagnosticsHandler()),
             fileSystem: self.fileSystem,
             executor: executor
         )

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -3525,14 +3525,6 @@ fileprivate extension PackageDependency {
     }
 }
 
-fileprivate extension DiagnosticsEngine {
-    func append(contentsOf other: DiagnosticsEngine) {
-        for diagnostic in other.diagnostics {
-            self.emit(diagnostic.message, location: diagnostic.location)
-        }
-    }
-}
-
 internal extension PackageReference {
     func makeRepositorySpecifier() throws -> RepositorySpecifier {
         switch self.kind {


### PR DESCRIPTION
### Motivation:

Since uses of `DiagnosticsEngine` are deprecated in SwiftPM, with https://github.com/apple/swift-driver/pull/1317 we can remove any traces of it from `Basics/Observability.swift` to clean that up. 

### Modifications:

Removed unused deprecated function that returned an instance of `DiagnosticsEngine`. Also broke up `import TSCBasic` into separate type imports to make clear what dependencies on TSC are there remaining.

### Result:

`TSCBasic.Diagnostic` still remains, but I think long-term we can move that to Swift Driver codebase to reduce dependencies on TSC.
