### PR TITLE
PackageSigning: mark `SigningEntityType` as `Sendable`

### DIFF
--- a/Sources/PackageSigning/SigningEntity/SigningEntity.swift
+++ b/Sources/PackageSigning/SigningEntity/SigningEntity.swift
@@ -76,7 +76,7 @@ public enum SigningEntity: Hashable, Codable, CustomStringConvertible, Sendable 
 
 // MARK: - SigningEntity types that SwiftPM recognizes
 
-public enum SigningEntityType: String, Hashable, Codable {
+public enum SigningEntityType: String, Hashable, Codable, Sendable {
     case adp // Apple Developer Program
 }
 


### PR DESCRIPTION
This fixes a warning currently triggered when building the `PackageSigning` target:

```
PackageSigning/SigningEntity/SigningEntity.swift:19:10: warning: associated value 'recognized(type:name:organizationalUnit:organization:)' of 'Sendable'-conforming enum 'SigningEntity' has non-sendable type 'SigningEntityType'
    case recognized(type: SigningEntityType, name: String, organizationalUnit: String, organization: String)
         ^
PackageSigning/SigningEntity/SigningEntity.swift:79:13: note: consider making enum 'SigningEntityType' conform to the 'Sendable' protocol
public enum SigningEntityType: String, Hashable, Codable {
            ^
                                                        , Sendable
```
