### PR TITLE
bootstrap: fix use of deprecated `-Xmanifest` flag

### DIFF
--- a/Sources/swift-bootstrap/main.swift
+++ b/Sources/swift-bootstrap/main.swift
@@ -81,7 +81,7 @@ struct SwiftBootstrapBuildTool: ParsableCommand {
                 visibility: .hidden))
     public var xcbuildFlags: [String] = []
 
-    @Option(name: .customLong("Xmanifest", withSingleDash: true),
+    @Option(name: .customLong("Xbuild-tools-swiftc", withSingleDash: true),
             parsing: .unconditionalSingleValue,
             help: ArgumentHelp("Pass flag to the manifest build invocation",
                                visibility: .hidden))

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -839,7 +839,7 @@ def get_swiftpm_flags(args):
 
     # Ensure we are not sharing the module cache with concurrent builds in CI
     local_module_cache_path=os.path.join(args.build_dir, "module-cache")
-    for modifier in ["-Xswiftc", "-Xmanifest"]:
+    for modifier in ["-Xswiftc", "-Xbuild-tools-swiftc"]:
         build_flags.extend([modifier, "-module-cache-path", modifier, local_module_cache_path])
 
     return build_flags


### PR DESCRIPTION
We should use `-Xbuild-tools-swiftc` instead, as the deprecation warning recommends.