### PR TITLE
Package.swift: make package name consistent with repo name

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -67,7 +67,7 @@ automatic linking type with `-auto` suffix appended to product's name.
 let autoProducts = [swiftPMProduct, swiftPMDataModelProduct]
 
 let package = Package(
-    name: "SwiftPM",
+    name: "swift-package-manager",
     platforms: [
         .macOS("12.0"),
         .iOS("15.0")


### PR DESCRIPTION
Rest of SwiftPM packages provided by Apple follow a dash-case naming scheme consistent with repository name, usually with `swift-` prefix.

This shouldn't have any impact on SwiftPM clients, since this `name` argument of `Package` initializer is only used for display purposes and not for package resolution.
