### PR TITLE
SourceControl: centralise git cloning

### DIFF
--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -122,8 +122,6 @@ public struct GitRepositoryProvider: RepositoryProvider, Cancellable {
             throw InternalError("\(path) already exists")
         }
 
-        // FIXME: Ideally we should pass `--progress` here and report status regularly.  We currently don't have callbacks for that.
-        //
         // NOTE: Explicitly set `core.symlinks=true` on `git clone` to ensure that symbolic links are correctly resolved.
         // NOTE: Explicitly set `core.fsmonitor` on `git clone` to ensure that we do not spawn a monitor on the repository.  This is
         //       particularly important for Windows where the process can prevent future operations.


### PR DESCRIPTION
Centralise the git clone command invocation to ensure that we uniformly handle the arguments for the clone.  This sets the stage for further tweaks needed to fix cloning some repositories on Windows.