### PR TITLE
PackageModel, CoreCommands: fix build flags not passed

### DIFF
--- a/Sources/CoreCommands/SwiftTool.swift
+++ b/Sources/CoreCommands/SwiftTool.swift
@@ -726,12 +726,15 @@ public final class SwiftTool {
             let dataPath = self.scratchDirectory.appending(
                 component: destinationTriple.platformBuildPathComponent(buildSystem: options.build.buildSystem)
             )
+            var buildFlags = options.build.buildFlags
+            buildFlags.append(destinationToolchain.extraFlags)
+
             return try BuildParameters(
                 dataPath: dataPath,
                 configuration: options.build.configuration,
                 toolchain: destinationToolchain,
                 destinationTriple: destinationTriple,
-                flags: options.build.buildFlags,
+                flags: buildFlags,
                 pkgConfigDirectories: options.locations.pkgConfigDirectories,
                 architectures: options.build.architectures,
                 workers: options.build.jobs ?? UInt32(ProcessInfo.processInfo.activeProcessorCount),

--- a/Sources/PackageModel/BuildFlags.swift
+++ b/Sources/PackageModel/BuildFlags.swift
@@ -40,4 +40,20 @@ public struct BuildFlags: Equatable, Encodable {
         self.linkerFlags = linkerFlags
         self.xcbuildFlags = xcbuildFlags
     }
+    
+    /// Appends corresponding properties of a different `BuildFlags` value into `self`.
+    /// - Parameter buildFlags: a `BuildFlags` value to merge flags from.
+    public mutating func append(_ buildFlags: BuildFlags) {
+        cCompilerFlags += buildFlags.cCompilerFlags
+        cxxCompilerFlags += buildFlags.cxxCompilerFlags
+        swiftCompilerFlags += buildFlags.swiftCompilerFlags
+        linkerFlags += buildFlags.linkerFlags
+
+        if var xcbuildFlags, let newXcbuildFlags = buildFlags.xcbuildFlags {
+            xcbuildFlags += newXcbuildFlags
+            self.xcbuildFlags = xcbuildFlags
+        } else if let xcbuildFlags = buildFlags.xcbuildFlags {
+            self.xcbuildFlags = xcbuildFlags
+        }
+    }
 }


### PR DESCRIPTION
### Motivation:

When computing `SwiftTool/_buildParameters`, command-line options that customize `BuildFlags` values are not merged with `BuildFlags` from the computed toolchain/destination.

rdar://106077959

### Modifications:


Added `mutating func append(_: BuildFlags)` on the `BuildFlags` type for easier merging of multiple values into one, which is then used in `SwiftTool/_buildParameters`.
