### PR TITLE
PackageLoadingTests: ensure that we use the correct path spelling

### DIFF
--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -1440,8 +1440,14 @@ class PackageBuilderTests: XCTestCase {
                     try TargetDescription(name: "Random", type: .system),
                 ]
             )
+            let map = "/\(predefinedSourceDir)/module.modulemap"
             PackageBuilderTester(manifest, in: fs) { _, diagnostics in
-                diagnostics.check(diagnostic: "package has unsupported layout; missing system target module map at '/\(predefinedSourceDir)/module.modulemap'", severity: .error)
+#if _runtime(_ObjC)
+                diagnostics.check(diagnostic: "package has unsupported layout; missing system target module map at '\(map)'", severity: .error)
+#else
+                // FIXME: there is a memory leak here
+                diagnostics.check(diagnostic: "package has unsupported layout; missing system target module map at '\(String(cString: map.fileSystemRepresentation))'", severity: .error)
+#endif
             }
         }
         do {

--- a/Tests/PackageLoadingTests/ToolsVersionParserTests.swift
+++ b/Tests/PackageLoadingTests/ToolsVersionParserTests.swift
@@ -161,7 +161,7 @@ class ToolsVersionParserTests: XCTestCase {
 
         XCTAssertThrowsError(
             try ToolsVersionParser.parse(manifestPath: manifestPath, fileSystem: fs),
-            "empty manifest '/lorem/ipsum/dolor/Package.swift'") { error in
+            "empty manifest '\(manifestPath.pathString)'") { error in
                 guard let error = error as? ManifestParseError, case .emptyManifest(let errorPath) = error else {
                     XCTFail("'ManifestParseError.emptyManifest' should've been thrown, but a different error is thrown")
                     return
@@ -172,7 +172,7 @@ class ToolsVersionParserTests: XCTestCase {
                     return
                 }
 
-                XCTAssertEqual(error.description, "'/lorem/ipsum/dolor/Package.swift' is empty")
+                XCTAssertEqual(error.description, "'\(manifestPath._nativePathString(escaped: false))' is empty")
             }
     }
 


### PR DESCRIPTION
Tests here verify the paths, which need the native representation.  This ensures that we get the correct spelling of the paths in these tests.

The memory leak on the non-Darwin platforms exists due to the path string not being pushed into an autorelease pool.  The use of `withUnsafeFileSystemRepresentation` ends up mismatching the arc separator resulting in a test failure.