### PR TITLE
[5.9] Add comma to executable template

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -271,7 +271,7 @@ public final class InitPackage {
                 if packageType == .executable {
                     param += """
                             .executableTarget(
-                                name: "\(pkgname)")
+                                name: "\(pkgname)"),
                         ]
                     """
                 } else if packageType == .tool {


### PR DESCRIPTION
We do this in all the other templates and it generally makes it easier to add new targets to the template after the fact.

(cherry picked from commit 2c57ad1d4ff1c40f988c6acfc0aa9fe58c68f25b)
