### PR TITLE
Add author and signer to package collection models

### DIFF
--- a/Fixtures/Collections/JSON/good.json
+++ b/Fixtures/Collections/JSON/good.json
@@ -66,6 +66,15 @@
             "name": "Apache-2.0",
             "url": "https://www.example.com/repos/RepoOne/LICENSE"
           },
+          "author": {
+            "name": "J. Appleseed"
+          },
+          "signer": {
+            "type": "ADP",
+            "commonName": "J. Appleseed",
+            "organizationalUnitName": "A1",
+            "organizationName": "Appleseed Inc."
+          },
           "createdAt": "2020-10-21T09:25:36Z"
         }
       ]

--- a/Fixtures/Collections/JSON/good_signed.json
+++ b/Fixtures/Collections/JSON/good_signed.json
@@ -66,6 +66,15 @@
             "name": "Apache-2.0",
             "url": "https://www.example.com/repos/RepoOne/LICENSE"
           },
+          "author": {
+            "name": "J. Appleseed"
+          },
+          "signer": {
+            "type": "ADP",
+            "commonName": "J. Appleseed",
+            "organizationalUnitName": "A1",
+            "organizationName": "Appleseed Inc."
+          },
           "createdAt": "2020-10-21T09:25:36Z"
         }
       ]

--- a/Package.swift
+++ b/Package.swift
@@ -370,6 +370,7 @@ let package = Package(
                 "PackageCollections",
                 "PackageModel",
                 "PackageRegistry",
+                "PackageSigning",
             ]
         ),
 

--- a/Sources/PackageCollections/Model/PackageTypes.swift
+++ b/Sources/PackageCollections/Model/PackageTypes.swift
@@ -143,6 +143,9 @@ extension PackageCollectionsModel.Package {
         
         /// The package version's author
         public let author: PackageCollectionsModel.Package.Author?
+        
+        /// The package version's signer
+        public let signer: PackageCollectionsModel.Signer?
 
         /// When the package version was created
         public let createdAt: Date?
@@ -221,6 +224,38 @@ extension PackageCollectionsModel.Package {
             /// The service name
             public let name: String
         }
+    }
+}
+
+extension PackageCollectionsModel {
+    public struct Signer: Equatable, Codable {
+        /// The signer type.
+        public let type: SignerType
+        
+        /// The common name of the signing certificate's subject.
+        public let commonName: String
+        
+        /// The organizational unit name of the signing certificate's subject.
+        public let organizationalUnitName: String
+        
+        /// The organization name of the signing certificate's subject.
+        public let organizationName: String
+
+        public init(
+            type: SignerType,
+            commonName: String,
+            organizationalUnitName: String,
+            organizationName: String
+        ) {
+            self.type = type
+            self.commonName = commonName
+            self.organizationalUnitName = organizationalUnitName
+            self.organizationName = organizationName
+        }
+    }
+    
+    public enum SignerType: String, Codable {
+        case adp // Apple Developer Program
     }
 }
 

--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -657,7 +657,8 @@ public struct PackageCollections: PackageCollectionsProtocol, Closable {
                          defaultToolsVersion: packageVersion.defaultToolsVersion,
                          verifiedCompatibility: packageVersion.verifiedCompatibility,
                          license: packageVersion.license,
-                         author: versionMetadata?.author,
+                         author: versionMetadata?.author ?? packageVersion.author,
+                         signer: packageVersion.signer,
                          createdAt: versionMetadata?.createdAt ?? packageVersion.createdAt)
         }
         versions.sort(by: >)

--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -251,6 +251,18 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
                     }
                     let license = version.license.flatMap { Model.License(from: $0) }
 
+                    let signer: Model.Signer?
+                    if let versionSigner = version.signer, let signerType = Model.SignerType(rawValue: versionSigner.type.lowercased()) {
+                        signer = .init(
+                            type: signerType,
+                            commonName: versionSigner.commonName,
+                            organizationalUnitName: versionSigner.organizationalUnitName,
+                            organizationName: versionSigner.organizationName
+                        )
+                    } else {
+                        signer = nil
+                    }
+
                     return .init(version: parsedVersion,
                                  title: nil,
                                  summary: version.summary,
@@ -258,7 +270,8 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
                                  defaultToolsVersion: defaultToolsVersion,
                                  verifiedCompatibility: verifiedCompatibility,
                                  license: license,
-                                 author: nil,
+                                 author: version.author.map { .init(username: $0.name, url: nil, service: nil) },
+                                 signer: signer,
                                  createdAt: version.createdAt)
                 }
                 if versions.count != package.versions.count {

--- a/Sources/PackageCollectionsModel/Formats/v1.md
+++ b/Sources/PackageCollectionsModel/Formats/v1.md
@@ -100,6 +100,13 @@ A version object has metadata extracted from `Package.swift` and optionally addi
 * `license`: The package version's license. **Optional.**
     * `url`: The URL of the license file.
     * `name`: License name. [SPDX identifier](https://spdx.org/licenses/) (e.g., `Apache-2.0`, `MIT`, etc.) preferred. Omit if unknown. **Optional.**
+* `author`: The package version's author. **Optional.**
+    * `name`: The author of the package version.
+* `signer`: The signer of the package version. **Optional.** Refer to [documentation](https://github.com/apple/swift-package-manager/blob/main/Documentation/PackageRegistryUsage.md#package-signing) on package signing for details.
+    * `type`: The signer type. Currently the only valid value is `ADP` (Apple Developer Program).
+    * `commonName`: The common name of the signing certificate's subject.
+    * `organizationalUnitName`: The organizational unit name of the signing certificate's subject.
+    * `organizationName`: The organization name of the signing certificate's subject.           
 * `createdAt`: The ISO 8601-formatted datetime string when the package version was created. **Optional.**
 
 ##### Version-specific manifests

--- a/Sources/PackageCollectionsModel/PackageCollectionModel+v1.swift
+++ b/Sources/PackageCollectionsModel/PackageCollectionModel+v1.swift
@@ -141,6 +141,12 @@ extension PackageCollectionModel.V1.Collection.Package {
         /// The package version's license.
         public let license: PackageCollectionModel.V1.License?
 
+        /// The author of the package version.
+        public let author: Author?
+
+        /// The signer of the package version.
+        public let signer: PackageCollectionModel.V1.Signer?
+
         /// When the package version was created.
         public let createdAt: Date?
 
@@ -152,6 +158,8 @@ extension PackageCollectionModel.V1.Collection.Package {
             defaultToolsVersion: String,
             verifiedCompatibility: [PackageCollectionModel.V1.Compatibility]?,
             license: PackageCollectionModel.V1.License?,
+            author: Author?,
+            signer: PackageCollectionModel.V1.Signer?,
             createdAt: Date?
         ) {
             self.version = version
@@ -160,6 +168,8 @@ extension PackageCollectionModel.V1.Collection.Package {
             self.defaultToolsVersion = defaultToolsVersion
             self.verifiedCompatibility = verifiedCompatibility
             self.license = license
+            self.author = author
+            self.signer = signer
             self.createdAt = createdAt
         }
 
@@ -192,6 +202,16 @@ extension PackageCollectionModel.V1.Collection.Package {
                 self.targets = targets
                 self.products = products
                 self.minimumPlatformVersions = minimumPlatformVersions
+            }
+        }
+
+        public struct Author: Equatable, Codable {
+            /// The author name.
+            public let name: String
+
+            /// Creates an `Author`
+            public init(name: String) {
+                self.name = name
             }
         }
     }
@@ -284,6 +304,32 @@ extension PackageCollectionModel.V1 {
         public init(name: String?, url: URL) {
             self.name = name
             self.url = url
+        }
+    }
+
+    public struct Signer: Equatable, Codable {
+        /// The signer type. (e.g., ADP)
+        public let type: String
+
+        /// The common name of the signing certificate's subject.
+        public let commonName: String
+
+        /// The organizational unit name of the signing certificate's subject.
+        public let organizationalUnitName: String
+
+        /// The organization name of the signing certificate's subject.
+        public let organizationName: String
+
+        public init(
+            type: String,
+            commonName: String,
+            organizationalUnitName: String,
+            organizationName: String
+        ) {
+            self.type = type
+            self.commonName = commonName
+            self.organizationalUnitName = organizationalUnitName
+            self.organizationName = organizationName
         }
     }
 }

--- a/Tests/PackageCollectionsModelTests/PackageCollectionModelTests.swift
+++ b/Tests/PackageCollectionsModelTests/PackageCollectionModelTests.swift
@@ -42,6 +42,13 @@ class PackageCollectionModelTests: XCTestCase {
                         defaultToolsVersion: "5.2",
                         verifiedCompatibility: [Model.Compatibility(platform: Model.Platform(name: "macOS"), swiftVersion: "5.2")],
                         license: .init(name: "Apache-2.0", url: "https://package-collection-tests.com/repos/foobar/LICENSE"),
+                        author: .init(name: "J. Appleseed"),
+                        signer: .init(
+                            type: "ADP",
+                            commonName: "J. Appleseed",
+                            organizationalUnitName: "A1",
+                            organizationName: "Appleseed Inc."
+                        ),
                         createdAt: Date()
                     ),
                 ],
@@ -88,6 +95,13 @@ class PackageCollectionModelTests: XCTestCase {
                         defaultToolsVersion: "5.2",
                         verifiedCompatibility: [Model.Compatibility(platform: Model.Platform(name: "macOS"), swiftVersion: "5.2")],
                         license: .init(name: "Apache-2.0", url: "https://package-collection-tests.com/repos/foobar/LICENSE"),
+                        author: .init(name: "J. Appleseed"),
+                        signer: .init(
+                            type: "ADP",
+                            commonName: "J. Appleseed",
+                            organizationalUnitName: "A1",
+                            organizationName: "Appleseed Inc."
+                        ),
                         createdAt: Date()
                     ),
                 ],

--- a/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
+++ b/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
@@ -76,6 +76,8 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             XCTAssertEqual(version.verifiedCompatibility!.first!.platform, .macOS)
             XCTAssertEqual(version.verifiedCompatibility!.first!.swiftVersion, SwiftLanguageVersion(string: "5.1")!)
             XCTAssertEqual(version.license, .init(type: .Apache2_0, url: "https://www.example.com/repos/RepoOne/LICENSE"))
+            XCTAssertEqual(version.author?.username, "J. Appleseed")
+            XCTAssertEqual(version.signer?.commonName, "J. Appleseed")
             XCTAssertNotNil(version.createdAt)
             XCTAssertFalse(collection.isSigned)
             
@@ -122,6 +124,9 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             XCTAssertEqual(version.verifiedCompatibility!.first!.platform, .macOS)
             XCTAssertEqual(version.verifiedCompatibility!.first!.swiftVersion, SwiftLanguageVersion(string: "5.1")!)
             XCTAssertEqual(version.license, .init(type: .Apache2_0, url: "https://www.example.com/repos/RepoOne/LICENSE"))
+            XCTAssertEqual(version.author?.username, "J. Appleseed")
+            XCTAssertEqual(version.signer?.commonName, "J. Appleseed")
+            XCTAssertNotNil(version.createdAt)
             XCTAssertFalse(collection.isSigned)
             
             XCTAssertEqual(collection.packages[1].identity, .init(urlString: "https://www.example.com/repos/RepoTwo.git"))
@@ -426,6 +431,8 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             XCTAssertEqual(version.verifiedCompatibility!.first!.platform, .macOS)
             XCTAssertEqual(version.verifiedCompatibility!.first!.swiftVersion, SwiftLanguageVersion(string: "5.1")!)
             XCTAssertEqual(version.license, .init(type: .Apache2_0, url: "https://www.example.com/repos/RepoOne/LICENSE"))
+            XCTAssertEqual(version.author?.username, "J. Appleseed")
+            XCTAssertEqual(version.signer?.commonName, "J. Appleseed")
             XCTAssertNotNil(version.createdAt)
             XCTAssertTrue(collection.isSigned)
             let signature = collection.signature!
@@ -496,6 +503,8 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             XCTAssertEqual(version.verifiedCompatibility!.first!.platform, .macOS)
             XCTAssertEqual(version.verifiedCompatibility!.first!.swiftVersion, SwiftLanguageVersion(string: "5.1")!)
             XCTAssertEqual(version.license, .init(type: .Apache2_0, url: "https://www.example.com/repos/RepoOne/LICENSE"))
+            XCTAssertEqual(version.author?.username, "J. Appleseed")
+            XCTAssertEqual(version.signer?.commonName, "J. Appleseed")
             XCTAssertNotNil(version.createdAt)
             XCTAssertTrue(collection.isSigned)
             let signature = collection.signature!
@@ -633,6 +642,9 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             XCTAssertEqual(version.verifiedCompatibility!.first!.platform, .macOS)
             XCTAssertEqual(version.verifiedCompatibility!.first!.swiftVersion, SwiftLanguageVersion(string: "5.1")!)
             XCTAssertEqual(version.license, .init(type: .Apache2_0, url: "https://www.example.com/repos/RepoOne/LICENSE"))
+            XCTAssertEqual(version.author?.username, "J. Appleseed")
+            XCTAssertEqual(version.signer?.commonName, "J. Appleseed")
+            XCTAssertNotNil(version.createdAt)
             XCTAssertTrue(collection.isSigned)
             let signature = collection.signature!
             XCTAssertTrue(signature.isVerified)
@@ -704,6 +716,8 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             XCTAssertEqual(version.verifiedCompatibility!.first!.platform, .macOS)
             XCTAssertEqual(version.verifiedCompatibility!.first!.swiftVersion, SwiftLanguageVersion(string: "5.1")!)
             XCTAssertEqual(version.license, .init(type: .Apache2_0, url: "https://www.example.com/repos/RepoOne/LICENSE"))
+            XCTAssertEqual(version.author?.username, "J. Appleseed")
+            XCTAssertEqual(version.signer?.commonName, "J. Appleseed")
             XCTAssertNotNil(version.createdAt)
             XCTAssertTrue(collection.isSigned)
             let signature = collection.signature!
@@ -781,6 +795,8 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             XCTAssertEqual(version.verifiedCompatibility!.first!.platform, .macOS)
             XCTAssertEqual(version.verifiedCompatibility!.first!.swiftVersion, SwiftLanguageVersion(string: "5.1")!)
             XCTAssertEqual(version.license, .init(type: .Apache2_0, url: "https://www.example.com/repos/RepoOne/LICENSE"))
+            XCTAssertEqual(version.author?.username, "J. Appleseed")
+            XCTAssertEqual(version.signer?.commonName, "J. Appleseed")
             XCTAssertNotNil(version.createdAt)
             XCTAssertTrue(collection.isSigned)
             let signature = collection.signature!

--- a/Tests/PackageCollectionsTests/PackageCollectionValidationTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionValidationTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2020-2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -42,6 +42,8 @@ class PackageCollectionValidationTests: XCTestCase {
                         defaultToolsVersion: "5.2",
                         verifiedCompatibility: nil,
                         license: nil,
+                        author: nil,
+                        signer: nil,
                         createdAt: nil
                     ),
                     Model.Collection.Package.Version(
@@ -59,6 +61,8 @@ class PackageCollectionValidationTests: XCTestCase {
                         defaultToolsVersion: "5.2",
                         verifiedCompatibility: nil,
                         license: nil,
+                        author: nil,
+                        signer: nil,
                         createdAt: nil
                     ),
                 ],
@@ -125,6 +129,8 @@ class PackageCollectionValidationTests: XCTestCase {
                         defaultToolsVersion: "5.2",
                         verifiedCompatibility: nil,
                         license: nil,
+                        author: nil,
+                        signer: nil,
                         createdAt: nil
                     ),
                 ],
@@ -151,6 +157,8 @@ class PackageCollectionValidationTests: XCTestCase {
                         defaultToolsVersion: "5.2",
                         verifiedCompatibility: nil,
                         license: nil,
+                        author: nil,
+                        signer: nil,
                         createdAt: nil
                     ),
                 ],
@@ -233,6 +241,8 @@ class PackageCollectionValidationTests: XCTestCase {
                         defaultToolsVersion: "5.2",
                         verifiedCompatibility: nil,
                         license: nil,
+                        author: nil,
+                        signer: nil,
                         createdAt: nil
                     ),
                     Model.Collection.Package.Version(
@@ -250,6 +260,8 @@ class PackageCollectionValidationTests: XCTestCase {
                         defaultToolsVersion: "5.2",
                         verifiedCompatibility: nil,
                         license: nil,
+                        author: nil,
+                        signer: nil,
                         createdAt: nil
                     ),
                 ],
@@ -310,6 +322,8 @@ class PackageCollectionValidationTests: XCTestCase {
                         defaultToolsVersion: "5.2",
                         verifiedCompatibility: nil,
                         license: nil,
+                        author: nil,
+                        signer: nil,
                         createdAt: nil
                     ),
                 ],
@@ -360,6 +374,8 @@ class PackageCollectionValidationTests: XCTestCase {
                         defaultToolsVersion: "5.2",
                         verifiedCompatibility: nil,
                         license: nil,
+                        author: nil,
+                        signer: nil,
                         createdAt: nil
                     ),
                     Model.Collection.Package.Version(
@@ -377,6 +393,8 @@ class PackageCollectionValidationTests: XCTestCase {
                         defaultToolsVersion: "5.2",
                         verifiedCompatibility: nil,
                         license: nil,
+                        author: nil,
+                        signer: nil,
                         createdAt: nil
                     ),
                 ],
@@ -403,6 +421,8 @@ class PackageCollectionValidationTests: XCTestCase {
                         defaultToolsVersion: "5.2",
                         verifiedCompatibility: nil,
                         license: nil,
+                        author: nil,
+                        signer: nil,
                         createdAt: nil
                     ),
                     Model.Collection.Package.Version(
@@ -420,6 +440,8 @@ class PackageCollectionValidationTests: XCTestCase {
                         defaultToolsVersion: "5.2",
                         verifiedCompatibility: nil,
                         license: nil,
+                        author: nil,
+                        signer: nil,
                         createdAt: nil
                     ),
                 ],
@@ -467,6 +489,8 @@ class PackageCollectionValidationTests: XCTestCase {
                         defaultToolsVersion: "5.2",
                         verifiedCompatibility: nil,
                         license: nil,
+                        author: nil,
+                        signer: nil,
                         createdAt: nil
                     ),
                 ],
@@ -517,6 +541,8 @@ class PackageCollectionValidationTests: XCTestCase {
                         defaultToolsVersion: "5.2",
                         verifiedCompatibility: nil,
                         license: nil,
+                        author: nil,
+                        signer: nil,
                         createdAt: nil
                     ),
                 ],
@@ -567,6 +593,8 @@ class PackageCollectionValidationTests: XCTestCase {
                         defaultToolsVersion: "5.1",
                         verifiedCompatibility: nil,
                         license: nil,
+                        author: nil,
+                        signer: nil,
                         createdAt: nil
                     ),
                 ],
@@ -617,6 +645,8 @@ class PackageCollectionValidationTests: XCTestCase {
                         defaultToolsVersion: "5.1",
                         verifiedCompatibility: nil,
                         license: nil,
+                        author: nil,
+                        signer: nil,
                         createdAt: nil
                     ),
                 ],

--- a/Tests/PackageCollectionsTests/PackageCollectionsModelTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsModelTests.swift
@@ -26,11 +26,11 @@ final class PackageCollectionsModelTests: XCTestCase {
             toolsVersion: toolsVersion, packageName: "FooBar", targets: targets, products: products, minimumPlatformVersions: nil
         )]
         let versions: [PackageCollectionsModel.Package.Version] = [
-            .init(version: .init(stringLiteral: "1.2.0"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, author: nil, createdAt: nil),
-            .init(version: .init(stringLiteral: "2.0.1"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, author: nil, createdAt: nil),
-            .init(version: .init(stringLiteral: "2.1.0-beta.3"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, author: nil, createdAt: nil),
-            .init(version: .init(stringLiteral: "2.1.0"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, author: nil, createdAt: nil),
-            .init(version: .init(stringLiteral: "3.0.0-beta.1"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, author: nil, createdAt: nil),
+            .init(version: .init(stringLiteral: "1.2.0"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, author: nil, signer: nil, createdAt: nil),
+            .init(version: .init(stringLiteral: "2.0.1"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, author: nil, signer: nil, createdAt: nil),
+            .init(version: .init(stringLiteral: "2.1.0-beta.3"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, author: nil, signer: nil, createdAt: nil),
+            .init(version: .init(stringLiteral: "2.1.0"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, author: nil, signer: nil, createdAt: nil),
+            .init(version: .init(stringLiteral: "3.0.0-beta.1"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, author: nil, signer: nil, createdAt: nil),
         ]
 
         XCTAssertEqual("2.1.0", versions.latestRelease?.version.description)
@@ -45,8 +45,8 @@ final class PackageCollectionsModelTests: XCTestCase {
             toolsVersion: toolsVersion, packageName: "FooBar", targets: targets, products: products, minimumPlatformVersions: nil
         )]
         let versions: [PackageCollectionsModel.Package.Version] = [
-            .init(version: .init(stringLiteral: "2.1.0-beta.3"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, author: nil, createdAt: nil),
-            .init(version: .init(stringLiteral: "3.0.0-beta.1"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, author: nil, createdAt: nil),
+            .init(version: .init(stringLiteral: "2.1.0-beta.3"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, author: nil, signer: nil, createdAt: nil),
+            .init(version: .init(stringLiteral: "3.0.0-beta.1"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, author: nil, signer: nil, createdAt: nil),
         ]
 
         XCTAssertNil(versions.latestRelease)
@@ -61,9 +61,9 @@ final class PackageCollectionsModelTests: XCTestCase {
             toolsVersion: toolsVersion, packageName: "FooBar", targets: targets, products: products, minimumPlatformVersions: nil
         )]
         let versions: [PackageCollectionsModel.Package.Version] = [
-            .init(version: .init(stringLiteral: "1.2.0"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, author: nil, createdAt: nil),
-            .init(version: .init(stringLiteral: "2.0.1"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, author: nil, createdAt: nil),
-            .init(version: .init(stringLiteral: "2.1.0"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, author: nil, createdAt: nil),
+            .init(version: .init(stringLiteral: "1.2.0"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, author: nil, signer: nil, createdAt: nil),
+            .init(version: .init(stringLiteral: "2.0.1"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, author: nil, signer: nil, createdAt: nil),
+            .init(version: .init(stringLiteral: "2.1.0"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, author: nil, signer: nil, createdAt: nil),
         ]
 
         XCTAssertEqual("2.1.0", versions.latestRelease?.version.description)

--- a/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
@@ -691,6 +691,7 @@ final class PackageCollectionsTests: XCTestCase {
                                                                   verifiedCompatibility: nil,
                                                                   license: nil,
                                                                   author: nil,
+                                                                  signer: nil,
                                                                   createdAt: nil)
 
         let url = "https://packages.mock/\(UUID().uuidString)"
@@ -859,6 +860,7 @@ final class PackageCollectionsTests: XCTestCase {
                                                                   verifiedCompatibility: nil,
                                                                   license: nil,
                                                                   author: nil,
+                                                                  signer: nil,
                                                                   createdAt: nil)
 
         let mockPackageURL = "https://packages.mock/\(UUID().uuidString)"
@@ -1301,6 +1303,7 @@ final class PackageCollectionsTests: XCTestCase {
                                                     ],
                                                     license: PackageCollectionsModel.License(type: .Apache2_0, url: "http://apache.license"),
                                                     author: .init(username: "\($0)", url: nil, service: nil),
+                                                    signer: .init(type: .adp, commonName: "\($0)", organizationalUnitName: "\($0) org unit", organizationName: "\($0) org"),
                                                     createdAt: Date())
         }
 
@@ -1349,6 +1352,7 @@ final class PackageCollectionsTests: XCTestCase {
             XCTAssertEqual(version.license, metadataVersion?.license, "license should match")
             XCTAssertEqual(mockMetadataVersion?.summary, metadataVersion?.summary, "summary should match")
             XCTAssertEqual(mockMetadataVersion?.author, metadataVersion?.author, "author should match")
+            XCTAssertEqual(version.signer, metadataVersion?.signer, "signer should match")
             XCTAssertEqual(mockMetadataVersion?.createdAt, metadataVersion?.createdAt, "createdAt should match")
         }
         XCTAssertEqual(metadata.latestVersion, metadata.versions.first, "versions should be sorted")
@@ -1537,6 +1541,7 @@ final class PackageCollectionsTests: XCTestCase {
                                                                   verifiedCompatibility: nil,
                                                                   license: nil,
                                                                   author: nil,
+                                                                  signer: nil,
                                                                   createdAt: nil)
 
         let mockPackageURL = "https://packages.mock/\(UUID().uuidString)"

--- a/Tests/PackageCollectionsTests/PackageIndexAndCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageIndexAndCollectionsTests.swift
@@ -133,6 +133,7 @@ class PackageIndexAndCollectionsTests: XCTestCase {
                                                                   verifiedCompatibility: nil,
                                                                   license: nil,
                                                                   author: nil,
+                                                                  signer: nil,
                                                                   createdAt: nil)
 
         let mockPackageURL = "https://packages.mock/\(UUID().uuidString)"
@@ -271,6 +272,7 @@ class PackageIndexAndCollectionsTests: XCTestCase {
                                                                   verifiedCompatibility: nil,
                                                                   license: nil,
                                                                   author: nil,
+                                                                  signer: nil,
                                                                   createdAt: nil)
 
         let mockPackageURL = "https://packages.mock/\(UUID().uuidString)"
@@ -488,6 +490,7 @@ class PackageIndexAndCollectionsTests: XCTestCase {
                                                                   verifiedCompatibility: nil,
                                                                   license: nil,
                                                                   author: nil,
+                                                                  signer: nil,
                                                                   createdAt: nil)
 
         let url = "https://packages.mock/\(UUID().uuidString)"
@@ -590,6 +593,7 @@ class PackageIndexAndCollectionsTests: XCTestCase {
                                                                   verifiedCompatibility: nil,
                                                                   license: nil,
                                                                   author: nil,
+                                                                  signer: nil,
                                                                   createdAt: nil)
 
         let url = "https://packages.mock/\(UUID().uuidString)"

--- a/Tests/PackageCollectionsTests/Utility.swift
+++ b/Tests/PackageCollectionsTests/Utility.swift
@@ -103,6 +103,7 @@ func makeMockPackage(id: String) -> PackageCollectionsModel.Package {
                                                        verifiedCompatibility: verifiedCompatibility,
                                                        license: license,
                                                        author: nil,
+                                                       signer: nil,
                                                        createdAt: Date())
     }
 


### PR DESCRIPTION
Motivation:
Package collection should have information about how a version was created. This includes the creator and signer.

https://github.com/apple/swift-package-manager/pull/6408 added `author` populated using GitHub data, but we can allow package collection author to specify version creator as well.

rdar://106674475

Modifications:
- Add `author` and `signer` to package collection models
- Update `PackageSearchClient` to use more information from collection/index results
