### PR TITLE
SwiftSDKBundle.swift: update strings to use "Swift SDK" naming

### DIFF
--- a/Sources/PackageModel/SwiftSDKBundle.swift
+++ b/Sources/PackageModel/SwiftSDKBundle.swift
@@ -85,7 +85,7 @@ public struct SwiftSDKBundle {
         guard let destinationsDirectory else {
             throw StringError(
                 """
-                No cross-compilation destinations directory found, specify one
+                No directory found for installed Swift SDKs, specify one
                 with `--experimental-swift-sdks-path` option.
                 """
             )

--- a/Sources/PackageModel/SwiftSDKBundle.swift
+++ b/Sources/PackageModel/SwiftSDKBundle.swift
@@ -86,7 +86,7 @@ public struct SwiftSDKBundle {
             throw StringError(
                 """
                 No cross-compilation destinations directory found, specify one
-                with `experimental-destinations-path` option.
+                with `--experimental-swift-sdks-path` option.
                 """
             )
         }
@@ -99,7 +99,7 @@ public struct SwiftSDKBundle {
 
         guard !validBundles.isEmpty else {
             throw StringError(
-                "No valid cross-compilation destination bundles found at \(destinationsDirectory)."
+                "No valid Swift SDK bundles found at \(destinationsDirectory)."
             )
         }
 
@@ -110,8 +110,8 @@ public struct SwiftSDKBundle {
         ) else {
             throw StringError(
                 """
-                No cross-compilation destination found matching query `\(selector)` and host triple
-                `\(hostTriple.tripleString)`. Use `swift package experimental-destination list` command to see
+                No Swift SDK found matching query `\(selector)` and host triple
+                `\(hostTriple.tripleString)`. Use `swift experimental-sdk list` command to see
                 available destinations.
                 """
             )
@@ -167,7 +167,7 @@ public struct SwiftSDKBundle {
 
                 bundlePath = downloadedBundlePath
 
-                print("Destination artifact bundle successfully downloaded from `\(bundleURL)`.")
+                print("Swift SDK bundle successfully downloaded from `\(bundleURL)`.")
             } else if
                 let cwd: AbsolutePath = fileSystem.currentWorkingDirectory,
                 let originalBundlePath = try? AbsolutePath(validating: bundlePathOrURL, relativeTo: cwd)
@@ -187,7 +187,7 @@ public struct SwiftSDKBundle {
             )
         }
 
-        print("Destination artifact bundle at `\(bundlePathOrURL)` successfully installed.")
+        print("Swift SDK bundle at `\(bundlePathOrURL)` successfully installed.")
     }
 
     /// Unpacks a destination bundle if it has an archive extension in its filename.
@@ -458,7 +458,7 @@ extension [SwiftSDKBundle] {
                                 observabilityScope.emit(
                                     warning:
                                     """
-                                    multiple destinations match target triple `\(selector)` and host triple \(
+                                    multiple Swift SDKs match target triple `\(selector)` and host triple \(
                                         hostTriple.tripleString
                                     ), selected one at \(
                                         matchedByTriple.path.appending(matchedByTriple.variant.metadata.path)
@@ -478,7 +478,7 @@ extension [SwiftSDKBundle] {
             observabilityScope.emit(
                 warning:
                 """
-                multiple destinations match the query `\(selector)` and host triple \(
+                multiple Swift SDKs match the query `\(selector)` and host triple \(
                     hostTriple.tripleString
                 ), selected one at \(matchedByID.path.appending(matchedByID.variant.metadata.path))
                 """


### PR DESCRIPTION
Some of user-visible strings refer to "cross-compilation destinations", while those are called "Swift SDKs" per the updated SE proposal. Let's update the strings to match the proposal.