### PR TITLE
Fix CHANGELOG.md’s link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -339,3 +339,7 @@ Swift 3.0
 [#6067]: https://github.com/apple/swift-package-manager/pull/6067
 [#6114]: https://github.com/apple/swift-package-manager/pull/6114
 [#6144]: https://github.com/apple/swift-package-manager/pull/6144
+[#6294]: https://github.com/apple/swift-package-manager/pull/6294
+[#6185]: https://github.com/apple/swift-package-manager/pull/6185
+[#6200]: https://github.com/apple/swift-package-manager/pull/6200
+[#6111]: https://github.com/apple/swift-package-manager/pull/6111


### PR DESCRIPTION
Close #6522 

### Result:

Fix the broken links

<img width="177" alt="image" src="https://github.com/apple/swift-package-manager/assets/43724855/02c07f3d-37e3-47b1-8081-15bef0dc9c98">

