### PR TITLE
[5.9] Include signing entity in version metadata

### DIFF
--- a/Sources/PackageMetadata/PackageMetadata.swift
+++ b/Sources/PackageMetadata/PackageMetadata.swift
@@ -48,6 +48,7 @@ public struct Package {
 }
 
 public struct PackageSearchClient {
+    private let fileSystem: FileSystem
     private let registryClient: RegistryClient
     private let indexAndCollections: PackageIndexAndCollections
     private let observabilityScope: ObservabilityScope
@@ -59,6 +60,7 @@ public struct PackageSearchClient {
     ) {
         self.registryClient = registryClient
         self.indexAndCollections = PackageIndexAndCollections(fileSystem: fileSystem, observabilityScope: observabilityScope)
+        self.fileSystem = fileSystem
         self.observabilityScope = observabilityScope
     }
 
@@ -87,6 +89,7 @@ public struct PackageSearchClient {
         self.registryClient.getPackageVersionMetadata(
             package: package,
             version: version,
+            fileSystem: self.fileSystem,
             observabilityScope: observabilityScope,
             callbackQueue: DispatchQueue.sharedConcurrent
         ) { result in

--- a/Sources/PackageRegistry/SignatureValidation.swift
+++ b/Sources/PackageRegistry/SignatureValidation.swift
@@ -513,6 +513,30 @@ struct SignatureValidation {
             }
         }
     }
+
+    // MARK: - signing entity
+
+    static func extractSigningEntity(
+        signature: [UInt8],
+        signatureFormat: SignatureFormat,
+        configuration: RegistryConfiguration.Security.Signing,
+        fileSystem: FileSystem,
+        completion: @Sendable @escaping (Result<SigningEntity?, Error>) -> Void
+    ) {
+        Task {
+            do {
+                let verifierConfiguration = try VerifierConfiguration.from(configuration, fileSystem: fileSystem)
+                let signingEntity = try await SignatureProvider.extractSigningEntity(
+                    signature: signature,
+                    format: signatureFormat,
+                    verifierConfiguration: verifierConfiguration
+                )
+                return completion(.success(signingEntity))
+            } catch {
+                return completion(.failure(error))
+            }
+        }
+    }
 }
 
 extension VerifierConfiguration {

--- a/Sources/PackageSigning/SignatureProvider.swift
+++ b/Sources/PackageSigning/SignatureProvider.swift
@@ -55,6 +55,18 @@ public enum SignatureProvider {
             observabilityScope: observabilityScope
         )
     }
+
+    public static func extractSigningEntity(
+        signature: [UInt8],
+        format: SignatureFormat,
+        verifierConfiguration: VerifierConfiguration
+    ) async throws -> SigningEntity {
+        let provider = format.provider
+        return try await provider.extractSigningEntity(
+            signature: signature,
+            verifierConfiguration: verifierConfiguration
+        )
+    }
 }
 
 public struct VerifierConfiguration {
@@ -162,6 +174,11 @@ protocol SignatureProviderProtocol {
         verifierConfiguration: VerifierConfiguration,
         observabilityScope: ObservabilityScope
     ) async throws -> SignatureStatus
+
+    func extractSigningEntity(
+        signature: [UInt8],
+        verifierConfiguration: VerifierConfiguration
+    ) async throws -> SigningEntity
 }
 
 // MARK: - CMS signature provider
@@ -230,6 +247,13 @@ struct CMSSignatureProvider: SignatureProviderProtocol {
         } catch {
             throw SigningError.signingFailed("\(error)")
         }
+    }
+
+    func extractSigningEntity(
+        signature: [UInt8],
+        verifierConfiguration: VerifierConfiguration
+    ) async throws -> SigningEntity {
+        throw StringError("not implemented")
     }
 
     func status(

--- a/Sources/PackageSigning/SigningEntity/SigningEntity.swift
+++ b/Sources/PackageSigning/SigningEntity/SigningEntity.swift
@@ -15,7 +15,7 @@
 
 // MARK: - SigningEntity is the entity that generated the signature
 
-public enum SigningEntity: Hashable, Codable, CustomStringConvertible {
+public enum SigningEntity: Hashable, Codable, CustomStringConvertible, Sendable {
     case recognized(type: SigningEntityType, name: String, organizationalUnit: String, organization: String)
     case unrecognized(name: String?, organizationalUnit: String?, organization: String?)
 

--- a/Tests/PackageRegistryTests/RegistryClientTests.swift
+++ b/Tests/PackageRegistryTests/RegistryClientTests.swift
@@ -3837,6 +3837,7 @@ extension RegistryClient {
             self.getPackageVersionMetadata(
                 package: package,
                 version: version,
+                fileSystem: InMemoryFileSystem(),
                 observabilityScope: ObservabilitySystem.NOOP,
                 callbackQueue: .sharedConcurrent,
                 completion: $0


### PR DESCRIPTION
Clients who are asking for metadata prior to download an archive from the registry may still want to display information from the signature which is non-trivial to extract. This includes it if possible.

(cherry picked from commit 638cc86af08296bc3da65bbed1117c0287d82054)