### PR TITLE
[5.9] Cherry-pick documentation fixes for `PluginNetworkPermissionScope`. (#6555)

### DIFF
--- a/Sources/PackageDescription/PackageDescription.docc/Curation/PluginPermission.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/PluginPermission.md
@@ -6,3 +6,7 @@
 
 - ``allowNetworkConnections(scope:reason:)``
 - ``writeToPackageDirectory(reason:)``
+
+### Allow network connection
+
+- ``PluginNetworkPermissionScope``

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -1486,7 +1486,9 @@ public enum PluginPermission {
     case writeToPackageDirectory(reason: String)
 }
 
-/// The scope of a network permission. This can be none, local connections only, or all connections.
+/// The scope of a network permission.
+///
+/// The scope can be none, local connections only, or all connections.
 @available(_PackageDescription, introduced: 5.9)
 public enum PluginNetworkPermissionScope {
     /// Do not allow network access.


### PR DESCRIPTION
Cherry-pick the documentation update from `main` to the `release/5.9` branch.

### Motivation:

The recent documentation fix should be included in the 5.9 release.

### Modifications:

Commit 0efea68 was cherry-picked.

### Result:

The `PluginNetworkPermissionScope` documentation fixes will be included in the `release/5.9` branch. Only DocC content changed. Two files changed:
- `Sources/PackageDescription/PackageDescription.docc/Curation/PluginPermission.md`
- `Sources/PackageDescription/Target.swift`
