### PR TITLE
[5.9] Package manifest checksum TOFU

### DIFF
--- a/Sources/PackageRegistry/RegistryDownloadsManager.swift
+++ b/Sources/PackageRegistry/RegistryDownloadsManager.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -26,7 +26,6 @@ public class RegistryDownloadsManager: Cancellable {
     private let path: AbsolutePath
     private let cachePath: AbsolutePath?
     private let registryClient: RegistryClient
-    private let checksumAlgorithm: HashAlgorithm
     private let delegate: Delegate?
 
     private var pendingLookups = [PackageIdentity: DispatchGroup]()
@@ -37,14 +36,12 @@ public class RegistryDownloadsManager: Cancellable {
         path: AbsolutePath,
         cachePath: AbsolutePath?,
         registryClient: RegistryClient,
-        checksumAlgorithm: HashAlgorithm,
         delegate: Delegate?
     ) {
         self.fileSystem = fileSystem
         self.path = path
         self.cachePath = cachePath
         self.registryClient = registryClient
-        self.checksumAlgorithm = checksumAlgorithm
         self.delegate = delegate
     }
 
@@ -174,7 +171,6 @@ public class RegistryDownloadsManager: Cancellable {
                             package: package,
                             version: version,
                             destinationPath: cachedPackagePath,
-                            checksumAlgorithm: self.checksumAlgorithm,
                             progressHandler: updateDownloadProgress,
                             fileSystem: self.fileSystem,
                             observabilityScope: observabilityScope,
@@ -202,7 +198,6 @@ public class RegistryDownloadsManager: Cancellable {
                     package: package,
                     version: version,
                     destinationPath: packagePath,
-                    checksumAlgorithm: self.checksumAlgorithm,
                     progressHandler: updateDownloadProgress,
                     fileSystem: self.fileSystem,
                     observabilityScope: observabilityScope,
@@ -219,7 +214,6 @@ public class RegistryDownloadsManager: Cancellable {
                 package: package,
                 version: version,
                 destinationPath: packagePath,
-                checksumAlgorithm: self.checksumAlgorithm,
                 progressHandler: updateDownloadProgress,
                 fileSystem: self.fileSystem,
                 observabilityScope: observabilityScope,

--- a/Sources/PackageRegistryTool/PackageRegistryTool+Auth.swift
+++ b/Sources/PackageRegistryTool/PackageRegistryTool+Auth.swift
@@ -198,7 +198,8 @@ extension SwiftPackageRegistryTool {
                 signingEntityStorage: .none,
                 signingEntityCheckingMode: .strict,
                 authorizationProvider: authorizationProvider,
-                delegate: .none
+                delegate: .none,
+                checksumAlgorithm: SHA256()
             )
 
             // Try logging in

--- a/Sources/PackageRegistryTool/PackageRegistryTool+Publish.swift
+++ b/Sources/PackageRegistryTool/PackageRegistryTool+Publish.swift
@@ -138,7 +138,8 @@ extension SwiftPackageRegistryTool {
                 signingEntityStorage: .none,
                 signingEntityCheckingMode: .strict,
                 authorizationProvider: authorizationProvider,
-                delegate: .none
+                delegate: .none,
+                checksumAlgorithm: SHA256()
             )
 
             // step 1: publishing configuration

--- a/Sources/SPMTestSupport/MockRegistry.swift
+++ b/Sources/SPMTestSupport/MockRegistry.swift
@@ -68,7 +68,8 @@ public class MockRegistry {
             authorizationProvider: .none,
             customHTTPClient: LegacyHTTPClient(handler: self.httpHandler),
             customArchiverProvider: { fileSystem in MockRegistryArchiver(fileSystem: fileSystem) },
-            delegate: .none
+            delegate: .none,
+            checksumAlgorithm: checksumAlgorithm
         )
     }
 

--- a/Sources/Workspace/SourceControlPackageContainer.swift
+++ b/Sources/Workspace/SourceControlPackageContainer.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2014-2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2014-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -168,13 +168,18 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
                     package: self.package,
                     version: version,
                     kind: .sourceControl,
+                    contentType: .sourceCode,
                     observabilityScope: self.observabilityScope,
                     callbackQueue: .sharedConcurrent,
                     callback: $0
                 )
             }
         } catch PackageFingerprintStorageError.notFound {
-            fingerprint = Fingerprint(origin: .sourceControl(sourceControlURL), value: revision.identifier)
+            fingerprint = Fingerprint(
+                origin: .sourceControl(sourceControlURL),
+                value: revision.identifier,
+                contentType: .sourceCode
+            )
             // Write to storage if fingerprint not yet recorded
             do {
                 try temp_await {

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -685,7 +685,8 @@ public class Workspace {
             signingEntityStorage: signingEntities,
             signingEntityCheckingMode: SigningEntityCheckingMode.map(configuration.signingEntityCheckingMode),
             authorizationProvider: registryAuthorizationProvider,
-            delegate: WorkspaceRegistryClientDelegate(workspaceDelegate: delegate)
+            delegate: WorkspaceRegistryClientDelegate(workspaceDelegate: delegate),
+            checksumAlgorithm: checksumAlgorithm
         )
 
         // set default registry if not already set by configuration
@@ -698,7 +699,6 @@ public class Workspace {
             path: location.registryDownloadDirectory,
             cachePath: configuration.sharedDependenciesCacheEnabled ? location.sharedRegistryDownloadsCacheDirectory : .none,
             registryClient: registryClient,
-            checksumAlgorithm: checksumAlgorithm,
             delegate: delegate.map(WorkspaceRegistryDownloadsManagerDelegate.init(workspaceDelegate:))
         )
         // register the registry dependencies downloader with the cancellation handler

--- a/Tests/PackageRegistryTests/RegistryDownloadsManagerTests.swift
+++ b/Tests/PackageRegistryTests/RegistryDownloadsManagerTests.swift
@@ -51,7 +51,6 @@ class RegistryDownloadsManagerTests: XCTestCase {
             path: downloadsPath,
             cachePath: .none, // cache disabled
             registryClient: registry.registryClient,
-            checksumAlgorithm: MockHashAlgorithm(),
             delegate: delegate
         )
 
@@ -184,7 +183,6 @@ class RegistryDownloadsManagerTests: XCTestCase {
             path: downloadsPath,
             cachePath: cachePath, // cache enabled
             registryClient: registry.registryClient,
-            checksumAlgorithm: MockHashAlgorithm(),
             delegate: delegate
         )
 
@@ -274,7 +272,6 @@ class RegistryDownloadsManagerTests: XCTestCase {
             path: downloadsPath,
             cachePath: .none, // cache disabled
             registryClient: registry.registryClient,
-            checksumAlgorithm: MockHashAlgorithm(),
             delegate: delegate
         )
 

--- a/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
@@ -468,7 +468,8 @@ class RegistryPackageContainerTests: XCTestCase {
                 }
             }),
             customArchiverProvider: { _ in archiver },
-            delegate: .none
+            delegate: .none,
+            checksumAlgorithm: MockHashAlgorithm()
         )
     }
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -13873,7 +13873,8 @@ final class WorkspaceTests: XCTestCase {
                 }
             }),
             customArchiverProvider: { _ in archiver },
-            delegate: .none
+            delegate: .none,
+            checksumAlgorithm: MockHashAlgorithm()
         )
     }
 }


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift-package-manager/pull/6322 to 5.9

---

Motivation:
SwiftPM should do checksum TOFU for package manifests.

Modifications:
- Modify fingerprint storage structure to store fingerprint by content type
- Modfiy fingerprint storage API to allow retrieving fingerprints by content type
- Add API to `ChecksumTOFU` for manifests
- Wire up manifest TOFU in `RegistryClient`

