### PR TITLE
fix functional test

### DIFF
--- a/Fixtures/DependencyResolution/External/Mirror/App/Package.swift
+++ b/Fixtures/DependencyResolution/External/Mirror/App/Package.swift
@@ -5,8 +5,8 @@ import PackageDescription
 let package = Package(
     name: "App",
     dependencies: [
-        .package(name: "Foo", url: "../Foo", .branch("main")),
-        .package(name: "Bar", url: "../Bar", .branch("main")),
+        .package(url: "../Foo", .branch("main")),
+        .package(url: "../Bar", .branch("main")),
     ],
     targets: [
         .target(name: "App", dependencies: [

--- a/Tests/FunctionalTests/DependencyResolutionTests.swift
+++ b/Tests/FunctionalTests/DependencyResolutionTests.swift
@@ -78,8 +78,6 @@ class DependencyResolutionTests: XCTestCase {
     }
 
     func testMirrors() throws {
-        try XCTSkipIf(true, "test is broken and needs investigation rdar://107970938")
-
         try fixture(name: "DependencyResolution/External/Mirror") { fixturePath in
             let prefix = try resolveSymlinks(fixturePath)
             let appPath = prefix.appending("App")


### PR DESCRIPTION
motivaiton: test coverage

change: update fixture to not force package name which is deprecated when using URLs
