### PR TITLE
[5.9] Expected signing entity verification

### DIFF
--- a/Sources/PackageModel/RegistryReleaseMetadata.swift
+++ b/Sources/PackageModel/RegistryReleaseMetadata.swift
@@ -105,7 +105,7 @@ public struct RegistryReleaseMetadata {
         }
     }
 
-    public enum SigningEntity: Codable {
+    public enum SigningEntity: Codable, Equatable {
         case recognized(type: String, commonName: String?, organization: String?, identity: String?)
         case unrecognized(commonName: String?, organization: String?)
     }

--- a/Sources/SPMTestSupport/MockPackage.swift
+++ b/Sources/SPMTestSupport/MockPackage.swift
@@ -76,6 +76,7 @@ public struct MockPackage {
         platforms: [PlatformDescription] = [],
         identity: String,
         alternativeURLs: [String]? = .none,
+        metadata: RegistryReleaseMetadata? = .none,
         targets: [MockTarget],
         products: [MockProduct],
         dependencies: [MockDependency] = [],
@@ -85,7 +86,11 @@ public struct MockPackage {
     ) {
         self.name = name
         self.platforms = platforms
-        self.location = .registry(identity: .plain(identity), alternativeURLs: alternativeURLs?.compactMap{ URL(string: $0) })
+        self.location = .registry(
+            identity: .plain(identity),
+            alternativeURLs: alternativeURLs?.compactMap{ URL(string: $0) },
+            metadata: metadata
+        )
         self.targets = targets
         self.products = products
         self.dependencies = dependencies
@@ -110,6 +115,6 @@ public struct MockPackage {
     public enum Location {
         case fileSystem(path: RelativePath)
         case sourceControl(url: URL)
-        case registry(identity: PackageIdentity, alternativeURLs: [URL]?)
+        case registry(identity: PackageIdentity, alternativeURLs: [URL]?, metadata: RegistryReleaseMetadata?)
     }
 }


### PR DESCRIPTION
This allows clients to pass in a dictionary with expected signing entities that SwiftPM will check after loading the package graph. This can be used by clients to provide a priori configuration of expected signing by the user or provide a way to verify that information that was previously shown to users matches what was verified during signature verification.

Note that since this operates at the workspace level, we're verifying against the data cached during signature verification, not against the actual data.

rdar://107162424

(cherry picked from commit a6fde25cb63ddd50e410691d33723ed51db5def9)
