### PR TITLE
Documentation fixes for `PluginNetworkPermissionScope`.

### DIFF
--- a/Sources/PackageDescription/PackageDescription.docc/Curation/PluginPermission.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/PluginPermission.md
@@ -6,3 +6,7 @@
 
 - ``allowNetworkConnections(scope:reason:)``
 - ``writeToPackageDirectory(reason:)``
+
+### Allow network connection
+
+- ``PluginNetworkPermissionScope``

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -1486,7 +1486,9 @@ public enum PluginPermission {
     case writeToPackageDirectory(reason: String)
 }
 
-/// The scope of a network permission. This can be none, local connections only, or all connections.
+/// The scope of a network permission.
+///
+/// The scope can be none, local connections only, or all connections.
 @available(_PackageDescription, introduced: 5.9)
 public enum PluginNetworkPermissionScope {
     /// Do not allow network access.


### PR DESCRIPTION
Documentation fixes for `PluginNetworkPermissionScope`.

### Motivation:

There were two issues with the documentation for `PluginNetworkPermissionScope`:
- It was not curated, and this caused the symbol to show up at the top level of the `PackageDescription` documentation. This was not desired.
- The abstract for the symbol was not on its own line in the DocC comments. This caused the abstract to have multiple sentences, which goes against style.

### Modifications:

- The `PluginNetworkPermissionScope` symbol was curated under the `PluginPermission` symbol.
- The DocC documentation for `PluginNetworkPermissionScope` was changed to provide a single sentence abstract on its own line, and one additional sentence on a separate line.

### Result:

The `PluginNetworkPermissionScope` documentation is now curated in the correct place, and the abstract looks correct.
