### PR TITLE
Registry login interactive mode cannot read password/token over 128 chars long

### DIFF
--- a/Sources/PackageRegistryTool/PackageRegistryTool+Auth.swift
+++ b/Sources/PackageRegistryTool/PackageRegistryTool+Auth.swift
@@ -31,18 +31,18 @@ private func readpassword(_ prompt: String) throws -> String {
 
     let hStdIn: HANDLE = GetStdHandle(STD_INPUT_HANDLE)
     if hStdIn == INVALID_HANDLE_VALUE {
-        throw StringError("unable to read input")
+        throw StringError("unable to read input: GetStdHandle returns INVALID_HANDLE_VALUE")
     }
 
     var dwMode: DWORD = 0
     guard GetConsoleMode(hStdIn, &dwMode) else {
-        throw StringError("unable to read input")
+        throw StringError("unable to read input: GetConsoleMode failed")
     }
 
     print(prompt, terminator: "")
 
     guard SetConsoleMode(hStdIn, DWORD(ENABLE_LINE_INPUT)) else {
-        throw StringError("unable to read input")
+        throw StringError("unable to read input: SetConsoleMode failed")
     }
     defer { SetConsoleMode(hStdIn, dwMode) }
 

--- a/Sources/PackageRegistryTool/PackageRegistryTool.swift
+++ b/Sources/PackageRegistryTool/PackageRegistryTool.swift
@@ -136,6 +136,7 @@ public struct SwiftPackageRegistryTool: ParsableCommand {
         case unknownRegistry
         case unknownCredentialStore
         case invalidCredentialStore(Error)
+        case credentialLengthLimitExceeded(Int)
     }
 
     static func getRegistriesConfig(_ swiftTool: SwiftTool) throws -> Workspace.Configuration.Registries {
@@ -180,6 +181,8 @@ extension SwiftPackageRegistryTool.ValidationError: CustomStringConvertible {
             return "no credential store available"
         case .invalidCredentialStore(let error):
             return "credential store is invalid: \(error.interpolationDescription)"
+        case .credentialLengthLimitExceeded(let limit):
+            return "password or access token must be \(limit) characters or less"
         }
     }
 }


### PR DESCRIPTION
Motivation:
`swift package-registry login` in interactive mode truncates input when the provided password/token is more than 128 chars long. This is a limitation of `getpass`.

rdar://109372320

Modifications:
- Use `readpassphrase`, which allows custom input length, instead of `getpass`.
- Improve error message when the provided password/token is too long.
- Increase password/token length limit to 512 chars
