### PR TITLE
Put `CommandsTests` behind `SWIFTCI_DISABLE_SDK_DEPENDENT_TESTS`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -671,24 +671,6 @@ let package = Package(
 #if !os(Windows)
 package.targets.append(contentsOf: [
     .testTarget(
-        name: "CommandsTests",
-        dependencies: [
-            "swift-build",
-            "swift-package",
-            "swift-test",
-            "swift-run",
-            "Basics",
-            "Build",
-            "Commands",
-            "PackageModel",
-            "PackageRegistryTool",
-            "SourceControl",
-            "SPMTestSupport",
-            "Workspace",
-        ]
-    ),
-
-    .testTarget(
         name: "FunctionalPerformanceTests",
         dependencies: [
             "swift-build",
@@ -710,6 +692,24 @@ if ProcessInfo.processInfo.environment["SWIFTCI_DISABLE_SDK_DEPENDENT_TESTS"] ==
                 "swift-test",
                 "PackageModel",
                 "SPMTestSupport"
+            ]
+        ),
+
+        .testTarget(
+            name: "CommandsTests",
+            dependencies: [
+                "swift-build",
+                "swift-package",
+                "swift-test",
+                "swift-run",
+                "Basics",
+                "Build",
+                "Commands",
+                "PackageModel",
+                "PackageRegistryTool",
+                "SourceControl",
+                "SPMTestSupport",
+                "Workspace",
             ]
         ),
     ])


### PR DESCRIPTION
Looks like these tests are suffering from some of the same problems as `FunctionalTests` which makes sense since they're conceptually very similar.
