### PR TITLE
Use exact SwiftCrypto version to work around self-hosting failure

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -747,7 +747,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         // dependency version changes here with those projects.
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.2.2")),
         .package(url: "https://github.com/apple/swift-driver.git", branch: relatedDependenciesBranch),
-        .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: "2.4.0")),
+        .package(url: "https://github.com/apple/swift-crypto.git", exact: "2.4.0"),
         .package(url: "https://github.com/apple/swift-system.git", .upToNextMinor(from: "1.1.1")),
         .package(url: "https://github.com/apple/swift-collections.git", .upToNextMinor(from: "1.0.1")),
         .package(url: "https://github.com/apple/swift-certificates.git", .upToNextMinor(from: "0.1.0")),


### PR DESCRIPTION
There's a regression in Swift Crypto 2.4.1 on Linux that makes our Linux self-hosted jobs to fail.
