### PR TITLE
Fix use of XCTest minimum deployment target

### DIFF
--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -737,7 +737,7 @@ private func computePlatforms(
         let platform = platformRegistry.platformByName[platformName]!
 
         let minimumSupportedVersion: PlatformVersion
-        if usingXCTest, let xcTestMinimumDeploymentTarget = xcTestMinimumDeploymentTargets[platform] {
+        if usingXCTest, let xcTestMinimumDeploymentTarget = xcTestMinimumDeploymentTargets[platform], xcTestMinimumDeploymentTarget > platform.oldestSupportedVersion {
             minimumSupportedVersion = xcTestMinimumDeploymentTarget
         } else {
             minimumSupportedVersion = platform.oldestSupportedVersion


### PR DESCRIPTION
If the computed XCTest minimum deployment target is lower than the oldest supported version of a platform, we should not use it as the basis for deployment targets of test targets.

This issue was actually also present in the tests which were written to expect the incorrect behavior of always preferring the XCTest minimum deployment target.

rdar://108462045
