### PR TITLE
[5.9] Expose `SigningEntity` via package metadata

### DIFF
--- a/Sources/PackageMetadata/PackageMetadata.swift
+++ b/Sources/PackageMetadata/PackageMetadata.swift
@@ -37,6 +37,7 @@ public struct Package {
         public let type: String
         public let checksum: String?
         public let signing: Signing?
+        public let signingEntity: RegistryReleaseMetadata.SigningEntity?
     }
 
     public struct Signing: Sendable {
@@ -421,13 +422,25 @@ extension Package.Signing {
     }
 }
 
+extension RegistryReleaseMetadata.SigningEntity {
+    fileprivate init(_ entity: SigningEntity) {
+        switch entity {
+        case .recognized(let type, let name, let organizationalUnit, let organization):
+            self = .recognized(type: type.rawValue, commonName: name, organization: organization, identity: organizationalUnit)
+        case .unrecognized(let name, _, let organization):
+            self = .unrecognized(commonName: name, organization: organization)
+        }
+    }
+}
+
 extension Package.Resource {
     fileprivate init(_ resource: RegistryClient.PackageVersionMetadata.Resource) {
         self.init(
             name: resource.name,
             type: resource.type,
             checksum: resource.checksum,
-            signing: resource.signing.map { .init($0) }
+            signing: resource.signing.map { .init($0) },
+            signingEntity: resource.signingEntity.map { .init($0) }
         )
     }
 }

--- a/Sources/PackageModel/RegistryReleaseMetadata.swift
+++ b/Sources/PackageModel/RegistryReleaseMetadata.swift
@@ -105,7 +105,7 @@ public struct RegistryReleaseMetadata {
         }
     }
 
-    public enum SigningEntity: Codable, Equatable {
+    public enum SigningEntity: Codable, Equatable, Sendable {
         case recognized(type: String, commonName: String?, organization: String?, identity: String?)
         case unrecognized(commonName: String?, organization: String?)
     }


### PR DESCRIPTION
Prior changes have laid the groundwork for this, but we haven't actually exposed the signing entity here yet.

rdar://107033737

(cherry picked from commit 7a8a9e1226bfcf4194afb8f223a22c790669ba87)