### PR TITLE
[5.9] Add token-file option to 'package-registry login'

### DIFF
--- a/Sources/PackageRegistryTool/PackageRegistryTool+Auth.swift
+++ b/Sources/PackageRegistryTool/PackageRegistryTool+Auth.swift
@@ -82,6 +82,12 @@ extension SwiftPackageRegistryTool {
         @Option(help: "Access token")
         var token: String?
 
+        @Option(
+            name: .customLong("token-file"),
+            help: "Path to the file containing access token"
+        )
+        var tokenFilePath: AbsolutePath?
+
         @Flag(help: "Allow writing to netrc file without confirmation")
         var noConfirm: Bool = false
 
@@ -144,6 +150,10 @@ extension SwiftPackageRegistryTool {
                 if let token = self.token {
                     // User provided token
                     storePassword = token
+                } else if let tokenFilePath {
+                    print("Reading access token from \(tokenFilePath).")
+                    storePassword = try localFileSystem.readFileContents(tokenFilePath)
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
                 } else if let stored = authorizationProvider.authentication(for: registryURL),
                           stored.user == storeUsername
                 {


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift-package-manager/pull/6567 to 5.9