### PR TITLE
sort identities from url lookup to make lookup result consistent

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -4139,7 +4139,7 @@ extension Workspace {
                     completion(.failure(error))
                 case .success(let identities):
                     // FIXME: returns first result... need to consider how to address multiple ones
-                    let identity = identities.first
+                    let identity = identities.sorted().first
                     self.identityLookupCache[url] = (result: .success(identity), expirationTime: .now() + self.cacheTTL)
                     completion(.success(identity))
                 }


### PR DESCRIPTION
motivation: url lookup results should be consistent

changes: sort identities before picking the one to use
