### PR TITLE
SourceControl: rename `useBuiltinFSMonitor` to `fsmonitor`

### DIFF
--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -125,10 +125,11 @@ public struct GitRepositoryProvider: RepositoryProvider, Cancellable {
         // FIXME: Ideally we should pass `--progress` here and report status regularly.  We currently don't have callbacks for that.
         //
         // NOTE: Explicitly set `core.symlinks=true` on `git clone` to ensure that symbolic links are correctly resolved.
-        // NOTE: Explicitly set `core.useBuiltinFSMonitor` on `git clone` to ensure that we do not spawn a monitor on the repository.  This is particularly important for Windows where the process can prevent future operations.
+        // NOTE: Explicitly set `core.fsmonitor` on `git clone` to ensure that we do not spawn a monitor on the repository.  This is
+        //       particularly important for Windows where the process can prevent future operations.
         try self.callGit("clone",
                          "-c", "core.symlinks=true",
-                         "-c", "core.useBuiltinFSMonitor=false",
+                         "-c", "core.fsmonitor=false",
                          "--mirror", repository.location.gitURL, path.pathString,
                          repository: repository,
                          failureMessage: "Failed to clone repository \(repository.location)",


### PR DESCRIPTION
Git 2.36.0 renamed `useBuiltinFSMonitor` to `fsmonitor`.  This configuration setting results in a warning.  Given that Git 2.36.0 is now over a year old, rename the option we use to silence the warning. In the case of an installation of git predating the configuration renaming, we could run into issues with git opening the files preventing subsequent git operations, but in the general case, this should be equivalent.