### PR TITLE
Enable armv7em and os none triples

### DIFF
--- a/Sources/Basics/Triple.swift
+++ b/Sources/Basics/Triple.swift
@@ -48,6 +48,7 @@ public struct Triple: Encodable, Equatable, Sendable {
         case aarch64
         case amd64
         case armv7
+        case armv7em
         case armv6
         case armv5
         case arm
@@ -73,6 +74,8 @@ public struct Triple: Encodable, Equatable, Sendable {
         case windows
         case wasi
         case openbsd
+        // 'OS' suffix purely to avoid name clash with Optional.none
+        case noneOS = "none"
     }
 
     public enum ABI: Encodable, Equatable, RawRepresentable, Sendable {
@@ -259,6 +262,8 @@ extension Triple {
             return ".dll"
         case .wasi:
             return ".wasm"
+        case .noneOS:
+            fatalError("Cannot create dynamic libraries for os \"none\".")
         }
     }
 
@@ -272,6 +277,8 @@ extension Triple {
             return ".wasm"
         case .windows:
             return ".exe"
+        case .noneOS:
+            return ""
         }
     }
 

--- a/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
+++ b/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
@@ -97,7 +97,7 @@ extension Triple.OS {
     /// Returns a representation of the receiver that can be compared with platform strings declared in an XCFramework.
     fileprivate var asXCFrameworkPlatformString: String? {
         switch self {
-        case .darwin, .linux, .wasi, .windows, .openbsd:
+        case .darwin, .linux, .wasi, .windows, .openbsd, .noneOS:
             return nil // XCFrameworks do not support any of these platforms today.
         case .macOS:
             return "macos"

--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -391,10 +391,14 @@ public struct BuildParameters: Encodable {
         return try buildPath.appending(binaryRelativePath(for: product))
     }
 
+    /// Returns the path to the dynamic library of a product for the current build parameters.
+    internal func potentialDynamicLibraryPath(for product: ResolvedProduct) throws -> RelativePath {
+        try RelativePath(validating: "\(triple.dynamicLibraryPrefix)\(product.name)\(triple.dynamicLibraryExtension)")
+    }
+
     /// Returns the path to the binary of a product for the current build parameters, relative to the build directory.
     public func binaryRelativePath(for product: ResolvedProduct) throws -> RelativePath {
         let potentialExecutablePath = try RelativePath(validating: "\(product.name)\(triple.executableExtension)")
-        let potentialLibraryPath = try RelativePath(validating: "\(triple.dynamicLibraryPrefix)\(product.name)\(triple.dynamicLibraryExtension)")
 
         switch product.type {
         case .executable, .snippet:
@@ -402,7 +406,7 @@ public struct BuildParameters: Encodable {
         case .library(.static):
             return try RelativePath(validating: "lib\(product.name)\(triple.staticLibraryExtension)")
         case .library(.dynamic):
-            return potentialLibraryPath
+            return try potentialDynamicLibraryPath(for: product)
         case .library(.automatic), .plugin:
             fatalError()
         case .test:
@@ -418,7 +422,7 @@ public struct BuildParameters: Encodable {
             }
         case .macro:
             #if BUILD_MACROS_AS_DYLIBS
-            return potentialLibraryPath
+            return try potentialDynamicLibraryPath(for: product)
             #else
             return potentialExecutablePath
             #endif

--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -392,7 +392,7 @@ public struct BuildParameters: Encodable {
     }
 
     /// Returns the path to the dynamic library of a product for the current build parameters.
-    internal func potentialDynamicLibraryPath(for product: ResolvedProduct) throws -> RelativePath {
+    func potentialDynamicLibraryPath(for product: ResolvedProduct) throws -> RelativePath {
         try RelativePath(validating: "\(triple.dynamicLibraryPrefix)\(product.name)\(triple.dynamicLibraryExtension)")
     }
 


### PR DESCRIPTION
- Adds preliminary knowledge of armv7em and no os environments to spm. Future diffs will be required to fully support these triples. This change allows a armv7em-apple-none-macho build via a destination v3 bundle to make it further through spm.