### PR TITLE
Wrap registry login errors

### DIFF
--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -1319,20 +1319,22 @@ public final class RegistryClient: Cancellable {
         let start = DispatchTime.now()
         observabilityScope.emit(info: "logging-in into \(request.url)")
         self.httpClient.execute(request, observabilityScope: observabilityScope, progress: nil) { result in
-            completion(
-                result.tryMap { response in
-                    observabilityScope
-                        .emit(
-                            debug: "server response for \(request.url): \(response.statusCode) in \(start.distance(to: .now()).descriptionInSeconds)"
-                        )
-                    switch response.statusCode {
-                    case 200:
-                        return ()
-                    default:
-                        throw self.unexpectedStatusError(response, expectedStatus: [200])
-                    }
+            switch result {
+            case .success(let response):
+                observabilityScope
+                    .emit(
+                        debug: "server response for \(request.url): \(response.statusCode) in \(start.distance(to: .now()).descriptionInSeconds)"
+                    )
+                switch response.statusCode {
+                case 200:
+                    return completion(.success(()))
+                default:
+                    let error = self.unexpectedStatusError(response, expectedStatus: [200])
+                    return completion(.failure(RegistryError.loginFailed(url: loginURL, error: error)))
                 }
-            )
+            case .failure(let error):
+                return completion(.failure(RegistryError.loginFailed(url: loginURL, error: error)))
+            }
         }
     }
 
@@ -1674,6 +1676,7 @@ public enum RegistryError: Error, CustomStringConvertible {
     case unauthorized
     case authenticationMethodNotSupported
     case forbidden
+    case loginFailed(url: URL, error: Error)
     case availabilityCheckFailed(registry: Registry, error: Error)
     case registryNotAvailable(Registry)
     case packageNotFound
@@ -1819,6 +1822,8 @@ public enum RegistryError: Error, CustomStringConvertible {
             let previousVersion
         ):
             return "the signing entity '\(String(describing: latest))' from \(registry) for \(package) version \(version) is different from the previously recorded value '\(previous)' for version \(previousVersion)"
+        case .loginFailed(let url, let error):
+            return "registry login using \(url) failed: \(error)"
         }
     }
 }

--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -1823,7 +1823,7 @@ public enum RegistryError: Error, CustomStringConvertible {
         ):
             return "the signing entity '\(String(describing: latest))' from \(registry) for \(package) version \(version) is different from the previously recorded value '\(previous)' for version \(previousVersion)"
         case .loginFailed(let url, let error):
-            return "registry login using \(url) failed: \(error)"
+            return "registry login using \(url) failed: \(error.interpolationDescription)"
         }
     }
 }

--- a/Tests/PackageRegistryTests/RegistryClientTests.swift
+++ b/Tests/PackageRegistryTests/RegistryClientTests.swift
@@ -3165,7 +3165,7 @@ final class RegistryClientTests: XCTestCase {
         )
 
         XCTAssertThrowsError(try registryClient.login(loginURL: loginURL)) { error in
-            guard case RegistryError.unauthorized = error else {
+            guard case RegistryError.loginFailed(_, _) = error else {
                 return XCTFail("Expected RegistryError.unauthorized, got \(error)")
             }
         }
@@ -3210,7 +3210,7 @@ final class RegistryClientTests: XCTestCase {
         )
 
         XCTAssertThrowsError(try registryClient.login(loginURL: loginURL)) { error in
-            guard case RegistryError.authenticationMethodNotSupported = error else {
+            guard case RegistryError.loginFailed = error else {
                 return XCTFail("Expected RegistryError.authenticationMethodNotSupported, got \(error)")
             }
         }


### PR DESCRIPTION
Similar to all other request types, this will guarantee more consistent diagnostics if there are underlying `URLSession` errors etc.