### PR TITLE
CoreCommands: fix comment typo

### DIFF
--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -297,7 +297,7 @@ public struct BuildDescription: Codable {
     /// The map of copy commands.
     let copyCommands: [BuildManifest.CmdName: LLBuildManifest.CopyTool]
 
-    /// A flag that inidcates this build should perform a check for whether targets only import
+    /// A flag that indicates this build should perform a check for whether targets only import
     /// their explicitly-declared dependencies
     let explicitTargetDependencyImportCheckingMode: BuildParameters.TargetDependencyImportCheckingMode
 

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -434,7 +434,7 @@ public struct BuildOptions: ParsableArguments {
     @Flag()
     public var useIntegratedSwiftDriver: Bool = false
 
-    /// A flag that inidcates this build should check whether targets only import
+    /// A flag that indicates this build should check whether targets only import
     /// their explicitly-declared dependencies
     @Option()
     public var explicitTargetDependencyImportCheck: TargetDependencyImportCheckingMode = .none

--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -174,7 +174,7 @@ public struct BuildParameters: Encodable {
     /// Whether to use the explicit module build flow (with the integrated driver).
     public var useExplicitModuleBuild: Bool
 
-    /// A flag that inidcates this build should check whether targets only import.
+    /// A flag that indicates this build should check whether targets only import.
     /// their explicitly-declared dependencies
     public var explicitTargetDependencyImportCheckingMode: TargetDependencyImportCheckingMode
 


### PR DESCRIPTION
`inidcates` -> `indicates`