### PR TITLE
[5.9] Support macro targets in plugin context

### DIFF
--- a/Sources/PackagePlugin/PackageModel.swift
+++ b/Sources/PackagePlugin/PackageModel.swift
@@ -235,6 +235,9 @@ public enum ModuleKind {
     case snippet
     /// A module that contains unit tests.
     case test
+    /// A module that contains code for a macro.
+    @available(_PackageDescription, introduced: 5.9)
+    case macro // FIXME: This should really come from `CompilerPluginSupport` somehow, but we lack the infrastructure to allow that currently.
 }
 
 /// Represents a target consisting of a source code module compiled using Swift.

--- a/Sources/PackagePlugin/PluginContextDeserializer.swift
+++ b/Sources/PackagePlugin/PluginContextDeserializer.swift
@@ -261,6 +261,8 @@ fileprivate extension ModuleKind {
             self = .snippet
         case .test:
             self = .test
+        case .macro:
+            self = .macro
         }
     }
 }

--- a/Sources/PackagePlugin/PluginMessages.swift
+++ b/Sources/PackagePlugin/PluginMessages.swift
@@ -173,6 +173,7 @@ enum HostToPluginMessage: Codable {
                         case executable
                         case snippet
                         case test
+                        case macro
                     }
 
                     enum BinaryArtifactKind: Codable {

--- a/Sources/SPMBuildCore/PluginContextSerializer.swift
+++ b/Sources/SPMBuildCore/PluginContextSerializer.swift
@@ -278,7 +278,9 @@ fileprivate extension WireInput.Target.TargetInfo.SourceModuleKind {
             self = .snippet
         case .test:
             self = .test
-        case .binary, .plugin, .systemModule, .macro:
+        case .macro:
+            self = .macro
+        case .binary, .plugin, .systemModule:
             throw StringError("unexpected target kind \(kind) for source module")
         }
     }


### PR DESCRIPTION
This currently prevents the use of plugins in any package graph that happens to include one or more macro targets which seems extremely unfortunate.

This fix is slightly ugly because `PackagePlugin` should not concretely know about macros. An alternative could be excluding macros from the project model that plugins see.

rdar://108531004

(cherry picked from commit 76744ca25260ca487b6f75f099219cdacb3fd231)
