### PR TITLE
sandbox: UInt8 is too small to hold a TCP or UDP port

### DIFF
--- a/Sources/Basics/Sandbox.swift
+++ b/Sources/Basics/Sandbox.swift
@@ -15,8 +15,8 @@ import func TSCBasic.determineTempDirectory
 
 public enum SandboxNetworkPermission: Equatable {
     case none
-    case local(ports: [UInt8])
-    case all(ports: [UInt8])
+    case local(ports: [Int])
+    case all(ports: [Int])
     case docker
     case unixDomainSocket
 
@@ -28,7 +28,7 @@ public enum SandboxNetworkPermission: Equatable {
         }
     }
 
-    fileprivate var ports: [UInt8] {
+    fileprivate var ports: [Int] {
         switch self {
         case .all(let ports): return ports
         case .local(let ports): return ports

--- a/Sources/Commands/Utilities/DescribedPackage.swift
+++ b/Sources/Commands/Utilities/DescribedPackage.swift
@@ -192,8 +192,8 @@ struct DescribedPackage: Encodable {
         struct Permission: Encodable {
             enum NetworkScope: Encodable {
                 case none
-                case local(ports: [UInt8])
-                case all(ports: [UInt8])
+                case local(ports: [Int])
+                case all(ports: [Int])
                 case docker
                 case unixDomainSocket
 

--- a/Sources/PackageDescription/PackageDescriptionSerialization.swift
+++ b/Sources/PackageDescription/PackageDescriptionSerialization.swift
@@ -184,8 +184,8 @@ enum Serialization {
 
     enum PluginNetworkPermissionScope: Codable {
         case none
-        case local(ports: [UInt8])
-        case all(ports: [UInt8])
+        case local(ports: [Int])
+        case all(ports: [Int])
         case docker
         case unixDomainSocket
     }

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -1492,21 +1492,21 @@ public enum PluginNetworkPermissionScope {
     /// Do not allow network access.
     case none
     /// Allow local network connections; can be limited to a list of allowed ports.
-    case local(ports: [UInt8] = [])
+    case local(ports: [Int] = [])
     /// Allow local and outgoing network connections; can be limited to a list of allowed ports.
-    case all(ports: [UInt8] = [])
+    case all(ports: [Int] = [])
     /// Allow connections to Docker through UNIX domain sockets.
     case docker
     /// Allow connections to any UNIX domain socket.
     case unixDomainSocket
 
     /// Allow local and outgoing network connections, limited to a range of allowed ports.
-    public static func all(ports: Range<UInt8>) -> PluginNetworkPermissionScope {
+    public static func all(ports: Range<Int>) -> PluginNetworkPermissionScope {
         return .all(ports: Array(ports))
     }
 
     /// Allow local network connections, limited to a range of allowed ports.
-    public static func local(ports: Range<UInt8>) -> PluginNetworkPermissionScope {
+    public static func local(ports: Range<Int>) -> PluginNetworkPermissionScope {
         return .local(ports: Array(ports))
     }
 }

--- a/Sources/PackageModel/Manifest/TargetDescription.swift
+++ b/Sources/PackageModel/Manifest/TargetDescription.swift
@@ -124,12 +124,12 @@ public struct TargetDescription: Equatable, Encodable, Sendable {
 
     public enum PluginNetworkPermissionScope: Equatable, Codable, Sendable {
         case none
-        case local(ports: [UInt8])
-        case all(ports: [UInt8])
+        case local(ports: [Int])
+        case all(ports: [Int])
         case docker
         case unixDomainSocket
 
-        public init?(_ scopeString: String, ports: [UInt8]) {
+        public init?(_ scopeString: String, ports: [Int]) {
             switch scopeString {
             case "none": self = .none
             case "local": self = .local(ports: ports)

--- a/Sources/PackageModel/Target.swift
+++ b/Sources/PackageModel/Target.swift
@@ -847,8 +847,8 @@ public enum PluginCommandIntent: Hashable, Codable {
 
 public enum PluginNetworkPermissionScope: Hashable, Codable {
     case none
-    case local(ports: [UInt8])
-    case all(ports: [UInt8])
+    case local(ports: [Int])
+    case all(ports: [Int])
     case docker
     case unixDomainSocket
 
@@ -872,7 +872,7 @@ public enum PluginNetworkPermissionScope: Hashable, Codable {
         }
     }
 
-    public var ports: [UInt8] {
+    public var ports: [Int] {
         switch self {
         case .all(let ports): return ports
         case .local(let ports): return ports

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -1890,8 +1890,8 @@ final class PackageToolTests: CommandsTestCase {
             reason: "internet good",
             remedy: ["--allow-network-connections", "all"])
         try testCommandPluginNetworkingPermissions(
-            permissionsManifestFragment: "[.allowNetworkConnections(scope: .all(ports: [23, 42]), reason: \"internet good\")]",
-            permissionError: "all network connections on ports: 23, 42",
+            permissionsManifestFragment: "[.allowNetworkConnections(scope: .all(ports: [23, 42, 443, 8080]), reason: \"internet good\")]",
+            permissionError: "all network connections on ports: 23, 42, 443, 8080",
             reason: "internet good",
             remedy: ["--allow-network-connections", "all"])
         try testCommandPluginNetworkingPermissions(
@@ -1906,8 +1906,8 @@ final class PackageToolTests: CommandsTestCase {
             reason: "localhost good",
             remedy: ["--allow-network-connections", "local"])
         try testCommandPluginNetworkingPermissions(
-            permissionsManifestFragment: "[.allowNetworkConnections(scope: .local(ports: [23, 42]), reason: \"localhost good\")]",
-            permissionError: "local network connections on ports: 23, 42",
+            permissionsManifestFragment: "[.allowNetworkConnections(scope: .local(ports: [23, 42, 443, 8080]), reason: \"localhost good\")]",
+            permissionError: "local network connections on ports: 23, 42, 443, 8080",
             reason: "localhost good",
             remedy: ["--allow-network-connections", "local"])
         try testCommandPluginNetworkingPermissions(

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -586,7 +586,7 @@ class ManifestSourceGenerationTests: XCTestCase {
             toolsVersion: .v5_9,
             dependencies: [],
             targets: [
-                try TargetDescription(name: "MyPlugin", type: .plugin, pluginCapability: .command(intent: .custom(verb: "foo", description: "bar"), permissions: [.allowNetworkConnections(scope: .all(ports: [23, 42]), reason: "internet good")]))
+                try TargetDescription(name: "MyPlugin", type: .plugin, pluginCapability: .command(intent: .custom(verb: "foo", description: "bar"), permissions: [.allowNetworkConnections(scope: .all(ports: [23, 42, 443, 8080]), reason: "internet good")]))
             ])
         let contents = try manifest.generateManifestFileContents(packageDirectory: manifest.path.parentDirectory)
         try testManifestWritingRoundTrip(manifestContents: contents, toolsVersion: .v5_9)


### PR DESCRIPTION
### Motivation:

TCP and UDP port numbers are unsigned 16-bit integers, but SandboxNetworkPermission uses UInt8s so trying to specify anything but a small subset of low port numbers causes an error:

    permissions: [
        .allowNetworkConnections(
            scope: .all(ports: [443, 8080]),
            reason: "This command accesses the network"
        )
    ]

leads to

    error: integer literal '443' overflows when stored into 'Array<UInt8>.ArrayLiteralElement' (aka 'UInt8')
    error: integer literal '8080' overflows when stored into 'Array<UInt8>.ArrayLiteralElement' (aka 'UInt8')

### Modifications:

This commit updates the type definitions and adds some higher-numbered ports to the .allowNetworkConnections test cases.

### Result:

It is possible to specify that a plugin needs access to ports higher than 255.