### PR TITLE
Fix some stream operator deprecation warnings

### DIFF
--- a/Sources/Basics/FileSystem/FileSystem+Extensions.swift
+++ b/Sources/Basics/FileSystem/FileSystem+Extensions.swift
@@ -302,10 +302,6 @@ extension FileSystem {
     public func writeFileContents(_ path: AbsolutePath, string: String) throws {
         return try self.writeFileContents(path, bytes: .init(encodingAsUTF8: string))
     }
-
-    public func writeFileContents(_ path: AbsolutePath, provider: () -> String) throws {
-        return try self.writeFileContents(path, body: { stream in stream.send(provider()) })
-    }
 }
 
 extension FileSystem {

--- a/Sources/Basics/FileSystem/FileSystem+Extensions.swift
+++ b/Sources/Basics/FileSystem/FileSystem+Extensions.swift
@@ -304,7 +304,7 @@ extension FileSystem {
     }
 
     public func writeFileContents(_ path: AbsolutePath, provider: () -> String) throws {
-        return try self.writeFileContents(path, body: { stream in stream <<< provider() })
+        return try self.writeFileContents(path, body: { stream in stream.send(provider()) })
     }
 }
 

--- a/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
@@ -310,20 +310,22 @@ public final class ClangTargetBuildDescription {
         let bundleBasename = bundlePath.basename
 
         let implFileStream = BufferedOutputByteStream()
-        implFileStream <<< """
-        #import <Foundation/Foundation.h>
+        implFileStream.send(
+            """
+            #import <Foundation/Foundation.h>
 
-        NSBundle* \(target.c99name)_SWIFTPM_MODULE_BUNDLE() {
-            NSURL *bundleURL = [[[NSBundle mainBundle] bundleURL] URLByAppendingPathComponent:@"\(bundleBasename)"];
+            NSBundle* \(target.c99name)_SWIFTPM_MODULE_BUNDLE() {
+                NSURL *bundleURL = [[[NSBundle mainBundle] bundleURL] URLByAppendingPathComponent:@"\(bundleBasename)"];
 
-            NSBundle *preferredBundle = [NSBundle bundleWithURL:bundleURL];
-            if (preferredBundle == nil) {
-              return [NSBundle bundleWithPath:@"\(bundlePath.pathString)"];
+                NSBundle *preferredBundle = [NSBundle bundleWithURL:bundleURL];
+                if (preferredBundle == nil) {
+                  return [NSBundle bundleWithPath:@"\(bundlePath.pathString)"];
+                }
+
+                return preferredBundle;
             }
-
-            return preferredBundle;
-        }
-        """
+            """
+        )
 
         let implFileSubpath = try RelativePath(validating: "resource_bundle_accessor.m")
 
@@ -338,21 +340,23 @@ public final class ClangTargetBuildDescription {
         )
 
         let headerFileStream = BufferedOutputByteStream()
-        headerFileStream <<< """
-        #import <Foundation/Foundation.h>
+        headerFileStream.send(
+            """
+            #import <Foundation/Foundation.h>
 
-        #if __cplusplus
-        extern "C" {
-        #endif
+            #if __cplusplus
+            extern "C" {
+            #endif
 
-        NSBundle* \(target.c99name)_SWIFTPM_MODULE_BUNDLE(void);
+            NSBundle* \(target.c99name)_SWIFTPM_MODULE_BUNDLE(void);
 
-        #define SWIFTPM_MODULE_BUNDLE \(target.c99name)_SWIFTPM_MODULE_BUNDLE()
+            #define SWIFTPM_MODULE_BUNDLE \(target.c99name)_SWIFTPM_MODULE_BUNDLE()
 
-        #if __cplusplus
-        }
-        #endif
-        """
+            #if __cplusplus
+            }
+            #endif
+            """
+        )
         let headerFile = derivedSources.root.appending("resource_bundle_accessor.h")
         self.resourceAccessorHeaderFile = headerFile
 

--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -331,7 +331,7 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
         let stream = BufferedOutputByteStream()
 
         for object in self.objects {
-            stream <<< object.pathString.spm_shellEscaped() <<< "\n"
+            stream.send("\(object.pathString.spm_shellEscaped())\n")
         }
 
         try fs.createDirectory(self.linkFileListPath.parentDirectory, recursive: true)

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -158,7 +158,7 @@ final class TestDiscoveryCommand: CustomLLBuildCommand, TestBuildCommand {
             public func __allDiscoveredTests() -> [XCTestCaseEntry] {
                 \#(testsKeyword) tests = [XCTestCaseEntry]()
 
-                \#(testsByModule.keys.map { "tests += __\($0)__allTests()" }.joined(separator: ",\n    "))
+                \#(testsByModule.keys.map { "tests += __\($0)__allTests()" }.joined(separator: "\n    "))
 
                 return tests
             }

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -68,40 +68,39 @@ final class TestDiscoveryCommand: CustomLLBuildCommand, TestBuildCommand {
 
         let testsByClassNames = Dictionary(grouping: tests, by: { $0.name }).sorted(by: { $0.key < $1.key })
 
-        stream <<< "import XCTest" <<< "\n"
-        stream <<< "@testable import " <<< module <<< "\n"
+        stream.send("import XCTest\n")
+        stream.send("@testable import \(module)\n")
 
         for iterator in testsByClassNames {
+            // 'className' provides uniqueness for derived class.
             let className = iterator.key
             let testMethods = iterator.value.flatMap(\.testMethods)
-            stream <<< "\n"
-            stream <<< "fileprivate extension " <<< className <<< " {" <<< "\n"
-            stream <<< indent(4) <<<
-                "@available(*, deprecated, message: \"Not actually deprecated. Marked as deprecated to allow inclusion of deprecated tests (which test deprecated functionality) without warnings\")" <<<
-                "\n"
-            // 'className' provides uniqueness for derived class.
-            stream <<< indent(4) <<< "static let __allTests__\(className) = [" <<< "\n"
-            for method in testMethods {
-                stream <<< indent(8) <<< method.allTestsEntry <<< ",\n"
-            }
-            stream <<< indent(4) <<< "]" <<< "\n"
-            stream <<< "}" <<< "\n"
+            stream.send(
+                #"""
+
+                fileprivate extension \#(className) {
+                    @available(*, deprecated, message: "Not actually deprecated. Marked as deprecated to allow \
+                inclusion of deprecated tests (which test deprecated functionality) without warnings")
+                    static let __allTests__\#(className) = [
+                        \#(testMethods.map { $0.allTestsEntry }.joined(separator: ",\n        "))
+                    ]
+                }
+
+                """#
+            )
         }
 
-        stream <<< """
-        @available(*, deprecated, message: "Not actually deprecated. Marked as deprecated to allow inclusion of deprecated tests (which test deprecated functionality) without warnings")
-        func __\(module)__allTests() -> [XCTestCaseEntry] {
-            return [\n
-        """
-
-        for iterator in testsByClassNames {
-            let className = iterator.key
-            stream <<< indent(8) <<< "testCase(\(className).__allTests__\(className)),\n"
-        }
-        stream <<< """
+        stream.send(
+        #"""
+        @available(*, deprecated, message: "Not actually deprecated. Marked as deprecated to allow inclusion of \
+        deprecated tests (which test deprecated functionality) without warnings")
+        func __\#(module)__allTests() -> [XCTestCaseEntry] {
+            return [
+                \#(testsByClassNames.map { "testCase(\($0.key).__allTests__\($0.key))" }
+                    .joined(separator: ",\n        "))
             ]
         }
-        """
+        """#)
 
         stream.flush()
     }
@@ -153,21 +152,21 @@ final class TestDiscoveryCommand: CustomLLBuildCommand, TestBuildCommand {
         // Write the main file.
         let stream = try LocalFileOutputByteStream(mainFile)
 
-        stream <<< "import XCTest" <<< "\n\n"
+        stream.send(
+            #"""
+            import XCTest
 
-        stream <<<
-            "@available(*, deprecated, message: \"Not actually deprecated. Marked as deprecated to allow inclusion of deprecated tests (which test deprecated functionality) without warnings\")" <<<
-            "\n"
-        stream <<< "public func __allDiscoveredTests() -> [XCTestCaseEntry] {" <<< "\n"
-        stream <<< indent(4) <<< "\(testsKeyword) tests = [XCTestCaseEntry]()" <<< "\n\n"
+            @available(*, deprecated, message: "Not actually deprecated. Marked as deprecated to allow inclusion of \
+            deprecated tests (which test deprecated functionality) without warnings")
+            public func __allDiscoveredTests() -> [XCTestCaseEntry] {
+                \#(testsKeyword) tests = [XCTestCaseEntry]()
 
-        for module in testsByModule.keys {
-            stream <<< indent(4) <<< "tests += __\(module)__allTests()" <<< "\n"
-        }
+                \#(testsByModule.keys.map { "tests += __\($0)__allTests()" }.joined(separator: ",\n    "))
 
-        stream <<< "\n"
-        stream <<< indent(4) <<< "return tests" <<< "\n"
-        stream <<< "}" <<< "\n"
+                return tests
+            }
+            """#
+        )
 
         stream.flush()
     }
@@ -211,21 +210,21 @@ final class TestEntryPointCommand: CustomLLBuildCommand, TestBuildCommand {
         // Write the main file.
         let stream = try LocalFileOutputByteStream(mainFile)
 
-        stream <<< "import XCTest" <<< "\n"
-        for discoveryModuleName in discoveryModuleNames {
-            stream <<< "import \(discoveryModuleName)" <<< "\n"
-        }
-        stream <<< "\n"
+        stream.send(
+            #"""
+            import XCTest
+            \#(discoveryModuleNames.map { "import \($0)" }.joined(separator: "\n"))
 
-        stream <<< "@main" <<< "\n"
-        stream <<<
-            "@available(*, deprecated, message: \"Not actually deprecated. Marked as deprecated to allow inclusion of deprecated tests (which test deprecated functionality) without warnings\")" <<<
-            "\n"
-        stream <<< "struct Runner" <<< " {" <<< "\n"
-        stream <<< indent(4) <<< "static func main()" <<< " {" <<< "\n"
-        stream <<< indent(8) <<< "XCTMain(__allDiscoveredTests())" <<< "\n"
-        stream <<< indent(4) <<< "}" <<< "\n"
-        stream <<< "}" <<< "\n"
+            @main
+            @available(*, deprecated, message: "Not actually deprecated. Marked as deprecated to allow inclusion of \
+            deprecated tests (which test deprecated functionality) without warnings")
+            struct Runner {
+                static func main() {
+                    XCTMain(__allDiscoveredTests())
+                }
+            }
+            """#
+        )
 
         stream.flush()
     }
@@ -381,7 +380,8 @@ public struct BuildDescription: Codable {
 
 /// A provider of advice about build errors.
 public protocol BuildErrorAdviceProvider {
-    /// Invoked after a command fails and an error message is detected in the output.  Should return a string containing advice or additional information, if any, based on the build plan.
+    /// Invoked after a command fails and an error message is detected in the output. Should return a string containing
+    /// advice or additional information, if any, based on the build plan.
     func provideBuildErrorAdvice(for target: String, command: String, message: String) -> String?
 }
 
@@ -622,7 +622,7 @@ final class BuildOperationBuildSystemDelegateHandler: LLBuildBuildSystemDelegate
         queue.async {
             self.delegate?.buildSystem(self.buildSystem, didStartCommand: BuildSystemCommand(command))
             if self.logLevel.isVerbose {
-                self.outputStream <<< command.verboseDescription <<< "\n"
+                self.outputStream.send("\(command.verboseDescription)\n")
                 self.outputStream.flush()
             }
         }
@@ -702,7 +702,7 @@ final class BuildOperationBuildSystemDelegateHandler: LLBuildBuildSystemDelegate
         queue.async {
             if let buffer = self.nonSwiftMessageBuffers[command.name] {
                 self.progressAnimation.clear()
-                self.outputStream <<< buffer
+                self.outputStream.send(buffer)
                 self.outputStream.flush()
                 self.nonSwiftMessageBuffers[command.name] = nil
             }
@@ -713,7 +713,8 @@ final class BuildOperationBuildSystemDelegateHandler: LLBuildBuildSystemDelegate
             self.cancelled = true
             self.delegate?.buildSystemDidCancel(self.buildSystem)
         case .failed:
-            // The command failed, so we queue up an asynchronous task to see if we have any error messages from the target to provide advice about.
+            // The command failed, so we queue up an asynchronous task to see if we have any error messages from the
+            target to provide advice about.
             queue.async {
                 guard let target = self.swiftParsers[command.name]?.targetName else { return }
                 guard let errorMessages = self.errorMessagesByTarget[target] else { return }
@@ -724,7 +725,7 @@ final class BuildOperationBuildSystemDelegateHandler: LLBuildBuildSystemDelegate
                         command: command.name,
                         message: errorMessage
                     ) {
-                        self.outputStream <<< "note: " <<< adviceMessage <<< "\n"
+                        self.outputStream.send("note: \(adviceMessage)\n")
                         self.outputStream.flush()
                     }
                 }
@@ -762,7 +763,7 @@ final class BuildOperationBuildSystemDelegateHandler: LLBuildBuildSystemDelegate
         queue.async {
             self.progressAnimation.clear()
             if !verboseOnly || self.logLevel.isVerbose {
-                self.outputStream <<< output.spm_chomp() <<< "\n"
+                self.outputStream.send("\(output.spm_chomp())\n")
                 self.outputStream.flush()
             }
         }
@@ -783,7 +784,7 @@ final class BuildOperationBuildSystemDelegateHandler: LLBuildBuildSystemDelegate
         queue.async {
             if self.logLevel.isVerbose {
                 if let text = message.verboseProgressText {
-                    self.outputStream <<< text <<< "\n"
+                    self.outputStream.send("\(text)\n")
                     self.outputStream.flush()
                 }
             } else {
@@ -797,10 +798,11 @@ final class BuildOperationBuildSystemDelegateHandler: LLBuildBuildSystemDelegate
                     self.progressAnimation.clear()
                 }
 
-                self.outputStream <<< output
+                self.outputStream.send(output)
                 self.outputStream.flush()
 
-                // next we want to try and scoop out any errors from the output (if reasonable size, otherwise this will be very slow),
+                // next we want to try and scoop out any errors from the output (if reasonable size, otherwise this
+                will be very slow),
                 // so they can later be passed to the advice provider in case of failure.
                 if output.utf8.count < 1024 * 10 {
                     let regex = try! RegEx(pattern: #".*(error:[^\n]*)\n.*"#, options: .dotMatchesLineSeparators)
@@ -825,7 +827,7 @@ final class BuildOperationBuildSystemDelegateHandler: LLBuildBuildSystemDelegate
     func buildStart(configuration: BuildConfiguration) {
         queue.sync {
             self.progressAnimation.clear()
-            self.outputStream <<< "Building for \(configuration == .debug ? "debugging" : "production")...\n"
+            self.outputStream.send("Building for \(configuration == .debug ? "debugging" : "production")...\n")
             self.outputStream.flush()
         }
     }
@@ -836,7 +838,7 @@ final class BuildOperationBuildSystemDelegateHandler: LLBuildBuildSystemDelegate
             if success {
                 let message = cancelled ? "Build cancelled!" : "Build complete!"
                 self.progressAnimation.clear()
-                self.outputStream <<< "\(message) (\(duration.descriptionInSeconds))\n"
+                self.outputStream.send("\(message) (\(duration.descriptionInSeconds))\n")
                 self.outputStream.flush()
             }
         }

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -802,8 +802,7 @@ final class BuildOperationBuildSystemDelegateHandler: LLBuildBuildSystemDelegate
                 self.outputStream.flush()
 
                 // next we want to try and scoop out any errors from the output (if reasonable size, otherwise this
-                will be very slow),
-                // so they can later be passed to the advice provider in case of failure.
+                // will be very slow), so they can later be passed to the advice provider in case of failure.
                 if output.utf8.count < 1024 * 10 {
                     let regex = try! RegEx(pattern: #".*(error:[^\n]*)\n.*"#, options: .dotMatchesLineSeparators)
                     for match in regex.matchGroups(in: output) {

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -714,7 +714,7 @@ final class BuildOperationBuildSystemDelegateHandler: LLBuildBuildSystemDelegate
             self.delegate?.buildSystemDidCancel(self.buildSystem)
         case .failed:
             // The command failed, so we queue up an asynchronous task to see if we have any error messages from the
-            target to provide advice about.
+            // target to provide advice about.
             queue.async {
                 guard let target = self.swiftParsers[command.name]?.targetName else { return }
                 guard let errorMessages = self.errorMessagesByTarget[target] else { return }

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -79,8 +79,7 @@ final class TestDiscoveryCommand: CustomLLBuildCommand, TestBuildCommand {
                 #"""
 
                 fileprivate extension \#(className) {
-                    @available(*, deprecated, message: "Not actually deprecated. Marked as deprecated to allow \
-                inclusion of deprecated tests (which test deprecated functionality) without warnings")
+                    @available(*, deprecated, message: "Not actually deprecated. Marked as deprecated to allow inclusion of deprecated tests (which test deprecated functionality) without warnings")
                     static let __allTests__\#(className) = [
                         \#(testMethods.map { $0.allTestsEntry }.joined(separator: ",\n        "))
                     ]
@@ -92,8 +91,7 @@ final class TestDiscoveryCommand: CustomLLBuildCommand, TestBuildCommand {
 
         stream.send(
         #"""
-        @available(*, deprecated, message: "Not actually deprecated. Marked as deprecated to allow inclusion of \
-        deprecated tests (which test deprecated functionality) without warnings")
+        @available(*, deprecated, message: "Not actually deprecated. Marked as deprecated to allow inclusion of deprecated tests (which test deprecated functionality) without warnings")
         func __\#(module)__allTests() -> [XCTestCaseEntry] {
             return [
                 \#(testsByClassNames.map { "testCase(\($0.key).__allTests__\($0.key))" }
@@ -156,8 +154,7 @@ final class TestDiscoveryCommand: CustomLLBuildCommand, TestBuildCommand {
             #"""
             import XCTest
 
-            @available(*, deprecated, message: "Not actually deprecated. Marked as deprecated to allow inclusion of \
-            deprecated tests (which test deprecated functionality) without warnings")
+            @available(*, deprecated, message: "Not actually deprecated. Marked as deprecated to allow inclusion of deprecated tests (which test deprecated functionality) without warnings")
             public func __allDiscoveredTests() -> [XCTestCaseEntry] {
                 \#(testsKeyword) tests = [XCTestCaseEntry]()
 
@@ -216,8 +213,7 @@ final class TestEntryPointCommand: CustomLLBuildCommand, TestBuildCommand {
             \#(discoveryModuleNames.map { "import \($0)" }.joined(separator: "\n"))
 
             @main
-            @available(*, deprecated, message: "Not actually deprecated. Marked as deprecated to allow inclusion of \
-            deprecated tests (which test deprecated functionality) without warnings")
+            @available(*, deprecated, message: "Not actually deprecated. Marked as deprecated to allow inclusion of deprecated tests (which test deprecated functionality) without warnings")
             struct Runner {
                 static func main() {
                     XCTMain(__allDiscoveredTests())

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -1077,7 +1077,8 @@ func generateResourceInfoPlist(
     }
 
     let stream = BufferedOutputByteStream()
-    stream <<< """
+    stream.send(
+        """
         <?xml version="1.0" encoding="UTF-8"?>
         <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
         <plist version="1.0">
@@ -1087,6 +1088,7 @@ func generateResourceInfoPlist(
         </dict>
         </plist>
         """
+    )
 
     try fileSystem.writeIfChanged(path: path, bytes: stream.bytes)
     return true

--- a/Sources/Commands/PackageTools/Config.swift
+++ b/Sources/Commands/PackageTools/Config.swift
@@ -177,7 +177,7 @@ extension SwiftPackageTool.Config {
             if let mirror = config.mirrors.mirror(for: original) {
                 print(mirror)
             } else {
-                stderrStream <<< "not found\n"
+                stderrStream.send("not found\n")
                 stderrStream.flush()
                 throw ExitCode.failure
             }

--- a/Sources/Commands/Utilities/DependenciesSerializer.swift
+++ b/Sources/Commands/Utilities/DependenciesSerializer.swift
@@ -55,7 +55,7 @@ final class FlatListDumper: DependenciesDumper {
     func dump(dependenciesOf rootpkg: ResolvedPackage, on stream: OutputByteStream) {
         func recursiveWalk(packages: [ResolvedPackage]) {
             for package in packages {
-                stream.send("\(package.identity.description)\n")
+                stream.send(package.identity.description).send("\n")
                 if !package.dependencies.isEmpty {
                     recursiveWalk(packages: package.dependencies)
                 }
@@ -74,7 +74,7 @@ final class DotDumper: DependenciesDumper {
             let url = package.manifest.packageLocation
             if nodesAlreadyPrinted.contains(url) { return }
             let pkgVersion = package.manifest.version?.description ?? "unspecified"
-            stream.send(#""\#(url)" [label="\#(package.identity.description)\n\#(url)\n\#(pkgVersion)"]\n"#)
+            stream.send(#""\#(url)" [label="\#(package.identity.description)\n\#(url)\n\#(pkgVersion)"]"#).send("\n")
             nodesAlreadyPrinted.insert(url)
         }
 
@@ -92,7 +92,7 @@ final class DotDumper: DependenciesDumper {
                 if dependenciesAlreadyPrinted.contains(urlPair) { continue }
 
                 printNode(dependency)
-                stream.send(#""\#(rootURL)" -> "\#(dependencyURL)"\n"#)
+                stream.send(#""\#(rootURL)" -> "\#(dependencyURL)""#).send("\n")
                 dependenciesAlreadyPrinted.insert(urlPair)
 
                 if !dependency.dependencies.isEmpty {

--- a/Sources/Commands/Utilities/DependenciesSerializer.swift
+++ b/Sources/Commands/Utilities/DependenciesSerializer.swift
@@ -30,7 +30,7 @@ final class PlainTextDumper: DependenciesDumper {
 
                 let pkgVersion = package.manifest.version?.description ?? "unspecified"
 
-                stream <<< "\(hanger)\(package.identity.description)<\(package.manifest.packageLocation)@\(pkgVersion)>\n"
+                stream.send("\(hanger)\(package.identity.description)<\(package.manifest.packageLocation)@\(pkgVersion)>\n")
 
                 if !package.dependencies.isEmpty {
                     let replacement = (index == packages.count - 1) ?  "    " : "│   "
@@ -43,10 +43,10 @@ final class PlainTextDumper: DependenciesDumper {
         }
 
         if !rootpkg.dependencies.isEmpty {
-            stream <<< (".\n")
+            stream.send(".\n")
             recursiveWalk(packages: rootpkg.dependencies)
         } else {
-            stream <<< "No external dependencies found\n"
+            stream.send("No external dependencies found\n")
         }
     }
 }
@@ -55,7 +55,7 @@ final class FlatListDumper: DependenciesDumper {
     func dump(dependenciesOf rootpkg: ResolvedPackage, on stream: OutputByteStream) {
         func recursiveWalk(packages: [ResolvedPackage]) {
             for package in packages {
-                stream <<< package.identity.description <<< "\n"
+                stream.send("\(package.identity.description)\n")
                 if !package.dependencies.isEmpty {
                     recursiveWalk(packages: package.dependencies)
                 }
@@ -74,7 +74,7 @@ final class DotDumper: DependenciesDumper {
             let url = package.manifest.packageLocation
             if nodesAlreadyPrinted.contains(url) { return }
             let pkgVersion = package.manifest.version?.description ?? "unspecified"
-            stream <<< #""\#(url)" [label="\#(package.identity.description)\n\#(url)\n\#(pkgVersion)"]"# <<< "\n"
+            stream.send(#""\#(url)" [label="\#(package.identity.description)\n\#(url)\n\#(pkgVersion)"]\n"#)
             nodesAlreadyPrinted.insert(url)
         }
 
@@ -92,7 +92,7 @@ final class DotDumper: DependenciesDumper {
                 if dependenciesAlreadyPrinted.contains(urlPair) { continue }
 
                 printNode(dependency)
-                stream <<< #""\#(rootURL)" -> "\#(dependencyURL)""# <<< "\n"
+                stream.send(#""\#(rootURL)" -> "\#(dependencyURL)"\n"#)
                 dependenciesAlreadyPrinted.insert(urlPair)
 
                 if !dependency.dependencies.isEmpty {
@@ -102,12 +102,17 @@ final class DotDumper: DependenciesDumper {
         }
 
         if !rootpkg.dependencies.isEmpty {
-            stream <<< "digraph DependenciesGraph {\n"
-            stream <<< "node [shape = box]\n"
+            stream.send(
+                """
+                digraph DependenciesGraph {
+                node [shape = box]
+
+                """
+            )
             recursiveWalk(rootpkg: rootpkg)
-            stream <<< "}\n"
+            stream.send("}\n")
         } else {
-            stream <<< "No external dependencies found\n"
+            stream.send("No external dependencies found\n")
         }
     }
 }
@@ -125,6 +130,6 @@ final class JSONDumper: DependenciesDumper {
             ])
         }
 
-        stream <<< convert(rootpkg).toString(prettyPrint: true) <<< "\n"
+        stream.send("\(convert(rootpkg).toString(prettyPrint: true))\n")
     }
 }

--- a/Sources/Commands/Utilities/DescribedPackage.swift
+++ b/Sources/Commands/Utilities/DescribedPackage.swift
@@ -348,10 +348,9 @@ public struct PlainTextEncoder {
             let codingPath: [CodingKey]
             
             private mutating func emit(_ key: CodingKey, _ value: String?) {
-                outputStream <<< String(repeating: "    ", count: codingPath.count)
-                outputStream <<< displayName(for: key) <<< ":"
-                if let value { outputStream <<< " " <<< value }
-                outputStream <<< "\n"
+                outputStream.send("\(String(repeating: "    ", count: codingPath.count))\(displayName(for: key)):")
+                if let value { outputStream.send(" \(value)") }
+                outputStream.send("\n")
             }
             mutating func encodeNil(forKey key: Key) throws { emit(key, "nil") }
             mutating func encode(_ value: Bool, forKey key: Key) throws { emit(key, "\(value)") }
@@ -402,9 +401,7 @@ public struct PlainTextEncoder {
             private(set) var count: Int = 0
             
             private mutating func emit(_ value: String) {
-                outputStream <<< String(repeating: "    ", count: codingPath.count)
-                outputStream <<< value
-                outputStream <<< "\n"
+                outputStream.send("\(String(repeating: "    ", count: codingPath.count))\(value)\n")
                 count += 1
             }
             mutating func encodeNil() throws { emit("nil") }
@@ -423,16 +420,26 @@ public struct PlainTextEncoder {
             mutating func encode(_ value: UInt32) throws { emit("\(value)") }
             mutating func encode(_ value: UInt64) throws { emit("\(value)") }
             mutating func encode<T: Encodable>(_ value: T) throws {
-                let textEncoder = _PlainTextEncoder(outputStream: outputStream, formattingOptions: formattingOptions, userInfo: userInfo, codingPath: codingPath)
+                let textEncoder = _PlainTextEncoder(
+                    outputStream: outputStream,
+                    formattingOptions: formattingOptions,
+                    userInfo: userInfo,
+                    codingPath: codingPath
+                )
                 try value.encode(to: textEncoder)
                 count += 1
                 // FIXME: This is a bit arbitrary and should be controllable.  We may also want an option to only emit
                 // newlines between entries, not after each one.
-                if codingPath.count < 2 { outputStream <<< "\n" }
+                if codingPath.count < 2 { outputStream.send("\n") }
             }
             
             mutating func nestedContainer<NestedKey: CodingKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> {
-                return KeyedEncodingContainer(PlainTextKeyedEncodingContainer<NestedKey>(outputStream: outputStream, formattingOptions: formattingOptions, userInfo: userInfo, codingPath: codingPath))
+                KeyedEncodingContainer(PlainTextKeyedEncodingContainer<NestedKey>(
+                    outputStream: outputStream,
+                    formattingOptions: formattingOptions,
+                    userInfo: userInfo,
+                    codingPath: codingPath
+                ))
             }
             
             mutating func nestedUnkeyedContainer() -> UnkeyedEncodingContainer {
@@ -452,9 +459,7 @@ public struct PlainTextEncoder {
             let codingPath: [CodingKey]
             
             private mutating func emit(_ value: String) {
-                outputStream <<< String(repeating: "    ", count: codingPath.count)
-                outputStream <<< value
-                outputStream <<< "\n"
+                outputStream.send("\(String(repeating: "    ", count: codingPath.count))\(value)\n")
             }
             mutating func encodeNil() throws { emit("nil") }
             mutating func encode(_ value: Bool) throws { emit("\(value)") }

--- a/Sources/LLBuildManifest/ManifestWriter.swift
+++ b/Sources/LLBuildManifest/ManifestWriter.swift
@@ -29,16 +29,16 @@ public struct ManifestWriter {
             client:
               name: basic
             tools: {}
-            targets:
-
+            targets:\n
             """
         )
 
         for (_, target) in manifest.targets.sorted(by: { $0.key < $1.key }) {
-            stream.send("  \(Format.asJSON(target.name)): \(Format.asJSON(target.nodes.map(\.name).sorted()))\n")
+            stream.send("  ").send(Format.asJSON(target.name))
+            stream.send(": ").send(Format.asJSON(target.nodes.map(\.name).sorted())).send("\n")
         }
 
-        stream.send("default: \(Format.asJSON(manifest.defaultTarget))\n")
+        stream.send("default: ").send(Format.asJSON(manifest.defaultTarget)).send("\n")
 
         // We need to explicitly configure  the directory structure nodes.
         let directoryStructureNodes = Set(manifest.commands
@@ -48,23 +48,18 @@ public struct ManifestWriter {
         )
 
         if !directoryStructureNodes.isEmpty {
-            stream.send("nodes:")
+            stream.send("nodes:\n")
         }
         let namesToExclude = [".git", ".build"]
         for node in directoryStructureNodes.sorted(by: { $0.name < $1.name }) {
-            stream.send(
-                """
-                  \(Format.asJSON(node)):
-                    is-directory-structure: true
-                    content-exclusion-patterns: \(Format.asJSON(namesToExclude))
-
-                """
-            )
+            stream.send("  ").send(Format.asJSON(node)).send(":\n")
+                .send("    is-directory-structure: true\n")
+                .send("    content-exclusion-patterns: ").send(Format.asJSON(namesToExclude)).send("\n")
         }
 
         stream.send("commands:\n")
         for (_,  command) in manifest.commands.sorted(by: { $0.key < $1.key }) {
-            stream.send("  \(Format.asJSON(command.name)):\n")
+            stream.send("  ").send(Format.asJSON(command.name)).send(":\n")
 
             let tool = command.tool
 
@@ -92,14 +87,14 @@ public final class ManifestToolStream {
     public subscript(key: String) -> Int {
         get { fatalError() }
         set {
-            stream.send("    \(key): \(Format.asJSON(newValue))\n")
+            stream.send("    \(key): ").send(Format.asJSON(newValue)).send("\n")
         }
     }
 
     public subscript(key: String) -> String {
         get { fatalError() }
         set {
-            stream.send("    \(key): \(Format.asJSON(newValue))\n")
+            stream.send("    \(key): ").send(Format.asJSON(newValue)).send("\n")
         }
     }
 
@@ -113,35 +108,35 @@ public final class ManifestToolStream {
     public subscript(key: String) -> AbsolutePath {
          get { fatalError() }
          set {
-            stream.send("    \(key): \(Format.asJSON(newValue.pathString))\n")
+             stream.send("    \(key): ").send(Format.asJSON(newValue.pathString)).send("\n")
          }
      }
 
     public subscript(key: String) -> [AbsolutePath] {
          get { fatalError() }
          set {
-            stream.send("    \(key): \(Format.asJSON(newValue.map(\.pathString)))\n")
+             stream.send("    \(key): ").send(Format.asJSON(newValue.map(\.pathString))).send("\n")
          }
      }
 
     public subscript(key: String) -> [Node] {
         get { fatalError() }
         set {
-            stream.send("    \(key): \(Format.asJSON(newValue))\n")
+            stream.send("    \(key): ").send(Format.asJSON(newValue)).send("\n")
         }
     }
 
     public subscript(key: String) -> Bool {
         get { fatalError() }
         set {
-            stream.send("    \(key): \(Format.asJSON(newValue))\n")
+            stream.send("    \(key): ").send(Format.asJSON(newValue)).send("\n")
         }
     }
 
     public subscript(key: String) -> [String] {
         get { fatalError() }
         set {
-            stream.send("    \(key): \(Format.asJSON(newValue))\n")
+            stream.send("    \(key): ").send(Format.asJSON(newValue)).send("\n")
         }
     }
 
@@ -150,7 +145,7 @@ public final class ManifestToolStream {
         set {
             stream.send("    \(key):\n")
             for (key, value) in newValue.sorted(by: { $0.key < $1.key }) {
-                stream.send("      \(Format.asJSON(key)): \(Format.asJSON(value))\n")
+                stream.send("      ").send(Format.asJSON(key)).send(": ").send(Format.asJSON(value)).send("\n")
             }
         }
     }

--- a/Sources/LLBuildManifest/ManifestWriter.swift
+++ b/Sources/LLBuildManifest/ManifestWriter.swift
@@ -24,19 +24,21 @@ public struct ManifestWriter {
         at path: AbsolutePath
     ) throws {
         let stream = BufferedOutputByteStream()
-        stream <<< """
+        stream.send(
+            """
             client:
               name: basic
             tools: {}
-            targets:\n
+            targets:
+
             """
+        )
 
         for (_, target) in manifest.targets.sorted(by: { $0.key < $1.key }) {
-            stream <<< "  " <<< Format.asJSON(target.name)
-            stream <<< ": " <<< Format.asJSON(target.nodes.map{ $0.name }.sorted()) <<< "\n"
+            stream.send("  \(Format.asJSON(target.name)): \(Format.asJSON(target.nodes.map(\.name).sorted()))\n")
         }
 
-        stream <<< "default: " <<< Format.asJSON(manifest.defaultTarget) <<< "\n"
+        stream.send("default: \(Format.asJSON(manifest.defaultTarget))\n")
 
         // We need to explicitly configure  the directory structure nodes.
         let directoryStructureNodes = Set(manifest.commands
@@ -46,18 +48,23 @@ public struct ManifestWriter {
         )
 
         if !directoryStructureNodes.isEmpty {
-            stream <<< "nodes:\n"
+            stream.send("nodes:")
         }
         let namesToExclude = [".git", ".build"]
         for node in directoryStructureNodes.sorted(by: { $0.name < $1.name }) {
-            stream <<< "  " <<< Format.asJSON(node) <<< ":\n"
-            stream <<< "    is-directory-structure: true\n"
-            stream <<< "    content-exclusion-patterns: " <<< Format.asJSON(namesToExclude) <<< "\n"
+            stream.send(
+                """
+                  \(Format.asJSON(node)):
+                    is-directory-structure: true
+                    content-exclusion-patterns: \(Format.asJSON(namesToExclude))
+
+                """
+            )
         }
 
-        stream <<< "commands:\n"
+        stream.send("commands:\n")
         for (_,  command) in manifest.commands.sorted(by: { $0.key < $1.key }) {
-            stream <<< "  " <<< Format.asJSON(command.name) <<< ":\n"
+            stream.send("  \(Format.asJSON(command.name)):\n")
 
             let tool = command.tool
 
@@ -68,7 +75,7 @@ public struct ManifestWriter {
 
             tool.write(to: manifestToolWriter)
 
-            stream <<< "\n"
+            stream.send("\n")
         }
 
         try self.fileSystem.writeFileContents(path, bytes: stream.bytes)
@@ -85,65 +92,65 @@ public final class ManifestToolStream {
     public subscript(key: String) -> Int {
         get { fatalError() }
         set {
-            stream <<< "    \(key): " <<< Format.asJSON(newValue) <<< "\n"
+            stream.send("    \(key): \(Format.asJSON(newValue))\n")
         }
     }
 
     public subscript(key: String) -> String {
         get { fatalError() }
         set {
-            stream <<< "    \(key): " <<< Format.asJSON(newValue) <<< "\n"
+            stream.send("    \(key): \(Format.asJSON(newValue))\n")
         }
     }
 
     public subscript(key: String) -> ToolProtocol {
         get { fatalError() }
         set {
-            stream <<< "    \(key): " <<< type(of: newValue).name <<< "\n"
+            stream.send("    \(key): \(type(of: newValue).name)\n")
         }
     }
 
     public subscript(key: String) -> AbsolutePath {
          get { fatalError() }
          set {
-            stream <<< "    \(key): " <<< Format.asJSON(newValue.pathString) <<< "\n"
+            stream.send("    \(key): \(Format.asJSON(newValue.pathString))\n")
          }
      }
 
     public subscript(key: String) -> [AbsolutePath] {
          get { fatalError() }
          set {
-            stream <<< "    \(key): " <<< Format.asJSON(newValue.map{$0.pathString}) <<< "\n"
+            stream.send("    \(key): \(Format.asJSON(newValue.map(\.pathString)))\n")
          }
      }
 
     public subscript(key: String) -> [Node] {
         get { fatalError() }
         set {
-            stream <<< "    \(key): " <<< Format.asJSON(newValue) <<< "\n"
+            stream.send("    \(key): \(Format.asJSON(newValue))\n")
         }
     }
 
     public subscript(key: String) -> Bool {
         get { fatalError() }
         set {
-            stream <<< "    \(key): " <<< Format.asJSON(newValue) <<< "\n"
+            stream.send("    \(key): \(Format.asJSON(newValue))\n")
         }
     }
 
     public subscript(key: String) -> [String] {
         get { fatalError() }
         set {
-            stream <<< "    \(key): " <<< Format.asJSON(newValue) <<< "\n"
+            stream.send("    \(key): \(Format.asJSON(newValue))\n")
         }
     }
 
     public subscript(key: String) -> [String: String] {
         get { fatalError() }
         set {
-            stream <<< "    \(key):\n"
+            stream.send("    \(key):\n")
             for (key, value) in newValue.sorted(by: { $0.key < $1.key }) {
-                stream <<< "      " <<< Format.asJSON(key) <<< ": " <<< Format.asJSON(value) <<< "\n"
+                stream.send("      \(Format.asJSON(key)): \(Format.asJSON(value))\n")
             }
         }
     }

--- a/Sources/PackageDescription/PackageDescriptionSerializationConversion.swift
+++ b/Sources/PackageDescription/PackageDescriptionSerializationConversion.swift
@@ -1,9 +1,9 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift open source project.
+// This source file is part of the Swift open source project
 //
-// Copyright (c) 2023 Apple Inc. and the Swift project authors.
-// Licensed under Apache License v2.0 with Runtime Library Exception.
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
@@ -198,7 +198,12 @@ extension Serialization.TargetDependency {
         case .targetItem(let name, let condition):
             self = .target(name: name, condition: condition.map { .init($0) })
         case .productItem(let name, let package, let moduleAliases, let condition):
-            self = .product(name: name, package: package, moduleAliases: moduleAliases, condition: condition.map { .init($0) })
+            self = .product(
+                name: name,
+                package: package,
+                moduleAliases: moduleAliases,
+                condition: condition.map { .init($0) }
+            )
         case .byNameItem(let name, let condition):
             self = .byName(name: name, condition: condition.map { .init($0) })
         }
@@ -223,7 +228,10 @@ extension Serialization.PluginCapability {
     init(_ capability: PackageDescription.Target.PluginCapability) {
         switch capability {
         case .buildTool: self = .buildTool
-        case .command(let intent, let permissions): self = .command(intent: .init(intent), permissions: permissions.map { .init($0) })
+        case .command(let intent, let permissions): self = .command(
+                intent: .init(intent),
+                permissions: permissions.map { .init($0) }
+            )
         }
     }
 }
@@ -241,7 +249,10 @@ extension Serialization.PluginCommandIntent {
 extension Serialization.PluginPermission {
     init(_ permission: PackageDescription.PluginPermission) {
         switch permission {
-        case .allowNetworkConnections(let scope, let reason): self = .allowNetworkConnections(scope: .init(scope), reason: reason)
+        case .allowNetworkConnections(let scope, let reason): self = .allowNetworkConnections(
+                scope: .init(scope),
+                reason: reason
+            )
         case .writeToPackageDirectory(let reason): self = .writeToPackageDirectory(reason: reason)
         }
     }

--- a/Sources/PackageGraph/PubGrub/DiagnosticReportBuilder.swift
+++ b/Sources/PackageGraph/PubGrub/DiagnosticReportBuilder.swift
@@ -54,16 +54,16 @@ struct DiagnosticReportBuilder {
         let padding = self.lineNumbers.isEmpty ? 0 : "\(Array(self.lineNumbers.values).last!) ".count
 
         for (idx, line) in self.lines.enumerated() {
-            stream <<< Format.asRepeating(string: " ", count: padding)
+            stream.send(Format.asRepeating(string: " ", count: padding))
             if line.number != -1 {
-                stream <<< Format.asRepeating(string: " ", count: padding)
-                stream <<< " (\(line.number)) "
+                stream.send(Format.asRepeating(string: " ", count: padding))
+                stream.send(" (\(line.number)) ")
             }
-            stream <<< line.message.prefix(1).capitalized
-            stream <<< line.message.dropFirst()
+            stream.send(line.message.prefix(1).capitalized)
+            stream.send(line.message.dropFirst())
 
             if self.lines.count - 1 != idx {
-                stream <<< "\n"
+                stream.send("\n")
             }
         }
 

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -922,13 +922,13 @@ extension ManifestLoader {
             swiftpmVersion: String
         ) throws -> String {
             let stream = BufferedOutputByteStream()
-            stream <<< packageIdentity
-            stream <<< manifestContents
-            stream <<< toolsVersion.description
+            stream.send(packageIdentity)
+            stream.send(manifestContents)
+            stream.send(toolsVersion.description)
             for (key, value) in env.sorted(by: { $0.key > $1.key }) {
-                stream <<< key <<< value
+                stream.send(key).send(value)
             }
-            stream <<< swiftpmVersion
+            stream.send(swiftpmVersion)
             return stream.bytes.sha256Checksum
         }
     }

--- a/Sources/PackageLoading/ModuleMapGenerator.swift
+++ b/Sources/PackageLoading/ModuleMapGenerator.swift
@@ -176,26 +176,30 @@ public struct ModuleMapGenerator {
 
     /// Generates a module map based of the specified type, throwing an error if anything goes wrong.  Any diagnostics are added to the receiver's diagnostics engine.
     public func generateModuleMap(type: GeneratedModuleMapType, at path: AbsolutePath) throws {
-        let stream = BufferedOutputByteStream()
-        stream <<< "module \(moduleName) {\n"
+        var moduleMap = "module \(moduleName) {\n"
         switch type {
         case .umbrellaHeader(let hdr):
-            stream <<< "    umbrella header \"\(hdr.moduleEscapedPathString)\"\n"
+            moduleMap.append("    umbrella header \"\(hdr.moduleEscapedPathString)\"\n")
         case .umbrellaDirectory(let dir):
-            stream <<< "    umbrella \"\(dir.moduleEscapedPathString)\"\n"
+            moduleMap.append("    umbrella \"\(dir.moduleEscapedPathString)\"\n")
         }
-        stream <<< "    export *\n"
-        stream <<< "}\n"
+        moduleMap.append(
+            """
+                export *
+            }
+
+            """
+        )
 
         // FIXME: This doesn't belong here.
         try fileSystem.createDirectory(path.parentDirectory, recursive: true)
 
         // If the file exists with the identical contents, we don't need to rewrite it.
         // Otherwise, compiler will recompile even if nothing else has changed.
-        if let contents = try? fileSystem.readFileContents(path), contents == stream.bytes {
+        if let contents = try? fileSystem.readFileContents(path).validDescription, contents == moduleMap {
             return
         }
-        try fileSystem.writeFileContents(path, bytes: stream.bytes)
+        try fileSystem.writeFileContents(path, string: moduleMap)
     }
 }
 

--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -133,25 +133,31 @@ public final class InitPackage {
         }
 
         try writePackageFile(manifest) { stream in
-            stream <<< """
+            stream.send(
+                """
                 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
                 import PackageDescription
 
                 """
+            )
 
             if packageType == .macro {
-                stream <<< """
+                stream.send(
+                  """
                   import CompilerPluginSupport
 
                   """
+                )
             }
 
-            stream <<< """
+            stream.send(
+                """
 
                 let package = Package(
 
                 """
+            )
 
             var pkgParams = [String]()
             pkgParams.append("""
@@ -336,7 +342,7 @@ public final class InitPackage {
                 pkgParams.append(param)
             }
 
-            stream <<< pkgParams.joined(separator: ",\n") <<< "\n)\n"
+            stream.send("\(pkgParams.joined(separator: ",\n"))\n)\n")
         }
 
         // Create a tools version with current version but with patch set to zero.
@@ -362,7 +368,8 @@ public final class InitPackage {
         }
 
         try writePackageFile(gitignore) { stream in
-            stream <<< """
+            stream.send(
+                """
                 .DS_Store
                 /.build
                 /Packages
@@ -373,6 +380,7 @@ public final class InitPackage {
                 .netrc
 
                 """
+            )
         }
     }
 
@@ -596,7 +604,8 @@ public final class InitPackage {
 
     private func writeLibraryTestsFile(_ path: AbsolutePath) throws {
         try writePackageFile(path) { stream in
-            stream <<< """
+            stream.send(
+                """
                 import XCTest
                 @testable import \(moduleName)
 
@@ -611,12 +620,13 @@ public final class InitPackage {
                 }
 
                 """
+            )
         }
     }
 
     private func writeMacroTestsFile(_ path: AbsolutePath) throws {
         try writePackageFile(path) { stream in
-            stream <<< ##"""
+            stream.send(##"""
                 import SwiftSyntax
                 import SwiftSyntaxBuilder
                 import SwiftSyntaxMacros
@@ -659,6 +669,7 @@ public final class InitPackage {
                 }
 
                 """##
+            )
         }
     }
 
@@ -666,7 +677,8 @@ public final class InitPackage {
         try makeDirectories(path)
 
         try writePackageFile(path.appending("\(moduleName)Macro.swift")) { stream in
-            stream <<< ##"""
+            stream.send(
+                ##"""
                 import SwiftCompilerPlugin
                 import SwiftSyntax
                 import SwiftSyntaxBuilder
@@ -702,6 +714,7 @@ public final class InitPackage {
                 }
 
                 """##
+            )
         }
     }
 
@@ -709,7 +722,8 @@ public final class InitPackage {
         try makeDirectories(path)
 
         try writePackageFile(path.appending("main.swift")) { stream in
-            stream <<< ##"""
+            stream.send(
+                ##"""
                 import \##(moduleName)
 
                 let a = 17
@@ -720,6 +734,7 @@ public final class InitPackage {
                 print("The value \(result) was produced by the code \"\(code)\"")
 
                 """##
+            )
         }
     }
 

--- a/Sources/Workspace/ToolsVersionSpecificationRewriter.swift
+++ b/Sources/Workspace/ToolsVersionSpecificationRewriter.swift
@@ -56,7 +56,7 @@ public struct ToolsVersionSpecificationWriter {
 
         let stream = BufferedOutputByteStream()
         // Write out the tools version specification, including the patch version if and only if it's not zero.
-        stream <<< toolsVersion.specification(roundedTo: .automatic) <<< "\n"
+        stream.send("\(toolsVersion.specification(roundedTo: .automatic))\n")
 
         // The following lines up to line 77 append the file contents except for the Swift tools version specification line.
 
@@ -71,9 +71,9 @@ public struct ToolsVersionSpecificationWriter {
         // Replace the Swift tools version specification line if and only if it's well-formed up to the version specifier.
         // This matches the behavior of the old (now removed) [`ToolsVersionLoader.split(:_)`](https://github.com/WowbaggersLiquidLunch/swift-package-manager/blob/49cfc46bc5defd3ce8e0c0261e3e2cb475bcdb91/Sources/PackageLoading/ToolsVersionLoader.swift#L160).
         if toolsVersionSpecificationComponents.everythingUpToVersionSpecifierIsWellFormed {
-            stream <<< ByteString(encodingAsUTF8: String(manifestComponents.contentsAfterToolsVersionSpecification))
+            stream.send(String(manifestComponents.contentsAfterToolsVersionSpecification))
         } else {
-            stream <<< contents
+            stream.send(contents)
         }
 
         try fileSystem.writeFileContents(manifestFilePath, bytes: stream.bytes)

--- a/Sources/XCBuildSupport/XCBuildDelegate.swift
+++ b/Sources/XCBuildSupport/XCBuildDelegate.swift
@@ -74,8 +74,7 @@ extension XCBuildDelegate: XCBuildOutputParserDelegate {
         case .taskOutput(let info):
             queue.async {
                 self.progressAnimation.clear()
-                self.outputStream <<< info.data
-                self.outputStream <<< "\n"
+                self.outputStream.send("\(info.data)\n")
                 self.outputStream.flush()
             }
         case .taskComplete(let info):
@@ -85,29 +84,25 @@ extension XCBuildDelegate: XCBuildOutputParserDelegate {
         case .buildDiagnostic(let info):
             queue.async {
                 self.progressAnimation.clear()
-                self.outputStream <<< info.message
-                self.outputStream <<< "\n"
+                self.outputStream.send("\(info.message)\n")
                 self.outputStream.flush()
             }
         case .taskDiagnostic(let info):
             queue.async {
                 self.progressAnimation.clear()
-                self.outputStream <<< info.message
-                self.outputStream <<< "\n"
+                self.outputStream.send("\(info.message)\n")
                 self.outputStream.flush()
             }
         case .targetDiagnostic(let info):
             queue.async {
                 self.progressAnimation.clear()
-                self.outputStream <<< info.message
-                self.outputStream <<< "\n"
+                self.outputStream.send("\(info.message)\n")
                 self.outputStream.flush()
             }
         case .buildOutput(let info):
             queue.async {
                 self.progressAnimation.clear()
-                self.outputStream <<< info.data
-                self.outputStream <<< "\n"
+                self.outputStream.send("\(info.data)\n")
                 self.outputStream.flush()
             }
         case .didUpdateProgress(let info):
@@ -120,7 +115,7 @@ extension XCBuildDelegate: XCBuildOutputParserDelegate {
             queue.async {
                 switch info.result {
                 case .aborted, .cancelled, .failed:
-                    self.outputStream <<< "Build \(info.result)\n"
+                    self.outputStream.send("Build \(info.result)\n")
                     self.outputStream.flush()
                     self.buildSystem.delegate?.buildSystem(self.buildSystem, didFinishWithResult: false)
                 case .ok:
@@ -158,12 +153,12 @@ public final class VerboseProgressAnimation: ProgressAnimationProtocol {
     }
 
     public func update(step: Int, total: Int, text: String) {
-        stream <<< text <<< "\n"
+        stream.send("\(text)\n")
         stream.flush()
     }
 
     public func complete(success: Bool) {
-        stream <<< "\n"
+        stream.send("\n")
         stream.flush()
     }
 

--- a/Tests/BasicsTests/CancellatorTests.swift
+++ b/Tests/BasicsTests/CancellatorTests.swift
@@ -47,15 +47,16 @@ final class CancellatorTests: XCTestCase {
 #if os(macOS)
         try withTemporaryDirectory { temporaryDirectory in
             let scriptPath = temporaryDirectory.appending("script")
-            try localFileSystem.writeFileContents(scriptPath) {
-                """
+            try localFileSystem.writeFileContents(
+                scriptPath,
+                string: """
                 set -e
 
                 echo "process started"
                 sleep 10
                 echo "exit normally"
                 """
-            }
+            )
 
             let observability = ObservabilitySystem.makeForTesting()
             let cancellator = Cancellator(observabilityScope: observability.topScope)
@@ -105,8 +106,9 @@ final class CancellatorTests: XCTestCase {
 #if os(macOS)
         try withTemporaryDirectory { temporaryDirectory in
             let scriptPath = temporaryDirectory.appending("script")
-            try localFileSystem.writeFileContents(scriptPath) {
-                """
+            try localFileSystem.writeFileContents(
+                scriptPath,
+                string: """
                 set -e
 
                 trap_handler() {
@@ -122,7 +124,7 @@ final class CancellatorTests: XCTestCase {
                 sleep 10
                 echo "exit normally"
                 """
-            }
+            )
 
             let observability = ObservabilitySystem.makeForTesting()
             let cancellator = Cancellator(observabilityScope: observability.topScope)
@@ -171,8 +173,9 @@ final class CancellatorTests: XCTestCase {
 #if os(macOS)
         try withTemporaryDirectory { temporaryDirectory in
             let scriptPath = temporaryDirectory.appending("script")
-            try localFileSystem.writeFileContents(scriptPath) {
-                """
+            try localFileSystem.writeFileContents(
+                scriptPath,
+                string: """
                 set -e
 
                 echo "process started"
@@ -180,7 +183,7 @@ final class CancellatorTests: XCTestCase {
                 sleep 10
                 echo "exit normally"
                 """
-            }
+            )
 
             let observability = ObservabilitySystem.makeForTesting()
             let cancellator = Cancellator(observabilityScope: observability.topScope)
@@ -233,8 +236,9 @@ final class CancellatorTests: XCTestCase {
 #if os(macOS)
         try withTemporaryDirectory { temporaryDirectory in
             let scriptPath = temporaryDirectory.appending("script")
-            try localFileSystem.writeFileContents(scriptPath) {
-                """
+            try localFileSystem.writeFileContents(
+                scriptPath,
+                string: """
                 set -e
 
                 trap_handler() {
@@ -250,7 +254,7 @@ final class CancellatorTests: XCTestCase {
                 sleep 10
                 echo "exit normally"
                 """
-            }
+            )
 
             let observability = ObservabilitySystem.makeForTesting()
             let cancellator = Cancellator(observabilityScope: observability.topScope)

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -34,10 +34,10 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testDuplicateProductNamesWithNonDefaultLibsThrowError() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/thisPkg/Sources/exe/main.swift",
-                                    "/fooPkg/Sources/FooLogging/file.swift",
-                                    "/barPkg/Sources/BarLogging/file.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles: "/thisPkg/Sources/exe/main.swift",
+            "/fooPkg/Sources/FooLogging/file.swift",
+            "/barPkg/Sources/BarLogging/file.swift"
         )
         let observability = ObservabilitySystem.makeForTesting()
         XCTAssertThrowsError(try loadPackageGraph(
@@ -718,19 +718,27 @@ final class BuildPlanTests: XCTestCase {
             let bSwift = bPath.appending("B.swift")
             let cSwift = cPath.appending("C.swift")
             try localFileSystem.writeFileContents(main) {
-              $0 <<< "baz();"
+                $0.send("baz();")
             }
             try localFileSystem.writeFileContents(aSwift) {
-                $0 <<< "import B;"
-                $0 <<< "import C;"
-                $0 <<< "public func baz() { bar() }"
+                $0.send(
+                    """
+                    import B;\
+                    import C;\
+                    public func baz() { bar() }
+                    """
+                )
             }
             try localFileSystem.writeFileContents(bSwift) {
-                $0 <<< "import C;"
-                $0 <<< "public func bar() { foo() }"
+                $0.send(
+                    """
+                    import C;
+                    public func bar() { foo() }
+                    """
+                )
             }
             try localFileSystem.writeFileContents(cSwift) {
-                $0 <<< "public func foo() {}"
+                $0.send("public func foo() {}")
             }
 
             // Plan package build with explicit module build

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -1833,8 +1833,9 @@ final class BuildPlanTests: XCTestCase {
             "/Pkg/Snippets/AtMainSnippet.swift"
         )
 
-        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe3/foo.swift")) {
-            """
+        try fs.writeFileContents(
+            "/Pkg/Sources/exe3/foo.swift",
+            string: """
             @main
             struct Runner {
               static func main() {
@@ -1842,10 +1843,11 @@ final class BuildPlanTests: XCTestCase {
               }
             }
             """
-        }
+        )
 
-        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe4/main.swift")) {
-            """
+        try fs.writeFileContents(
+            "/Pkg/Sources/exe4/main.swift",
+            string: """
             @main
             struct Runner {
               static func main() {
@@ -1853,33 +1855,37 @@ final class BuildPlanTests: XCTestCase {
               }
             }
             """
-        }
+        )
 
-        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe5/comments.swift")) {
-            """
+        try fs.writeFileContents(
+            "/Pkg/Sources/exe5/comments.swift",
+            string: """
             // @main in comment
             print("hello world")
             """
-        }
+        )
 
-        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe6/comments.swift")) {
-            """
+        try fs.writeFileContents(
+            "/Pkg/Sources/exe6/comments.swift",
+            string: """
             /* @main in comment */
             print("hello world")
             """
-        }
+        )
 
-        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe7/comments.swift")) {
-            """
+        try fs.writeFileContents(
+            "/Pkg/Sources/exe7/comments.swift",
+            string: """
             /*
             @main in comment
             */
             print("hello world")
             """
-        }
+        )
 
-        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe8/comments.swift")) {
-            """
+        try fs.writeFileContents(
+            "/Pkg/Sources/exe8/comments.swift",
+            string: """
             /*
             @main
             struct Runner {
@@ -1890,10 +1896,11 @@ final class BuildPlanTests: XCTestCase {
             */
             print("hello world")
             """
-        }
+        )
 
-        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe9/comments.swift")) {
-            """
+        try fs.writeFileContents(
+            "/Pkg/Sources/exe9/comments.swift",
+            string: """
             /*@main
             struct Runner {
               static func main() {
@@ -1901,10 +1908,11 @@ final class BuildPlanTests: XCTestCase {
               }
             }*/
             """
-        }
+        )
 
-        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe10/comments.swift")) {
-            """
+        try fs.writeFileContents(
+            "/Pkg/Sources/exe10/comments.swift",
+            string: """
             // @main in comment
             @main
             struct Runner {
@@ -1913,10 +1921,11 @@ final class BuildPlanTests: XCTestCase {
               }
             }
             """
-        }
+        )
 
-        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe11/comments.swift")) {
-            """
+        try fs.writeFileContents(
+            "/Pkg/Sources/exe11/comments.swift",
+            string: """
             /* @main in comment */
             @main
             struct Runner {
@@ -1925,10 +1934,11 @@ final class BuildPlanTests: XCTestCase {
               }
             }
             """
-        }
+        )
 
-        try fs.writeFileContents(AbsolutePath("/Pkg/Sources/exe12/comments.swift")) {
-            """
+        try fs.writeFileContents(
+            "/Pkg/Sources/exe12/comments.swift",
+            string: """
             /*
             @main
             struct Runner {
@@ -1943,10 +1953,11 @@ final class BuildPlanTests: XCTestCase {
               }
             }
             """
-        }
+        )
 
-        try fs.writeFileContents("/Pkg/Snippets/TopLevelCodeSnippet.swift") {
-            """
+        try fs.writeFileContents(
+            "/Pkg/Snippets/TopLevelCodeSnippet.swift",
+            string: """
             struct Foo {
               init() {}
               func foo() {}
@@ -1954,10 +1965,11 @@ final class BuildPlanTests: XCTestCase {
             let foo = Foo()
             foo.foo()
             """
-        }
+        )
 
-        try fs.writeFileContents("/Pkg/Snippets/AtMainSnippet.swift") {
-            """
+        try fs.writeFileContents(
+            "/Pkg/Snippets/AtMainSnippet.swift",
+            string: """
             @main
             struct Runner {
               static func main() {
@@ -1965,7 +1977,7 @@ final class BuildPlanTests: XCTestCase {
               }
             }
             """
-        }
+        )
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadPackageGraph(

--- a/Tests/BuildTests/IncrementalBuildTests.swift
+++ b/Tests/BuildTests/IncrementalBuildTests.swift
@@ -54,7 +54,7 @@ final class IncrementalBuildTests: XCTestCase {
             // for the granularity of the file system to represent as distinct values).
             let sourceFile = fixturePath.appending(components: "Sources", "Foo.c")
             let sourceStream = BufferedOutputByteStream()
-            sourceStream <<< (try localFileSystem.readFileContents(sourceFile)) <<< "\n"
+            sourceStream.send("\(try localFileSystem.readFileContents(sourceFile))\n")
             try localFileSystem.writeFileContents(sourceFile, bytes: sourceStream.bytes)
 
             // Read the first llbuild manifest.
@@ -83,7 +83,7 @@ final class IncrementalBuildTests: XCTestCase {
             // for the granularity of the file system to represent as distinct values).
             let headerFile = fixturePath.appending(components: "Sources", "include", "Foo.h")
             let headerStream = BufferedOutputByteStream()
-            headerStream <<< (try localFileSystem.readFileContents(headerFile)) <<< "\n"
+            headerStream.send("\(try localFileSystem.readFileContents(headerFile))\n")
             try localFileSystem.writeFileContents(headerFile, bytes: headerStream.bytes)
 
             // Now build again.  This should be an incremental build.

--- a/Tests/CommandsTests/APIDiffTests.swift
+++ b/Tests/CommandsTests/APIDiffTests.swift
@@ -66,7 +66,7 @@ final class APIDiffTests: CommandsTestCase {
             let packageRoot = fixturePath.appending("Foo")
             // Overwrite the existing decl.
             try localFileSystem.writeFileContents(packageRoot.appending("Foo.swift")) {
-                $0 <<< "public let foo = 42"
+                $0.send("public let foo = 42")
             }
             XCTAssertThrowsCommandExecutionError(try execute(["diagnose-api-breaking-changes", "1.2.3"], packagePath: packageRoot)) { error in
                 XCTAssertFalse(error.stdout.isEmpty)
@@ -80,7 +80,7 @@ final class APIDiffTests: CommandsTestCase {
             let packageRoot = fixturePath.appending("Foo")
             // Overwrite the existing decl.
             try localFileSystem.writeFileContents(packageRoot.appending("Foo.swift")) {
-                $0 <<< "public let foo = 42"
+                $0.send("public let foo = 42")
             }
             XCTAssertThrowsCommandExecutionError(try execute(["diagnose-api-breaking-changes", "1.2.3"], packagePath: packageRoot)) { error in
                 XCTAssertMatch(error.stdout, .contains("1 breaking change detected in Foo"))
@@ -94,10 +94,10 @@ final class APIDiffTests: CommandsTestCase {
         try fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
             let packageRoot = fixturePath.appending("Bar")
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Baz", "Baz.swift")) {
-                $0 <<< "public func baz() -> String { \"hello, world!\" }"
+                $0.send(#"public func baz() -> String { "hello, world!" }"#)
             }
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Qux", "Qux.swift")) {
-                $0 <<< "public class Qux<T, U> { private let x = 1 }"
+                $0.send("public class Qux<T, U> { private let x = 1 }")
             }
             XCTAssertThrowsCommandExecutionError(try execute(["diagnose-api-breaking-changes", "1.2.3"], packagePath: packageRoot)) { error in
                 XCTAssertMatch(error.stdout, .contains("2 breaking changes detected in Qux"))
@@ -114,14 +114,14 @@ final class APIDiffTests: CommandsTestCase {
         try fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
             let packageRoot = fixturePath.appending("Bar")
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Baz", "Baz.swift")) {
-                $0 <<< "public func baz() -> String { \"hello, world!\" }"
+                $0.send(#"public func baz() -> String { "hello, world!" }"#)
             }
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Qux", "Qux.swift")) {
-                $0 <<< "public class Qux<T, U> { private let x = 1 }"
+                $0.send("public class Qux<T, U> { private let x = 1 }")
             }
             let customAllowlistPath = packageRoot.appending(components: "foo", "allowlist.txt")
             try localFileSystem.writeFileContents(customAllowlistPath) {
-                $0 <<< "API breakage: class Qux has generic signature change from <T> to <T, U>\n"
+                $0.send("API breakage: class Qux has generic signature change from <T> to <T, U>\n")
             }
             XCTAssertThrowsCommandExecutionError(
                 try execute(["diagnose-api-breaking-changes", "1.2.3", "--breakage-allowlist-path", customAllowlistPath.pathString],
@@ -142,16 +142,16 @@ final class APIDiffTests: CommandsTestCase {
         try fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
             let packageRoot = fixturePath.appending("NonAPILibraryTargets")
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Foo", "Foo.swift")) {
-                $0 <<< "public func baz() -> String { \"hello, world!\" }"
+                $0.send(#"public func baz() -> String { "hello, world!" }"#)
             }
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Bar", "Bar.swift")) {
-                $0 <<< "public class Qux<T, U> { private let x = 1 }"
+                $0.send("public class Qux<T, U> { private let x = 1 }")
             }
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Baz", "Baz.swift")) {
-                $0 <<< "public enum Baz {case a, b, c }"
+                $0.send("public enum Baz {case a, b, c }")
             }
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Qux", "Qux.swift")) {
-                $0 <<< "public class Qux<T, U> { private let x = 1 }"
+                $0.send("public class Qux<T, U> { private let x = 1 }")
             }
             XCTAssertThrowsCommandExecutionError(try execute(["diagnose-api-breaking-changes", "1.2.3"], packagePath: packageRoot)) { error in
                 XCTAssertMatch(error.stdout, .contains("1 breaking change detected in Foo"))
@@ -175,16 +175,16 @@ final class APIDiffTests: CommandsTestCase {
         try fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
             let packageRoot = fixturePath.appending("NonAPILibraryTargets")
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Foo", "Foo.swift")) {
-                $0 <<< "public func baz() -> String { \"hello, world!\" }"
+                $0.send(#"public func baz() -> String { "hello, world!" }"#)
             }
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Bar", "Bar.swift")) {
-                $0 <<< "public class Qux<T, U> { private let x = 1 }"
+                $0.send("public class Qux<T, U> { private let x = 1 }")
             }
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Baz", "Baz.swift")) {
-                $0 <<< "public enum Baz {case a, b, c }"
+                $0.send("public enum Baz {case a, b, c }")
             }
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Qux", "Qux.swift")) {
-                $0 <<< "public class Qux<T, U> { private let x = 1 }"
+                $0.send("public class Qux<T, U> { private let x = 1 }")
             }
             XCTAssertThrowsCommandExecutionError(
                 try execute(["diagnose-api-breaking-changes", "1.2.3", "--products", "One", "--targets", "Bar"], packagePath: packageRoot)
@@ -237,14 +237,16 @@ final class APIDiffTests: CommandsTestCase {
             let packageRoot = fixturePath.appending("CTargetDep")
             // Overwrite the existing decl.
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Bar", "Bar.swift")) {
-                $0 <<< """
-                import Foo
+                $0.send(
+                    """
+                    import Foo
 
-                public func bar() -> String {
-                    foo()
-                    return "hello, world!"
-                }
-                """
+                    public func bar() -> String {
+                        foo()
+                        return "hello, world!"
+                    }
+                    """
+                )
             }
             XCTAssertThrowsCommandExecutionError(try execute(["diagnose-api-breaking-changes", "1.2.3"], packagePath: packageRoot)) { error in
                 XCTAssertMatch(error.stdout, .contains("1 breaking change detected in Bar"))
@@ -264,7 +266,7 @@ final class APIDiffTests: CommandsTestCase {
             let packageRoot = fixturePath.appending("Bar")
             // Introduce an API-compatible change
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Baz", "Baz.swift")) {
-                $0 <<< "public func bar() -> Int { 100 }"
+                $0.send("public func bar() -> Int { 100 }")
             }
             let (output, _) = try execute(["diagnose-api-breaking-changes", "1.2.3"], packagePath: packageRoot)
             XCTAssertMatch(output, .contains("No breaking changes detected in Baz"))
@@ -278,26 +280,28 @@ final class APIDiffTests: CommandsTestCase {
             let packageRoot = fixturePath.appending("Bar")
             try localFileSystem.createDirectory(packageRoot.appending(components: "Sources", "Foo"))
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Foo", "Foo.swift")) {
-                $0 <<< "public let foo = \"All new module!\""
+                $0.send(#"public let foo = "All new module!""#)
             }
             try localFileSystem.writeFileContents(packageRoot.appending("Package.swift")) {
-                $0 <<< """
-                // swift-tools-version:4.2
-                import PackageDescription
+                $0.send(
+                    """
+                    // swift-tools-version:4.2
+                    import PackageDescription
 
-                let package = Package(
-                    name: "Bar",
-                    products: [
-                        .library(name: "Baz", targets: ["Baz"]),
-                        .library(name: "Qux", targets: ["Qux", "Foo"]),
-                    ],
-                    targets: [
-                        .target(name: "Baz"),
-                        .target(name: "Qux"),
-                        .target(name: "Foo")
-                    ]
+                    let package = Package(
+                        name: "Bar",
+                        products: [
+                            .library(name: "Baz", targets: ["Baz"]),
+                            .library(name: "Qux", targets: ["Qux", "Foo"]),
+                        ],
+                        targets: [
+                            .target(name: "Baz"),
+                            .target(name: "Qux"),
+                            .target(name: "Foo")
+                        ]
+                    )
+                    """
                 )
-                """
             }
             let (output, _) = try execute(["diagnose-api-breaking-changes", "1.2.3"], packagePath: packageRoot)
             XCTAssertMatch(output, .contains("No breaking changes detected in Baz"))
@@ -325,7 +329,7 @@ final class APIDiffTests: CommandsTestCase {
                 try repo.checkout(newBranch: "feature")
                 // Overwrite the existing decl.
                 try localFileSystem.writeFileContents(packageRoot.appending("Foo.swift")) {
-                    $0 <<< "public let foo = 42"
+                    $0.send("public let foo = 42")
                 }
                 try repo.stage(file: "Foo.swift")
                 try repo.commit(message: "Add foo")
@@ -341,7 +345,7 @@ final class APIDiffTests: CommandsTestCase {
                 // Update `main` and ensure the baseline is regenerated.
                 try repo.checkout(revision: .init(identifier: "main"))
                 try localFileSystem.writeFileContents(packageRoot.appending("Foo.swift")) {
-                    $0 <<< "public let foo = 42"
+                    $0.send("public let foo = 42")
                 }
                 try repo.stage(file: "Foo.swift")
                 try repo.commit(message: "Add foo")
@@ -359,7 +363,7 @@ final class APIDiffTests: CommandsTestCase {
             let packageRoot = fixturePath.appending("Foo")
             // Overwrite the existing decl.
             try localFileSystem.writeFileContents(packageRoot.appending("Foo.swift")) {
-                $0 <<< "public let foo = 42"
+                $0.send("public let foo = 42")
             }
 
             let baselineDir = fixturePath.appending("Baselines")
@@ -382,7 +386,7 @@ final class APIDiffTests: CommandsTestCase {
             let packageRoot = fixturePath.appending("Foo")
             // Overwrite the existing decl.
             try localFileSystem.writeFileContents(packageRoot.appending("Foo.swift")) {
-                $0 <<< "public let foo = 42"
+                $0.send("public let foo = 42")
             }
 
             let repo = GitRepository(path: packageRoot)
@@ -393,7 +397,7 @@ final class APIDiffTests: CommandsTestCase {
 
             try localFileSystem.createDirectory(fooBaselinePath.parentDirectory, recursive: true)
             try localFileSystem.writeFileContents(fooBaselinePath) {
-                $0 <<< "Old Baseline"
+                $0.send("Old Baseline")
             }
 
             XCTAssertThrowsCommandExecutionError(

--- a/Tests/CommandsTests/MultiRootSupportTests.swift
+++ b/Tests/CommandsTests/MultiRootSupportTests.swift
@@ -26,7 +26,8 @@ final class MultiRootSupportTests: CommandsTestCase {
         ])
         let path = AbsolutePath("/tmp/test/Workspace.xcworkspace")
         try fs.writeFileContents(path.appending("contents.xcworkspacedata")) {
-            $0 <<< """
+            $0.send(
+                """
                 <?xml version="1.0" encoding="UTF-8"?>
                 <Workspace
                 version = "1.0">
@@ -38,6 +39,7 @@ final class MultiRootSupportTests: CommandsTestCase {
                 </FileRef>
                 </Workspace>
                 """
+            )
         }
 
         let observability = ObservabilitySystem.makeForTesting()

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -118,9 +118,10 @@ final class PackageToolTests: CommandsTestCase {
         try fixture(name: "DependencyResolution/External/XCFramework") { fixturePath in
             let fs = localFileSystem
             let netrcPath = fixturePath.appending(".netrc")
-            try fs.writeFileContents(netrcPath) { stream in
-                stream <<< "machine mymachine.labkey.org login user@labkey.org password mypassword"
-            }
+            try fs.writeFileContents(
+                netrcPath,
+                string: "machine mymachine.labkey.org login user@labkey.org password mypassword"
+            )
 
             // valid .netrc file path
             try execute(["resolve", "--netrc-file", netrcPath.pathString], packagePath: fixturePath)
@@ -647,31 +648,35 @@ final class PackageToolTests: CommandsTestCase {
             let dep = tmpPath.appending(components: "dep")
 
             // Create root package.
-            try fs.writeFileContents(root.appending(components: "Sources", "root", "main.swift")) { $0 <<< "" }
+            try fs.writeFileContents(root.appending(components: "Sources", "root", "main.swift"), string: "")
             try fs.writeFileContents(root.appending("Package.swift")) {
-                $0 <<< """
-                // swift-tools-version:4.2
-                import PackageDescription
-                let package = Package(
-                name: "root",
-                dependencies: [.package(url: "../dep", from: "1.0.0")],
-                targets: [.target(name: "root", dependencies: ["dep"])]
+                $0.send(
+                    """
+                    // swift-tools-version:4.2
+                    import PackageDescription
+                    let package = Package(
+                        name: "root",
+                        dependencies: [.package(url: "../dep", from: "1.0.0")],
+                        targets: [.target(name: "root", dependencies: ["dep"])]
+                    )
+                    """
                 )
-                """
             }
 
             // Create dependency.
-            try fs.writeFileContents(dep.appending(components: "Sources", "dep", "lib.swift")) { $0 <<< "" }
+            try fs.writeFileContents(dep.appending(components: "Sources", "dep", "lib.swift")) { $0.send("") }
             try fs.writeFileContents(dep.appending("Package.swift")) {
-                $0 <<< """
-                // swift-tools-version:4.2
-                import PackageDescription
-                let package = Package(
-                name: "dep",
-                products: [.library(name: "dep", targets: ["dep"])],
-                targets: [.target(name: "dep")]
+                $0.send(
+                    """
+                    // swift-tools-version:4.2
+                    import PackageDescription
+                    let package = Package(
+                        name: "dep",
+                        products: [.library(name: "dep", targets: ["dep"])],
+                        targets: [.target(name: "dep")]
+                    )
+                    """
                 )
-                """
             }
             do {
                 let depGit = GitRepository(path: dep)
@@ -817,7 +822,7 @@ final class PackageToolTests: CommandsTestCase {
             // Edit a file in baz ToT checkout.
             let bazTotPackageFile = bazTot.appending("Package.swift")
             let stream = BufferedOutputByteStream()
-            stream <<< (try localFileSystem.readFileContents(bazTotPackageFile)) <<< "\n// Edited."
+            stream.send(try localFileSystem.readFileContents(bazTotPackageFile)).send("\n// Edited.")
             try localFileSystem.writeFileContents(bazTotPackageFile, bytes: stream.bytes)
 
             // Unediting baz will remove the symlink but not the checked out package.
@@ -1029,7 +1034,8 @@ final class PackageToolTests: CommandsTestCase {
     func testOnlyUseVersionsFromResolvedFileFetchesWithExistingState() throws {
         func writeResolvedFile(packageDir: AbsolutePath, repositoryURL: String, revision: String, version: String) throws {
             try localFileSystem.writeFileContents(packageDir.appending("Package.resolved")) {
-                $0 <<< """
+                $0.send(
+                    """
                     {
                       "object": {
                         "pins": [
@@ -1046,27 +1052,32 @@ final class PackageToolTests: CommandsTestCase {
                       },
                       "version": 1
                     }
-                """
+                    """
+                )
             }
         }
 
         try testWithTemporaryDirectory { tmpPath in
             let packageDir = tmpPath.appending(components: "library")
             try localFileSystem.writeFileContents(packageDir.appending("Package.swift")) {
-                $0 <<< """
-                // swift-tools-version:5.0
-                import PackageDescription
-                let package = Package(
-                    name: "library",
-                    products: [ .library(name: "library", targets: ["library"]) ],
-                    targets: [ .target(name: "library") ]
+                $0.send(
+                    """
+                    // swift-tools-version:5.0
+                    import PackageDescription
+                    let package = Package(
+                        name: "library",
+                        products: [ .library(name: "library", targets: ["library"]) ],
+                        targets: [ .target(name: "library") ]
+                    )
+                    """
                 )
-                """
             }
             try localFileSystem.writeFileContents(packageDir.appending(components: "Sources", "library", "library.swift")) {
-                $0 <<< """
+                $0.send(
+                    """
                     public func Foo() { }
-                """
+                    """
+                )
             }
 
             let depGit = GitRepository(path: packageDir)
@@ -1080,20 +1091,24 @@ final class PackageToolTests: CommandsTestCase {
 
             let clientDir = tmpPath.appending(components: "client")
             try localFileSystem.writeFileContents(clientDir.appending("Package.swift")) {
-                $0 <<< """
-                // swift-tools-version:5.0
-                import PackageDescription
-                let package = Package(
-                    name: "client",
-                    dependencies: [ .package(url: "\(repositoryURL)", from: "1.0.0") ],
-                    targets: [ .target(name: "client", dependencies: [ "library" ]) ]
+                $0.send(
+                    """
+                    // swift-tools-version:5.0
+                    import PackageDescription
+                    let package = Package(
+                        name: "client",
+                        dependencies: [ .package(url: "\(repositoryURL)", from: "1.0.0") ],
+                        targets: [ .target(name: "client", dependencies: [ "library" ]) ]
+                    )
+                    """
                 )
-                """
             }
             try localFileSystem.writeFileContents(clientDir.appending(components: "Sources", "client", "main.swift")) {
-                $0 <<< """
+                $0.send(
+                    """
                     print("hello")
-                """
+                    """
+                )
             }
 
             // Initial resolution with clean state.
@@ -1102,9 +1117,11 @@ final class PackageToolTests: CommandsTestCase {
 
             // Make a change to the dependency and tag a new version.
             try localFileSystem.writeFileContents(packageDir.appending(components: "Sources", "library", "library.swift")) {
-                $0 <<< """
+                $0.send(
+                    """
                     public func Best() { }
-                """
+                    """
+                )
             }
             try depGit.stageEverything()
             try depGit.commit()
@@ -1125,32 +1142,36 @@ final class PackageToolTests: CommandsTestCase {
             let depSym = path.appending(components: "depSym")
 
             // Create root package.
-            try fs.writeFileContents(root.appending(components: "Sources", "root", "main.swift")) { $0 <<< "" }
+            try fs.writeFileContents(root.appending(components: "Sources", "root", "main.swift")) { $0.send("") }
             try fs.writeFileContents(root.appending("Package.swift")) {
-                $0 <<< """
-                // swift-tools-version:4.2
-                import PackageDescription
-                let package = Package(
-                name: "root",
-                dependencies: [.package(url: "../depSym", from: "1.0.0")],
-                targets: [.target(name: "root", dependencies: ["dep"])]
-                )
+                $0.send(
+                    """
+                    // swift-tools-version:4.2
+                    import PackageDescription
+                    let package = Package(
+                        name: "root",
+                        dependencies: [.package(url: "../depSym", from: "1.0.0")],
+                        targets: [.target(name: "root", dependencies: ["dep"])]
+                    )
 
-                """
+                    """
+                )
             }
 
             // Create dependency.
-            try fs.writeFileContents(dep.appending(components: "Sources", "dep", "lib.swift")) { $0 <<< "" }
+            try fs.writeFileContents(dep.appending(components: "Sources", "dep", "lib.swift")) { $0.send("") }
             try fs.writeFileContents(dep.appending("Package.swift")) {
-                $0 <<< """
-                // swift-tools-version:4.2
-                import PackageDescription
-                let package = Package(
-                name: "dep",
-                products: [.library(name: "dep", targets: ["dep"])],
-                targets: [.target(name: "dep")]
+                $0.send(
+                    """
+                    // swift-tools-version:4.2
+                    import PackageDescription
+                    let package = Package(
+                        name: "dep",
+                        products: [.library(name: "dep", targets: ["dep"])],
+                        targets: [.target(name: "dep")]
+                    )
+                    """
                 )
-                """
             }
             do {
                 let depGit = GitRepository(path: dep)
@@ -1385,11 +1406,13 @@ final class PackageToolTests: CommandsTestCase {
                 for fakeCmdName in ["xcrun", "sandbox-exec"] {
                     let fakeCmdPath = fakeBinDir.appending(component: fakeCmdName)
                     try localFileSystem.writeFileContents(fakeCmdPath, body: { stream in
-                        stream <<< """
-                        #!/bin/sh
-                        echo "wrong \(fakeCmdName) invoked"
-                        exit 1
-                        """
+                        stream.send(
+                            """
+                            #!/bin/sh
+                            echo "wrong \(fakeCmdName) invoked"
+                            exit 1
+                            """
+                        )
                     })
                     try localFileSystem.chmod(.executable, path: fakeCmdPath)
                 }
@@ -1415,43 +1438,52 @@ final class PackageToolTests: CommandsTestCase {
             // Create a sample package with a library target and a plugin.
             let packageDir = tmpPath.appending(components: "MyPackage")
             try localFileSystem.writeFileContents(packageDir.appending("Package.swift")) {
-                $0 <<< """
-                // swift-tools-version: 5.5
-                import PackageDescription
-                let package = Package(
-                    name: "MyPackage",
-                    targets: [
-                        .target(
-                            name: "MyLibrary",
-                            plugins: [
-                                "MyPlugin",
-                            ]
-                        ),
-                        .plugin(
-                            name: "MyPlugin",
-                            capability: .buildTool()
-                        ),
-                    ]
+                $0.send(
+                    """
+                    // swift-tools-version: 5.5
+                    import PackageDescription
+                    let package = Package(
+                        name: "MyPackage",
+                        targets: [
+                            .target(
+                                name: "MyLibrary",
+                                plugins: [
+                                    "MyPlugin",
+                                ]
+                            ),
+                            .plugin(
+                                name: "MyPlugin",
+                                capability: .buildTool()
+                            ),
+                        ]
+                    )
+                    """
                 )
-                """
             }
             try localFileSystem.writeFileContents(packageDir.appending(components: "Sources", "MyLibrary", "library.swift")) {
-                $0 <<< """
+                $0.send(
+                    """
                     public func Foo() { }
-                """
+                    """
+                )
             }
             try localFileSystem.writeFileContents(packageDir.appending(components: "Sources", "MyLibrary", "library.foo")) {
-                $0 <<< """
+                $0.send(
+                    """
                     a file with a filename suffix handled by the plugin
-                """
+                    """
+                )
             }
             try localFileSystem.writeFileContents(packageDir.appending(components: "Sources", "MyLibrary", "library.bar")) {
-                $0 <<< """
+                $0.send(
+                    """
                     a file with a filename suffix not handled by the plugin
-                """
+                    """
+                )
             }
             try localFileSystem.writeFileContents(packageDir.appending(components: "Plugins", "MyPlugin", "plugin.swift")) {
-                $0 <<< """
+                $0.send(
+                    """
                     import PackagePlugin
                     import Foundation
                     @main
@@ -1477,7 +1509,8 @@ final class PackageToolTests: CommandsTestCase {
 
                     }
                     extension String : Error {}
-                """
+                    """
+                )
             }
 
             // Invoke it, and check the results.
@@ -1634,176 +1667,182 @@ final class PackageToolTests: CommandsTestCase {
             // Create a sample package with a library target, a plugin, and a local tool. It depends on a sample package which also has a tool.
             let packageDir = tmpPath.appending(components: "MyPackage")
             try localFileSystem.writeFileContents(packageDir.appending(components: "Package.swift")) {
-                $0 <<< """
-                // swift-tools-version: 5.6
-                import PackageDescription
-                let package = Package(
-                    name: "MyPackage",
-                    dependencies: [
-                        .package(name: "HelperPackage", path: "VendoredDependencies/HelperPackage")
-                    ],
-                    targets: [
-                        .target(
-                            name: "MyLibrary",
-                            dependencies: [
-                                .product(name: "HelperLibrary", package: "HelperPackage")
-                            ]
-                        ),
-                        .plugin(
-                            name: "MyPlugin",
-                            capability: .command(
-                                intent: .custom(verb: "mycmd", description: "What is mycmd anyway?")
+                $0.send(
+                    """
+                    // swift-tools-version: 5.6
+                    import PackageDescription
+                    let package = Package(
+                        name: "MyPackage",
+                        dependencies: [
+                            .package(name: "HelperPackage", path: "VendoredDependencies/HelperPackage")
+                        ],
+                        targets: [
+                            .target(
+                                name: "MyLibrary",
+                                dependencies: [
+                                    .product(name: "HelperLibrary", package: "HelperPackage")
+                                ]
                             ),
-                            dependencies: [
-                                .target(name: "LocalBuiltTool"),
-                                .target(name: "LocalBinaryTool"),
-                                .product(name: "RemoteBuiltTool", package: "HelperPackage")
-                            ]
-                        ),
-                        .binaryTarget(
-                            name: "LocalBinaryTool",
-                            path: "Binaries/LocalBinaryTool.artifactbundle"
-                        ),
-                        .executableTarget(
-                            name: "LocalBuiltTool"
-                        )
-                    ]
+                            .plugin(
+                                name: "MyPlugin",
+                                capability: .command(
+                                    intent: .custom(verb: "mycmd", description: "What is mycmd anyway?")
+                                ),
+                                dependencies: [
+                                    .target(name: "LocalBuiltTool"),
+                                    .target(name: "LocalBinaryTool"),
+                                    .product(name: "RemoteBuiltTool", package: "HelperPackage")
+                                ]
+                            ),
+                            .binaryTarget(
+                                name: "LocalBinaryTool",
+                                path: "Binaries/LocalBinaryTool.artifactbundle"
+                            ),
+                            .executableTarget(
+                                name: "LocalBuiltTool"
+                            )
+                        ]
+                    )
+                    """
                 )
-                """
             }
             try localFileSystem.writeFileContents(packageDir.appending(components: "Sources", "MyLibrary", "library.swift")) {
-                $0 <<< """
-                public func Foo() { }
-                """
+                $0.send(
+                    """
+                    public func Foo() { }
+                    """
+                )
             }
             try localFileSystem.writeFileContents(packageDir.appending(components: "Sources", "MyLibrary", "test.docc")) {
-                $0 <<< """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
-                <plist version="1.0">
-                <dict>
-                    <key>CFBundleName</key>
-                    <string>sample</string>
-                </dict>
-                """
+                $0.send(
+                    """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+                    <plist version="1.0">
+                    <dict>
+                        <key>CFBundleName</key>
+                        <string>sample</string>
+                    </dict>
+                    """
+                )
             }
             let hostTriple = try UserToolchain(destination: .hostDestination()).triple
             let hostTripleString = hostTriple.isDarwin() ? hostTriple.tripleString(forPlatformVersion: "") : hostTriple.tripleString
             try localFileSystem.writeFileContents(packageDir.appending(components: "Binaries", "LocalBinaryTool.artifactbundle", "info.json")) {
-                $0 <<< """
-                {   "schemaVersion": "1.0",
-                    "artifacts": {
-                        "LocalBinaryTool": {
-                            "type": "executable",
-                            "version": "1.2.3",
-                            "variants": [
-                                {   "path": "LocalBinaryTool.sh",
-                                    "supportedTriples": ["\(hostTripleString)"]
-                                },
-                            ]
-                        }
-                    }
-                }
-                """
-            }
-            try localFileSystem.writeFileContents(packageDir.appending(components: "Sources", "LocalBuiltTool", "main.swift")) {
-                $0 <<< """
-                print("Hello")
-                """
-            }
-            try localFileSystem.writeFileContents(packageDir.appending(components: "Plugins", "MyPlugin", "plugin.swift")) {
-                $0 <<< """
-                import PackagePlugin
-                import Foundation
-                @main
-                struct MyCommandPlugin: CommandPlugin {
-                    func performCommand(
-                        context: PluginContext,
-                        arguments: [String]
-                    ) throws {
-                        print("This is MyCommandPlugin.")
-
-                        // Print out the initial working directory so we can check it in the test.
-                        print("Initial working directory: \\(FileManager.default.currentDirectoryPath)")
-
-                        // Check that we can find a binary-provided tool in the same package.
-                        print("Looking for LocalBinaryTool...")
-                        let localBinaryTool = try context.tool(named: "LocalBinaryTool")
-                        print("... found it at \\(localBinaryTool.path)")
-
-                        // Check that we can find a source-built tool in the same package.
-                        print("Looking for LocalBuiltTool...")
-                        let localBuiltTool = try context.tool(named: "LocalBuiltTool")
-                        print("... found it at \\(localBuiltTool.path)")
-
-                        // Check that we can find a source-built tool in another package.
-                        print("Looking for RemoteBuiltTool...")
-                        let remoteBuiltTool = try context.tool(named: "RemoteBuiltTool")
-                        print("... found it at \\(remoteBuiltTool.path)")
-
-                        // Check that we can find a tool in the toolchain.
-                        print("Looking for swiftc...")
-                        let swiftc = try context.tool(named: "swiftc")
-                        print("... found it at \\(swiftc.path)")
-
-                        // Check that we can find a standard tool.
-                        print("Looking for sed...")
-                        let sed = try context.tool(named: "sed")
-                        print("... found it at \\(sed.path)")
-
-                        // Extract the `--target` arguments.
-                        var argExtractor = ArgumentExtractor(arguments)
-                        let targetNames = argExtractor.extractOption(named: "target")
-                        let targets = try context.package.targets(named: targetNames)
-
-                        // Print out the source files so that we can check them.
-                        if let sourceFiles = targets.first(where: { $0.name == "MyLibrary" })?.sourceModule?.sourceFiles {
-                            for file in sourceFiles {
-                                print("  \\(file.path): \\(file.type)")
+                $0.send(
+                    """
+                    {   "schemaVersion": "1.0",
+                        "artifacts": {
+                            "LocalBinaryTool": {
+                                "type": "executable",
+                                "version": "1.2.3",
+                                "variants": [
+                                    {   "path": "LocalBinaryTool.sh",
+                                        "supportedTriples": ["\(hostTripleString)"]
+                                    },
+                                ]
                             }
                         }
                     }
-                }
-                """
+                    """
+                )
+            }
+            try localFileSystem.writeFileContents(packageDir.appending(components: "Sources", "LocalBuiltTool", "main.swift")) {
+                $0.send(#"print("Hello")"#)
+            }
+            try localFileSystem.writeFileContents(packageDir.appending(components: "Plugins", "MyPlugin", "plugin.swift")) {
+                $0.send(
+                    """
+                    import PackagePlugin
+                    import Foundation
+                    @main
+                    struct MyCommandPlugin: CommandPlugin {
+                        func performCommand(
+                            context: PluginContext,
+                            arguments: [String]
+                        ) throws {
+                            print("This is MyCommandPlugin.")
+
+                            // Print out the initial working directory so we can check it in the test.
+                            print("Initial working directory: \\(FileManager.default.currentDirectoryPath)")
+
+                            // Check that we can find a binary-provided tool in the same package.
+                            print("Looking for LocalBinaryTool...")
+                            let localBinaryTool = try context.tool(named: "LocalBinaryTool")
+                            print("... found it at \\(localBinaryTool.path)")
+
+                            // Check that we can find a source-built tool in the same package.
+                            print("Looking for LocalBuiltTool...")
+                            let localBuiltTool = try context.tool(named: "LocalBuiltTool")
+                            print("... found it at \\(localBuiltTool.path)")
+
+                            // Check that we can find a source-built tool in another package.
+                            print("Looking for RemoteBuiltTool...")
+                            let remoteBuiltTool = try context.tool(named: "RemoteBuiltTool")
+                            print("... found it at \\(remoteBuiltTool.path)")
+
+                            // Check that we can find a tool in the toolchain.
+                            print("Looking for swiftc...")
+                            let swiftc = try context.tool(named: "swiftc")
+                            print("... found it at \\(swiftc.path)")
+
+                            // Check that we can find a standard tool.
+                            print("Looking for sed...")
+                            let sed = try context.tool(named: "sed")
+                            print("... found it at \\(sed.path)")
+
+                            // Extract the `--target` arguments.
+                            var argExtractor = ArgumentExtractor(arguments)
+                            let targetNames = argExtractor.extractOption(named: "target")
+                            let targets = try context.package.targets(named: targetNames)
+
+                            // Print out the source files so that we can check them.
+                            if let sourceFiles = targets.first(where: { $0.name == "MyLibrary" })?.sourceModule?.sourceFiles {
+                                for file in sourceFiles {
+                                    print("  \\(file.path): \\(file.type)")
+                                }
+                            }
+                        }
+                    }
+                    """
+                )
             }
 
             // Create the sample vendored dependency package.
             try localFileSystem.writeFileContents(packageDir.appending(components: "VendoredDependencies", "HelperPackage", "Package.swift")) {
-                $0 <<< """
-                // swift-tools-version: 5.5
-                import PackageDescription
-                let package = Package(
-                    name: "HelperPackage",
-                    products: [
-                        .library(
-                            name: "HelperLibrary",
-                            targets: ["HelperLibrary"]
-                        ),
-                        .executable(
-                            name: "RemoteBuiltTool",
-                            targets: ["RemoteBuiltTool"]
-                        ),
-                    ],
-                    targets: [
-                        .target(
-                            name: "HelperLibrary"
-                        ),
-                        .executableTarget(
-                            name: "RemoteBuiltTool"
-                        ),
-                    ]
+                $0.send(
+                    """
+                    // swift-tools-version: 5.5
+                    import PackageDescription
+                    let package = Package(
+                        name: "HelperPackage",
+                        products: [
+                            .library(
+                                name: "HelperLibrary",
+                                targets: ["HelperLibrary"]
+                            ),
+                            .executable(
+                                name: "RemoteBuiltTool",
+                                targets: ["RemoteBuiltTool"]
+                            ),
+                        ],
+                        targets: [
+                            .target(
+                                name: "HelperLibrary"
+                            ),
+                            .executableTarget(
+                                name: "RemoteBuiltTool"
+                            ),
+                        ]
+                    )
+                    """
                 )
-                """
             }
             try localFileSystem.writeFileContents(packageDir.appending(components: "VendoredDependencies", "HelperPackage", "Sources", "HelperLibrary", "library.swift")) {
-                $0 <<< """
-                public func Bar() { }
-                """
+                $0.send("public func Bar() { }")
             }
             try localFileSystem.writeFileContents(packageDir.appending(components: "VendoredDependencies", "HelperPackage", "Sources", "RemoteBuiltTool", "main.swift")) {
-                $0 <<< """
-                print("Hello")
-                """
+                $0.send(#"print("Hello")"#)
             }
 
             // Check that we can invoke the plugin with the "plugin" subcommand.
@@ -1866,7 +1905,8 @@ final class PackageToolTests: CommandsTestCase {
             // Create a sample package with a library target and a plugin.
             let packageDir = tmpPath.appending(components: "MyPackage")
             try localFileSystem.writeFileContents(packageDir.appending(components: "Package.swift")) {
-                $0 <<< """
+                $0.send(
+                    """
                     // swift-tools-version: 5.9
                     import PackageDescription
                     let package = Package(
@@ -1877,14 +1917,14 @@ final class PackageToolTests: CommandsTestCase {
                         ]
                     )
                     """
+                )
             }
             try localFileSystem.writeFileContents(packageDir.appending(components: "Sources", "MyLibrary", "library.swift")) {
-                $0 <<< """
-                    public func Foo() { }
-                    """
+                $0.send("public func Foo() { }")
             }
             try localFileSystem.writeFileContents(packageDir.appending(components: "Plugins", "MyPlugin", "plugin.swift")) {
-                $0 <<< """
+                $0.send(
+                    """
                     import PackagePlugin
 
                     @main
@@ -1894,6 +1934,7 @@ final class PackageToolTests: CommandsTestCase {
                         }
                     }
                     """
+                )
             }
 
             #if os(macOS)
@@ -1969,56 +2010,58 @@ final class PackageToolTests: CommandsTestCase {
             // Create a sample package with a library target and a plugin.
             let packageDir = tmpPath.appending(components: "MyPackage")
             try localFileSystem.writeFileContents(packageDir.appending(components: "Package.swift")) {
-                $0 <<< """
-                // swift-tools-version: 5.6
-                import PackageDescription
-                import Foundation
-                let package = Package(
-                    name: "MyPackage",
-                    targets: [
-                        .target(
-                            name: "MyLibrary"
-                        ),
-                        .plugin(
-                            name: "MyPlugin",
-                            capability: .command(
-                                intent: .custom(verb: "PackageScribbler", description: "Help description"),
-                                // We use an environment here so we can control whether we declare the permission.
-                                permissions: ProcessInfo.processInfo.environment["DECLARE_PACKAGE_WRITING_PERMISSION"] == "1"
-                                    ? [.writeToPackageDirectory(reason: "For testing purposes")]
-                                    : []
-                            )
-                        ),
-                    ]
+                $0.send(
+                    """
+                    // swift-tools-version: 5.6
+                    import PackageDescription
+                    import Foundation
+                    let package = Package(
+                        name: "MyPackage",
+                        targets: [
+                            .target(
+                                name: "MyLibrary"
+                            ),
+                            .plugin(
+                                name: "MyPlugin",
+                                capability: .command(
+                                    intent: .custom(verb: "PackageScribbler", description: "Help description"),
+                                    // We use an environment here so we can control whether we declare the permission.
+                                    permissions: ProcessInfo.processInfo.environment["DECLARE_PACKAGE_WRITING_PERMISSION"] == "1"
+                                        ? [.writeToPackageDirectory(reason: "For testing purposes")]
+                                        : []
+                                )
+                            ),
+                        ]
+                    )
+                    """
                 )
-                """
             }
             try localFileSystem.writeFileContents(packageDir.appending(components: "Sources", "MyLibrary", "library.swift")) {
-                $0 <<< """
-                public func Foo() { }
-                """
+                $0.send("public func Foo() { }")
             }
             try localFileSystem.writeFileContents(packageDir.appending(components: "Plugins", "MyPlugin", "plugin.swift")) {
-                $0 <<< """
-                import PackagePlugin
-                import Foundation
+                $0.send(
+                    """
+                    import PackagePlugin
+                    import Foundation
 
-                @main
-                struct MyCommandPlugin: CommandPlugin {
-                    func performCommand(
-                        context: PluginContext,
-                        arguments: [String]
-                    ) throws {
-                        // Check that we can write to the package directory.
-                        print("Trying to write to the package directory...")
-                        guard FileManager.default.createFile(atPath: context.package.directory.appending("Foo").string, contents: Data("Hello".utf8)) else {
-                            throw "Couldn’t create file at path \\(context.package.directory.appending("Foo"))"
+                    @main
+                    struct MyCommandPlugin: CommandPlugin {
+                        func performCommand(
+                            context: PluginContext,
+                            arguments: [String]
+                        ) throws {
+                            // Check that we can write to the package directory.
+                            print("Trying to write to the package directory...")
+                            guard FileManager.default.createFile(atPath: context.package.directory.appending("Foo").string, contents: Data("Hello".utf8)) else {
+                                throw "Couldn’t create file at path \\(context.package.directory.appending("Foo"))"
+                            }
+                            print("... successfully created it")
                         }
-                        print("... successfully created it")
                     }
-                }
-                extension String: Error {}
-                """
+                    extension String: Error {}
+                    """
+                )
             }
 
             // Check that we get an error if the plugin needs permission but if we don't give it to them. Note that sandboxing is only currently supported on macOS.
@@ -2084,8 +2127,11 @@ final class PackageToolTests: CommandsTestCase {
         try testWithTemporaryDirectory { tmpPath in
             // Create a sample package with a library target and a plugin.
             let packageDir = tmpPath.appending(components: "MyPackage")
-            try localFileSystem.writeFileContents(packageDir.appending(components: "Package.swift")) {
-                """
+
+            try localFileSystem.createDirectory(packageDir)
+            try localFileSystem.writeFileContents(
+                packageDir.appending(components: "Package.swift"),
+                string: """
                 // swift-tools-version: 5.6
                 import PackageDescription
                 import Foundation
@@ -2101,9 +2147,13 @@ final class PackageToolTests: CommandsTestCase {
                     ]
                 )
                 """
-            }
-            try localFileSystem.writeFileContents(packageDir.appending(components: "Plugins", "MyPlugin", "plugin.swift")) {
-                """
+            )
+
+            let pluginDir = packageDir.appending(components: "Plugins", "MyPlugin")
+            try localFileSystem.createDirectory(pluginDir, recursive: true)
+            try localFileSystem.writeFileContents(
+                pluginDir.appending("plugin.swift"),
+                string: """
                 import PackagePlugin
                 import Foundation
 
@@ -2131,7 +2181,7 @@ final class PackageToolTests: CommandsTestCase {
                 }
                 extension String: Error {}
                 """
-            }
+            )
 
             // Check arguments
             do {
@@ -2161,8 +2211,10 @@ final class PackageToolTests: CommandsTestCase {
         try testWithTemporaryDirectory { tmpPath in
             // Create a sample package with a library, and executable, and a plugin.
             let packageDir = tmpPath.appending(components: "MyPackage")
-            try localFileSystem.writeFileContents(packageDir.appending(components: "Package.swift")) {
-                $0 <<< """
+            try localFileSystem.createDirectory(packageDir)
+            try localFileSystem.writeFileContents(
+                packageDir.appending(components: "Package.swift"),
+                string: """
                 // swift-tools-version: 5.6
                 import PackageDescription
                 let package = Package(
@@ -2184,20 +2236,30 @@ final class PackageToolTests: CommandsTestCase {
                     ]
                 )
                 """
-            }
-            try localFileSystem.writeFileContents(packageDir.appending(components: "Sources", "MyLibrary", "library.swift")) {
-                $0 <<< """
-                public func GetGreeting() -> String { return "Hello" }
-                """
-            }
-            try localFileSystem.writeFileContents(packageDir.appending(components: "Sources", "MyCommand", "main.swift")) {
-                $0 <<< """
+            )
+
+            let libraryPath = packageDir.appending(components: "Sources", "MyLibrary", "library.swift")
+            try localFileSystem.createDirectory(libraryPath.parentDirectory, recursive: true)
+            try localFileSystem.writeFileContents(
+                libraryPath,
+                string: #"public func GetGreeting() -> String { return "Hello" }"#
+            )
+
+            let commandPath = packageDir.appending(components: "Sources", "MyCommand", "main.swift")
+            try localFileSystem.createDirectory(commandPath.parentDirectory, recursive: true)
+            try localFileSystem.writeFileContents(
+                commandPath,
+                string: """
                 import MyLibrary
                 print("\\(GetGreeting()), World!")
                 """
-            }
-            try localFileSystem.writeFileContents(packageDir.appending(components: "Plugins", "MyPlugin", "plugin.swift")) {
-                $0 <<< """
+            )
+
+            let pluginPath = packageDir.appending(components: "Plugins", "MyPlugin", "plugin.swift")
+            try localFileSystem.createDirectory(pluginPath.parentDirectory, recursive: true)
+            try localFileSystem.writeFileContents(
+                pluginPath,
+                string: """
                 import PackagePlugin
                 import Foundation
 
@@ -2221,7 +2283,7 @@ final class PackageToolTests: CommandsTestCase {
                     }
                 }
                 """
-            }
+            )
 
             // Check that if we don't pass any target, we successfully get symbol graph information for all targets in the package, and at different paths.
             do {

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -648,7 +648,9 @@ final class PackageToolTests: CommandsTestCase {
             let dep = tmpPath.appending(components: "dep")
 
             // Create root package.
-            try fs.writeFileContents(root.appending(components: "Sources", "root", "main.swift"), string: "")
+            let mainFilePath = root.appending(components: "Sources", "root", "main.swift")
+            try fs.createDirectory(mainFilePath.parentDirectory, recursive: true)
+            try fs.writeFileContents(mainFilePath, string: "")
             try fs.writeFileContents(root.appending("Package.swift")) {
                 $0.send(
                     """

--- a/Tests/CommandsTests/RunToolTests.swift
+++ b/Tests/CommandsTests/RunToolTests.swift
@@ -106,8 +106,9 @@ final class RunToolTests: CommandsTestCase {
         try fixture(name: "Miscellaneous/SwiftRun") { fixturePath in
             let mainFilePath = fixturePath.appending("main.swift")
             try localFileSystem.removeFileTree(mainFilePath)
-            try localFileSystem.writeFileContents(mainFilePath) {
-                """
+            try localFileSystem.writeFileContents(
+                mainFilePath,
+                string: """
                 import Foundation
 
                 print("sleeping")
@@ -116,7 +117,7 @@ final class RunToolTests: CommandsTestCase {
                 sleep(10)
                 print("done")
                 """
-            }
+            )
 
             let sync = DispatchGroup()
             let outputHandler = OutputHandler(sync: sync)

--- a/Tests/CommandsTests/SwiftToolTests.swift
+++ b/Tests/CommandsTests/SwiftToolTests.swift
@@ -162,9 +162,10 @@ final class SwiftToolTests: CommandsTestCase {
             // custom .netrc file
             do {
                 let customPath = try fs.tempDirectory.appending(component: UUID().uuidString)
-                try fs.writeFileContents(customPath) {
-                    "machine mymachine.labkey.org login custom@labkey.org password custom"
-                }
+                try fs.writeFileContents(
+                    customPath,
+                    string: "machine mymachine.labkey.org login custom@labkey.org password custom"
+                )
 
                 let options = try GlobalOptions.parse(["--package-path", fixturePath.pathString, "--netrc-file", customPath.pathString])
                 let tool = try SwiftTool.createSwiftToolForTest(options: options)
@@ -196,9 +197,10 @@ final class SwiftToolTests: CommandsTestCase {
             // custom .netrc file
             do {
                 let customPath = try fs.tempDirectory.appending(component: UUID().uuidString)
-                try fs.writeFileContents(customPath) {
-                    "machine mymachine.labkey.org login custom@labkey.org password custom"
-                }
+                try fs.writeFileContents(
+                    customPath,
+                    string: "machine mymachine.labkey.org login custom@labkey.org password custom"
+                )
 
                 let options = try GlobalOptions.parse(["--package-path", fixturePath.pathString, "--netrc-file", customPath.pathString])
                 let tool = try SwiftTool.createSwiftToolForTest(options: options)

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -219,7 +219,7 @@ class MiscellaneousTestCase: XCTestCase {
             let pcFile = fixturePath.appending("libSystemModule.pc")
 
             let stream = BufferedOutputByteStream()
-            stream <<< """
+            stream.send("""
                 prefix=\(systemModule.pathString)
                 exec_prefix=${prefix}
                 libdir=${exec_prefix}
@@ -232,6 +232,7 @@ class MiscellaneousTestCase: XCTestCase {
                 Libs: -L${libdir} -lSystemModule
 
                 """
+            )
             try localFileSystem.writeFileContents(pcFile, bytes: stream.bytes)
 
             let moduleUser = fixturePath.appending("SystemModuleUserClang")

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -263,13 +263,14 @@ class MiscellaneousTestCase: XCTestCase {
 
             // Write out fake git.
             let stream = BufferedOutputByteStream()
-            stream <<< """
+            stream.send("""
                 #!/bin/sh
                 set -e
                 printf "$$" >> \(waitFile)
                 while true; do sleep 1; done
 
                 """
+            )
             try localFileSystem.writeFileContents(fakeGit, bytes: stream.bytes)
 
             // Make it executable.

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -179,8 +179,9 @@ class PluginTests: XCTestCase {
             let packageDir = tmpPath.appending(components: "MyPackage")
             let manifestFile = packageDir.appending("Package.swift")
             try localFileSystem.createDirectory(manifestFile.parentDirectory, recursive: true)
-            try localFileSystem.writeFileContents(manifestFile) {
-                """
+            try localFileSystem.writeFileContents(
+                manifestFile,
+                string: """
                 // swift-tools-version: 5.6
                 import PackageDescription
                 let package = Package(
@@ -223,18 +224,20 @@ class PluginTests: XCTestCase {
                     ]
                 )
                 """
-            }
+            )
             let librarySourceFile = packageDir.appending(components: "Sources", "MyLibrary", "library.swift")
             try localFileSystem.createDirectory(librarySourceFile.parentDirectory, recursive: true)
-            try localFileSystem.writeFileContents(librarySourceFile) {
-                """
+            try localFileSystem.writeFileContents(
+                librarySourceFile,
+                string: """
                 public func Foo() { }
                 """
-            }
+            )
             let printingPluginSourceFile = packageDir.appending(components: "Plugins", "PluginPrintingInfo", "plugin.swift")
             try localFileSystem.createDirectory(printingPluginSourceFile.parentDirectory, recursive: true)
-            try localFileSystem.writeFileContents(printingPluginSourceFile) {
-                """
+            try localFileSystem.writeFileContents(
+                printingPluginSourceFile,
+                string: """
                 import PackagePlugin
                 @main struct MyCommandPlugin: CommandPlugin {
                     func performCommand(
@@ -250,11 +253,12 @@ class PluginTests: XCTestCase {
                     }
                 }
                 """
-            }
+            )
             let pluginFailingWithErrorSourceFile = packageDir.appending(components: "Plugins", "PluginFailingWithError", "plugin.swift")
             try localFileSystem.createDirectory(pluginFailingWithErrorSourceFile.parentDirectory, recursive: true)
-            try localFileSystem.writeFileContents(pluginFailingWithErrorSourceFile) {
-                """
+            try localFileSystem.writeFileContents(
+                pluginFailingWithErrorSourceFile,
+                string: """
                 import PackagePlugin
                 @main struct MyCommandPlugin: CommandPlugin {
                     func performCommand(
@@ -270,11 +274,12 @@ class PluginTests: XCTestCase {
                 }
                 extension String: Error { }
                 """
-            }
+            )
             let pluginFailingWithoutErrorSourceFile = packageDir.appending(components: "Plugins", "PluginFailingWithoutError", "plugin.swift")
             try localFileSystem.createDirectory(pluginFailingWithoutErrorSourceFile.parentDirectory, recursive: true)
-            try localFileSystem.writeFileContents(pluginFailingWithoutErrorSourceFile) {
-                """
+            try localFileSystem.writeFileContents(
+                pluginFailingWithoutErrorSourceFile,
+                string: """
                 import PackagePlugin
                 import Foundation
                 @main struct MyCommandPlugin: CommandPlugin {
@@ -291,11 +296,12 @@ class PluginTests: XCTestCase {
                 }
                 extension String: Error { }
                 """
-            }
+            )
             let neverendingPluginSourceFile = packageDir.appending(components: "Plugins", "NeverendingPlugin", "plugin.swift")
             try localFileSystem.createDirectory(neverendingPluginSourceFile.parentDirectory, recursive: true)
-            try localFileSystem.writeFileContents(neverendingPluginSourceFile) {
-                """
+            try localFileSystem.writeFileContents(
+                neverendingPluginSourceFile,
+                string: """
                 import PackagePlugin
                 import Foundation
                 @main struct MyCommandPlugin: CommandPlugin {
@@ -312,13 +318,14 @@ class PluginTests: XCTestCase {
                 }
                 extension String: Error { }
                 """
-            }
+            )
 
             // Create the sample vendored dependency package.
             let library1Path = packageDir.appending(components: "VendoredDependencies", "HelperPackage", "Package.swift")
             try localFileSystem.createDirectory(library1Path.parentDirectory, recursive: true)
-            try localFileSystem.writeFileContents(library1Path) {
-                """
+            try localFileSystem.writeFileContents(
+                library1Path,
+                string: """
                 // swift-tools-version: 5.5
                 import PackageDescription
                 let package = Package(
@@ -336,15 +343,16 @@ class PluginTests: XCTestCase {
                     ]
                 )
                 """
-            }
+            )
 
             let library2Path = packageDir.appending(components: "VendoredDependencies", "HelperPackage", "Sources", "HelperLibrary", "library.swift")
             try localFileSystem.createDirectory(library2Path.parentDirectory, recursive: true)
-            try localFileSystem.writeFileContents(library2Path) {
-                """
+            try localFileSystem.writeFileContents(
+                library2Path,
+                string: """
                 public func Bar() { }
                 """
-            }
+            )
 
             // Load a workspace from the package.
             let observability = ObservabilitySystem.makeForTesting()
@@ -568,8 +576,9 @@ class PluginTests: XCTestCase {
             // Create a sample package with a couple of plugins a other targets and products.
             let packageDir = tmpPath.appending(components: "MyPackage")
             try localFileSystem.createDirectory(packageDir, recursive: true)
-            try localFileSystem.writeFileContents(packageDir.appending(components: "Package.swift")) {
-                """
+            try localFileSystem.writeFileContents(
+                packageDir.appending(components: "Package.swift"),
+                string: """
                 // swift-tools-version: 5.6
                 import PackageDescription
                 let package = Package(
@@ -593,18 +602,20 @@ class PluginTests: XCTestCase {
                     ]
                 )
                 """
-            }
+            )
             let myLibraryTargetDir = packageDir.appending(components: "Sources", "MyLibrary")
             try localFileSystem.createDirectory(myLibraryTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(myLibraryTargetDir.appending("library.swift")) {
-                """
+            try localFileSystem.writeFileContents(
+                myLibraryTargetDir.appending("library.swift"),
+                string: """
                 public func GetGreeting() -> String { return "Hello" }
                 """
-            }
+            )
             let neverendingPluginTargetDir = packageDir.appending(components: "Plugins", "NeverendingPlugin")
             try localFileSystem.createDirectory(neverendingPluginTargetDir, recursive: true)
-            try localFileSystem.writeFileContents(neverendingPluginTargetDir.appending("plugin.swift")) {
-                """
+            try localFileSystem.writeFileContents(
+                neverendingPluginTargetDir.appending("plugin.swift"),
+                string: """
                 import PackagePlugin
                 import Foundation
                 @main struct NeverendingPlugin: CommandPlugin {
@@ -620,7 +631,7 @@ class PluginTests: XCTestCase {
                     }
                 }
                 """
-            }
+            )
 
             // Load a workspace from the package.
             let observability = ObservabilitySystem.makeForTesting()
@@ -779,8 +790,9 @@ class PluginTests: XCTestCase {
             // Create a sample package that uses three packages that vend plugins.
             let packageDir = tmpPath.appending(components: "MyPackage")
             try localFileSystem.createDirectory(packageDir, recursive: true)
-            try localFileSystem.writeFileContents(packageDir.appending("Package.swift")) {
-                """
+            try localFileSystem.writeFileContents(
+                packageDir.appending("Package.swift"),
+                string: """
                 // swift-tools-version: 5.6
                 import PackageDescription
                 let package = Package(
@@ -801,18 +813,20 @@ class PluginTests: XCTestCase {
                     ]
                 )
                 """
-            }
-            try localFileSystem.writeFileContents(packageDir.appending("Library.swift")) {
-                """
+            )
+            try localFileSystem.writeFileContents(
+                packageDir.appending("Library.swift"),
+                string: """
                 public var Foo: String
                 """
-            }
+            )
 
             // Create the depended-upon package that vends a build tool plugin that is used by the main package.
             let buildToolPluginPackageDir = packageDir.appending(components: "VendoredDependencies", "BuildToolPluginPackage")
             try localFileSystem.createDirectory(buildToolPluginPackageDir, recursive: true)
-            try localFileSystem.writeFileContents(buildToolPluginPackageDir.appending("Package.swift")) {
-                """
+            try localFileSystem.writeFileContents(
+                buildToolPluginPackageDir.appending("Package.swift"),
+                string: """
                 // swift-tools-version: 5.6
                 import PackageDescription
                 let package = Package(
@@ -830,9 +844,10 @@ class PluginTests: XCTestCase {
                     ]
                 )
                 """
-            }
-            try localFileSystem.writeFileContents(buildToolPluginPackageDir.appending("Plugin.swift")) {
-                """
+            )
+            try localFileSystem.writeFileContents(
+                buildToolPluginPackageDir.appending("Plugin.swift"),
+                string: """
                 import PackagePlugin
                 @main struct MyPlugin: BuildToolPlugin {
                     func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
@@ -840,13 +855,14 @@ class PluginTests: XCTestCase {
                     }
                 }
                 """
-            }
+            )
 
             // Create the depended-upon package that vends a build tool plugin that is not used by the main package.
             let unusedBuildToolPluginPackageDir = packageDir.appending(components: "VendoredDependencies", "UnusedBuildToolPluginPackage")
             try localFileSystem.createDirectory(unusedBuildToolPluginPackageDir, recursive: true)
-            try localFileSystem.writeFileContents(unusedBuildToolPluginPackageDir.appending("Package.swift")) {
-                """
+            try localFileSystem.writeFileContents(
+                unusedBuildToolPluginPackageDir.appending("Package.swift"),
+                string: """
                 // swift-tools-version: 5.6
                 import PackageDescription
                 let package = Package(
@@ -864,9 +880,10 @@ class PluginTests: XCTestCase {
                     ]
                 )
                 """
-            }
-            try localFileSystem.writeFileContents(unusedBuildToolPluginPackageDir.appending("Plugin.swift")) {
-                """
+            )
+            try localFileSystem.writeFileContents(
+                unusedBuildToolPluginPackageDir.appending("Plugin.swift"),
+                string: """
                 import PackagePlugin
                 @main struct MyPlugin: BuildToolPlugin {
                     func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
@@ -874,13 +891,14 @@ class PluginTests: XCTestCase {
                     }
                 }
                 """
-            }
+            )
 
             // Create the depended-upon package that vends a command plugin.
             let commandPluginPackageDir = packageDir.appending(components: "VendoredDependencies", "CommandPluginPackage")
             try localFileSystem.createDirectory(commandPluginPackageDir, recursive: true)
-            try localFileSystem.writeFileContents(commandPluginPackageDir.appending("Package.swift")) {
-                """
+            try localFileSystem.writeFileContents(
+                commandPluginPackageDir.appending("Package.swift"),
+                string: """
                 // swift-tools-version: 5.6
                 import PackageDescription
                 let package = Package(
@@ -898,16 +916,17 @@ class PluginTests: XCTestCase {
                     ]
                 )
                 """
-            }
-            try localFileSystem.writeFileContents(commandPluginPackageDir.appending("Plugin.swift")) {
-                """
+            )
+            try localFileSystem.writeFileContents(
+                commandPluginPackageDir.appending("Plugin.swift"),
+                string: """
                 import PackagePlugin
                 @main struct MyPlugin: CommandPlugin {
                     func performCommand(context: PluginContext, targets: [Target], arguments: [String]) throws {
                     }
                 }
                 """
-            }
+            )
 
             // Load a workspace from the package.
             let observability = ObservabilitySystem.makeForTesting()

--- a/Tests/FunctionalTests/ToolsVersionTests.swift
+++ b/Tests/FunctionalTests/ToolsVersionTests.swift
@@ -69,6 +69,7 @@ class ToolsVersionTests: XCTestCase {
 
             // Create the primary repository.
             let primaryPath = path.appending("Primary")
+            try fs.createDirectory(primaryPath, recursive: true)
             try fs.writeFileContents(
                 primaryPath.appending("Package.swift"),
                 string: """

--- a/Tests/FunctionalTests/VersionSpecificTests.swift
+++ b/Tests/FunctionalTests/VersionSpecificTests.swift
@@ -73,6 +73,7 @@ class VersionSpecificTests: XCTestCase {
 
             // Create the primary repository.
             let primaryPath = path.appending("Primary")
+            try fs.createDirectory(primaryPath, recursive: true)
             try fs.writeFileContents(
                 primaryPath.appending("Package.swift"),
                 string: """

--- a/Tests/FunctionalTests/VersionSpecificTests.swift
+++ b/Tests/FunctionalTests/VersionSpecificTests.swift
@@ -29,8 +29,9 @@ class VersionSpecificTests: XCTestCase {
             let repo = GitRepository(path: depPath)
 
             // Create the initial commit.
-            try fs.writeFileContents(depPath.appending("Package.swift")) {
-                $0 <<< """
+            try fs.writeFileContents(
+                depPath.appending("Package.swift"),
+                string: """
                     // swift-tools-version:4.2
                     import PackageDescription
                     let package = Package(
@@ -43,24 +44,28 @@ class VersionSpecificTests: XCTestCase {
                         ]
                     )
                     """
-            }
+            )
             try repo.stage(file: "Package.swift")
             try repo.commit(message: "Initial")
             try repo.tag(name: "1.0.0")
 
             // Create the version to test against.
-            try fs.writeFileContents(depPath.appending("Package.swift")) {
+            try fs.writeFileContents(
+                depPath.appending("Package.swift"),
                 // FIXME: We end up filtering this manifest if it has an invalid
                 // tools version as they're assumed to be v3 manifests. Should we
                 // do something better?
-                $0 <<< "// swift-tools-version:4.2\n"
-                $0 <<< "NOT_A_VALID_PACKAGE"
-            }
-            try fs.writeFileContents(depPath.appending("foo.swift")) {
-                $0 <<< """
+                string: """
+                // swift-tools-version:4.2
+                NOT_A_VALID_PACKAGE
+                """
+            )
+            try fs.writeFileContents(
+                depPath.appending("foo.swift"),
+                string: """
                     public func foo() { print("foo\\n") }
                     """
-            }
+            )
             try repo.stage(file: "Package.swift")
             try repo.stage(file: "foo.swift")
             try repo.commit(message: "Bogus v1.1.0")
@@ -68,8 +73,9 @@ class VersionSpecificTests: XCTestCase {
 
             // Create the primary repository.
             let primaryPath = path.appending("Primary")
-            try fs.writeFileContents(primaryPath.appending("Package.swift")) {
-                $0 <<< """
+            try fs.writeFileContents(
+                primaryPath.appending("Package.swift"),
+                string: """
                     // swift-tools-version:4.2
                     import PackageDescription
                     let package = Package(
@@ -82,21 +88,23 @@ class VersionSpecificTests: XCTestCase {
                         ]
                     )
                     """
-            }
+            )
             // This build should fail, because of the invalid package.
             XCTAssertBuildFails(primaryPath)
 
             // Create a file which requires a version 1.1.0 resolution.
-            try fs.writeFileContents(primaryPath.appending("main.swift")) {
-                $0 <<< """
+            try fs.writeFileContents(
+                primaryPath.appending("main.swift"),
+                string: """
                     import Dep
                     Dep.foo()
                     """
-            }
+            )
 
             // Create a version-specific tag, which should work.
-            try fs.writeFileContents(depPath.appending("Package.swift")) {
-                $0 <<< """
+            try fs.writeFileContents(
+                depPath.appending("Package.swift"),
+                string: """
                     // swift-tools-version:4.2
                     import PackageDescription
                     let package = Package(
@@ -109,7 +117,7 @@ class VersionSpecificTests: XCTestCase {
                         ]
                     )
                     """
-            }
+            )
             try repo.stage(file: "Package.swift")
             try repo.commit(message: "OK v1.1.0")
             try repo.tag(name: "1.1.0@swift-\(SwiftVersion.current.major)")

--- a/Tests/PackageLoadingTests/ManifestLoaderSQLiteCacheTests.swift
+++ b/Tests/PackageLoadingTests/ManifestLoaderSQLiteCacheTests.swift
@@ -48,8 +48,10 @@ private func makeMockManifests(fileSystem: FileSystem, rootPath: AbsolutePath, c
     for index in 0 ..< count {
         let manifestPath = rootPath.appending(components: "\(index)", "Package.swift")
 
-        try fileSystem.writeFileContents(manifestPath) { stream in
-            stream <<< """
+        try fileSystem.createDirectory(manifestPath.parentDirectory, recursive: true)
+        try fileSystem.writeFileContents(
+            manifestPath,
+            string: """
             import PackageDescription
             let package = Package(
             name: "Trivial-\(index)",
@@ -60,7 +62,7 @@ private func makeMockManifests(fileSystem: FileSystem, rootPath: AbsolutePath, c
 
             )
             """
-        }
+        )
         let key = try ManifestLoader.CacheKey(packageIdentity: PackageIdentity(path: manifestPath),
                                               manifestPath: manifestPath,
                                               toolsVersion: ToolsVersion.current,

--- a/Tests/PackageLoadingTests/ManifestSignatureParserTests.swift
+++ b/Tests/PackageLoadingTests/ManifestSignatureParserTests.swift
@@ -23,8 +23,9 @@ class ManifestSignatureParserTests: XCTestCase {
             let manifestPath = tmpPath.appending("Package.swift")
             let signatureBytes = Array(UUID().uuidString.utf8)
 
-            try localFileSystem.writeFileContents(manifestPath) {
-                $0 <<< """
+            try localFileSystem.writeFileContents(
+                manifestPath,
+                string: """
                 // swift-tools-version: 5.7
 
                 import PackageDescription
@@ -36,7 +37,7 @@ class ManifestSignatureParserTests: XCTestCase {
 
                 // signature: cms-1.0.0;\(Data(signatureBytes).base64EncodedString())
                 """
-            }
+            )
 
             let components = try ManifestSignatureParser.parse(manifestPath: manifestPath, fileSystem: localFileSystem)
             XCTAssertNotNil(components)
@@ -61,8 +62,9 @@ class ManifestSignatureParserTests: XCTestCase {
             let manifestPath = tmpPath.appending("Package.swift")
             let signatureBytes = Array(UUID().uuidString.utf8)
 
-            try localFileSystem.writeFileContents(manifestPath) {
-                $0 <<< """
+            try localFileSystem.writeFileContents(
+                manifestPath,
+                string: """
                 // swift-tools-version: 5.7
 
                 import PackageDescription
@@ -76,7 +78,7 @@ class ManifestSignatureParserTests: XCTestCase {
 
 
                 """
-            }
+            )
 
             let components = try ManifestSignatureParser.parse(manifestPath: manifestPath, fileSystem: localFileSystem)
             XCTAssertNotNil(components)
@@ -99,8 +101,9 @@ class ManifestSignatureParserTests: XCTestCase {
     func testUnsignedManifest() throws {
         try testWithTemporaryDirectory { tmpPath in
             let manifestPath = tmpPath.appending("Package.swift")
-            try localFileSystem.writeFileContents(manifestPath) {
-                $0 <<< """
+            try localFileSystem.writeFileContents(
+                manifestPath,
+                string: """
                 // swift-tools-version: 5.7
 
                 import PackageDescription
@@ -111,7 +114,7 @@ class ManifestSignatureParserTests: XCTestCase {
                 )
 
                 """
-            }
+            )
 
             let components = try ManifestSignatureParser.parse(manifestPath: manifestPath, fileSystem: localFileSystem)
             XCTAssertNil(components)
@@ -121,8 +124,9 @@ class ManifestSignatureParserTests: XCTestCase {
     func testManifestWithCommentAsLastLine() throws {
         try testWithTemporaryDirectory { tmpPath in
             let manifestPath = tmpPath.appending("Package.swift")
-            try localFileSystem.writeFileContents(manifestPath) {
-                $0 <<< """
+            try localFileSystem.writeFileContents(
+                manifestPath,
+                string: """
                 // swift-tools-version: 5.7
 
                 import PackageDescription
@@ -134,7 +138,7 @@ class ManifestSignatureParserTests: XCTestCase {
 
                 // xxx
                 """
-            }
+            )
 
             let components = try ManifestSignatureParser.parse(manifestPath: manifestPath, fileSystem: localFileSystem)
             XCTAssertNil(components)
@@ -144,8 +148,9 @@ class ManifestSignatureParserTests: XCTestCase {
     func testManifestWithIncompleteSignatureLine1() throws {
         try testWithTemporaryDirectory { tmpPath in
             let manifestPath = tmpPath.appending("Package.swift")
-            try localFileSystem.writeFileContents(manifestPath) {
-                $0 <<< """
+            try localFileSystem.writeFileContents(
+                manifestPath,
+                string: """
                 // swift-tools-version: 5.7
 
                 import PackageDescription
@@ -157,7 +162,7 @@ class ManifestSignatureParserTests: XCTestCase {
 
                 // signature
                 """
-            }
+            )
 
             let components = try ManifestSignatureParser.parse(manifestPath: manifestPath, fileSystem: localFileSystem)
             XCTAssertNil(components)
@@ -167,8 +172,9 @@ class ManifestSignatureParserTests: XCTestCase {
     func testManifestWithIncompleteSignatureLine2() throws {
         try testWithTemporaryDirectory { tmpPath in
             let manifestPath = tmpPath.appending("Package.swift")
-            try localFileSystem.writeFileContents(manifestPath) {
-                $0 <<< """
+            try localFileSystem.writeFileContents(
+                manifestPath,
+                string: """
                 // swift-tools-version: 5.7
 
                 import PackageDescription
@@ -180,7 +186,7 @@ class ManifestSignatureParserTests: XCTestCase {
 
                 // signature:
                 """
-            }
+            )
 
             let components = try ManifestSignatureParser.parse(manifestPath: manifestPath, fileSystem: localFileSystem)
             XCTAssertNil(components)
@@ -190,8 +196,9 @@ class ManifestSignatureParserTests: XCTestCase {
     func testManifestWithIncompleteSignatureLine3() throws {
         try testWithTemporaryDirectory { tmpPath in
             let manifestPath = tmpPath.appending("Package.swift")
-            try localFileSystem.writeFileContents(manifestPath) {
-                $0 <<< """
+            try localFileSystem.writeFileContents(
+                manifestPath,
+                string: """
                 // swift-tools-version: 5.7
 
                 import PackageDescription
@@ -203,7 +210,7 @@ class ManifestSignatureParserTests: XCTestCase {
 
                     // signature: cms
                 """
-            }
+            )
 
             let components = try ManifestSignatureParser.parse(manifestPath: manifestPath, fileSystem: localFileSystem)
             XCTAssertNil(components)
@@ -213,8 +220,9 @@ class ManifestSignatureParserTests: XCTestCase {
     func testManifestWithIncompleteSignatureLine4() throws {
         try testWithTemporaryDirectory { tmpPath in
             let manifestPath = tmpPath.appending("Package.swift")
-            try localFileSystem.writeFileContents(manifestPath) {
-                $0 <<< """
+            try localFileSystem.writeFileContents(
+                manifestPath,
+                string: """
                 // swift-tools-version: 5.7
 
                 import PackageDescription
@@ -226,7 +234,7 @@ class ManifestSignatureParserTests: XCTestCase {
 
                     // signature: cms;
                 """
-            }
+            )
 
             let components = try ManifestSignatureParser.parse(manifestPath: manifestPath, fileSystem: localFileSystem)
             XCTAssertNil(components)
@@ -236,8 +244,9 @@ class ManifestSignatureParserTests: XCTestCase {
     func testManifestWithMalformedSignature() throws {
         try testWithTemporaryDirectory { tmpPath in
             let manifestPath = tmpPath.appending("Package.swift")
-            try localFileSystem.writeFileContents(manifestPath) {
-                $0 <<< """
+            try localFileSystem.writeFileContents(
+                manifestPath,
+                string: """
                 // swift-tools-version: 5.7
 
                 import PackageDescription
@@ -249,7 +258,7 @@ class ManifestSignatureParserTests: XCTestCase {
 
                     // signature: cms-1.0.0;signature-not-base64-encoded
                 """
-            }
+            )
 
             XCTAssertThrowsError(
                 try ManifestSignatureParser.parse(manifestPath: manifestPath, fileSystem: localFileSystem)

--- a/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
@@ -571,8 +571,10 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             let observability = ObservabilitySystem.makeForTesting()
 
             let manifestPath = path.appending(components: "pkg", "Package.swift")
-            try fs.writeFileContents(manifestPath) { stream in
-                stream <<< """
+            try fs.createDirectory(manifestPath.parentDirectory, recursive: true)
+            try fs.writeFileContents(
+                manifestPath,
+                string: """
                     import PackageDescription
                     let package = Package(
                         name: "Trivial",
@@ -583,7 +585,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                         ]
                     )
                     """
-            }
+            )
 
             let delegate = ManifestTestDelegate()
 
@@ -631,8 +633,10 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             let observability = ObservabilitySystem.makeForTesting()
 
             let manifestPath = path.appending(components: "pkg", "Package.swift")
-            try fs.writeFileContents(manifestPath) { stream in
-                stream <<< """
+            try fs.createDirectory(manifestPath.parentDirectory, recursive: true)
+            try fs.writeFileContents(
+                manifestPath,
+                string: """
                     import PackageDescription
                     let package = Package(
                         name: "Trivial",
@@ -643,7 +647,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                         ]
                     )
                     """
-            }
+            )
 
             let delegate = ManifestTestDelegate()
 
@@ -673,8 +677,9 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                 check(loader: manifestLoader, expectCached: true)
             }
 
-            try fs.writeFileContents(manifestPath) { stream in
-                stream <<< """
+            try fs.writeFileContents(
+                manifestPath,
+                string: """
                     import PackageDescription
 
                     let package = Package(
@@ -688,7 +693,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                     )
 
                     """
-            }
+            )
 
             check(loader: manifestLoader, expectCached: false)
             for _ in 0..<2 {
@@ -711,7 +716,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
     func testContentBasedCaching() throws {
         try testWithTemporaryDirectory { path in
             let stream = BufferedOutputByteStream()
-            stream <<< """
+            stream.send("""
                 import PackageDescription
                 let package = Package(
                     name: "Trivial",
@@ -720,6 +725,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                     ]
                 )
                 """
+            )
 
             let delegate = ManifestTestDelegate()
 
@@ -759,7 +765,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             }
 
             do {
-                stream <<< "\n\n"
+                stream.send("\n\n")
                 delegate.prepare()
                 try check(loader: manifestLoader)
                 XCTAssertEqual(try delegate.loaded(timeout: .now() + 1).count, 3)
@@ -799,8 +805,9 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             let total = 1000
             let manifestPath = path.appending(components: "pkg", "Package.swift")
             try localFileSystem.createDirectory(manifestPath.parentDirectory)
-            try localFileSystem.writeFileContents(manifestPath) {
-                """
+            try localFileSystem.writeFileContents(
+                manifestPath,
+                string: """
                 import PackageDescription
                 let package = Package(
                     name: "Trivial",
@@ -811,7 +818,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                     ]
                 )
                 """
-            }
+            )
 
             let observability = ObservabilitySystem.makeForTesting()
             let delegate = ManifestTestDelegate()
@@ -905,8 +912,9 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                 let manifestPath = path.appending(components: "pkg-\(random)", "Package.swift")
                 if !localFileSystem.exists(manifestPath) {
                     try localFileSystem.createDirectory(manifestPath.parentDirectory)
-                    try localFileSystem.writeFileContents(manifestPath) {
-                        """
+                    try localFileSystem.writeFileContents(
+                        manifestPath,
+                        string: """
                         import PackageDescription
                         let package = Package(
                             name: "Trivial-\(random)",
@@ -917,7 +925,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                             ]
                         )
                         """
-                    }
+                    )
                 }
 
                 sync.enter()

--- a/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
@@ -373,8 +373,10 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
             do {
                 let observability = ObservabilitySystem.makeForTesting()
 
-                try fs.writeFileContents(manifestPath) { stream in
-                    stream <<< """
+                try fs.createDirectory(manifestPath.parentDirectory)
+                try fs.writeFileContents(
+                    manifestPath,
+                    string: """
                     import PackageDescription
                     let package = Package(
                     name: "Trivial",
@@ -385,7 +387,7 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
 
                     )
                     """
-                }
+                )
 
                 do {
                     _ = try loader.load(
@@ -405,8 +407,9 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
             do {
                 let observability = ObservabilitySystem.makeForTesting()
 
-                try fs.writeFileContents(manifestPath) { stream in
-                    stream <<< """
+                try fs.writeFileContents(
+                    manifestPath,
+                    string: """
                     import PackageDescription
                     func foo() {
                         let a = 5
@@ -420,8 +423,7 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
                         ]
                     )
                     """
-                }
-
+                )
 
                 _ = try loader.load(
                     manifestPath: manifestPath,
@@ -587,9 +589,11 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
             let fs = localFileSystem
 
             let packagePath = path.appending("pkg")
+            try fs.createDirectory(packagePath)
             let manifestPath = packagePath.appending("Package.swift")
-            try fs.writeFileContents(manifestPath) { stream in
-                stream <<< """
+            try fs.writeFileContents(
+                manifestPath,
+                string: """
                 // swift-tools-version:5
                 import PackageDescription
 
@@ -602,7 +606,7 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
                     ]
                 )
                 """
-            }
+            )
 
             let moduleTraceFilePath = path.appending("swift-module-trace")
             var env = EnvironmentVariables.process()

--- a/Tests/PackageLoadingTests/PkgConfigParserTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigParserTests.swift
@@ -173,19 +173,18 @@ final class PkgConfigParserTests: XCTestCase {
 #endif
             try localFileSystem.createDirectory(fakePkgConfig.parentDirectory)
 
-            let stream = BufferedOutputByteStream()
 #if os(Windows)
-            stream <<< """
+            let script = """
             @echo off
             echo /Volumes/BestDrive/pkgconfig
             """
 #else
-            stream <<< """
+            let script = """
             #!/bin/sh
             echo "/Volumes/BestDrive/pkgconfig"
             """
 #endif
-            try localFileSystem.writeFileContents(fakePkgConfig, bytes: stream.bytes)
+            try localFileSystem.writeFileContents(fakePkgConfig, string: script)
             try localFileSystem.chmod(.executable, path: fakePkgConfig, options: [])
 
 #if os(Windows)

--- a/Tests/PackageLoadingTests/ToolsVersionParserTests.swift
+++ b/Tests/PackageLoadingTests/ToolsVersionParserTests.swift
@@ -117,20 +117,32 @@ class ToolsVersionParserTests: XCTestCase {
 
 
         do {
-            let stream = BufferedOutputByteStream()
-            stream <<< "// swift-tools-version:3.1.0\n\n\n\n\n"
-            stream <<< "let package = .."
-            try self.parse(stream.bytes.validDescription!) { toolsVersion in
+            try self.parse(
+                """
+                // swift-tools-version:3.1.0
+
+
+
+                let package = ..
+                """
+            ) { toolsVersion in
                 XCTAssertEqual(toolsVersion.description, "3.1.0")
             }
         }
 
         do {
-            let stream = BufferedOutputByteStream()
-            stream <<< "// swift-tools-version:3.1.0\n"
-            stream <<< "// swift-tools-version:4.1.0\n\n\n\n"
-            stream <<< "let package = .."
-            try self.parse(stream.bytes.validDescription!) { toolsVersion in
+            try self.parse(
+                """
+                // swift-tools-version:3.1.0
+
+                // swift-tools-version:4.1.0
+
+
+
+
+                let package = ..
+                """
+            ) { toolsVersion in
                 XCTAssertEqual(toolsVersion.description, "3.1.0")
             }
         }

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -1156,8 +1156,14 @@ class PluginInvocationTests: XCTestCase {
                 """
             }
 
+            let bundleMetadataPath = packageDir.appending(
+                components: "Binaries",
+                "LocalBinaryTool.artifactbundle",
+                "info.json"
+            )
+            try localFileSystem.createDirectory(bundleMetadataPath.parentDirectory, recursive: true)
             try localFileSystem.writeFileContents(
-                packageDir.appending(components: "Binaries", "LocalBinaryTool.artifactbundle", "info.json"),
+                bundleMetadataPath,
                 string: """
                 {   "schemaVersion": "1.0",
                     "artifacts": {

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -1126,11 +1126,12 @@ class PluginInvocationTests: XCTestCase {
 
             let libDir = packageDir.appending(components: "Sources", "MyLibrary")
             try localFileSystem.createDirectory(libDir, recursive: true)
-            try localFileSystem.writeFileContents(libDir.appending(components: "library.swift")) {
-                $0 <<< """
+            try localFileSystem.writeFileContents(
+                libDir.appending(components: "library.swift"),
+                string: """
                 public func myLib() { }
                 """
-            }
+            )
 
             let myPluginTargetDir = packageDir.appending(components: "Plugins", "Foo")
             try localFileSystem.createDirectory(myPluginTargetDir, recursive: true)
@@ -1155,8 +1156,9 @@ class PluginInvocationTests: XCTestCase {
                 """
             }
 
-            try localFileSystem.writeFileContents(packageDir.appending(components: "Binaries", "LocalBinaryTool.artifactbundle", "info.json")) {
-                $0 <<< """
+            try localFileSystem.writeFileContents(
+                packageDir.appending(components: "Binaries", "LocalBinaryTool.artifactbundle", "info.json"),
+                string: """
                 {   "schemaVersion": "1.0",
                     "artifacts": {
                         "LocalBinaryTool": {
@@ -1169,7 +1171,7 @@ class PluginInvocationTests: XCTestCase {
                     }
                 }
                 """
-            }
+            )
             // Load a workspace from the package.
             let observability = ObservabilitySystem.makeForTesting()
             let workspace = try Workspace(

--- a/Tests/WorkspaceTests/AuthorizationProviderTests.swift
+++ b/Tests/WorkspaceTests/AuthorizationProviderTests.swift
@@ -27,9 +27,10 @@ final class AuthorizationProviderTests: XCTestCase {
 
             let customPath = try fileSystem.homeDirectory.appending(components: UUID().uuidString, "custom-netrc-file")
             try fileSystem.createDirectory(customPath.parentDirectory, recursive: true)
-            try fileSystem.writeFileContents(customPath) {
-                "machine mymachine.labkey.org login custom@labkey.org password custom"
-            }
+            try fileSystem.writeFileContents(
+                customPath,
+                string: "machine mymachine.labkey.org login custom@labkey.org password custom"
+            )
 
             let configuration = Workspace.Configuration.Authorization(netrc: .custom(customPath), keychain: .disabled)
             let authorizationProvider = try configuration.makeAuthorizationProvider(fileSystem: fileSystem, observabilityScope: observability.topScope) as? CompositeAuthorizationProvider
@@ -55,9 +56,10 @@ final class AuthorizationProviderTests: XCTestCase {
 
             let userPath = try fileSystem.homeDirectory.appending(".netrc")
             try fileSystem.createDirectory(userPath.parentDirectory, recursive: true)
-            try fileSystem.writeFileContents(userPath) {
-                "machine mymachine.labkey.org login user@labkey.org password user"
-            }
+            try fileSystem.writeFileContents(
+                userPath,
+                string: "machine mymachine.labkey.org login user@labkey.org password user"
+            )
 
             let configuration = Workspace.Configuration.Authorization(netrc: .user, keychain: .disabled)
             let authorizationProvider = try configuration.makeAuthorizationProvider(fileSystem: fileSystem, observabilityScope: observability.topScope) as? CompositeAuthorizationProvider
@@ -89,9 +91,10 @@ final class AuthorizationProviderTests: XCTestCase {
 
             let customPath = try fileSystem.homeDirectory.appending(components: UUID().uuidString, "custom-netrc-file")
             try fileSystem.createDirectory(customPath.parentDirectory, recursive: true)
-            try fileSystem.writeFileContents(customPath) {
-                "machine mymachine.labkey.org login custom@labkey.org password custom"
-            }
+            try fileSystem.writeFileContents(
+                customPath,
+                string: "machine mymachine.labkey.org login custom@labkey.org password custom"
+            )
 
             let configuration = Workspace.Configuration.Authorization(netrc: .custom(customPath), keychain: .disabled)
             let netrcProvider = try configuration.makeRegistryAuthorizationProvider(fileSystem: fileSystem, observabilityScope: observability.topScope) as? NetrcAuthorizationProvider
@@ -117,9 +120,10 @@ final class AuthorizationProviderTests: XCTestCase {
 
             let userPath = try fileSystem.homeDirectory.appending(".netrc")
             try fileSystem.createDirectory(userPath.parentDirectory, recursive: true)
-            try fileSystem.writeFileContents(userPath) {
-                "machine mymachine.labkey.org login user@labkey.org password user"
-            }
+            try fileSystem.writeFileContents(
+                userPath,
+                string: "machine mymachine.labkey.org login user@labkey.org password user"
+            )
 
             let configuration = Workspace.Configuration.Authorization(netrc: .user, keychain: .disabled)
             let netrcProvider = try configuration.makeRegistryAuthorizationProvider(fileSystem: fileSystem, observabilityScope: observability.topScope) as? NetrcAuthorizationProvider

--- a/Tests/WorkspaceTests/MirrorsConfigurationTests.swift
+++ b/Tests/WorkspaceTests/MirrorsConfigurationTests.swift
@@ -23,19 +23,20 @@ final class MirrorsConfigurationTests: XCTestCase {
         let originalURL = "https://github.com/apple/swift-argument-parser.git"
         let mirrorURL = "https://github.com/mona/swift-argument-parser.git"
 
-        try fs.writeFileContents(configFile) {
-            $0 <<< """
+        try fs.writeFileContents(
+            configFile,
+            string: """
+            {
+              "object": [
                 {
-                  "object": [
-                    {
-                      "mirror": "\(mirrorURL)",
-                      "original": "\(originalURL)"
-                    }
-                  ],
-                  "version": 1
+                  "mirror": "\(mirrorURL)",
+                  "original": "\(originalURL)"
                 }
-                """
-        }
+              ],
+              "version": 1
+            }
+            """
+        )
 
         let config = Workspace.Configuration.MirrorsStorage(path: configFile, fileSystem: fs, deleteWhenEmpty: true)
         let mirrors = try config.get()

--- a/Tests/WorkspaceTests/MirrorsConfigurationTests.swift
+++ b/Tests/WorkspaceTests/MirrorsConfigurationTests.swift
@@ -23,6 +23,7 @@ final class MirrorsConfigurationTests: XCTestCase {
         let originalURL = "https://github.com/apple/swift-argument-parser.git"
         let mirrorURL = "https://github.com/mona/swift-argument-parser.git"
 
+        try fs.createDirectory(configFile.parentDirectory)
         try fs.writeFileContents(
             configFile,
             string: """

--- a/Tests/WorkspaceTests/ToolsVersionSpecificationRewriterTests.swift
+++ b/Tests/WorkspaceTests/ToolsVersionSpecificationRewriterTests.swift
@@ -76,7 +76,7 @@ class ToolsVersionSpecificationRewriterTests: XCTestCase {
         // Contents with invalid tools version specification (ignoring the validity of the version specifier).
         stream = BufferedOutputByteStream()
         stream.send("""
-            // swift-tools-version:3.1.2
+            // swift-tool-version:3.1.2
             ...
             """
         )
@@ -115,7 +115,7 @@ class ToolsVersionSpecificationRewriterTests: XCTestCase {
         
         stream = BufferedOutputByteStream()
         stream.send("let package = ... \n")
-        
+
         rewriteToolsVersionSpecificationToDefaultManifest(
             stream: stream,
             version: toolsVersion

--- a/Tests/WorkspaceTests/ToolsVersionSpecificationRewriterTests.swift
+++ b/Tests/WorkspaceTests/ToolsVersionSpecificationRewriterTests.swift
@@ -27,7 +27,7 @@ class ToolsVersionSpecificationRewriterTests: XCTestCase {
     func testNonVersionSpecificManifests() throws {
         // Empty file.
         var stream = BufferedOutputByteStream()
-        stream <<< ""
+        stream.send("")
 
         rewriteToolsVersionSpecificationToDefaultManifest(stream: stream) { result in
             XCTAssertEqual(result, "// swift-tools-version:4.1.2\n")
@@ -35,7 +35,7 @@ class ToolsVersionSpecificationRewriterTests: XCTestCase {
 
         // File with just a new line.
         stream = BufferedOutputByteStream()
-        stream <<< "\n"
+        stream.send("\n")
 
         rewriteToolsVersionSpecificationToDefaultManifest(stream: stream) { result in
             XCTAssertEqual(result, "// swift-tools-version:4.1.2\n\n")
@@ -43,7 +43,7 @@ class ToolsVersionSpecificationRewriterTests: XCTestCase {
 
         // File with some contents.
         stream = BufferedOutputByteStream()
-        stream <<< "let package = ... \n"
+        stream.send("let package = ... \n")
 
         rewriteToolsVersionSpecificationToDefaultManifest(stream: stream) { result in
             XCTAssertEqual(result, "// swift-tools-version:4.1.2\nlet package = ... \n")
@@ -51,8 +51,11 @@ class ToolsVersionSpecificationRewriterTests: XCTestCase {
 
         // File already having a valid version specifier.
         stream = BufferedOutputByteStream()
-        stream <<< "// swift-tools-version:3.1.2\n"
-        stream <<< "..."
+        stream.send("""
+            // swift-tools-version:3.1.2
+            ...
+            """
+        )
 
         rewriteToolsVersionSpecificationToDefaultManifest(stream: stream) { result in
             XCTAssertEqual(result, "// swift-tools-version:4.1.2\n...")
@@ -60,8 +63,11 @@ class ToolsVersionSpecificationRewriterTests: XCTestCase {
 
         // Write a version with zero in patch number.
         stream = BufferedOutputByteStream()
-        stream <<< "// swift-tools-version:3.1.2\n"
-        stream <<< "..."
+        stream.send("""
+            // swift-tools-version:3.1.2
+            ...
+            """
+        )
 
         rewriteToolsVersionSpecificationToDefaultManifest(stream: stream, version: ToolsVersion(version: "2.1.0")) { result in
             XCTAssertEqual(result, "// swift-tools-version:2.1\n...")
@@ -69,8 +75,11 @@ class ToolsVersionSpecificationRewriterTests: XCTestCase {
 
         // Contents with invalid tools version specification (ignoring the validity of the version specifier).
         stream = BufferedOutputByteStream()
-        stream <<< "// swift-tool-version:3.1.2\n"
-        stream <<< "..."
+        stream.send("""
+            // swift-tools-version:3.1.2
+            ...
+            """
+        )
 
         rewriteToolsVersionSpecificationToDefaultManifest(stream: stream) { result in
             XCTAssertEqual(result, "// swift-tools-version:4.1.2\n// swift-tool-version:3.1.2\n...")
@@ -78,8 +87,11 @@ class ToolsVersionSpecificationRewriterTests: XCTestCase {
 
         // Contents with invalid version specifier.
         stream = BufferedOutputByteStream()
-        stream <<< "// swift-tools-version:-3.1.2\n"
-        stream <<< "..."
+        stream.send("""
+            // swift-tools-version:3.1.2
+            ...
+            """
+        )
 
         rewriteToolsVersionSpecificationToDefaultManifest(stream: stream) { result in
             XCTAssertEqual(result, "// swift-tools-version:4.1.2\n...")
@@ -87,8 +99,11 @@ class ToolsVersionSpecificationRewriterTests: XCTestCase {
 
         // Contents with invalid version specifier and some meta data.
         stream = BufferedOutputByteStream()
-        stream <<< "// swift-tools-version:-3.1.2;hello\n"
-        stream <<< "..."
+        stream.send("""
+            // swift-tools-version:3.1.2
+            ...
+            """
+        )
 
         rewriteToolsVersionSpecificationToDefaultManifest(stream: stream) { result in
             // Note: Right now we lose the metadata but if we ever start using it, we should preserve it.
@@ -99,7 +114,7 @@ class ToolsVersionSpecificationRewriterTests: XCTestCase {
         let toolsVersion = ToolsVersion(version: "4.1.2-alpha.beta+sha.1234")
         
         stream = BufferedOutputByteStream()
-        stream <<< "let package = ... \n"
+        stream.send("let package = ... \n")
         
         rewriteToolsVersionSpecificationToDefaultManifest(
             stream: stream,

--- a/Tests/WorkspaceTests/WorkspaceStateTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceStateTests.swift
@@ -23,8 +23,9 @@ final class WorkspaceStateTests: XCTestCase {
         try fs.createDirectory(buildDir, recursive: true)
 
         let statePath = buildDir.appending("workspace-state.json")
-        try fs.writeFileContents(statePath) {
-            """
+        try fs.writeFileContents(
+            statePath,
+            string: """
             {
                 "version": 4,
                 "object": {
@@ -82,7 +83,7 @@ final class WorkspaceStateTests: XCTestCase {
                 }
             }
             """
-        }
+        )
 
         let state = WorkspaceState(fileSystem: fs, storageDirectory: buildDir)
         XCTAssertTrue(state.dependencies.contains(where: { $0.packageRef.identity == .plain("yams") }))
@@ -97,8 +98,9 @@ final class WorkspaceStateTests: XCTestCase {
         try fs.createDirectory(buildDir, recursive: true)
 
         let statePath = buildDir.appending("workspace-state.json")
-        try fs.writeFileContents(statePath) {
-            """
+        try fs.writeFileContents(
+            statePath,
+            string: """
             {
                 "version": 4,
                 "object": {
@@ -156,7 +158,7 @@ final class WorkspaceStateTests: XCTestCase {
                 }
             }
             """
-        }
+        )
 
         let state = WorkspaceState(fileSystem: fs, storageDirectory: buildDir)
         XCTAssertTrue(state.dependencies.contains(where: { $0.packageRef.identity == .plain("yams") }))
@@ -171,8 +173,9 @@ final class WorkspaceStateTests: XCTestCase {
         try fs.createDirectory(buildDir, recursive: true)
 
         let statePath = buildDir.appending("workspace-state.json")
-        try fs.writeFileContents(statePath) {
-            """
+        try fs.writeFileContents(
+            statePath,
+            string: """
             {
                 "version": 5,
                 "object": {
@@ -230,7 +233,7 @@ final class WorkspaceStateTests: XCTestCase {
                 }
             }
             """
-        }
+        )
 
         let state = WorkspaceState(fileSystem: fs, storageDirectory: buildDir)
         XCTAssertTrue(state.dependencies.contains(where: { $0.packageRef.identity == .plain("yams") }))
@@ -245,8 +248,9 @@ final class WorkspaceStateTests: XCTestCase {
         try fs.createDirectory(buildDir, recursive: true)
 
         let statePath = buildDir.appending("workspace-state.json")
-        try fs.writeFileContents(statePath) {
-            """
+        try fs.writeFileContents(
+            statePath,
+            string: """
             {
                 "version": 5,
                 "object": {
@@ -290,7 +294,7 @@ final class WorkspaceStateTests: XCTestCase {
                 }
             }
             """
-        }
+        )
 
         let state = WorkspaceState(fileSystem: fs, storageDirectory: buildDir)
         try state.save()
@@ -310,8 +314,9 @@ final class WorkspaceStateTests: XCTestCase {
         try fs.createDirectory(buildDir, recursive: true)
 
         let statePath = buildDir.appending("workspace-state.json")
-        try fs.writeFileContents(statePath) {
-            """
+        try fs.writeFileContents(
+            statePath,
+            string: """
             {
                 "version": 5,
                 "object": {
@@ -366,7 +371,7 @@ final class WorkspaceStateTests: XCTestCase {
                 }
             }
             """
-        }
+        )
 
         let state = WorkspaceState(fileSystem: fs, storageDirectory: buildDir)
         XCTAssertTrue(state.artifacts.contains(where: { $0.packageRef.identity == .plain("foo") && $0.targetName == "foo" }))
@@ -382,8 +387,9 @@ final class WorkspaceStateTests: XCTestCase {
         try fs.createDirectory(buildDir, recursive: true)
 
         let statePath = buildDir.appending("workspace-state.json")
-        try fs.writeFileContents(statePath) {
-            """
+        try fs.writeFileContents(
+            statePath,
+            string: """
             {
                 "version": 5,
                 "object": {
@@ -427,7 +433,7 @@ final class WorkspaceStateTests: XCTestCase {
                 }
             }
             """
-        }
+        )
 
         let state = WorkspaceState(fileSystem: fs, storageDirectory: buildDir)
         // empty since we have dups so we warn and fail the loading
@@ -443,8 +449,9 @@ final class WorkspaceStateTests: XCTestCase {
         try fs.createDirectory(buildDir, recursive: true)
 
         let statePath = buildDir.appending("workspace-state.json")
-        try fs.writeFileContents(statePath) {
-            """
+        try fs.writeFileContents(
+            statePath,
+            string: """
             {
                 "version": 5,
                 "object": {
@@ -484,7 +491,7 @@ final class WorkspaceStateTests: XCTestCase {
                 }
             }
             """
-        }
+        )
 
         let state = WorkspaceState(fileSystem: fs, storageDirectory: buildDir)
         // empty since we have dups so we warn and fail the loading

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -215,6 +215,7 @@ final class WorkspaceTests: XCTestCase {
 
         try testWithTemporaryDirectory { path in
             let pkgDir = path.appending("MyPkg")
+            try localFileSystem.createDirectory(pkgDir)
             try localFileSystem.writeFileContents(
                 pkgDir.appending("Package.swift"),
                 string: """

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -10827,6 +10827,7 @@ final class WorkspaceTests: XCTestCase {
 
             let foo = path.appending("foo")
 
+            try fs.createDirectory(foo)
             try fs.writeFileContents(
                 foo.appending("Package.swift"),
                 string: """

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -178,7 +178,7 @@ final class WorkspaceTests: XCTestCase {
 
             do {
                 let ws = try createWorkspace {
-                    $0 <<<
+                    $0.send(
                         """
                         // swift-tools-version:4.0
                         import PackageDescription
@@ -186,6 +186,7 @@ final class WorkspaceTests: XCTestCase {
                             name: "foo"
                         )
                         """
+                    )
                 }
 
                 XCTAssertMatch(ws.interpreterFlags(for: foo), [.equal("-swift-version"), .equal("4")])
@@ -193,7 +194,7 @@ final class WorkspaceTests: XCTestCase {
 
             do {
                 let ws = try createWorkspace {
-                    $0 <<<
+                    $0.send(
                         """
                         // swift-tools-version:3.1
                         import PackageDescription
@@ -201,6 +202,7 @@ final class WorkspaceTests: XCTestCase {
                             name: "foo"
                         )
                         """
+                    )
                 }
 
                 XCTAssertEqual(ws.interpreterFlags(for: foo), [])
@@ -213,17 +215,17 @@ final class WorkspaceTests: XCTestCase {
 
         try testWithTemporaryDirectory { path in
             let pkgDir = path.appending("MyPkg")
-            try localFileSystem.writeFileContents(pkgDir.appending("Package.swift")) {
-                $0 <<<
-                    """
-                    // swift-tools-version:4.0
-                    import PackageDescription
-                    #error("An error in MyPkg")
-                    let package = Package(
-                        name: "MyPkg"
-                    )
-                    """
-            }
+            try localFileSystem.writeFileContents(
+                pkgDir.appending("Package.swift"),
+                string: """
+                // swift-tools-version:4.0
+                import PackageDescription
+                #error("An error in MyPkg")
+                let package = Package(
+                    name: "MyPkg"
+                )
+                """
+            )
             let workspace = try Workspace(
                 fileSystem: localFileSystem,
                 forRootPackage: pkgDir,
@@ -10824,19 +10826,19 @@ final class WorkspaceTests: XCTestCase {
 
             let foo = path.appending("foo")
 
-            try fs.writeFileContents(foo.appending("Package.swift")) {
-                $0 <<<
-                    """
-                    // swift-tools-version:5.3
-                    import PackageDescription
-                    let package = Package(
-                        name: "Best",
-                        targets: [
-                            .binaryTarget(name: "best", path: "/best.xcframework")
-                        ]
-                    )
-                    """
-            }
+            try fs.writeFileContents(
+                foo.appending("Package.swift"),
+                string: """
+                // swift-tools-version:5.3
+                import PackageDescription
+                let package = Package(
+                    name: "Best",
+                    targets: [
+                        .binaryTarget(name: "best", path: "/best.xcframework")
+                    ]
+                )
+                """
+            )
 
             let manifestLoader = try ManifestLoader(toolchain: UserToolchain.default)
             let sandbox = path.appending("ws")


### PR DESCRIPTION
Addresses some of the deprecations introduced in https://github.com/apple/swift-tools-support-core/pull/413.

Also using this as an opportunity to use string interpolation and raw string literals to make this more readable.

Leaving warnings in `GenerateLinuxMain` untouched and to be addressed in https://github.com/apple/swift-package-manager/pull/6490.