### PR TITLE
[5.9] Cherry-pick documentation updates

### DIFF
--- a/Sources/PackageDescription/BuildSettings.swift
+++ b/Sources/PackageDescription/BuildSettings.swift
@@ -12,6 +12,7 @@
 
 /// The build configuration such as debug or release.
 public struct BuildConfiguration {
+    /// The configuration of the build. Valid values are `debug` and `release`.
     let config: String
 
     private init(_ config: String) {
@@ -54,7 +55,9 @@ public struct BuildConfiguration {
 /// ),
 /// ```
 public struct BuildSettingCondition {
+    /// The applicable platforms for this build setting condition.
     let platforms: [Platform]?
+    /// The applicable build configuration for this build setting condition.
     let config: BuildConfiguration?
 
     private init(platforms: [Platform]?, config: BuildConfiguration?) {
@@ -113,6 +116,7 @@ struct BuildSettingData {
 
 /// A C-language build setting.
 public struct CSetting {
+    /// The abstract build setting data.
     let data: BuildSettingData
 
     private init(name: String, value: [String], condition: BuildSettingCondition?) {
@@ -182,6 +186,7 @@ public struct CSetting {
 
 /// A CXX-language build setting.
 public struct CXXSetting {
+    /// The abstract build setting data.
     let data: BuildSettingData
 
     private init(name: String, value: [String], condition: BuildSettingCondition?) {
@@ -250,6 +255,7 @@ public struct CXXSetting {
 
 /// A Swift language build setting.
 public struct SwiftSetting {
+    /// The abstract build setting data.
     let data: BuildSettingData
 
     private init(name: String, value: [String], condition: BuildSettingCondition?) {
@@ -306,13 +312,13 @@ public struct SwiftSetting {
 
     /// Enable an upcoming feature with the given name.
     ///
-    /// An upcoming feature is one that has been accepted into Swift as of a
+    /// An upcoming feature is one that is available in Swift as of a
     /// certain language version, but is not available by default in prior
     /// language modes because it has some impact on source compatibility.
     ///
-    /// Multiple upcoming features can be added to a given target, and can
-    /// be used in a target without affecting its dependencies. An unknown
-    /// upcoming feature will be ignored by the implementation.
+    /// You can add multiple upcoming features to a given target, and can
+    /// use in a target without affecting its dependencies. Targets will ignore any unknown
+    /// upcoming features.
     ///
     /// - Since: First available in PackageDescription 5.8.
     ///
@@ -332,11 +338,11 @@ public struct SwiftSetting {
     /// Enable an experimental feature with the given name.
     ///
     /// An experimental feature is one that is in development, but
-    /// has not been accepted into Swift as a language feature.
+    /// is not yet available in Swift as a language feature.
     ///
-    /// Multiple experimental features can be added to a given target, and can
-    /// be used in a target without affecting its dependencies. An unknown
-    /// experimental feature will be ignored by the implementation.
+    /// You can add multiple experimental features to a given target, and can
+    /// use in a target without affecting its dependencies. Targets will ignore any  unknown
+    /// experimental features.
     ///
     /// - Since: First available in PackageDescription 5.8.
     ///
@@ -391,6 +397,7 @@ public struct SwiftSetting {
 
 /// A linker build setting.
 public struct LinkerSetting {
+    /// The abstract build setting data.
     let data: BuildSettingData
 
     private init(name: String, value: [String], condition: BuildSettingCondition?) {

--- a/Sources/PackageDescription/BuildSettings.swift
+++ b/Sources/PackageDescription/BuildSettings.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// The build configuration such as debug or release.
+/// The build configuration, such as debug or release.
 public struct BuildConfiguration {
     /// The configuration of the build. Valid values are `debug` and `release`.
     let config: String
@@ -114,7 +114,7 @@ struct BuildSettingData {
     let condition: BuildSettingCondition?
 }
 
-/// A C-language build setting.
+/// A C language build setting.
 public struct CSetting {
     /// The abstract build setting data.
     let data: BuildSettingData
@@ -135,7 +135,7 @@ public struct CSetting {
     ///
     /// - Parameters:
     ///   - path: The path of the directory that contains the headers. The path is relative to the target's directory.
-    ///   - condition: A condition that restricts the application of the build setting.
+    ///   - condition: A condition that restricts the use of the build setting.
     @available(_PackageDescription, introduced: 5.0)
     public static func headerSearchPath(_ path: String, _ condition: BuildSettingCondition? = nil) -> CSetting {
         return CSetting(name: "headerSearchPath", value: [path], condition: condition)
@@ -150,7 +150,7 @@ public struct CSetting {
     /// - Parameters:
     ///   - name: The name of the macro.
     ///   - value: The value of the macro.
-    ///   - condition: A condition that restricts the application of the build
+    ///   - condition: A condition that restricts the use of the build
     /// setting.
     @available(_PackageDescription, introduced: 5.0)
     public static func define(_ name: String, to value: String? = nil, _ condition: BuildSettingCondition? = nil) -> CSetting {
@@ -186,7 +186,7 @@ public struct CSetting {
 
 /// A CXX-language build setting.
 public struct CXXSetting {
-    /// The abstract build setting data.
+    /// The data store for the CXX build setting.
     let data: BuildSettingData
 
     private init(name: String, value: [String], condition: BuildSettingCondition?) {
@@ -205,6 +205,7 @@ public struct CXXSetting {
     ///
     /// - Parameters:
     ///   - path: The path of the directory that contains the headers. The path is
+    ///   relative to the target's directory.
     ///   - condition: A condition that restricts the application of the build setting.
     @available(_PackageDescription, introduced: 5.0)
     public static func headerSearchPath(_ path: String, _ condition: BuildSettingCondition? = nil) -> CXXSetting {
@@ -255,7 +256,7 @@ public struct CXXSetting {
 
 /// A Swift language build setting.
 public struct SwiftSetting {
-    /// The abstract build setting data.
+    /// The data store for the Swift build setting.
     let data: BuildSettingData
 
     private init(name: String, value: [String], condition: BuildSettingCondition?) {
@@ -313,17 +314,17 @@ public struct SwiftSetting {
     /// Enable an upcoming feature with the given name.
     ///
     /// An upcoming feature is one that is available in Swift as of a
-    /// certain language version, but is not available by default in prior
+    /// certain language version, but isn't available by default in prior
     /// language modes because it has some impact on source compatibility.
     ///
-    /// You can add multiple upcoming features to a given target, and can
-    /// use in a target without affecting its dependencies. Targets will ignore any unknown
+    /// You can add and use multiple upcoming features in a given target
+    /// without affecting its dependencies. Targets will ignore any unknown
     /// upcoming features.
     ///
     /// - Since: First available in PackageDescription 5.8.
     ///
     /// - Parameters:
-    ///   - name: The name of the upcoming feature, e.g., ConciseMagicFile.
+    ///   - name: The name of the upcoming feature; for example, `ConciseMagicFile`.
     ///   - condition: A condition that restricts the application of the build
     /// setting.
     @available(_PackageDescription, introduced: 5.8)
@@ -337,17 +338,17 @@ public struct SwiftSetting {
 
     /// Enable an experimental feature with the given name.
     ///
-    /// An experimental feature is one that is in development, but
+    /// An experimental feature is one that's in development, but
     /// is not yet available in Swift as a language feature.
     ///
-    /// You can add multiple experimental features to a given target, and can
-    /// use in a target without affecting its dependencies. Targets will ignore any  unknown
+    /// You can add and use multiple experimental features in a given target
+    /// without affecting its dependencies. Targets will ignore any  unknown
     /// experimental features.
     ///
     /// - Since: First available in PackageDescription 5.8.
     ///
     /// - Parameters:
-    ///   - name: The name of the experimental feature, e.g., VariadicGenerics.
+    ///   - name: The name of the experimental feature; for example, `VariadicGenerics`.
     ///   - condition: A condition that restricts the application of the build
     /// setting.
     @available(_PackageDescription, introduced: 5.8)
@@ -366,18 +367,18 @@ public struct SwiftSetting {
 
     /// Enable Swift interoperability with a given language.
     ///
-    /// This is useful for enabling Swift/C++ interoperability for a given
+    /// This is useful for enabling interoperability with Swift and C++ for a given
     /// target.
     ///
     /// Enabling C++ interoperability mode might alter the way some existing
-    /// C/Objective-C APIs are imported.
+    /// C and Objective-C APIs are imported.
     ///
     /// - Since: First available in PackageDescription 5.9.
     ///
     /// - Parameters:
-    ///   - mode: The language mode, either C or Cxx.
-    ///   - version: If Cxx language mode is used, the version of Swift/C++
-    /// interoperability, otherwise `nil`.
+    ///   - mode: The language mode, either C or CXX.
+    ///   - version: When using the CXX language mode, pass the version of Swift and C++
+    /// interoperability; otherwise, `nil`.
     ///   - condition: A condition that restricts the application of the build
     /// setting.
     @available(_PackageDescription, introduced: 5.9)
@@ -397,7 +398,7 @@ public struct SwiftSetting {
 
 /// A linker build setting.
 public struct LinkerSetting {
-    /// The abstract build setting data.
+    /// The data store for the Linker setting.
     let data: BuildSettingData
 
     private init(name: String, value: [String], condition: BuildSettingCondition?) {

--- a/Sources/PackageDescription/PackageDependency.swift
+++ b/Sources/PackageDescription/PackageDependency.swift
@@ -17,7 +17,7 @@ extension Package {
     /// A package dependency consists of a Git URL to the source of the package,
     /// and a requirement for the version of the package.
     ///
-    /// Swift Package Manager performs a process called _dependency resolution_ to figure out
+    /// Swift Package Manager performs a process called _dependency resolution_ to determine
     /// the exact version of the package dependencies that an app or other Swift
     /// package can use. The `Package.resolved` file records the results of the
     /// dependency resolution and lives in the top-level directory of a Swift
@@ -25,7 +25,7 @@ extension Package {
     /// for an Apple platform, you can find the `Package.resolved` file inside
     /// your `.xcodeproj` or `.xcworkspace`.
     public class Dependency {
-        /// The kind of dependency.
+        /// The type of dependency.
         @available(_PackageDescription, introduced: 5.6)
         public enum Kind {
             /// A dependency located at the given path.
@@ -482,11 +482,11 @@ extension Package.Dependency {
     /// Adds a package dependency that uses the exact version requirement.
     ///
     /// Specifying exact version requirements are not recommended as
-    /// they can cause conflicts in your dependency graph when multiple other packages depend on a package.
+    /// they can cause conflicts in your dependency graph when other packages depend on this package.
     /// As Swift packages follow the semantic versioning convention,
     /// think about specifying a version range instead.
     ///
-    /// The following example instruct the Swift Package Manager to use version `1.2.3`.
+    /// The following example instructs the Swift Package Manager to use version `1.2.3`.
     ///
     /// ```swift
     /// .package(url: "https://example.com/example-package.git", exact: "1.2.3"),
@@ -587,10 +587,10 @@ extension Package.Dependency {
     ///
     /// Specifying exact version requirements are not recommended as
     /// they can cause conflicts in your dependency graph when multiple other packages depend on a package.
-    /// As Swift packages follow the semantic versioning convention,
+    /// Because Swift packages follow the semantic versioning convention,
     /// think about specifying a version range instead.
     ///
-    /// The following example instruct the Swift Package Manager to use version `1.2.3`.
+    /// The following example instructs the Swift Package Manager to use version `1.2.3`.
     ///
     /// ```swift
     /// .package(id: "scope.name", exact: "1.2.3"),

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/Product-Executable.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Extensions/Product-Executable.md
@@ -2,6 +2,6 @@
 
 ## Topics
 
-### Describing an Executable Product
+### Describing an executable product
 
 - ``targets``

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Platform.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Platform.md
@@ -17,7 +17,7 @@
 - ``wasi``
 - ``windows``
 
-### Type Methods
+### Type methods
 
 - ``custom(_:)``
 

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Plugin.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Plugin.md
@@ -2,6 +2,6 @@
 
 ## Topics
 
-### Describing a Plugin Product
+### Describing a plug-in product
 
 - ``targets``

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/PluginPermission.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/PluginPermission.md
@@ -2,7 +2,7 @@
 
 ## Topics
 
-### Create a Permission
+### Create a permission
 
 - ``allowNetworkConnections(scope:reason:)``
 - ``writeToPackageDirectory(reason:)``

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Product.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Product.md
@@ -17,6 +17,6 @@
 - ``Product/plugin(name:targets:)``
 - ``Plugin``
 
-### Naming the Product
+### Naming the product
 
 - ``name``

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/SupportedPlatforms.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/SupportedPlatforms.md
@@ -48,7 +48,7 @@
 
 - <doc:/documentation/PackageDescription/Platform/linux>
 
-### Type Methods
+### Type methods
 
 - ``custom(_:versionString:)``
 

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/Target-Dependency.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/Target-Dependency.md
@@ -18,7 +18,7 @@
 - ``init(extendedGraphemeClusterLiteral:)``
 - ``init(unicodeScalarLiteral:)``
 
-### Identifying Related Types
+### Identifying related types
 
 - ``ExtendedGraphemeClusterLiteralType``
 - ``StringLiteralType``

--- a/Sources/PackageDescription/PackageDescription.swift
+++ b/Sources/PackageDescription/PackageDescription.swift
@@ -380,6 +380,7 @@ public enum SystemPackageProvider {
     /// Packages installable by the yum package manager.
     @available(_PackageDescription, introduced: 5.3)
     case yumItem([String])
+    /// Packages installable by the NuGet package manager.
     @available(_PackageDescription, introduced: 999.0)
     case nugetItem([String])
 
@@ -416,7 +417,7 @@ public enum SystemPackageProvider {
     }
 
     /// Creates a system package provider with a list of installable packages
-    /// for users of the nuget package manager on Linux or Windows.
+    /// for users of the NuGet package manager on Linux or Windows.
     ///
     /// - Parameter packages: The list of package names.
     ///

--- a/Sources/PackageDescription/PackageDescription.swift
+++ b/Sources/PackageDescription/PackageDescription.swift
@@ -315,10 +315,10 @@ public final class Package {
 /// [RFC5646](https://tools.ietf.org/html/rfc5646).
 public struct LanguageTag: Hashable {
 
-    /// An IETF language tag.
+    /// An IETF BCP 47 standard language tag.
     let tag: String
 
-    /// Creates a language tag from its IETF string representation.
+    /// Creates a language tag from its [IETF BCP 47](https://datatracker.ietf.org/doc/html/rfc5646) string representation.
     ///
     /// - Parameter tag: The string representation of an IETF language tag.
     private init(_ tag: String) {
@@ -377,7 +377,7 @@ public enum SystemPackageProvider {
     case brewItem([String])
     /// Packages installable by the apt-get package manager.
     case aptItem([String])
-    /// Packages installable by the yum package manager.
+    /// Packages installable by the Yellowdog Updated, Modified (YUM) package manager.
     @available(_PackageDescription, introduced: 5.3)
     case yumItem([String])
     /// Packages installable by the NuGet package manager.
@@ -385,7 +385,7 @@ public enum SystemPackageProvider {
     case nugetItem([String])
 
     /// Creates a system package provider with a list of installable packages
-    /// for users of the HomeBrew package manager on macOS.
+    /// for people who use the HomeBrew package manager on macOS.
     ///
     /// - Parameter packages: The list of package names.
     ///
@@ -452,7 +452,7 @@ private func dumpPackageAtExit(_ package: Package, to handle: Int) {
         guard let dumpInfo = dumpInfo else { return }
 
         let hFile: HANDLE = HANDLE(bitPattern: dumpInfo.handle)!
-        // NOTE: `_open_osfhandle` transfers ownership of the HANDLE to the file
+        // NOTE: `_open_osfhandle` transfers ownership of the `HANDLE` to the file
         // descriptor.  DO NOT invoke `CloseHandle` on `hFile`.
         let fd: CInt = _open_osfhandle(Int(bitPattern: hFile), _O_APPEND)
         // NOTE: `_fdopen` transfers ownership of the file descriptor to the

--- a/Sources/PackageDescription/PackageDescriptionSerializationConversion.swift
+++ b/Sources/PackageDescription/PackageDescriptionSerializationConversion.swift
@@ -1,9 +1,9 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift open source project
+// This source file is part of the Swift open source project.
 //
-// Copyright (c) 2023 Apple Inc. and the Swift project authors
-// Licensed under Apache License v2.0 with Runtime Library Exception
+// Copyright (c) 2023 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception.
 //
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors

--- a/Sources/PackageDescription/Product.swift
+++ b/Sources/PackageDescription/Product.swift
@@ -105,9 +105,9 @@ public class Product {
         }
     }
 
-    /// The plugin product of a Swift package.
+    /// The plug-in product of a Swift package.
     public final class Plugin: Product {
-        /// The name of the plugin target to vend as a product.
+        /// The name of the plug-in target to vend as a product.
         public let targets: [String]
 
         init(name: String, targets: [String]) {

--- a/Sources/PackageDescription/Resource.swift
+++ b/Sources/PackageDescription/Resource.swift
@@ -47,7 +47,7 @@ public struct Resource {
 
     /// The rule for the resource.
     let rule: String
-
+	
     /// The path of the resource.
     let path: String
 
@@ -97,6 +97,10 @@ public struct Resource {
     }
 
     /// Applies the embed rule to a resource at the given path.
+    ///
+    /// You can use the embed rule to embed the contents of the resource into the executable code.
+    /// - Parameter path: The path for a resource.
+    /// - Returns: A `Resource` instance.
     @available(_PackageDescription, introduced: 5.9)
     public static func embedInCode(_ path: String) -> Resource {
         return Resource(rule: "embedInCode", path: path, localization: nil)

--- a/Sources/PackageDescription/Resource.swift
+++ b/Sources/PackageDescription/Resource.swift
@@ -38,7 +38,7 @@ public struct Resource {
     /// Defines the explicit type of localization for resources.
     public enum Localization: String {
 
-        /// A constant that represents default internationalization.
+        /// A constant that represents default localization.
         case `default`
 
         /// A constant that represents base internationalization.

--- a/Sources/PackageDescription/SupportedPlatforms.swift
+++ b/Sources/PackageDescription/SupportedPlatforms.swift
@@ -601,8 +601,11 @@ extension SupportedPlatform {
         public static let v22: DriverKitVersion = .init(string: "22.0")
     }
 
+    /// A supported custom platform version.
     public struct CustomPlatformVersion: AppleOSVersion {
+        /// The name of the custom platform.
         static var name: String = "custom platform"
+        /// The minimum valid major version number.
         static var minimumMajorVersion = 0
 
         fileprivate init(uncheckedVersion version: String) {

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -35,7 +35,7 @@ public final class Target {
         case system
         /// A target that references a binary artifact.
         case binary
-        /// A target that provides a package plugin.
+        /// A target that provides a package plug-in.
         case plugin
         /// A target that provides a Swift macro.
         case `macro`
@@ -147,40 +147,40 @@ public final class Target {
     /// The providers array for a system library target.
     public let providers: [SystemPackageProvider]?
 
-    /// The capability provided by a package plugin target.
+    /// The capability provided by a package plug-in target.
     @available(_PackageDescription, introduced: 5.5)
     public var pluginCapability: PluginCapability?
 
-    /// The different types of capability that a plugin can provide.
+    /// The different types of capability that a plug-in can provide.
     ///
-    /// In this version of SwiftPM, only build tool and command plugins are supported;
-    /// this enum will be extended as new plugin capabilities are added.
+    /// In this version of SwiftPM, only build tool and command plug-ins are supported;
+    /// this enumeration will be extended as new plug-in capabilities are added.
     public enum PluginCapability {
-        /// Specifies that the plugin provides a build tool capability.
+        /// Specifies that the plug-in provides a build tool capability.
         ///
-        /// The plugin will be applied to each target that uses it and should create commands
-        /// that will run before or during the build of the target.
+        /// The plug-in to apply to each target that uses it, and creates commands
+        /// that run before or during the build of the target.
         @available(_PackageDescription, introduced: 5.5)
         case buildTool
 
-        /// Specifies that the plugin provides a user command capability.
+        /// Specifies that the plug-in provides a user command capability.
         ///
         ///- Parameters:
-        ///   - intent: The semantic intent of the plugin (either one of the predefined intents,
-        ///     or a custom intent).
-        ///   - permissions: Any permissions needed by the command plugin. This affects what the
-        ///     sandbox in which the plugin is run allows. Some permissions may require
-        ///     approval by the user.
+        ///   - intent: The semantic intent of the plug-in; either one of the predefined intents,
+        ///     or a custom intent.
+        ///   - permissions: Any permissions needed by the command plug-in. This affects what the
+        ///     sandbox in which the plug-in is run allows. Some permissions may require
+        ///     user approval.
         ///
-        /// Plugins that specify a `command` capability define commands that can be run
+        /// Plug-ins that specify a `command` capability define commands that can run
         /// using the SwiftPM command line interface, or in an IDE that supports
-        /// Swift Packages. The command will be available to invoke manually on one or more targets in a package.
+        /// Swift packages. You can invoke the command manually on one or more targets in a package.
         ///
         ///```swift
         ///swift package <verb>
         ///```
         ///
-        /// The package can specify the verb that is used to invoke the command.
+        /// The package can specify the _verb_ used to invoke the command.
         @available(_PackageDescription, introduced: 5.6)
         case command(intent: PluginCommandIntent, permissions: [PluginPermission] = [])
     }
@@ -215,18 +215,18 @@ public final class Target {
     @available(_PackageDescription, introduced: 5.3)
     public var checksum: String?
 
-    /// The uses of package plugins by the target.
+    /// The uses of package plug-ins by the target.
     @available(_PackageDescription, introduced: 5.5)
     public var plugins: [PluginUsage]?
     
-    /// A plugin used in a target.
+    /// A plug-in used in a target.
     @available(_PackageDescription, introduced: 5.5)
     public enum PluginUsage {
-        /// Specifies use of a plugin product in a package dependency.
+        /// Specifies the use of a plug-in product in a package dependency.
         ///
         /// - Parameters:
-        ///   - name: The name of the plugin target.
-        ///   - package: The name of the package in which the plugin target is defined.
+        ///   - name: The name of the plug-in target.
+        ///   - package: The name of the package that defines the plug-in target.
         case plugin(name: String, package: String?)
     }
 
@@ -509,7 +509,7 @@ public final class Target {
     ///   - cxxSettings: The C++ settings for this target.
     ///   - swiftSettings: The Swift settings for this target.
     ///   - linkerSettings: The linker settings for this target.
-    ///   - plugins: The plugins used by this target.
+    ///   - plugins: The plug-ins used by this target.
     @available(_PackageDescription, introduced: 5.5, obsoleted: 999.0)
     public static func target(
         name: String,
@@ -546,12 +546,11 @@ public final class Target {
     /// Creates a regular target.
     ///
     /// A target can contain either Swift or C-family source files, but not both. It contains code that is built as
-    /// a regular module that can be included in a library or executable product, but that cannot itself be used as
+    /// a regular module for inclusion in a library or executable product, but that cannot itself be used as
     /// the main target of an executable product.
     ///
     /// - Parameters:
     ///   - name: The name of the target.
-    ///   - group: The group this target belongs to, where access to the target's group-specific APIs is not allowed from outside. The default value is `package`.
     ///   - dependencies: The dependencies of the target. A dependency can be another target in the package or a product from a package dependency.
     ///   - path: The custom path for the target. By default, the Swift Package Manager requires a target's sources to reside at predefined search paths;
     ///       for example, `[PackageRoot]/Sources/[TargetName]`.
@@ -560,15 +559,15 @@ public final class Target {
     ///       A path is relative to the target's directory.
     ///       This parameter has precedence over the ``sources`` parameter.
     ///   - sources: An explicit list of source files. If you provide a path to a directory,
-    ///       the Swift Package Manager searches for valid source files recursively.
+    ///       Swift Package Manager searches for valid source files recursively.
     ///   - resources: An explicit list of resources files.
-    ///   - publicHeadersPath: The directory containing public headers of a C-family library target.
+    ///   - publicHeadersPath: The directory that contains public headers of a C-family library target.
     ///   - packageAccess: Allows package symbols from other targets in the package.
     ///   - cSettings: The C settings for this target.
     ///   - cxxSettings: The C++ settings for this target.
     ///   - swiftSettings: The Swift settings for this target.
     ///   - linkerSettings: The linker settings for this target.
-    ///   - plugins: The plugins used by this target
+    ///   - plugins: The plug-ins used by this target
     @available(_PackageDescription, introduced: 999.0)
     public static func target(
         name: String,
@@ -682,7 +681,7 @@ public final class Target {
     ///   - cxxSettings: The C++ settings for this target.
     ///   - swiftSettings: The Swift settings for this target.
     ///   - linkerSettings: The linker settings for this target.
-    ///   - plugins: The plugins used by this target.
+    ///   - plugins: The plug-ins used by this target.
     @available(_PackageDescription, introduced: 5.5, obsoleted: 999.0)
     public static func executableTarget(
         name: String,
@@ -718,30 +717,29 @@ public final class Target {
     /// Creates an executable target.
     ///
     /// An executable target can contain either Swift or C-family source files, but not both. It contains code that
-    /// is built as an executable module that can be used as the main target of an executable product. The target
+    /// is built as an executable module for use as the main target of an executable product. The target
     /// is expected to either have a source file named `main.swift`, `main.m`, `main.c`, or `main.cpp`, or a source
     /// file that contains the `@main` keyword.
     ///
     /// - Parameters:
     ///   - name: The name of the target.
-    ///   - group: The group this target belongs to, where access to the target's group-specific APIs is not allowed from outside. The default value is `package`.
     ///   - dependencies: The dependencies of the target. A dependency can be another target in the package or a product from a package dependency.
-    ///   - path: The custom path for the target. By default, the Swift Package Manager requires a target's sources to reside at predefined search paths;
+    ///   - path: The custom path for the target. By default, Swift Package Manager requires a target's sources to reside at predefined search paths;
     ///       for example, `[PackageRoot]/Sources/[TargetName]`.
     ///       Don't escape the package root; for example, values like `../Foo` or `/Foo` are invalid.
-    ///   - exclude: A list of paths to files or directories that the Swift Package Manager shouldn't consider to be source or resource files.
+    ///   - exclude: A list of paths to files or directories that Swift Package Manager shouldn't consider to be source or resource files.
     ///       A path is relative to the target's directory.
     ///       This parameter has precedence over the ``sources`` parameter.
     ///   - sources: An explicit list of source files. If you provide a path to a directory,
-    ///       the Swift Package Manager searches for valid source files recursively.
+    ///       Swift Package Manager searches for valid source files recursively.
     ///   - resources: An explicit list of resources files.
-    ///   - publicHeadersPath: The directory containing public headers of a C-family library target.
+    ///   - publicHeadersPath: The directory that contains public headers of a C-family library target.
     ///   - packageAccess: Allows package symbols from other targets in the package.
     ///   - cSettings: The C settings for this target.
     ///   - cxxSettings: The C++ settings for this target.
     ///   - swiftSettings: The Swift settings for this target.
     ///   - linkerSettings: The linker settings for this target.
-    ///   - plugins: The plugins used by this target
+    ///   - plugins: The plug-ins used by this target
     @available(_PackageDescription, introduced: 999.0)
     public static func executableTarget(
         name: String,
@@ -932,7 +930,7 @@ public final class Target {
     ///   - cxxSettings: The C++ settings for this target.
     ///   - swiftSettings: The Swift settings for this target.
     ///   - linkerSettings: The linker settings for this target.
-    ///   - plugins: The plugins used by this target.
+    ///   - plugins: The plug-ins used by this target.
     @available(_PackageDescription, introduced: 5.5, obsoleted: 999.0)
     public static func testTarget(
         name: String,
@@ -972,23 +970,22 @@ public final class Target {
     ///
     /// - Parameters:
     ///   - name: The name of the target.
-    ///   - group: The group this target belongs to, where access to the target's group-specific APIs is not allowed from outside. The default value is `package`.
     ///   - dependencies: The dependencies of the target. A dependency can be another target in the package or a product from a package dependency.
-    ///   - path: The custom path for the target. By default, the Swift Package Manager requires a target's sources to reside at predefined search paths;
+    ///   - path: The custom path for the target. By default, Swift Package Manager requires a target's sources to reside at predefined search paths;
     ///       for example, `[PackageRoot]/Sources/[TargetName]`.
     ///       Don't escape the package root; for example, values like `../Foo` or `/Foo` are invalid.
-    ///   - exclude: A list of paths to files or directories that the Swift Package Manager shouldn't consider to be source or resource files.
+    ///   - exclude: A list of paths to files or directories that Swift Package Manager shouldn't consider to be source or resource files.
     ///       A path is relative to the target's directory.
     ///       This parameter has precedence over the ``sources`` parameter.
     ///   - sources: An explicit list of source files. If you provide a path to a directory,
-    ///       the Swift Package Manager searches for valid source files recursively.
+    ///       Swift Package Manager searches for valid source files recursively.
     ///   - resources: An explicit list of resources files.
-    ///   - packageAccess: Allows access to package symbols from other targets in the package
+    ///   - packageAccess: Allows access to package symbols from other targets in the package.
     ///   - cSettings: The C settings for this target.
     ///   - cxxSettings: The C++ settings for this target.
     ///   - swiftSettings: The Swift settings for this target.
     ///   - linkerSettings: The linker settings for this target.
-    ///   - plugins: The plugins used by this target.
+    ///   - plugins: The plug-ins used by this target.
     @available(_PackageDescription, introduced: 999.0)
     public static func testTarget(
         name: String,
@@ -1150,8 +1147,8 @@ public final class Target {
     ///   - capability: The type of capability the plugin target provides.
     ///   - dependencies: The plugin target's dependencies.
     ///   - path: The path of the plugin target, relative to the package root.
-    ///   - exclude: The paths to source and resource files you want to exclude from the plugin target.
-    ///   - sources: The source files in the plugin target.
+    ///   - exclude: The paths to source and resource files that you want to exclude from the plug-in target.
+    ///   - sources: The source files in the plug-in target.
     /// - Returns: A `Target` instance.
     @available(_PackageDescription, introduced: 5.5, obsoleted: 999.0)
     public static func plugin(
@@ -1174,49 +1171,48 @@ public final class Target {
             pluginCapability: capability)
     }
 
-    /// Defines a new package plugin target.
+    /// Defines a new package plug-in target.
     ///
-    /// A plugin target provides custom build commands to SwiftPM (and to
+    /// A plug-in target provides custom build commands to SwiftPM (and to
     /// any IDEs based on libSwiftPM).
     ///
     /// The capability determines what kind of build commands it can add. Besides
     /// determining at what point in the build those commands run, the capability
-    /// determines the context that is available to the plugin and the kinds of
+    /// determines the context that is available to the plug-in and the kinds of
     /// commands it can create.
     ///
     /// In the initial version of this proposal, three capabilities are provided:
-    /// prebuild, build tool, and postbuild. See the declaration of each capability
-    /// under ``PluginCapability-swift.enum`` for more information.
+    /// prebuild, build tool, and postbuild. For more information, see the declaration of each capability
+    /// under ``PluginCapability-swift.enum``.
     ///
-    /// The package plugin itself is implemented using a Swift script that is
+    /// The package plug-in itself is implemented using a Swift script that is
     /// invoked for each target that uses it. The script is invoked after the
     /// package graph has been resolved, but before the build system creates its
-    /// dependency graph. It is also invoked after changes to the target or the
+    /// dependency graph. It's also invoked after changes to the target or the
     /// build parameters.
     ///
-    /// Note that the role of the package plugin is only to define the commands
-    /// that will run before, during, or after the build. It does not itself run
-    /// those commands. The commands are defined in an IDE-neutral way, and are
+    /// Note that the role of the package plug-in is only to define the commands
+    /// that run before, during, or after the build. It doesn't run
+    /// those commands itself. The commands are defined in an IDE-neutral way, and are
     /// run as appropriate by the build system that builds the package. The extension
     /// itself is only a procedural way of generating commands and their input
     /// and output dependencies.
     ///
-    /// The package plugin may specify the executable targets or binary targets
-    /// that provide the build tools that will be used by the generated commands
+    /// The package plug-in may specify the executable or binary targets
+    /// that provide the build tools used by the generated commands
     /// during the build. In the initial implementation, prebuild actions can only
-    /// depend on binary targets. Build tool and postbuild plugins can depend
+    /// depend on binary targets. Build tool and postbuild plug-ins can depend
     /// on executables as well as binary targets. This is due to how
     /// Swift Package Manager constructs its build plan.
     ///
     /// - Parameters:
-    ///   - name: The name of the plugin target.
-    ///   - group: The group this target belongs to, where access to the target's group-specific APIs is not allowed from outside. The default value is `package`.
-    ///   - capability: The type of capability the plugin target provides.
-    ///   - dependencies: The plugin target's dependencies.
-    ///   - path: The path of the plugin target, relative to the package root.
-    ///   - exclude: The paths to source and resource files you want to exclude from the plugin target.
-    ///   - sources: The source files in the plugin target.
-    ///   - packageAccess: Allows access to package symbols from other targets in the package
+    ///   - name: The name of the plug-in target.
+    ///   - capability: The type of capability the plug-in target provides.
+    ///   - dependencies: The plug-in target's dependencies.
+    ///   - path: The path of the plug-in target relative to the package root.
+    ///   - exclude: The paths to source and resource files that you want to exclude from the plug-in target.
+    ///   - sources: The source files in the plug-in target.
+    ///   - packageAccess: Allows access to package symbols from other targets in the package.
     /// - Returns: A `Target` instance.
     @available(_PackageDescription, introduced: 999.0)
     public static func plugin(
@@ -1406,40 +1402,40 @@ public struct TargetDependencyCondition {
 
 extension Target.PluginCapability {
     
-    /// The plugin is a build tool.
+    /// The plug-in is a build tool.
     ///
-    /// The plugin will be applied to each target that uses it and should create commands
-    /// that will run before or during the build of the target.
+    /// The plug-in to apply to each target that uses it, and creates commands
+    /// that run before or during the build of the target.
     ///
-    ///  - Returns: A plugin capability that defines a build tool.
+    ///  - Returns: A plug-in capability that defines a build tool.
     @available(_PackageDescription, introduced: 5.5)
     public static func buildTool() -> Target.PluginCapability {
         return .buildTool
     }
 }
 
-/// The intended use case of the command plugin.
+/// The intended use case of the command plug-in.
 @available(_PackageDescription, introduced: 5.6)
 public enum PluginCommandIntent {
-    /// The plugin generates documentation.
+    /// The plug-in generates documentation.
     ///
-    /// The intent of the command is to generate documentation, either by parsing the
+    /// The command used to generate documentation, either by parsing the
     /// package contents directly or by using the build system support for generating
     /// symbol graphs. Invoked by a `generate-documentation` verb to `swift package`.
     case documentationGeneration
 
-    /// The plugin formats source code.
+    /// The plug-in formats source code.
     ///
-    /// The intent of the command is to modify the source code in the package based
+    /// The command used to modify the source code in the package based
     /// on a set of rules. Invoked by a `format-source-code` verb to `swift package`.
     case sourceCodeFormatting
 
-    /// A custom command plugin intent.
+    /// A custom command plug-in intent.
     ///
-    ///  Use this case when none of the predefined cases fit the role of the plugin.
+    ///  Use this case when none of the predefined cases fulfill the role of the plug-in.
     ///  - Parameters:
-    ///    - verb: The invocation verb of the plugin.
-    ///    - description: A human readable description of the plugin's role.
+    ///    - verb: The invocation verb of the plug-in.
+    ///    - description: A human readable description of the plug-in's role.
     case custom(verb: String, description: String)
 }
 
@@ -1456,7 +1452,7 @@ public extension PluginCommandIntent {
         return documentationGeneration
     }
 
-    /// The plugin formats source code.
+    /// The plug-in formats source code.
     ///
     /// The intent of the command is to modify the source code in the package based
     /// on a set of rules. Invoked by a `format-source-code` verb to `swift package`.
@@ -1467,26 +1463,26 @@ public extension PluginCommandIntent {
     }
 }
 
-/// The type of permission a plugin requires.
+/// The type of permission a plug-in requires.
 ///
 /// Supported types are ``allowNetworkConnections(scope:reason:)`` and ``writeToPackageDirectory(reason:)``.
 @available(_PackageDescription, introduced: 5.6)
 public enum PluginPermission {
     /// Create a permission to make network connections.
     ///
-    /// The command plugin wants permission to make network connections. The `reason` string is shown
-    /// to the user at the time of request for approval, explaining why the plugin is requesting this access.
+    /// The command plug-in requires permission to make network connections. The `reason` string is shown
+    /// to the user at the time of request for approval, explaining why the plug-in is requesting access.
     ///   - Parameter scope: The scope of the permission.
-    ///   - Parameter reason: A reason why the permission is needed. This will be shown to the user.
+    ///   - Parameter reason: A reason why the permission is needed. This is shown to the user when permission is sought.
     @available(_PackageDescription, introduced: 5.9)
     case allowNetworkConnections(scope: PluginNetworkPermissionScope, reason: String)
 
     /// Create a permission to modify files in the package's directory.
     ///
-    /// The command plugin wants permission to modify the files under the package
+    /// The command plug-in requires permission to modify the files under the package
     /// directory. The `reason` string is shown to the user at the time of request
-    /// for approval, explaining why the plugin is requesting this access.
-    ///   - Parameter reason: A reason why the permission is needed. This will be shown to the user.
+    /// for approval, explaining why the plug-in requests access.
+    ///   - Parameter reason: A reason why the permission is needed. This is shown to the user when permission is sought.
     case writeToPackageDirectory(reason: String)
 }
 
@@ -1495,13 +1491,13 @@ public enum PluginPermission {
 public enum PluginNetworkPermissionScope {
     /// Do not allow network access.
     case none
-    /// Allow local network connections, can be limited to a list of allowed ports.
+    /// Allow local network connections; can be limited to a list of allowed ports.
     case local(ports: [UInt8] = [])
-    /// Allow local and outgoing network connections, can be limited to a list of allowed ports.
+    /// Allow local and outgoing network connections; can be limited to a list of allowed ports.
     case all(ports: [UInt8] = [])
-    /// Allow connections to Docker through unix domain sockets.
+    /// Allow connections to Docker through UNIX domain sockets.
     case docker
-    /// Allow connections to any unix domain socket.
+    /// Allow connections to any UNIX domain socket.
     case unixDomainSocket
 
     /// Allow local and outgoing network connections, limited to a range of allowed ports.
@@ -1509,7 +1505,7 @@ public enum PluginNetworkPermissionScope {
         return .all(ports: Array(ports))
     }
 
-    /// Allow local network connections,  limited to a range of allowed ports.
+    /// Allow local network connections, limited to a range of allowed ports.
     public static func local(ports: Range<UInt8>) -> PluginNetworkPermissionScope {
         return .local(ports: Array(ports))
     }
@@ -1552,3 +1548,4 @@ extension Target.PluginUsage: ExpressibleByStringLiteral {
         self = .plugin(name: value, package: nil)
     }
 }
+

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -551,7 +551,7 @@ public final class Target {
     ///
     /// - Parameters:
     ///   - name: The name of the target.
-    ///   - group: The group this target belongs to, where access to the target's group-specific APIs is not allowed from outside (package by default).
+    ///   - group: The group this target belongs to, where access to the target's group-specific APIs is not allowed from outside. The default value is `package`.
     ///   - dependencies: The dependencies of the target. A dependency can be another target in the package or a product from a package dependency.
     ///   - path: The custom path for the target. By default, the Swift Package Manager requires a target's sources to reside at predefined search paths;
     ///       for example, `[PackageRoot]/Sources/[TargetName]`.
@@ -724,7 +724,7 @@ public final class Target {
     ///
     /// - Parameters:
     ///   - name: The name of the target.
-    ///   - group: The group this target belongs to, where access to the target's group-specific APIs is not allowed from outside (package by default).
+    ///   - group: The group this target belongs to, where access to the target's group-specific APIs is not allowed from outside. The default value is `package`.
     ///   - dependencies: The dependencies of the target. A dependency can be another target in the package or a product from a package dependency.
     ///   - path: The custom path for the target. By default, the Swift Package Manager requires a target's sources to reside at predefined search paths;
     ///       for example, `[PackageRoot]/Sources/[TargetName]`.
@@ -972,7 +972,7 @@ public final class Target {
     ///
     /// - Parameters:
     ///   - name: The name of the target.
-    ///   - group: The group this target belongs to, where access to the target's group-specific APIs is not allowed from outside (package by default).
+    ///   - group: The group this target belongs to, where access to the target's group-specific APIs is not allowed from outside. The default value is `package`.
     ///   - dependencies: The dependencies of the target. A dependency can be another target in the package or a product from a package dependency.
     ///   - path: The custom path for the target. By default, the Swift Package Manager requires a target's sources to reside at predefined search paths;
     ///       for example, `[PackageRoot]/Sources/[TargetName]`.
@@ -1210,7 +1210,7 @@ public final class Target {
     ///
     /// - Parameters:
     ///   - name: The name of the plugin target.
-    ///   - group: The group this target belongs to, where access to the target's group-specific APIs is not allowed from outside (package by default).
+    ///   - group: The group this target belongs to, where access to the target's group-specific APIs is not allowed from outside. The default value is `package`.
     ///   - capability: The type of capability the plugin target provides.
     ///   - dependencies: The plugin target's dependencies.
     ///   - path: The path of the plugin target, relative to the package root.
@@ -1406,7 +1406,7 @@ public struct TargetDependencyCondition {
 
 extension Target.PluginCapability {
     
-    /// Specifies that the plugin provides a build tool capability.
+    /// The plugin is a build tool.
     ///
     /// The plugin will be applied to each target that uses it and should create commands
     /// that will run before or during the build of the target.
@@ -1490,7 +1490,7 @@ public enum PluginPermission {
     case writeToPackageDirectory(reason: String)
 }
 
-/// The scope of a network permission. This can be none, local connections only or all connections.
+/// The scope of a network permission. This can be none, local connections only, or all connections.
 @available(_PackageDescription, introduced: 5.9)
 public enum PluginNetworkPermissionScope {
     /// Do not allow network access.
@@ -1504,7 +1504,7 @@ public enum PluginNetworkPermissionScope {
     /// Allow connections to any unix domain socket.
     case unixDomainSocket
 
-    /// Allow local and outgoing network connections,  limited to a range of allowed ports.
+    /// Allow local and outgoing network connections, limited to a range of allowed ports.
     public static func all(ports: Range<UInt8>) -> PluginNetworkPermissionScope {
         return .all(ports: Array(ports))
     }


### PR DESCRIPTION
Cherry-pick documentation updates from `main` into `release/5.9`

### Motivation:

I made documentation updates in `main` in 942a1e8 and 7a8f7f6, and now those need to migrate into `release/5.9`.

### Modifications:

I cherry-picked 942a1e8 and 7a8f7f6 from `main`.

### Result:

Only DocC documentation should change, and only in `Source/PackageDescription/`.
