### PR TITLE
PackageLoading: anchor relative paths for Windows

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -1036,9 +1036,10 @@ public final class PackageBuilder {
                 }
 
                 // Ensure that the search path is contained within the package.
-                let subpath = try RelativePath(validating: value)
-                guard targetRoot.appending(subpath).isDescendantOfOrEqual(to: self.packagePath) else {
-                    throw ModuleError.invalidHeaderSearchPath(subpath.pathString)
+                _ = try RelativePath(validating: value)
+                let path = try AbsolutePath(value, relativeTo: targetRoot)
+                guard path.isDescendantOfOrEqual(to: self.packagePath) else {
+                    throw ModuleError.invalidHeaderSearchPath(value)
                 }
 
             case .define(let value):


### PR DESCRIPTION
We currently cannot use `..` as a header search path for Windows even though it may be contained within the package root.  This is due to the fact that the path itself was unanchored, and a raw `..` would be treated as the drive root which will almost always be outside of the package root.  Construct the absolute path relative to the target root rather than appending, permitting us to form a well-formed path which can be checked for ancestry.