### PR TITLE
[5.9] Bump swift-certificates to 0.4.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -741,7 +741,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: "2.5.0")),
         .package(url: "https://github.com/apple/swift-system.git", .upToNextMinor(from: "1.1.1")),
         .package(url: "https://github.com/apple/swift-collections.git", .upToNextMinor(from: "1.0.1")),
-        .package(url: "https://github.com/apple/swift-certificates.git", .upToNextMinor(from: "0.4.0")),
+        .package(url: "https://github.com/apple/swift-certificates.git", .upToNextMinor(from: "0.4.1")),
     ]
 } else {
     package.dependencies += [


### PR DESCRIPTION
Cherry pick https://github.com/apple/swift-package-manager/pull/6465 to 5.9

---

Motivation:
Windows build is broken due to `CoreFoundation` usage in `swift-certificates`.

Modifications:
https://github.com/apple/swift-certificates/pull/72 is the patch so update to that.
