### PR TITLE
[5.9] Fix symlinked `swift-experimental-destination` invocations

### DIFF
--- a/Sources/CrossCompilationDestinationsTool/DestinationCommand.swift
+++ b/Sources/CrossCompilationDestinationsTool/DestinationCommand.swift
@@ -22,7 +22,7 @@ import var TSCBasic.localFileSystem
 import var TSCBasic.stdoutStream
 
 /// A protocol for functions and properties common to all destination subcommands.
-protocol DestinationCommand: AsyncParsableCommand {
+protocol DestinationCommand: ParsableCommand {
     /// Common locations options provided by ArgumentParser.
     var locations: LocationOptions { get }
 
@@ -35,7 +35,7 @@ protocol DestinationCommand: AsyncParsableCommand {
         buildTimeTriple: Triple,
         _ destinationsDirectory: AbsolutePath,
         _ observabilityScope: ObservabilityScope
-    ) async throws
+    ) throws
 }
 
 extension DestinationCommand {
@@ -62,7 +62,7 @@ extension DestinationCommand {
         return destinationsDirectory
     }
 
-    public func run() async throws {
+    public func run() throws {
         let observabilityHandler = SwiftToolObservabilityHandler(outputStream: stdoutStream, logLevel: .info)
         let observabilitySystem = ObservabilitySystem(observabilityHandler)
         let observabilityScope = observabilitySystem.topScope
@@ -73,7 +73,7 @@ extension DestinationCommand {
 
         var commandError: Error? = nil
         do {
-            try await self.run(buildTimeTriple: triple, destinationsDirectory, observabilityScope)
+            try self.run(buildTimeTriple: triple, destinationsDirectory, observabilityScope)
             if observabilityScope.errorsReported {
                 throw ExitCode.failure
             }

--- a/Sources/CrossCompilationDestinationsTool/InstallDestination.swift
+++ b/Sources/CrossCompilationDestinationsTool/InstallDestination.swift
@@ -42,8 +42,8 @@ public struct InstallDestination: DestinationCommand {
         buildTimeTriple: Triple,
         _ destinationsDirectory: AbsolutePath,
         _ observabilityScope: ObservabilityScope
-    ) async throws {
-        try await DestinationBundle.install(
+    ) throws {
+        try DestinationBundle.install(
             bundlePathOrURL: bundlePathOrURL,
             destinationsDirectory: destinationsDirectory,
             self.fileSystem,

--- a/Sources/CrossCompilationDestinationsTool/SwiftDestinationTool.swift
+++ b/Sources/CrossCompilationDestinationsTool/SwiftDestinationTool.swift
@@ -13,7 +13,7 @@
 import ArgumentParser
 import Basics
 
-public struct SwiftDestinationTool: AsyncParsableCommand {
+public struct SwiftDestinationTool: ParsableCommand {
     public static let configuration = CommandConfiguration(
         commandName: "experimental-destination",
         _superCommandName: "swift",

--- a/Sources/swift-experimental-destination/SwiftDestinationTool.swift
+++ b/Sources/swift-experimental-destination/SwiftDestinationTool.swift
@@ -15,7 +15,7 @@ import Basics
 import CrossCompilationDestinationsTool
 
 @main
-struct SwiftDestinationTool: AsyncParsableCommand {
+struct SwiftDestinationTool: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "experimental-destination",
         _superCommandName: "swift",

--- a/Sources/swift-package-manager/SwiftPM.swift
+++ b/Sources/swift-package-manager/SwiftPM.swift
@@ -29,7 +29,7 @@ struct SwiftPM {
         case "swift-build":
             SwiftBuildTool.main()
         case "swift-experimental-destination":
-            await SwiftDestinationTool.main()
+            SwiftDestinationTool.main()
         case "swift-test":
             SwiftTestTool.main()
         case "swift-run":

--- a/Sources/swift-package-manager/SwiftPM.swift
+++ b/Sources/swift-package-manager/SwiftPM.swift
@@ -22,7 +22,7 @@ let execName = (try? AbsolutePath(validating: firstArg).basenameWithoutExt) ??
 
 @main
 struct SwiftPM {
-    static func main() async {
+    static func main() {
         switch execName {
         case "swift-package":
             SwiftPackageTool.main()

--- a/Sources/swift-package-manager/SwiftPM.swift
+++ b/Sources/swift-package-manager/SwiftPM.swift
@@ -22,14 +22,14 @@ let execName = (try? AbsolutePath(validating: firstArg).basenameWithoutExt) ??
 
 @main
 struct SwiftPM {
-    static func main() {
+    static func main() async {
         switch execName {
         case "swift-package":
             SwiftPackageTool.main()
         case "swift-build":
             SwiftBuildTool.main()
         case "swift-experimental-destination":
-            SwiftDestinationTool.main()
+            await SwiftDestinationTool.main()
         case "swift-test":
             SwiftTestTool.main()
         case "swift-run":


### PR DESCRIPTION
`swift experimental-destination` subcommands no longer work and always display help output. This is a regression introduced in https://github.com/apple/swift-package-manager/pull/6362 after making `SwiftDestinationTool` conform to  `AsyncParsableCommand` instead of `ParsableCommand` but not updating `swift-package-manager` command sources to call `async` overload of `main()` function on `SwiftDestinationTool`.

rdar://107618266