### PR TITLE
[5.9] Enable macros in 5.9 tools-version

### DIFF
--- a/Sources/CompilerPluginSupport/TargetExtensions.swift
+++ b/Sources/CompilerPluginSupport/TargetExtensions.swift
@@ -13,7 +13,7 @@
 @_spi(PackageDescriptionInternal) import PackageDescription
 
 public extension Target {
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 5.9)
     static func macro(
         name: String,
         group: TargetGroup = .package,

--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -342,8 +342,7 @@ public final class InitPackage {
         // Create a tools version with current version but with patch set to zero.
         // We do this to avoid adding unnecessary constraints to patch versions, if
         // the package really needs it, they should add it manually.
-        let version = packageType == .macro ? ToolsVersion.vNext
-            : InitPackage.newPackageToolsVersion.zeroedPatch
+        let version = InitPackage.newPackageToolsVersion.zeroedPatch
 
         // Write the current tools version.
         try ToolsVersionSpecificationWriter.rewriteSpecification(


### PR DESCRIPTION
SE-0394 has been accepted, so we're making macros available as part of the 5.9 tools-version.

(cherry picked from commit 4dbef25208c030eade3359de2a95d2f44956603b)