### PR TITLE
Add support for iOS triples in swift build

### DIFF
--- a/Sources/Basics/Triple.swift
+++ b/Sources/Basics/Triple.swift
@@ -72,6 +72,7 @@ public struct Triple: Encodable, Equatable, Sendable {
     public enum OS: String, Encodable, CaseIterable, Sendable {
         case darwin
         case macOS = "macosx"
+        case iOS = "ios"
         case linux
         case windows
         case wasi
@@ -83,11 +84,14 @@ public struct Triple: Encodable, Equatable, Sendable {
     public enum ABI: Encodable, Equatable, RawRepresentable, Sendable {
         case unknown
         case android
+        case simulator
         case other(name: String)
 
         public init?(rawValue: String) {
             if rawValue.hasPrefix(ABI.android.rawValue) {
                 self = .android
+            } else if rawValue.hasPrefix(ABI.simulator.rawValue) {
+                self = .simulator
             } else if let version = rawValue.firstIndex(where: { $0.isNumber }) {
                 self = .other(name: String(rawValue[..<version]))
             } else {
@@ -98,6 +102,7 @@ public struct Triple: Encodable, Equatable, Sendable {
         public var rawValue: String {
             switch self {
             case .android: return "android"
+            case .simulator: return "simulator"
             case .other(let name): return name
             case .unknown: return "unknown"
             }
@@ -176,7 +181,7 @@ public struct Triple: Encodable, Equatable, Sendable {
         switch (vendor, os) {
         case (.apple, .noneOS):
             return false
-        case (.apple, _), (_, .macOS), (_, .darwin):
+        case (.apple, _), (_, .macOS), (_, .iOS), (_, .darwin):
             return true
         default:
             return false
@@ -273,7 +278,7 @@ extension Triple {
     /// The file extension for dynamic libraries (eg. `.dll`, `.so`, or `.dylib`)
     public var dynamicLibraryExtension: String {
         switch os {
-        case .darwin, .macOS:
+        case .darwin, .macOS, .iOS:
             return ".dylib"
         case .linux, .openbsd:
             return ".so"
@@ -288,7 +293,7 @@ extension Triple {
 
     public var executableExtension: String {
         switch os {
-        case .darwin, .macOS:
+        case .darwin, .macOS, .iOS:
             return ""
         case .linux, .openbsd:
             return ""
@@ -309,7 +314,7 @@ extension Triple {
     /// The file extension for Foundation-style bundle.
     public var nsbundleExtension: String {
         switch os {
-        case .darwin, .macOS:
+        case .darwin, .macOS, .iOS:
             return ".bundle"
         default:
             // See: https://github.com/apple/swift-corelibs-foundation/blob/master/Docs/FHS%20Bundles.md

--- a/Sources/Commands/Utilities/TestingSupport.swift
+++ b/Sources/Commands/Utilities/TestingSupport.swift
@@ -87,10 +87,10 @@ enum TestingSupport {
             )
 
             // Add the sdk platform path if we have it. If this is not present, we might always end up failing.
-            let sdkPlatformFrameworksPath = try Destination.sdkPlatformFrameworkPaths()
+            let sdkPlatformFrameworksPath = try Destination.sdkPlatformPaths(os: .macOS)
             // appending since we prefer the user setting (if set) to the one we inject
-            env.appendPath("DYLD_FRAMEWORK_PATH", value: sdkPlatformFrameworksPath.fwk.pathString)
-            env.appendPath("DYLD_LIBRARY_PATH", value: sdkPlatformFrameworksPath.lib.pathString)
+            env.appendPath("DYLD_FRAMEWORK_PATH", value: sdkPlatformFrameworksPath.frameworkPath.pathString)
+            env.appendPath("DYLD_LIBRARY_PATH", value: sdkPlatformFrameworksPath.libraryPath.pathString)
 
             try TSCBasic.Process.checkNonZeroExit(arguments: args, environment: env)
             // Read the temporary file's content.

--- a/Sources/CoreCommands/SwiftTool.swift
+++ b/Sources/CoreCommands/SwiftTool.swift
@@ -678,31 +678,34 @@ public final class SwiftTool {
                 component: destinationTriple.platformBuildPathComponent(buildSystem: options.build.buildSystem)
             )
 
+            var buildFlags = self.options.build.buildFlags
+            buildFlags.append(destinationToolchain.extraFlags)
+
             return try BuildParameters(
                 dataPath: dataPath,
-                configuration: options.build.configuration,
+                configuration: self.options.build.configuration,
                 toolchain: destinationToolchain,
                 destinationTriple: destinationTriple,
-                flags: options.build.buildFlags,
-                pkgConfigDirectories: options.locations.pkgConfigDirectories,
-                architectures: options.build.architectures,
-                workers: options.build.jobs ?? UInt32(ProcessInfo.processInfo.activeProcessorCount),
-                shouldLinkStaticSwiftStdlib: options.linker.shouldLinkStaticSwiftStdlib,
+                flags: buildFlags,
+                pkgConfigDirectories: self.options.locations.pkgConfigDirectories,
+                architectures: self.options.build.architectures,
+                workers: self.options.build.jobs ?? UInt32(ProcessInfo.processInfo.activeProcessorCount),
+                shouldLinkStaticSwiftStdlib: self.options.linker.shouldLinkStaticSwiftStdlib,
                 canRenameEntrypointFunctionName: driverSupport.checkSupportedFrontendFlags(
                     flags: ["entry-point-function-name"], toolchain: destinationToolchain, fileSystem: self.fileSystem
                 ),
                 sanitizers: options.build.enabledSanitizers,
                 enableCodeCoverage: false, // set by test commands when appropriate
-                indexStoreMode: options.build.indexStoreMode.buildParameter,
-                enableParseableModuleInterfaces: options.build.shouldEnableParseableModuleInterfaces,
-                emitSwiftModuleSeparately: options.build.emitSwiftModuleSeparately,
-                useIntegratedSwiftDriver: options.build.useIntegratedSwiftDriver,
-                useExplicitModuleBuild: options.build.useExplicitModuleBuild,
-                isXcodeBuildSystemEnabled: options.build.buildSystem == .xcode,
-                forceTestDiscovery: options.build.enableTestDiscovery, // backwards compatibility, remove with --enable-test-discovery
-                testEntryPointPath: options.build.testEntryPointPath,
-                explicitTargetDependencyImportCheckingMode: options.build.explicitTargetDependencyImportCheck.modeParameter,
-                linkerDeadStrip: options.linker.linkerDeadStrip,
+                indexStoreMode: self.options.build.indexStoreMode.buildParameter,
+                enableParseableModuleInterfaces: self.options.build.shouldEnableParseableModuleInterfaces,
+                emitSwiftModuleSeparately: self.options.build.emitSwiftModuleSeparately,
+                useIntegratedSwiftDriver: self.options.build.useIntegratedSwiftDriver,
+                useExplicitModuleBuild: self.options.build.useExplicitModuleBuild,
+                isXcodeBuildSystemEnabled: self.options.build.buildSystem == .xcode,
+                forceTestDiscovery: self.options.build.enableTestDiscovery, // backwards compatibility, remove with --enable-test-discovery
+                testEntryPointPath: self.options.build.testEntryPointPath,
+                explicitTargetDependencyImportCheckingMode: self.options.build.explicitTargetDependencyImportCheck.modeParameter,
+                linkerDeadStrip: self.options.linker.linkerDeadStrip,
                 verboseOutput: self.logLevel <= .info
             )
         })
@@ -734,10 +737,8 @@ public final class SwiftTool {
                 } else {
                     return .failure(DestinationError.noDestinationsDecoded(customDestination))
                 }
-            } else if let triple = options.build.customCompileTriple,
-                      let targetDestination = Destination.defaultDestination(for: triple, host: hostDestination)
-            {
-                destination = targetDestination
+            } else if let triple = options.build.customCompileTriple {
+                destination = try Destination.defaultDestination(for: triple, host: hostDestination)
             } else if let swiftSDKSelector = options.build.swiftSDKSelector {
                 destination = try SwiftSDKBundle.selectBundle(
                     fromBundlesAt: sharedSwiftSDKsDirectory,

--- a/Sources/PackageModel/BuildFlags.swift
+++ b/Sources/PackageModel/BuildFlags.swift
@@ -40,4 +40,20 @@ public struct BuildFlags: Equatable, Encodable {
         self.linkerFlags = linkerFlags
         self.xcbuildFlags = xcbuildFlags
     }
+
+    /// Appends corresponding properties of a different `BuildFlags` value into `self`.
+    /// - Parameter buildFlags: a `BuildFlags` value to merge flags from.
+    public mutating func append(_ buildFlags: BuildFlags) {
+        cCompilerFlags += buildFlags.cCompilerFlags
+        cxxCompilerFlags += buildFlags.cxxCompilerFlags
+        swiftCompilerFlags += buildFlags.swiftCompilerFlags
+        linkerFlags += buildFlags.linkerFlags
+
+        if var xcbuildFlags, let newXcbuildFlags = buildFlags.xcbuildFlags {
+            xcbuildFlags += newXcbuildFlags
+            self.xcbuildFlags = xcbuildFlags
+        } else if let xcbuildFlags = buildFlags.xcbuildFlags {
+            self.xcbuildFlags = xcbuildFlags
+        }
+    }
 }

--- a/Sources/PackageModel/Destination.swift
+++ b/Sources/PackageModel/Destination.swift
@@ -444,8 +444,8 @@ public struct Destination: Equatable {
         abi: Triple.ABI? = nil,
         environment: EnvironmentVariables = .process()
     ) throws -> PlatformSDKPaths {
-        if let sdkPlatform = _sdkPlatform {
-            return sdkPlatform
+        if let sdkPlatformPaths = _sdkPlatformPaths {
+            return sdkPlatformPaths
         }
 
         guard let sdkName = sdkName(os: os, abi: abi) else {
@@ -479,14 +479,17 @@ public struct Destination: Equatable {
         // For building on Apple platforms other than macOS
         let sdk = try AbsolutePath(validating: platformSDKPath)
 
-        let platformSDK = PlatformSDKPaths(
+        let sdkPlatformPaths = PlatformSDKPaths(
             libraryPath: library,
             frameworkPath: framework,
             sdkPath: sdk
         )
 
-        return platformSDK
+        _sdkPlatformPaths = sdkPlatformPaths
+        return sdkPlatformPaths
     }
+
+    private static var _sdkPlatformPaths: PlatformSDKPaths? = nil
 
     private static func sdkName(os: Triple.OS, abi: Triple.ABI?) -> String? {
         switch (os, abi) {
@@ -496,8 +499,6 @@ public struct Destination: Equatable {
             default: return nil
         }
     }
-
-    private static var _sdkPlatform: PlatformSDKPaths? = nil
 
     /// Returns a default destination of a given target environment
     public static func defaultDestination(for triple: Triple, host: Destination) throws -> Destination {

--- a/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
+++ b/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
@@ -36,9 +36,6 @@ public struct ExecutableInfo: Equatable {
     public let supportedTriples: [Triple]
 }
 
-/// Triple: arm64-apple-darwin (ios-simulator) should be arm64-apple-ios-simulator
-///XCFramework: id: ios-arm64_x86_64-simulator archs: arm64, x86_64 platform: ios variant: simulator
-
 extension BinaryTarget {
     public func parseXCFrameworks(for triple: Triple, fileSystem: FileSystem) throws -> [LibraryInfo] {
         // At the moment we return at most a single library.

--- a/Sources/SPMBuildCore/XCFrameworkMetadata.swift
+++ b/Sources/SPMBuildCore/XCFrameworkMetadata.swift
@@ -24,6 +24,7 @@ public struct XCFrameworkMetadata: Equatable {
         public let libraryPath: String
         public let headersPath: String?
         public let platform: String
+        public let platformVariant: String?
         public let architectures: [String]
 
         public init(
@@ -31,12 +32,14 @@ public struct XCFrameworkMetadata: Equatable {
             libraryPath: String,
             headersPath: String?,
             platform: String,
+            platformVariant: String?,
             architectures: [String]
         ) {
             self.libraryIdentifier = libraryIdentifier
             self.libraryPath = libraryPath
             self.headersPath = headersPath
             self.platform = platform
+            self.platformVariant = platformVariant
             self.architectures = architectures
         }
     }
@@ -77,6 +80,7 @@ extension XCFrameworkMetadata.Library: Decodable {
         case libraryPath = "LibraryPath"
         case headersPath = "HeadersPath"
         case platform = "SupportedPlatform"
+        case platformVariant = "SupportedPlatformVariant"
         case architectures = "SupportedArchitectures"
     }
 }

--- a/Tests/FunctionalTests/SwiftPMXCTestHelperTests.swift
+++ b/Tests/FunctionalTests/SwiftPMXCTestHelperTests.swift
@@ -49,7 +49,7 @@ class SwiftPMXCTestHelperTests: XCTestCase {
 
     func XCTAssertXCTestHelper(_ bundlePath: AbsolutePath, testCases: NSDictionary) throws {
         #if os(macOS)
-        let env = ["DYLD_FRAMEWORK_PATH": try Destination.sdkPlatformFrameworkPaths().fwk.pathString]
+        let env = ["DYLD_FRAMEWORK_PATH": try Destination.sdkPlatformPaths(os: .macOS).frameworkPath.pathString]
         let outputFile = bundlePath.parentDirectory.appending("tests.txt")
         try SwiftPM.XCTestHelper.execute([bundlePath.pathString, outputFile.pathString], env: env)
         guard let data = NSData(contentsOfFile: outputFile.pathString) else {

--- a/Tests/SPMBuildCoreTests/XCFrameworkMetadataTests.swift
+++ b/Tests/SPMBuildCoreTests/XCFrameworkMetadataTests.swift
@@ -55,6 +55,7 @@ final class XCFrameworkMetadataTests: XCTestCase {
                                libraryPath: "MyFramework.framework",
                                headersPath: nil,
                                platform: "macos",
+                               platformVariant: nil,
                                architectures: ["x86_64"]
                            ),
                        ]))
@@ -82,6 +83,8 @@ final class XCFrameworkMetadataTests: XCTestCase {
                         </array>
                         <key>SupportedPlatform</key>
                         <string>macos</string>
+                        <key>SupportedPlatformVariant</key>
+                        <string>simulator</string>
                     </dict>
                 </array>
                 <key>CFBundlePackageType</key>
@@ -102,6 +105,7 @@ final class XCFrameworkMetadataTests: XCTestCase {
                                    libraryPath: "MyLibrary.a",
                                    headersPath: "Headers",
                                    platform: "macos",
+                                   platformVariant: "simulator",
                                    architectures: ["x86_64"]
                                ),
                            ]))


### PR DESCRIPTION
Add support for iOS/iOS Simulator triples in swift build

### Motivation:
Fixes the issue - #6571
Details provided there

### Modifications:
- Add parsing of ios/ios-simulator triples
- Add parsing of SupportedPlatformVariant to XCFrameworkMetadata
- Add ios to Triple.OS and simulator to Triple.ABI

### Result:
- `swift build` accepts the following triples `arm64/x86_64-apple-ios`, `arm64/x86_64-apple-ios-simulator`
- SwiftPM able to resolve the necessary `XCFramework` slice for provided triple
