### PR TITLE
Adopt `swift-certificates` `0.6.0`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -726,7 +726,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: "2.5.0")),
         .package(url: "https://github.com/apple/swift-system.git", .upToNextMinor(from: "1.1.1")),
         .package(url: "https://github.com/apple/swift-collections.git", .upToNextMinor(from: "1.0.1")),
-        .package(url: "https://github.com/apple/swift-certificates.git", .upToNextMinor(from: "0.4.1")),
+        .package(url: "https://github.com/apple/swift-certificates.git", .upToNextMinor(from: "0.6.0")),
     ]
 } else {
     package.dependencies += [

--- a/Sources/PackageSigning/SignatureProvider.swift
+++ b/Sources/PackageSigning/SignatureProvider.swift
@@ -280,9 +280,11 @@ struct CMSSignatureProvider: SignatureProviderProtocol {
                 // the WWDR roots are in the trust store or not, which by default
                 // they are but user may disable that through configuration.
                 additionalIntermediateCertificates: Certificates.wwdrIntermediates,
-                trustRoots: CertificateStore(trustRoots),
-                policy: self.buildPolicySet(configuration: verifierConfiguration, httpClient: self.httpClient)
-            )
+                trustRoots: CertificateStore(trustRoots)
+            ) {
+                self.buildPolicySet(configuration: verifierConfiguration, httpClient: self.httpClient)
+            }
+            
 
             switch result {
             case .success(let valid):
@@ -341,9 +343,9 @@ struct CMSSignatureProvider: SignatureProviderProtocol {
                 // For self-signed certificate, the signature should include intermediate(s).
                 untrustedIntermediates.append(contentsOf: cmsSignature.certificates)
 
-                let policySet = self.buildPolicySet(configuration: verifierConfiguration, httpClient: self.httpClient)
-
-                var verifier = Verifier(rootCertificates: CertificateStore(trustRoots), policy: policySet)
+                var verifier = Verifier(rootCertificates: CertificateStore(trustRoots)) {
+                    self.buildPolicySet(configuration: verifierConfiguration, httpClient: self.httpClient)
+                }
                 let result = await verifier.validate(
                     leafCertificate: signingCertificate,
                     intermediates: CertificateStore(untrustedIntermediates)

--- a/Tests/PackageCollectionsSigningTests/Utilities.swift
+++ b/Tests/PackageCollectionsSigningTests/Utilities.swift
@@ -56,17 +56,16 @@ struct TestCertificatePolicy: CertificatePolicy {
         validationTime: Date,
         callback: @escaping (Result<Void, Error>) -> Void
     ) {
-        var policies = [VerifierPolicy]()
-        // Must be a code signing certificate
-        policies.append(_CodeSigningPolicy())
-        // Basic validations including expiry check
-        policies.append(RFC5280Policy(validationTime: validationTime))
-        // Doesn't require OCSP
-
         self.verify(
             certChain: certChain,
             trustedRoots: self.trustedRoots,
-            policies: policies,
+            policies: {
+                // Must be a code signing certificate
+                _CodeSigningPolicy()
+                // Basic validations including expiry check
+                RFC5280Policy(validationTime: validationTime)
+                // Doesn't require OCSP
+            },
             observabilityScope: ObservabilitySystem.NOOP,
             callbackQueue: callbackQueue,
             callback: callback

--- a/Tests/PackageSigningTests/SigningTests.swift
+++ b/Tests/PackageSigningTests/SigningTests.swift
@@ -1241,7 +1241,10 @@ extension BasicOCSPResponse {
         responses: [OCSPSingleResponse],
         privateKey: P256.Signing.PrivateKey,
         certs: [Certificate]? = [],
-        @ExtensionsBuilder responseExtensions: () -> Certificate.Extensions = { .init() }
+        @ExtensionsBuilder responseExtensions: () throws -> Result<Certificate.Extensions, any Error> = {
+            // workaround for rdar://108897294
+            Result.success(Certificate.Extensions())
+        }
     ) throws -> Self {
         try .signed(
             responseData: .init(
@@ -1249,7 +1252,7 @@ extension BasicOCSPResponse {
                 responderID: responderID,
                 producedAt: producedAt,
                 responses: responses,
-                responseExtensions: responseExtensions()
+                responseExtensions: try .init(builder: responseExtensions)
             ),
             privateKey: privateKey,
             certs: certs


### PR DESCRIPTION
`swift-certificates` has released a new version with a couple breaking changes:
- `PolicySet` is deprecated in favour of a [new result builder DSL](https://github.com/apple/swift-certificates/pull/79) and returns an opaque `VerifierPolicy`. Verifier is now generic over the concrete `VerifierPolicy` and uses the `@PolicyBuilder` to constructs its policy.
- `Certificate.Extensions` now [gracefully fails extension serialization](https://github.com/apple/swift-certificates/pull/80) but now needs to return `Result<Certificate.Extensions, any Error>`.

This PR adopts these new changes.
