### PR TITLE
WorkspaceTests: simplify constant construction

### DIFF
--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -244,7 +244,7 @@ final class WorkspaceTests: XCTestCase {
             testDiagnostics(observability.diagnostics) { result in
                 let diagnostic = result.check(
                     diagnostic: .contains(
-                        "\(path.appending(components: "MyPkg", "Package.swift")):4:8: error: An error in MyPkg"
+                        "\(pkgDir.appending("Package.swift")):4:8: error: An error in MyPkg"
                     ),
                     severity: .error
                 )


### PR DESCRIPTION
Reuse the base path from a local variable reducing the arcs that we append to reduce the amount of duplication and avoid having multiple sites to modify for changes.