### PR TITLE
Fix product lookup

### DIFF
--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -2550,6 +2550,43 @@ class PackageGraphTests: XCTestCase {
 
         XCTAssertEqual(observability.diagnostics.count, 0, "unexpected diagnostics: \(observability.diagnostics.map { $0.description })")
     }
+
+    func testCustomNameInPackageDependency() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/Foo/Sources/Foo/source.swift",
+            "/Bar2/Sources/Bar/source.swift"
+        )
+
+        let observability = ObservabilitySystem.makeForTesting()
+        _ = try loadPackageGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "Foo",
+                    path: .init(path: "/Foo"),
+                    toolsVersion: .v5_9,
+                    dependencies: [
+                        .fileSystem(deprecatedName: "Bar", path: "/Bar2"),
+                    ],
+                    targets: [
+                        TargetDescription(name: "Foo", dependencies: [.product(name: "Bar", package: "BAR")]),
+                    ]),
+                Manifest.createFileSystemManifest(
+                    displayName: "Bar",
+                    path: .init(path: "/Bar2"),
+                    toolsVersion: .v5_9,
+                    products: [
+                        ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "Bar"),
+                    ]),
+            ],
+            observabilityScope: observability.topScope
+        )
+
+        XCTAssertEqual(observability.diagnostics.count, 0, "unexpected diagnostics: \(observability.diagnostics.map { $0.description })")
+    }
 }
 
 


### PR DESCRIPTION
For module aliasing, we changed the product lookup to include package identity, but product references can use a local identity as specified by the `name` attribute of the package dependency declaration. So for packages where the local `name` attribute didn't match the identity, we would not longer find the corresponding products at all. This switches us back to use the local identity that is also called `explicitNameForTargetDependencyResolutionOnly` in package reference.
    
rdar://106578471