### PR TITLE
[5.9] rdar://109108066 (Derive '-external-plugin-path' compiler arguments in SwiftPM)

### DIFF
--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -393,6 +393,18 @@ public final class SwiftTargetBuildDescription {
         }
         #endif
 
+        // If we're using an OSS toolchain, add the required arguments bringing in the plugin server from the default toolchain if available.
+        if self.buildParameters.toolchain.isSwiftDevelopmentToolchain, driverSupport.checkSupportedFrontendFlags(flags: ["-external-plugin-path"], toolchain: self.buildParameters.toolchain, fileSystem: self.fileSystem), let pluginServer = self.buildParameters.toolchain.swiftPluginServerPath {
+            let toolchainUsrPath = pluginServer.parentDirectory.parentDirectory
+            let pluginPathComponents = ["lib", "swift", "host", "plugins"]
+
+            let pluginPath = toolchainUsrPath.appending(components: pluginPathComponents)
+            args += ["-Xfrontend", "-external-plugin-path", "-Xfrontend", "\(pluginPath)#\(pluginServer.pathString)"]
+
+            let localPluginPath = toolchainUsrPath.appending(components: ["local"] + pluginPathComponents)
+            args += ["-Xfrontend", "-external-plugin-path", "-Xfrontend", "\(localPluginPath)#\(pluginServer.pathString)"]
+        }
+
         return args
     }
 

--- a/Sources/PackageModel/Toolchain.swift
+++ b/Sources/PackageModel/Toolchain.swift
@@ -19,6 +19,12 @@ public protocol Toolchain {
     /// Path of the `swiftc` compiler.
     var swiftCompilerPath: AbsolutePath { get }
 
+    /// Whether the used compiler is from a open source development toolchain.
+    var isSwiftDevelopmentToolchain: Bool { get }
+
+    /// Path to the Swift plugin server utility.
+    var swiftPluginServerPath: AbsolutePath? { get }
+
     /// Path containing the macOS Swift stdlib.
     var macosSwiftStdlib: AbsolutePath { get throws }
 

--- a/Sources/PackageModel/ToolchainConfiguration.swift
+++ b/Sources/PackageModel/ToolchainConfiguration.swift
@@ -43,6 +43,9 @@ public struct ToolchainConfiguration {
     /// This is optional for example on macOS w/o Xcode.
     public var xctestPath: AbsolutePath?
 
+    /// Path to the Swift plugin server utility.
+    public var swiftPluginServerPath: AbsolutePath?
+
     /// Creates the set of manifest resources associated with a `swiftc` executable.
     ///
     /// - Parameters:
@@ -53,6 +56,7 @@ public struct ToolchainConfiguration {
     ///     - swiftPMLibrariesRootPath: Custom path for SwiftPM libraries. Computed based on the compiler path by default.
     ///     - sdkRootPath: Optional path to SDK root.
     ///     - xctestPath: Optional path to XCTest.
+    ///     - swiftPluginServerPath: Optional path to the Swift plugin server executable.
     public init(
         librarianPath: AbsolutePath,
         swiftCompilerPath: AbsolutePath,
@@ -60,7 +64,8 @@ public struct ToolchainConfiguration {
         swiftCompilerEnvironment: EnvironmentVariables = .process(),
         swiftPMLibrariesLocation: SwiftPMLibrariesLocation? = nil,
         sdkRootPath: AbsolutePath? = nil,
-        xctestPath: AbsolutePath? = nil
+        xctestPath: AbsolutePath? = nil,
+        swiftPluginServerPath: AbsolutePath? = nil
     ) {
         let swiftPMLibrariesLocation = swiftPMLibrariesLocation ?? {
             return .init(swiftCompilerPath: swiftCompilerPath)
@@ -73,6 +78,7 @@ public struct ToolchainConfiguration {
         self.swiftPMLibrariesLocation = swiftPMLibrariesLocation
         self.sdkRootPath = sdkRootPath
         self.xctestPath = xctestPath
+        self.swiftPluginServerPath = swiftPluginServerPath
     }
 }
 

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -60,6 +60,8 @@ public final class UserToolchain: Toolchain {
 
     private let environment: EnvironmentVariables
 
+    public let isSwiftDevelopmentToolchain: Bool
+
     /// Returns the runtime library for the given sanitizer.
     public func runtimeLibrary(for sanitizer: Sanitizer) throws -> AbsolutePath {
         // FIXME: This is only for SwiftPM development time support. It is OK
@@ -452,6 +454,22 @@ public final class UserToolchain: Toolchain {
         self.swiftCompilerPath = swiftCompilers.compile
         self.architectures = destination.architectures
 
+        #if canImport(Darwin)
+        let toolchainPlistPath = self.swiftCompilerPath.parentDirectory.parentDirectory.parentDirectory
+            .appending(component: "Info.plist")
+        if localFileSystem.exists(toolchainPlistPath), let toolchainPlist = try? NSDictionary(
+            contentsOf: URL(fileURLWithPath: toolchainPlistPath.pathString),
+            error: ()
+        ), let overrideBuildSettings = toolchainPlist["OverrideBuildSettings"] as? NSDictionary,
+        let isSwiftDevelopmentToolchainStringValue = overrideBuildSettings["SWIFT_DEVELOPMENT_TOOLCHAIN"] as? String {
+            self.isSwiftDevelopmentToolchain = isSwiftDevelopmentToolchainStringValue == "YES"
+        } else {
+            self.isSwiftDevelopmentToolchain = false
+        }
+        #else
+        self.isSwiftDevelopmentToolchain = false
+        #endif
+
         // Use the triple from destination or compute the host triple using swiftc.
         var triple = try destination.targetTriple ?? Triple.getHostTriple(usingSwiftCompiler: swiftCompilers.compile)
 
@@ -535,10 +553,13 @@ public final class UserToolchain: Toolchain {
             environment: environment
         )
 
+        let swiftPluginServerPath: AbsolutePath?
         let xctestPath: AbsolutePath?
         if case .custom(_, let useXcrun) = searchStrategy, !useXcrun {
+            swiftPluginServerPath = nil
             xctestPath = nil
         } else {
+            swiftPluginServerPath = try Self.derivePluginServerPath(triple: triple)
             xctestPath = try Self.deriveXCTestPath(
                 destination: self.destination,
                 triple: triple,
@@ -553,7 +574,8 @@ public final class UserToolchain: Toolchain {
             swiftCompilerEnvironment: environment,
             swiftPMLibrariesLocation: swiftPMLibrariesLocation,
             sdkRootPath: self.destination.pathsConfiguration.sdkRootPath,
-            xctestPath: xctestPath
+            xctestPath: xctestPath,
+            swiftPluginServerPath: swiftPluginServerPath
         )
     }
 
@@ -623,6 +645,17 @@ public final class UserToolchain: Toolchain {
 
         // we are using a SwiftPM outside a toolchain, use the compiler path to compute the location
         return .init(swiftCompilerPath: swiftCompilerPath)
+    }
+
+    private static func derivePluginServerPath(triple: Triple) throws -> AbsolutePath? {
+        if triple.isDarwin() {
+            let xctestFindArgs = ["/usr/bin/xcrun", "--find", "swift-plugin-server"]
+            if let path = try? TSCBasic.Process.checkNonZeroExit(arguments: xctestFindArgs, environment: [:])
+                .spm_chomp() {
+                return try AbsolutePath(validating: path)
+            }
+        }
+        return .none
     }
 
     // TODO: We should have some general utility to find tools.
@@ -746,5 +779,9 @@ public final class UserToolchain: Toolchain {
 
     public var xctestPath: AbsolutePath? {
         configuration.xctestPath
+    }
+
+    public var swiftPluginServerPath: AbsolutePath? {
+        configuration.swiftPluginServerPath
     }
 }

--- a/Tests/BuildTests/MockBuildTestHelper.swift
+++ b/Tests/BuildTests/MockBuildTestHelper.swift
@@ -29,12 +29,15 @@ struct MockToolchain: PackageModel.Toolchain {
     let librarianPath = AbsolutePath("/fake/path/to/ar")
 #endif
     let swiftCompilerPath = AbsolutePath("/fake/path/to/swiftc")
+    let isSwiftDevelopmentToolchain = false
+    let swiftPluginServerPath: AbsolutePath? = nil
     
     #if os(macOS)
     let extraFlags = BuildFlags(cxxCompilerFlags: ["-lc++"])
     #else
     let extraFlags = BuildFlags(cxxCompilerFlags: ["-lstdc++"])
     #endif
+
     func getClangCompiler() throws -> AbsolutePath {
         return AbsolutePath(path: "/fake/path/to/clang")
     }


### PR DESCRIPTION
This derives the required `-external-plugin-path` arguments when using an OSS toolchain with SwiftPM.

(cherry picked from commit 72d5b34f9a64956b0157d52b0ff9eb4e16aa252b)
