### PR TITLE
Update BUG_REPORT.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -34,6 +34,6 @@ body:
     required: false 
 - type: textarea
   attributes:
-    label: Swift & OS version (output of `swift --version && uname -a`)
+    label: Swift & OS version (output of `swift --version ; uname -a`)
   validations:
     required: false 


### PR DESCRIPTION
Prefer separating commands with `;` which is more portable (works across bash, zsh, and PowerShell.

### Motivation:
Try to make the command more platform agnostic, particularly as Windows support improves, the reports are more likely to be cross-platform.

### Modifications:

Change the command chaining to use `;` rather than `&&` which also has the benefit of ensuring that the failure of one does not impact the other.

### Result:

The command can now partially run on Windows under PowerShell.