### PR TITLE
Fix plugin templates

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -293,7 +293,7 @@ public final class InitPackage {
                 } else if packageType == .buildToolPlugin {
                     param += """
                             .plugin(
-                                name: "\(typeName)",
+                                name: "\(pkgname)",
                                 capability: .buildTool()
                             ),
                         ]
@@ -301,7 +301,7 @@ public final class InitPackage {
                 } else if packageType == .commandPlugin {
                     param += """
                             .plugin(
-                                name: "\(typeName)",
+                                name: "\(pkgname)",
                                 capability: .command(intent: .custom(
                                     verb: "\(typeName)",
                                     description: "prints hello world"


### PR DESCRIPTION
We are using `pkgname` everywhere as target names and also as dependency references, but plugin targets were using `typeName` which leads to newly created plugin packages being broken if the difference was meaningful (e.g. if the name includes dashes).