### PR TITLE
Add author to collection package release metadata

### DIFF
--- a/Sources/PackageCollections/Model/PackageTypes.swift
+++ b/Sources/PackageCollections/Model/PackageTypes.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2020-2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -140,6 +140,9 @@ extension PackageCollectionsModel.Package {
 
         /// The package version's license
         public let license: PackageCollectionsModel.License?
+        
+        /// The package version's author
+        public let author: PackageCollectionsModel.Package.Author?
 
         /// When the package version was created
         public let createdAt: Date?

--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2020-2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -657,6 +657,7 @@ public struct PackageCollections: PackageCollectionsProtocol, Closable {
                          defaultToolsVersion: packageVersion.defaultToolsVersion,
                          verifiedCompatibility: packageVersion.verifiedCompatibility,
                          license: packageVersion.license,
+                         author: versionMetadata?.author,
                          createdAt: versionMetadata?.createdAt ?? packageVersion.createdAt)
         }
         versions.sort(by: >)

--- a/Sources/PackageCollections/PackageIndex.swift
+++ b/Sources/PackageCollections/PackageIndex.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -262,6 +262,7 @@ extension PackageIndex: PackageMetadataProvider {
                             version: version.version,
                             title: version.title,
                             summary: version.summary,
+                            author: version.author,
                             createdAt: version.createdAt
                         )
                     },

--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -258,6 +258,7 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
                                  defaultToolsVersion: defaultToolsVersion,
                                  verifiedCompatibility: verifiedCompatibility,
                                  license: license,
+                                 author: nil,
                                  createdAt: version.createdAt)
                 }
                 if versions.count != package.versions.count {

--- a/Sources/PackageCollections/Providers/PackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/PackageMetadataProvider.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2020-2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -49,6 +49,7 @@ extension Model {
         let version: TSCUtility.Version
         let title: String?
         let summary: String?
+        let author: PackageCollectionsModel.Package.Author?
         let createdAt: Date?
     }
 }

--- a/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
+++ b/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2020-2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -109,9 +109,11 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
                 XCTAssertEqual(metadata.versions[0].version, TSCUtility.Version(tag: "v2.0.0"))
                 XCTAssertEqual(metadata.versions[0].title, "2.0.0")
                 XCTAssertEqual(metadata.versions[0].summary, "Description of the release")
+                XCTAssertEqual(metadata.versions[0].author?.username, "octocat")
                 XCTAssertEqual(metadata.versions[1].version, TSCUtility.Version("1.0.0"))
                 XCTAssertEqual(metadata.versions[1].title, "1.0.0")
                 XCTAssertEqual(metadata.versions[1].summary, "Description of the release")
+                XCTAssertEqual(metadata.versions[1].author?.username, "octocat")
                 XCTAssertEqual(metadata.authors, [PackageCollectionsModel.Package.Author(username: "octocat",
                                                                                          url: "https://api.github.com/users/octocat",
                                                                                          service: .init(name: "GitHub"))])

--- a/Tests/PackageCollectionsTests/PackageCollectionsModelTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsModelTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2020-2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -26,11 +26,11 @@ final class PackageCollectionsModelTests: XCTestCase {
             toolsVersion: toolsVersion, packageName: "FooBar", targets: targets, products: products, minimumPlatformVersions: nil
         )]
         let versions: [PackageCollectionsModel.Package.Version] = [
-            .init(version: .init(stringLiteral: "1.2.0"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
-            .init(version: .init(stringLiteral: "2.0.1"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
-            .init(version: .init(stringLiteral: "2.1.0-beta.3"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
-            .init(version: .init(stringLiteral: "2.1.0"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
-            .init(version: .init(stringLiteral: "3.0.0-beta.1"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
+            .init(version: .init(stringLiteral: "1.2.0"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, author: nil, createdAt: nil),
+            .init(version: .init(stringLiteral: "2.0.1"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, author: nil, createdAt: nil),
+            .init(version: .init(stringLiteral: "2.1.0-beta.3"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, author: nil, createdAt: nil),
+            .init(version: .init(stringLiteral: "2.1.0"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, author: nil, createdAt: nil),
+            .init(version: .init(stringLiteral: "3.0.0-beta.1"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, author: nil, createdAt: nil),
         ]
 
         XCTAssertEqual("2.1.0", versions.latestRelease?.version.description)
@@ -45,8 +45,8 @@ final class PackageCollectionsModelTests: XCTestCase {
             toolsVersion: toolsVersion, packageName: "FooBar", targets: targets, products: products, minimumPlatformVersions: nil
         )]
         let versions: [PackageCollectionsModel.Package.Version] = [
-            .init(version: .init(stringLiteral: "2.1.0-beta.3"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
-            .init(version: .init(stringLiteral: "3.0.0-beta.1"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
+            .init(version: .init(stringLiteral: "2.1.0-beta.3"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, author: nil, createdAt: nil),
+            .init(version: .init(stringLiteral: "3.0.0-beta.1"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, author: nil, createdAt: nil),
         ]
 
         XCTAssertNil(versions.latestRelease)
@@ -61,9 +61,9 @@ final class PackageCollectionsModelTests: XCTestCase {
             toolsVersion: toolsVersion, packageName: "FooBar", targets: targets, products: products, minimumPlatformVersions: nil
         )]
         let versions: [PackageCollectionsModel.Package.Version] = [
-            .init(version: .init(stringLiteral: "1.2.0"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
-            .init(version: .init(stringLiteral: "2.0.1"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
-            .init(version: .init(stringLiteral: "2.1.0"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
+            .init(version: .init(stringLiteral: "1.2.0"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, author: nil, createdAt: nil),
+            .init(version: .init(stringLiteral: "2.0.1"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, author: nil, createdAt: nil),
+            .init(version: .init(stringLiteral: "2.1.0"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, author: nil, createdAt: nil),
         ]
 
         XCTAssertEqual("2.1.0", versions.latestRelease?.version.description)

--- a/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2020-2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -690,6 +690,7 @@ final class PackageCollectionsTests: XCTestCase {
                                                                   defaultToolsVersion: toolsVersion,
                                                                   verifiedCompatibility: nil,
                                                                   license: nil,
+                                                                  author: nil,
                                                                   createdAt: nil)
 
         let url = "https://packages.mock/\(UUID().uuidString)"
@@ -857,6 +858,7 @@ final class PackageCollectionsTests: XCTestCase {
                                                                   defaultToolsVersion: toolsVersion,
                                                                   verifiedCompatibility: nil,
                                                                   license: nil,
+                                                                  author: nil,
                                                                   createdAt: nil)
 
         let mockPackageURL = "https://packages.mock/\(UUID().uuidString)"
@@ -1298,6 +1300,7 @@ final class PackageCollectionsTests: XCTestCase {
                                                         .init(platform: .linux, swiftVersion: SwiftLanguageVersion.knownSwiftLanguageVersions.randomElement()!),
                                                     ],
                                                     license: PackageCollectionsModel.License(type: .Apache2_0, url: "http://apache.license"),
+                                                    author: .init(username: "\($0)", url: nil, service: nil),
                                                     createdAt: Date())
         }
 
@@ -1315,7 +1318,7 @@ final class PackageCollectionsTests: XCTestCase {
 
         let mockMetadata = PackageCollectionsModel.PackageBasicMetadata(summary: "\(mockPackage.summary!) 2",
                                                                         keywords: mockPackage.keywords.flatMap { $0.map { "\($0)-2" } },
-                                                                        versions: mockPackage.versions.map { PackageCollectionsModel.PackageBasicVersionMetadata(version: $0.version, title: "\($0.title!) 2", summary: "\($0.summary!) 2", createdAt: Date()) },
+                                                                        versions: mockPackage.versions.map { PackageCollectionsModel.PackageBasicVersionMetadata(version: $0.version, title: "\($0.title!) 2", summary: "\($0.summary!) 2", author: .init(username: "\(($0.author?.username ?? "") + "2")", url: nil, service: nil), createdAt: Date()) },
                                                                         watchersCount: mockPackage.watchersCount! + 1,
                                                                         readmeURL: "\(mockPackage.readmeURL!.absoluteString)-2",
                                                                         license: PackageCollectionsModel.License(type: .Apache2_0, url: "\(mockPackage.license!.url.absoluteString)-2"),
@@ -1345,6 +1348,7 @@ final class PackageCollectionsTests: XCTestCase {
             XCTAssertEqual(version.verifiedCompatibility, metadataVersion?.verifiedCompatibility, "verifiedCompatibility should match")
             XCTAssertEqual(version.license, metadataVersion?.license, "license should match")
             XCTAssertEqual(mockMetadataVersion?.summary, metadataVersion?.summary, "summary should match")
+            XCTAssertEqual(mockMetadataVersion?.author, metadataVersion?.author, "author should match")
             XCTAssertEqual(mockMetadataVersion?.createdAt, metadataVersion?.createdAt, "createdAt should match")
         }
         XCTAssertEqual(metadata.latestVersion, metadata.versions.first, "versions should be sorted")
@@ -1532,6 +1536,7 @@ final class PackageCollectionsTests: XCTestCase {
                                                                   defaultToolsVersion: toolsVersion,
                                                                   verifiedCompatibility: nil,
                                                                   license: nil,
+                                                                  author: nil,
                                                                   createdAt: nil)
 
         let mockPackageURL = "https://packages.mock/\(UUID().uuidString)"

--- a/Tests/PackageCollectionsTests/PackageIndexAndCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageIndexAndCollectionsTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -132,6 +132,7 @@ class PackageIndexAndCollectionsTests: XCTestCase {
                                                                   defaultToolsVersion: toolsVersion,
                                                                   verifiedCompatibility: nil,
                                                                   license: nil,
+                                                                  author: nil,
                                                                   createdAt: nil)
 
         let mockPackageURL = "https://packages.mock/\(UUID().uuidString)"
@@ -269,6 +270,7 @@ class PackageIndexAndCollectionsTests: XCTestCase {
                                                                   defaultToolsVersion: toolsVersion,
                                                                   verifiedCompatibility: nil,
                                                                   license: nil,
+                                                                  author: nil,
                                                                   createdAt: nil)
 
         let mockPackageURL = "https://packages.mock/\(UUID().uuidString)"
@@ -485,6 +487,7 @@ class PackageIndexAndCollectionsTests: XCTestCase {
                                                                   defaultToolsVersion: toolsVersion,
                                                                   verifiedCompatibility: nil,
                                                                   license: nil,
+                                                                  author: nil,
                                                                   createdAt: nil)
 
         let url = "https://packages.mock/\(UUID().uuidString)"
@@ -586,6 +589,7 @@ class PackageIndexAndCollectionsTests: XCTestCase {
                                                                   defaultToolsVersion: toolsVersion,
                                                                   verifiedCompatibility: nil,
                                                                   license: nil,
+                                                                  author: nil,
                                                                   createdAt: nil)
 
         let url = "https://packages.mock/\(UUID().uuidString)"

--- a/Tests/PackageCollectionsTests/Utility.swift
+++ b/Tests/PackageCollectionsTests/Utility.swift
@@ -102,6 +102,7 @@ func makeMockPackage(id: String) -> PackageCollectionsModel.Package {
                                                        defaultToolsVersion: toolsVersion,
                                                        verifiedCompatibility: verifiedCompatibility,
                                                        license: license,
+                                                       author: nil,
                                                        createdAt: Date())
     }
 
@@ -120,7 +121,13 @@ func makeMockPackage(id: String) -> PackageCollectionsModel.Package {
 func makeMockPackageBasicMetadata() -> PackageCollectionsModel.PackageBasicMetadata {
     return .init(summary: UUID().uuidString,
                  keywords: (0 ..< Int.random(in: 1 ... 3)).map { "keyword \($0)" },
-                 versions: (0 ..< Int.random(in: 1 ... 10)).map { .init(version: TSCUtility.Version($0, 0, 0), title: "title \($0)", summary: "description \($0)", createdAt: Date()) },
+                 versions: (0 ..< Int.random(in: 1 ... 10)).map { .init(
+                    version: TSCUtility.Version($0, 0, 0),
+                    title: "title \($0)",
+                    summary: "description \($0)",
+                    author: nil,
+                    createdAt: Date()
+                 )},
                  watchersCount: Int.random(in: 0 ... 50),
                  readmeURL: "https://package-readme",
                  license: PackageCollectionsModel.License(type: .Apache2_0, url: "https://package-license"),


### PR DESCRIPTION
Motivation:
Package collection should have information about how a version was created. This includes the creator and timestamp.
 - "Who created the package version?": added in this PR
 - "When was the version created?": this is version's `createdAt`, which already exists.

rdar://106674475

Modifications:
Extract `author` from GitHub API's release data and make it available through package collection's `Package` model.
