### PR TITLE
[5.8] Fix linking of bootstrap PackageCollectionsSigning

### DIFF
--- a/Sources/PackageCollectionsSigning/CMakeLists.txt
+++ b/Sources/PackageCollectionsSigning/CMakeLists.txt
@@ -43,6 +43,6 @@ target_link_libraries(PackageCollectionsSigning PUBLIC
   PackageCollectionsModel
   TSCBasic)
 target_link_libraries(PackageCollectionsSigning PRIVATE
-  PackageCollectionsSigningLibc
-  $<$<PLATFORM_ID:Darwin>:SHELL:-Xlinker -framework -Xlinker Security>)
-
+  PackageCollectionsSigningLibc)
+target_link_options(PackageCollectionsSigning PRIVATE
+  "$<$<PLATFORM_ID:Darwin>:SHELL:-Xlinker -framework -Xlinker Security>")


### PR DESCRIPTION
This was causing our bootstrap build to fail in NixOS packaging.

Doesn't appear to be necessary for `release/5.9` or `main`.