### PR TITLE
Fix `Triple` formatting in error messages

### DIFF
--- a/Sources/Basics/Triple.swift
+++ b/Sources/Basics/Triple.swift
@@ -18,7 +18,7 @@ import class TSCBasic.Process
 
 /// Triple - Helper class for working with Destination.target values
 ///
-/// Used for parsing values such as x86_64-apple-macosx10.10 into
+/// Used for parsing values such as `x86_64-apple-macosx10.10` into
 /// set of enums. For os/arch/abi based conditions in build plan.
 ///
 /// @see Destination.target

--- a/Sources/Basics/Triple.swift
+++ b/Sources/Basics/Triple.swift
@@ -318,6 +318,10 @@ extension Triple {
     }
 }
 
+extension Triple: CustomStringConvertible {
+    public var description: String { tripleString }
+}
+
 extension Triple.Error: CustomNSError {
     public var errorUserInfo: [String: Any] {
         [NSLocalizedDescriptionKey: "\(self)"]

--- a/Tests/BasicsTests/TripleTests.swift
+++ b/Tests/BasicsTests/TripleTests.swift
@@ -76,4 +76,9 @@ final class TripleTests: XCTestCase {
         XCTAssertTriple("i686-pc-windows-gnu", isApple: false, isDarwin: false)
         XCTAssertTriple("i686-pc-windows-cygnus", isApple: false, isDarwin: false)
     }
+
+    func testDescription() throws {
+        let triple = try Triple("x86_64-pc-linux-gnu")
+        XCTAssertEqual("foo \(triple) bar", "foo x86_64-pc-linux-gnu bar")
+    }
 }


### PR DESCRIPTION
Currently `Triple` is not `CustomStringConvertible`, which leads to issues when using it in string interpolations. It uses default implementation that prints all of the triple components separately, which isn't user-readable.

For example, when using `swift experimental-sdk configuration show` subcommand on a bundle that has wrong triples, an error message is printed which is badly formatted and likely does not show the root cause of the issue.

rdar://107882041

### Motivation:

Added `CustomStringConvertible` conformance on `Triple`, which uses underlying `tripleString` as a return value.

### Result:

`Triple` values are more human-readable when displayed in user-visible strings.
