### PR TITLE
Supplemental fix for XcodeProjectPlugin support in package init template

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -422,7 +422,7 @@ public final class InitPackage {
 
                 extension \(typeName): XcodeBuildToolPlugin {
                     // Entry point for creating build commands for targets in Xcode projects.
-                    func createBuildCommands(context: XcodePluginContext, target: XcodeTarget) async throws -> [Command] {
+                    func createBuildCommands(context: XcodePluginContext, target: XcodeTarget) throws -> [Command] {
                         // Find the code generator tool to run (replace this with the actual one).
                         let generatorTool = try context.tool(named: "my-code-generator")
 
@@ -469,9 +469,9 @@ public final class InitPackage {
                 #if canImport(XcodeProjectPlugin)
                 import XcodeProjectPlugin
 
-                extension MyCommandPlugin: CommandPlugin {
+                extension MyCommandPlugin: XcodeCommandPlugin {
                     // Entry point for command plugins applied to Xcode projects.
-                    func performCommand(context: XcodePluginContext, arguments: [String]) async throws {
+                    func performCommand(context: XcodePluginContext, arguments: [String]) throws {
                         print("Hello, World!")
                     }
                 }

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -179,6 +179,7 @@ class InitTests: XCTestCase {
             XCTAssertMatch(sourceContents, .contains("struct MyCommandPlugin: CommandPlugin"))
             XCTAssertMatch(sourceContents, .contains("performCommand(context: PluginContext"))
             XCTAssertMatch(sourceContents, .contains("import XcodeProjectPlugin"))
+            XCTAssertMatch(sourceContents, .contains("extension MyCommandPlugin: XcodeCommandPlugin"))
             XCTAssertMatch(sourceContents, .contains("performCommand(context: XcodePluginContext"))
         }
     }
@@ -212,6 +213,7 @@ class InitTests: XCTestCase {
             XCTAssertMatch(sourceContents, .contains("struct MyBuildToolPlugin: BuildToolPlugin"))
             XCTAssertMatch(sourceContents, .contains("createBuildCommands(context: PluginContext"))
             XCTAssertMatch(sourceContents, .contains("import XcodeProjectPlugin"))
+            XCTAssertMatch(sourceContents, .contains("extension MyBuildToolPlugin: XcodeBuildToolPlugin"))
             XCTAssertMatch(sourceContents, .contains("createBuildCommands(context: XcodePluginContext"))
         }
     }


### PR DESCRIPTION
This is a supplemental fix for https://github.com/apple/swift-package-manager/pull/6446 that removes the `async` specifier and corrects the protocol conformance of the Xcode command plug-in.  This change should have been part of that PR.

- remove the `async` specifier since the entry point that XcodeProjectPlugin defines isn't async
- correct the protocol conformance of the Xcode command plug-in
- update the unit tests

rdar://108166582