### PR TITLE
[5.9] Swift SDKs: refactor and extend `SwiftSDKBundleTests`

### DIFF
--- a/Sources/PackageModel/SwiftSDKBundle.swift
+++ b/Sources/PackageModel/SwiftSDKBundle.swift
@@ -134,7 +134,7 @@ public struct SwiftSDKBundle {
     ///   - observabilityScope: Observability scope for reporting warnings and errors.
     public static func install(
         bundlePathOrURL: String,
-        destinationsDirectory: AbsolutePath,
+        swiftSDKsDirectory: AbsolutePath,
         _ fileSystem: some FileSystem,
         _ archiver: some Archiver,
         _ observabilityScope: ObservabilityScope
@@ -182,7 +182,7 @@ public struct SwiftSDKBundle {
 
             try installIfValid(
                 bundlePath: bundlePath,
-                destinationsDirectory: destinationsDirectory,
+                destinationsDirectory: swiftSDKsDirectory,
                 temporaryDirectory: temporaryDirectory,
                 fileSystem,
                 archiver,

--- a/Sources/SwiftSDKTool/InstallSwiftSDK.swift
+++ b/Sources/SwiftSDKTool/InstallSwiftSDK.swift
@@ -47,7 +47,7 @@ public struct InstallSwiftSDK: SwiftSDKSubcommand {
         cancellator.installSignalHandlers()
         try SwiftSDKBundle.install(
             bundlePathOrURL: bundlePathOrURL,
-            destinationsDirectory: destinationsDirectory,
+            swiftSDKsDirectory: destinationsDirectory,
             self.fileSystem,
             UniversalArchiver(self.fileSystem, cancellator),
             observabilityScope

--- a/Tests/PackageModelTests/SwiftSDKBundleTests.swift
+++ b/Tests/PackageModelTests/SwiftSDKBundleTests.swift
@@ -17,6 +17,7 @@ import XCTest
 
 import struct TSCBasic.AbsolutePath
 import struct TSCBasic.ByteString
+import protocol TSCBasic.FileSystem
 import class TSCBasic.InMemoryFileSystem
 
 private let testArtifactID = "test-artifact"
@@ -122,7 +123,6 @@ final class SwiftSDKBundleTests: XCTestCase {
                 return
             }
 
-            print(error)
             switch error {
             case .invalidBundleName(let bundleName):
                 XCTAssertEqual(bundleName, invalidPath)

--- a/Tests/PackageModelTests/SwiftSDKBundleTests.swift
+++ b/Tests/PackageModelTests/SwiftSDKBundleTests.swift
@@ -21,47 +21,77 @@ import class TSCBasic.InMemoryFileSystem
 
 private let testArtifactID = "test-artifact"
 
-private let infoJSON = ByteString(stringLiteral: """
-{
-  "artifacts" : {
-    "\(testArtifactID)" : {
-      "type" : "swiftSDK",
-      "version" : "0.0.1",
-      "variants" : [
-        {
-          "path" : "\(testArtifactID)/aarch64-unknown-linux",
-          "supportedTriples" : [
-            "arm64-apple-macosx13.0"
-          ]
-        }
-      ]
+private func generateInfoJSON(artifacts: [String: [Triple]]) -> String {
+    """
+    {
+        "artifacts" : {
+            \(artifacts.map {
+                    """
+                    "\($0)" : {
+                        "type" : "swiftSDK",
+                        "version" : "0.0.1",
+                        "variants" : [
+                            {
+                                "path" : "\($0)/aarch64-unknown-linux",
+                                "supportedTriples" : \($1.map(\.tripleString))
+                            }
+                        ]
+                    }
+                    """
+                }.joined(separator: ",\n")
+            )
+        },
+        "schemaVersion" : "1.0"
     }
-  },
-  "schemaVersion" : "1.0"
+    """
 }
-""")
+
+private struct MockBundle {
+    let name: String
+    let path: String
+    let artifacts: [String: Triple]
+}
+
+private func generateTestFileSystem(bundleArtifacts: [[String: Triple]]) throws -> (some FileSystem, [MockBundle], AbsolutePath) {
+    let bundles = bundleArtifacts.enumerated().map { (i, artifacts) in
+        let bundleName = "test\(i).artifactbundle"
+        return MockBundle(name: "test\(i).artifactbundle", path: "/\(bundleName)", artifacts: artifacts)
+    }
+
+    let fileSystem = InMemoryFileSystem(
+        files: Dictionary(uniqueKeysWithValues: bundles.map {
+            (
+                "\($0.path)/info.json",
+                ByteString(
+                    encodingAsUTF8: generateInfoJSON(artifacts: $0.artifacts)
+                )
+            )
+        })
+    )
+
+    let swiftSDKsDirectory = try AbsolutePath(validating: "/sdks")
+    try fileSystem.createDirectory(fileSystem.tempDirectory)
+    try fileSystem.createDirectory(swiftSDKsDirectory)
+
+    return (fileSystem, bundles, swiftSDKsDirectory)
+}
+
+let arm64Triple = try! Triple("arm64-apple-macosx13.0")
+let i686Triple = try! Triple("i686-apple-macosx13.0")
 
 final class SwiftSDKBundleTests: XCTestCase {
     func testInstall() async throws {
         let system = ObservabilitySystem.makeForTesting()
 
-        let bundleName1 = "test1.artifactbundle"
-        let bundleName2 = "test2.artifactbundle"
-        let bundlePath1 = "/\(bundleName1)"
-        let bundlePath2 = "/\(bundleName2)"
-        let destinationsDirectory = try AbsolutePath(validating: "/destinations")
-        let fileSystem = InMemoryFileSystem(files: [
-            "\(bundlePath1)/info.json": infoJSON,
-            "\(bundlePath2)/info.json": infoJSON,
-        ])
-        try fileSystem.createDirectory(fileSystem.tempDirectory)
-        try fileSystem.createDirectory(destinationsDirectory)
+        let (fileSystem, bundles, swiftSDKsDirectory) = try generateTestFileSystem(
+            bundleArtifacts: [arm64Triple, arm64Triple]
+        )
 
         let archiver = MockArchiver()
 
         try SwiftSDKBundle.install(
-            bundlePathOrURL: bundlePath1,
-            destinationsDirectory: destinationsDirectory,
+            bundlePathOrURL: bundles[0].path,
+            swiftSDKsDirectory: swiftSDKsDirectory,
             fileSystem,
             archiver,
             system.topScope
@@ -70,8 +100,8 @@ final class SwiftSDKBundleTests: XCTestCase {
         let invalidPath = "foobar"
         do {
             try SwiftSDKBundle.install(
-                bundlePathOrURL: invalidPath,
-                destinationsDirectory: destinationsDirectory,
+                bundlePathOrURL: "foobar",
+                swiftSDKsDirectory: swiftSDKsDirectory,
                 fileSystem,
                 archiver,
                 system.topScope
@@ -95,8 +125,8 @@ final class SwiftSDKBundleTests: XCTestCase {
 
         do {
             try SwiftSDKBundle.install(
-                bundlePathOrURL: bundlePath1,
-                destinationsDirectory: destinationsDirectory,
+                bundlePathOrURL: bundles[0].path,
+                swiftSDKsDirectory: swiftSDKsDirectory,
                 fileSystem,
                 archiver,
                 system.topScope
@@ -111,7 +141,7 @@ final class SwiftSDKBundleTests: XCTestCase {
 
             switch error {
             case .destinationBundleAlreadyInstalled(let installedBundleName):
-                XCTAssertEqual(bundleName1, installedBundleName)
+                XCTAssertEqual(bundles[0].name, installedBundleName)
             default:
                 XCTFail("Unexpected error value")
             }
@@ -119,8 +149,8 @@ final class SwiftSDKBundleTests: XCTestCase {
 
         do {
             try SwiftSDKBundle.install(
-                bundlePathOrURL: bundlePath2,
-                destinationsDirectory: destinationsDirectory,
+                bundlePathOrURL: bundles[1].path,
+                swiftSDKsDirectory: swiftSDKsDirectory,
                 fileSystem,
                 archiver,
                 system.topScope
@@ -135,12 +165,37 @@ final class SwiftSDKBundleTests: XCTestCase {
 
             switch error {
             case .destinationArtifactAlreadyInstalled(let installedBundleName, let newBundleName, let artifactID):
-                XCTAssertEqual(bundleName1, installedBundleName)
-                XCTAssertEqual(bundleName2, newBundleName)
+                XCTAssertEqual(bundles[0].name, installedBundleName)
+                XCTAssertEqual(bundles[1].name, newBundleName)
                 XCTAssertEqual(artifactID, testArtifactID)
             default:
                 XCTFail("Unexpected error value")
             }
         }
+    }
+
+    func testList() async throws {
+        let (fileSystem, bundles, swiftSDKsDirectory) = try generateTestFileSystem(
+            bundleArtifacts: [arm64Triple, i686Triple]
+        )
+        let system = ObservabilitySystem.makeForTesting()
+
+        for bundle in bundles {
+            try SwiftSDKBundle.install(
+                bundlePathOrURL: bundle.path,
+                swiftSDKsDirectory: swiftSDKsDirectory,
+                fileSystem,
+                MockArchiver(),
+                system.topScope
+            )
+        }
+
+        let validBundles = try SwiftSDKBundle.getAllValidBundles(
+            swiftSDKsDirectory: swiftSDKsDirectory,
+            fileSystem: fileSystem,
+            observabilityScope: system.topScope
+        )
+
+        XCTAssertEqual(validBundles.count, bundles.count)
     }
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-package-manager/pull/6588

`SwiftSDKBundleTests` should cover the `list` subcommand and verify that all installed Swift SDK bundles are listed.

New `testList` test function was added, while `testInstall` was refactored to share mock Swift SDK generation code with it.

rdar://107882144