### PR TITLE
Remove the version parameter for C++ interop mode build setting

### DIFF
--- a/Sources/PackageDescription/BuildSettings.swift
+++ b/Sources/PackageDescription/BuildSettings.swift
@@ -377,22 +377,15 @@ public struct SwiftSetting {
     ///
     /// - Parameters:
     ///   - mode: The language mode, either C or CXX.
-    ///   - version: When using the CXX language mode, pass either the version
-    /// of Swift and C++ interoperability or `nil`; otherwise, `nil`.
     ///   - condition: A condition that restricts the application of the build
     /// setting.
     @available(_PackageDescription, introduced: 5.9)
     public static func interoperabilityMode(
       _ mode: InteroperabilityMode,
-      version: String? = nil,
       _ condition: BuildSettingCondition? = nil
     ) -> SwiftSetting {
-        var values: [String] = [mode.rawValue]
-        if let version {
-            values.append(version)
-        }
         return SwiftSetting(
-          name: "interoperabilityMode", value: values, condition: condition)
+          name: "interoperabilityMode", value: [mode.rawValue], condition: condition)
     }
 }
 

--- a/Sources/PackageLoading/ManifestJSONParser.swift
+++ b/Sources/PackageLoading/ManifestJSONParser.swift
@@ -685,16 +685,10 @@ extension TargetBuildSettingDescription.Kind {
             guard let lang = TargetBuildSettingDescription.InteroperabilityMode(rawValue: rawLang) else {
                 throw InternalError("unknown interoperability mode: \(rawLang)")
             }
-            if values.count > 2 {
+            if values.count > 1 {
                 throw InternalError("invalid build settings value")
             }
-            let version: String?
-            if values.count == 2 {
-                version = values[1]
-            } else {
-                version = nil
-            }
-            return .interoperabilityMode(lang, version)
+            return .interoperabilityMode(lang)
         case "enableUpcomingFeature":
             guard let value = values.first else {
                 throw InternalError("invalid (empty) build settings value")

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -1079,7 +1079,7 @@ public final class PackageBuilder {
                     decl = .LINK_FRAMEWORKS
                 }
 
-            case .interoperabilityMode(let lang, let version):
+            case .interoperabilityMode(let lang):
                 switch setting.tool {
                 case .c, .cxx, .linker:
                     throw InternalError("only Swift supports interoperability")
@@ -1089,10 +1089,7 @@ public final class PackageBuilder {
                 }
 
                 if lang == .Cxx {
-                    // `version` is the compatibility version of Swift/C++ interop,
-                    // which is meant to preserve source compatibility for
-                    // user projects while Swift/C++ interop is evolving.
-                    values = ["-cxx-interoperability-mode=\(version ?? "default")"]
+                    values = ["-cxx-interoperability-mode=default"]
                 } else {
                     values = []
                 }

--- a/Sources/PackageModel/Manifest/TargetBuildSettingDescription.swift
+++ b/Sources/PackageModel/Manifest/TargetBuildSettingDescription.swift
@@ -33,7 +33,7 @@ public enum TargetBuildSettingDescription {
         case linkedLibrary(String)
         case linkedFramework(String)
 
-        case interoperabilityMode(InteroperabilityMode, String?)
+        case interoperabilityMode(InteroperabilityMode)
 
         case enableUpcomingFeature(String)
         case enableExperimentalFeature(String)

--- a/Sources/PackageModel/ManifestSourceGeneration.swift
+++ b/Sources/PackageModel/ManifestSourceGeneration.swift
@@ -513,11 +513,8 @@ fileprivate extension SourceCodeFragment {
                 params.append(SourceCodeFragment(from: condition))
             }
             self.init(enum: setting.kind.name, subnodes: params)
-        case .interoperabilityMode(let lang, let version):
+        case .interoperabilityMode(let lang):
             params.append(SourceCodeFragment(enum: lang.rawValue))
-            if let version {
-                params.append(SourceCodeFragment(key: "version", string: version))
-            }
             self.init(enum: setting.kind.name, subnodes: params)
         case .unsafeFlags(let values):
             params.append(SourceCodeFragment(strings: values))

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -3311,8 +3311,8 @@ final class BuildPlanTests: XCTestCase {
                         .init(tool: .swift, kind: .define("RLINUX"), condition: .init(platformNames: ["linux"], config: "release")),
                         .init(tool: .swift, kind: .define("DMACOS"), condition: .init(platformNames: ["macos"], config: "debug")),
                         .init(tool: .swift, kind: .unsafeFlags(["-Isfoo", "-L", "sbar"])),
-                        .init(tool: .swift, kind: .interoperabilityMode(.Cxx, "swift-5.9"), condition: .init(platformNames: ["linux"])),
-                        .init(tool: .swift, kind: .interoperabilityMode(.Cxx, "swift-6.0"), condition: .init(platformNames: ["macos"])),
+                        .init(tool: .swift, kind: .interoperabilityMode(.Cxx), condition: .init(platformNames: ["linux"])),
+                        .init(tool: .swift, kind: .interoperabilityMode(.Cxx), condition: .init(platformNames: ["macos"])),
                         .init(tool: .swift, kind: .enableUpcomingFeature("BestFeature")),
                         .init(tool: .swift, kind: .enableUpcomingFeature("WorstFeature"), condition: .init(platformNames: ["macos"], config: "debug"))
                     ]
@@ -3321,8 +3321,8 @@ final class BuildPlanTests: XCTestCase {
                     name: "exe", dependencies: ["bar"],
                     settings: [
                         .init(tool: .swift, kind: .define("FOO")),
-                        .init(tool: .swift, kind: .interoperabilityMode(.C, nil), condition: .init(platformNames: ["linux"])),
-                        .init(tool: .swift, kind: .interoperabilityMode(.Cxx, nil), condition: .init(platformNames: ["macos"])),
+                        .init(tool: .swift, kind: .interoperabilityMode(.C), condition: .init(platformNames: ["linux"])),
+                        .init(tool: .swift, kind: .interoperabilityMode(.Cxx), condition: .init(platformNames: ["macos"])),
                         .init(tool: .linker, kind: .linkedLibrary("sqlite3")),
                         .init(tool: .linker, kind: .linkedFramework("CoreData"), condition: .init(platformNames: ["macos"])),
                         .init(tool: .linker, kind: .unsafeFlags(["-Ilfoo", "-L", "lbar"])),
@@ -3381,7 +3381,7 @@ final class BuildPlanTests: XCTestCase {
             XCTAssertMatch(cbar, [.anySequence, "-DCCC=2", "-I\(A.appending(components: "Sources", "cbar", "Sources", "headers"))", "-I\(A.appending(components: "Sources", "cbar", "Sources", "cppheaders"))", "-Icfoo", "-L", "cbar", "-Icxxfoo", "-L", "cxxbar", .end])
 
             let bar = try result.target(for: "bar").swiftTarget().compileArguments()
-            XCTAssertMatch(bar, [.anySequence, "-DLINUX", "-Isfoo", "-L", "sbar", "-cxx-interoperability-mode=swift-5.9", "-enable-upcoming-feature", "BestFeature", .end])
+            XCTAssertMatch(bar, [.anySequence, "-DLINUX", "-Isfoo", "-L", "sbar", "-cxx-interoperability-mode=default", "-enable-upcoming-feature", "BestFeature", .end])
 
             let exe = try result.target(for: "exe").swiftTarget().compileArguments()
             XCTAssertMatch(exe, [.anySequence, "-DFOO", .end])
@@ -3397,7 +3397,7 @@ final class BuildPlanTests: XCTestCase {
             XCTAssertMatch(cbar, [.anySequence, "-DCCC=2", "-I\(A.appending(components: "Sources", "cbar", "Sources", "headers"))", "-I\(A.appending(components: "Sources", "cbar", "Sources", "cppheaders"))", "-Icfoo", "-L", "cbar", "-Icxxfoo", "-L", "cxxbar", .end])
 
             let bar = try result.target(for: "bar").swiftTarget().compileArguments()
-            XCTAssertMatch(bar, [.anySequence, "-DDMACOS", "-Isfoo", "-L", "sbar", "-cxx-interoperability-mode=swift-6.0", "-enable-upcoming-feature", "BestFeature", "-enable-upcoming-feature", "WorstFeature", .end])
+            XCTAssertMatch(bar, [.anySequence, "-DDMACOS", "-Isfoo", "-L", "sbar", "-cxx-interoperability-mode=default", "-enable-upcoming-feature", "BestFeature", "-enable-upcoming-feature", "WorstFeature", .end])
 
             let exe = try result.target(for: "exe").swiftTarget().compileArguments()
             XCTAssertMatch(exe, [.anySequence, "-DFOO", "-cxx-interoperability-mode=default", .end])


### PR DESCRIPTION
### Motivation:

The version of C++ interoperability is going to be tied to Swift language version.

### Modifications:

This change removes the explicit version parameter for the `.interoperabilityMode(.Cxx)` build setting.

rdar://109525217