### PR TITLE
[5.9] ManifestSourceGeneration incorrectly writes out `DriverKit` instead of `driverKit` (#6405)

### DIFF
--- a/Sources/PackageModel/ManifestSourceGeneration.swift
+++ b/Sources/PackageModel/ManifestSourceGeneration.swift
@@ -143,7 +143,7 @@ fileprivate extension SourceCodeFragment {
         case "watchos":
             self.init(enum: "watchOS", string: platform.version)
         case "driverkit":
-            self.init(enum: "DriverKit", string: platform.version)
+            self.init(enum: "driverKit", string: platform.version)
         default:
             self.init(enum: "custom", subnodes: [ .init(string: platform.platformName), .init(key: "versionString", string: platform.version) ])
         }
@@ -367,7 +367,7 @@ fileprivate extension SourceCodeFragment {
             case "ios": return SourceCodeFragment(enum: "iOS")
             case "tvos": return SourceCodeFragment(enum: "tvOS")
             case "watchos": return SourceCodeFragment(enum: "watchOS")
-            case "driverkit": return SourceCodeFragment(enum: "DriverKit")
+            case "driverkit": return SourceCodeFragment(enum: "driverKit")
             default: return SourceCodeFragment(enum: platformName)
             }
         }

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -423,6 +423,58 @@ class ManifestSourceGenerationTests: XCTestCase {
         XCTAssertTrue(newContents.contains("import Foundation\n"), "contents: \(newContents)")
     }
 
+    func testLatestPlatformVersions() throws {
+        let manifestContents = """
+            // swift-tools-version: 5.9
+            // The swift-tools-version declares the minimum version of Swift required to build this package.
+
+            import PackageDescription
+
+            let package = Package(
+                name: "MyPackage",
+                platforms: [
+                    .macOS(.v13),
+                    .iOS(.v16),
+                    .tvOS(.v16),
+                    .watchOS(.v9),
+                    .macCatalyst(.v16),
+                    .driverKit(.v22)
+                ],
+                targets: [
+                ]
+            )
+            """
+        try testManifestWritingRoundTrip(manifestContents: manifestContents, toolsVersion: .v5_9)
+    }
+
+    func testTargetPlatformConditions() throws {
+        let manifestContents = """
+            // swift-tools-version: 5.9
+            // The swift-tools-version declares the minimum version of Swift required to build this package.
+
+            import PackageDescription
+
+            let package = Package(
+                name: "MyPackage",
+                targets: [
+                    .target(
+                        name: "MyExe",
+                        dependencies: [
+                            .target(name: "MyLib", condition: .when(platforms: [
+                                .macOS, .macCatalyst, .iOS, .tvOS, .watchOS, .driverKit,
+                                .linux, .windows, .android, .wasi, .openbsd
+                            ]))
+                        ]
+                    ),
+                    .target(
+                        name: "MyLib"
+                    ),
+                ]
+            )
+            """
+        try testManifestWritingRoundTrip(manifestContents: manifestContents, toolsVersion: .v5_9)
+    }
+    
     func testCustomProductSourceGeneration() throws {
         // Create a manifest containing a product for which we'd like to do custom source fragment generation.
         let packageDir = AbsolutePath("/tmp/MyLibrary")


### PR DESCRIPTION
This is a SwiftPM 5.9 nomination of #6405.

rdar://107795051

(cherry picked from commit 5d83b595f9650c2f477fe757907d80265df6ad33)
