### PR TITLE
Stop using llbuild's Swift compiler tool

### DIFF
--- a/IntegrationTests/Tests/IntegrationTests/BasicTests.swift
+++ b/IntegrationTests/Tests/IntegrationTests/BasicTests.swift
@@ -215,7 +215,7 @@ final class BasicTests: XCTestCase {
 
             // Check the build.
             let buildOutput = try sh(swiftBuild, "--package-path", packagePath, "-v").stdout
-            XCTAssertMatch(buildOutput, .regex(#"swiftc.* -module-name special_tool .* ".*/more spaces/special tool/some file.swift""#))
+            XCTAssertMatch(buildOutput, .regex(#"swiftc.* -module-name special_tool .* '.*/more spaces/special tool/some file.swift'"#))
             XCTAssertMatch(buildOutput, .contains("Build complete"))
 
             // Verify that the tool exists and works.

--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -677,7 +677,7 @@ public final class SwiftTargetBuildDescription {
         self.buildParameters.triple.isDarwin() && self.target.type == .library
     }
 
-    private func writeOutputFileMap() throws -> AbsolutePath {
+    func writeOutputFileMap() throws -> AbsolutePath {
         let path = self.tempsPath.appending("output-file-map.json")
         let masterDepsPath = self.tempsPath.appending("master.swiftdeps")
 

--- a/Sources/Build/LLBuildManifestBuilder.swift
+++ b/Sources/Build/LLBuildManifestBuilder.swift
@@ -629,7 +629,8 @@ extension LLBuildManifestBuilder {
             otherArguments: try target.compileArguments(),
             sources: target.sources,
             isLibrary: isLibrary,
-            wholeModuleOptimization: self.buildParameters.configuration == .release
+            wholeModuleOptimization: self.buildParameters.configuration == .release,
+            outputFileMapPath: try target.writeOutputFileMap() // FIXME: Eliminate side effect.
         )
     }
 

--- a/Sources/LLBuildManifest/BuildManifest.swift
+++ b/Sources/LLBuildManifest/BuildManifest.swift
@@ -174,7 +174,8 @@ public struct BuildManifest {
         otherArguments: [String],
         sources: [AbsolutePath],
         isLibrary: Bool,
-        wholeModuleOptimization: Bool
+        wholeModuleOptimization: Bool,
+        outputFileMapPath: AbsolutePath
     ) {
         assert(commands[name] == nil, "already had a command named '\(name)'")
         let tool = SwiftCompilerTool(
@@ -190,7 +191,8 @@ public struct BuildManifest {
             otherArguments: otherArguments,
             sources: sources,
             isLibrary: isLibrary,
-            wholeModuleOptimization: wholeModuleOptimization
+            wholeModuleOptimization: wholeModuleOptimization,
+            outputFileMapPath: outputFileMapPath
         )
         commands[name] = Command(name: name, tool: tool)
     }


### PR DESCRIPTION
This allows us to take control of these compiler invocations and is a first step towards unifying all the various ways of generating compiler arguments that are currently in `SwiftTargetBuildDescription`.
    
This PR aims to keep the behavior of the existing tool as far as possible, the only known differences are single quotes instead of double for arguments with spaces and the fact that the output file map will be created eagerly.
    
resolves https://github.com/apple/swift-package-manager/issues/6575