### PR TITLE
Add a minimal test for the PD macro API

### DIFF
--- a/Tests/PackageLoadingTests/PD_Next_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_Next_LoadingTests.swift
@@ -39,4 +39,21 @@ class PackageDescriptionNextLoadingTests: PackageDescriptionLoadingTests {
             }
         }
     }
+
+    func testMacroTargets() throws {
+        let content = """
+            import CompilerPluginSupport
+            import PackageDescription
+
+            let package = Package(name: "MyPackage",
+                targets: [
+                    .macro(name: "MyMacro"),
+                ]
+            )
+            """
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let (_, diagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
+        XCTAssertEqual(diagnostics.count, 0, "unexpected diagnostics: \(diagnostics)")
+    }
 }


### PR DESCRIPTION
This should avoid regressions like the one introduced by #6356
