### PR TITLE
Do not pollute home directory with test data

### DIFF
--- a/Tests/CommandsTests/SwiftToolTests.swift
+++ b/Tests/CommandsTests/SwiftToolTests.swift
@@ -161,7 +161,7 @@ final class SwiftToolTests: CommandsTestCase {
 
             // custom .netrc file
             do {
-                let customPath = try fs.homeDirectory.appending(component: UUID().uuidString)
+                let customPath = try fs.tempDirectory.appending(component: UUID().uuidString)
                 try fs.writeFileContents(customPath) {
                     "machine mymachine.labkey.org login custom@labkey.org password custom"
                 }
@@ -195,7 +195,7 @@ final class SwiftToolTests: CommandsTestCase {
 
             // custom .netrc file
             do {
-                let customPath = try fs.homeDirectory.appending(component: UUID().uuidString)
+                let customPath = try fs.tempDirectory.appending(component: UUID().uuidString)
                 try fs.writeFileContents(customPath) {
                     "machine mymachine.labkey.org login custom@labkey.org password custom"
                 }


### PR DESCRIPTION
We can just write those files into /tmp
