### PR TITLE
[5.9] Update to swift-crypto 2.4.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -738,7 +738,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         // dependency version changes here with those projects.
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.2.2")),
         .package(url: "https://github.com/apple/swift-driver.git", branch: relatedDependenciesBranch),
-        .package(url: "https://github.com/apple/swift-crypto.git", exact: "2.4.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: "2.4.1")),
         .package(url: "https://github.com/apple/swift-system.git", .upToNextMinor(from: "1.1.1")),
         .package(url: "https://github.com/apple/swift-collections.git", .upToNextMinor(from: "1.0.1")),
         .package(url: "https://github.com/apple/swift-certificates.git", .upToNextMinor(from: "0.1.0")),

--- a/Sources/PackageCollectionsSigning/Certificate/Certificate.swift
+++ b/Sources/PackageCollectionsSigning/Certificate/Certificate.swift
@@ -184,7 +184,7 @@ final class BoringSSLCertificate {
         return try self.keyType(of: key)
     }
 
-    private func keyType(of key: UnsafeMutablePointer<EVP_PKEY>) throws -> KeyType {
+    private func keyType(of key: OpaquePointer) throws -> KeyType {
         let algorithm = CCryptoBoringSSL_EVP_PKEY_id(key)
 
         switch algorithm {

--- a/Sources/PackageCollectionsSigning/Key/Key+RSA.swift
+++ b/Sources/PackageCollectionsSigning/Key/Key+RSA.swift
@@ -148,7 +148,7 @@ final class BoringSSLRSAPublicKey: PublicKey, BoringSSLKey {
     /// `data` should be in the PKCS #1 format
     init(data: Data) throws {
         let bytes = data.copyBytes()
-        let key = try bytes.withUnsafeBufferPointer { (ptr: UnsafeBufferPointer<UInt8>) throws -> UnsafeMutablePointer<EVP_PKEY> in
+        let key = try bytes.withUnsafeBufferPointer { ptr in
             var pointer = ptr.baseAddress
             guard let key = CCryptoBoringSSL_d2i_PublicKey(EVP_PKEY_RSA, nil, &pointer, numericCast(data.count)) else {
                 throw BoringSSLKeyError.failedToLoadKeyFromBytes


### PR DESCRIPTION
Cherry pick https://github.com/apple/swift-package-manager/pull/6431 to 5.9

---

Motivation:
swift-crypto 2.4.1 includes updates in BoringSSL that cause `Unsafe*Pointer<EVP_PKEY>` become `OpaquePointer` and without this code adjustment SwiftPM fails to build with `error: cannot find type 'EVP_PKEY' in scope`.

Modifications:
- Update dependency from 2.4.0 to 2.4.1
- Replace `Unsafe*Pointer<EVP_PKEY>` with `OpaquePointer`.
