### PR TITLE
[5.9] Run build tool plugins for C-family targets

### DIFF
--- a/Sources/Build/BuildDescription/SharedTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SharedTargetBuildDescription.swift
@@ -1,0 +1,67 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import PackageGraph
+import PackageLoading
+import PackageModel
+import SPMBuildCore
+
+import struct TSCBasic.AbsolutePath
+
+/// Shared functionality between `ClangTargetBuildDescription` and `SwiftTargetBuildDescription` with the eventual hope of having a single type.
+struct SharedTargetBuildDescription {
+    static func computePluginGeneratedFiles(
+        target: ResolvedTarget,
+        toolsVersion: ToolsVersion,
+        additionalFileRules: [FileRuleDescription],
+        buildParameters: BuildParameters,
+        buildToolPluginInvocationResults: [BuildToolPluginInvocationResult],
+        prebuildCommandResults: [PrebuildCommandResult],
+        observabilityScope: ObservabilityScope
+    ) -> (pluginDerivedSources: Sources, pluginDerivedResources: [Resource]) {
+        var pluginDerivedSources = Sources(paths: [], root: buildParameters.dataPath)
+
+        // Add any derived files that were declared for any commands from plugin invocations.
+        var pluginDerivedFiles = [AbsolutePath]()
+        for command in buildToolPluginInvocationResults.reduce([], { $0 + $1.buildCommands }) {
+            for absPath in command.outputFiles {
+                pluginDerivedFiles.append(absPath)
+            }
+        }
+
+        // Add any derived files that were discovered from output directories of prebuild commands.
+        for result in prebuildCommandResults {
+            for path in result.derivedFiles {
+                pluginDerivedFiles.append(path)
+            }
+        }
+
+        // Let `TargetSourcesBuilder` compute the treatment of plugin generated files.
+        let (derivedSources, derivedResources) = TargetSourcesBuilder.computeContents(
+            for: pluginDerivedFiles,
+            toolsVersion: toolsVersion,
+            additionalFileRules: additionalFileRules,
+            defaultLocalization: target.defaultLocalization,
+            targetName: target.name,
+            targetPath: target.underlyingTarget.path,
+            observabilityScope: observabilityScope
+        )
+        let pluginDerivedResources = derivedResources
+        derivedSources.forEach { absPath in
+            let relPath = absPath.relative(to: pluginDerivedSources.root)
+            pluginDerivedSources.relativePaths.append(relPath)
+        }
+
+        return (pluginDerivedSources, pluginDerivedResources)
+    }
+}

--- a/Sources/Build/BuildDescription/TargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/TargetBuildDescription.swift
@@ -13,6 +13,7 @@
 import class PackageGraph.ResolvedTarget
 import struct PackageModel.Resource
 import struct TSCBasic.AbsolutePath
+import struct SPMBuildCore.BuildToolPluginInvocationResult
 
 /// A target description which can either be for a Swift or Clang target.
 public enum TargetBuildDescription {
@@ -40,8 +41,7 @@ public enum TargetBuildDescription {
         case .swift(let target):
             return target.resources
         case .clang(let target):
-            // TODO: Clang targets should support generated resources in the future.
-            return target.target.underlyingTarget.resources
+            return target.resources
         }
     }
 
@@ -80,6 +80,15 @@ public enum TargetBuildDescription {
             return target.resourceBundleInfoPlistPath
         case .clang(let target):
             return target.resourceBundleInfoPlistPath
+        }
+    }
+
+    var buildToolPluginInvocationResults: [BuildToolPluginInvocationResult] {
+        switch self {
+        case .swift(let target):
+            return target.buildToolPluginInvocationResults
+        case .clang(let target):
+            return target.buildToolPluginInvocationResults
         }
     }
 }

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -493,8 +493,13 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
                 targetMap[target] = try .clang(ClangTargetBuildDescription(
                     target: target,
                     toolsVersion: toolsVersion,
+                    additionalFileRules: additionalFileRules,
                     buildParameters: buildParameters,
-                    fileSystem: fileSystem))
+                    buildToolPluginInvocationResults: buildToolPluginInvocationResults[target] ?? [],
+                    prebuildCommandResults: prebuildCommandResults[target] ?? [],
+                    fileSystem: fileSystem,
+                    observabilityScope: observabilityScope)
+                )
             case is PluginTarget:
                 guard let package = graph.package(for: target) else {
                     throw InternalError("package not found for \(target)")

--- a/Sources/Build/CMakeLists.txt
+++ b/Sources/Build/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(Build
   BuildDescription/ClangTargetBuildDescription.swift
   BuildDescription/PluginDescription.swift
   BuildDescription/ProductBuildDescription.swift
+  BuildDescription/SharedTargetBuildDescription.swift
   BuildDescription/SwiftTargetBuildDescription.swift
   BuildDescription/TargetBuildDescription.swift
   BuildOperationBuildSystemDelegateHandler.swift


### PR DESCRIPTION
While we intentionally don't support generating C sources from plugins today since we haven't figured out how to deal with headers etc, not running plugins at all without any diagnostics whatsoever seems like an implementation oversight based on the fact that we have two completely different implementations for Swift and C-family targets (which is something we also need to rectify at some point).

With this change, we're running build-tool plugins in the exact same way as we are doing it for Swift targets. We are only doing this for packages with tools-version 5.9 or higher in order to have any unintentional impact on existing packages.

rdar://101671614

Co-authored-by: Max Desiatov <m_desiatov@apple.com>

(cherry picked from commit 678e6831c7b113b9715543f0378c40ef821da71c)
