### PR TITLE
[5.9] rdar://105991217 (Make macros testable)

### DIFF
--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -234,8 +234,8 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
             // Support for linking tests against executables is conditional on the tools
             // version of the package that defines the executable product.
             let executableTarget = try product.executableTarget
-            if executableTarget.underlyingTarget is SwiftTarget, self.toolsVersion >= .v5_5,
-               self.buildParameters.canRenameEntrypointFunctionName, executableTarget.underlyingTarget.type != .macro
+            if let target = executableTarget.underlyingTarget as? SwiftTarget, self.toolsVersion >= .v5_5,
+               self.buildParameters.canRenameEntrypointFunctionName, target.supportsTestableExecutablesFeature
             {
                 if let flags = buildParameters.linkerFlagsForRenamingMainFunction(of: executableTarget) {
                     args += flags

--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -93,7 +93,7 @@ public final class SwiftTargetBuildDescription {
     var moduleOutputPath: AbsolutePath {
         // If we're an executable and we're not allowing test targets to link against us, we hide the module.
         let allowLinkingAgainstExecutables = (buildParameters.triple.isDarwin() || self.buildParameters.triple
-            .isLinux() || self.buildParameters.triple.isWindows()) && self.toolsVersion >= .v5_5 && target.type != .macro
+            .isLinux() || self.buildParameters.triple.isWindows()) && self.toolsVersion >= .v5_5
         let dirPath = (target.type == .executable && !allowLinkingAgainstExecutables) ? self.tempsPath : self
             .buildParameters.buildPath
         return dirPath.appending(component: self.target.c99name + ".swiftmodule")
@@ -450,7 +450,7 @@ public final class SwiftTargetBuildDescription {
         // when we link the executable, we will ask the linker to rename the entry point
         // symbol to just `_main` again (or if the linker doesn't support it, we'll
         // generate a source containing a redirect).
-        if (self.target.type == .executable || self.target.type == .snippet)
+        if (self.target.underlyingTarget as? SwiftTarget)?.supportsTestableExecutablesFeature == true
             && !self.isTestTarget && self.toolsVersion >= .v5_5
         {
             // We only do this if the linker supports it, as indicated by whether we

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -731,10 +731,10 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
                 // In tool version .v5_5 or greater, we also include executable modules implemented in Swift in
                 // any test products... this is to allow testing of executables.  Note that they are also still
                 // built as separate products that the test can invoke as subprocesses.
-                case .executable, .snippet:
+                case .executable, .snippet, .macro:
                     if product.targets.contains(target) {
                         staticTargets.append(target)
-                    } else if product.type == .test && target.underlyingTarget is SwiftTarget {
+                    } else if product.type == .test && (target.underlyingTarget as? SwiftTarget)?.supportsTestableExecutablesFeature == true {
                         if let toolsVersion = graph.package(for: product)?.manifest.toolsVersion, toolsVersion >= .v5_5 {
                             staticTargets.append(target)
                         }

--- a/Sources/PackageModel/Target.swift
+++ b/Sources/PackageModel/Target.swift
@@ -426,6 +426,15 @@ public final class SwiftTarget: Target {
         self.swiftVersion = try container.decode(SwiftLanguageVersion.self, forKey: .swiftVersion)
         try super.init(from: decoder)
     }
+
+    public var supportsTestableExecutablesFeature: Bool {
+        // Exclude macros from testable executables if they are built as dylibs.
+        #if BUILD_MACROS_AS_DYLIBS
+        return type == .executable || type == .snippet
+        #else
+        return type == .executable || type == .macro || type == .snippet
+        #endif
+    }
 }
 
 public final class SystemLibraryTarget: Target {


### PR DESCRIPTION
Opt macros into testable executables if we're building them as executables.

(cherry picked from commit e02a8b5323dd096d4a4749c3ce3602690f0958f3)
