### PR TITLE
[5.9] Format test target in the macro package consistently with other targets

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -319,12 +319,7 @@ public final class InitPackage {
                             .executableTarget(name: "\(pkgname)Client", dependencies: ["\(pkgname)"]),
 
                             // A test target used to develop the macro implementation.
-                            .testTarget(
-                                name: "\(pkgname)Tests",
-                                dependencies: [
-                                   "\(pkgname)Macros",
-                                ]
-                            ),
+                            .testTarget(name: "\(pkgname)Tests", dependencies: ["\(pkgname)Macros"]),
                         ]
                     """
                 } else {


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift-package-manager/pull/6421 to `release/5.9`.