### PR TITLE
BuildPlan: infer `-lc++` based on run-time triple

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -632,9 +632,9 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
         // Note: This will come from build settings in future.
         for target in dependencies.staticTargets {
             if case let target as ClangTarget = target.underlyingTarget, target.isCXX {
-                if buildParameters.hostTriple.isDarwin() {
+                if buildParameters.triple.isDarwin() {
                     buildProduct.additionalFlags += ["-lc++"]
-                } else if buildParameters.hostTriple.isWindows() {
+                } else if buildParameters.triple.isWindows() {
                     // Don't link any C++ library.
                 } else {
                     buildProduct.additionalFlags += ["-lstdc++"]

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -2174,7 +2174,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: BuildPlan(
+        var result = try BuildPlanResult(plan: BuildPlan(
             buildParameters: mockBuildParameters(),
             graph: graph,
             fileSystem: fs,
@@ -2182,13 +2182,26 @@ final class BuildPlanTests: XCTestCase {
         ))
         result.checkProductsCount(1)
         result.checkTargetsCount(2)
-        let linkArgs = try result.buildProduct(for: "exe").linkArguments()
+        var linkArgs = try result.buildProduct(for: "exe").linkArguments()
 
       #if os(macOS)
         XCTAssertMatch(linkArgs, ["-lc++"])
       #elseif !os(Windows)
         XCTAssertMatch(linkArgs, ["-lstdc++"])
       #endif
+
+        // Verify that `-lstdc++` is passed instead of `-lc++` when cross-compiling to Linux.
+        result = try BuildPlanResult(plan: BuildPlan(
+            buildParameters: mockBuildParameters(destinationTriple: .arm64Linux),
+            graph: graph,
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        ))
+        result.checkProductsCount(1)
+        result.checkTargetsCount(2)
+        linkArgs = try result.buildProduct(for: "exe").linkArguments()
+
+        XCTAssertMatch(linkArgs, ["-lstdc++"])
     }
 
     func testDynamicProducts() throws {

--- a/Tests/BuildTests/MockBuildTestHelper.swift
+++ b/Tests/BuildTests/MockBuildTestHelper.swift
@@ -45,6 +45,7 @@ struct MockToolchain: PackageModel.Toolchain {
 
 
 extension Basics.Triple {
+    static let x86_64MacOS = try! Self("x86_64-apple-macosx")
     static let x86_64Linux = try! Self("x86_64-unknown-linux-gnu")
     static let arm64Linux = try! Self("aarch64-unknown-linux-gnu")
     static let arm64Android = try! Self("aarch64-unknown-linux-android")


### PR DESCRIPTION
Currently, when cross-compiling from Darwin to platforms that don't expect `-lc++` by default (e.g. most Linux distributions), the build will fail because `-lc++` is always passed. When should check the destination triple and not the host triple in the build plan code paths.

This leads to confusing build errors when cross-compiling more complex projects like Vapor.

rdar://107487090

### Modifications:

Modified `BuildPlan.swift` to check the value of the `triple` property instead of `hostTriple`. Added a test that verifies this cross-compilation case.

### Result:

Projects that contain C++ can now be cross-compiled from macOS to Linux.