### PR TITLE
NFC: fix comment typo in `ZipArchiver`

### DIFF
--- a/Sources/Basics/Archiver+Zip.swift
+++ b/Sources/Basics/Archiver+Zip.swift
@@ -26,7 +26,7 @@ public struct ZipArchiver: Archiver, Cancellable {
     /// Creates a `ZipArchiver`.
     ///
     /// - Parameters:
-    ///   - fileSystem: The file-system to used by the `ZipArchiver`.
+    ///   - fileSystem: The file-system to be used by the `ZipArchiver`.
     ///   - cancellator: Cancellation handler
     public init(fileSystem: FileSystem, cancellator: Cancellator? = .none) {
         self.fileSystem = fileSystem


### PR DESCRIPTION
`to used by` -> `to be used by`