### PR TITLE
[5.9] fix VersionSetSpecifier calculation for versions with pre-release identifiers

### DIFF
--- a/Sources/PackageGraph/PubGrub/PartialSolution.swift
+++ b/Sources/PackageGraph/PubGrub/PartialSolution.swift
@@ -55,7 +55,7 @@ public struct PartialSolution {
     /// Create a new derivation assignment and add it to the partial solution's
     /// list of known assignments.
     public mutating func derive(_ term: Term, cause: Incompatibility) {
-        let derivation = Assignment.derivation(term, cause: cause, decisionLevel: decisionLevel)
+        let derivation = Assignment.derivation(term, cause: cause, decisionLevel: self.decisionLevel)
         self.assignments.append(derivation)
         register(derivation)
     }

--- a/Sources/PackageGraph/PubGrub/PubGrubDependencyResolver.swift
+++ b/Sources/PackageGraph/PubGrub/PubGrubDependencyResolver.swift
@@ -514,9 +514,9 @@ public struct PubGrubDependencyResolver {
             return .conflict
         }
 
-        self.delegate?.derived(term: unsatisfiedTerm.inverse)
-        state.derive(unsatisfiedTerm.inverse, cause: incompatibility)
 
+        state.derive(unsatisfiedTerm.inverse, cause: incompatibility)
+        self.delegate?.derived(term: unsatisfiedTerm.inverse)
         return .almostSatisfied(node: unsatisfiedTerm.node)
     }
 

--- a/Sources/PackageGraph/Version+Extensions.swift
+++ b/Sources/PackageGraph/Version+Extensions.swift
@@ -14,6 +14,10 @@ import struct TSCUtility.Version
 
 extension Version {
     func nextPatch() -> Version {
-        return Version(major, minor, patch + 1)
+        if self.prereleaseIdentifiers.isEmpty {
+            return Version(self.major, self.minor, self.patch + 1)
+        } else {
+            return Version(self.major, self.minor, self.patch, prereleaseIdentifiers: self.prereleaseIdentifiers + ["0"])
+        }
     }
 }

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -227,7 +227,7 @@ final class PubgrubTests: XCTestCase {
         XCTAssertEqual(a2?.requirement, .range(v1..<v1_5))
     }
 
-    func testSolutionUndecided() {
+    func testSolutionUndecided() throws {
         var solution = PartialSolution()
         solution.derive("a^1.0.0", cause: rootCause)
         solution.decide(.empty(package: "b"), at: v2)
@@ -240,7 +240,7 @@ final class PubgrubTests: XCTestCase {
         XCTAssertEqual(undecided, [Term("a^1.5.0"), Term("d^1.9.9")])
     }
 
-    func testSolutionAddAssignments() {
+    func testSolutionAddAssignments() throws {
         let root = Term(rootNode, .exact("1.0.0"))
         let a = Term("a@1.0.0")
         let b = Term("b@2.0.0")
@@ -404,7 +404,7 @@ final class PubgrubTests: XCTestCase {
         XCTAssertEqual(state2.solution.assignments.count, 2)
     }
 
-    func testSolutionFindSatisfiers() {
+    func testSolutionFindSatisfiers() throws {
         var solution = PartialSolution()
         solution.decide(rootNode, at: v1) // ← previous, but actually nil because this is the root decision
         solution.derive(Term(.product("a", package: aRef), .any), cause: _cause) // ← satisfier
@@ -1168,6 +1168,37 @@ final class PubgrubTests: XCTestCase {
         ])
     }
 
+    // top level package -> beta version
+    //  beta version -> version
+    func testHappyPath10() throws {
+        let package = PackageReference.root(identity: .plain("package"), path: .root)
+        try builder.serve(package, at: .unversioned, with: [
+            "module": [
+                "foo": (.versionSet(.range("1.0.0-alpha" ..< "2.0.0")), .specific(["foo"]))
+            ]])
+        try builder.serve("foo", at: "1.0.0-alpha.1", with: ["foo": ["bar": (.versionSet(v1Range), .specific(["bar"]))]])
+        try builder.serve("foo", at: "1.0.0-alpha.2", with: ["foo": ["bar": (.versionSet(v1Range), .specific(["bar"]))]])
+        try builder.serve("foo", at: "1.0.0-beta.1", with: ["foo": ["bar": (.versionSet(v1Range), .specific(["bar"]))]])
+        try builder.serve("foo", at: "1.0.0-beta.2", with: ["foo": ["bar": (.versionSet(v1Range), .specific(["bar"]))]])
+        try builder.serve("foo", at: "1.0.0-beta.3", with: ["foo": ["bar": (.versionSet(v1Range), .specific(["bar"]))]])
+        try builder.serve("bar", at: v1)
+        try builder.serve("bar", at: v1_1)
+        try builder.serve("bar", at: v1_5)
+
+        let resolver = builder.create()
+        let dependencies = builder.create(dependencies: [
+            package: (.unversioned, .everything)
+        ])
+
+        let result = resolver.solve(constraints: dependencies)
+
+        AssertResult(result, [
+            ("package", .unversioned),
+            ("foo", .version("1.0.0-beta.3")),
+            ("bar", .version(v1_5))
+        ])
+    }
+
     func testResolutionWithSimpleBranchBasedDependency() throws {
         try builder.serve("foo", at: .revision("master"), with: ["foo": ["bar": (.versionSet(v1Range), .specific(["bar"]))]])
         try builder.serve("bar", at: v1)
@@ -1826,16 +1857,16 @@ final class PubGrubTestsBasicGraphs: XCTestCase {
 final class PubGrubDiagnosticsTests: XCTestCase {
 
     func testMissingVersion() throws {
-        try builder.serve("foopkg", at: v1_1)
+        try builder.serve("package", at: v1_1)
 
         let resolver = builder.create()
         let dependencies = try builder.create(dependencies: [
-            "foopkg": (.versionSet(v2Range), .specific(["foopkg"])),
+            "package": (.versionSet(v2Range), .specific(["package"])),
         ])
         let result = resolver.solve(constraints: dependencies)
 
         XCTAssertEqual(result.errorMsg, """
-            Dependencies could not be resolved because no versions of 'foopkg' match the requirement 2.0.0..<3.0.0 and root depends on 'foopkg' 2.0.0..<3.0.0.
+            Dependencies could not be resolved because no versions of 'package' match the requirement 2.0.0..<3.0.0 and root depends on 'package' 2.0.0..<3.0.0.
             """)
     }
 
@@ -1850,6 +1881,74 @@ final class PubGrubDiagnosticsTests: XCTestCase {
 
         XCTAssertEqual(result.errorMsg, """
             Dependencies could not be resolved because no versions of 'package' match the requirement 1.0.0 and root depends on 'package' 1.0.0.
+            """)
+    }
+
+    func testResolutionNonExistentBetaVersion() throws {
+        try builder.serve("package", at: "0.0.1")
+
+        let resolver = builder.create()
+        let dependencies = try builder.create(dependencies: [
+            "package": (.versionSet(.range("1.0.0-beta" ..< "2.0.0")), .specific(["package"])),
+        ])
+        let result = resolver.solve(constraints: dependencies)
+
+        XCTAssertEqual(result.errorMsg, """
+            Dependencies could not be resolved because no versions of 'package' match the requirement 1.0.0-beta..<2.0.0 and root depends on 'package' 1.0.0-beta..<2.0.0.
+            """)
+    }
+
+    func testResolutionNonExistentTransitiveVersion() throws {
+        try builder.serve("package", at: v1_5, with: [
+            "package": ["foo": (.versionSet(v1Range), .specific(["foo"]))]
+        ])
+        try builder.serve("foo", at: "0.0.1")
+
+        let resolver = builder.create()
+        let dependencies = try builder.create(dependencies: [
+            "package": (.versionSet(v1Range), .specific(["package"]))
+        ])
+        let result = resolver.solve(constraints: dependencies)
+
+        XCTAssertEqual(result.errorMsg, """
+            Dependencies could not be resolved because no versions of 'foo' match the requirement 1.0.0..<2.0.0 and root depends on 'package' 1.0.0..<2.0.0.
+            'package' practically depends on 'foo' 1.0.0..<2.0.0 because no versions of 'package' match the requirement {1.0.0..<1.5.0, 1.5.1..<2.0.0} and 'package' 1.5.0 depends on 'foo' 1.0.0..<2.0.0.
+            """)
+    }
+
+    func testResolutionNonExistentTransitiveBetaVersion() throws {
+        try builder.serve("package", at: v1_5, with: [
+            "package": ["foo": (.versionSet(.range("1.0.0-beta" ..< "2.0.0")), .specific(["foo"]))]
+        ])
+        try builder.serve("foo", at: "0.0.1")
+
+        let resolver = builder.create()
+        let dependencies = try builder.create(dependencies: [
+            "package": (.versionSet(v1Range), .specific(["package"]))
+        ])
+        let result = resolver.solve(constraints: dependencies)
+
+        XCTAssertEqual(result.errorMsg, """
+            Dependencies could not be resolved because no versions of 'foo' match the requirement 1.0.0-beta..<2.0.0 and root depends on 'package' 1.0.0..<2.0.0.
+            'package' practically depends on 'foo' 1.0.0-beta..<2.0.0 because no versions of 'package' match the requirement {1.0.0..<1.5.0, 1.5.1..<2.0.0} and 'package' 1.5.0 depends on 'foo' 1.0.0-beta..<2.0.0.
+            """)
+    }
+
+    func testResolutionBetaVersionNonExistentTransitiveVersion() throws {
+        try builder.serve("package", at: "1.0.0-beta.1", with: [
+            "package": ["foo": (.versionSet(v1Range), .specific(["foo"]))]
+        ])
+        try builder.serve("foo", at: "0.0.1")
+
+        let resolver = builder.create()
+        let dependencies = try builder.create(dependencies: [
+            "package": (.versionSet(.range("1.0.0-beta" ..< "2.0.0")), .specific(["package"])),
+        ])
+        let result = resolver.solve(constraints: dependencies)
+
+        XCTAssertEqual(result.errorMsg, """
+            Dependencies could not be resolved because no versions of 'foo' match the requirement 1.0.0..<2.0.0 and root depends on 'package' 1.0.0-beta..<2.0.0.
+            'package' practically depends on 'foo' 1.0.0..<2.0.0 because no versions of 'package' match the requirement {1.0.0-beta..<1.0.0-beta.1, 1.0.0-beta.1.0..<2.0.0} and 'package' 1.0.0-beta.1 depends on 'foo' 1.0.0..<2.0.0.
             """)
     }
 
@@ -2355,6 +2454,8 @@ final class PubGrubDiagnosticsTests: XCTestCase {
         try builder.serve("foo", at: v1_1, with: [
             "foo": ["bar": (.revision("master"), .specific(["bar"]))]
         ])
+        try builder.serve("bar", at: .revision("master"))
+
         let resolver = builder.create()
         let dependencies = try builder.create(dependencies: [
             "foo": (.versionSet(v1Range), .specific(["foo"])),
@@ -2367,10 +2468,12 @@ final class PubGrubDiagnosticsTests: XCTestCase {
             """)
     }
 
-    func testNonVersionDependencyInVersionDependency3() throws {
+    func testNonVersionDependencyInVersionDependency2() throws {
         try builder.serve("foo", at: v1, with: [
             "foo": ["bar": (.unversioned, .specific(["bar"]))]
         ])
+        try builder.serve("bar", at: .unversioned)
+
         let resolver = builder.create()
         let dependencies = try builder.create(dependencies: [
             "foo": (.versionSet(.exact(v1)), .specific(["foo"])),
@@ -2379,6 +2482,31 @@ final class PubGrubDiagnosticsTests: XCTestCase {
 
         XCTAssertEqual(result.errorMsg, """
             Dependencies could not be resolved because package 'foo' is required using a stable-version but 'foo' depends on an unstable-version package 'bar' and root depends on 'foo' 1.0.0.
+            """)
+    }
+
+    func testNonVersionDependencyInVersionDependency3() throws {
+        try builder.serve("foo", at: "1.0.0-beta.1", with: [
+            "foo": ["bar": (.revision("master"), .specific(["bar"]))]
+        ])
+        try builder.serve("foo", at: "1.0.0-beta.2", with: [
+            "foo": ["bar": (.revision("master"), .specific(["bar"]))]
+        ])
+        try builder.serve("foo", at: "1.0.0-beta.3", with: [
+            "foo": ["bar": (.revision("master"), .specific(["bar"]))]
+        ])
+        try builder.serve("bar", at: .revision("master"))
+
+        let resolver = builder.create()
+        let dependencies = try builder.create(dependencies: [
+            "foo": (.versionSet(.range("1.0.0-beta" ..< "2.0.0")), .specific(["foo"])),
+        ])
+        let result = resolver.solve(constraints: dependencies)
+
+        XCTAssertEqual(result.errorMsg, """
+            Dependencies could not be resolved because package 'foo' is required using a stable-version but 'foo' depends on an unstable-version package 'bar' and root depends on 'foo' 1.0.0-beta..<2.0.0.
+            'foo' {1.0.0-beta..<1.0.0-beta.3, 1.0.0-beta.3.0..<2.0.0} cannot be used because package 'foo' is required using a stable-version but 'foo' depends on an unstable-version package 'bar'.
+            'foo' {1.0.0-beta..<1.0.0-beta.2, 1.0.0-beta.2.0..<1.0.0-beta.3, 1.0.0-beta.3.0..<2.0.0} cannot be used because no versions of 'foo' match the requirement {1.0.0-beta..<1.0.0-beta.1, 1.0.0-beta.1.0..<1.0.0-beta.2, 1.0.0-beta.2.0..<1.0.0-beta.3, 1.0.0-beta.3.0..<2.0.0} and package 'foo' is required using a stable-version but 'foo' depends on an unstable-version package 'bar'.
             """)
     }
 

--- a/Tests/PackageGraphTests/VersionSetSpecifierTests.swift
+++ b/Tests/PackageGraphTests/VersionSetSpecifierTests.swift
@@ -99,6 +99,26 @@ final class VersionSetSpecifierTests: XCTestCase {
         XCTAssertEqual(VersionSetSpecifier.ranges(["1.0.0"..<"2.0.0", "2.0.1"..<"5.0.0"]).difference(.range("1.0.0"..<"2.0.0")), .range("2.0.1"..<"5.0.0"))
         XCTAssertEqual(VersionSetSpecifier.ranges(["3.2.0"..<"3.2.3", "3.2.4"..<"4.0.0"]).difference(.exact("3.2.2")), .ranges(["3.2.0"..<"3.2.2", "3.2.4"..<"4.0.0"]))
         XCTAssertEqual(VersionSetSpecifier.ranges(["3.2.0"..<"3.2.1", "3.2.3"..<"4.0.0"]).difference(.exact("3.2.0")), .range("3.2.3"..<"4.0.0"))
+
+
+        XCTAssertEqual(VersionSetSpecifier.exact("1.0.0-beta").difference(.exact("1.0.0-beta")), .empty)
+        XCTAssertEqual(VersionSetSpecifier.exact("2.0.0-beta").difference(.exact("1.0.0")), .exact("2.0.0-beta"))
+        XCTAssertEqual(VersionSetSpecifier.exact("2.0.0-beta").difference(.exact("1.0.0-beta")), .exact("2.0.0-beta"))
+
+        XCTAssertEqual(VersionSetSpecifier.range("1.0.0-beta"..<"1.0.0-beta").difference(.range("1.0.0-beta"..<"1.0.0-beta")), .empty)
+        XCTAssertEqual(VersionSetSpecifier.range("2.0.0-beta"..<"2.0.0-beta").difference(.range("1.0.0"..<"2.0.0")), .range("2.0.0-beta"..<"2.0.0-beta"))
+        XCTAssertEqual(VersionSetSpecifier.range("2.0.0-beta"..<"2.0.0-beta").difference(.range("1.0.0-beta"..<"2.0.0")), .range("2.0.0-beta"..<"2.0.0-beta"))
+
+        XCTAssertEqual(VersionSetSpecifier.range("1.0.0-beta"..<"2.0.0").difference(.exact("2.0.0")), .range("1.0.0-beta"..<"2.0.0"))
+        XCTAssertEqual(VersionSetSpecifier.range("1.0.0-beta"..<"2.0.0").difference(.exact("1.0.0-beta")), .range("1.0.0-beta.0"..<"2.0.0"))
+        XCTAssertEqual(VersionSetSpecifier.range("1.0.0-beta"..<"2.0.0").difference(.exact("1.0.0-beta.5")), .ranges(["1.0.0-beta"..<"1.0.0-beta.5", "1.0.0-beta.5.0"..<"2.0.0"]))
+
+        XCTAssertEqual(VersionSetSpecifier.range("1.0.0-beta"..<"2.0.0").difference(.range("1.0.0-beta.3" ..< "2.0.0")), .range("1.0.0-beta"..<"1.0.0-beta.3"))
+        XCTAssertEqual(VersionSetSpecifier.range("1.0.0-beta.5"..<"1.0.0-beta.30").difference(.range("1.0.0-beta.10" ..< "2.0.0")), .range("1.0.0-beta.5"..<"1.0.0-beta.10"))
+        XCTAssertEqual(VersionSetSpecifier.range("1.0.0-beta"..<"1.0.0-beta.30").difference(.range("1.0.0-beta.3" ..< "1.0.0-beta.10")), .ranges(["1.0.0-beta"..<"1.0.0-beta.3", "1.0.0-beta.10"..<"1.0.0-beta.30"]))
+
+        XCTAssertEqual(VersionSetSpecifier.range("1.0.0-alpha"..<"2.0.0").difference(.range("1.0.0-beta" ..< "2.0.0")), .range("1.0.0-alpha"..<"1.0.0-beta"))
+        XCTAssertEqual(VersionSetSpecifier.range("1.0.0-beta"..<"2.0.0").difference(.range("1.0.0-alpha" ..< "2.0.0")), .empty)
     }
 
     func testEquality() {


### PR DESCRIPTION
5.9 cherry pick of #6492
