### PR TITLE
[main] temporarily disable flaky part of test

### DIFF
--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -189,6 +189,8 @@ final class BuildToolTests: CommandsTestCase {
         }
     }
     
+    // disabled due to intermittant failures rdar://107759919
+    /*
     func testAtMainSupport() throws {
         try fixture(name: "Miscellaneous/AtMainSupport") { fixturePath in
             let fullPath = try resolveSymlinks(fixturePath)
@@ -209,6 +211,7 @@ final class BuildToolTests: CommandsTestCase {
             }
         }
     }
+    */
 
     func testNonReachableProductsAndTargetsFunctional() throws {
         try fixture(name: "Miscellaneous/UnreachableTargets") { fixturePath in


### PR DESCRIPTION
this test is failing in PR testing on and off on `release/5.9` and `main`.