### PR TITLE
improve string interpolation of errors

### DIFF
--- a/Sources/Basics/AuthorizationProvider.swift
+++ b/Sources/Basics/AuthorizationProvider.swift
@@ -24,7 +24,13 @@ public protocol AuthorizationProvider {
 }
 
 public protocol AuthorizationWriter {
-    func addOrUpdate(for url: URL, user: String, password: String, persist: Bool, callback: @escaping (Result<Void, Error>) -> Void)
+    func addOrUpdate(
+        for url: URL,
+        user: String,
+        password: String,
+        persist: Bool,
+        callback: @escaping (Result<Void, Error>) -> Void
+    )
 
     func remove(for url: URL, callback: @escaping (Result<Void, Error>) -> Void)
 }
@@ -36,9 +42,9 @@ public enum AuthorizationProviderError: Error {
     case other(String)
 }
 
-public extension AuthorizationProvider {
+extension AuthorizationProvider {
     @Sendable
-    func httpAuthorizationHeader(for url: URL) -> String? {
+    public func httpAuthorizationHeader(for url: URL) -> String? {
         guard let (user, password) = self.authentication(for: url) else {
             return nil
         }
@@ -50,8 +56,8 @@ public extension AuthorizationProvider {
     }
 }
 
-private extension URL {
-    var authenticationID: String? {
+extension URL {
+    fileprivate var authenticationID: String? {
         guard let host = host?.lowercased() else {
             return nil
         }
@@ -75,7 +81,13 @@ public class NetrcAuthorizationProvider: AuthorizationProvider, AuthorizationWri
         _ = try Self.load(fileSystem: fileSystem, path: path)
     }
 
-    public func addOrUpdate(for url: URL, user: String, password: String, persist: Bool = true, callback: @escaping (Result<Void, Error>) -> Void) {
+    public func addOrUpdate(
+        for url: URL,
+        user: String,
+        password: String,
+        persist: Bool = true,
+        callback: @escaping (Result<Void, Error>) -> Void
+    ) {
         guard let machine = url.authenticationID else {
             return callback(.failure(AuthorizationProviderError.invalidURLHost))
         }
@@ -87,7 +99,9 @@ public class NetrcAuthorizationProvider: AuthorizationProvider, AuthorizationWri
 
         // Same entry already exists, no need to add or update
         let netrc = try? Self.load(fileSystem: self.fileSystem, path: self.path)
-        guard netrc?.machines.first(where: { $0.name.lowercased() == machine && $0.login == user && $0.password == password }) == nil else {
+        guard netrc?.machines
+            .first(where: { $0.name.lowercased() == machine && $0.login == user && $0.password == password }) == nil
+        else {
             return callback(.success(()))
         }
 
@@ -108,12 +122,18 @@ public class NetrcAuthorizationProvider: AuthorizationProvider, AuthorizationWri
 
             callback(.success(()))
         } catch {
-            callback(.failure(AuthorizationProviderError.other("Failed to update netrc file at \(self.path): \(error)")))
+            callback(.failure(
+                AuthorizationProviderError
+                    .other("Failed to update netrc file at \(self.path): \(error.interpolationDescription)")
+            ))
         }
     }
 
     public func remove(for url: URL, callback: @escaping (Result<Void, Error>) -> Void) {
-        callback(.failure(AuthorizationProviderError.other("User must edit netrc file at \(self.path) manually to remove entries")))
+        callback(.failure(
+            AuthorizationProviderError
+                .other("User must edit netrc file at \(self.path) manually to remove entries")
+        ))
     }
 
     public func authentication(for url: URL) -> (user: String, password: String)? {
@@ -124,7 +144,9 @@ public class NetrcAuthorizationProvider: AuthorizationProvider, AuthorizationWri
     }
 
     private func machine(for url: URL) -> Basics.Netrc.Machine? {
-        if let machine = url.authenticationID, let existing = self.machines.first(where: { $0.name.lowercased() == machine }) {
+        if let machine = url.authenticationID,
+           let existing = self.machines.first(where: { $0.name.lowercased() == machine })
+        {
             return existing
         }
         if let existing = self.machines.first(where: { $0.isDefault }) {
@@ -164,7 +186,13 @@ public class KeychainAuthorizationProvider: AuthorizationProvider, Authorization
         self.observabilityScope = observabilityScope
     }
 
-    public func addOrUpdate(for url: URL, user: String, password: String, persist: Bool = true, callback: @escaping (Result<Void, Error>) -> Void) {
+    public func addOrUpdate(
+        for url: URL,
+        user: String,
+        password: String,
+        persist: Bool = true,
+        callback: @escaping (Result<Void, Error>) -> Void
+    ) {
         guard let server = url.authenticationID else {
             return callback(.failure(AuthorizationProviderError.invalidURLHost))
         }
@@ -214,12 +242,14 @@ public class KeychainAuthorizationProvider: AuthorizationProvider, Authorization
         }
 
         do {
-            guard let existingItem = try self.search(server: server, protocol: self.protocol(for: url)) as? [String: Any],
-                  let passwordData = existingItem[kSecValueData as String] as? Data,
-                  let password = String(data: passwordData, encoding: String.Encoding.utf8),
-                  let account = existingItem[kSecAttrAccount as String] as? String
+            guard let existingItem = try self
+                .search(server: server, protocol: self.protocol(for: url)) as? [String: Any],
+                let passwordData = existingItem[kSecValueData as String] as? Data,
+                let password = String(data: passwordData, encoding: String.Encoding.utf8),
+                let account = existingItem[kSecAttrAccount as String] as? String
             else {
-                throw AuthorizationProviderError.other("Failed to extract credentials for server \(server) from keychain")
+                throw AuthorizationProviderError
+                    .other("Failed to extract credentials for server \(server) from keychain")
             }
             return (user: account, password: password)
         } catch {
@@ -229,7 +259,10 @@ public class KeychainAuthorizationProvider: AuthorizationProvider, Authorization
             case AuthorizationProviderError.other(let detail):
                 self.observabilityScope.emit(error: detail)
             default:
-                self.observabilityScope.emit(error: "Failed to find credentials for server \(server) in keychain: \(error)")
+                self.observabilityScope.emit(
+                    error: "Failed to find credentials for server \(server) in keychain",
+                    underlyingError: error
+                )
             }
             return nil
         }
@@ -244,7 +277,8 @@ public class KeychainAuthorizationProvider: AuthorizationProvider, Authorization
 
         let status = SecItemAdd(query as CFDictionary, nil)
         guard status == errSecSuccess else {
-            throw AuthorizationProviderError.other("Failed to save credentials for server \(server) to keychain: status \(status)")
+            throw AuthorizationProviderError
+                .other("Failed to save credentials for server \(server) to keychain: status \(status)")
         }
     }
 
@@ -260,7 +294,8 @@ public class KeychainAuthorizationProvider: AuthorizationProvider, Authorization
             return false
         }
         guard status == errSecSuccess else {
-            throw AuthorizationProviderError.other("Failed to update credentials for server \(server) in keychain: status \(status)")
+            throw AuthorizationProviderError
+                .other("Failed to update credentials for server \(server) in keychain: status \(status)")
         }
         return true
     }
@@ -271,7 +306,8 @@ public class KeychainAuthorizationProvider: AuthorizationProvider, Authorization
                                     kSecAttrProtocol as String: `protocol`]
         let status = SecItemDelete(query as CFDictionary)
         guard status == errSecSuccess else {
-            throw AuthorizationProviderError.other("Failed to delete credentials for server \(server) from keychain: status \(status)")
+            throw AuthorizationProviderError
+                .other("Failed to delete credentials for server \(server) from keychain: status \(status)")
         }
     }
 
@@ -290,7 +326,8 @@ public class KeychainAuthorizationProvider: AuthorizationProvider, Authorization
             throw AuthorizationProviderError.notFound
         }
         guard status == errSecSuccess else {
-            throw AuthorizationProviderError.other("Failed to find credentials for server \(server) in keychain: status \(status)")
+            throw AuthorizationProviderError
+                .other("Failed to find credentials for server \(server) in keychain: status \(status)")
         }
 
         return item

--- a/Sources/Basics/Cancellator.swift
+++ b/Sources/Basics/Cancellator.swift
@@ -25,7 +25,11 @@ public final class Cancellator: Cancellable {
 
     private let observabilityScope: ObservabilityScope?
     private let registry = ThreadSafeKeyValueStore<String, (name: String, handler: CancellationHandler)>()
-    private let cancelationQueue = DispatchQueue(label: "org.swift.swiftpm.cancellator", qos: .userInteractive, attributes: .concurrent)
+    private let cancelationQueue = DispatchQueue(
+        label: "org.swift.swiftpm.cancellator",
+        qos: .userInteractive,
+        attributes: .concurrent
+    )
     private let cancelling = ThreadSafeBox<Bool>(false)
 
     private static let signalHandlerLock = NSLock()
@@ -44,48 +48,48 @@ public final class Cancellator: Cancellable {
     public func installSignalHandlers() {
         Self.signalHandlerLock.withLock {
             precondition(!Self.isSignalHandlerInstalled)
-            
-#if os(Windows)
+
+            #if os(Windows)
             // Closures passed to `SetConsoleCtrlHandler` can't capture context, working around that with a global.
             Self.shared = self
-            
+
             // set shutdown handler to terminate sub-processes, etc
             _ = SetConsoleCtrlHandler({ _ in
                 // Terminate all processes on receiving an interrupt signal.
                 try? Cancellator.shared?.cancel(deadline: .now() + .seconds(30))
-                
+
                 // Reset the handler.
                 _ = SetConsoleCtrlHandler(nil, false)
-                
+
                 // Exit as if by signal()
                 TerminateProcess(GetCurrentProcess(), 3)
-                
+
                 return true
             }, true)
-#else
+            #else
             // trap SIGINT to terminate sub-processes, etc
             signal(SIGINT, SIG_IGN)
             let interruptSignalSource = DispatchSource.makeSignalSource(signal: SIGINT)
             interruptSignalSource.setEventHandler { [weak self] in
                 // cancel the trap?
                 interruptSignalSource.cancel()
-                
+
                 // Terminate all processes on receiving an interrupt signal.
                 try? self?.cancel(deadline: .now() + .seconds(30))
-                
-#if canImport(Darwin) || os(OpenBSD)
+
+                #if canImport(Darwin) || os(OpenBSD)
                 // Install the default signal handler.
                 var action = sigaction()
                 action.__sigaction_u.__sa_handler = SIG_DFL
                 sigaction(SIGINT, &action, nil)
                 kill(getpid(), SIGINT)
-#elseif os(Android)
+                #elseif os(Android)
                 // Install the default signal handler.
                 var action = sigaction()
                 action.sa_handler = SIG_DFL
                 sigaction(SIGINT, &action, nil)
                 kill(getpid(), SIGINT)
-#else
+                #else
                 var action = sigaction()
                 action.__sigaction_handler = unsafeBitCast(
                     SIG_DFL,
@@ -93,11 +97,11 @@ public final class Cancellator: Cancellable {
                 )
                 sigaction(SIGINT, &action, nil)
                 kill(getpid(), SIGINT)
-#endif
+                #endif
             }
             interruptSignalSource.resume()
-#endif
-            
+            #endif
+
             Self.isSignalHandlerInstalled = true
         }
     }
@@ -138,20 +142,21 @@ public final class Cancellator: Cancellable {
         self.registry[key] = nil
     }
 
-    public func cancel(deadline: DispatchTime) throws -> Void {
+    public func cancel(deadline: DispatchTime) throws {
         self._cancel(deadline: deadline)
     }
 
     // marked internal for testing
     @discardableResult
-    internal func _cancel(deadline: DispatchTime? = .none)-> Int {
+    internal func _cancel(deadline: DispatchTime? = .none) -> Int {
         self.cancelling.put(true)
 
-        self.observabilityScope?.emit(info: "starting cancellation cycle with \(self.registry.count) cancellation handlers registered")
+        self.observabilityScope?
+            .emit(info: "starting cancellation cycle with \(self.registry.count) cancellation handlers registered")
 
         let deadline = deadline ?? .now() + .seconds(30)
         // deadline for individual handlers set slightly before overall deadline
-        let delta: DispatchTimeInterval = .nanoseconds(abs(deadline.distance(to: .now()).nanoseconds() ?? 0)  / 5)
+        let delta: DispatchTimeInterval = .nanoseconds(abs(deadline.distance(to: .now()).nanoseconds() ?? 0) / 5)
         let handlersDeadline = deadline - delta
 
         let cancellationHandlers = self.registry.get()
@@ -164,13 +169,19 @@ public final class Cancellator: Cancellable {
                     try handler(handlersDeadline)
                     cancelled.append(name)
                 } catch {
-                    self.observabilityScope?.emit(warning: "failed cancelling '\(name)': \(error)")
+                    self.observabilityScope?.emit(
+                        warning: "failed cancelling '\(name)'",
+                        underlyingError: error
+                    )
                 }
             }
         }
 
         if case .timedOut = group.wait(timeout: deadline) {
-            self.observabilityScope?.emit(warning: "timeout waiting for cancellation with \(cancellationHandlers.count - cancelled.count) cancellation handlers remaining")
+            self.observabilityScope?
+                .emit(
+                    warning: "timeout waiting for cancellation with \(cancellationHandlers.count - cancelled.count) cancellation handlers remaining"
+                )
         } else {
             self.observabilityScope?.emit(info: "cancellation cycle completed successfully")
         }
@@ -197,7 +208,8 @@ public struct CancellationError: Error, CustomStringConvertible {
     }
 
     static func failedToRegisterProcess(_ process: TSCBasic.Process) -> Self {
-        Self(description: """
+        Self(
+            description: """
             failed to register a cancellation handler for this process invocation `\(
                 process.arguments.joined(separator: " ")
             )`

--- a/Sources/Basics/Errors.swift
+++ b/Sources/Basics/Errors.swift
@@ -32,7 +32,7 @@ extension Error {
         switch self {
         // special case because `LocalizedError` conversion will hide the underlying error
         case let _error as DecodingError:
-            return "\(self)"
+            return "\(_error)"
         case let _error as LocalizedError:
             var description = _error.errorDescription ?? _error.localizedDescription
             if let recoverySuggestion = _error.recoverySuggestion {

--- a/Sources/Basics/Errors.swift
+++ b/Sources/Basics/Errors.swift
@@ -30,6 +30,9 @@ public struct InternalError: Error {
 extension Error {
     public var interpolationDescription: String {
         switch self {
+        // special case because `LocalizedError` conversion will hide the underlying error
+        case let _error as DecodingError:
+            return "\(self)"
         case let _error as LocalizedError:
             var description = _error.localizedDescription
             if let recoverySuggestion = _error.recoverySuggestion {
@@ -45,7 +48,6 @@ extension Error {
                 description += ". \(localizedRecoverySuggestion)"
             }
             return description
-
         default:
             return "\(self)"
         }

--- a/Sources/Basics/Errors.swift
+++ b/Sources/Basics/Errors.swift
@@ -34,7 +34,7 @@ extension Error {
         case let _error as DecodingError:
             return "\(self)"
         case let _error as LocalizedError:
-            var description = _error.localizedDescription
+            var description = _error.errorDescription ?? _error.localizedDescription
             if let recoverySuggestion = _error.recoverySuggestion {
                 description += ". \(recoverySuggestion)"
             }

--- a/Sources/Basics/Observability.swift
+++ b/Sources/Basics/Observability.swift
@@ -262,6 +262,8 @@ extension DiagnosticsEmitterProtocol {
         }
     }
 
+    /// If `underlyingError` is not `nil`, its human-readable description is interpolated with `message`,
+    /// otherwise `message` itself is returned.
     private func makeMessage(from message: String, underlyingError: Error?) -> String {
         if let underlyingError {
             return "\(message): \(underlyingError.interpolationDescription)"

--- a/Sources/Basics/Observability.swift
+++ b/Sources/Basics/Observability.swift
@@ -13,12 +13,12 @@
 import Dispatch
 import Foundation
 
-import class TSCBasic.UnknownLocation
-import enum TSCUtility.Diagnostics
+import struct TSCBasic.Diagnostic
 import protocol TSCBasic.DiagnosticData
 import protocol TSCBasic.DiagnosticLocation
+import class TSCBasic.UnknownLocation
 import protocol TSCUtility.DiagnosticDataConvertible
-import struct TSCBasic.Diagnostic
+import enum TSCUtility.Diagnostics
 
 // this could become a struct when we remove the "errorsReported" pattern
 
@@ -46,7 +46,8 @@ public class ObservabilitySystem {
     private struct SingleDiagnosticsHandler: ObservabilityHandlerProvider, DiagnosticsHandler {
         var diagnosticsHandler: DiagnosticsHandler { self }
 
-        let underlying: @Sendable (ObservabilityScope, Diagnostic) -> Void
+        let underlying: @Sendable (ObservabilityScope, Diagnostic)
+            -> Void
 
         init(_ underlying: @escaping @Sendable (ObservabilityScope, Diagnostic) -> Void) {
             self.underlying = underlying
@@ -109,13 +110,13 @@ public final class ObservabilityScope: DiagnosticsEmitterProtocol, Sendable, Cus
     }
 
     // FIXME: we want to remove this functionality and move to more conventional error handling
-    //@available(*, deprecated, message: "this pattern is deprecated, transition to error handling instead")
+    // @available(*, deprecated, message: "this pattern is deprecated, transition to error handling instead")
     public var errorsReported: Bool {
         self.diagnosticsHandler.errorsReported
     }
 
     // FIXME: we want to remove this functionality and move to more conventional error handling
-    //@available(*, deprecated, message: "this pattern is deprecated, transition to error handling instead")
+    // @available(*, deprecated, message: "this pattern is deprecated, transition to error handling instead")
     public var errorsReportedInAnyScope: Bool {
         if self.errorsReported {
             return true
@@ -173,45 +174,69 @@ extension DiagnosticsEmitterProtocol {
         self.emit(.init(severity: severity, message: message, metadata: metadata))
     }
 
-    public func emit(error message: String, metadata: ObservabilityMetadata? = .none) {
+    public func emit(error message: String, metadata: ObservabilityMetadata? = .none, underlyingError: Error? = .none) {
+        let message = makeMessage(from: message, underlyingError: underlyingError)
         self.emit(.init(severity: .error, message: message, metadata: metadata))
     }
 
-    public func emit(error message: CustomStringConvertible, metadata: ObservabilityMetadata? = .none) {
-        self.emit(error: message.description, metadata: metadata)
+    public func emit(
+        error message: CustomStringConvertible,
+        metadata: ObservabilityMetadata? = .none,
+        underlyingError: Error? = .none
+    ) {
+        self.emit(error: message.description, metadata: metadata, underlyingError: underlyingError)
     }
 
     public func emit(_ error: Error, metadata: ObservabilityMetadata? = .none) {
         self.emit(.error(error, metadata: metadata))
     }
 
-    public func emit(warning message: String, metadata: ObservabilityMetadata? = .none) {
+    public func emit(
+        warning message: String,
+        metadata: ObservabilityMetadata? = .none,
+        underlyingError: Error? = .none
+    ) {
+        let message = makeMessage(from: message, underlyingError: underlyingError)
         self.emit(severity: .warning, message: message, metadata: metadata)
     }
 
-    public func emit(warning message: CustomStringConvertible, metadata: ObservabilityMetadata? = .none) {
-        self.emit(warning: message.description, metadata: metadata)
+    public func emit(
+        warning message: CustomStringConvertible,
+        metadata: ObservabilityMetadata? = .none,
+        underlyingError: Error? = .none
+    ) {
+        self.emit(warning: message.description, metadata: metadata, underlyingError: underlyingError)
     }
 
-    public func emit(info message: String, metadata: ObservabilityMetadata? = .none) {
+    public func emit(info message: String, metadata: ObservabilityMetadata? = .none, underlyingError: Error? = .none) {
+        let message = makeMessage(from: message, underlyingError: underlyingError)
         self.emit(severity: .info, message: message, metadata: metadata)
     }
 
-    public func emit(info message: CustomStringConvertible, metadata: ObservabilityMetadata? = .none) {
-        self.emit(info: message.description, metadata: metadata)
+    public func emit(
+        info message: CustomStringConvertible,
+        metadata: ObservabilityMetadata? = .none,
+        underlyingError: Error? = .none
+    ) {
+        self.emit(info: message.description, metadata: metadata, underlyingError: underlyingError)
     }
 
-    public func emit(debug message: String, metadata: ObservabilityMetadata? = .none) {
+    public func emit(debug message: String, metadata: ObservabilityMetadata? = .none, underlyingError: Error? = .none) {
+        let message = makeMessage(from: message, underlyingError: underlyingError)
         self.emit(severity: .debug, message: message, metadata: metadata)
     }
 
-    public func emit(debug message: CustomStringConvertible, metadata: ObservabilityMetadata? = .none) {
-        self.emit(debug: message.description, metadata: metadata)
+    public func emit(
+        debug message: CustomStringConvertible,
+        metadata: ObservabilityMetadata? = .none,
+        underlyingError: Error? = .none
+    ) {
+        self.emit(debug: message.description, metadata: metadata, underlyingError: underlyingError)
     }
 
     /// trap a throwing closure, emitting diagnostics on error and returning the value returned by the closure
     public func trap<T>(_ closure: () throws -> T) -> T? {
-        do  {
+        do {
             return try closure()
         } catch Diagnostics.fatalError {
             // FIXME: (diagnostics) deprecate this with Diagnostics.fatalError
@@ -225,7 +250,7 @@ extension DiagnosticsEmitterProtocol {
     /// trap a throwing closure, emitting diagnostics on error and returning boolean representing success
     @discardableResult
     public func trap(_ closure: () throws -> Void) -> Bool {
-        do  {
+        do {
             try closure()
             return true
         } catch Diagnostics.fatalError {
@@ -234,6 +259,14 @@ extension DiagnosticsEmitterProtocol {
         } catch {
             self.emit(error)
             return false
+        }
+    }
+
+    private func makeMessage(from message: String, underlyingError: Error?) -> String {
+        if let underlyingError {
+            return "\(message): \(underlyingError.interpolationDescription)"
+        } else {
+            return message
         }
     }
 }
@@ -258,7 +291,7 @@ public struct DiagnosticsEmitter: DiagnosticsEmitterProtocol {
 public struct Diagnostic: Sendable, CustomStringConvertible {
     public let severity: Severity
     public let message: String
-    public internal (set) var metadata: ObservabilityMetadata?
+    public internal(set) var metadata: ObservabilityMetadata?
 
     public init(severity: Severity, message: String, metadata: ObservabilityMetadata?) {
         self.severity = severity
@@ -267,7 +300,7 @@ public struct Diagnostic: Sendable, CustomStringConvertible {
     }
 
     public var description: String {
-        return "[\(self.severity)]: \(self.message)"
+        "[\(self.severity)]: \(self.message)"
     }
 
     public static func error(_ message: String, metadata: ObservabilityMetadata? = .none) -> Self {
@@ -292,12 +325,8 @@ public struct Diagnostic: Sendable, CustomStringConvertible {
             message = "\(diagnosticData)"
         } else if let convertible = error as? DiagnosticDataConvertible {
             message = "\(convertible.diagnosticData)"
-        } else if let decodingError = error as? DecodingError { // special case because `LocalizedError` conversion will hide the underlying error
-            message = "\(decodingError)"
-        } else if let localizedError = error as? LocalizedError {
-            message = localizedError.errorDescription ?? localizedError.localizedDescription
         } else {
-            message = "\(error)"
+            message = error.interpolationDescription
         }
 
         return Self(severity: .error, message: message, metadata: metadata)
@@ -347,7 +376,7 @@ public struct Diagnostic: Sendable, CustomStringConvertible {
         }
 
         public static func < (lhs: Self, rhs: Self) -> Bool {
-            return lhs.naturalIntegralValue < rhs.naturalIntegralValue
+            lhs.naturalIntegralValue < rhs.naturalIntegralValue
         }
     }
 }
@@ -425,10 +454,10 @@ public struct ObservabilityMetadata: Sendable, CustomDebugStringConvertible {
 
     public func merging(_ other: ObservabilityMetadata) -> ObservabilityMetadata {
         var merged = ObservabilityMetadata()
-        self.forEach { (key, value) in
+        self.forEach { key, value in
             merged._storage[key] = value
         }
-        other.forEach { (key, value) in
+        other.forEach { key, value in
             merged._storage[key] = value
         }
         return merged
@@ -446,23 +475,26 @@ public struct ObservabilityMetadata: Sendable, CustomDebugStringConvertible {
     // ideally Value would conform to Equatable but that has generic requirement
     // luckily, this is about to change so we can clean this up soon
     /*
-    public static func == (lhs: ObservabilityMetadata, rhs: ObservabilityMetadata) -> Bool {
-        if lhs.count != rhs.count {
-            return false
-        }
+     public static func == (lhs: ObservabilityMetadata, rhs: ObservabilityMetadata) -> Bool {
+         if lhs.count != rhs.count {
+             return false
+         }
 
-        var equals = true
-        lhs.forEach { (key, value) in
-            if rhs._storage[key]?.description != value.description {
-                equals = false
-                return
-            }
-        }
+         var equals = true
+         lhs.forEach { (key, value) in
+             if rhs._storage[key]?.description != value.description {
+                 equals = false
+                 return
+             }
+         }
 
-        return equals
-    }*/
+         return equals
+     }*/
 
-    fileprivate static func mergeLeft(_ lhs: ObservabilityMetadata?, _ rhs: ObservabilityMetadata?) -> ObservabilityMetadata? {
+    fileprivate static func mergeLeft(
+        _ lhs: ObservabilityMetadata?,
+        _ rhs: ObservabilityMetadata?
+    ) -> ObservabilityMetadata? {
         switch (lhs, rhs) {
         case (.none, .none):
             return .none
@@ -518,7 +550,7 @@ extension ObservabilityMetadata {
     public struct UnderlyingError: CustomStringConvertible {
         let underlying: Error
 
-        public init (_ underlying: Error) {
+        public init(_ underlying: Error) {
             self.underlying = underlying
         }
 
@@ -578,7 +610,7 @@ extension ObservabilityMetadata {
     public struct DiagnosticLocationWrapper: Sendable, CustomStringConvertible {
         let underlying: DiagnosticLocation
 
-        public init (_ underlying: DiagnosticLocation) {
+        public init(_ underlying: DiagnosticLocation) {
             self.underlying = underlying
         }
 
@@ -606,7 +638,7 @@ extension ObservabilityMetadata {
     struct DiagnosticDataWrapper: Sendable, CustomStringConvertible {
         let underlying: DiagnosticData
 
-        public init (_ underlying: DiagnosticData) {
+        public init(_ underlying: DiagnosticData) {
             self.underlying = underlying
         }
 

--- a/Sources/Basics/Triple.swift
+++ b/Sources/Basics/Triple.swift
@@ -209,7 +209,7 @@ public struct Triple: Encodable, Equatable, Sendable {
             #if os(macOS)
             return .macOS
             #else
-            throw InternalError("Failed to get target info (\(error))")
+            throw InternalError("Failed to get target info (\(error.interpolationDescription))")
             #endif
         }
         // Parse the compiler's JSON output.
@@ -217,20 +217,26 @@ public struct Triple: Encodable, Equatable, Sendable {
         do {
             parsedTargetInfo = try JSON(string: compilerOutput)
         } catch {
-            throw InternalError("Failed to parse target info (\(error)).\nRaw compiler output: \(compilerOutput)")
+            throw InternalError(
+                "Failed to parse target info (\(error.interpolationDescription)).\nRaw compiler output: \(compilerOutput)"
+            )
         }
         // Get the triple string from the parsed JSON.
         let tripleString: String
         do {
             tripleString = try parsedTargetInfo.get("target").get("triple")
         } catch {
-            throw InternalError("Target info does not contain a triple string (\(error)).\nTarget info: \(parsedTargetInfo)")
+            throw InternalError(
+                "Target info does not contain a triple string (\(error.interpolationDescription)).\nTarget info: \(parsedTargetInfo)"
+            )
         }
         // Parse the triple string.
         do {
             return try Triple(tripleString)
         } catch {
-            throw InternalError("Failed to parse triple string (\(error)).\nTriple string: \(tripleString)")
+            throw InternalError(
+                "Failed to parse triple string (\(error.interpolationDescription)).\nTriple string: \(tripleString)"
+            )
         }
     }
 

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -148,7 +148,10 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
                     }
                 } catch {
                     // since caching is an optimization, warn about failing to load the cached version
-                    self.observabilityScope.emit(warning: "failed to load the cached build description: \(error)")
+                    self.observabilityScope.emit(
+                        warning: "failed to load the cached build description",
+                        underlyingError: error
+                    )
                 }
             }
             // We need to perform actual planning if we reach here.
@@ -271,7 +274,10 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         if self.fileSystem.exists(oldBuildPath) {
             do { try self.fileSystem.removeFileTree(oldBuildPath) }
             catch {
-                self.observabilityScope.emit(warning: "unable to delete \(oldBuildPath), skip creating symbolic link: \(error)")
+                self.observabilityScope.emit(
+                    warning: "unable to delete \(oldBuildPath), skip creating symbolic link",
+                    underlyingError: error
+                )
                 return
             }
         }
@@ -279,7 +285,10 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         do {
             try self.fileSystem.createSymbolicLink(oldBuildPath, pointingAt: buildParameters.buildPath, relative: true)
         } catch {
-            self.observabilityScope.emit(warning: "unable to create symbolic link at \(oldBuildPath): \(error)")
+            self.observabilityScope.emit(
+                warning: "unable to create symbolic link at \(oldBuildPath)",
+                underlyingError: error
+            )
         }
     }
 

--- a/Sources/Commands/PackageTools/APIDiff.swift
+++ b/Sources/Commands/PackageTools/APIDiff.swift
@@ -136,7 +136,7 @@ struct APIDiff: SwiftCommand {
                         results.append(comparisonResult)
                     }
                 } catch {
-                    swiftTool.observabilityScope.emit(error: "failed to compare API to baseline: \(error)")
+                    swiftTool.observabilityScope.emit(error: "failed to compare API to baseline", underlyingError: error)
                 }
                 semaphore.signal()
             }

--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -417,7 +417,10 @@ public struct PackageCollections: PackageCollectionsProtocol, Closable {
                 self.metadataProvider.get(identity: packageSearchResult.package.identity, location: packageSearchResult.package.location) { result, provider in
                     switch result {
                     case .failure(let error):
-                        self.observabilityScope.emit(warning: "Failed fetching information about \(identity) from \(self.metadataProvider.self): \(error)")
+                        self.observabilityScope.emit(
+                            warning: "Failed fetching information about \(identity) from \(self.metadataProvider.self)",
+                            underlyingError: error
+                        )
                         let metadata = Model.PackageMetadata(
                             package: Self.mergedPackageMetadata(package: packageSearchResult.package, basicMetadata: nil),
                             collections: packageSearchResult.collections,

--- a/Sources/PackageCollections/PackageIndex.swift
+++ b/Sources/PackageCollections/PackageIndex.swift
@@ -89,7 +89,10 @@ struct PackageIndex: PackageIndexProtocol, Closable {
                                 observabilityScope: self.observabilityScope
                             )
                         } catch {
-                            self.observabilityScope.emit(warning: "Failed to save index metadata for package \(identity) to cache: \(error)")
+                            self.observabilityScope.emit(
+                                warning: "Failed to save index metadata for package \(identity) to cache",
+                                underlyingError: error
+                            )
                         }
                         
                         return (package: package, collections: [], provider: self.createContext(host: url.host, error: nil))

--- a/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
@@ -176,7 +176,10 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider, Closable {
                             observabilityScope: self.observabilityScope
                         )
                     } catch {
-                        self.observabilityScope.emit(warning: "Failed to save GitHub metadata for package \(identity) to cache: \(error)")
+                        self.observabilityScope.emit(
+                            warning: "Failed to save GitHub metadata for package \(identity) to cache",
+                            underlyingError: error
+                        )
                     }
 
                     callback(.success(model), self.createContext(apiHost: baseURL.host, error: nil))

--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -172,7 +172,10 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
                                     return callback(.failure(InternalError("Expected at least one package collection signature validation failure but got none")))
                                 }
 
-                                self.observabilityScope.emit(warning: "The signature of package collection [\(source)] is invalid: \(error)")
+                                self.observabilityScope.emit(
+                                    warning: "The signature of package collection [\(source)] is invalid",
+                                    underlyingError: error
+                                )
                                 if PackageCollectionSigningError.noTrustedRootCertsConfigured == error as? PackageCollectionSigningError {
                                     callback(.failure(PackageCollectionError.cannotVerifySignature))
                                 } else {

--- a/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
+++ b/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
@@ -855,7 +855,10 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
                 return callback(.success(()))
             }
         } catch {
-            self.observabilityScope.emit(warning: "Failed to determine if database is empty or not: \(error)")
+            self.observabilityScope.emit(
+                warning: "Failed to determine if database is empty or not",
+                underlyingError: error
+            )
             // Try again in background
         }
 

--- a/Sources/PackageCollectionsSigning/Certificate/CertificatePolicy.swift
+++ b/Sources/PackageCollectionsSigning/Certificate/CertificatePolicy.swift
@@ -558,7 +558,10 @@ extension CertificatePolicy {
                 do {
                     certs.append(try Certificate(derEncoded: Data(contentsOf: fileURL)))
                 } catch {
-                    observabilityScope.emit(warning: "The certificate \(fileURL) is invalid: \(error)")
+                    observabilityScope.emit(
+                        warning: "The certificate \(fileURL) is invalid",
+                        underlyingError: error
+                    )
                 }
             }
         }

--- a/Sources/PackageCollectionsSigning/PackageCollectionSigning.swift
+++ b/Sources/PackageCollectionsSigning/PackageCollectionSigning.swift
@@ -107,7 +107,10 @@ public struct PackageCollectionSigning: PackageCollectionSigner, PackageCollecti
             do {
                 return try Certificate(derEncoded: data)
             } catch {
-                observabilityScope.emit(error: "The certificate \($0) is not in valid DER format: \(error)")
+                observabilityScope.emit(
+                    error: "The certificate \($0) is not in valid DER format",
+                    underlyingError: error
+                )
                 return nil
             }
         } }
@@ -257,7 +260,10 @@ public struct PackageCollectionSigning: PackageCollectionSigner, PackageCollecti
             certPolicy.validate(certChain: certChain) { result in
                 switch result {
                 case .failure(let error):
-                    observabilityScope.emit(error: "\(certPolicyKey): The certificate chain is invalid: \(error)")
+                    observabilityScope.emit(
+                        error: "\(certPolicyKey): The certificate chain is invalid",
+                        underlyingError: error
+                    )
                     if CertificatePolicyError.noTrustedRootCertsConfigured == error as? CertificatePolicyError {
                         callback(.failure(PackageCollectionSigningError.noTrustedRootCertsConfigured))
                     } else {
@@ -268,7 +274,10 @@ public struct PackageCollectionSigning: PackageCollectionSigner, PackageCollecti
                 }
             }
         } catch {
-            observabilityScope.emit(error: "An error has occurred while validating certificate chain: \(error)")
+            observabilityScope.emit(
+                error: "An error has occurred while validating certificate chain",
+                underlyingError: error
+            )
             callback(.failure(PackageCollectionSigningError.invalidCertChain))
         }
     }

--- a/Sources/PackageGraph/PinsStore.swift
+++ b/Sources/PackageGraph/PinsStore.swift
@@ -85,7 +85,7 @@ public final class PinsStore {
         } catch {
             self._pins = .init()
             throw StringError(
-                "Package.resolved file is corrupted or malformed; fix or delete the file to continue: \(error)"
+                "Package.resolved file is corrupted or malformed; fix or delete the file to continue: \(error.interpolationDescription)"
             )
         }
     }

--- a/Sources/PackageLoading/ManifestJSONParser.swift
+++ b/Sources/PackageLoading/ManifestJSONParser.swift
@@ -63,7 +63,7 @@ enum ManifestJSONParser {
             versionedInput = try decoder.decode(VersionedInput.self, from: jsonString)
         } catch {
             // If we cannot even decode the version, assume that a pre-5.9 PD library is being used which emits an incompatible JSON format.
-            throw ManifestParseError.unsupportedVersion(version: 1, underlyingError: "\(error)")
+            throw ManifestParseError.unsupportedVersion(version: 1, underlyingError: "\(error.interpolationDescription)")
         }
         guard versionedInput.version == 2 else {
             throw ManifestParseError.unsupportedVersion(version: versionedInput.version)

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -369,7 +369,10 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             do {
                 try cache?.close()
             } catch {
-                observabilityScope.emit(warning: "failed closing cache: \(error)")
+                observabilityScope.emit(
+                    warning: "failed closing cache",
+                    underlyingError: error
+                )
             }
 
             callbackQueue.async {
@@ -407,7 +410,10 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                 return closingCompletion(.success(parsedManifest))
             }
         } catch {
-            observabilityScope.emit(warning: "failed loading cached manifest for '\(key.packageIdentity)': \(error)")
+            observabilityScope.emit(
+                warning: "failed loading cached manifest for '\(key.packageIdentity)'",
+                underlyingError: error
+            )
         }
 
         // shells out and compiles the manifest, finally output a JSON
@@ -440,7 +446,10 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                         // FIXME: (diagnostics) pass in observability scope when we have one
                         try cache?.put(key: key.sha256Checksum, value: evaluationResult)
                     } catch {
-                        observabilityScope.emit(warning: "failed storing manifest for '\(key.packageIdentity)' in cache: \(error)")
+                        observabilityScope.emit(
+                            warning: "failed storing manifest for '\(key.packageIdentity)' in cache",
+                            underlyingError: error
+                        )
                     }
 
                     return closingCompletion(.success(parseManifest))
@@ -864,7 +873,10 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         do {
             try localFileSystem.removeFileTree(manifestCacheDBPath)
         } catch {
-            observabilityScope.emit(error: "Error purging manifests cache at '\(manifestCacheDBPath)': \(error))")
+            observabilityScope.emit(
+                error: "Error purging manifests cache at '\(manifestCacheDBPath)'",
+                underlyingError: error
+            )
         }
     }
 }

--- a/Sources/PackageLoading/Target+PkgConfig.swift
+++ b/Sources/PackageLoading/Target+PkgConfig.swift
@@ -122,7 +122,7 @@ public func pkgConfigArgs(
             )
         } else if let error = result.error {
             observabilityScope.emit(
-                warning: "\(error)",
+                warning: error.interpolationDescription,
                 metadata: .pkgConfig(pcFile: result.pkgConfigName, targetName: target.name)
             )
         }

--- a/Sources/PackageModel/ArtifactsArchiveMetadata.swift
+++ b/Sources/PackageModel/ArtifactsArchiveMetadata.swift
@@ -85,7 +85,7 @@ extension ArtifactsArchiveMetadata {
                 )
             }
         } catch {
-            throw StringError("failed parsing ArtifactsArchive info.json at '\(path)': \(error)")
+            throw StringError("failed parsing ArtifactsArchive info.json at '\(path)': \(error.interpolationDescription)")
         }
     }
 }

--- a/Sources/PackageModel/SwiftSDKBundle.swift
+++ b/Sources/PackageModel/SwiftSDKBundle.swift
@@ -63,9 +63,8 @@ public struct SwiftSDKBundle {
                 )
             } catch {
                 observabilityScope.emit(
-                    .warning(
-                        "Couldn't parse `info.json` manifest of a destination bundle at \($0): \(error)"
-                    )
+                    warning: "Couldn't parse `info.json` manifest of a destination bundle at \($0)",
+                    underlyingError: error
                 )
                 return nil
             }
@@ -371,9 +370,8 @@ extension ArtifactsArchiveMetadata {
                     variants.append(.init(metadata: variantMetadata, swiftSDKs: destinations))
                 } catch {
                     observabilityScope.emit(
-                        .warning(
-                            "Couldn't parse Swift SDK artifact metadata at \(variantConfigurationPath): \(error)"
-                        )
+                        warning: "Couldn't parse Swift SDK artifact metadata at \(variantConfigurationPath)",
+                        underlyingError: error
                     )
                 }
             }

--- a/Sources/PackageModel/Toolset.swift
+++ b/Sources/PackageModel/Toolset.swift
@@ -75,7 +75,7 @@ extension Toolset {
             decoded = try decoder.decode(path: toolsetPath, fileSystem: fileSystem, as: DecodedToolset.self)
         } catch {
             // Throw a more detailed warning that includes the location of the toolset file we couldn't parse.
-            throw StringError("Couldn't parse toolset configuration at `\(toolsetPath)`: \(error)")
+            throw StringError("Couldn't parse toolset configuration at `\(toolsetPath)`: \(error.interpolationDescription)")
         }
 
         guard decoded.schemaVersion == Version(1, 0, 0) else {

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -326,7 +326,7 @@ public final class UserToolchain: Toolchain {
 
                     if let settings = WindowsSDKSettings(
                         reading: sdkroot.appending("SDKSettings.plist"),
-                        diagnostics: nil,
+                        observabilityScope: nil,
                         filesystem: localFileSystem
                     ) {
                         switch settings.defaults.runtime {
@@ -351,7 +351,7 @@ public final class UserToolchain: Toolchain {
 
                     if let info = WindowsPlatformInfo(
                         reading: platform.appending("Info.plist"),
-                        diagnostics: nil,
+                        observabilityScope: nil,
                         filesystem: localFileSystem
                     ) {
                         let installation: AbsolutePath =
@@ -495,7 +495,7 @@ public final class UserToolchain: Toolchain {
             if let SDKROOT = environment["SDKROOT"], let root = try? AbsolutePath(validating: SDKROOT) {
                 if let settings = WindowsSDKSettings(
                     reading: root.appending("SDKSettings.plist"),
-                    diagnostics: nil,
+                    observabilityScope: nil,
                     filesystem: localFileSystem
                 ) {
                     switch settings.defaults.runtime {
@@ -660,7 +660,7 @@ public final class UserToolchain: Toolchain {
 
             if let info = WindowsPlatformInfo(
                 reading: platform.appending("Info.plist"),
-                diagnostics: nil,
+                observabilityScope: nil,
                 filesystem: localFileSystem
             ) {
                 let xctest: AbsolutePath =

--- a/Sources/PackageModel/WindowsToolchainInfo.swift
+++ b/Sources/PackageModel/WindowsToolchainInfo.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Basics
 import Foundation
 import TSCBasic
 
@@ -53,9 +54,9 @@ extension WindowsSDKSettings: Decodable {
 }
 
 extension WindowsSDKSettings {
-    public init?(reading path: AbsolutePath, diagnostics: DiagnosticsEngine?, filesystem: FileSystem) {
+    public init?(reading path: AbsolutePath, observabilityScope: ObservabilityScope?, filesystem: FileSystem) {
         guard filesystem.exists(path) else {
-            diagnostics?.emit(error: "missing SDKSettings.plist at '\(path)'")
+            observabilityScope?.emit(error: "missing SDKSettings.plist at '\(path)'")
             return nil
         }
 
@@ -63,7 +64,10 @@ extension WindowsSDKSettings {
             let data: Data = try filesystem.readFileContents(path)
             self = try PropertyListDecoder().decode(WindowsSDKSettings.self, from: data)
         } catch {
-            diagnostics?.emit(error: "failed to load SDKSettings.plist at '\(path)': \(error)")
+            observabilityScope?.emit(
+                error: "failed to load SDKSettings.plist at '\(path)'",
+                underlyingError: error
+            )
             return nil
         }
     }
@@ -97,9 +101,9 @@ extension WindowsPlatformInfo: Decodable {
 }
 
 extension WindowsPlatformInfo {
-    public init?(reading path: AbsolutePath, diagnostics: DiagnosticsEngine?, filesystem: FileSystem) {
+    public init?(reading path: AbsolutePath, observabilityScope: ObservabilityScope?, filesystem: FileSystem) {
         guard filesystem.exists(path) else {
-            diagnostics?.emit(error: "missing Info.plist at '\(path)'")
+            observabilityScope?.emit(error: "missing Info.plist at '\(path)'")
             return nil
         }
 
@@ -107,7 +111,10 @@ extension WindowsPlatformInfo {
             let data: Data = try filesystem.readFileContents(path)
             self = try PropertyListDecoder().decode(WindowsPlatformInfo.self, from: data)
         } catch {
-            diagnostics?.emit(error: "failed to load Info.plist at '\(path)': \(error)")
+            observabilityScope?.emit(
+                error: "failed to load Info.plist at '\(path)'",
+                underlyingError: error
+            )
             return nil
         }
     }

--- a/Sources/PackageRegistry/ChecksumTOFU.swift
+++ b/Sources/PackageRegistry/ChecksumTOFU.swift
@@ -221,7 +221,8 @@ struct PackageVersionChecksumTOFU {
             case .failure(let error):
                 observabilityScope
                     .emit(
-                        error: "failed to get registry fingerprint for \(contentType) of \(package) \(version) from storage: \(error)"
+                        error: "failed to get registry fingerprint for \(contentType) of \(package) \(version) from storage",
+                        underlyingError: error
                     )
                 completion(.failure(error))
             }

--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -1135,7 +1135,7 @@ public final class RegistryClient: Cancellable {
                                                                         )
                                                                     }.mapError { error in
                                                                         StringError(
-                                                                            "failed extracting '\(downloadPath)' to '\(destinationPath)': \(error)"
+                                                                            "failed extracting '\(downloadPath)' to '\(destinationPath)': \(error.interpolationDescription)"
                                                                         )
                                                                     })
                                                                 }
@@ -1730,7 +1730,7 @@ public enum RegistryError: Error, CustomStringConvertible {
         case .unsupportedHashAlgorithm(let algorithm):
             return "unsupported hash algorithm '\(algorithm)'"
         case .failedToComputeChecksum(let error):
-            return "failed computing registry source archive checksum: \(error)"
+            return "failed computing registry source archive checksum: \(error.interpolationDescription)"
         case .checksumChanged(let latest, let previous):
             return "the latest checksum '\(latest)' is different from the previously recorded value '\(previous)'"
         case .invalidChecksum(let expected, let actual):

--- a/Sources/PackageRegistry/RegistryDownloadsManager.swift
+++ b/Sources/PackageRegistry/RegistryDownloadsManager.swift
@@ -191,7 +191,10 @@ public class RegistryDownloadsManager: Cancellable {
                 }
             } catch {
                 // download without populating the cache in the case of an error.
-                observabilityScope.emit(warning: "skipping cache due to an error: \(error)")
+                observabilityScope.emit(
+                    warning: "skipping cache due to an error",
+                    underlyingError: error
+                )
                 // it is possible that we already created the directory from failed attempts, so clear leftover data if present.
                 try? self.fileSystem.removeFileTree(packagePath)
                 self.registryClient.downloadSourceArchive(
@@ -247,7 +250,10 @@ public class RegistryDownloadsManager: Cancellable {
         do {
             try self.fileSystem.removeFileTree(self.path)
         } catch {
-            observabilityScope.emit(error: "Error resetting registry downloads at '\(self.path)': \(error)")
+            observabilityScope.emit(
+                error: "Error resetting registry downloads at '\(self.path)'",
+                underlyingError: error
+            )
         }
     }
 
@@ -268,12 +274,18 @@ public class RegistryDownloadsManager: Cancellable {
                     do {
                         try self.fileSystem.removeFileTree(pathToDelete)
                     } catch {
-                        observabilityScope.emit(error: "Error removing cached package at '\(pathToDelete)': \(error)")
+                        observabilityScope.emit(
+                            error: "Error removing cached package at '\(pathToDelete)'",
+                            underlyingError: error
+                        )
                     }
                 }
             }
         } catch {
-            observabilityScope.emit(error: "Error purging registry downloads cache at '\(cachePath)': \(error)")
+            observabilityScope.emit(
+                error: "Error purging registry downloads cache at '\(cachePath)'",
+                underlyingError: error
+            )
         }
     }
 

--- a/Sources/PackageRegistry/SignatureValidation.swift
+++ b/Sources/PackageRegistry/SignatureValidation.swift
@@ -432,8 +432,9 @@ struct SignatureValidation {
         } catch {
             observabilityScope
                 .emit(
-                    debug: "cannot determine if \(manifestName) should be signed because retrieval of source archive signature for \(package) \(version) from \(registry) failed: \(error)",
-                    metadata: .registryPackageMetadata(identity: package)
+                    debug: "cannot determine if \(manifestName) should be signed because retrieval of source archive signature for \(package) \(version) from \(registry) failed",
+                    metadata: .registryPackageMetadata(identity: package),
+                    underlyingError: error
                 )
             completion(.success(.none))
         }
@@ -552,7 +553,7 @@ extension VerifierConfiguration {
             do {
                 trustedRootsDirectory = try AbsolutePath(validating: trustedRootsDirectoryPath)
             } catch {
-                throw RegistryError.badConfiguration(details: "\(trustedRootsDirectoryPath) is invalid: \(error)")
+                throw RegistryError.badConfiguration(details: "\(trustedRootsDirectoryPath) is invalid: \(error.interpolationDescription)")
             }
 
             guard fileSystem.isDirectory(trustedRootsDirectory) else {
@@ -566,7 +567,7 @@ extension VerifierConfiguration {
                 }
                 verifierConfiguration.trustedRoots = trustedRoots
             } catch {
-                throw RegistryError.badConfiguration(details: "failed to load trust roots: \(error)")
+                throw RegistryError.badConfiguration(details: "failed to load trust roots: \(error.interpolationDescription)")
             }
         }
 

--- a/Sources/PackageRegistry/SigningEntityTOFU.swift
+++ b/Sources/PackageRegistry/SigningEntityTOFU.swift
@@ -78,7 +78,10 @@ struct PackageSigningEntityTOFU {
                     }
                 }
             case .failure(let error):
-                observabilityScope.emit(error: "Failed to get signing entity for \(package) from storage: \(error)")
+                observabilityScope.emit(
+                    error: "Failed to get signing entity for \(package) from storage",
+                    underlyingError: error
+                )
                 completion(.failure(error))
             }
         }

--- a/Sources/PackageRegistryTool/PackageRegistryTool.swift
+++ b/Sources/PackageRegistryTool/PackageRegistryTool.swift
@@ -180,7 +180,7 @@ extension SwiftPackageRegistryTool.ValidationError: CustomStringConvertible {
         case .unknownCredentialStore:
             return "no credential store available"
         case .invalidCredentialStore(let error):
-            return "credential store is invalid: \(error)"
+            return "credential store is invalid: \(error.interpolationDescription)"
         }
     }
 }

--- a/Sources/PackageSigning/SignatureProvider.swift
+++ b/Sources/PackageSigning/SignatureProvider.swift
@@ -228,7 +228,7 @@ struct CMSSignatureProvider: SignatureProviderProtocol {
                     certificate: try Certificate(secIdentity: secIdentity)
                 )
             } catch {
-                throw SigningError.signingFailed("\(error)")
+                throw SigningError.signingFailed("\(error.interpolationDescription)")
             }
         }
         #endif
@@ -250,7 +250,7 @@ struct CMSSignatureProvider: SignatureProviderProtocol {
         } catch let error as CertificateError where error.code == .unsupportedSignatureAlgorithm {
             throw SigningError.keyDoesNotSupportSignatureAlgorithm
         } catch {
-            throw SigningError.signingFailed("\(error)")
+            throw SigningError.signingFailed("\(error.interpolationDescription)")
         }
     }
 
@@ -302,10 +302,10 @@ struct CMSSignatureProvider: SignatureProviderProtocol {
             case .failure(CMS.VerificationError.invalidCMSBlock(let error)):
                 return .invalid(error.reason)
             case .failure(let error):
-                return .invalid("\(error)")
+                return .invalid("\(error.interpolationDescription)")
             }
         } catch {
-            throw SigningError.unableToValidateSignature("\(error)")
+            throw SigningError.unableToValidateSignature("\(error.interpolationDescription)")
         }
     }
 
@@ -364,7 +364,7 @@ struct CMSSignatureProvider: SignatureProviderProtocol {
             } catch let error as SigningError {
                 throw error
             } catch {
-                throw SigningError.invalidSignature("\(error)")
+                throw SigningError.invalidSignature("\(error.interpolationDescription)")
             }
         }
     }
@@ -393,7 +393,7 @@ extension SecKey {
             &error
         ) as Data? else {
             if let error = error?.takeRetainedValue() as Error? {
-                throw SigningError.signingFailed("\(error)")
+                throw SigningError.signingFailed("\(error.interpolationDescription)")
             }
             throw SigningError.signingFailed("Failed to sign with SecKey")
         }

--- a/Sources/PackageSigning/SigningIdentity.swift
+++ b/Sources/PackageSigning/SigningIdentity.swift
@@ -46,7 +46,7 @@ public struct SwiftSigningIdentity: SigningIdentity {
         do {
             self.certificate = try Certificate(certificate)
         } catch {
-            throw StringError("Invalid certificate: \(error)")
+            throw StringError("Invalid certificate: \(error.interpolationDescription)")
         }
 
         do {
@@ -57,7 +57,7 @@ public struct SwiftSigningIdentity: SigningIdentity {
         } catch let error as StringError {
             throw error
         } catch {
-            throw StringError("Invalid key: \(error)")
+            throw StringError("Invalid key: \(error.interpolationDescription)")
         }
     }
 }

--- a/Sources/SPMBuildCore/PluginContextSerializer.swift
+++ b/Sources/SPMBuildCore/PluginContextSerializer.swift
@@ -114,7 +114,7 @@ internal struct PluginContextSerializer {
             ) {
                 if let error = result.error {
                     observabilityScope.emit(
-                        warning: "\(error)",
+                        warning: "\(error.interpolationDescription)",
                         metadata: .pkgConfig(pcFile: result.pkgConfigName, targetName: target.name)
                     )
                 }

--- a/Sources/SPMBuildCore/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/PluginInvocation.swift
@@ -222,7 +222,7 @@ extension PluginTarget {
                             }
                         }
                         catch {
-                            self.observabilityScope.emit(debug: "couldn't send reply to plugin \(error)")
+                            self.observabilityScope.emit(debug: "couldn't send reply to plugin", underlyingError: error)
                         }
                     }
 
@@ -237,7 +237,7 @@ extension PluginTarget {
                             }
                         }
                         catch {
-                            self.observabilityScope.emit(debug: "couldn't send reply to plugin \(error)")
+                            self.observabilityScope.emit(debug: "couldn't send reply to plugin", underlyingError: error)
                         }
                     }
 
@@ -253,7 +253,7 @@ extension PluginTarget {
                             }
                         }
                         catch {
-                            self.observabilityScope.emit(debug: "couldn't send reply to plugin \(error)")
+                            self.observabilityScope.emit(debug: "couldn't send reply to plugin", underlyingError: error)
                         }
                     }
                 }

--- a/Sources/SPMBuildCore/XCFrameworkMetadata.swift
+++ b/Sources/SPMBuildCore/XCFrameworkMetadata.swift
@@ -58,7 +58,7 @@ extension XCFrameworkMetadata {
             let decoder = PropertyListDecoder()
             return try decoder.decode(XCFrameworkMetadata.self, from: data)
         } catch {
-            throw StringError("failed parsing XCFramework Info.plist at '\(path)': \(error)")
+            throw StringError("failed parsing XCFramework Info.plist at '\(path)': \(error.interpolationDescription)")
         }
     }
 }

--- a/Sources/SPMLLBuild/llbuild.swift
+++ b/Sources/SPMLLBuild/llbuild.swift
@@ -212,7 +212,7 @@ public extension LLBuildKey {
             } else {
                 stringValue = String(describing: data)
             }
-            throw InternalError("LLBuildKey: ###\(error)### ----- ###\(stringValue)###")
+            throw InternalError("LLBuildKey: ###\(error.interpolationDescription)### ----- ###\(stringValue)###")
         }
     }
 

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -738,7 +738,7 @@ public final class MockWorkspace {
             let workspace = try self.getOrCreateWorkspace()
             try result(ManagedDependencyResult(workspace.state.dependencies))
         } catch {
-            XCTFail("Failed with error \(error)", file: file, line: line)
+            XCTFail("Failed with error \(error.interpolationDescription)", file: file, line: line)
         }
     }
 
@@ -747,7 +747,7 @@ public final class MockWorkspace {
             let workspace = try self.getOrCreateWorkspace()
             try result(ManagedArtifactResult(workspace.state.artifacts))
         } catch {
-            XCTFail("Failed with error \(error)", file: file, line: line)
+            XCTFail("Failed with error \(error.interpolationDescription)", file: file, line: line)
         }
     }
 
@@ -804,7 +804,7 @@ public final class MockWorkspace {
             let workspace = try self.getOrCreateWorkspace()
             try result(ResolvedResult(workspace.pinsStore.load()))
         } catch {
-            XCTFail("Failed with error \(error)", file: file, line: line)
+            XCTFail("Failed with error \(error.interpolationDescription)", file: file, line: line)
         }
     }
 }

--- a/Sources/SPMTestSupport/XCTAssertHelpers.swift
+++ b/Sources/SPMTestSupport/XCTAssertHelpers.swift
@@ -121,7 +121,7 @@ public func XCTAssertThrowsCommandExecutionError<T>(
         guard case SwiftPMProductError.executionFailure(let processError, let stdout, let stderr) = error,
               case ProcessResult.Error.nonZeroExit(let processResult) = processError,
               processResult.exitStatus != .terminated(code: 0) else {
-            return XCTFail("Unexpected error type: \(error)", file: file, line: line)
+            return XCTFail("Unexpected error type: \(error.interpolationDescription)", file: file, line: line)
         }
         errorHandler(CommandExecutionError(result: processResult, stdout: stdout, stderr: stderr))
     }

--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -144,7 +144,7 @@ public func initGitRepo(
         }
         try systemQuietly([Git.tool, "-C", dir.pathString, "branch", "-m", "main"])
     } catch {
-        XCTFail("\(error)", file: file, line: line)
+        XCTFail("\(error.interpolationDescription)", file: file, line: line)
     }
 }
 

--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -343,7 +343,10 @@ public class RepositoryManager: Cancellable {
                 } else {
                     cacheUsed = false
                     // Fetch without populating the cache in the case of an error.
-                    observabilityScope.emit(warning: "skipping cache due to an error: \(error)")
+                    observabilityScope.emit(
+                        warning: "skipping cache due to an error",
+                        underlyingError: error
+                    )
                     // it is possible that we already created the directory from failed attempts, so clear leftover data if present.
                     try? self.fileSystem.removeFileTree(repositoryPath)
                     try self.provider.fetch(repository: handle.repository, to: repositoryPath, progressHandler: updateFetchProgress(progress:))
@@ -407,7 +410,10 @@ public class RepositoryManager: Cancellable {
         do {
             try self.fileSystem.removeFileTree(self.path)
         } catch {
-            observabilityScope.emit(error: "Error reseting repository manager at '\(self.path)': \(error)")
+            observabilityScope.emit(
+                error: "Error reseting repository manager at '\(self.path)'",
+                underlyingError: error
+            )
         }
     }
 
@@ -437,12 +443,18 @@ public class RepositoryManager: Cancellable {
                     do {
                         try self.fileSystem.removeFileTree(pathToDelete)
                     } catch {
-                        observabilityScope.emit(error: "Error removing cached repository at '\(pathToDelete)': \(error)")
+                        observabilityScope.emit(
+                            error: "Error removing cached repository at '\(pathToDelete)'",
+                            underlyingError: error
+                        )
                     }
                 }
             }
         } catch {
-            observabilityScope.emit(error: "Error purging repository cache at '\(cachePath)': \(error)")
+            observabilityScope.emit(
+                error: "Error purging repository cache at '\(cachePath)'",
+                underlyingError: error
+            )
         }
     }
 }

--- a/Sources/Workspace/DefaultPluginScriptRunner.swift
+++ b/Sources/Workspace/DefaultPluginScriptRunner.swift
@@ -256,7 +256,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
         }
         catch {
             // We couldn't compute the hash. We warn about it but proceed with the compilation (a cache miss).
-            observabilityScope.emit(debug: "Couldn't compute hash of plugin compilation inputs (\(error))")
+            observabilityScope.emit(debug: "Couldn't compute hash of plugin compilation inputs", underlyingError: error)
             compilerInputHash = .none
         }
         
@@ -310,7 +310,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
             }
             catch {
                 // We couldn't read the compilation state file even though it existed. We warn about it but proceed with recompiling.
-                observabilityScope.emit(debug: "Couldn't read previous compilation state (\(error))")
+                observabilityScope.emit(debug: "Couldn't read previous compilation state", underlyingError: error)
             }
         }
         
@@ -340,7 +340,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
             try fileSystem.removeFileTree(stateFilePath)
         }
         catch {
-            observabilityScope.emit(debug: "Couldn't clean up before invoking compiler (\(error))")
+            observabilityScope.emit(debug: "Couldn't clean up before invoking compiler", underlyingError: error)
         }
         
         // Now invoke the compiler asynchronously.
@@ -366,7 +366,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
                 }
                 catch {
                     // We couldn't write out the `.state` file. We warn about it but proceed.
-                    observabilityScope.emit(debug: "Couldn't save plugin compilation state (\(error))")
+                    observabilityScope.emit(debug: "Couldn't save plugin compilation state", underlyingError: error)
                 }
 
                 // Construct a PluginCompilationResult for both the successful and unsuccessful cases (to convey diagnostics, etc).
@@ -490,19 +490,19 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
                                             try outputHandle.writePluginMessage(data)
                                         }
                                         catch {
-                                            print("error while trying to send message to plugin: \(error)")
+                                            print("error while trying to send message to plugin: \(error.interpolationDescription)")
                                         }
                                     }
                                 })
                             }
                             catch {
-                                print("error while trying to handle message from plugin: \(error)")
+                                print("error while trying to handle message from plugin: \(error.interpolationDescription)")
                             }
                         }
                     }
                 }
                 catch {
-                    print("error while trying to read message from plugin: \(error)")
+                    print("error while trying to read message from plugin: \(error.interpolationDescription)")
                 }
             }
         }
@@ -622,11 +622,11 @@ public enum DefaultPluginScriptRunnerError: Error, CustomStringConvertible {
         case .pluginUnavailable(let reason):
             return "plugin is unavailable: \(reason)"
         case .compilationPreparationFailed(let error):
-            return "plugin compilation preparation failed: \(error)"
+            return "plugin compilation preparation failed: \(error.interpolationDescription)"
         case .compilationFailed(let result):
             return "plugin compilation failed: \(result)"
         case .invocationFailed(let error, let command):
-            return "plugin invocation failed: \(error) \(makeContextString(command, ""))"
+            return "plugin invocation failed: \(error.interpolationDescription) \(makeContextString(command, ""))"
         case .invocationEndedBySignal(let signal, let command, let output):
             return "plugin process ended by an uncaught signal: \(signal) \(makeContextString(command, output))"
         case .invocationEndedWithNonZeroExitCode(let exitCode, let command, let output):

--- a/Sources/Workspace/SourceControlPackageContainer.swift
+++ b/Sources/Workspace/SourceControlPackageContainer.swift
@@ -202,7 +202,10 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
                 }
             }
         } catch {
-            self.observabilityScope.emit(error: "Failed to get source control fingerprint for \(self.package) version \(version) from storage: \(error)")
+            self.observabilityScope.emit(
+                error: "Failed to get source control fingerprint for \(self.package) version \(version) from storage",
+                underlyingError: error
+            )
             throw error
         }
 

--- a/Sources/Workspace/Workspace+BinaryArtifacts.swift
+++ b/Sources/Workspace/Workspace+BinaryArtifacts.swift
@@ -192,8 +192,10 @@ extension Workspace {
                             }
                         } catch {
                             errors.append(error)
-                            observabilityScope
-                                .emit(error: "failed retrieving '\(indexFile.url)': \(error.interpolationDescription)")
+                            observabilityScope.emit(
+                                error: "failed retrieving '\(indexFile.url)'",
+                                underlyingError: error
+                            )
                         }
                     }
                 }
@@ -692,7 +694,7 @@ extension Workspace.BinaryArtifactsManager {
                 _ = try decoder.decode(XCFrameworkMetadata.self, from: fileSystem.readFileContents(infoPlist))
                 return .xcframework
             } catch {
-                observabilityScope.emit(debug: "info.plist found in '\(path)' but failed to parse: \(error)")
+                observabilityScope.emit(debug: "info.plist found in '\(path)' but failed to parse: \(error.interpolationDescription)")
             }
         }
 
@@ -701,7 +703,10 @@ extension Workspace.BinaryArtifactsManager {
                 _ = try ArtifactsArchiveMetadata.parse(fileSystem: fileSystem, rootPath: infoJSON.parentDirectory)
                 return .artifactsArchive
             } catch {
-                observabilityScope.emit(debug: "info.json found in '\(path)' but failed to parse: \(error)")
+                observabilityScope.emit(
+                    debug: "info.json found in '\(path)' but failed to parse",
+                    underlyingError: error
+                )
             }
         }
 

--- a/Sources/Workspace/Workspace+Configuration.swift
+++ b/Sources/Workspace/Workspace+Configuration.swift
@@ -383,7 +383,10 @@ extension Workspace.Configuration {
             do {
                 return try NetrcAuthorizationProvider(path: path, fileSystem: fileSystem)
             } catch {
-                observabilityScope.emit(warning: "Failed to load netrc file at \(path). Error: \(error)")
+                observabilityScope.emit(
+                    warning: "Failed to load netrc file at \(path)",
+                    underlyingError: error
+                )
                 return .none
             }
         }
@@ -688,7 +691,7 @@ extension Workspace.Configuration {
                 let decoder = JSONDecoder.makeWithDefaults()
                 return try decoder.decode(path: self.path, fileSystem: self.fileSystem, as: RegistryConfiguration.self)
             } catch {
-                throw StringError("Failed loading registries configuration from '\(self.path)': \(error)")
+                throw StringError("Failed loading registries configuration from '\(self.path)': \(error.interpolationDescription)")
             }
         }
 

--- a/Sources/Workspace/Workspace+State.swift
+++ b/Sources/Workspace/Workspace+State.swift
@@ -57,7 +57,7 @@ public final class WorkspaceState {
             self.dependencies = Workspace.ManagedDependencies()
             self.artifacts = Workspace.ManagedArtifacts()
             try? self.storage.reset()
-            initializationWarningHandler("unable to restore workspace state: \(error)")
+            initializationWarningHandler("unable to restore workspace state: \(error.interpolationDescription)")
         }
     }
 

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -951,7 +951,10 @@ extension Workspace {
         do {
             try self.fileSystem.removeFileTree(self.location.scratchDirectory)
         } catch {
-            observabilityScope.emit(error: "Error removing scratch directory at '\(self.location.scratchDirectory)': \(error)")
+            observabilityScope.emit(
+                error: "Error removing scratch directory at '\(self.location.scratchDirectory)'",
+                underlyingError: error
+            )
         }
     }
 
@@ -2131,7 +2134,10 @@ extension Workspace {
             fileSystem = try self.getFileSystem(package: package, state: managedDependency.state, observabilityScope: observabilityScope)
         } catch {
             // only warn here in case of issues since we should not even get here without a valid package container
-            observabilityScope.emit(warning: "unexpected failure while accessing custom package container: \(error)")
+            observabilityScope.emit(
+                warning: "unexpected failure while accessing custom package container",
+                underlyingError: error
+            )
             fileSystem = nil
         }
 
@@ -2821,7 +2827,7 @@ extension Workspace {
                 requirement: requirement
             ))
         case .failure(let error):
-            return .required(reason: .other("\(error)"))
+            return .required(reason: .other("\(error.interpolationDescription)"))
         }
     }
 
@@ -3963,7 +3969,10 @@ extension Workspace {
                         switch result {
                         case .failure(let error):
                             // do not raise error, only report it as warning
-                            observabilityScope.emit(warning: "failed querying registry identity for '\(url)': \(error)")
+                            observabilityScope.emit(
+                                warning: "failed querying registry identity for '\(url)'",
+                                underlyingError: error
+                            )
                         case .success(.some(let identity)):
                             transformations[dependency] = identity
                         case .success(.none):

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -712,7 +712,7 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         ) {
             if let error = result.error {
                 self.observabilityScope.emit(
-                    warning: "\(error)",
+                    warning: "\(error.interpolationDescription)",
                     metadata: .pkgConfig(pcFile: result.pkgConfigName, targetName: target.name)
                 )
             } else {


### PR DESCRIPTION
motivation: better error messages

changes:
* audit usage of "\(error)" and replace them with "\(error.interpolationDescription)"
* add ADPI to pass an optional underlying error to observability's debug, info and warn calls such that it automatically interpolates the error correctly
* update call sites

rdar://108418554
