### PR TITLE
Delete macOS triple hardcode

### DIFF
--- a/Sources/Basics/Triple.swift
+++ b/Sources/Basics/Triple.swift
@@ -207,8 +207,6 @@ public struct Triple: Encodable, Equatable, Sendable {
         return String(self.tripleString.dropLast(self.osVersion?.count ?? 0)) + version
     }
 
-    public static let macOS = try! Triple("x86_64-apple-macosx")
-
     /// Determine the versioned host triple using the Swift compiler.
     public static func getHostTriple(usingSwiftCompiler swiftCompiler: AbsolutePath) throws -> Triple {
         // Call the compiler to get the target info JSON.
@@ -217,13 +215,7 @@ public struct Triple: Encodable, Equatable, Sendable {
             let result = try Process.popen(args: swiftCompiler.pathString, "-print-target-info")
             compilerOutput = try result.utf8Output().spm_chomp()
         } catch {
-            // FIXME: Remove the macOS special-casing once the latest version of Xcode comes with
-            // a Swift compiler that supports -print-target-info.
-            #if os(macOS)
-            return .macOS
-            #else
             throw InternalError("Failed to get target info (\(error.interpolationDescription))")
-            #endif
         }
         // Parse the compiler's JSON output.
         let parsedTargetInfo: JSON

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -3078,7 +3078,7 @@ final class BuildPlanTests: XCTestCase {
                 observabilityScope: observability.topScope
             ))
         }
-        let supportingTriples: [Basics.Triple] = [.x86_64Linux, .macOS]
+        let supportingTriples: [Basics.Triple] = [.x86_64Linux, .x86_64MacOS]
         for triple in supportingTriples {
             let result = try createResult(for: triple)
             let exe = try result.target(for: "exe").swiftTarget().compileArguments()
@@ -3252,7 +3252,7 @@ final class BuildPlanTests: XCTestCase {
 
         XCTAssertThrows(Diagnostics.fatalError) {
             _ = try BuildPlan(
-                buildParameters: mockBuildParameters(destinationTriple: .macOS),
+                buildParameters: mockBuildParameters(destinationTriple: .x86_64MacOS),
                 graph: graph,
                 fileSystem: fileSystem,
                 observabilityScope: observability.topScope
@@ -3391,7 +3391,7 @@ final class BuildPlanTests: XCTestCase {
         }
 
         do {
-            let result = try createResult(for: .macOS)
+            let result = try createResult(for: .x86_64MacOS)
 
             let cbar = try result.target(for: "cbar").clangTarget().basicArguments(isCXX: false)
             XCTAssertMatch(cbar, [.anySequence, "-DCCC=2", "-I\(A.appending(components: "Sources", "cbar", "Sources", "headers"))", "-I\(A.appending(components: "Sources", "cbar", "Sources", "cppheaders"))", "-Icfoo", "-L", "cbar", "-Icxxfoo", "-L", "cxxbar", .end])
@@ -4481,7 +4481,7 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testXCFrameworkBinaryTargets() throws {
-        try testXCFrameworkBinaryTargets(platform: "macos", arch: "x86_64", destinationTriple: .macOS)
+        try testXCFrameworkBinaryTargets(platform: "macos", arch: "x86_64", destinationTriple: .x86_64MacOS)
 
         let arm64Triple = try Basics.Triple("arm64-apple-macosx")
         try testXCFrameworkBinaryTargets(platform: "macos", arch: "arm64", destinationTriple: arm64Triple)
@@ -4559,7 +4559,7 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testArtifactsArchiveBinaryTargets() throws {
-        XCTAssertTrue(try testArtifactsArchiveBinaryTargets(artifactTriples: [.macOS], destinationTriple: .macOS))
+        XCTAssertTrue(try testArtifactsArchiveBinaryTargets(artifactTriples: [.x86_64MacOS], destinationTriple: .x86_64MacOS))
 
         do {
             let triples = try ["arm64-apple-macosx",  "x86_64-apple-macosx", "x86_64-unknown-linux-gnu"].map(Basics.Triple.init)
@@ -4568,7 +4568,7 @@ final class BuildPlanTests: XCTestCase {
 
         do {
             let triples = try ["x86_64-unknown-linux-gnu"].map(Basics.Triple.init)
-            XCTAssertFalse(try testArtifactsArchiveBinaryTargets(artifactTriples: triples, destinationTriple: .macOS))
+            XCTAssertFalse(try testArtifactsArchiveBinaryTargets(artifactTriples: triples, destinationTriple: .x86_64MacOS))
         }
     }
 

--- a/Tests/BuildTests/MockBuildTestHelper.swift
+++ b/Tests/BuildTests/MockBuildTestHelper.swift
@@ -93,7 +93,7 @@ func mockBuildParameters(environment: BuildEnvironment) -> BuildParameters {
     let triple: Basics.Triple
     switch environment.platform {
     case .macOS:
-        triple = Triple.macOS
+        triple = Triple.x86_64MacOS
     case .linux:
         triple = Triple.arm64Linux
     case .android:

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -9130,7 +9130,8 @@ final class WorkspaceTests: XCTestCase {
 
         let hostToolchain = try UserToolchain(destination: .hostDestination())
         let androidTriple = try Triple("x86_64-unknown-linux-android")
-        let notHostTriple = hostToolchain.triple == androidTriple ? .macOS : androidTriple
+        let macTriple = try Triple("arm64-apple-macosx")
+        let notHostTriple = hostToolchain.triple == androidTriple ? macTriple : androidTriple
 
         let ari = """
         {


### PR DESCRIPTION
On macOS hostTriple hardcoded as `x86_64-apple-macosx` which may not reflect the real host triple. As far as I understand the latest Xcode version are shipped with `-print-target-info` compatible compiler which allows to get rid of this `FIXME`

### Motivation:
Xcode ships with necessary `-print-target-info` option
Cleanup of small FIXME and misleading hardcoded value

### Modifications:
Make a call to swift compiler on macOS to retrieve the triple information

### Result:
macOS triple now reflects real value received from swift compiler