### PR TITLE
move Product, SwiftPMProductError from TSC to SwiftPM

### DIFF
--- a/Fixtures/Miscellaneous/SkipTests/.gitignore
+++ b/Fixtures/Miscellaneous/SkipTests/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj

--- a/Fixtures/Miscellaneous/SkipTests/Package.swift
+++ b/Fixtures/Miscellaneous/SkipTests/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "Example",
+    targets: [
+        .target(
+            name: "Example",
+            dependencies: []),
+        .testTarget(
+            name: "ExampleTests",
+            dependencies: ["Example"]),
+    ]
+)

--- a/Fixtures/Miscellaneous/SkipTests/Sources/Example/Example.swift
+++ b/Fixtures/Miscellaneous/SkipTests/Sources/Example/Example.swift
@@ -1,0 +1,4 @@
+struct Example {
+    var text = "Hello, World!"
+    var bool = false
+}

--- a/Fixtures/Miscellaneous/SkipTests/Tests/ExampleTests/MoreTests.swift
+++ b/Fixtures/Miscellaneous/SkipTests/Tests/ExampleTests/MoreTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import Example
+
+class MoreTests: XCTestCase {
+    func testExample3() {
+      XCTAssertEqual(Example().text, "Hello, World!")
+    }
+
+    func testExample4() {
+        XCTAssertEqual(Example().bool, false)
+    }
+}

--- a/Fixtures/Miscellaneous/SkipTests/Tests/ExampleTests/Tests.swift
+++ b/Fixtures/Miscellaneous/SkipTests/Tests/ExampleTests/Tests.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import Example
+
+class SomeTests: XCTestCase {
+    func testExample1() {
+        XCTAssertEqual(Example().text, "Hello, World!")
+    }
+
+    func testExample2() {
+        XCTAssertEqual(Example().bool, false)
+    }
+}

--- a/Sources/SPMTestSupport/SwiftPMProduct.swift
+++ b/Sources/SPMTestSupport/SwiftPMProduct.swift
@@ -10,33 +10,144 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TSCBasic
+import struct TSCBasic.AbsolutePath
+import var TSCBasic.localFileSystem
+import class TSCBasic.Process
+import struct TSCBasic.ProcessResult
+import struct TSCBasic.RelativePath
 
-@_exported import TSCTestSupport
+import Foundation
 
-public enum SwiftPMProduct: Product {
-    case SwiftBuild
-    case SwiftPackage
-    case SwiftPackageRegistry
-    case SwiftTest
-    case SwiftRun
+/// Defines the executables used by SwiftPM.
+/// Contains path to the currently built executable and
+/// helper method to execute them.
+public enum SwiftPM {
+    case Build
+    case Package
+    case Registry
+    case Test
+    case Run
     case XCTestHelper
+}
 
+extension SwiftPM {
     /// Executable name.
-    public var exec: RelativePath {
+    private var executableName: RelativePath {
         switch self {
-        case .SwiftBuild:
-            return RelativePath("swift-build")
-        case .SwiftPackage:
-            return RelativePath("swift-package")
-        case .SwiftPackageRegistry:
-            return RelativePath("swift-package-registry")
-        case .SwiftTest:
-            return RelativePath("swift-test")
-        case .SwiftRun:
-            return RelativePath("swift-run")
+        case .Build:
+            return "swift-build"
+        case .Package:
+            return "swift-package"
+        case .Registry:
+            return "swift-package-registry"
+        case .Test:
+            return "swift-test"
+        case .Run:
+            return "swift-run"
         case .XCTestHelper:
-            return RelativePath("swiftpm-xctest-helper")
+            return "swiftpm-xctest-helper"
         }
     }
+
+    /// Path to currently built binary.
+    public var path: AbsolutePath {
+        #if canImport(Darwin)
+        for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
+            return try! AbsolutePath(AbsolutePath(validating: bundle.bundlePath).parentDirectory, self.executableName)
+        }
+        fatalError()
+        #else
+        return try! AbsolutePath(CommandLine.arguments.first!, relativeTo: localFileSystem.currentWorkingDirectory!)
+            .parentDirectory.appending(self.executableName)
+        #endif
+    }
+}
+
+extension SwiftPM {
+    /// Executes the product with specified arguments.
+    ///
+    /// - Parameters:
+    ///         - args: The arguments to pass.
+    ///         - env: Additional environment variables to pass. The values here are merged with default env.
+    ///         - packagePath: Adds argument `--package-path <path>` if not nil.
+    ///
+    /// - Returns: The output of the process.
+    @discardableResult
+    public func execute(
+        _ args: [String] = [],
+        packagePath: AbsolutePath? = nil,
+        env: [String: String]? = nil
+    ) throws -> (stdout: String, stderr: String) {
+        let result = try executeProcess(
+            args,
+            packagePath: packagePath,
+            env: env
+        )
+        
+        let stdout = try result.utf8Output()
+        let stderr = try result.utf8stderrOutput()
+        
+        if result.exitStatus == .terminated(code: 0) {
+            return (stdout: stdout, stderr: stderr)
+        }
+        throw SwiftPMError.executionFailure(
+            underlying: ProcessResult.Error.nonZeroExit(result),
+            stdout: stdout,
+            stderr: stderr
+        )
+    }
+    
+    private func executeProcess(
+        _ args: [String],
+        packagePath: AbsolutePath? = nil,
+        env: [String: String]? = nil
+    ) throws -> ProcessResult {
+        var environment = ProcessInfo.processInfo.environment
+        for (key, value) in env ?? [:] {
+            environment[key] = value
+        }
+#if Xcode
+        // Unset these variables which causes issues when running tests via Xcode.
+        environment["XCTestConfigurationFilePath"] = nil
+        environment["XCTestSessionIdentifier"] = nil
+        environment["XCTestBundlePath"] = nil
+        environment["NSUnbufferedIO"] = nil
+#endif
+        // FIXME: We use this private environment variable hack to be able to
+        // create special conditions in swift-build for swiftpm tests.
+        environment["SWIFTPM_TESTS_MODULECACHE"] = self.path.parentDirectory.pathString
+#if !os(Windows)
+        environment["SDKROOT"] = nil
+#endif
+        
+        // Unset the internal env variable that allows skipping certain tests.
+        environment["_SWIFTPM_SKIP_TESTS_LIST"] = nil
+        
+        var completeArgs = [self.path.pathString]
+        if let packagePath = packagePath {
+            completeArgs += ["--package-path", packagePath.pathString]
+        }
+        completeArgs += args
+        
+        return try Process.popen(arguments: completeArgs, environment: environment)
+    }
+}
+
+extension SwiftPM {
+    public static func packagePath(for packageName: String, packageRoot: AbsolutePath) throws -> AbsolutePath {
+        // FIXME: The directory paths are hard coded right now and should be replaced by --get-package-path
+        // whenever we design that. https://bugs.swift.org/browse/SR-2753
+        let packagesPath = packageRoot.appending(components: ".build", "checkouts")
+        for name in try localFileSystem.getDirectoryContents(packagesPath) {
+            if name.hasPrefix(packageName) {
+                return try AbsolutePath(validating: name, relativeTo: packagesPath)
+            }
+        }
+        throw SwiftPMError.packagePathNotFound
+    }
+}
+
+public enum SwiftPMError: Error {
+    case packagePathNotFound
+    case executionFailure(underlying: Error, stdout: String, stderr: String)
 }

--- a/Sources/SPMTestSupport/XCTAssertHelpers.swift
+++ b/Sources/SPMTestSupport/XCTAssertHelpers.swift
@@ -118,7 +118,7 @@ public func XCTAssertThrowsCommandExecutionError<T>(
     _ errorHandler: (_ error: CommandExecutionError) -> Void = { _ in }
 ) {
     XCTAssertThrowsError(try expression(), message(), file: file, line: line) { error in
-        guard case SwiftPMProductError.executionFailure(let processError, let stdout, let stderr) = error,
+        guard case SwiftPMError.executionFailure(let processError, let stdout, let stderr) = error,
               case ProcessResult.Error.nonZeroExit(let processResult) = processError,
               processResult.exitStatus != .terminated(code: 0) else {
             return XCTFail("Unexpected error type: \(error.interpolationDescription)", file: file, line: line)

--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -98,7 +98,7 @@ public func fixture(
                 try body(tmpDirPath)
             }
         }
-    } catch SwiftPMProductError.executionFailure(let error, let output, let stderr) {
+    } catch SwiftPMError.executionFailure(let error, let output, let stderr) {
         print("**** FAILURE EXECUTING SUBPROCESS ****")
         print("output:", output)
         print("stderr:", stderr)
@@ -159,7 +159,7 @@ public func executeSwiftBuild(
     env: EnvironmentVariables? = nil
 ) throws -> (stdout: String, stderr: String) {
     let args = swiftArgs(configuration: configuration, extraArgs: extraArgs, Xcc: Xcc, Xld: Xld, Xswiftc: Xswiftc)
-    return try SwiftPMProduct.SwiftBuild.execute(args, packagePath: packagePath, env: env)
+    return try SwiftPM.Build.execute(args, packagePath: packagePath, env: env)
 }
 
 @discardableResult
@@ -175,7 +175,7 @@ public func executeSwiftRun(
 ) throws -> (stdout: String, stderr: String) {
     var args = swiftArgs(configuration: configuration, extraArgs: extraArgs, Xcc: Xcc, Xld: Xld, Xswiftc: Xswiftc)
     args.append(executable)
-    return try SwiftPMProduct.SwiftRun.execute(args, packagePath: packagePath, env: env)
+    return try SwiftPM.Run.execute(args, packagePath: packagePath, env: env)
 }
 
 @discardableResult
@@ -189,7 +189,7 @@ public func executeSwiftPackage(
     env: EnvironmentVariables? = nil
 ) throws -> (stdout: String, stderr: String) {
     let args = swiftArgs(configuration: configuration, extraArgs: extraArgs, Xcc: Xcc, Xld: Xld, Xswiftc: Xswiftc)
-    return try SwiftPMProduct.SwiftPackage.execute(args, packagePath: packagePath, env: env)
+    return try SwiftPM.Package.execute(args, packagePath: packagePath, env: env)
 }
 
 @discardableResult
@@ -203,7 +203,7 @@ public func executeSwiftTest(
     env: EnvironmentVariables? = nil
 ) throws -> (stdout: String, stderr: String) {
     let args = swiftArgs(configuration: configuration, extraArgs: extraArgs, Xcc: Xcc, Xld: Xld, Xswiftc: Xswiftc)
-    return try SwiftPMProduct.SwiftTest.execute(args, packagePath: packagePath, env: env)
+    return try SwiftPM.Test.execute(args, packagePath: packagePath, env: env)
 }
 
 private func swiftArgs(

--- a/Tests/CommandsTests/APIDiffTests.swift
+++ b/Tests/CommandsTests/APIDiffTests.swift
@@ -34,7 +34,7 @@ final class APIDiffTests: CommandsTestCase {
         var environment = env ?? [:]
         // don't ignore local packages when caching
         environment["SWIFTPM_TESTS_PACKAGECACHE"] = "1"
-        return try SwiftPMProduct.SwiftPackage.execute(args, packagePath: packagePath, env: environment)
+        return try SwiftPM.Package.execute(args, packagePath: packagePath, env: environment)
     }
 
     func skipIfApiDigesterUnsupportedOrUnset() throws {

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -26,18 +26,18 @@ import XCTest
 final class PackageToolTests: CommandsTestCase {
     @discardableResult
     private func execute(
-        _ args: [String],
+        _ args: [String] = [],
         packagePath: AbsolutePath? = nil,
         env: EnvironmentVariables? = nil
     ) throws -> (stdout: String, stderr: String) {
         var environment = env ?? [:]
         // don't ignore local packages when caching
         environment["SWIFTPM_TESTS_PACKAGECACHE"] = "1"
-        return try SwiftPMProduct.SwiftPackage.execute(args, packagePath: packagePath, env: environment)
+        return try SwiftPM.Package.execute(args, packagePath: packagePath, env: environment)
     }
 
     func testNoParameters() throws {
-        let stdout = try execute([]).stdout
+        let stdout = try execute().stdout
         XCTAssertMatch(stdout, .contains("USAGE: swift package"))
     }
 
@@ -45,7 +45,7 @@ final class PackageToolTests: CommandsTestCase {
         do {
             _ = try execute(["-help"])
             XCTFail("expecting `execute` to fail")
-        } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
+        } catch SwiftPMError.executionFailure(_, _, let stderr) {
             XCTAssertMatch(stderr, .contains("Usage: swift package"))
         } catch {
             throw error
@@ -248,7 +248,7 @@ final class PackageToolTests: CommandsTestCase {
 
             // Check that `resolve` works.
             _ = try execute(["resolve"], packagePath: packageRoot)
-            let path = try SwiftPMProduct.packagePath(for: "Foo", packageRoot: packageRoot)
+            let path = try SwiftPM.packagePath(for: "Foo", packageRoot: packageRoot)
             XCTAssertEqual(try GitRepository(path: path).getTags(), ["1.2.3"])
         }
     }
@@ -259,7 +259,7 @@ final class PackageToolTests: CommandsTestCase {
 
             // Perform an initial fetch.
             _ = try execute(["resolve"], packagePath: packageRoot)
-            var path = try SwiftPMProduct.packagePath(for: "Foo", packageRoot: packageRoot)
+            var path = try SwiftPM.packagePath(for: "Foo", packageRoot: packageRoot)
             XCTAssertEqual(try GitRepository(path: path).getTags(), ["1.2.3"])
 
             // Retag the dependency, and update.
@@ -268,7 +268,7 @@ final class PackageToolTests: CommandsTestCase {
             _ = try execute(["update"], packagePath: packageRoot)
 
             // We shouldn't assume package path will be same after an update so ask again for it.
-            path = try SwiftPMProduct.packagePath(for: "Foo", packageRoot: packageRoot)
+            path = try SwiftPM.packagePath(for: "Foo", packageRoot: packageRoot)
             XCTAssertEqual(try GitRepository(path: path).getTags(), ["1.2.3", "1.2.4"])
         }
     }
@@ -308,8 +308,7 @@ final class PackageToolTests: CommandsTestCase {
     func testDescribe() throws {
         try fixture(name: "Miscellaneous/ExeTest") { fixturePath in
             // Generate the JSON description.
-            let jsonResult = try SwiftPMProduct.SwiftPackage.executeProcess(["describe", "--type=json"], packagePath: fixturePath)
-            let jsonOutput = try jsonResult.utf8Output()
+            let (jsonOutput, _) = try SwiftPM.Package.execute(["describe", "--type=json"], packagePath: fixturePath)
             let json = try JSON(bytes: ByteString(encodingAsUTF8: jsonOutput))
 
             // Check that tests don't appear in the product memberships.
@@ -322,8 +321,7 @@ final class PackageToolTests: CommandsTestCase {
 
         try fixture(name: "CFamilyTargets/SwiftCMixed") { fixturePath in
             // Generate the JSON description.
-            let jsonResult = try SwiftPMProduct.SwiftPackage.executeProcess(["describe", "--type=json"], packagePath: fixturePath)
-            let jsonOutput = try jsonResult.utf8Output()
+            let (jsonOutput, _) = try SwiftPM.Package.execute(["describe", "--type=json"], packagePath: fixturePath)
             let json = try JSON(bytes: ByteString(encodingAsUTF8: jsonOutput))
 
             // Check that the JSON description contains what we expect it to.
@@ -350,8 +348,7 @@ final class PackageToolTests: CommandsTestCase {
             XCTAssertEqual(jsonTarget2["product_memberships"]?.array?[0].stringValue, "CExec")
 
             // Generate the text description.
-            let textResult = try SwiftPMProduct.SwiftPackage.executeProcess(["describe", "--type=text"], packagePath: fixturePath)
-            let textOutput = try textResult.utf8Output()
+            let (textOutput, _) = try SwiftPM.Package.execute(["describe", "--type=text"], packagePath: fixturePath)
             let textChunks = textOutput.components(separatedBy: "\n").reduce(into: [""]) { chunks, line in
                 // Split the text into chunks based on presence or absence of leading whitespace.
                 if line.hasPrefix(" ") == chunks[chunks.count-1].hasPrefix(" ") {
@@ -405,8 +402,7 @@ final class PackageToolTests: CommandsTestCase {
 
         try fixture(name: "DependencyResolution/External/Simple/Bar") { fixturePath in
             // Generate the JSON description.
-            let jsonResult = try SwiftPMProduct.SwiftPackage.executeProcess(["describe", "--type=json"], packagePath: fixturePath)
-            let jsonOutput = try jsonResult.utf8Output()
+            let (jsonOutput, _) = try SwiftPM.Package.execute(["describe", "--type=json"], packagePath: fixturePath)
             let json = try JSON(bytes: ByteString(encodingAsUTF8: jsonOutput))
 
             // Check that product dependencies and memberships are as expected.
@@ -422,9 +418,8 @@ final class PackageToolTests: CommandsTestCase {
     func testDescribePackageUsingPlugins() throws {
         try fixture(name: "Miscellaneous/Plugins/MySourceGenPlugin") { fixturePath in
             // Generate the JSON description.
-            let result = try SwiftPMProduct.SwiftPackage.executeProcess(["describe", "--type=json"], packagePath: fixturePath)
-            XCTAssert(result.exitStatus == .terminated(code: 0), "`swift-package describe` failed: \(String(describing: try? result.utf8stderrOutput()))")
-            let json = try JSON(bytes: ByteString(encodingAsUTF8: result.utf8Output()))
+            let (stdout, _) = try SwiftPM.Package.execute(["describe", "--type=json"], packagePath: fixturePath)
+            let json = try JSON(bytes: ByteString(encodingAsUTF8: stdout))
 
             // Check the contents of the JSON.
             XCTAssertEqual(try XCTUnwrap(json["name"]).string, "MySourceGenPlugin")
@@ -479,7 +474,7 @@ final class PackageToolTests: CommandsTestCase {
 
         let arguments = withPrettyPrinting ? ["dump-symbol-graph", "--pretty-print"] : ["dump-symbol-graph"]
 
-        _ = try SwiftPMProduct.SwiftPackage.executeProcess(arguments, packagePath: path, env: ["SWIFT_SYMBOLGRAPH_EXTRACT": symbolGraphExtractorPath.pathString])
+        _ = try SwiftPM.Package.execute(arguments, packagePath: path, env: ["SWIFT_SYMBOLGRAPH_EXTRACT": symbolGraphExtractorPath.pathString])
         let enumerator = try XCTUnwrap(FileManager.default.enumerator(at: URL(fileURLWithPath: path.pathString), includingPropertiesForKeys: nil), file: file, line: line)
 
         var symbolGraphURL: URL?
@@ -521,10 +516,10 @@ final class PackageToolTests: CommandsTestCase {
     func testShowDependencies() throws {
         try fixture(name: "DependencyResolution/External/Complex") { fixturePath in
             let packageRoot = fixturePath.appending("app")
-            let textOutput = try SwiftPMProduct.SwiftPackage.executeProcess(["show-dependencies", "--format=text"], packagePath: packageRoot).utf8Output()
+            let (textOutput, _) = try SwiftPM.Package.execute(["show-dependencies", "--format=text"], packagePath: packageRoot)
             XCTAssert(textOutput.contains("FisherYates@1.2.3"))
 
-            let jsonOutput = try SwiftPMProduct.SwiftPackage.executeProcess(["show-dependencies", "--format=json"], packagePath: packageRoot).utf8Output()
+            let (jsonOutput, _) = try SwiftPM.Package.execute(["show-dependencies", "--format=json"], packagePath: packageRoot)
             let json = try JSON(bytes: ByteString(encodingAsUTF8: jsonOutput))
             guard case let .dictionary(contents) = json else { XCTFail("unexpected result"); return }
             guard case let .string(name)? = contents["name"] else { XCTFail("unexpected result"); return }
@@ -760,12 +755,12 @@ final class PackageToolTests: CommandsTestCase {
         try fixture(name: "Miscellaneous/PackageEdit") { fixturePath in
             let fooPath = fixturePath.appending("foo")
             func build() throws -> (stdout: String, stderr: String) {
-                return try SwiftPMProduct.SwiftBuild.execute([], packagePath: fooPath)
+                return try SwiftPM.Build.execute(packagePath: fooPath)
             }
 
             // Put bar and baz in edit mode.
-            _ = try SwiftPMProduct.SwiftPackage.execute(["edit", "bar", "--branch", "bugfix"], packagePath: fooPath)
-            _ = try SwiftPMProduct.SwiftPackage.execute(["edit", "baz", "--branch", "bugfix"], packagePath: fooPath)
+            _ = try SwiftPM.Package.execute(["edit", "bar", "--branch", "bugfix"], packagePath: fooPath)
+            _ = try SwiftPM.Package.execute(["edit", "baz", "--branch", "bugfix"], packagePath: fooPath)
 
             // Path to the executable.
             let exec = [fooPath.appending(components: ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug", "foo").pathString]
@@ -792,7 +787,7 @@ final class PackageToolTests: CommandsTestCase {
 
             // It shouldn't be possible to unedit right now because of uncommited changes.
             do {
-                _ = try SwiftPMProduct.SwiftPackage.execute(["unedit", "bar"], packagePath: fooPath)
+                _ = try SwiftPM.Package.execute(["unedit", "bar"], packagePath: fooPath)
                 XCTFail("Unexpected unedit success")
             } catch {}
 
@@ -801,7 +796,7 @@ final class PackageToolTests: CommandsTestCase {
 
             // It shouldn't be possible to unedit right now because of unpushed changes.
             do {
-                _ = try SwiftPMProduct.SwiftPackage.execute(["unedit", "bar"], packagePath: fooPath)
+                _ = try SwiftPM.Package.execute(["unedit", "bar"], packagePath: fooPath)
                 XCTFail("Unexpected unedit success")
             } catch {}
 
@@ -809,11 +804,11 @@ final class PackageToolTests: CommandsTestCase {
             try editsRepo.push(remote: "origin", branch: "bugfix")
 
             // We should be able to unedit now.
-            _ = try SwiftPMProduct.SwiftPackage.execute(["unedit", "bar"], packagePath: fooPath)
+            _ = try SwiftPM.Package.execute(["unedit", "bar"], packagePath: fooPath)
 
             // Test editing with a path i.e. ToT development.
             let bazTot = fixturePath.appending("tot")
-            try SwiftPMProduct.SwiftPackage.execute(["edit", "baz", "--path", bazTot.pathString], packagePath: fooPath)
+            try SwiftPM.Package.execute(["edit", "baz", "--path", bazTot.pathString], packagePath: fooPath)
             XCTAssertTrue(localFileSystem.exists(bazTot))
             XCTAssertTrue(localFileSystem.isSymlink(bazEditsPath))
 
@@ -824,12 +819,12 @@ final class PackageToolTests: CommandsTestCase {
             try localFileSystem.writeFileContents(bazTotPackageFile, string: content)
 
             // Unediting baz will remove the symlink but not the checked out package.
-            try SwiftPMProduct.SwiftPackage.execute(["unedit", "baz"], packagePath: fooPath)
+            try SwiftPM.Package.execute(["unedit", "baz"], packagePath: fooPath)
             XCTAssertTrue(localFileSystem.exists(bazTot))
             XCTAssertFalse(localFileSystem.isSymlink(bazEditsPath))
 
             // Check that on re-editing with path, we don't make a new clone.
-            try SwiftPMProduct.SwiftPackage.execute(["edit", "baz", "--path", bazTot.pathString], packagePath: fooPath)
+            try SwiftPM.Package.execute(["edit", "baz", "--path", bazTot.pathString], packagePath: fooPath)
             XCTAssertTrue(localFileSystem.isSymlink(bazEditsPath))
             XCTAssertEqual(try localFileSystem.readFileContents(bazTotPackageFile), content)
         }
@@ -885,7 +880,7 @@ final class PackageToolTests: CommandsTestCase {
 
             @discardableResult
             func execute(_ args: String..., printError: Bool = true) throws -> String {
-                return try SwiftPMProduct.SwiftPackage.execute([] + args, packagePath: fooPath).stdout
+                return try SwiftPM.Package.execute([] + args, packagePath: fooPath).stdout
             }
 
             try execute("update")
@@ -929,7 +924,7 @@ final class PackageToolTests: CommandsTestCase {
         try fixture(name: "Miscellaneous/PackageEdit") { fixturePath in
             let fooPath = fixturePath.appending("foo")
             func build() throws -> String {
-                return try SwiftPMProduct.SwiftBuild.execute([], packagePath: fooPath).stdout
+                return try SwiftPM.Build.execute(packagePath: fooPath).stdout
             }
             let exec = [fooPath.appending(components: ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug", "foo").pathString]
 
@@ -938,7 +933,7 @@ final class PackageToolTests: CommandsTestCase {
             XCTAssertEqual(try TSCBasic.Process.checkNonZeroExit(arguments: exec).spm_chomp(), "\(5)")
 
             // Get path to bar checkout.
-            let barPath = try SwiftPMProduct.packagePath(for: "bar", packageRoot: fooPath)
+            let barPath = try SwiftPM.packagePath(for: "bar", packageRoot: fooPath)
 
             // Checks the content of checked out bar.swift.
             func checkBar(_ value: Int, file: StaticString = #file, line: UInt = #line) throws {
@@ -955,7 +950,7 @@ final class PackageToolTests: CommandsTestCase {
                 let pinsStore = try PinsStore(pinsFile: pinsFile, workingDirectory: fixturePath, fileSystem: localFileSystem, mirrors: .init())
                 XCTAssertEqual(pinsStore.pins.map{$0}.count, 2)
                 for pkg in ["bar", "baz"] {
-                    let path = try SwiftPMProduct.packagePath(for: pkg, packageRoot: fooPath)
+                    let path = try SwiftPM.packagePath(for: pkg, packageRoot: fooPath)
                     let pin = pinsStore.pinsMap[PackageIdentity(path: path)]!
                     XCTAssertEqual(pin.packageRef.identity, PackageIdentity(path: path))
                     guard case .localSourceControl(let path) = pin.packageRef.kind, path.pathString.hasSuffix(pkg) else {
@@ -972,7 +967,7 @@ final class PackageToolTests: CommandsTestCase {
 
             @discardableResult
             func execute(_ args: String...) throws -> String {
-                return try SwiftPMProduct.SwiftPackage.execute([] + args, packagePath: fooPath).stdout
+                return try SwiftPM.Package.execute([] + args, packagePath: fooPath).stdout
             }
 
             // Try to pin bar.
@@ -1278,11 +1273,9 @@ final class PackageToolTests: CommandsTestCase {
             try execute(["config", "set-mirror", "--original", "https://scm.com/org/foo", "--mirror", "https://scm.com/org/bar"], packagePath: packageRoot)
             XCTAssertTrue(fs.isFile(configFile))
 
-            let result = try SwiftPMProduct.SwiftPackage.executeProcess(["dump-package"], packagePath: packageRoot)
-            let output = try result.utf8Output() + result.utf8stderrOutput()
-            XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
-            XCTAssertMatch(output, .contains("https://scm.com/org/bar"))
-            XCTAssertNoMatch(output, .contains("https://scm.com/org/foo"))
+            let (stdout, _) = try SwiftPM.Package.execute(["dump-package"], packagePath: packageRoot)
+            XCTAssertMatch(stdout, .contains("https://scm.com/org/bar"))
+            XCTAssertNoMatch(stdout, .contains("https://scm.com/org/foo"))
         }
     }
 
@@ -1323,11 +1316,9 @@ final class PackageToolTests: CommandsTestCase {
             try execute(["config", "set-mirror", "--original", "https://scm.com/org/foo", "--mirror", "org.bar"], packagePath: packageRoot)
             XCTAssertTrue(fs.isFile(configFile))
 
-            let result = try SwiftPMProduct.SwiftPackage.executeProcess(["dump-package"], packagePath: packageRoot)
-            let output = try result.utf8Output() + result.utf8stderrOutput()
-            XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
-            XCTAssertMatch(output, .contains("org.bar"))
-            XCTAssertNoMatch(output, .contains("https://scm.com/org/foo"))
+            let (stdout, _) = try SwiftPM.Package.execute(["dump-package"], packagePath: packageRoot)
+            XCTAssertMatch(stdout, .contains("org.bar"))
+            XCTAssertNoMatch(stdout, .contains("https://scm.com/org/foo"))
         }
     }
 
@@ -1368,11 +1359,9 @@ final class PackageToolTests: CommandsTestCase {
             try execute(["config", "set-mirror", "--original", "org.foo", "--mirror", "https://scm.com/org/bar"], packagePath: packageRoot)
             XCTAssertTrue(fs.isFile(configFile))
 
-            let result = try SwiftPMProduct.SwiftPackage.executeProcess(["dump-package"], packagePath: packageRoot)
-            let output = try result.utf8Output() + result.utf8stderrOutput()
-            XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
-            XCTAssertMatch(output, .contains("https://scm.com/org/bar"))
-            XCTAssertNoMatch(output, .contains("org.foo"))
+            let (stdout, _) = try SwiftPM.Package.execute(["dump-package"], packagePath: packageRoot)
+            XCTAssertMatch(stdout, .contains("https://scm.com/org/bar"))
+            XCTAssertNoMatch(stdout, .contains("org.foo"))
         }
     }
 
@@ -1400,12 +1389,11 @@ final class PackageToolTests: CommandsTestCase {
                 // Invoke `swift-package`, passing in the overriding `PATH` environment variable.
                 let packageRoot = fixturePath.appending("Library")
                 let patchedPATH = fakeBinDir.pathString + ":" + ProcessInfo.processInfo.environment["PATH"]!
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["dump-package"], packagePath: packageRoot, env: ["PATH": patchedPATH])
-                let textOutput = try result.utf8Output() + result.utf8stderrOutput()
+                let (stdout, _) = try SwiftPM.Package.execute(["dump-package"], packagePath: packageRoot, env: ["PATH": patchedPATH])
 
                 // Check that the wrong tools weren't invoked.  We can't just check the exit code because of fallbacks.
-                XCTAssertNoMatch(textOutput, .contains("wrong xcrun invoked"))
-                XCTAssertNoMatch(textOutput, .contains("wrong sandbox-exec invoked"))
+                XCTAssertNoMatch(stdout, .contains("wrong xcrun invoked"))
+                XCTAssertNoMatch(stdout, .contains("wrong sandbox-exec invoked"))
             }
         }
     }
@@ -1484,16 +1472,13 @@ final class PackageToolTests: CommandsTestCase {
             )
 
             // Invoke it, and check the results.
-            let result = try SwiftPMProduct.SwiftBuild.executeProcess([], packagePath: packageDir)
-            let output = try result.utf8Output() + result.utf8stderrOutput()
-            XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
-            XCTAssert(output.contains("Build complete!"))
+            let (stdout, stderr) = try SwiftPM.Build.execute(packagePath: packageDir)
+            XCTAssert(stdout.contains("Build complete!"))
 
             // We expect a warning about `library.bar` but not about `library.foo`.
-            let stderrOutput = try result.utf8stderrOutput()
-            XCTAssertMatch(stderrOutput, .contains("found 1 file(s) which are unhandled"))
-            XCTAssertNoMatch(stderrOutput, .contains("Sources/MyLibrary/library.foo"))
-            XCTAssertMatch(stderrOutput, .contains("Sources/MyLibrary/library.bar"))
+            XCTAssertMatch(stderr, .contains("found 1 file(s) which are unhandled"))
+            XCTAssertNoMatch(stderr, .contains("Sources/MyLibrary/library.foo"))
+            XCTAssertMatch(stderr, .contains("Sources/MyLibrary/library.bar"))
         }
     }
 
@@ -1553,12 +1538,14 @@ final class PackageToolTests: CommandsTestCase {
             )
 
             // Invoke it, and check the results.
-            let result = try SwiftPMProduct.SwiftBuild.executeProcess(["-v"], packagePath: packageDir)
-            let output = try result.utf8Output() + result.utf8stderrOutput()
-            XCTAssertNotEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
-            XCTAssertMatch(output, .contains("This is text from the plugin"))
-            XCTAssertMatch(output, .contains("error: This is an error from the plugin"))
-            XCTAssertMatch(output, .contains("build stopped due to build-tool plugin failures"))
+            XCTAssertThrowsError(try SwiftPM.Build.execute(["-v"], packagePath: packageDir)) { error in
+                guard case SwiftPMError.executionFailure(_, _, let stderr) = error else {
+                    return XCTFail("invalid error \(error)")
+                }
+                XCTAssertMatch(stderr, .contains("This is text from the plugin"))
+                XCTAssertMatch(stderr, .contains("error: This is an error from the plugin"))
+                XCTAssertMatch(stderr, .contains("build stopped due to build-tool plugin failures"))
+            }
         }
     }
 
@@ -1568,63 +1555,53 @@ final class PackageToolTests: CommandsTestCase {
 
             // Running without arguments or options
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["archive-source"], packagePath: packageRoot)
-                XCTAssertEqual(result.exitStatus, .terminated(code: 0))
+                let (stdout, _) = try SwiftPM.Package.execute(["archive-source"], packagePath: packageRoot)
+                XCTAssert(stdout.contains("Created Bar.zip"), #"actual: "\#(stdout)""#)
+            }
 
-                let stdoutOutput = try result.utf8Output()
-                XCTAssert(stdoutOutput.contains("Created Bar.zip"), #"actual: "\#(stdoutOutput)""#)
-
-                // Running without arguments or options again, overwriting existing archive
-                do {
-                    let result = try SwiftPMProduct.SwiftPackage.executeProcess(["archive-source"], packagePath: packageRoot)
-                    XCTAssertEqual(result.exitStatus, .terminated(code: 0))
-
-                    let stdoutOutput = try result.utf8Output()
-                    XCTAssert(stdoutOutput.contains("Created Bar.zip"), #"actual: "\#(stdoutOutput)""#)
-                }
+            // Running without arguments or options again, overwriting existing archive
+            do {
+                let (stdout, _) = try SwiftPM.Package.execute(["archive-source"], packagePath: packageRoot)
+                XCTAssert(stdout.contains("Created Bar.zip"), #"actual: "\#(stdout)""#)
             }
 
             // Running with output as absolute path within package root
             do {
                 let destination = packageRoot.appending("Bar-1.2.3.zip")
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["archive-source", "--output", destination.pathString], packagePath: packageRoot)
-                XCTAssertEqual(result.exitStatus, .terminated(code: 0))
-
-                let stdoutOutput = try result.utf8Output()
-                XCTAssert(stdoutOutput.contains("Created Bar-1.2.3.zip"), #"actual: "\#(stdoutOutput)""#)
+                let (stdout, _) = try SwiftPM.Package.execute(["archive-source", "--output", destination.pathString], packagePath: packageRoot)
+                XCTAssert(stdout.contains("Created Bar-1.2.3.zip"), #"actual: "\#(stdout)""#)
             }
 
             // Running with output is outside the package root
             try withTemporaryDirectory { tempDirectory in
                 let destination = tempDirectory.appending("Bar-1.2.3.zip")
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["archive-source", "--output", destination.pathString], packagePath: packageRoot)
-                XCTAssertEqual(result.exitStatus, .terminated(code: 0))
-
-                let stdoutOutput = try result.utf8Output()
-                XCTAssert(stdoutOutput.hasPrefix("Created /"), #"actual: "\#(stdoutOutput)""#)
-                XCTAssert(stdoutOutput.contains("Bar-1.2.3.zip"), #"actual: "\#(stdoutOutput)""#)
+                let (stdout, _) = try SwiftPM.Package.execute(["archive-source", "--output", destination.pathString], packagePath: packageRoot)
+                XCTAssert(stdout.hasPrefix("Created /"), #"actual: "\#(stdout)""#)
+                XCTAssert(stdout.contains("Bar-1.2.3.zip"), #"actual: "\#(stdout)""#)
             }
 
             // Running without arguments or options in non-package directory
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["archive-source"], packagePath: fixturePath)
-                XCTAssertEqual(result.exitStatus, .terminated(code: 1))
-
-                let stderrOutput = try result.utf8stderrOutput()
-                XCTAssert(stderrOutput.contains("error: Could not find Package.swift in this directory or any of its parent directories."), #"actual: "\#(stderrOutput)""#)
+                XCTAssertThrowsError(try SwiftPM.Package.execute(["archive-source"], packagePath: fixturePath)) { error in
+                    guard case SwiftPMError.executionFailure(_, _, let stderr) = error else {
+                        return XCTFail("invalid error \(error)")
+                    }
+                    XCTAssert(stderr.contains("error: Could not find Package.swift in this directory or any of its parent directories."), #"actual: "\#(stderr)""#)
+                }
             }
 
             // Running with output as absolute path to existing directory
             do {
                 let destination = AbsolutePath.root
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["archive-source", "--output", destination.pathString], packagePath: packageRoot)
-                XCTAssertEqual(result.exitStatus, .terminated(code: 1))
-
-                let stderrOutput = try result.utf8stderrOutput()
-                XCTAssert(
-                    stderrOutput.contains("error: Couldn’t create an archive:"),
-                    #"actual: "\#(stderrOutput)""#
-                )
+                XCTAssertThrowsError(try SwiftPM.Package.execute(["archive-source", "--output", destination.pathString], packagePath: packageRoot)) { error in
+                    guard case SwiftPMError.executionFailure(_, _, let stderr) = error else {
+                        return XCTFail("invalid error \(error)")
+                    }
+                    XCTAssert(
+                        stderr.contains("error: Couldn’t create an archive:"),
+                        #"actual: "\#(stderr)""#
+                    )
+                }
             }
         }
     }
@@ -1803,52 +1780,44 @@ final class PackageToolTests: CommandsTestCase {
 
             // Check that we can invoke the plugin with the "plugin" subcommand.
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["plugin", "mycmd"], packagePath: packageDir)
-                let output = try result.utf8Output() + result.utf8stderrOutput()
-                XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
-                XCTAssertMatch(output, .contains("This is MyCommandPlugin."))
+                let (stdout, _) = try SwiftPM.Package.execute(["plugin", "mycmd"], packagePath: packageDir)
+                XCTAssertMatch(stdout, .contains("This is MyCommandPlugin."))
             }
 
             // Check that we can also invoke it without the "plugin" subcommand.
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["mycmd"], packagePath: packageDir)
-                let output = try result.utf8Output() + result.utf8stderrOutput()
-                XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
-                XCTAssertMatch(output, .contains("This is MyCommandPlugin."))
+                let (stdout, _) = try SwiftPM.Package.execute(["mycmd"], packagePath: packageDir)
+                XCTAssertMatch(stdout, .contains("This is MyCommandPlugin."))
             }
 
             // Testing listing the available command plugins.
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["plugin", "--list"], packagePath: packageDir)
-                let output = try result.utf8Output() + result.utf8stderrOutput()
-                XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
-                XCTAssertMatch(output, .contains("‘mycmd’ (plugin ‘MyPlugin’ in package ‘MyPackage’)"))
+                let (stdout, _) = try SwiftPM.Package.execute(["plugin", "--list"], packagePath: packageDir)
+                XCTAssertMatch(stdout, .contains("‘mycmd’ (plugin ‘MyPlugin’ in package ‘MyPackage’)"))
             }
 
             // Check that we get the expected error if trying to invoke a plugin with the wrong name.
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["my-nonexistent-cmd"], packagePath: packageDir)
-                let output = try result.utf8Output() + result.utf8stderrOutput()
-                XCTAssertNotEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
-                XCTAssertMatch(output, .contains("Unknown subcommand or plugin name ‘my-nonexistent-cmd’"))
+                XCTAssertThrowsError(try SwiftPM.Package.execute(["my-nonexistent-cmd"], packagePath: packageDir)) { error in
+                    guard case SwiftPMError.executionFailure(_, _, let stderr) = error else {
+                        return XCTFail("invalid error \(error)")
+                    }
+                    XCTAssertMatch(stderr, .contains("Unknown subcommand or plugin name ‘my-nonexistent-cmd’"))
+                }
             }
 
             // Check that the .docc file was properly vended to the plugin.
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["mycmd", "--target", "MyLibrary"], packagePath: packageDir)
-                let output = try result.utf8Output() + result.utf8stderrOutput()
-                XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
-                XCTAssertMatch(output, .contains("Sources/MyLibrary/library.swift: source"))
-                XCTAssertMatch(output, .contains("Sources/MyLibrary/test.docc: unknown"))
+                let (stdout, _) = try SwiftPM.Package.execute(["mycmd", "--target", "MyLibrary"], packagePath: packageDir)
+                XCTAssertMatch(stdout, .contains("Sources/MyLibrary/library.swift: source"))
+                XCTAssertMatch(stdout, .contains("Sources/MyLibrary/test.docc: unknown"))
             }
 
             // Check that the initial working directory is what we expected.
             do {
                 let workingDirectory = FileManager.default.currentDirectoryPath
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["mycmd"], packagePath: packageDir)
-                let output = try result.utf8Output() + result.utf8stderrOutput()
-                XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
-                XCTAssertMatch(output, .contains("Initial working directory: \(workingDirectory)"))
+                let (stdout, _) = try SwiftPM.Package.execute(["mycmd"], packagePath: packageDir)
+                XCTAssertMatch(stdout, .contains("Initial working directory: \(workingDirectory)"))
             }
         }
     }
@@ -1889,20 +1858,22 @@ final class PackageToolTests: CommandsTestCase {
 
             #if os(macOS)
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["plugin", "Network"], packagePath: packageDir)
-                XCTAssertNotEqual(result.exitStatus, .terminated(code: 0))
-                XCTAssertNoMatch(try result.utf8Output(), .contains("hello world"))
-                XCTAssertMatch(try result.utf8stderrOutput(), .contains("error: Plugin ‘MyPlugin’ wants permission to allow \(permissionError)."))
-                XCTAssertMatch(try result.utf8stderrOutput(), .contains("Stated reason: “\(reason)”."))
-                XCTAssertMatch(try result.utf8stderrOutput(), .contains("Use `\(remedy.joined(separator: " "))` to allow this."))
+                XCTAssertThrowsError(try SwiftPM.Package.execute(["plugin", "Network"], packagePath: packageDir)) { error in
+                    guard case SwiftPMError.executionFailure(_, let stdout, let stderr) = error else {
+                        return XCTFail("invalid error \(error)")
+                    }
+                    XCTAssertNoMatch(stdout, .contains("hello world"))
+                    XCTAssertMatch(stderr, .contains("error: Plugin ‘MyPlugin’ wants permission to allow \(permissionError)."))
+                    XCTAssertMatch(stderr, .contains("Stated reason: “\(reason)”."))
+                    XCTAssertMatch(stderr, .contains("Use `\(remedy.joined(separator: " "))` to allow this."))
+                }
             }
             #endif
 
             // Check that we don't get an error (and also are allowed to write to the package directory) if we pass `--allow-writing-to-package-directory`.
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["plugin"] + remedy + ["Network"], packagePath: packageDir)
-                XCTAssertEqual(result.exitStatus, .terminated(code: 0))
-                XCTAssertMatch(try result.utf8Output(), .contains("hello world"))
+                let (stdout, _) = try SwiftPM.Package.execute(["plugin"] + remedy + ["Network"], packagePath: packageDir)
+                XCTAssertMatch(stdout, .contains("hello world"))
             }
         }
     }
@@ -2018,55 +1989,57 @@ final class PackageToolTests: CommandsTestCase {
             // Check that we get an error if the plugin needs permission but if we don't give it to them. Note that sandboxing is only currently supported on macOS.
           #if os(macOS)
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["plugin", "PackageScribbler"], packagePath: packageDir, env: ["DECLARE_PACKAGE_WRITING_PERMISSION": "1"])
-                XCTAssertNotEqual(result.exitStatus, .terminated(code: 0))
-                XCTAssertNoMatch(try result.utf8Output(), .contains("successfully created it"))
-                XCTAssertMatch(try result.utf8stderrOutput(), .contains("error: Plugin ‘MyPlugin’ wants permission to write to the package directory."))
-                XCTAssertMatch(try result.utf8stderrOutput(), .contains("Stated reason: “For testing purposes”."))
-                XCTAssertMatch(try result.utf8stderrOutput(), .contains("Use `--allow-writing-to-package-directory` to allow this."))
+                XCTAssertThrowsError(try SwiftPM.Package.execute(["plugin", "PackageScribbler"], packagePath: packageDir, env: ["DECLARE_PACKAGE_WRITING_PERMISSION": "1"])) { error in
+                    guard case SwiftPMError.executionFailure(_, let stdout, let stderr) = error else {
+                        return XCTFail("invalid error \(error)")
+                    }
+                    XCTAssertNoMatch(stdout, .contains("successfully created it"))
+                    XCTAssertMatch(stderr, .contains("error: Plugin ‘MyPlugin’ wants permission to write to the package directory."))
+                    XCTAssertMatch(stderr, .contains("Stated reason: “For testing purposes”."))
+                    XCTAssertMatch(stderr, .contains("Use `--allow-writing-to-package-directory` to allow this."))
+                }
             }
           #endif
 
             // Check that we don't get an error (and also are allowed to write to the package directory) if we pass `--allow-writing-to-package-directory`.
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["plugin", "--allow-writing-to-package-directory", "PackageScribbler"], packagePath: packageDir, env: ["DECLARE_PACKAGE_WRITING_PERMISSION": "1"])
-                XCTAssertEqual(result.exitStatus, .terminated(code: 0))
-                XCTAssertMatch(try result.utf8Output(), .contains("successfully created it"))
-                XCTAssertNoMatch(try result.utf8stderrOutput(), .contains("error: Couldn’t create file at path"))
+                let (stdout, stderr) = try SwiftPM.Package.execute(["plugin", "--allow-writing-to-package-directory", "PackageScribbler"], packagePath: packageDir, env: ["DECLARE_PACKAGE_WRITING_PERMISSION": "1"])
+                XCTAssertMatch(stdout, .contains("successfully created it"))
+                XCTAssertNoMatch(stderr, .contains("error: Couldn’t create file at path"))
             }
 
             // Check that we get an error if the plugin doesn't declare permission but tries to write anyway. Note that sandboxing is only currently supported on macOS.
           #if os(macOS)
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["plugin", "PackageScribbler"], packagePath: packageDir, env: ["DECLARE_PACKAGE_WRITING_PERMISSION": "0"])
-                XCTAssertNotEqual(result.exitStatus, .terminated(code: 0))
-                XCTAssertNoMatch(try result.utf8Output(), .contains("successfully created it"))
-                XCTAssertMatch(try result.utf8stderrOutput(), .contains("error: Couldn’t create file at path"))
+                XCTAssertThrowsError(try SwiftPM.Package.execute(["plugin", "PackageScribbler"], packagePath: packageDir, env: ["DECLARE_PACKAGE_WRITING_PERMISSION": "0"])) { error in
+                    guard case SwiftPMError.executionFailure(_, let stdout, let stderr) = error else {
+                        return XCTFail("invalid error \(error)")
+                    }
+                    XCTAssertNoMatch(stdout, .contains("successfully created it"))
+                    XCTAssertMatch(stderr, .contains("error: Couldn’t create file at path"))
+                }
             }
           #endif
 
             // Check default command with arguments
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["--allow-writing-to-package-directory", "PackageScribbler"], packagePath: packageDir, env: ["DECLARE_PACKAGE_WRITING_PERMISSION": "1"])
-                XCTAssertEqual(result.exitStatus, .terminated(code: 0))
-                XCTAssertMatch(try result.utf8Output(), .contains("successfully created it"))
-                XCTAssertNoMatch(try result.utf8stderrOutput(), .contains("error: Couldn’t create file at path"))
+                let (stdout, stderr) = try SwiftPM.Package.execute(["--allow-writing-to-package-directory", "PackageScribbler"], packagePath: packageDir, env: ["DECLARE_PACKAGE_WRITING_PERMISSION": "1"])
+                XCTAssertMatch(stdout, .contains("successfully created it"))
+                XCTAssertNoMatch(stderr, .contains("error: Couldn’t create file at path"))
             }
 
             // Check plugin arguments after plugin name
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["plugin", "PackageScribbler",  "--allow-writing-to-package-directory"], packagePath: packageDir, env: ["DECLARE_PACKAGE_WRITING_PERMISSION": "1"])
-                XCTAssertEqual(result.exitStatus, .terminated(code: 0))
-                XCTAssertMatch(try result.utf8Output(), .contains("successfully created it"))
-                XCTAssertNoMatch(try result.utf8stderrOutput(), .contains("error: Couldn’t create file at path"))
+                let (stdout, stderr) = try SwiftPM.Package.execute(["plugin", "PackageScribbler",  "--allow-writing-to-package-directory"], packagePath: packageDir, env: ["DECLARE_PACKAGE_WRITING_PERMISSION": "1"])
+                XCTAssertMatch(stdout, .contains("successfully created it"))
+                XCTAssertNoMatch(stderr, .contains("error: Couldn’t create file at path"))
             }
 
             // Check default command with arguments after plugin name
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["PackageScribbler", "--allow-writing-to-package-directory", ], packagePath: packageDir, env: ["DECLARE_PACKAGE_WRITING_PERMISSION": "1"])
-                XCTAssertEqual(result.exitStatus, .terminated(code: 0))
-                XCTAssertMatch(try result.utf8Output(), .contains("successfully created it"))
-                XCTAssertNoMatch(try result.utf8stderrOutput(), .contains("error: Couldn’t create file at path"))
+                let (stdout, stderr) = try SwiftPM.Package.execute(["PackageScribbler", "--allow-writing-to-package-directory", ], packagePath: packageDir, env: ["DECLARE_PACKAGE_WRITING_PERMISSION": "1"])
+                XCTAssertMatch(stdout, .contains("successfully created it"))
+                XCTAssertNoMatch(stderr, .contains("error: Couldn’t create file at path"))
             }
         }
     }
@@ -2136,18 +2109,16 @@ final class PackageToolTests: CommandsTestCase {
 
             // Check arguments
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["plugin", "MyPlugin", "--foo", "--help", "--version", "--verbose"], packagePath: packageDir)
-                XCTAssertEqual(result.exitStatus, .terminated(code: 0))
-                XCTAssertMatch(try result.utf8Output(), .contains("success"))
-                XCTAssertEqual(try result.utf8stderrOutput(), "")
+                let (stdout, stderr) = try SwiftPM.Package.execute(["plugin", "MyPlugin", "--foo", "--help", "--version", "--verbose"], packagePath: packageDir)
+                XCTAssertMatch(stdout, .contains("success"))
+                XCTAssertEqual(stderr, "")
             }
 
             // Check default command arguments
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["MyPlugin", "--foo", "--help", "--version", "--verbose"], packagePath: packageDir)
-                XCTAssertEqual(result.exitStatus, .terminated(code: 0))
-                XCTAssertMatch(try result.utf8Output(), .contains("success"))
-                XCTAssertEqual(try result.utf8stderrOutput(), "")
+                let (stdout, stderr) = try SwiftPM.Package.execute(["MyPlugin", "--foo", "--help", "--version", "--verbose"], packagePath: packageDir)
+                XCTAssertMatch(stdout, .contains("success"))
+                XCTAssertEqual(stderr, "")
             }
         }
     }
@@ -2238,21 +2209,17 @@ final class PackageToolTests: CommandsTestCase {
 
             // Check that if we don't pass any target, we successfully get symbol graph information for all targets in the package, and at different paths.
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["generate-documentation"], packagePath: packageDir)
-                let output = try result.utf8Output() + result.utf8stderrOutput()
-                XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
-                XCTAssertMatch(output, .and(.contains("MyLibrary:"), .contains("mypackage/MyLibrary")))
-                XCTAssertMatch(output, .and(.contains("MyCommand:"), .contains("mypackage/MyCommand")))
+                let (stdout, _) = try SwiftPM.Package.execute(["generate-documentation"], packagePath: packageDir)
+                XCTAssertMatch(stdout, .and(.contains("MyLibrary:"), .contains("mypackage/MyLibrary")))
+                XCTAssertMatch(stdout, .and(.contains("MyCommand:"), .contains("mypackage/MyCommand")))
 
             }
 
             // Check that if we pass a target, we successfully get symbol graph information for just the target we asked for.
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["generate-documentation", "--target", "MyLibrary"], packagePath: packageDir)
-                let output = try result.utf8Output() + result.utf8stderrOutput()
-                XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
-                XCTAssertMatch(output, .and(.contains("MyLibrary:"), .contains("mypackage/MyLibrary")))
-                XCTAssertNoMatch(output, .and(.contains("MyCommand:"), .contains("mypackage/MyCommand")))
+                let (stdout, _) = try SwiftPM.Package.execute(["generate-documentation", "--target", "MyLibrary"], packagePath: packageDir)
+                XCTAssertMatch(stdout, .and(.contains("MyLibrary:"), .contains("mypackage/MyLibrary")))
+                XCTAssertNoMatch(stdout, .and(.contains("MyCommand:"), .contains("mypackage/MyCommand")))
             }
         }
     }
@@ -2371,59 +2338,51 @@ final class PackageToolTests: CommandsTestCase {
 
             // Invoke the plugin with parameters choosing a verbose build of MyExecutable for debugging.
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["my-build-tester", "--product", "MyExecutable", "--print-commands"], packagePath: packageDir)
-                let output = try result.utf8Output() + result.utf8stderrOutput()
-                XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
-                XCTAssertMatch(output, .contains("Building for debugging..."))
-                XCTAssertNoMatch(output, .contains("Building for production..."))
-                XCTAssertMatch(output, .contains("-module-name MyExecutable"))
-                XCTAssertMatch(output, .contains("-DEXTRA_SWIFT_FLAG"))
-                XCTAssertMatch(output, .contains("Build complete!"))
-                XCTAssertMatch(output, .contains("succeeded: true"))
-                XCTAssertMatch(output, .and(.contains("artifact-path:"), .contains("debug/MyExecutable")))
-                XCTAssertMatch(output, .and(.contains("artifact-kind:"), .contains("executable")))
+                let (stdout, _) = try SwiftPM.Package.execute(["my-build-tester", "--product", "MyExecutable", "--print-commands"], packagePath: packageDir)
+                XCTAssertMatch(stdout, .contains("Building for debugging..."))
+                XCTAssertNoMatch(stdout, .contains("Building for production..."))
+                XCTAssertMatch(stdout, .contains("-module-name MyExecutable"))
+                XCTAssertMatch(stdout, .contains("-DEXTRA_SWIFT_FLAG"))
+                XCTAssertMatch(stdout, .contains("Build complete!"))
+                XCTAssertMatch(stdout, .contains("succeeded: true"))
+                XCTAssertMatch(stdout, .and(.contains("artifact-path:"), .contains("debug/MyExecutable")))
+                XCTAssertMatch(stdout, .and(.contains("artifact-kind:"), .contains("executable")))
             }
 
             // Invoke the plugin with parameters choosing a concise build of MyExecutable for release.
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["my-build-tester", "--product", "MyExecutable", "--release"], packagePath: packageDir)
-                let output = try result.utf8Output() + result.utf8stderrOutput()
-                XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
-                XCTAssertMatch(output, .contains("Building for production..."))
-                XCTAssertNoMatch(output, .contains("Building for debug..."))
-                XCTAssertNoMatch(output, .contains("-module-name MyExecutable"))
-                XCTAssertMatch(output, .contains("Build complete!"))
-                XCTAssertMatch(output, .contains("succeeded: true"))
-                XCTAssertMatch(output, .and(.contains("artifact-path:"), .contains("release/MyExecutable")))
-                XCTAssertMatch(output, .and(.contains("artifact-kind:"), .contains("executable")))
+                let (stdout, _) = try SwiftPM.Package.execute(["my-build-tester", "--product", "MyExecutable", "--release"], packagePath: packageDir)
+                XCTAssertMatch(stdout, .contains("Building for production..."))
+                XCTAssertNoMatch(stdout, .contains("Building for debug..."))
+                XCTAssertNoMatch(stdout, .contains("-module-name MyExecutable"))
+                XCTAssertMatch(stdout, .contains("Build complete!"))
+                XCTAssertMatch(stdout, .contains("succeeded: true"))
+                XCTAssertMatch(stdout, .and(.contains("artifact-path:"), .contains("release/MyExecutable")))
+                XCTAssertMatch(stdout, .and(.contains("artifact-kind:"), .contains("executable")))
             }
 
             // Invoke the plugin with parameters choosing a verbose build of MyStaticLibrary for release.
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["my-build-tester", "--product", "MyStaticLibrary", "--print-commands", "--release"], packagePath: packageDir)
-                let output = try result.utf8Output() + result.utf8stderrOutput()
-                XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
-                XCTAssertMatch(output, .contains("Building for production..."))
-                XCTAssertNoMatch(output, .contains("Building for debug..."))
-                XCTAssertNoMatch(output, .contains("-module-name MyLibrary"))
-                XCTAssertMatch(output, .contains("Build complete!"))
-                XCTAssertMatch(output, .contains("succeeded: true"))
-                XCTAssertMatch(output, .and(.contains("artifact-path:"), .contains("release/libMyStaticLibrary.")))
-                XCTAssertMatch(output, .and(.contains("artifact-kind:"), .contains("staticLibrary")))
+                let (stdout, _) = try SwiftPM.Package.execute(["my-build-tester", "--product", "MyStaticLibrary", "--print-commands", "--release"], packagePath: packageDir)
+                XCTAssertMatch(stdout, .contains("Building for production..."))
+                XCTAssertNoMatch(stdout, .contains("Building for debug..."))
+                XCTAssertNoMatch(stdout, .contains("-module-name MyLibrary"))
+                XCTAssertMatch(stdout, .contains("Build complete!"))
+                XCTAssertMatch(stdout, .contains("succeeded: true"))
+                XCTAssertMatch(stdout, .and(.contains("artifact-path:"), .contains("release/libMyStaticLibrary.")))
+                XCTAssertMatch(stdout, .and(.contains("artifact-kind:"), .contains("staticLibrary")))
             }
 
             // Invoke the plugin with parameters choosing a verbose build of MyDynamicLibrary for release.
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["my-build-tester", "--product", "MyDynamicLibrary", "--print-commands", "--release"], packagePath: packageDir)
-                let output = try result.utf8Output() + result.utf8stderrOutput()
-                XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
-                XCTAssertMatch(output, .contains("Building for production..."))
-                XCTAssertNoMatch(output, .contains("Building for debug..."))
-                XCTAssertNoMatch(output, .contains("-module-name MyLibrary"))
-                XCTAssertMatch(output, .contains("Build complete!"))
-                XCTAssertMatch(output, .contains("succeeded: true"))
-                XCTAssertMatch(output, .and(.contains("artifact-path:"), .contains("release/libMyDynamicLibrary.")))
-                XCTAssertMatch(output, .and(.contains("artifact-kind:"), .contains("dynamicLibrary")))
+                let (stdout, _) = try SwiftPM.Package.execute(["my-build-tester", "--product", "MyDynamicLibrary", "--print-commands", "--release"], packagePath: packageDir)
+                XCTAssertMatch(stdout, .contains("Building for production..."))
+                XCTAssertNoMatch(stdout, .contains("Building for debug..."))
+                XCTAssertNoMatch(stdout, .contains("-module-name MyLibrary"))
+                XCTAssertMatch(stdout, .contains("Build complete!"))
+                XCTAssertMatch(stdout, .contains("succeeded: true"))
+                XCTAssertMatch(stdout, .and(.contains("artifact-path:"), .contains("release/libMyDynamicLibrary.")))
+                XCTAssertMatch(stdout, .and(.contains("artifact-kind:"), .contains("dynamicLibrary")))
             }
         }
     }
@@ -2545,12 +2504,7 @@ final class PackageToolTests: CommandsTestCase {
             )
 
             // Check basic usage with filtering and code coverage. The plugin itself asserts a bunch of values.
-            do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["my-test-tester"], packagePath: packageDir)
-                let output = try result.utf8Output() + result.utf8stderrOutput()
-                print(output)
-                XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
-            }
+            try SwiftPM.Package.execute(["my-test-tester"], packagePath: packageDir)
 
             // We'll add checks for various error conditions here in a future commit.
         }
@@ -2726,49 +2680,39 @@ final class PackageToolTests: CommandsTestCase {
 
             // Check that a target doesn't include itself in its recursive dependencies.
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["print-target-dependencies", "--target", "SecondTarget"], packagePath: packageDir)
-                let output = try result.utf8Output() + result.utf8stderrOutput()
-                XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
-                XCTAssertMatch(output, .contains("Recursive dependencies of 'SecondTarget': [\"FirstTarget\"]"))
-                XCTAssertMatch(output, .contains("Module kind of 'SecondTarget': generic"))
+                let (stdout, _) = try SwiftPM.Package.execute(["print-target-dependencies", "--target", "SecondTarget"], packagePath: packageDir)
+                XCTAssertMatch(stdout, .contains("Recursive dependencies of 'SecondTarget': [\"FirstTarget\"]"))
+                XCTAssertMatch(stdout, .contains("Module kind of 'SecondTarget': generic"))
             }
 
             // Check that targets are not included twice in recursive dependencies.
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["print-target-dependencies", "--target", "ThirdTarget"], packagePath: packageDir)
-                let output = try result.utf8Output() + result.utf8stderrOutput()
-                XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
-                XCTAssertMatch(output, .contains("Recursive dependencies of 'ThirdTarget': [\"FirstTarget\"]"))
-                XCTAssertMatch(output, .contains("Module kind of 'ThirdTarget': generic"))
+                let (stdout, _) = try SwiftPM.Package.execute(["print-target-dependencies", "--target", "ThirdTarget"], packagePath: packageDir)
+                XCTAssertMatch(stdout, .contains("Recursive dependencies of 'ThirdTarget': [\"FirstTarget\"]"))
+                XCTAssertMatch(stdout, .contains("Module kind of 'ThirdTarget': generic"))
             }
 
             // Check that product dependencies work in recursive dependencies.
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["print-target-dependencies", "--target", "FourthTarget"], packagePath: packageDir)
-                let output = try result.utf8Output() + result.utf8stderrOutput()
-                XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
-                XCTAssertMatch(output, .contains("Recursive dependencies of 'FourthTarget': [\"FirstTarget\", \"SecondTarget\", \"ThirdTarget\", \"HelperLibrary\"]"))
-                XCTAssertMatch(output, .contains("Module kind of 'FourthTarget': generic"))
+                let (stdout, _) = try SwiftPM.Package.execute(["print-target-dependencies", "--target", "FourthTarget"], packagePath: packageDir)
+                XCTAssertMatch(stdout, .contains("Recursive dependencies of 'FourthTarget': [\"FirstTarget\", \"SecondTarget\", \"ThirdTarget\", \"HelperLibrary\"]"))
+                XCTAssertMatch(stdout, .contains("Module kind of 'FourthTarget': generic"))
             }
 
             // Check some of the other utility APIs.
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["print-target-dependencies", "--target", "FifthTarget"], packagePath: packageDir)
-                let output = try result.utf8Output() + result.utf8stderrOutput()
-                XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
-                XCTAssertMatch(output, .contains("execProducts: [\"FifthTarget\"]"))
-                XCTAssertMatch(output, .contains("swiftTargets: [\"ThirdTarget\", \"TestTarget\", \"SecondTarget\", \"FourthTarget\", \"FirstTarget\", \"FifthTarget\"]"))
-                XCTAssertMatch(output, .contains("swiftSources: [\"library.swift\", \"tests.swift\", \"library.swift\", \"library.swift\", \"library.swift\", \"main.swift\"]"))
-                XCTAssertMatch(output, .contains("Module kind of 'FifthTarget': executable"))
+                let (stdout, _) = try SwiftPM.Package.execute(["print-target-dependencies", "--target", "FifthTarget"], packagePath: packageDir)
+                XCTAssertMatch(stdout, .contains("execProducts: [\"FifthTarget\"]"))
+                XCTAssertMatch(stdout, .contains("swiftTargets: [\"ThirdTarget\", \"TestTarget\", \"SecondTarget\", \"FourthTarget\", \"FirstTarget\", \"FifthTarget\"]"))
+                XCTAssertMatch(stdout, .contains("swiftSources: [\"library.swift\", \"tests.swift\", \"library.swift\", \"library.swift\", \"library.swift\", \"main.swift\"]"))
+                XCTAssertMatch(stdout, .contains("Module kind of 'FifthTarget': executable"))
             }
 
             // Check a test target.
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["print-target-dependencies", "--target", "TestTarget"], packagePath: packageDir)
-                let output = try result.utf8Output() + result.utf8stderrOutput()
-                XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
-                XCTAssertMatch(output, .contains("Recursive dependencies of 'TestTarget': [\"FirstTarget\", \"SecondTarget\"]"))
-                XCTAssertMatch(output, .contains("Module kind of 'TestTarget': test"))
+                let (stdout, _) = try SwiftPM.Package.execute(["print-target-dependencies", "--target", "TestTarget"], packagePath: packageDir)
+                XCTAssertMatch(stdout, .contains("Recursive dependencies of 'TestTarget': [\"FirstTarget\", \"SecondTarget\"]"))
+                XCTAssertMatch(stdout, .contains("Module kind of 'TestTarget': test"))
             }
         }
     }
@@ -2861,22 +2805,18 @@ final class PackageToolTests: CommandsTestCase {
 
             // Check that building without options compiles both plugins and that the build proceeds.
             do {
-                let result = try SwiftPMProduct.SwiftBuild.executeProcess([], packagePath: packageDir)
-                let output = try result.utf8Output() + result.utf8stderrOutput()
-                XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
-                XCTAssertMatch(output, .contains("Compiling plugin MyBuildToolPlugin"))
-                XCTAssertMatch(output, .contains("Compiling plugin MyCommandPlugin"))
-                XCTAssertMatch(output, .contains("Building for debugging..."))
+                let (stdout, _) = try SwiftPM.Build.execute(packagePath: packageDir)
+                XCTAssertMatch(stdout, .contains("Compiling plugin MyBuildToolPlugin"))
+                XCTAssertMatch(stdout, .contains("Compiling plugin MyCommandPlugin"))
+                XCTAssertMatch(stdout, .contains("Building for debugging..."))
             }
 
             // Check that building just one of them just compiles that plugin and doesn't build anything else.
             do {
-                let result = try SwiftPMProduct.SwiftBuild.executeProcess(["--target", "MyCommandPlugin"], packagePath: packageDir)
-                let output = try result.utf8Output() + result.utf8stderrOutput()
-                XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
-                XCTAssertNoMatch(output, .contains("Compiling plugin MyBuildToolPlugin"))
-                XCTAssertMatch(output, .contains("Compiling plugin MyCommandPlugin"))
-                XCTAssertNoMatch(output, .contains("Building for debugging..."))
+                let (stdout, _) = try SwiftPM.Build.execute(["--target", "MyCommandPlugin"], packagePath: packageDir)
+                XCTAssertNoMatch(stdout, .contains("Compiling plugin MyBuildToolPlugin"))
+                XCTAssertMatch(stdout, .contains("Compiling plugin MyCommandPlugin"))
+                XCTAssertNoMatch(stdout, .contains("Building for debugging..."))
             }
 
             // Deliberately break the command plugin.
@@ -2896,13 +2836,15 @@ final class PackageToolTests: CommandsTestCase {
             // Check that building stops after compiling the plugin and doesn't proceed.
             // Run this test a number of times to try to catch any race conditions.
             for _ in 1...5 {
-                let result = try SwiftPMProduct.SwiftBuild.executeProcess([], packagePath: packageDir)
-                let output = try result.utf8Output() + result.utf8stderrOutput()
-                XCTAssertNotEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
-                XCTAssertMatch(output, .contains("Compiling plugin MyBuildToolPlugin"))
-                XCTAssertMatch(output, .contains("Compiling plugin MyCommandPlugin"))
-                XCTAssertMatch(output, .contains("error: consecutive statements on a line must be separated by ';'"))
-                XCTAssertNoMatch(output, .contains("Building for debugging..."))
+                XCTAssertThrowsError(try SwiftPM.Build.execute(packagePath: packageDir)) { error in
+                    guard case SwiftPMError.executionFailure(_, let stdout, _) = error else {
+                        return XCTFail("invalid error \(error)")
+                    }
+                    XCTAssertMatch(stdout, .contains("Compiling plugin MyBuildToolPlugin"))
+                    XCTAssertMatch(stdout, .contains("Compiling plugin MyCommandPlugin"))
+                    XCTAssertMatch(stdout, .contains("error: consecutive statements on a line must be separated by ';'"))
+                    XCTAssertNoMatch(stdout, .contains("Building for debugging..."))
+                }
             }
         }
     }

--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -19,7 +19,7 @@ import XCTest
 final class TestToolTests: CommandsTestCase {
     
     private func execute(_ args: [String], packagePath: AbsolutePath? = nil) throws -> (stdout: String, stderr: String) {
-        return try SwiftPMProduct.SwiftTest.execute(args, packagePath: packagePath)
+        return try SwiftPM.Test.execute(args, packagePath: packagePath)
     }
     
     func testUsage() throws {
@@ -89,13 +89,13 @@ final class TestToolTests: CommandsTestCase {
     func testSwiftTestParallel() throws {
         try fixture(name: "Miscellaneous/ParallelTestsPkg") { fixturePath in
             // First try normal serial testing.
-            XCTAssertThrowsCommandExecutionError(try SwiftPMProduct.SwiftTest.execute([], packagePath: fixturePath)) { error in
+            XCTAssertThrowsCommandExecutionError(try SwiftPM.Test.execute(packagePath: fixturePath)) { error in
                 // in "swift test" test output goes to stdout
                 XCTAssertMatch(error.stdout, .contains("Executed 2 tests"))
             }
 
             // Run tests in parallel.
-            XCTAssertThrowsCommandExecutionError(try SwiftPMProduct.SwiftTest.execute(["--parallel"], packagePath: fixturePath)) { error in
+            XCTAssertThrowsCommandExecutionError(try SwiftPM.Test.execute(["--parallel"], packagePath: fixturePath)) { error in
                 // in "swift test" test output goes to stdout
                 XCTAssertMatch(error.stdout, .contains("testExample1"))
                 XCTAssertMatch(error.stdout, .contains("testExample2"))
@@ -108,7 +108,7 @@ final class TestToolTests: CommandsTestCase {
                 let xUnitOutput = fixturePath.appending("result.xml")
                 // Run tests in parallel with verbose output.
                 XCTAssertThrowsCommandExecutionError(
-                    try SwiftPMProduct.SwiftTest.execute(["--parallel", "--verbose", "--xunit-output", xUnitOutput.pathString], packagePath: fixturePath)
+                    try SwiftPM.Test.execute(["--parallel", "--verbose", "--xunit-output", xUnitOutput.pathString], packagePath: fixturePath)
                 ) { error in
                     // in "swift test" test output goes to stdout
                     XCTAssertMatch(error.stdout, .contains("testExample1"))
@@ -129,52 +129,51 @@ final class TestToolTests: CommandsTestCase {
     }
 
     func testSwiftTestFilter() throws {
-        try fixture(name: "Miscellaneous/ParallelTestsPkg") { fixturePath in
-            let result = try SwiftPMProduct.SwiftTest.executeProcess(["--filter", ".*1"], packagePath: fixturePath)
-            let stdout = try result.utf8Output()
+        try fixture(name: "Miscellaneous/SkipTests") { fixturePath in
+            let (stdout, _) = try SwiftPM.Test.execute(["--filter", ".*1"], packagePath: fixturePath)
             // in "swift test" test output goes to stdout
             XCTAssertMatch(stdout, .contains("testExample1"))
             XCTAssertNoMatch(stdout, .contains("testExample2"))
-            XCTAssertNoMatch(stdout, .contains("testSureFailure"))
+            XCTAssertNoMatch(stdout, .contains("testExample3"))
+            XCTAssertNoMatch(stdout, .contains("testExample4"))
         }
 
-        try fixture(name: "Miscellaneous/ParallelTestsPkg") { fixturePath in
-            let result = try SwiftPMProduct.SwiftTest.executeProcess(["--filter", "ParallelTestsTests", "--skip", ".*1", "--filter", "testSureFailure"], packagePath: fixturePath)
-            let stdout = try result.utf8Output()
+        try fixture(name: "Miscellaneous/SkipTests") { fixturePath in
+            let (stdout, _) = try SwiftPM.Test.execute(["--filter", "SomeTests", "--skip", ".*1", "--filter", "testExample3"], packagePath: fixturePath)
             // in "swift test" test output goes to stdout
             XCTAssertNoMatch(stdout, .contains("testExample1"))
             XCTAssertMatch(stdout, .contains("testExample2"))
-            XCTAssertMatch(stdout, .contains("testSureFailure"))
+            XCTAssertMatch(stdout, .contains("testExample3"))
+            XCTAssertNoMatch(stdout, .contains("testExample4"))
         }
     }
 
     func testSwiftTestSkip() throws {
-        try fixture(name: "Miscellaneous/ParallelTestsPkg") { fixturePath in
-            let result = try SwiftPMProduct.SwiftTest.executeProcess(["--skip", "ParallelTestsTests"], packagePath: fixturePath)
-            let stdout = try result.utf8Output()
+        try fixture(name: "Miscellaneous/SkipTests") { fixturePath in
+            let (stdout, _) = try SwiftPM.Test.execute(["--skip", "SomeTests"], packagePath: fixturePath)
             // in "swift test" test output goes to stdout
             XCTAssertNoMatch(stdout, .contains("testExample1"))
             XCTAssertNoMatch(stdout, .contains("testExample2"))
-            XCTAssertMatch(stdout, .contains("testSureFailure"))
+            XCTAssertMatch(stdout, .contains("testExample3"))
+            XCTAssertMatch(stdout, .contains("testExample4"))
         }
 
-        try fixture(name: "Miscellaneous/ParallelTestsPkg") { fixturePath in
-            let result = try SwiftPMProduct.SwiftTest.executeProcess(["--filter", "ParallelTestsTests", "--skip", ".*2", "--filter", "TestsFailure", "--skip", "testSureFailure"], packagePath: fixturePath)
-            let stdout = try result.utf8Output()
+        try fixture(name: "Miscellaneous/SkipTests") { fixturePath in
+            let (stdout, _) = try SwiftPM.Test.execute(["--filter", "ExampleTests", "--skip", ".*2", "--filter", "MoreTests", "--skip", "testExample3"], packagePath: fixturePath)
             // in "swift test" test output goes to stdout
             XCTAssertMatch(stdout, .contains("testExample1"))
             XCTAssertNoMatch(stdout, .contains("testExample2"))
-            XCTAssertNoMatch(stdout, .contains("testSureFailure"))
+            XCTAssertNoMatch(stdout, .contains("testExample3"))
+            XCTAssertMatch(stdout, .contains("testExample4"))
         }
 
-        try fixture(name: "Miscellaneous/ParallelTestsPkg") { fixturePath in
-            let result = try SwiftPMProduct.SwiftTest.executeProcess(["--skip", "Tests"], packagePath: fixturePath)
-            let stdout = try result.utf8Output()
-            let stderr = try result.utf8stderrOutput()
+        try fixture(name: "Miscellaneous/SkipTests") { fixturePath in
+            let (stdout, stderr) = try SwiftPM.Test.execute(["--skip", "Tests"], packagePath: fixturePath)
             // in "swift test" test output goes to stdout
             XCTAssertNoMatch(stdout, .contains("testExample1"))
             XCTAssertNoMatch(stdout, .contains("testExample2"))
-            XCTAssertNoMatch(stdout, .contains("testSureFailure"))
+            XCTAssertNoMatch(stdout, .contains("testExample3"))
+            XCTAssertNoMatch(stdout, .contains("testExample4"))
             XCTAssertMatch(stderr, .contains("No matching test cases were run"))
         }
     }
@@ -184,26 +183,26 @@ final class TestToolTests: CommandsTestCase {
         #if canImport(Darwin)
         // should emit when LinuxMain is present
         try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
-            let (_, stderr) = try SwiftPMProduct.SwiftTest.execute(["--enable-test-discovery"] + compilerDiagnosticFlags, packagePath: fixturePath)
+            let (_, stderr) = try SwiftPM.Test.execute(["--enable-test-discovery"] + compilerDiagnosticFlags, packagePath: fixturePath)
             XCTAssertMatch(stderr, .contains("warning: '--enable-test-discovery' option is deprecated"))
         }
 
         // should emit when LinuxMain is not present
         try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
             try localFileSystem.writeFileContents(fixturePath.appending(components: "Tests", SwiftTarget.defaultTestEntryPointName), bytes: "fatalError(\"boom\")")
-            let (_, stderr) = try SwiftPMProduct.SwiftTest.execute(["--enable-test-discovery"] + compilerDiagnosticFlags, packagePath: fixturePath)
+            let (_, stderr) = try SwiftPM.Test.execute(["--enable-test-discovery"] + compilerDiagnosticFlags, packagePath: fixturePath)
             XCTAssertMatch(stderr, .contains("warning: '--enable-test-discovery' option is deprecated"))
         }
         #else
         // should emit when LinuxMain is present
         try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
-            let (_, stderr) = try SwiftPMProduct.SwiftTest.execute(["--enable-test-discovery"] + compilerDiagnosticFlags, packagePath: fixturePath)
+            let (_, stderr) = try SwiftPM.Test.execute(["--enable-test-discovery"] + compilerDiagnosticFlags, packagePath: fixturePath)
             XCTAssertMatch(stderr, .contains("warning: '--enable-test-discovery' option is deprecated"))
         }
         // should not emit when LinuxMain is present
         try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
             try localFileSystem.writeFileContents(fixturePath.appending(components: "Tests", SwiftTarget.defaultTestEntryPointName), bytes: "fatalError(\"boom\")")
-            let (_, stderr) = try SwiftPMProduct.SwiftTest.execute(["--enable-test-discovery"] + compilerDiagnosticFlags, packagePath: fixturePath)
+            let (_, stderr) = try SwiftPM.Test.execute(["--enable-test-discovery"] + compilerDiagnosticFlags, packagePath: fixturePath)
             XCTAssertNoMatch(stderr, .contains("warning: '--enable-test-discovery' option is deprecated"))
         }
         #endif
@@ -211,7 +210,7 @@ final class TestToolTests: CommandsTestCase {
 
     func testList() throws {
         try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
-            let (stdout, stderr) = try SwiftPMProduct.SwiftTest.execute(["list"], packagePath: fixturePath)
+            let (stdout, stderr) = try SwiftPM.Test.execute(["list"], packagePath: fixturePath)
             // build was run
             XCTAssertMatch(stderr, .contains("Build complete!"))
             // getting the lists
@@ -223,12 +222,12 @@ final class TestToolTests: CommandsTestCase {
         try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
             // build first
             do {
-                let (stdout, _) = try SwiftPMProduct.SwiftBuild.execute(["--build-tests"], packagePath: fixturePath)
+                let (stdout, _) = try SwiftPM.Build.execute(["--build-tests"], packagePath: fixturePath)
                 XCTAssertMatch(stdout, .contains("Build complete!"))
             }
             // list
             do {
-                let (stdout, stderr) = try SwiftPMProduct.SwiftTest.execute(["list"], packagePath: fixturePath)
+                let (stdout, stderr) = try SwiftPM.Test.execute(["list"], packagePath: fixturePath)
                 // build was run
                 XCTAssertMatch(stderr, .contains("Build complete!"))
                 // getting the lists
@@ -241,12 +240,12 @@ final class TestToolTests: CommandsTestCase {
         try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
             // build first
             do {
-                let (stdout, _) = try SwiftPMProduct.SwiftBuild.execute(["--build-tests"], packagePath: fixturePath)
+                let (stdout, _) = try SwiftPM.Build.execute(["--build-tests"], packagePath: fixturePath)
                 XCTAssertMatch(stdout, .contains("Build complete!"))
             }
             // list while skipping build
             do {
-                let (stdout, stderr) = try SwiftPMProduct.SwiftTest.execute(["list", "--skip-build"], packagePath: fixturePath)
+                let (stdout, stderr) = try SwiftPM.Test.execute(["list", "--skip-build"], packagePath: fixturePath)
                 // build was not run
                 XCTAssertNoMatch(stderr, .contains("Build complete!"))
                 // getting the lists

--- a/Tests/FunctionalPerformanceTests/BuildPerfTests.swift
+++ b/Tests/FunctionalPerformanceTests/BuildPerfTests.swift
@@ -22,11 +22,11 @@ class BuildPerfTests: XCTestCasePerf {
     @discardableResult
     func execute(args: [String] = [], packagePath: AbsolutePath) throws -> (stdout: String, stderr: String) {
         // FIXME: We should pass the SWIFT_EXEC at lower level.
-        return try SwiftPMProduct.SwiftBuild.execute(args + [], packagePath: packagePath, env: ["SWIFT_EXEC": UserToolchain.default.swiftCompilerPath.pathString])
+        return try SwiftPM.Build.execute(args + [], packagePath: packagePath, env: ["SWIFT_EXEC": UserToolchain.default.swiftCompilerPath.pathString])
     }
 
     func clean(packagePath: AbsolutePath) throws {
-        _ = try SwiftPMProduct.SwiftPackage.execute(["clean"], packagePath: packagePath)
+        _ = try SwiftPM.Package.execute(["clean"], packagePath: packagePath)
     }
 
     func testTrivialPackageFullBuild() throws {

--- a/Tests/FunctionalTests/CFamilyTargetTests.swift
+++ b/Tests/FunctionalTests/CFamilyTargetTests.swift
@@ -52,7 +52,7 @@ class CFamilyTargetTestCase: XCTestCase {
             let debugPath = fixturePath.appending(components: "Bar", ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Sea.c.o")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Foo.c.o")
-            let path = try SwiftPMProduct.packagePath(for: "Foo", packageRoot: packageRoot)
+            let path = try SwiftPM.packagePath(for: "Foo", packageRoot: packageRoot)
             XCTAssertEqual(try GitRepository(path: path).getTags(), ["1.2.3"])
         }
     }

--- a/Tests/FunctionalTests/DependencyResolutionTests.swift
+++ b/Tests/FunctionalTests/DependencyResolutionTests.swift
@@ -55,7 +55,7 @@ class DependencyResolutionTests: XCTestCase {
             let packageRoot = fixturePath.appending("Bar")
             XCTAssertBuilds(packageRoot)
             XCTAssertFileExists(fixturePath.appending(components: "Bar", ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Bar"))
-            let path = try SwiftPMProduct.packagePath(for: "Foo", packageRoot: packageRoot)
+            let path = try SwiftPM.packagePath(for: "Foo", packageRoot: packageRoot)
             XCTAssert(try GitRepository(path: path).getTags().contains("1.2.3"))
         }
     }
@@ -72,8 +72,7 @@ class DependencyResolutionTests: XCTestCase {
         try fixture(name: "DependencyResolution/External/Branch") { fixturePath in
             // Tests the convenience init .package(url: , branch: )
             let app = fixturePath.appending("Bar")
-            let result = try SwiftPMProduct.SwiftBuild.executeProcess([], packagePath: app)
-            XCTAssertEqual(result.exitStatus, .terminated(code: 0))
+            try SwiftPM.Build.execute(packagePath: app)
         }
     }
 
@@ -141,8 +140,7 @@ class DependencyResolutionTests: XCTestCase {
 
     func testPackageLookupCaseInsensitive() throws {
         try fixture(name: "DependencyResolution/External/PackageLookupCaseInsensitive") { fixturePath in
-            let result = try SwiftPMProduct.SwiftPackage.executeProcess(["update"], packagePath: fixturePath.appending("pkg"))
-            XCTAssert(result.exitStatus == .terminated(code: 0), try! result.utf8Output() + result.utf8stderrOutput())
+            try SwiftPM.Package.execute(["update"], packagePath: fixturePath.appending("pkg"))
         }
     }
 }

--- a/Tests/FunctionalTests/ModuleAliasingFixtureTests.swift
+++ b/Tests/FunctionalTests/ModuleAliasingFixtureTests.swift
@@ -28,9 +28,7 @@ class ModuleAliasingFixtureTests: XCTestCase {
             XCTAssertFileExists(buildPath.appending(components: "App"))
             XCTAssertFileExists(buildPath.appending(components: "GameUtils.swiftmodule"))
             XCTAssertFileExists(buildPath.appending(components: "Utils.swiftmodule"))
-            let result = try SwiftPMProduct.SwiftBuild.executeProcess([], packagePath: pkgPath)
-            let output = try result.utf8Output() + result.utf8stderrOutput()
-            XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
+            _ = try SwiftPM.Build.execute(packagePath: pkgPath)
         }
     }
 
@@ -42,9 +40,7 @@ class ModuleAliasingFixtureTests: XCTestCase {
             XCTAssertFileExists(buildPath.appending(components: "App"))
             XCTAssertFileExists(buildPath.appending(components: "AUtils.swiftmodule"))
             XCTAssertFileExists(buildPath.appending(components: "BUtils.swiftmodule"))
-            let result = try SwiftPMProduct.SwiftBuild.executeProcess([], packagePath: pkgPath)
-            let output = try result.utf8Output() + result.utf8stderrOutput()
-            XCTAssertEqual(result.exitStatus, .terminated(code: 0), "output: \(output)")
+            _ = try SwiftPM.Build.execute(packagePath: pkgPath)
         }
     }
 }

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -1012,7 +1012,7 @@ class PluginTests: XCTestCase {
         try fixture(name: "Miscellaneous/Plugins") { fixturePath in
             do {
                 try executeSwiftBuild(fixturePath.appending("MissingPlugin"))
-            } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
+            } catch SwiftPMError.executionFailure(_, _, let stderr) {
                 XCTAssert(stderr.contains("error: 'missingplugin': no plugin named 'NonExistingPlugin' found"), "stderr:\n\(stderr)")
             }
         }

--- a/Tests/FunctionalTests/SwiftPMXCTestHelperTests.swift
+++ b/Tests/FunctionalTests/SwiftPMXCTestHelperTests.swift
@@ -51,7 +51,7 @@ class SwiftPMXCTestHelperTests: XCTestCase {
         #if os(macOS)
         let env = ["DYLD_FRAMEWORK_PATH": try Destination.sdkPlatformFrameworkPaths().fwk.pathString]
         let outputFile = bundlePath.parentDirectory.appending("tests.txt")
-        let _ = try SwiftPMProduct.XCTestHelper.execute([bundlePath.pathString, outputFile.pathString], env: env)
+        try SwiftPM.XCTestHelper.execute([bundlePath.pathString, outputFile.pathString], env: env)
         guard let data = NSData(contentsOfFile: outputFile.pathString) else {
             XCTFail("No output found in : \(outputFile)"); return;
         }

--- a/Tests/FunctionalTests/ToolsVersionTests.swift
+++ b/Tests/FunctionalTests/ToolsVersionTests.swift
@@ -57,7 +57,7 @@ class ToolsVersionTests: XCTestCase {
             try repo.tag(name: "1.0.0")
 
             // v1.0.1
-            _ = try SwiftPMProduct.SwiftPackage.execute(
+            _ = try SwiftPM.Package.execute(
                 ["tools-version", "--set", "10000.1"], packagePath: depPath)
             try fs.writeFileContents(
                 depPath.appending("foo.swift"),
@@ -89,20 +89,20 @@ class ToolsVersionTests: XCTestCase {
                     Dep.foo()
                     """
             )
-            _ = try SwiftPMProduct.SwiftPackage.execute(
+            _ = try SwiftPM.Package.execute(
                 ["tools-version", "--set", "4.2"], packagePath: primaryPath).stdout.spm_chomp()
 
             // Build the primary package.
-            _ = try SwiftPMProduct.SwiftBuild.execute([], packagePath: primaryPath)
+            _ = try SwiftPM.Build.execute(packagePath: primaryPath)
             let exe = primaryPath.appending(components: ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Primary").pathString
             // v1 should get selected because v1.0.1 depends on a (way) higher set of tools.
             XCTAssertEqual(try Process.checkNonZeroExit(args: exe).spm_chomp(), "foo@1.0")
 
             // Set the tools version to something high.
-            _ = try SwiftPMProduct.SwiftPackage.execute(
+            _ = try SwiftPM.Package.execute(
                 ["tools-version", "--set", "10000.1"], packagePath: primaryPath)
 
-            XCTAssertThrowsCommandExecutionError(try SwiftPMProduct.SwiftBuild.execute([], packagePath: primaryPath)) { error in
+            XCTAssertThrowsCommandExecutionError(try SwiftPM.Build.execute(packagePath: primaryPath)) { error in
                 XCTAssert(error.stderr.contains("is using Swift tools version 10000.1.0 but the installed version is \(ToolsVersion.current)"), error.stderr)
             }
 
@@ -118,10 +118,10 @@ class ToolsVersionTests: XCTestCase {
                         swiftLanguageVersions: [.version("1000")])
                     """
             )
-            _ = try SwiftPMProduct.SwiftPackage.execute(
+            _ = try SwiftPM.Package.execute(
                 ["tools-version", "--set", "4.2"], packagePath: primaryPath).stdout.spm_chomp()
 
-            XCTAssertThrowsCommandExecutionError(try SwiftPMProduct.SwiftBuild.execute([], packagePath: primaryPath)) { error in
+            XCTAssertThrowsCommandExecutionError(try SwiftPM.Build.execute(packagePath: primaryPath)) { error in
                 XCTAssertTrue(error.stderr.contains("package 'primary' requires minimum Swift language version 1000 which is not supported by the current tools version (\(ToolsVersion.current))"), error.stderr)
             }
 
@@ -136,9 +136,9 @@ class ToolsVersionTests: XCTestCase {
                         swiftLanguageVersions: [.version("\(ToolsVersion.current.major)"), .version("1000")])
                     """
              )
-             _ = try SwiftPMProduct.SwiftPackage.execute(
+             _ = try SwiftPM.Package.execute(
                  ["tools-version", "--set", "4.2"], packagePath: primaryPath).stdout.spm_chomp()
-             _ = try SwiftPMProduct.SwiftBuild.execute([], packagePath: primaryPath)
+             _ = try SwiftPM.Build.execute(packagePath: primaryPath)
         }
     }
 }

--- a/Tests/FunctionalTests/VersionSpecificTests.swift
+++ b/Tests/FunctionalTests/VersionSpecificTests.swift
@@ -124,7 +124,7 @@ class VersionSpecificTests: XCTestCase {
             try repo.tag(name: "1.1.0@swift-\(SwiftVersion.current.major)")
 
             // The build should work now.
-            _ = try SwiftPMProduct.SwiftPackage.execute(["reset"], packagePath: primaryPath)
+            _ = try SwiftPM.Package.execute(["reset"], packagePath: primaryPath)
             XCTAssertBuilds(primaryPath)
         }
     }


### PR DESCRIPTION
motivation: these are specific to SwiftPM and should not be in TSC

changes:
* move Product, SwiftPMProductError from TSC to SwiftPM
* refactor how SwiftPMProduct is used in tests
* update all callsites (tests)