### PR TITLE
Destinations: pass `-Xfrontend -validate-tbd-against-ir=none`

### DIFF
--- a/Sources/CrossCompilationDestinationsTool/CMakeLists.txt
+++ b/Sources/CrossCompilationDestinationsTool/CMakeLists.txt
@@ -27,6 +27,9 @@ target_link_libraries(CrossCompilationDestinationsTool PUBLIC
 set_target_properties(CrossCompilationDestinationsTool PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 
+target_compile_options(CrossCompilationDestinationsTool PRIVATE
+  -Xfrontend -validate-tbd-against-ir=none)
+
 if(USE_CMAKE_INSTALL)
 install(TARGETS CrossCompilationDestinationsTool
   ARCHIVE DESTINATION lib


### PR DESCRIPTION
This fixes an issue with the Windows build introduced with the conversion of `SwiftDestinationTool` to `AsyncParsableCommand`, as reported at https://github.com/apple/swift-package-manager/pull/6361#issuecomment-1496129406
