### PR TITLE
[5.9] Update macro API

### DIFF
--- a/Sources/CompilerPluginSupport/TargetExtensions.swift
+++ b/Sources/CompilerPluginSupport/TargetExtensions.swift
@@ -20,7 +20,10 @@ public extension Target {
         dependencies: [Dependency] = [],
         path: String? = nil,
         exclude: [String] = [],
-        sources: [String]? = nil
+        sources: [String]? = nil,
+        swiftSettings: [SwiftSetting]? = nil,
+        linkerSettings: [LinkerSetting]? = nil,
+        plugins: [PluginUsage]? = nil
     ) -> Target {
         return Target(name: name,
                       group: group,
@@ -29,6 +32,9 @@ public extension Target {
                       exclude: exclude,
                       sources: sources,
                       publicHeadersPath: nil,
-                      type: .macro)
+                      type: .macro,
+                      swiftSettings: swiftSettings,
+                      linkerSettings: linkerSettings,
+                      plugins: plugins)
     }
 }

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -344,10 +344,7 @@ public final class Target {
                 providers == nil &&
                 pluginCapability == nil &&
                 cSettings == nil &&
-                cxxSettings == nil &&
-                swiftSettings == nil &&
-                linkerSettings == nil &&
-                plugins == nil
+                cxxSettings == nil
             )
         }
     }

--- a/Sources/PackageModel/Manifest/TargetDescription.swift
+++ b/Sources/PackageModel/Manifest/TargetDescription.swift
@@ -230,8 +230,6 @@ public struct TargetDescription: Equatable, Encodable, Sendable {
             if pkgConfig != nil { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "pkgConfig") }
             if providers != nil { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "providers") }
             if pluginCapability != nil { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "pluginCapability") }
-            if !settings.isEmpty { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "settings") }
-            if pluginUsages != nil { throw Error.disallowedPropertyInTarget(targetName: name, propertyName: "pluginUsages") }
         }
 
         self.name = name

--- a/Tests/PackageLoadingTests/PD_Next_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_Next_LoadingTests.swift
@@ -39,4 +39,21 @@ class PackageDescriptionNextLoadingTests: PackageDescriptionLoadingTests {
             }
         }
     }
+
+    func testMacroTargets() throws {
+        let content = """
+            import CompilerPluginSupport
+            import PackageDescription
+
+            let package = Package(name: "MyPackage",
+                targets: [
+                    .macro(name: "MyMacro", swiftSettings: [.define("BEST")], linkerSettings: [.linkedLibrary("best")]),
+                ]
+            )
+            """
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let (_, diagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
+        XCTAssertEqual(diagnostics.count, 0, "unexpected diagnostics: \(diagnostics)")
+    }
 }


### PR DESCRIPTION
We're amending SE-0394 to allow Swift/linker settings as well as plugin dependencies. This updates the implementation to match.

(cherry picked from commit 1828be2bd6afb0e69dccbc79d6e67d747e024be6)