### PR TITLE
rdar://109108066 (Derive '-external-plugin-path' compiler arguments in SwiftPM)

### DIFF
--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -392,6 +392,18 @@ public final class SwiftTargetBuildDescription {
         }
         #endif
 
+        // If we're using an OSS toolchain, add the required arguments bringing in the plugin server from the default toolchain if available.
+        if self.buildParameters.toolchain.isSwiftDevelopmentToolchain, driverSupport.checkSupportedFrontendFlags(flags: ["-external-plugin-path"], toolchain: self.buildParameters.toolchain, fileSystem: self.fileSystem), let pluginServer = self.buildParameters.toolchain.swiftPluginServerPath {
+            let toolchainUsrPath = pluginServer.parentDirectory.parentDirectory
+            let pluginPathComponents = ["lib", "swift", "host", "plugins"]
+
+            let pluginPath = toolchainUsrPath.appending(components: pluginPathComponents)
+            args += ["-Xfrontend", "-external-plugin-path", "-Xfrontend", "\(pluginPath)#\(pluginServer.pathString)"]
+
+            let localPluginPath = toolchainUsrPath.appending(components: ["local"] + pluginPathComponents)
+            args += ["-Xfrontend", "-external-plugin-path", "-Xfrontend", "\(localPluginPath)#\(pluginServer.pathString)"]
+        }
+
         return args
     }
 

--- a/Sources/PackageModel/Toolchain.swift
+++ b/Sources/PackageModel/Toolchain.swift
@@ -19,6 +19,12 @@ public protocol Toolchain {
     /// Path of the `swiftc` compiler.
     var swiftCompilerPath: AbsolutePath { get }
 
+    /// Whether the used compiler is from a open source development toolchain.
+    var isSwiftDevelopmentToolchain: Bool { get }
+
+    /// Path to the Swift plugin server utility.
+    var swiftPluginServerPath: AbsolutePath? { get }
+
     /// Path containing the macOS Swift stdlib.
     var macosSwiftStdlib: AbsolutePath { get throws }
 

--- a/Sources/PackageModel/ToolchainConfiguration.swift
+++ b/Sources/PackageModel/ToolchainConfiguration.swift
@@ -42,6 +42,9 @@ public struct ToolchainConfiguration {
     /// This is optional for example on macOS w/o Xcode.
     public var xctestPath: AbsolutePath?
 
+    /// Path to the Swift plugin server utility.
+    public var swiftPluginServerPath: AbsolutePath?
+
     /// Creates the set of manifest resources associated with a `swiftc` executable.
     ///
     /// - Parameters:
@@ -52,6 +55,7 @@ public struct ToolchainConfiguration {
     ///     - swiftPMLibrariesRootPath: Custom path for SwiftPM libraries. Computed based on the compiler path by default.
     ///     - sdkRootPath: Optional path to SDK root.
     ///     - xctestPath: Optional path to XCTest.
+    ///     - swiftPluginServerPath: Optional path to the Swift plugin server executable.
     public init(
         librarianPath: AbsolutePath,
         swiftCompilerPath: AbsolutePath,
@@ -59,7 +63,8 @@ public struct ToolchainConfiguration {
         swiftCompilerEnvironment: EnvironmentVariables = .process(),
         swiftPMLibrariesLocation: SwiftPMLibrariesLocation? = nil,
         sdkRootPath: AbsolutePath? = nil,
-        xctestPath: AbsolutePath? = nil
+        xctestPath: AbsolutePath? = nil,
+        swiftPluginServerPath: AbsolutePath? = nil
     ) {
         let swiftPMLibrariesLocation = swiftPMLibrariesLocation ?? {
             return .init(swiftCompilerPath: swiftCompilerPath)
@@ -72,6 +77,7 @@ public struct ToolchainConfiguration {
         self.swiftPMLibrariesLocation = swiftPMLibrariesLocation
         self.sdkRootPath = sdkRootPath
         self.xctestPath = xctestPath
+        self.swiftPluginServerPath = swiftPluginServerPath
     }
 }
 

--- a/Tests/BuildTests/MockBuildTestHelper.swift
+++ b/Tests/BuildTests/MockBuildTestHelper.swift
@@ -28,6 +28,8 @@ struct MockToolchain: PackageModel.Toolchain {
     let librarianPath = AbsolutePath("/fake/path/to/ar")
 #endif
     let swiftCompilerPath = AbsolutePath("/fake/path/to/swiftc")
+    let isSwiftDevelopmentToolchain = false
+    let swiftPluginServerPath: AbsolutePath? = nil
     let extraFlags = PackageModel.BuildFlags()
 
     func getClangCompiler() throws -> AbsolutePath {


### PR DESCRIPTION
This derives the required `-external-plugin-path` arguments when using an OSS toolchain with SwiftPM.