### PR TITLE
Improve error message for 'package-registry publish'

### DIFF
--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -1611,9 +1611,14 @@ public final class RegistryClient: Cancellable {
             return RegistryError.unauthorized
         case 403:
             return RegistryError.forbidden
+        case 400...499:
+            return RegistryError.clientError(
+                code: response.statusCode,
+                details: response.body.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+            )
         case 501:
             return RegistryError.authenticationMethodNotSupported
-        case 500, 502, 503:
+        case 500...599:
             return RegistryError.serverError(
                 code: response.statusCode,
                 details: response.body.flatMap { String(data: $0, encoding: .utf8) } ?? ""
@@ -1673,6 +1678,7 @@ public enum RegistryError: Error, CustomStringConvertible {
     case failedPublishing(Error)
     case missingPublishingLocation
     case serverError(code: Int, details: String)
+    case clientError(code: Int, details: String)
     case unauthorized
     case authenticationMethodNotSupported
     case forbidden
@@ -1771,6 +1777,8 @@ public enum RegistryError: Error, CustomStringConvertible {
             return "response missing registry source archive"
         case .serverError(let code, let details):
             return "server error \(code): \(details)"
+        case .clientError(let code, let details):
+            return "client error \(code): \(details)"
         case .unauthorized:
             return "missing or invalid authentication credentials"
         case .authenticationMethodNotSupported:

--- a/Sources/PackageRegistryTool/PackageRegistryTool+Publish.swift
+++ b/Sources/PackageRegistryTool/PackageRegistryTool+Publish.swift
@@ -199,36 +199,41 @@ extension SwiftPackageRegistryTool {
                 return
             }
 
-            swiftTool.observabilityScope
-                .emit(info: "publishing \(self.packageIdentity) archive at '\(archivePath)' to \(registryURL)")
-            let result = try temp_await {
-                registryClient.publish(
-                    registryURL: registryURL,
-                    packageIdentity: self.packageIdentity,
-                    packageVersion: self.packageVersion,
-                    packageArchive: archivePath,
-                    packageMetadata: metadataLocation?.path,
-                    signature: archiveSignature,
-                    metadataSignature: metadataSignature,
-                    signatureFormat: self.signatureFormat,
-                    fileSystem: localFileSystem,
-                    observabilityScope: swiftTool.observabilityScope,
-                    callbackQueue: .sharedConcurrent,
-                    completion: $0
-                )
-            }
-
-            switch result {
-            case .published(.none):
-                print("\(packageIdentity) version \(packageVersion) was successfully published to \(registryURL)")
-            case .published(.some(let location)):
-                print(
-                    "\(packageIdentity) version \(packageVersion) was successfully published to \(registryURL) and is available at '\(location)'"
-                )
-            case .processing(let statusURL, _):
-                print(
-                    "\(packageIdentity) version \(packageVersion) was successfully submitted to \(registryURL) and is being processed. Publishing status is available at '\(statusURL)'."
-                )
+            do {
+                swiftTool.observabilityScope
+                    .emit(info: "publishing \(self.packageIdentity) archive at '\(archivePath)' to \(registryURL)")
+                let result = try temp_await {
+                    registryClient.publish(
+                        registryURL: registryURL,
+                        packageIdentity: self.packageIdentity,
+                        packageVersion: self.packageVersion,
+                        packageArchive: archivePath,
+                        packageMetadata: metadataLocation?.path,
+                        signature: archiveSignature,
+                        metadataSignature: metadataSignature,
+                        signatureFormat: self.signatureFormat,
+                        fileSystem: localFileSystem,
+                        observabilityScope: swiftTool.observabilityScope,
+                        callbackQueue: .sharedConcurrent,
+                        completion: $0
+                    )
+                }
+                
+                switch result {
+                case .published(.none):
+                    print("\(packageIdentity) version \(packageVersion) was successfully published to \(registryURL)")
+                case .published(.some(let location)):
+                    print(
+                        "\(packageIdentity) version \(packageVersion) was successfully published to \(registryURL) and is available at '\(location)'"
+                    )
+                case .processing(let statusURL, _):
+                    print(
+                        "\(packageIdentity) version \(packageVersion) was successfully submitted to \(registryURL) and is being processed. Publishing status is available at '\(statusURL)'."
+                    )
+                }
+            } catch RegistryError.failedPublishing(let error) {
+                // Throw the error that has more details
+                throw error
             }
         }
     }

--- a/Sources/PackageRegistryTool/PackageRegistryTool+Publish.swift
+++ b/Sources/PackageRegistryTool/PackageRegistryTool+Publish.swift
@@ -22,8 +22,8 @@ import Workspace
 @_implementationOnly import X509 // FIXME: need this import or else SwiftSigningIdentity initializer fails
 
 import struct TSCBasic.ByteString
-import struct TSCBasic.SHA256
 import struct TSCBasic.RegEx
+import struct TSCBasic.SHA256
 
 import struct TSCUtility.Version
 
@@ -199,41 +199,36 @@ extension SwiftPackageRegistryTool {
                 return
             }
 
-            do {
-                swiftTool.observabilityScope
-                    .emit(info: "publishing \(self.packageIdentity) archive at '\(archivePath)' to \(registryURL)")
-                let result = try temp_await {
-                    registryClient.publish(
-                        registryURL: registryURL,
-                        packageIdentity: self.packageIdentity,
-                        packageVersion: self.packageVersion,
-                        packageArchive: archivePath,
-                        packageMetadata: metadataLocation?.path,
-                        signature: archiveSignature,
-                        metadataSignature: metadataSignature,
-                        signatureFormat: self.signatureFormat,
-                        fileSystem: localFileSystem,
-                        observabilityScope: swiftTool.observabilityScope,
-                        callbackQueue: .sharedConcurrent,
-                        completion: $0
-                    )
-                }
-                
-                switch result {
-                case .published(.none):
-                    print("\(packageIdentity) version \(packageVersion) was successfully published to \(registryURL)")
-                case .published(.some(let location)):
-                    print(
-                        "\(packageIdentity) version \(packageVersion) was successfully published to \(registryURL) and is available at '\(location)'"
-                    )
-                case .processing(let statusURL, _):
-                    print(
-                        "\(packageIdentity) version \(packageVersion) was successfully submitted to \(registryURL) and is being processed. Publishing status is available at '\(statusURL)'."
-                    )
-                }
-            } catch RegistryError.failedPublishing(let error) {
-                // Throw the error that has more details
-                throw error
+            swiftTool.observabilityScope
+                .emit(info: "publishing \(self.packageIdentity) archive at '\(archivePath)' to \(registryURL)")
+            let result = try temp_await {
+                registryClient.publish(
+                    registryURL: registryURL,
+                    packageIdentity: self.packageIdentity,
+                    packageVersion: self.packageVersion,
+                    packageArchive: archivePath,
+                    packageMetadata: metadataLocation?.path,
+                    signature: archiveSignature,
+                    metadataSignature: metadataSignature,
+                    signatureFormat: self.signatureFormat,
+                    fileSystem: localFileSystem,
+                    observabilityScope: swiftTool.observabilityScope,
+                    callbackQueue: .sharedConcurrent,
+                    completion: $0
+                )
+            }
+
+            switch result {
+            case .published(.none):
+                print("\(packageIdentity) version \(packageVersion) was successfully published to \(registryURL)")
+            case .published(.some(let location)):
+                print(
+                    "\(packageIdentity) version \(packageVersion) was successfully published to \(registryURL) and is available at '\(location)'"
+                )
+            case .processing(let statusURL, _):
+                print(
+                    "\(packageIdentity) version \(packageVersion) was successfully submitted to \(registryURL) and is being processed. Publishing status is available at '\(statusURL)'."
+                )
             }
         }
     }


### PR DESCRIPTION
Motivation:
When registry publish fails with client error, the current error message is "Error: failed publishing: invalid registry response status '400', expected '[201, 202]'", which doesn't provide much information on what went wrong.

rdar://109410245

Modifications:
- Wrap 4xx status response in `RegistryError.clientError` and 5xx in `RegistryError.serverError`. Both errors include response body as details.
- Change `package-registry publish` to throw the wrapped `clientError` such that more details (i.e., response body) get displayed.
