### PR TITLE
Build: remove unused parameter

### DIFF
--- a/Sources/Build/LLBuildManifestBuilder.swift
+++ b/Sources/Build/LLBuildManifestBuilder.swift
@@ -619,7 +619,6 @@ extension LLBuildManifestBuilder {
             inputs: inputs,
             outputs: cmdOutputs,
             executable: self.buildParameters.toolchain.swiftCompilerPath,
-            packageName: target.package.identity.description.spm_mangledToC99ExtendedIdentifier(),
             moduleName: target.target.c99name,
             moduleAliases: target.target.moduleAliases,
             moduleOutputPath: target.moduleOutputPath,

--- a/Sources/LLBuildManifest/BuildManifest.swift
+++ b/Sources/LLBuildManifest/BuildManifest.swift
@@ -164,7 +164,6 @@ public struct BuildManifest {
         inputs: [Node],
         outputs: [Node],
         executable: AbsolutePath,
-        packageName: String,
         moduleName: String,
         moduleAliases: [String: String]?,
         moduleOutputPath: AbsolutePath,


### PR DESCRIPTION
This parameter was unused, remove it to simplify he signature. Identified when trying to investigate the removal of the use of the builtin command in llbuild.