### PR TITLE
Disable development mode for 5.9 branch

### DIFF
--- a/Fixtures/Miscellaneous/CXX17CompilerCrash/v5_8/Package.swift
+++ b/Fixtures/Miscellaneous/CXX17CompilerCrash/v5_8/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:999.0.0
+// swift-tools-version:5.8.0
 
 import PackageDescription
 

--- a/Fixtures/Miscellaneous/Plugins/PluginsAndSnippets/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/PluginsAndSnippets/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 999.0
+// swift-tools-version: 5.9
 import PackageDescription
 
 let package = Package(

--- a/Sources/Basics/SwiftVersion.swift
+++ b/Sources/Basics/SwiftVersion.swift
@@ -55,7 +55,7 @@ extension SwiftVersion {
     /// The current version of the package manager.
     public static let current = SwiftVersion(
         version: (5, 9, 0),
-        isDevelopment: true,
+        isDevelopment: false,
         buildIdentifier: getBuildIdentifier()
     )
 }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -537,6 +537,7 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testPackageNameFlag() throws {
+        try XCTSkipIf(!SwiftVersion.current.isDevelopment, "test needs tools-version 999.0")
         let isFlagSupportedInDriver = try driverSupport.checkToolchainDriverFlags(flags: ["package-name"], toolchain: UserToolchain.default, fileSystem: localFileSystem)
         try fixture(name: "Miscellaneous/PackageNameFlag") { fixturePath in
             let (stdout, _) = try executeSwiftBuild(fixturePath.appending("appPkg"), extraArgs: ["-v"])
@@ -559,6 +560,7 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testTargetGroupToPackageNameFlag() throws {
+        try XCTSkipIf(!SwiftVersion.current.isDevelopment, "test needs tools-version 999.0")
         let isFlagSupportedInDriver = try driverSupport.checkToolchainDriverFlags(flags: ["package-name"], toolchain: UserToolchain.default, fileSystem: localFileSystem)
         try fixture(name: "Miscellaneous/TargetGrouping") { fixturePath in
             let (stdout, _) = try executeSwiftBuild(fixturePath.appending("libPkg"), extraArgs: ["-v"])


### PR DESCRIPTION
Also tweak some tests that were either errorneously using 999.0 as their tools-version or those which require it.
