### PR TITLE
Basics: allow reusing cancellator handlers from `SwiftTool`

### DIFF
--- a/Sources/Basics/Cancellator.swift
+++ b/Sources/Basics/Cancellator.swift
@@ -20,7 +20,7 @@ import WinSDK
 
 public typealias CancellationHandler = (DispatchTime) throws -> Void
 
-public class Cancellator: Cancellable {
+public final class Cancellator: Cancellable {
     public typealias RegistrationKey = String
 
     private let observabilityScope: ObservabilityScope?

--- a/Sources/Basics/Cancellator.swift
+++ b/Sources/Basics/Cancellator.swift
@@ -52,7 +52,7 @@ public final class Cancellator: Cancellable {
             // set shutdown handler to terminate sub-processes, etc
             _ = SetConsoleCtrlHandler({ _ in
                 // Terminate all processes on receiving an interrupt signal.
-                try? Self.shared?.cancel(deadline: .now() + .seconds(30))
+                try? Cancellator.shared?.cancel(deadline: .now() + .seconds(30))
                 
                 // Reset the handler.
                 _ = SetConsoleCtrlHandler(nil, false)

--- a/Sources/CoreCommands/SwiftTool.swift
+++ b/Sources/CoreCommands/SwiftTool.swift
@@ -275,6 +275,7 @@ public final class SwiftTool {
     internal init(
         outputStream: OutputByteStream,
         options: GlobalOptions,
+        shouldInstallSignalHandlers: Bool = true,
         toolWorkspaceConfiguration: ToolWorkspaceConfiguration,
         workspaceDelegateProvider: @escaping WorkspaceDelegateProvider,
         workspaceLoaderProvider: @escaping WorkspaceLoaderProvider
@@ -308,7 +309,9 @@ public final class SwiftTool {
                 try ProcessEnv.chdir(packagePath)
             }
 
-            cancellator.installSignalHandlers()
+            if shouldInstallSignalHandlers {
+                cancellator.installSignalHandlers()
+            }
             self.cancellator = cancellator
         } catch {
             self.observabilityScope.emit(error)

--- a/Sources/CoreCommands/SwiftTool.swift
+++ b/Sources/CoreCommands/SwiftTool.swift
@@ -50,13 +50,16 @@ import var TSCUtility.verbosity
 typealias Diagnostic = Basics.Diagnostic
 
 public struct ToolWorkspaceConfiguration {
+    let shouldInstallSignalHandlers: Bool
     let wantsMultipleTestProducts: Bool
     let wantsREPLProduct: Bool
 
     public init(
+        shouldInstallSignalHandlers: Bool = true,
         wantsMultipleTestProducts: Bool = false,
         wantsREPLProduct: Bool = false
     ) {
+        self.shouldInstallSignalHandlers = shouldInstallSignalHandlers
         self.wantsMultipleTestProducts = wantsMultipleTestProducts
         self.wantsREPLProduct = wantsREPLProduct
     }
@@ -275,7 +278,6 @@ public final class SwiftTool {
     internal init(
         outputStream: OutputByteStream,
         options: GlobalOptions,
-        shouldInstallSignalHandlers: Bool = true,
         toolWorkspaceConfiguration: ToolWorkspaceConfiguration,
         workspaceDelegateProvider: @escaping WorkspaceDelegateProvider,
         workspaceLoaderProvider: @escaping WorkspaceLoaderProvider
@@ -309,7 +311,7 @@ public final class SwiftTool {
                 try ProcessEnv.chdir(packagePath)
             }
 
-            if shouldInstallSignalHandlers {
+            if toolWorkspaceConfiguration.shouldInstallSignalHandlers {
                 cancellator.installSignalHandlers()
             }
             self.cancellator = cancellator

--- a/Tests/CommandsTests/SwiftToolTests.swift
+++ b/Tests/CommandsTests/SwiftToolTests.swift
@@ -237,6 +237,7 @@ extension SwiftTool {
         return try SwiftTool(
             outputStream: outputStream,
             options: options,
+            shouldInstallSignalHandlers: false,
             toolWorkspaceConfiguration: .init(),
             workspaceDelegateProvider: {
                 ToolWorkspaceDelegate(

--- a/Tests/CommandsTests/SwiftToolTests.swift
+++ b/Tests/CommandsTests/SwiftToolTests.swift
@@ -237,8 +237,7 @@ extension SwiftTool {
         return try SwiftTool(
             outputStream: outputStream,
             options: options,
-            shouldInstallSignalHandlers: false,
-            toolWorkspaceConfiguration: .init(),
+            toolWorkspaceConfiguration: .init(shouldInstallSignalHandlers: false),
             workspaceDelegateProvider: {
                 ToolWorkspaceDelegate(
                     observabilityScope: $0,


### PR DESCRIPTION
### Motivation:

These signal handlers are useful to other tools that don't have access to `SwiftTool`. For example, `DestinationCommand` would benefit from this as it needs to set up its own cancellator for handling archiver processes.

### Modifications:

Moved signal handler setup to a new `installSignalHandlers` function on `Cancellator`. Made captures of `Cancellator` in handler closures weak so that it's not referenced indefinitely and is released when no longer needed.

### Result:

`Cancellator/installSignalHandler` can be used in more places.
