### PR TITLE
Skip SDK dependent tests in macOS bootstrap

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -367,9 +367,14 @@ def test(args):
     """Builds SwiftPM, then tests itself."""
     build(args)
 
+    if '-macosx' in args.build_target:
+        extra_env = ["SWIFTCI_DISABLE_SDK_DEPENDENT_TESTS=YES"]
+    else:
+        extra_env = []
+
     note("Testing")
     parse_test_args(args)
-    cmd = [
+    cmd = extra_env + [
         "SWIFT_EXEC=" + args.swiftc_path,
         "SWIFT_DRIVER_SWIFT_EXEC=" + args.swiftc_path,
         os.path.join(args.bin_dir, "swift-test")


### PR DESCRIPTION
This is manifesting itself as `cannot find 'XCTAssertEqual' in scope` on Swift CI again, but instead of disabling these tests wholesale like we did before, we want to take a more targetted approach.

rdar://108519765
