### PR TITLE
Add comma to executable template

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -278,7 +278,7 @@ public final class InitPackage {
                 if packageType == .executable {
                     param += """
                             .executableTarget(
-                                name: "\(pkgname)")
+                                name: "\(pkgname)"),
                         ]
                     """
                 } else if packageType == .tool {


### PR DESCRIPTION
We do this in all the other templates and it generally makes it easier to add new targets to the template after the fact.