### PR TITLE
[5.9] Reduce errors from manifest signature validation (#6325)

### DIFF
--- a/Sources/PackageLoading/ManifestSignatureParser.swift
+++ b/Sources/PackageLoading/ManifestSignatureParser.swift
@@ -128,8 +128,6 @@ public enum ManifestSignatureParser {
     public enum Error: Swift.Error {
         /// Package manifest file is inaccessible (missing, unreadable, etc).
         case inaccessibleManifest(path: AbsolutePath, reason: String)
-        /// Package manifest file's content can not be decoded as a UTF-8 string.
-        case nonUTF8EncodedManifest(path: AbsolutePath)
         /// Malformed manifest signature.
         case malformedManifestSignature
     }

--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -2259,14 +2259,29 @@ extension RegistryReleaseMetadata {
 private struct RegistryClientSignatureValidationDelegate: SignatureValidation.Delegate {
     let underlying: RegistryClient.Delegate?
 
+    private let onUnsignedResponseCache = ThreadSafeKeyValueStore<ResponseCacheKey, Bool>()
+    private let onUntrustedResponseCache = ThreadSafeKeyValueStore<ResponseCacheKey, Bool>()
+
     func onUnsigned(
         registry: Registry,
         package: PackageModel.PackageIdentity,
         version: TSCUtility.Version,
         completion: (Bool) -> Void
     ) {
+        let responseCacheKey = ResponseCacheKey(registry: registry, package: package, version: version)
+        if let cachedResponse = self.onUnsignedResponseCache[responseCacheKey] {
+            return completion(cachedResponse)
+        }
+
         if let underlying = self.underlying {
-            underlying.onUnsigned(registry: registry, package: package, version: version, completion: completion)
+            underlying.onUnsigned(
+                registry: registry,
+                package: package,
+                version: version
+            ) { response in
+                self.onUnsignedResponseCache[responseCacheKey] = response
+                completion(response)
+            }
         } else {
             // true == continue resolution
             // false == stop dependency resolution
@@ -2280,13 +2295,31 @@ private struct RegistryClientSignatureValidationDelegate: SignatureValidation.De
         version: TSCUtility.Version,
         completion: (Bool) -> Void
     ) {
+        let responseCacheKey = ResponseCacheKey(registry: registry, package: package, version: version)
+        if let cachedResponse = self.onUntrustedResponseCache[responseCacheKey] {
+            return completion(cachedResponse)
+        }
+
         if let underlying = self.underlying {
-            underlying.onUntrusted(registry: registry, package: package, version: version, completion: completion)
+            underlying.onUntrusted(
+                registry: registry,
+                package: package,
+                version: version
+            ) { response in
+                self.onUntrustedResponseCache[responseCacheKey] = response
+                completion(response)
+            }
         } else {
             // true == continue resolution
             // false == stop dependency resolution
             completion(false)
         }
+    }
+
+    private struct ResponseCacheKey: Hashable {
+        let registry: Registry
+        let package: PackageModel.PackageIdentity
+        let version: TSCUtility.Version
     }
 }
 

--- a/Sources/PackageRegistry/SignatureValidation.swift
+++ b/Sources/PackageRegistry/SignatureValidation.swift
@@ -53,6 +53,8 @@ struct SignatureValidation {
         self.delegate = delegate
     }
 
+    // MARK: - source archive
+
     func validate(
         registry: Registry,
         package: PackageIdentity.RegistryIdentity,
@@ -69,7 +71,7 @@ struct SignatureValidation {
             return completion(.success(.none))
         }
 
-        self.getAndValidateSignature(
+        self.getAndValidateSourceArchiveSignature(
             registry: registry,
             package: package,
             version: version,
@@ -100,7 +102,7 @@ struct SignatureValidation {
         }
     }
 
-    private func getAndValidateSignature(
+    private func getAndValidateSourceArchiveSignature(
         registry: Registry,
         package: PackageIdentity.RegistryIdentity,
         version: Version,
@@ -136,7 +138,7 @@ struct SignatureValidation {
                 throw RegistryError.unknownSignatureFormat(signatureFormatString)
             }
 
-            self.validateSignature(
+            self.validateSourceArchiveSignature(
                 registry: registry,
                 package: package,
                 version: version,
@@ -165,13 +167,14 @@ struct SignatureValidation {
 
             switch onUnsigned {
             case .prompt:
-                self.delegate.onUnsigned(registry: registry, package: package.underlying, version: version) { `continue` in
-                    if `continue` {
-                        completion(.success(.none))
-                    } else {
-                        completion(.failure(sourceArchiveNotSignedError))
+                self.delegate
+                    .onUnsigned(registry: registry, package: package.underlying, version: version) { `continue` in
+                        if `continue` {
+                            completion(.success(.none))
+                        } else {
+                            completion(.failure(sourceArchiveNotSignedError))
+                        }
                     }
-                }
             case .error:
                 completion(.failure(sourceArchiveNotSignedError))
             case .warn:
@@ -201,148 +204,7 @@ struct SignatureValidation {
         }
     }
 
-    func validate(
-        registry: Registry,
-        package: PackageIdentity.RegistryIdentity,
-        version: Version,
-        toolsVersion: ToolsVersion?,
-        manifestContent: String,
-        configuration: RegistryConfiguration.Security.Signing,
-        timeout: DispatchTimeInterval?,
-        fileSystem: FileSystem,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        completion: @escaping (Result<SigningEntity?, Error>) -> Void
-    ) {
-        guard !self.skipSignatureValidation else {
-            return completion(.success(.none))
-        }
-
-        self.getAndValidateSignature(
-            registry: registry,
-            package: package,
-            version: version,
-            toolsVersion: toolsVersion,
-            manifestContent: manifestContent,
-            configuration: configuration,
-            timeout: timeout,
-            fileSystem: fileSystem,
-            observabilityScope: observabilityScope,
-            callbackQueue: callbackQueue,
-            completion: completion
-        )
-        // FIXME: do publisher TOFU like we do for source archive?
-    }
-
-    private func getAndValidateSignature(
-        registry: Registry,
-        package: PackageIdentity.RegistryIdentity,
-        version: Version,
-        toolsVersion: ToolsVersion?,
-        manifestContent: String,
-        configuration: RegistryConfiguration.Security.Signing,
-        timeout: DispatchTimeInterval?,
-        fileSystem: FileSystem,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        completion: @escaping (Result<SigningEntity?, Error>) -> Void
-    ) {
-        do {
-            let versionMetadata = try self.versionMetadataProvider(package, version)
-
-            guard let sourceArchiveResource = versionMetadata.sourceArchive else {
-                throw RegistryError.missingSourceArchive
-            }
-            guard sourceArchiveResource.signing?.signatureBase64Encoded != nil else {
-                throw RegistryError.sourceArchiveNotSigned(
-                    registry: registry,
-                    package: package.underlying,
-                    version: version
-                )
-            }
-
-            // source archive is signed, so the manifest must also be signed
-            guard let manifestSignature = try ManifestSignatureParser.parse(utf8String: manifestContent) else {
-                return completion(.failure(RegistryError.manifestNotSigned(
-                    registry: registry,
-                    package: package.underlying,
-                    version: version,
-                    toolsVersion: toolsVersion
-                )))
-            }
-
-            guard let signatureFormat = SignatureFormat(rawValue: manifestSignature.signatureFormat) else {
-                return completion(.failure(RegistryError.unknownSignatureFormat(manifestSignature.signatureFormat)))
-            }
-
-            self.validateSignature(
-                registry: registry,
-                package: package,
-                version: version,
-                signature: manifestSignature.signature,
-                signatureFormat: signatureFormat,
-                content: manifestSignature.contents,
-                configuration: configuration,
-                fileSystem: fileSystem,
-                observabilityScope: observabilityScope,
-                completion: completion
-            )
-        } catch ManifestSignatureParser.Error.malformedManifestSignature {
-            completion(.failure(RegistryError.invalidSignature(reason: "manifest signature is malformed")))
-        } catch RegistryError.sourceArchiveNotSigned {
-            observabilityScope.emit(
-                info: "\(package) \(version) from \(registry) is unsigned",
-                metadata: .registryPackageMetadata(identity: package)
-            )
-            guard let onUnsigned = configuration.onUnsigned else {
-                return completion(.failure(RegistryError.missingConfiguration(details: "security.signing.onUnsigned")))
-            }
-
-            let sourceArchiveNotSignedError = RegistryError.sourceArchiveNotSigned(
-                registry: registry,
-                package: package.underlying,
-                version: version
-            )
-
-            switch onUnsigned {
-            case .prompt:
-                self.delegate.onUnsigned(registry: registry, package: package.underlying, version: version) { `continue` in
-                    if `continue` {
-                        completion(.success(.none))
-                    } else {
-                        completion(.failure(sourceArchiveNotSignedError))
-                    }
-                }
-            case .error:
-                completion(.failure(sourceArchiveNotSignedError))
-            case .warn:
-                observabilityScope.emit(
-                    warning: "\(sourceArchiveNotSignedError)",
-                    metadata: .registryPackageMetadata(identity: package)
-                )
-                completion(.success(.none))
-            case .silentAllow:
-                // Continue without logging
-                completion(.success(.none))
-            }
-        } catch RegistryError.failedRetrievingReleaseInfo(_, _, _, let error) {
-            completion(.failure(RegistryError.failedRetrievingSourceArchiveSignature(
-                registry: registry,
-                package: package.underlying,
-                version: version,
-                error: error
-            )))
-        } catch {
-            completion(.failure(RegistryError.failedRetrievingSourceArchiveSignature(
-                registry: registry,
-                package: package.underlying,
-                version: version,
-                error: error
-            )))
-        }
-    }
-
-    private func validateSignature(
+    private func validateSourceArchiveSignature(
         registry: Registry,
         package: PackageIdentity.RegistryIdentity,
         version: Version,
@@ -378,7 +240,8 @@ struct SignatureValidation {
                 case .certificateNotTrusted(let signingEntity):
                     observabilityScope
                         .emit(
-                            info: "\(package) \(version) from \(registry) signing entity '\(signingEntity)' is untrusted"
+                            info: "\(package) \(version) from \(registry) signing entity '\(signingEntity)' is untrusted",
+                            metadata: .registryPackageMetadata(identity: package)
                         )
 
                     guard let onUntrusted = configuration.onUntrustedCertificate else {
@@ -413,6 +276,235 @@ struct SignatureValidation {
                         completion(.success(.none))
                     case .silentAllow:
                         // Continue without logging
+                        completion(.success(.none))
+                    }
+                }
+            } catch {
+                completion(.failure(RegistryError.failedToValidateSignature(error)))
+            }
+        }
+    }
+
+    // MARK: - manifests
+
+    func validate(
+        registry: Registry,
+        package: PackageIdentity.RegistryIdentity,
+        version: Version,
+        toolsVersion: ToolsVersion?,
+        manifestContent: String,
+        configuration: RegistryConfiguration.Security.Signing,
+        timeout: DispatchTimeInterval?,
+        fileSystem: FileSystem,
+        observabilityScope: ObservabilityScope,
+        callbackQueue: DispatchQueue,
+        completion: @escaping (Result<SigningEntity?, Error>) -> Void
+    ) {
+        guard !self.skipSignatureValidation else {
+            return completion(.success(.none))
+        }
+
+        self.getAndValidateManifestSignature(
+            registry: registry,
+            package: package,
+            version: version,
+            toolsVersion: toolsVersion,
+            manifestContent: manifestContent,
+            configuration: configuration,
+            timeout: timeout,
+            fileSystem: fileSystem,
+            observabilityScope: observabilityScope,
+            callbackQueue: callbackQueue
+        ) { result in
+            switch result {
+            case .success(let signingEntity):
+                // Always do signing entity TOFU check at the end,
+                // whether the manifest is signed or not.
+                self.signingEntityTOFU.validate(
+                    registry: registry,
+                    package: package,
+                    version: version,
+                    signingEntity: signingEntity,
+                    observabilityScope: observabilityScope,
+                    callbackQueue: callbackQueue
+                ) { _ in
+                    completion(.success(signingEntity))
+                }
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+
+    private func getAndValidateManifestSignature(
+        registry: Registry,
+        package: PackageIdentity.RegistryIdentity,
+        version: Version,
+        toolsVersion: ToolsVersion?,
+        manifestContent: String,
+        configuration: RegistryConfiguration.Security.Signing,
+        timeout: DispatchTimeInterval?,
+        fileSystem: FileSystem,
+        observabilityScope: ObservabilityScope,
+        callbackQueue: DispatchQueue,
+        completion: @escaping (Result<SigningEntity?, Error>) -> Void
+    ) {
+        let manifestName = toolsVersion.map { "Package@swift-\($0).swift" } ?? Manifest.filename
+
+        do {
+            let versionMetadata = try self.versionMetadataProvider(package, version)
+
+            guard let sourceArchiveResource = versionMetadata.sourceArchive else {
+                observabilityScope
+                    .emit(
+                        debug: "cannot determine if \(manifestName) should be signed because source archive for \(package) \(version) is not found in \(registry)",
+                        metadata: .registryPackageMetadata(identity: package)
+                    )
+                return completion(.success(.none))
+            }
+            guard sourceArchiveResource.signing?.signatureBase64Encoded != nil else {
+                throw RegistryError.sourceArchiveNotSigned(
+                    registry: registry,
+                    package: package.underlying,
+                    version: version
+                )
+            }
+
+            // source archive is signed, so the manifest must also be signed
+            guard let manifestSignature = try ManifestSignatureParser.parse(utf8String: manifestContent) else {
+                return completion(.failure(RegistryError.manifestNotSigned(
+                    registry: registry,
+                    package: package.underlying,
+                    version: version,
+                    toolsVersion: toolsVersion
+                )))
+            }
+
+            guard let signatureFormat = SignatureFormat(rawValue: manifestSignature.signatureFormat) else {
+                return completion(.failure(RegistryError.unknownSignatureFormat(manifestSignature.signatureFormat)))
+            }
+
+            self.validateManifestSignature(
+                registry: registry,
+                package: package,
+                version: version,
+                manifestName: manifestName,
+                signature: manifestSignature.signature,
+                signatureFormat: signatureFormat,
+                content: manifestSignature.contents,
+                configuration: configuration,
+                fileSystem: fileSystem,
+                observabilityScope: observabilityScope,
+                completion: completion
+            )
+        } catch RegistryError.sourceArchiveNotSigned {
+            observabilityScope.emit(
+                debug: "\(manifestName) is not signed because source archive for \(package) \(version) from \(registry) is not signed",
+                metadata: .registryPackageMetadata(identity: package)
+            )
+            guard let onUnsigned = configuration.onUnsigned else {
+                return completion(.failure(RegistryError.missingConfiguration(details: "security.signing.onUnsigned")))
+            }
+
+            let sourceArchiveNotSignedError = RegistryError.sourceArchiveNotSigned(
+                registry: registry,
+                package: package.underlying,
+                version: version
+            )
+
+            // Prompt if configured, otherwise just continue (this differs
+            // from source archive to minimize duplicate loggings).
+            switch onUnsigned {
+            case .prompt:
+                self.delegate
+                    .onUnsigned(registry: registry, package: package.underlying, version: version) { `continue` in
+                        if `continue` {
+                            completion(.success(.none))
+                        } else {
+                            completion(.failure(sourceArchiveNotSignedError))
+                        }
+                    }
+            default:
+                completion(.success(.none))
+            }
+        } catch ManifestSignatureParser.Error.malformedManifestSignature {
+            completion(.failure(RegistryError.invalidSignature(reason: "manifest signature is malformed")))
+        } catch {
+            observabilityScope
+                .emit(
+                    debug: "cannot determine if \(manifestName) should be signed because retrieval of source archive signature for \(package) \(version) from \(registry) failed: \(error)",
+                    metadata: .registryPackageMetadata(identity: package)
+                )
+            completion(.success(.none))
+        }
+    }
+
+    private func validateManifestSignature(
+        registry: Registry,
+        package: PackageIdentity.RegistryIdentity,
+        version: Version,
+        manifestName: String,
+        signature: [UInt8],
+        signatureFormat: SignatureFormat,
+        content: [UInt8],
+        configuration: RegistryConfiguration.Security.Signing,
+        fileSystem: FileSystem,
+        observabilityScope: ObservabilityScope,
+        completion: @escaping (Result<SigningEntity?, Error>) -> Void
+    ) {
+        Task {
+            do {
+                let signatureStatus = try await SignatureProvider.status(
+                    signature: signature,
+                    content: content,
+                    format: signatureFormat,
+                    verifierConfiguration: try VerifierConfiguration.from(configuration, fileSystem: fileSystem),
+                    observabilityScope: observabilityScope
+                )
+
+                switch signatureStatus {
+                case .valid(let signingEntity):
+                    observabilityScope
+                        .emit(
+                            info: "\(package) \(version) \(manifestName) from \(registry) is signed with a valid entity '\(signingEntity)'"
+                        )
+                    completion(.success(signingEntity))
+                case .invalid(let reason):
+                    completion(.failure(RegistryError.invalidSignature(reason: reason)))
+                case .certificateInvalid(let reason):
+                    completion(.failure(RegistryError.invalidSigningCertificate(reason: reason)))
+                case .certificateNotTrusted(let signingEntity):
+                    observabilityScope
+                        .emit(
+                            debug: "the signer '\(signingEntity)' of \(package) \(version) \(manifestName) from \(registry) is not trusted",
+                            metadata: .registryPackageMetadata(identity: package)
+                        )
+
+                    guard let onUntrusted = configuration.onUntrustedCertificate else {
+                        return completion(.failure(
+                            RegistryError.missingConfiguration(details: "security.signing.onUntrustedCertificate")
+                        ))
+                    }
+
+                    let signerNotTrustedError = RegistryError.signerNotTrusted(package.underlying, signingEntity)
+
+                    // Prompt if configured, otherwise just continue (this differs
+                    // from source archive to minimize duplicate loggings).
+                    switch onUntrusted {
+                    case .prompt:
+                        self.delegate
+                            .onUntrusted(
+                                registry: registry,
+                                package: package.underlying,
+                                version: version
+                            ) { `continue` in
+                                if `continue` {
+                                    completion(.success(.none))
+                                } else {
+                                    completion(.failure(signerNotTrustedError))
+                                }
+                            }
+                    default:
                         completion(.success(.none))
                     }
                 }


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift-package-manager/pull/6325 to 5.9

Motivation:
Manifest signature validation works similarly as source archive signature validation, meaning user could see duplicate errors (e.g., source archive not signed).

Modifications:
- Change most error throwing to logging diagnostics for manifest signature validation
- Continue to prompt if that's what user has configured for unsigned packages or untrusted signers; cache responses in memory to prevent repeatedly prompting for manifest and source archive downloads for the same package version.
- Wire up publisher TOFU for manifest signing
- Adjust tests
