### PR TITLE
cleanup mirror config command

### DIFF
--- a/Sources/Commands/PackageTools/Config.swift
+++ b/Sources/Commands/PackageTools/Config.swift
@@ -20,108 +20,161 @@ extension SwiftPackageTool {
     struct Config: ParsableCommand {
         static let configuration = CommandConfiguration(
             abstract: "Manipulate configuration of the package",
-            subcommands: [SetMirror.self, UnsetMirror.self, GetMirror.self])
+            subcommands: [SetMirror.self, UnsetMirror.self, GetMirror.self]
+        )
     }
 }
 
 extension SwiftPackageTool.Config {
     struct SetMirror: SwiftCommand {
         static let configuration = CommandConfiguration(
-            abstract: "Set a mirror for a dependency")
+            abstract: "Set a mirror for a dependency"
+        )
 
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
 
-        @Option(help: "The package dependency url")
-        var packageURL: String?
+        @Option(name: .customLong("package-url"), help: .hidden)
+        var _deprecate_packageURL: String?
 
-        @Option(help: "The original url")
-        var originalURL: String?
+        @Option(name: .customLong("original-url"), help: .hidden)
+        var _deprecate_originalURL: String?
 
-        @Option(help: "The mirror url")
-        var mirrorURL: String
+        @Option(name: .customLong("mirror-url"), help: .hidden)
+        var _deprecate_mirrorURL: String?
+
+        @Option(help: "The original url or identity")
+        var original: String?
+
+        @Option(help: "The mirror url or identity")
+        var mirror: String?
 
         func run(_ swiftTool: SwiftTool) throws {
             let config = try getMirrorsConfig(swiftTool)
 
-            if self.packageURL != nil {
+            if self._deprecate_packageURL != nil {
                 swiftTool.observabilityScope.emit(
-                    warning: "'--package-url' option is deprecated; use '--original-url' instead")
+                    warning: "'--package-url' option is deprecated; use '--original' instead"
+                )
+            }
+            if self._deprecate_originalURL != nil {
+                swiftTool.observabilityScope.emit(
+                    warning: "'--original-url' option is deprecated; use '--original' instead"
+                )
+            }
+            if self._deprecate_mirrorURL != nil {
+                swiftTool.observabilityScope.emit(
+                    warning: "'--mirror-url' option is deprecated; use '--mirror' instead"
+                )
             }
 
-            guard let originalURL = self.packageURL ?? self.originalURL else {
-                swiftTool.observabilityScope.emit(.missingRequiredArg("--original-url"))
+            guard let original = self._deprecate_packageURL ?? self._deprecate_originalURL ?? self.original else {
+                swiftTool.observabilityScope.emit(.missingRequiredArg("--original"))
+                throw ExitCode.failure
+            }
+
+            guard let mirror = self._deprecate_mirrorURL ?? self.mirror else {
+                swiftTool.observabilityScope.emit(.missingRequiredArg("--mirror"))
                 throw ExitCode.failure
             }
 
             try config.applyLocal { mirrors in
-                mirrors.set(mirrorURL: self.mirrorURL, forURL: originalURL)
+                mirrors.set(mirror: mirror, for: original)
             }
         }
     }
 
     struct UnsetMirror: SwiftCommand {
         static let configuration = CommandConfiguration(
-            abstract: "Remove an existing mirror")
+            abstract: "Remove an existing mirror"
+        )
 
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
 
-        @Option(help: "The package dependency url")
-        var packageURL: String?
+        @Option(name: .customLong("package-url"), help: .hidden)
+        var _deprecate_packageURL: String?
 
-        @Option(help: "The original url")
-        var originalURL: String?
+        @Option(name: .customLong("original-url"), help: .hidden)
+        var _deprecate_originalURL: String?
 
-        @Option(help: "The mirror url")
-        var mirrorURL: String?
+        @Option(name: .customLong("mirror-url"), help: .hidden)
+        var _deprecate_mirrorURL: String?
+
+        @Option(help: "The original url or identity")
+        var original: String?
+
+        @Option(help: "The mirror url or identity")
+        var mirror: String?
 
         func run(_ swiftTool: SwiftTool) throws {
             let config = try getMirrorsConfig(swiftTool)
 
-            if self.packageURL != nil {
+            if self._deprecate_packageURL != nil {
                 swiftTool.observabilityScope.emit(
-                    warning: "'--package-url' option is deprecated; use '--original-url' instead")
+                    warning: "'--package-url' option is deprecated; use '--original' instead"
+                )
+            }
+            if self._deprecate_originalURL != nil {
+                swiftTool.observabilityScope.emit(
+                    warning: "'--original-url' option is deprecated; use '--original' instead"
+                )
+            }
+            if self._deprecate_mirrorURL != nil {
+                swiftTool.observabilityScope.emit(
+                    warning: "'--mirror-url' option is deprecated; use '--mirror' instead"
+                )
             }
 
-            guard let originalOrMirrorURL = self.packageURL ?? self.originalURL ?? self.mirrorURL else {
-                swiftTool.observabilityScope.emit(.missingRequiredArg("--original-url or --mirror-url"))
+            guard let originalOrMirror = self._deprecate_packageURL ?? self._deprecate_originalURL ?? self
+                .original ?? self._deprecate_mirrorURL ?? self.mirror
+            else {
+                swiftTool.observabilityScope.emit(.missingRequiredArg("--original or --mirror"))
                 throw ExitCode.failure
             }
 
             try config.applyLocal { mirrors in
-                try mirrors.unset(originalOrMirrorURL: originalOrMirrorURL)
+                try mirrors.unset(originalOrMirror: originalOrMirror)
             }
         }
     }
 
     struct GetMirror: SwiftCommand {
         static let configuration = CommandConfiguration(
-            abstract: "Print mirror configuration for the given package dependency")
+            abstract: "Print mirror configuration for the given package dependency"
+        )
 
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
+        @Option(name: .customLong("package-url"), help: .hidden)
+        var _deprecate_packageURL: String?
 
-        @Option(help: "The package dependency url")
-        var packageURL: String?
+        @Option(name: .customLong("original-url"), help: .hidden)
+        var _deprecate_originalURL: String?
 
-        @Option(help: "The original url")
-        var originalURL: String?
+        @Option(help: "The original url or identity")
+        var original: String?
 
         func run(_ swiftTool: SwiftTool) throws {
             let config = try getMirrorsConfig(swiftTool)
 
-            if self.packageURL != nil {
+            if self._deprecate_packageURL != nil {
                 swiftTool.observabilityScope.emit(
-                    warning: "'--package-url' option is deprecated; use '--original-url' instead")
+                    warning: "'--package-url' option is deprecated; use '--original' instead"
+                )
+            }
+            if self._deprecate_originalURL != nil {
+                swiftTool.observabilityScope.emit(
+                    warning: "'--original-url' option is deprecated; use '--original' instead"
+                )
             }
 
-            guard let originalURL = self.packageURL ?? self.originalURL else {
-                swiftTool.observabilityScope.emit(.missingRequiredArg("--original-url"))
+            guard let original = self._deprecate_packageURL ?? self._deprecate_originalURL ?? self.original else {
+                swiftTool.observabilityScope.emit(.missingRequiredArg("--original"))
                 throw ExitCode.failure
             }
 
-            if let mirror = config.mirrors.mirrorURL(for: originalURL) {
+            if let mirror = config.mirrors.mirror(for: original) {
                 print(mirror)
             } else {
                 stderrStream <<< "not found\n"
@@ -141,8 +194,8 @@ extension SwiftPackageTool.Config {
     }
 }
 
-private extension Basics.Diagnostic {
-    static func missingRequiredArg(_ argument: String) -> Self {
+extension Basics.Diagnostic {
+    fileprivate static func missingRequiredArg(_ argument: String) -> Self {
         .error("missing required argument \(argument)")
     }
 }

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -71,7 +71,7 @@ public final class MockWorkspace {
         self.signingEntities = customSigningEntities ?? MockPackageSigningEntityStorage()
         self.mirrors = customMirrors ?? DependencyMirrors()
         self.identityResolver = DefaultIdentityResolver(
-            locationMapper: self.mirrors.effectiveURL(for:),
+            locationMapper: self.mirrors.effective(for:),
             identityMapper: self.mirrors.effectiveIdentity(for:)
         )
         self.manifestLoader = MockManifestLoader(manifests: [:])

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -640,7 +640,7 @@ public class Workspace {
 
         
         let identityResolver = customIdentityResolver ?? DefaultIdentityResolver(
-            locationMapper: mirrors.effectiveURL(for:),
+            locationMapper: mirrors.effective(for:),
             identityMapper: mirrors.effectiveIdentity(for:)
         )
         let checksumAlgorithm = customChecksumAlgorithm ?? SHA256()
@@ -1770,7 +1770,7 @@ extension Workspace {
                 // we only care about remoteSourceControl for this validation. it would otherwise trigger for
                 // a dependency is put into edit mode, which we want to deprecate anyways
                 if case .remoteSourceControl = $0.1.packageKind {
-                    let effectiveURL = workspace.mirrors.effectiveURL(for: $0.1.packageLocation)
+                    let effectiveURL = workspace.mirrors.effective(for: $0.1.packageLocation)
                     guard effectiveURL == $0.1.packageKind.locationString else {
                         preconditionFailure("effective url for \($0.1.packageLocation) is \(effectiveURL), different from expected \($0.1.packageKind.locationString)")
                     }

--- a/Tests/WorkspaceTests/MirrorsConfigurationTests.swift
+++ b/Tests/WorkspaceTests/MirrorsConfigurationTests.swift
@@ -40,8 +40,8 @@ final class MirrorsConfigurationTests: XCTestCase {
         let config = Workspace.Configuration.MirrorsStorage(path: configFile, fileSystem: fs, deleteWhenEmpty: true)
         let mirrors = try config.get()
 
-        XCTAssertEqual(mirrors.mirrorURL(for: originalURL),mirrorURL)
-        XCTAssertEqual(mirrors.originalURL(for: mirrorURL), originalURL)
+        XCTAssertEqual(mirrors.mirror(for: originalURL),mirrorURL)
+        XCTAssertEqual(mirrors.original(for: mirrorURL), originalURL)
     }
 
     func testThrowsWhenNotFound() throws {
@@ -52,7 +52,7 @@ final class MirrorsConfigurationTests: XCTestCase {
         let mirrors = try config.get()
 
         XCTAssertThrows(StringError("Mirror not found for 'https://github.com/apple/swift-argument-parser.git'")) {
-            try mirrors.unset(originalOrMirrorURL: "https://github.com/apple/swift-argument-parser.git")
+            try mirrors.unset(originalOrMirror: "https://github.com/apple/swift-argument-parser.git")
         }
     }
 
@@ -69,12 +69,12 @@ final class MirrorsConfigurationTests: XCTestCase {
         let mirrorURL = "https://github.com/mona/swift-argument-parser.git"
 
         try config.apply{ mirrors in
-            mirrors.set(mirrorURL: mirrorURL, forURL: originalURL)
+            mirrors.set(mirror: mirrorURL, for: originalURL)
         }
         XCTAssertTrue(fs.exists(configFile))
 
         try config.apply{ mirrors in
-            try mirrors.unset(originalOrMirrorURL: originalURL)
+            try mirrors.unset(originalOrMirror: originalURL)
         }
         XCTAssertFalse(fs.exists(configFile))
     }
@@ -92,12 +92,12 @@ final class MirrorsConfigurationTests: XCTestCase {
         let mirrorURL = "https://github.com/mona/swift-argument-parser.git"
 
         try config.apply{ mirrors in
-            mirrors.set(mirrorURL: mirrorURL, forURL: originalURL)
+            mirrors.set(mirror: mirrorURL, for: originalURL)
         }
         XCTAssertTrue(fs.exists(configFile))
 
         try config.apply{ mirrors in
-            try mirrors.unset(originalOrMirrorURL: originalURL)
+            try mirrors.unset(originalOrMirror: originalURL)
         }
         XCTAssertTrue(fs.exists(configFile))
         XCTAssertTrue(try config.get().isEmpty)
@@ -120,12 +120,12 @@ final class MirrorsConfigurationTests: XCTestCase {
         let mirror1URL = "https://github.com/mona/swift-argument-parser.git"
 
         try config.applyShared { mirrors in
-            mirrors.set(mirrorURL: mirror1URL, forURL: original1URL)
+            mirrors.set(mirror: mirror1URL, for: original1URL)
         }
 
         XCTAssertEqual(config.mirrors.count, 1)
-        XCTAssertEqual(config.mirrors.mirrorURL(for: original1URL), mirror1URL)
-        XCTAssertEqual(config.mirrors.originalURL(for: mirror1URL), original1URL)
+        XCTAssertEqual(config.mirrors.mirror(for: original1URL), mirror1URL)
+        XCTAssertEqual(config.mirrors.original(for: mirror1URL), original1URL)
 
         // now write to local location
 
@@ -133,15 +133,15 @@ final class MirrorsConfigurationTests: XCTestCase {
         let mirror2URL = "https://github.com/mona/swift-nio.git"
 
         try config.applyLocal { mirrors in
-            mirrors.set(mirrorURL: mirror2URL, forURL: original2URL)
+            mirrors.set(mirror: mirror2URL, for: original2URL)
         }
 
         XCTAssertEqual(config.mirrors.count, 1)
-        XCTAssertEqual(config.mirrors.mirrorURL(for: original2URL), mirror2URL)
-        XCTAssertEqual(config.mirrors.originalURL(for: mirror2URL), original2URL)
+        XCTAssertEqual(config.mirrors.mirror(for: original2URL), mirror2URL)
+        XCTAssertEqual(config.mirrors.original(for: mirror2URL), original2URL)
 
         // should not see the shared any longer
-        XCTAssertEqual(config.mirrors.mirrorURL(for: original1URL), nil)
-        XCTAssertEqual(config.mirrors.originalURL(for: mirror1URL), nil)
+        XCTAssertEqual(config.mirrors.mirror(for: original1URL), nil)
+        XCTAssertEqual(config.mirrors.original(for: mirror1URL), nil)
     }
 }

--- a/Tests/WorkspaceTests/PinsStoreTests.swift
+++ b/Tests/WorkspaceTests/PinsStoreTests.swift
@@ -300,8 +300,8 @@ final class PinsStoreTests: XCTestCase {
         let bazIdentity = PackageIdentity(url: bazURL)
 
         let mirrors = DependencyMirrors()
-        mirrors.set(mirrorURL: fooMirroredURL.absoluteString, forURL: fooURL.absoluteString)
-        mirrors.set(mirrorURL: barMirroredURL.absoluteString, forURL: barURL.absoluteString)
+        mirrors.set(mirror: fooMirroredURL.absoluteString, for: fooURL.absoluteString)
+        mirrors.set(mirror: barMirroredURL.absoluteString, for: barURL.absoluteString)
 
         let fileSystem = InMemoryFileSystem()
         let pinsFile = AbsolutePath("/pins.txt")
@@ -350,10 +350,10 @@ final class PinsStoreTests: XCTestCase {
         let fooMirroredURL = URL("https://github.corporate.com/team/foo")
 
         let mirrors = DependencyMirrors()
-        mirrors.set(mirrorURL: fooMirroredURL.absoluteString, forURL: fooURL1.absoluteString)
-        mirrors.set(mirrorURL: fooMirroredURL.absoluteString, forURL: fooURL2.absoluteString)
-        mirrors.set(mirrorURL: fooMirroredURL.absoluteString, forURL: fooURL3.absoluteString)
-        mirrors.set(mirrorURL: fooMirroredURL.absoluteString, forURL: fooURL4.absoluteString)
+        mirrors.set(mirror: fooMirroredURL.absoluteString, for: fooURL1.absoluteString)
+        mirrors.set(mirror: fooMirroredURL.absoluteString, for: fooURL2.absoluteString)
+        mirrors.set(mirror: fooMirroredURL.absoluteString, for: fooURL3.absoluteString)
+        mirrors.set(mirror: fooMirroredURL.absoluteString, for: fooURL4.absoluteString)
 
         let fileSystem = InMemoryFileSystem()
         let pinsFile = AbsolutePath("/pins.txt")
@@ -403,9 +403,9 @@ final class PinsStoreTests: XCTestCase {
                 URL4.absoluteString: mirroredURL.absoluteString
             ])
 
-            XCTAssertEqual(mirrors.mirrorURL(for: URL2.absoluteString), mirroredURL.absoluteString)
+            XCTAssertEqual(mirrors.mirror(for: URL2.absoluteString), mirroredURL.absoluteString)
             // reverse index is sorted by "visited", then alphabetically
-            XCTAssertEqual(mirrors.originalURL(for: mirroredURL.absoluteString), URL2.absoluteString)
+            XCTAssertEqual(mirrors.original(for: mirroredURL.absoluteString), URL2.absoluteString)
         }
 
         do {
@@ -416,9 +416,9 @@ final class PinsStoreTests: XCTestCase {
                 URL4.absoluteString: mirroredURL.absoluteString
             ])
 
-            XCTAssertEqual(mirrors.mirrorURL(for: URL3.absoluteString), mirroredURL.absoluteString)
+            XCTAssertEqual(mirrors.mirror(for: URL3.absoluteString), mirroredURL.absoluteString)
             // reverse index is sorted by "visited", then alphabetically
-            XCTAssertEqual(mirrors.originalURL(for: mirroredURL.absoluteString), URL3.absoluteString)
+            XCTAssertEqual(mirrors.original(for: mirroredURL.absoluteString), URL3.absoluteString)
         }
 
         do {
@@ -429,10 +429,10 @@ final class PinsStoreTests: XCTestCase {
                 URL4.absoluteString: mirroredURL.absoluteString
             ])
 
-            XCTAssertEqual(mirrors.mirrorURL(for: URL2.absoluteString), mirroredURL.absoluteString)
-            XCTAssertEqual(mirrors.mirrorURL(for: URL3.absoluteString), mirroredURL.absoluteString)
+            XCTAssertEqual(mirrors.mirror(for: URL2.absoluteString), mirroredURL.absoluteString)
+            XCTAssertEqual(mirrors.mirror(for: URL3.absoluteString), mirroredURL.absoluteString)
             // reverse index is sorted by "visited", then alphabetically
-            XCTAssertEqual(mirrors.originalURL(for: mirroredURL.absoluteString), URL2.absoluteString)
+            XCTAssertEqual(mirrors.original(for: mirroredURL.absoluteString), URL2.absoluteString)
         }
 
         do {
@@ -443,10 +443,10 @@ final class PinsStoreTests: XCTestCase {
                 URL4.absoluteString: mirroredURL.absoluteString
             ])
 
-            XCTAssertEqual(mirrors.mirrorURL(for: URL3.absoluteString), mirroredURL.absoluteString)
-            XCTAssertEqual(mirrors.mirrorURL(for: URL2.absoluteString), mirroredURL.absoluteString)
+            XCTAssertEqual(mirrors.mirror(for: URL3.absoluteString), mirroredURL.absoluteString)
+            XCTAssertEqual(mirrors.mirror(for: URL2.absoluteString), mirroredURL.absoluteString)
             // reverse index is sorted by "visited", then alphabetically
-            XCTAssertEqual(mirrors.originalURL(for: mirroredURL.absoluteString), URL3.absoluteString)
+            XCTAssertEqual(mirrors.original(for: mirroredURL.absoluteString), URL3.absoluteString)
         }
 
         do {
@@ -458,7 +458,7 @@ final class PinsStoreTests: XCTestCase {
             ])
 
             // reverse index is sorted by "visited", then alphabetically
-            XCTAssertEqual(mirrors.originalURL(for: mirroredURL.absoluteString), URL1.absoluteString)
+            XCTAssertEqual(mirrors.original(for: mirroredURL.absoluteString), URL1.absoluteString)
         }
     }
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -4001,12 +4001,12 @@ final class WorkspaceTests: XCTestCase {
 
         let mirrors = DependencyMirrors()
         mirrors.set(
-            mirrorURL: sandbox.appending(components: "pkgs", "BarMirror").pathString,
-            forURL: sandbox.appending(components: "pkgs", "Bar").pathString
+            mirror: sandbox.appending(components: "pkgs", "BarMirror").pathString,
+            for: sandbox.appending(components: "pkgs", "Bar").pathString
         )
         mirrors.set(
-            mirrorURL: sandbox.appending(components: "pkgs", "BazMirror").pathString,
-            forURL: sandbox.appending(components: "pkgs", "Baz").pathString
+            mirror: sandbox.appending(components: "pkgs", "BazMirror").pathString,
+            for: sandbox.appending(components: "pkgs", "Baz").pathString
         )
 
         let workspace = try MockWorkspace(
@@ -4093,12 +4093,12 @@ final class WorkspaceTests: XCTestCase {
 
         let mirrors = DependencyMirrors()
         mirrors.set(
-            mirrorURL: sandbox.appending(components: "pkgs", "BarMirror").pathString,
-            forURL: sandbox.appending(components: "pkgs", "Bar").pathString
+            mirror: sandbox.appending(components: "pkgs", "BarMirror").pathString,
+            for: sandbox.appending(components: "pkgs", "Bar").pathString
         )
         mirrors.set(
-            mirrorURL: sandbox.appending(components: "pkgs", "BarMirror").pathString,
-            forURL: sandbox.appending(components: "pkgs", "Baz").pathString
+            mirror: sandbox.appending(components: "pkgs", "BarMirror").pathString,
+            for: sandbox.appending(components: "pkgs", "Baz").pathString
         )
 
         let workspace = try MockWorkspace(
@@ -4195,8 +4195,8 @@ final class WorkspaceTests: XCTestCase {
         let fs = InMemoryFileSystem()
 
         let mirrors = DependencyMirrors()
-        mirrors.set(mirrorURL: "https://scm.com/org/bar-mirror", forURL: "https://scm.com/org/bar")
-        mirrors.set(mirrorURL: "https://scm.com/org/baz-mirror", forURL: "https://scm.com/org/baz")
+        mirrors.set(mirror: "https://scm.com/org/bar-mirror", for: "https://scm.com/org/bar")
+        mirrors.set(mirror: "https://scm.com/org/baz-mirror", for: "https://scm.com/org/baz")
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
@@ -4284,8 +4284,8 @@ final class WorkspaceTests: XCTestCase {
         let fs = InMemoryFileSystem()
 
         let mirrors = DependencyMirrors()
-        mirrors.set(mirrorURL: "https://scm.com/org/bar-mirror", forURL: "https://scm.com/org/bar")
-        mirrors.set(mirrorURL: "https://scm.com/org/bar-mirror", forURL: "https://scm.com/org/baz")
+        mirrors.set(mirror: "https://scm.com/org/bar-mirror", for: "https://scm.com/org/bar")
+        mirrors.set(mirror: "https://scm.com/org/bar-mirror", for: "https://scm.com/org/baz")
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
@@ -4389,7 +4389,7 @@ final class WorkspaceTests: XCTestCase {
         let fs = InMemoryFileSystem()
 
         let mirrors = DependencyMirrors()
-        mirrors.set(mirrorURL: "org.bar-mirror", forURL: "https://scm.com/org/bar")
+        mirrors.set(mirror: "org.bar-mirror", for: "https://scm.com/org/bar")
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
@@ -4459,7 +4459,7 @@ final class WorkspaceTests: XCTestCase {
         let fs = InMemoryFileSystem()
 
         let mirrors = DependencyMirrors()
-        mirrors.set(mirrorURL: "https://scm.com/org/bar-mirror", forURL: "org.bar")
+        mirrors.set(mirror: "https://scm.com/org/bar-mirror", for: "org.bar")
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,


### PR DESCRIPTION
motivation: the mirrors config command no takes both URLs and registry identities

changes:
* nupdate flags to use "original" and "mirror" so it is not URL specific
* update API to not use URL suffix
* update call sites and tests
