### PR TITLE
[5.9] Destinations: throw error on duplicate artifact ID

### DIFF
--- a/Sources/PackageModel/DestinationBundle.swift
+++ b/Sources/PackageModel/DestinationBundle.swift
@@ -121,7 +121,14 @@ public struct DestinationBundle {
 
         return selectedDestination
     }
-
+    
+    /// Installs a destination bundle from a given path or URL to a destinations installation directory.
+    /// - Parameters:
+    ///   - bundlePathOrURL: A string passed on the command line, which is either an absolute or relative to a current
+    ///   working directory path, or a URL to a destination artifact bundle.
+    ///   - destinationsDirectory: a directory where the destination artifact bundle should be installed.
+    ///   - fileSystem: file system on which all of the file operations should run.
+    ///   - observabilityScope: observability scope for reporting warnings and errors.
     public static func install(
         bundlePathOrURL: String,
         destinationsDirectory: AbsolutePath,
@@ -169,7 +176,13 @@ public struct DestinationBundle {
 
         observabilityScope.emit(info: "Destination artifact bundle at `\(bundlePathOrURL)` successfully installed.")
     }
-
+    
+    /// Installs an unpacked destination bundle to a destinations installation directory.
+    /// - Parameters:
+    ///   - bundlePath: absolute path to an unpacked destination bundle directory.
+    ///   - destinationsDirectory: a directory where the destination artifact bundle should be installed.
+    ///   - fileSystem: file system on which all of the file operations should run.
+    ///   - observabilityScope: observability scope for reporting warnings and errors.
     private static func installIfValid(
         bundlePath: AbsolutePath,
         destinationsDirectory: AbsolutePath,

--- a/Sources/PackageModel/DestinationBundle.swift
+++ b/Sources/PackageModel/DestinationBundle.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -12,6 +12,8 @@
 
 import Basics
 import TSCBasic
+
+import struct Foundation.URL
 
 /// Represents an `.artifactbundle` on the filesystem that contains cross-compilation destinations.
 public struct DestinationBundle {
@@ -118,6 +120,100 @@ public struct DestinationBundle {
         selectedDestination.applyPathCLIOptions()
 
         return selectedDestination
+    }
+
+    public static func install(
+        bundlePathOrURL: String,
+        destinationsDirectory: AbsolutePath,
+        _ fileSystem: some FileSystem,
+        _ observabilityScope: ObservabilityScope
+    ) throws {
+        let installedBundlePath: AbsolutePath
+
+        if
+            let bundleURL = URL(string: bundlePathOrURL),
+            let scheme = bundleURL.scheme,
+            scheme == "http" || scheme == "https"
+        {
+            let response = try tsc_await { (completion: @escaping (Result<HTTPClientResponse, Error>) -> Void) in
+                let client = LegacyHTTPClient()
+                client.execute(
+                    .init(method: .get, url: bundleURL),
+                    observabilityScope: observabilityScope,
+                    progress: nil,
+                    completion: completion
+                )
+            }
+
+            guard let body = response.body else {
+                throw StringError("No downloadable data available at URL `\(bundleURL)`.")
+            }
+
+            let fileName = bundleURL.lastPathComponent
+            installedBundlePath = destinationsDirectory.appending(component: fileName)
+
+            try fileSystem.writeFileContents(installedBundlePath, data: body)
+        } else if
+            let cwd = fileSystem.currentWorkingDirectory,
+            let originalBundlePath = try? AbsolutePath(validating: bundlePathOrURL, relativeTo: cwd)
+        {
+            try installIfValid(
+                bundlePath: originalBundlePath,
+                destinationsDirectory: destinationsDirectory,
+                fileSystem,
+                observabilityScope
+            )
+        } else {
+            throw DestinationError.invalidPathOrURL(bundlePathOrURL)
+        }
+
+        observabilityScope.emit(info: "Destination artifact bundle at `\(bundlePathOrURL)` successfully installed.")
+    }
+
+    private static func installIfValid(
+        bundlePath: AbsolutePath,
+        destinationsDirectory: AbsolutePath,
+        _ fileSystem: some FileSystem,
+        _ observabilityScope: ObservabilityScope
+    ) throws {
+        guard
+            fileSystem.isDirectory(bundlePath),
+            let bundleName = bundlePath.components.last
+        else {
+            throw DestinationError.pathIsNotDirectory(bundlePath)
+        }
+
+        let installedBundlePath = destinationsDirectory.appending(component: bundleName)
+        guard !fileSystem.exists(installedBundlePath) else {
+            throw DestinationError.destinationBundleAlreadyInstalled(bundleName: bundleName)
+        }
+
+        let validatedBundle = try Self.parseAndValidate(
+            bundlePath: bundlePath,
+            fileSystem: fileSystem,
+            observabilityScope: observabilityScope
+        )
+        let newArtifactIDs = validatedBundle.artifacts.keys
+
+        let installedBundles = try Self.getAllValidBundles(
+            destinationsDirectory: destinationsDirectory,
+            fileSystem: fileSystem,
+            observabilityScope: observabilityScope
+        )
+
+        for installedBundle in installedBundles {
+            for artifactID in installedBundle.artifacts.keys {
+                guard !newArtifactIDs.contains(artifactID) else {
+                    throw DestinationError.destinationArtifactAlreadyInstalled(
+                        installedBundleName: installedBundle.name,
+                        newBundleName: validatedBundle.name,
+                        artifactID: artifactID
+                    )
+                }
+            }
+        }
+
+        try fileSystem.copy(from: bundlePath, to: installedBundlePath)
     }
 
     /// Parses metadata of an `.artifactbundle` and validates it as a bundle containing

--- a/Sources/PackageModel/DestinationConfigurationStore.swift
+++ b/Sources/PackageModel/DestinationConfigurationStore.swift
@@ -59,7 +59,7 @@ public final class DestinationConfigurationStore {
 
         if fileSystem.exists(configurationDirectoryPath) {
             guard fileSystem.isDirectory(configurationDirectoryPath) else {
-                throw DestinationError.configurationPathIsNotDirectory(configurationDirectoryPath)
+                throw DestinationError.pathIsNotDirectory(configurationDirectoryPath)
             }
         } else {
             try fileSystem.createDirectory(configurationDirectoryPath)

--- a/Tests/PackageModelTests/DestinationBundleTests.swift
+++ b/Tests/PackageModelTests/DestinationBundleTests.swift
@@ -1,0 +1,125 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import PackageModel
+import XCTest
+
+import struct TSCBasic.AbsolutePath
+import struct TSCBasic.ByteString
+import class TSCBasic.InMemoryFileSystem
+
+private let testArtifactID = "test-artifact"
+
+private let infoJSON = ByteString(stringLiteral: """
+{
+  "artifacts" : {
+    "\(testArtifactID)" : {
+      "type" : "crossCompilationDestination",
+      "version" : "0.0.1",
+      "variants" : [
+        {
+          "path" : "\(testArtifactID)/aarch64-unknown-linux",
+          "supportedTriples" : [
+            "arm64-apple-macosx13.0"
+          ]
+        }
+      ]
+    }
+  },
+  "schemaVersion" : "1.0"
+}
+""")
+
+final class DestinationBundleTests: XCTestCase {
+    func testInstallDestination() throws {
+        let system = ObservabilitySystem.makeForTesting()
+
+        let bundleName1 = "test1.artifactbundle"
+        let bundleName2 = "test2.artifactbundle"
+        let bundlePath1 = "/\(bundleName1)"
+        let bundlePath2 = "/\(bundleName2)"
+        let destinationsDirectory = try AbsolutePath(validating: "/destinations")
+        let fileSystem = InMemoryFileSystem(files: [
+            "\(bundlePath1)/info.json": infoJSON,
+            "\(bundlePath2)/info.json": infoJSON,
+        ])
+        try fileSystem.createDirectory(destinationsDirectory)
+
+        try DestinationBundle.install(
+            bundlePathOrURL: bundlePath1,
+            destinationsDirectory: destinationsDirectory,
+            fileSystem,
+            system.topScope
+        )
+
+        let invalidPath = "foobar"
+        XCTAssertThrowsError(try DestinationBundle.install(
+            bundlePathOrURL: "foobar",
+            destinationsDirectory: destinationsDirectory,
+            fileSystem,
+            system.topScope
+        )) {
+            guard let error = $0 as? DestinationError else {
+                XCTFail("Unexpected error type")
+                return
+            }
+
+            switch error {
+            case .pathIsNotDirectory(let path):
+                XCTAssertEqual(path.pathString, "/\(invalidPath)")
+            default:
+                XCTFail("Unexpected error value")
+            }
+        }
+
+        XCTAssertThrowsError(try DestinationBundle.install(
+            bundlePathOrURL: bundlePath1,
+            destinationsDirectory: destinationsDirectory,
+            fileSystem,
+            system.topScope
+        )) {
+            guard let error = $0 as? DestinationError else {
+                XCTFail("Unexpected error type")
+                return
+            }
+
+            switch error {
+            case .destinationBundleAlreadyInstalled(let installedBundleName):
+                XCTAssertEqual(bundleName1, installedBundleName)
+            default:
+                XCTFail("Unexpected error value")
+            }
+        }
+
+        XCTAssertThrowsError(try DestinationBundle.install(
+            bundlePathOrURL: bundlePath2,
+            destinationsDirectory: destinationsDirectory,
+            fileSystem,
+            system.topScope
+        )) {
+            guard let error = $0 as? DestinationError else {
+                XCTFail("Unexpected error type")
+                return
+            }
+
+            switch error {
+            case .destinationArtifactAlreadyInstalled(let installedBundleName, let newBundleName, let artifactID):
+                XCTAssertEqual(bundleName1, installedBundleName)
+                XCTAssertEqual(bundleName2, newBundleName)
+                XCTAssertEqual(artifactID, testArtifactID)
+            default:
+                XCTFail("Unexpected error value")
+            }
+        }
+    }
+}


### PR DESCRIPTION
`swift experimental-destination install` command doesn't check if a newly installed bundle contains same IDs as already installed bundles.

Moved installation code from `InstallDestination.swift` to separate static functions on `DestinationBundle` to make it testable. Also added tests that exercise these code paths and verify that installation is successful or throws correct errors when needed.

rdar://106090132
