### PR TITLE
BuildTests: remove some likely debugging leftovers

### DIFF
--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -4445,7 +4445,6 @@ final class BuildPlanTests: XCTestCase {
         try llbuild.generateManifest(at: yaml)
 
         let yamlContents: String = try fs.readFileContents(yaml)
-        print(yamlContents)
         XCTAssertMatch(yamlContents, .contains("""
             inputs: ["/Pkg/Snippets/ASnippet.swift","/Pkg/.build/debug/Lib.swiftmodule"
         """))


### PR DESCRIPTION
This removes some extraneous printing during the test execution which is unnecessary and likely some debugging leftovers.