### PR TITLE
Tests: adjust windows librarian test slightly

### DIFF
--- a/Tests/PackageModelTests/PackageModelTests.swift
+++ b/Tests/PackageModelTests/PackageModelTests.swift
@@ -124,7 +124,7 @@ class PackageModelTests: XCTestCase {
                 try XCTAssertEqual(
                     UserToolchain.determineLibrarian(
                         triple: triple, binDirectories: [bin], useXcrun: false, environment: [:], searchPaths: [],
-                        extraSwiftFlags: ["-Xswiftc", "-use-ld=not-link\(suffix)"]
+                        extraSwiftFlags: ["-Xswiftc", "-use-ld=not-link"]
                     ),
                     not
                 )


### PR DESCRIPTION
Use the unsuffixed version of the tool's spelling.  Although we should accept the suffixed variant (which `clang` does do!) the lookup in SPM currently does not properly handle the path lookup with that.