### PR TITLE
Destinations: use `UniversalArchiver` in `install` command

### DIFF
--- a/Sources/Basics/Archiver/UniversalArchiver.swift
+++ b/Sources/Basics/Archiver/UniversalArchiver.swift
@@ -20,7 +20,7 @@ public struct UniversalArchiver: Archiver {
 
     /// Errors specific to the implementation of ``UniversalArchiver``.
     enum Error: Swift.Error {
-        case unknownFormat([Substring], AbsolutePath)
+        case unknownFormat([String], AbsolutePath)
         case noFileNameExtension(AbsolutePath)
 
         var description: String {
@@ -66,7 +66,7 @@ public struct UniversalArchiver: Archiver {
 
         if let archiver = self.formatMapping[extensions.joined(separator: ".")] {
             return archiver
-        } else if let lastExtension = extensions.last, let archiver = self.formatMapping[String(lastExtension)] {
+        } else if let lastExtension = extensions.last, let archiver = self.formatMapping[lastExtension] {
             return archiver
         } else {
             throw Error.unknownFormat(extensions, archivePath)

--- a/Sources/Basics/Archiver/UniversalArchiver.swift
+++ b/Sources/Basics/Archiver/UniversalArchiver.swift
@@ -20,13 +20,13 @@ public struct UniversalArchiver: Archiver {
 
     /// Errors specific to the implementation of ``UniversalArchiver``.
     enum Error: Swift.Error {
-        case unknownFormat(String, AbsolutePath)
+        case unknownFormat([Substring], AbsolutePath)
         case noFileNameExtension(AbsolutePath)
 
         var description: String {
             switch self {
             case .unknownFormat(let ext, let path):
-                return "unknown format with extension \(ext) at path `\(path)`"
+                return "unknown format with extension \(ext.joined(separator: ".")) at path `\(path)`"
             case .noFileNameExtension(let path):
                 return "file at path `\(path)` has no extension to detect archival format from"
             }
@@ -55,15 +55,22 @@ public struct UniversalArchiver: Archiver {
     }
 
     private func archiver(for archivePath: AbsolutePath) throws -> any Archiver {
-        guard let extensions = archivePath.allExtensions else {
+        guard var extensions = archivePath.allExtensions, extensions.count > 1 else {
             throw Error.noFileNameExtension(archivePath)
         }
 
-        guard let archiver = self.formatMapping[extensions] else {
-            throw Error.unknownFormat(extensions, archivePath)
+        // None of the archivers support extensions with more than 2 extension components
+        if extensions.count > 2 {
+            extensions = extensions.suffix(2)
         }
 
-        return archiver
+        if let archiver = self.formatMapping[extensions.joined(separator: ".")] {
+            return archiver
+        } else if let lastExtension = extensions.last, let archiver = self.formatMapping[String(lastExtension)] {
+            return archiver
+        } else {
+            throw Error.unknownFormat(extensions, archivePath)
+        }
     }
 
     public func extract(

--- a/Sources/Basics/Archiver/UniversalArchiver.swift
+++ b/Sources/Basics/Archiver/UniversalArchiver.swift
@@ -55,7 +55,7 @@ public struct UniversalArchiver: Archiver {
     }
 
     private func archiver(for archivePath: AbsolutePath) throws -> any Archiver {
-        guard var extensions = archivePath.allExtensions, extensions.count > 1 else {
+        guard var extensions = archivePath.allExtensions, extensions.count > 0 else {
             throw Error.noFileNameExtension(archivePath)
         }
 

--- a/Sources/Basics/FileSystem/Path+Extensions.swift
+++ b/Sources/Basics/FileSystem/Path+Extensions.swift
@@ -40,7 +40,7 @@ extension AbsolutePath {
     }
 
     /// Unlike ``AbsolutePath//extension``, this property returns all characters after the first `.` character in a
-    /// `````. If no dot character is present in the filename or first dot is the last character, `nil` is returned.
+    /// filename. If no dot character is present in the filename or first dot is the last character, `nil` is returned.
     var allExtensions: [String]? {
         guard let firstDot = basename.firstIndex(of: ".") else {
             return nil

--- a/Sources/Basics/FileSystem/Path+Extensions.swift
+++ b/Sources/Basics/FileSystem/Path+Extensions.swift
@@ -41,7 +41,7 @@ extension AbsolutePath {
 
     /// Unlike ``AbsolutePath//extension``, this property returns all characters after the first `.` character in a
     /// `````. If no dot character is present in the filename or first dot is the last character, `nil` is returned.
-    var allExtensions: String? {
+    var allExtensions: [Substring]? {
         guard let firstDot = basename.firstIndex(of: ".") else {
             return nil
         }
@@ -54,6 +54,6 @@ extension AbsolutePath {
 
         extensions.removeFirst()
 
-        return extensions
+        return extensions.split(separator: ".")
     }
 }

--- a/Sources/Basics/FileSystem/Path+Extensions.swift
+++ b/Sources/Basics/FileSystem/Path+Extensions.swift
@@ -41,7 +41,7 @@ extension AbsolutePath {
 
     /// Unlike ``AbsolutePath//extension``, this property returns all characters after the first `.` character in a
     /// `````. If no dot character is present in the filename or first dot is the last character, `nil` is returned.
-    var allExtensions: [Substring]? {
+    var allExtensions: [String]? {
         guard let firstDot = basename.firstIndex(of: ".") else {
             return nil
         }
@@ -54,6 +54,6 @@ extension AbsolutePath {
 
         extensions.removeFirst()
 
-        return extensions.split(separator: ".")
+        return extensions.split(separator: ".").map(String.init)
     }
 }

--- a/Sources/CrossCompilationDestinationsTool/InstallDestination.swift
+++ b/Sources/CrossCompilationDestinationsTool/InstallDestination.swift
@@ -47,7 +47,7 @@ public struct InstallDestination: DestinationCommand {
             bundlePathOrURL: bundlePathOrURL,
             destinationsDirectory: destinationsDirectory,
             self.fileSystem,
-            ZipArchiver(fileSystem: self.fileSystem),
+            UniversalArchiver(self.fileSystem, Cancellator(observabilityScope: observabilityScope)),
             observabilityScope
         )
     }

--- a/Sources/CrossCompilationDestinationsTool/InstallDestination.swift
+++ b/Sources/CrossCompilationDestinationsTool/InstallDestination.swift
@@ -43,11 +43,13 @@ public struct InstallDestination: DestinationCommand {
         _ destinationsDirectory: AbsolutePath,
         _ observabilityScope: ObservabilityScope
     ) throws {
+        let cancellator = Cancellator(observabilityScope: observabilityScope)
+        cancellator.installSignalHandlers()
         try DestinationBundle.install(
             bundlePathOrURL: bundlePathOrURL,
             destinationsDirectory: destinationsDirectory,
             self.fileSystem,
-            UniversalArchiver(self.fileSystem, Cancellator(observabilityScope: observabilityScope)),
+            UniversalArchiver(self.fileSystem, cancellator),
             observabilityScope
         )
     }

--- a/Sources/PackageModel/DestinationBundle.swift
+++ b/Sources/PackageModel/DestinationBundle.swift
@@ -225,12 +225,12 @@ public struct DestinationBundle {
             throw DestinationError.destinationBundleAlreadyInstalled(bundleName: unpackedBundleName)
         }
 
-        print("\(bundleName) is assumed to be an archive, unpacking...")
-
         // If there's no archive extension on the bundle name, assuming it's not archived and returning the same path.
         guard unpackedBundleName != bundleName else {
             return bundlePath
         }
+
+        print("\(bundleName) is assumed to be an archive, unpacking...")
 
         try tsc_await { archiver.extract(from: bundlePath, to: temporaryDirectory, completion: $0) }
 


### PR DESCRIPTION
Fixes `.tar.gz` archives support in `experimental-destination install` subcommand.

Tweaks multi-component extensions calculation so that at most last 2 components are taken into consideration. This fixes an issue with bundle names that have dots. For example, for `5.7.3-RELEASE_ubuntu_22.04_aarch64.tar.gz` previously `allExtensions` returned `7.3-RELEASE_ubuntu_22.04_aarch64.tar.gz`, and that didn't match any of the archivers, even though the actual extension was valid.

rdar://107485048