### PR TITLE
[5.9] Fix plugin templates

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -287,7 +287,7 @@ public final class InitPackage {
                 } else if packageType == .buildToolPlugin {
                     param += """
                             .plugin(
-                                name: "\(typeName)",
+                                name: "\(pkgname)",
                                 capability: .buildTool()
                             ),
                         ]
@@ -295,7 +295,7 @@ public final class InitPackage {
                 } else if packageType == .commandPlugin {
                     param += """
                             .plugin(
-                                name: "\(typeName)",
+                                name: "\(pkgname)",
                                 capability: .command(intent: .custom(
                                     verb: "\(typeName)",
                                     description: "prints hello world"


### PR DESCRIPTION
We are using `pkgname` everywhere as target names and also as dependency references, but plugin targets were using `typeName` which leads to newly created plugin packages being broken if the difference was meaningful (e.g. if the name includes dashes).

(cherry picked from commit 78cceb7b6bd32b334999cb0a4837e970bdce990a)