### PR TITLE
Basics: make `supportedExtensions` in `UniversalArchiver` constant

### DIFF
--- a/Sources/Basics/Archiver/UniversalArchiver.swift
+++ b/Sources/Basics/Archiver/UniversalArchiver.swift
@@ -16,7 +16,7 @@ import protocol TSCBasic.FileSystem
 /// An `Archiver` that handles multiple formats by delegating to other existing archivers each dedicated to its own
 /// format.
 public struct UniversalArchiver: Archiver {
-    public var supportedExtensions: Set<String>
+    public let supportedExtensions: Set<String>
 
     /// Errors specific to the implementation of ``UniversalArchiver``.
     enum Error: Swift.Error {


### PR DESCRIPTION
This was marked as a mutable property by mistake when implementing `Archiver` protocol conformance. This property is assigned an initial value in `UniversalArchiver/init` and isn't supposed to be ever changed for a given archiver.
