### PR TITLE
     Set a default value to the group param for a macro target

### DIFF
--- a/Sources/CompilerPluginSupport/TargetExtensions.swift
+++ b/Sources/CompilerPluginSupport/TargetExtensions.swift
@@ -16,7 +16,7 @@ public extension Target {
     @available(_PackageDescription, introduced: 999.0)
     static func macro(
         name: String,
-        group: TargetGroup,
+        group: TargetGroup = .package,
         dependencies: [Dependency] = [],
         path: String? = nil,
         exclude: [String] = [],


### PR DESCRIPTION
Set a default value to the group param for a macro target to un-break macro packages per https://github.com/apple/swift-package-manager/pull/6365 