### PR TITLE
[5.8] skip testCompilationDiagnostics

### DIFF
--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -229,6 +229,8 @@ class PluginInvocationTests: XCTestCase {
     }
     
     func testCompilationDiagnostics() throws {
+        throw XCTSkip("disabled on release/5.8 due to CI toolchain mismatch")
+
         try testWithTemporaryDirectory { tmpPath in
             // Create a sample package with a library target and a plugin.
             let packageDir = tmpPath.appending(components: "MyPackage")


### PR DESCRIPTION
motivation: stable CI

changes: disable testCompilationDiagnostics test since 5.8 has mismatched compiler
