### PR TITLE
[5.9] Use assertMacroExpansion in test cases of macro template

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -231,7 +231,8 @@ public final class InitPackage {
                         // Products define the executables and libraries a package produces, making them visible to other packages.
                         .library(
                             name: "\(pkgname)",
-                            targets: ["\(pkgname)"]),
+                            targets: ["\(pkgname)"]
+                        ),
                         .executable(
                             name: "\(pkgname)Client",
                             targets: ["\(pkgname)Client"]
@@ -279,7 +280,8 @@ public final class InitPackage {
                                 name: "\(pkgname)",
                                 dependencies: [
                                     .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                                ]),
+                                ]
+                            ),
                         ]
                     """
                 } else if packageType == .buildToolPlugin {
@@ -303,11 +305,11 @@ public final class InitPackage {
                     """
                 } else if packageType == .macro {
                     param += """
-                            // Macro implementation, only built for the host and never part of a client program.
+                            // Macro implementation that performs the source transformation of a macro.
                             .macro(name: "\(pkgname)Macros",
                                    dependencies: [
-                                     .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
-                                     .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
+                                       .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+                                       .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
                                    ]
                             ),
 
@@ -623,7 +625,7 @@ public final class InitPackage {
                 import XCTest
                 import \##(moduleName)Macros
 
-                var testMacros: [String: Macro.Type] = [
+                let testMacros: [String: Macro.Type] = [
                     "stringify" : StringifyMacro.self,
                 ]
 


### PR DESCRIPTION
* **Explanation**: SwiftSyntax just introduced an `assertMacroExpansion` function to test macros. The macro temple should use that
* **Scope**: The macro template generated by `swift package init --type macro`
* **Risk**: Low, only affects new macro templates
* **Testing**: Tested that the newly generated template builds and passes tests
* **Issue**: rdar://107971349
* **Reviewer**: 