### PR TITLE
[5.9] 🍒Allow enabling C++ interop without explicit version (#6416)

### DIFF
--- a/Sources/PackageDescription/BuildSettings.swift
+++ b/Sources/PackageDescription/BuildSettings.swift
@@ -377,8 +377,8 @@ public struct SwiftSetting {
     ///
     /// - Parameters:
     ///   - mode: The language mode, either C or CXX.
-    ///   - version: When using the CXX language mode, pass the version of Swift and C++
-    /// interoperability; otherwise, `nil`.
+    ///   - version: When using the CXX language mode, pass either the version
+    /// of Swift and C++ interoperability or `nil`; otherwise, `nil`.
     ///   - condition: A condition that restricts the application of the build
     /// setting.
     @available(_PackageDescription, introduced: 5.9)

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -1089,14 +1089,7 @@ public final class PackageBuilder {
                     // `version` is the compatibility version of Swift/C++ interop,
                     // which is meant to preserve source compatibility for
                     // user projects while Swift/C++ interop is evolving.
-                    // At the moment the only supported interop version is
-                    // `swift-5.9` which is aligned with the version of
-                    // Swift itself, but this might not always be the case
-                    // in the future.
-                    guard let version else {
-                        throw InternalError("C++ interoperability requires a version (e.g. 'swift-5.9')")
-                    }
-                    values = ["-cxx-interoperability-mode=\(version)"]
+                    values = ["-cxx-interoperability-mode=\(version ?? "default")"]
                 } else {
                     values = []
                 }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -3299,7 +3299,8 @@ final class BuildPlanTests: XCTestCase {
                     name: "exe", dependencies: ["bar"],
                     settings: [
                         .init(tool: .swift, kind: .define("FOO")),
-                        .init(tool: .swift, kind: .interoperabilityMode(.C, nil)),
+                        .init(tool: .swift, kind: .interoperabilityMode(.C, nil), condition: .init(platformNames: ["linux"])),
+                        .init(tool: .swift, kind: .interoperabilityMode(.Cxx, nil), condition: .init(platformNames: ["macos"])),
                         .init(tool: .linker, kind: .linkedLibrary("sqlite3")),
                         .init(tool: .linker, kind: .linkedFramework("CoreData"), condition: .init(platformNames: ["macos"])),
                         .init(tool: .linker, kind: .unsafeFlags(["-Ilfoo", "-L", "lbar"])),
@@ -3377,7 +3378,7 @@ final class BuildPlanTests: XCTestCase {
             XCTAssertMatch(bar, [.anySequence, "-DDMACOS", "-Isfoo", "-L", "sbar", "-cxx-interoperability-mode=swift-6.0", "-enable-upcoming-feature", "BestFeature", "-enable-upcoming-feature", "WorstFeature", .end])
 
             let exe = try result.target(for: "exe").swiftTarget().compileArguments()
-            XCTAssertMatch(exe, [.anySequence, "-DFOO", .end])
+            XCTAssertMatch(exe, [.anySequence, "-DFOO", "-cxx-interoperability-mode=default", .end])
 
             let linkExe = try result.buildProduct(for: "exe").linkArguments()
             XCTAssertMatch(linkExe, [.anySequence, "-lsqlite3", "-llibz", "-framework", "CoreData", "-framework", "best", "-Ilfoo", "-L", "lbar", .anySequence])


### PR DESCRIPTION
The Swift compiler now supports `-cxx-interoperability-mode=default` flag.

This change makes sure SwiftPM accepts `nil` as a version of Swift/C++ interoperability.

rdar://107908465

(cherry picked from commit a54a87f4dec65ca958bb53a637fc3bdf54856cba)