### PR TITLE
[5.9] Rearrangement in preparation for 5.9 branching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,20 @@ Note: This is in reverse chronological order, so newer entries are added to the 
 Swift Next
 -----------
 
-* [#5966]
-
-  Plugin compilation can be influenced by using `-Xbuild-tools-swiftc` arguments in the SwiftPM command line. This is similar to the existing mechanism for influencing the manifest compilation using `-Xmanifest` arguments. Manifest compilation will also be influenced by `-Xbuild-tools-swiftc`, but only if no other `-Xmanifest` arguments are provided. Using `-Xmanifest` will show a deprecation message. `-Xmanifest` will be removed in the future.
-
 * [#5728]
 
   In packages that specify resources using a future tools version, the generated resource bundle accessor will import `Foundation.Bundle` for its own implementation only. _Clients_ of such packages therefore no longer silently import `Foundation`, preventing inadvertent use of Foundation extensions to standard library APIs, which helps to avoid unexpected code size increases.
+
+* [#6185], [#6200]
+
+  Add a new `CompilerPluginSupport` module which contains the definition for macro targets. Macro targets allow authoring and distribution of custom Swift macros such as [expression macros](https://github.com/apple/swift-evolution/blob/main/proposals/0382-expression-macros.md).
+
+Swift 5.9
+-----------
+
+* [#5966]
+
+  Plugin compilation can be influenced by using `-Xbuild-tools-swiftc` arguments in the SwiftPM command line. This is similar to the existing mechanism for influencing the manifest compilation using `-Xmanifest` arguments. Manifest compilation will also be influenced by `-Xbuild-tools-swiftc`, but only if no other `-Xmanifest` arguments are provided. Using `-Xmanifest` will show a deprecation message. `-Xmanifest` will be removed in the future.
 
 * [#6067]
 
@@ -20,9 +27,6 @@ Swift Next
   static let best_txt: [UInt8] = [104,101,108,108,111,32,119,111,114,108,100,10]
   }
   ```
-
-Swift 5.9
------------
 
 * [#6294]
 

--- a/Fixtures/Miscellaneous/PackageNameFlag/appPkg/Package.swift
+++ b/Fixtures/Miscellaneous/PackageNameFlag/appPkg/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:999.0
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/Miscellaneous/PackageNameFlag/fooPkg/Package.swift
+++ b/Fixtures/Miscellaneous/PackageNameFlag/fooPkg/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:999.0
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/Resources/EmbedInCodeSimple/Package.swift
+++ b/Fixtures/Resources/EmbedInCodeSimple/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 999.0
+// swift-tools-version: 5.9
 
 import PackageDescription
 

--- a/Sources/PackageDescription/Resource.swift
+++ b/Sources/PackageDescription/Resource.swift
@@ -97,7 +97,7 @@ public struct Resource {
     }
 
     /// Applies the embed rule to a resource at the given path.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 5.9)
     public static func embedInCode(_ path: String) -> Resource {
         return Resource(rule: "embedInCode", path: path, localization: nil)
     }

--- a/Sources/PackageModel/PackageModel.swift
+++ b/Sources/PackageModel/PackageModel.swift
@@ -126,7 +126,7 @@ extension Manifest {
         return self.toolsVersion >= .v5_8
     }
     public var usePackageNameFlag: Bool {
-        return self.toolsVersion >= .v5_9
+        return self.toolsVersion >= .vNext
     }
 }
 


### PR DESCRIPTION
- `embedInCode` should be marked as part of 5.9
- `-package-name` hasn't been accepted by evolution, yet, so should be using `vNext`
- support for macros also stays intentionally behind 999.0 tools-version since it hasn't been accepted by evolution yet
- Update `CHANGELOG`

(cherry picked from commit aa6f358ecb587bb6c7cb58891be322ac8dc14d06)
