### PR TITLE
Fix warnings

### DIFF
--- a/Sources/Basics/Observability.swift
+++ b/Sources/Basics/Observability.swift
@@ -564,6 +564,7 @@ extension ObservabilityMetadata {
 
 // MARK: - Compatibility with TSC Diagnostics APIs
 
+@available(*, deprecated, message: "temporary for transition TSCBasic.Diagnostic -> SwiftDriver.Diagnostic")
 extension ObservabilityScope {
     public func makeDiagnosticsHandler() -> (TSCBasic.Diagnostic) -> Void {
         { Diagnostic($0).map { self.diagnosticsHandler.handleDiagnostic(scope: self, diagnostic: $0) } }

--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -355,12 +355,17 @@ public final class RegistryClient: Cancellable {
                                         return nil
                                     }
                                     let configuration = self.configuration.signing(for: package, registry: registry)
-                                    return try? tsc_await { SignatureValidation.extractSigningEntity(
+                                    return try? tsc_await { completion in
+                                        let wrappedCompletion: @Sendable (Result<SigningEntity?, Error>) -> Void = {
+                                            completion($0)
+                                        }
+
+                                        SignatureValidation.extractSigningEntity(
                                         signature: [UInt8](signatureData),
                                         signatureFormat: signatureFormat,
                                         configuration: configuration,
                                         fileSystem: fileSystem,
-                                        completion: $0
+                                        completion: wrappedCompletion
                                     ) }
                                 }
                             )

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -274,7 +274,7 @@ final class BuildToolTests: CommandsTestCase {
     }
 
     func testBuildCompleteMessage() throws {
-        throw XCTSkip("This test fails to match the 'Compiling' regex; rdar://101815761")
+        try XCTSkipIf(true, "This test fails to match the 'Compiling' regex; rdar://101815761")
 
         try fixture(name: "DependencyResolution/Internal/Simple") { fixturePath in
             do {


### PR DESCRIPTION
Remaining warnings:
- `GenerateLinuxMain`, should get fixed by https://github.com/apple/swift-package-manager/pull/6490
- Linker warning for `swiftpm-xctest-helper` since XCTest on macOS has a 13.0 deployment target. Nothing we can really do right now, but we should switch our deployment target to 13.0 as soon as we can.
- `ObservabilityScope.makeDiagnosticsHandler()` which is needed for compatibility with swift-driver