### PR TITLE
Bump swift-certificates to 0.4.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -754,7 +754,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: "2.5.0")),
         .package(url: "https://github.com/apple/swift-system.git", .upToNextMinor(from: "1.1.1")),
         .package(url: "https://github.com/apple/swift-collections.git", .upToNextMinor(from: "1.0.1")),
-        .package(url: "https://github.com/apple/swift-certificates.git", .upToNextMinor(from: "0.4.0")),
+        .package(url: "https://github.com/apple/swift-certificates.git", .upToNextMinor(from: "0.4.1")),
     ]
 } else {
     package.dependencies += [


### PR DESCRIPTION
Motivation:
Windows build is broken due to `CoreFoundation` usage in `swift-certificates`.

Modifications:
https://github.com/apple/swift-certificates/pull/72 is the patch so update to that.
