### PR TITLE
Newly created build tool and command plugin templates should have conditional support for XcodeProjectPlugin

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -402,27 +402,56 @@ public final class InitPackage {
             if packageType == .buildToolPlugin {
                 content += """
                 struct \(typeName): BuildToolPlugin {
+                    /// Entry point for creating build commands for targets in Swift packages.
                     func createBuildCommands(context: PluginContext, target: Target) async throws -> [Command] {
-                        // The plugin can choose what parts of the package to process.
+                        // This plugin only runs for package targets that can have source files.
                         guard let sourceFiles = target.sourceModule?.sourceFiles else { return [] }
 
                         // Find the code generator tool to run (replace this with the actual one).
                         let generatorTool = try context.tool(named: "my-code-generator")
 
                         // Construct a build command for each source file with a particular suffix.
-                        return sourceFiles.map(\\.path).compactMap { inputPath in
-                            guard inputPath.extension == "my-input-suffix" else { return .none }
-                            let inputName = inputPath.lastComponent
-                            let outputName = inputPath.stem + ".swift"
-                            let outputPath = context.pluginWorkDirectory.appending(outputName)
-                            return .buildCommand(
-                                displayName: "Generating \\(outputName) from \\(inputName)",
-                                executable: generatorTool.path,
-                                arguments: ["\\(inputPath)", "-o", "\\(outputPath)"],
-                                inputFiles: [inputPath],
-                                outputFiles: [outputPath]
-                            )
+                        return sourceFiles.map(\\.path).compactMap {
+                            createBuildCommand(for: $0, in: context.pluginWorkDirectory, with: generatorTool.path)
                         }
+                    }
+                }
+
+                #if canImport(XcodeProjectPlugin)
+                import XcodeProjectPlugin
+
+                extension \(typeName): XcodeBuildToolPlugin {
+                    // Entry point for creating build commands for targets in Xcode projects.
+                    func createBuildCommands(context: XcodePluginContext, target: XcodeTarget) async throws -> [Command] {
+                        // Find the code generator tool to run (replace this with the actual one).
+                        let generatorTool = try context.tool(named: "my-code-generator")
+
+                        // Construct a build command for each source file with a particular suffix.
+                        return target.inputFiles.map(\\.path).compactMap {
+                            createBuildCommand(for: $0, in: context.pluginWorkDirectory, with: generatorTool.path)
+                        }
+                    }
+                }
+
+                #endif
+
+                extension \(typeName) {
+                    /// Shared function that returns a configured build command if the input files is one that should be processed.
+                    func createBuildCommand(for inputPath: Path, in outputDirectoryPath: Path, with generatorToolPath: Path) -> Command? {
+                        // Skip any file that doesn't have the extension we're looking for (replace this with the actual one).
+                        guard inputPath.extension == "my-input-suffix" else { return .none }
+                        
+                        // Return a command that will run during the build to generate the output file.
+                        let inputName = inputPath.lastComponent
+                        let outputName = inputPath.stem + ".swift"
+                        let outputPath = outputDirectoryPath.appending(outputName)
+                        return .buildCommand(
+                            displayName: "Generating \\(outputName) from \\(inputName)",
+                            executable: generatorToolPath,
+                            arguments: ["\\(inputPath)", "-o", "\\(outputPath)"],
+                            inputFiles: [inputPath],
+                            outputFiles: [outputPath]
+                        )
                     }
                 }
 
@@ -431,10 +460,23 @@ public final class InitPackage {
             else {
                 content += """
                 struct \(typeName): CommandPlugin {
+                    // Entry point for command plugins applied to Swift Packages.
                     func performCommand(context: PluginContext, arguments: [String]) async throws {
                         print("Hello, World!")
                     }
                 }
+
+                #if canImport(XcodeProjectPlugin)
+                import XcodeProjectPlugin
+
+                extension MyCommandPlugin: CommandPlugin {
+                    // Entry point for command plugins applied to Xcode projects.
+                    func performCommand(context: XcodePluginContext, arguments: [String]) async throws {
+                        print("Hello, World!")
+                    }
+                }
+
+                #endif
 
                 """
             }

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -172,10 +172,14 @@ class InitTests: XCTestCase {
             XCTAssertMatch(manifestContents, .and(.contains(".plugin("),
                 .and(.contains("capability: .command(intent: .custom("), .contains("verb: \"MyCommandPlugin\""))))
 
+            // Check basic content that we expect in the plugin source file
             let source = path.appending("Plugins", "MyCommandPlugin.swift")
             XCTAssertFileExists(source)
             let sourceContents: String = try localFileSystem.readFileContents(source)
             XCTAssertMatch(sourceContents, .contains("struct MyCommandPlugin: CommandPlugin"))
+            XCTAssertMatch(sourceContents, .contains("performCommand(context: PluginContext"))
+            XCTAssertMatch(sourceContents, .contains("import XcodeProjectPlugin"))
+            XCTAssertMatch(sourceContents, .contains("performCommand(context: XcodePluginContext"))
         }
     }
     
@@ -201,10 +205,14 @@ class InitTests: XCTestCase {
             XCTAssertMatch(manifestContents, .and(.contains(".plugin("), .contains("targets: [\"MyBuildToolPlugin\"]")))
             XCTAssertMatch(manifestContents, .and(.contains(".plugin("), .contains("capability: .buildTool()")))
 
+            // Check basic content that we expect in the plugin source file
             let source = path.appending("Plugins", "MyBuildToolPlugin.swift")
             XCTAssertFileExists(source)
             let sourceContents: String = try localFileSystem.readFileContents(source)
             XCTAssertMatch(sourceContents, .contains("struct MyBuildToolPlugin: BuildToolPlugin"))
+            XCTAssertMatch(sourceContents, .contains("createBuildCommands(context: PluginContext"))
+            XCTAssertMatch(sourceContents, .contains("import XcodeProjectPlugin"))
+            XCTAssertMatch(sourceContents, .contains("createBuildCommands(context: XcodePluginContext"))
         }
     }
 


### PR DESCRIPTION
Package plugins can be applied to packages in Xcode without any modification.  But Xcode also has an additional `XcodeProjectPlugin` module that provides extra API for applying plugins to Xcode projects.  Since this is a common use case, it makes sense for newly created plugins to have conditional use of that extra API by default.  If there is support for applying plugins to the project formats of other IDEs in the future, it would make sense to add those to the templates as well.

This support is currently always added but we could consider having options in the API for whether to add it.

Changes:
- extended the template-generated source code
- added to the unit tests

rdar://108166582
