### PR TITLE
[5.9] BuildPlan: infer `-lc++` based on run-time triple

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -629,9 +629,9 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
         // Note: This will come from build settings in future.
         for target in dependencies.staticTargets {
             if case let target as ClangTarget = target.underlyingTarget, target.isCXX {
-                if buildParameters.hostTriple.isDarwin() {
+                if buildParameters.triple.isDarwin() {
                     buildProduct.additionalFlags += ["-lc++"]
-                } else if buildParameters.hostTriple.isWindows() {
+                } else if buildParameters.triple.isWindows() {
                     // Don't link any C++ library.
                 } else {
                     buildProduct.additionalFlags += ["-lstdc++"]

--- a/Tests/BuildTests/MockBuildTestHelper.swift
+++ b/Tests/BuildTests/MockBuildTestHelper.swift
@@ -50,6 +50,7 @@ struct MockToolchain: PackageModel.Toolchain {
 
 
 extension Basics.Triple {
+    static let x86_64MacOS = try! Self("x86_64-apple-macosx")
     static let x86_64Linux = try! Self("x86_64-unknown-linux-gnu")
     static let arm64Linux = try! Self("aarch64-unknown-linux-gnu")
     static let arm64Android = try! Self("aarch64-unknown-linux-android")


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-package-manager/pull/6581

Currently, when cross-compiling from Darwin to platforms that don't expect `-lc++` by default (e.g. most Linux distributions), the build will fail because `-lc++` is always passed. When should check the destination triple and not the host triple in the build plan code paths.

This leads to confusing build errors when cross-compiling more complex projects like Vapor.

rdar://107487090

### Modifications:

Modified `BuildPlan.swift` to check the value of the `triple` property instead of `hostTriple`. Added a test that verifies this cross-compilation case.

### Result:

Projects that contain C++ can now be cross-compiled from macOS to Linux.