### PR TITLE
Workspace: log both branch and revision during checkout

### DIFF
--- a/Sources/Workspace/CheckoutState.swift
+++ b/Sources/Workspace/CheckoutState.swift
@@ -30,7 +30,20 @@ extension CheckoutState: CustomStringConvertible {
         case .version(let version, _):
             return version.description
         case .branch(let branch, let revision):
-            return "\(branch)#\(revision.identifier)"
+            return "\(branch) (\(revision.identifier.prefix(7)))"
+        }
+    }
+}
+
+extension CheckoutState: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        switch self {
+        case .revision(let revision):
+            return revision.identifier
+        case .version(let version, let revision):
+            return "\(version.description) (\(revision.identifier))"
+        case .branch(let branch, let revision):
+            return "\(branch) (\(revision.identifier))"
         }
     }
 }

--- a/Sources/Workspace/CheckoutState.swift
+++ b/Sources/Workspace/CheckoutState.swift
@@ -29,8 +29,8 @@ extension CheckoutState: CustomStringConvertible {
             return revision.identifier
         case .version(let version, _):
             return version.description
-        case .branch(let branch, _):
-            return branch
+        case .branch(let branch, let revision):
+            return "\(branch)#\(revision.identifier)"
         }
     }
 }

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -3329,6 +3329,7 @@ extension Workspace {
         // Inform the delegate that we're done.
         let duration = start.distance(to: .now())
         delegate?.didCheckOut(package: package.identity, repository: repository.location.description, revision: checkoutState.description, at: checkoutPath, duration: duration)
+        observabilityScope.emit(debug: "`\(repository.location.description)` checked out at \(checkoutState.debugDescription)")
 
         return checkoutPath
     }


### PR DESCRIPTION
This makes it easier to diagnose cases where a stale branch was fetched from source control cache. Currently, no revision is printed when a branch is checked out, which makes it hard to understand which exact revision is stored for that branch in the cache.

### Motivation:

We have a CI failure, which is likely caused by a stale cache: https://ci.swift.org/job/pr-swift-tools-support-core-macos/254/consoleFull. To confirm this hypothesis, it would be great if exact revision was printed together with a branch when checking out. See current output:

```
Working copy of https://github.com/apple/swift-certificates.git resolved at 0.4.1
Creating working copy for https://github.com/apple/swift-crypto.git
Working copy of https://github.com/apple/swift-crypto.git resolved at 2.5.0
Creating working copy for https://github.com/apple/swift-syntax.git
Working copy of https://github.com/apple/swift-syntax.git resolved at main
```

There is no way to know which commit of `main` was checked out without having access to this machine.

### Modifications:

Updated `description` implementation for `CheckoutState` type.

### Result:

`didCheckOut` implementation of `ToolWorkspaceDelegate` prints a branch name together with the revision it currently points at.
