### PR TITLE
Build: fix duplicate `case` of `switch` in `BuildPlan.swift`

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -770,10 +770,6 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
                     case.unknown:
                         throw InternalError("unknown binary target '\(target.name)' type")
                     }
-                case .macro:
-                    if product.type == .macro {
-                        staticTargets.append(target)
-                    }
                 case .plugin:
                     continue
                 }


### PR DESCRIPTION
The way this `switch` is written currently triggers a warning:

```
/Build/BuildPlan.swift:770:22: warning: case is already handled by previous patterns; consider removing it
                case .macro:
```

Since this `case .macro` on line 770 is never reached due to another `case .macro` covering it above on line 737, it seems safe to remove the unused case altogether.