### PR TITLE
[5.9] Remove 10.15 fallback for manifest/plugin compilation

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -640,10 +640,13 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 #endif
         }
 
-        // Use the same minimum deployment target as the PackageDescription library (with a fallback of 10.15).
+        // Use the same minimum deployment target as the PackageDescription library (with a fallback to the default host triple).
 #if os(macOS)
-        let version = self.toolchain.swiftPMLibrariesLocation.manifestLibraryMinimumDeploymentTarget.versionString
-        cmd += ["-target", "\(self.toolchain.triple.tripleString(forPlatformVersion: version))"]
+        if let version = self.toolchain.swiftPMLibrariesLocation.manifestLibraryMinimumDeploymentTarget?.versionString {
+            cmd += ["-target", "\(self.toolchain.triple.tripleString(forPlatformVersion: version))"]
+        } else {
+            cmd += ["-target", self.toolchain.triple.tripleString]
+        }
 #endif
 
         // Add any extra flags required as indicated by the ManifestLoader.

--- a/Sources/PackageModel/ToolchainConfiguration.swift
+++ b/Sources/PackageModel/ToolchainConfiguration.swift
@@ -88,7 +88,7 @@ extension ToolchainConfiguration {
             } else if let manifestLibraryMinimumDeploymentTarget = try? MinimumDeploymentTarget.computeMinimumDeploymentTarget(of: Self.macOSManifestLibraryPath(for: manifestLibraryPath), platform: .macOS) {
                 self.manifestLibraryMinimumDeploymentTarget = manifestLibraryMinimumDeploymentTarget
             } else {
-                self.manifestLibraryMinimumDeploymentTarget = Self.defaultMinimumDeploymentTarget
+                self.manifestLibraryMinimumDeploymentTarget = nil
             }
 
             if let pluginLibraryMinimumDeploymentTarget = pluginLibraryMinimumDeploymentTarget {
@@ -96,7 +96,7 @@ extension ToolchainConfiguration {
             } else if let pluginLibraryMinimumDeploymentTarget = try? MinimumDeploymentTarget.computeMinimumDeploymentTarget(of: Self.macOSPluginLibraryPath(for: pluginLibraryPath), platform: .macOS) {
                 self.pluginLibraryMinimumDeploymentTarget = pluginLibraryMinimumDeploymentTarget
             } else {
-                self.pluginLibraryMinimumDeploymentTarget = Self.defaultMinimumDeploymentTarget
+                self.pluginLibraryMinimumDeploymentTarget = nil
             }
             #else
             precondition(manifestLibraryMinimumDeploymentTarget == nil && pluginLibraryMinimumDeploymentTarget == nil, "deployment targets can only be specified on macOS")
@@ -123,10 +123,8 @@ extension ToolchainConfiguration {
         }
 
 #if os(macOS)
-        private static let defaultMinimumDeploymentTarget = PlatformVersion("10.15")
-
-        public var manifestLibraryMinimumDeploymentTarget: PlatformVersion
-        public var pluginLibraryMinimumDeploymentTarget: PlatformVersion
+        public var manifestLibraryMinimumDeploymentTarget: PlatformVersion?
+        public var pluginLibraryMinimumDeploymentTarget: PlatformVersion?
 
         private static func macOSManifestLibraryPath(for manifestAPI: AbsolutePath) -> AbsolutePath {
             if manifestAPI.extension == "framework" {

--- a/Sources/Workspace/DefaultPluginScriptRunner.swift
+++ b/Sources/Workspace/DefaultPluginScriptRunner.swift
@@ -170,10 +170,13 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
         }
         #endif
 
-        // Use the same minimum deployment target as the PackageDescription library (with a fallback of 10.15).
+        // Use the same minimum deployment target as the PackagePlugin library (with a fallback to the default host triple).
         #if os(macOS)
-        let version = self.toolchain.swiftPMLibrariesLocation.pluginLibraryMinimumDeploymentTarget.versionString
-        commandLine += ["-target", self.hostTriple.tripleString(forPlatformVersion: version)]
+        if let version = self.toolchain.swiftPMLibrariesLocation.pluginLibraryMinimumDeploymentTarget?.versionString {
+            commandLine += ["-target", "\(self.toolchain.triple.tripleString(forPlatformVersion: version))"]
+        } else {
+            commandLine += ["-target", self.toolchain.triple.tripleString]
+        }
         #endif
 
         // Add any extra flags required as indicated by the ManifestLoader.


### PR DESCRIPTION
This does not seem like a good fallback anymore since e.g. it'll always fail on Apple Silicon machines in case it is reached. Instead, use the default host triple as the fallback.

rdar://109066834

(cherry picked from commit 5e2dcee623b30d1c2f1551243b04ecfdaf1e2dec)