### PR TITLE
Basics: introduce some native path representation helpers

### DIFF
--- a/Sources/Basics/CMakeLists.txt
+++ b/Sources/Basics/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(Basics
   ImportScanning.swift
   JSON+Extensions.swift
   JSONDecoder+Extensions.swift
+  NativePathExtensions.swift
   Netrc.swift
   Observability.swift
   SQLite.swift

--- a/Sources/Basics/NativePathExtensions.swift
+++ b/Sources/Basics/NativePathExtensions.swift
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import struct TSCBasic.AbsolutePath
+
+extension AbsolutePath {
+    public func _nativePathString(escaped: Bool) -> String {
+        return URL(fileURLWithPath: self.pathString).withUnsafeFileSystemRepresentation {
+            let repr = String(cString: $0!)
+            if escaped {
+                return repr.replacingOccurrences(of: "\\", with: "\\\\")
+            }
+            return repr
+        }
+    }
+}

--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -681,7 +681,7 @@ public final class SwiftTargetBuildDescription {
             content +=
                 #"""
                     "dependencies": "\#(
-                    self.tempsPath.appending(component: moduleName + ".d").nativePathString(escaped: true)
+                    self.tempsPath.appending(component: moduleName + ".d")._nativePathString(escaped: true)
                 )",
 
                 """#
@@ -690,7 +690,7 @@ public final class SwiftTargetBuildDescription {
             content +=
                 #"""
                     "object": "\#(
-                    self.tempsPath.appending(component: moduleName + ".o").nativePathString(escaped: true)
+                    self.tempsPath.appending(component: moduleName + ".o")._nativePathString(escaped: true)
                 )",
 
                 """#
@@ -698,7 +698,7 @@ public final class SwiftTargetBuildDescription {
         }
         content +=
             #"""
-                "swift-dependencies": "\#(masterDepsPath.nativePathString(escaped: true))"
+                "swift-dependencies": "\#(masterDepsPath._nativePathString(escaped: true))"
               },
 
             """#
@@ -716,7 +716,7 @@ public final class SwiftTargetBuildDescription {
 
             content +=
                 #"""
-                  "\#(source.nativePathString(escaped: true))": {
+                  "\#(source._nativePathString(escaped: true))": {
 
                 """#
 
@@ -724,7 +724,7 @@ public final class SwiftTargetBuildDescription {
                 let depsPath = objectDir.appending(component: sourceFileName + ".d")
                 content +=
                     #"""
-                        "dependencies": "\#(depsPath.nativePathString(escaped: true))",
+                        "dependencies": "\#(depsPath._nativePathString(escaped: true))",
 
                     """#
                 // FIXME: Need to record this deps file for processing it later.
@@ -735,9 +735,9 @@ public final class SwiftTargetBuildDescription {
 
             content +=
                 #"""
-                    "object": "\#(object.nativePathString(escaped: true))",
-                    "swiftmodule": "\#(partialModulePath.nativePathString(escaped: true))",
-                    "swift-dependencies": "\#(swiftDepsPath.nativePathString(escaped: true))"
+                    "object": "\#(object._nativePathString(escaped: true))",
+                    "swiftmodule": "\#(partialModulePath._nativePathString(escaped: true))",
+                    "swift-dependencies": "\#(swiftDepsPath._nativePathString(escaped: true))"
                   }\#((idx + 1) < sources.count ? "," : "")
 
                 """#

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -30,18 +30,6 @@ extension String {
     }
 }
 
-extension AbsolutePath {
-    internal func nativePathString(escaped: Bool) -> String {
-        return URL(fileURLWithPath: self.pathString).withUnsafeFileSystemRepresentation {
-            let repr = String(cString: $0!)
-            if escaped {
-                return repr.replacingOccurrences(of: "\\", with: "\\\\")
-            }
-            return repr
-        }
-    }
-}
-
 extension BuildParameters {
     /// Returns the directory to be used for module cache.
     public var moduleCache: AbsolutePath {


### PR DESCRIPTION
We end up needing these in a few places, and while we could make it `internal` and use `@testable` imports in the tests, this ends up being needed in `Build` and `PackageLoading`.  Ideally, we would give it package visibility, but that functionality would not be backwards compatible.  This is a reluctant approach at solving that problem by using `public` visibility.