### PR TITLE
Allow `--product` option for automatic library products

### DIFF
--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -84,10 +84,6 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope
     ) throws {
-        guard product.type != .library(.automatic) else {
-            throw InternalError("Automatic type libraries should not be described.")
-        }
-
         self.package = package
         self.product = product
         self.toolsVersion = toolsVersion
@@ -199,10 +195,8 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
         switch derivedProductType {
         case .macro:
             throw InternalError("macro not supported") // should never be reached
-        case .library(.automatic):
-            throw InternalError("automatic library not supported")
-        case .library(.static):
-            // No arguments for static libraries.
+        case .library(.static), .library(.automatic):
+            // No arguments for static (and automatic) libraries.
             return []
         case .test:
             // Test products are bundle when using objectiveC, executable when using test entry point.

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -734,15 +734,6 @@ extension BuildSubset {
                 observabilityScope.emit(error: "no product named '\(productName)'")
                 return nil
             }
-            // If the product is automatic, we build the main target because automatic products
-            // do not produce a binary right now.
-            if product.type == .library(.automatic) {
-                observabilityScope.emit(
-                    warning:
-                        "'--product' cannot be used with the automatic product '\(productName)'; building the default target instead"
-                )
-                return LLBuildManifestBuilder.TargetKind.main.targetName
-            }
             return observabilityScope.trap {
                 try product.getLLBuildTargetName(config: config)
             }

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -1104,10 +1104,6 @@ extension ResolvedPackage {
 }
 
 extension ResolvedProduct {
-    private var isAutomaticLibrary: Bool {
-        return self.type == .library(.automatic)
-    }
-
     private var isBinaryOnly: Bool {
         return self.targets.filter({ !($0.underlyingTarget is BinaryTarget) }).isEmpty
     }
@@ -1116,9 +1112,9 @@ extension ResolvedProduct {
         return self.type == .plugin
     }
 
-    // We shouldn't create product descriptions for automatic libraries, plugins or products which consist solely of binary targets, because they don't produce any output.
+    // We shouldn't create product descriptions for plugins or products which consist solely of binary targets, because they don't produce any output.
     fileprivate var shouldCreateProductDescription: Bool {
-        return !isAutomaticLibrary && !isBinaryOnly && !isPlugin
+        return !isBinaryOnly && !isPlugin
     }
 }
 

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -154,9 +154,10 @@ final class BuildToolTests: CommandsTestCase {
             }
 
             do {
-                let (_, stderr) = try execute(["--product", "lib1"], packagePath: fullPath)
+                let result = try build(["--product", "lib1"], packagePath: fullPath)
                 try SwiftPM.Package.execute(["clean"], packagePath: fullPath)
-                XCTAssertMatch(stderr, .contains("'--product' cannot be used with the automatic product 'lib1'; building the default target instead"))
+                XCTAssertMatch(result.binContents, ["lib1.build"])
+                XCTAssertNoMatch(result.binContents, ["exec1"])
             }
 
             do {


### PR DESCRIPTION
This is currently explicitly disallowed because we're not producing a binary for these products, but that seems like an odd restriction since `--target` also only produces intermediates. It seems like it can be useful to build a subset of the package for other reasons than wanting to produce a particular binary.
