### PR TITLE
Handle swift-sdk search paths

### DIFF
--- a/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
@@ -304,6 +304,11 @@ public final class ClangTargetBuildDescription {
             args += ["-flto=thin"]
         }
 
+        // Pass default include paths from the toolchain.
+        for includeSearchPath in self.buildParameters.toolchain.includeSearchPaths {
+            args += ["-I", includeSearchPath.pathString]
+        }
+
         return args
     }
 

--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -318,6 +318,11 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
         // User arguments (from -Xlinker) should follow generated arguments to allow user overrides
         args += self.buildParameters.flags.linkerFlags.asSwiftcLinkerFlags()
 
+        // Pass default library paths from the toolchain.
+        for librarySearchPath in self.buildParameters.toolchain.librarySearchPaths {
+            args += ["-L", librarySearchPath.pathString]
+        }
+
         // Add toolchain's libdir at the very end (even after the user -Xlinker arguments).
         //
         // This will allow linking to libraries shipped in the toolchain.

--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -528,6 +528,11 @@ public final class SwiftTargetBuildDescription {
             args += ["-lto=llvm-thin"]
         }
 
+        // Pass default include paths from the toolchain.
+        for includeSearchPath in self.buildParameters.toolchain.includeSearchPaths {
+            args += ["-I", includeSearchPath.pathString]
+        }
+
         // suppress warnings if the package is remote
         if self.package.isRemote {
             args += ["-suppress-warnings"]
@@ -627,6 +632,11 @@ public final class SwiftTargetBuildDescription {
         result += try self.buildSettingsFlags()
         result += try self.macroArguments()
 
+        // Pass default include paths from the toolchain.
+        for includeSearchPath in self.buildParameters.toolchain.includeSearchPaths {
+            result += ["-I", includeSearchPath.pathString]
+        }
+
         return result
     }
 
@@ -704,6 +714,11 @@ public final class SwiftTargetBuildDescription {
             result += ["-lto=llvm-full"]
         case .thin:
             result += ["-lto=llvm-thin"]
+        }
+
+        // Pass default include paths from the toolchain.
+        for includeSearchPath in self.buildParameters.toolchain.includeSearchPaths {
+            result += ["-I", includeSearchPath.pathString]
         }
 
         result += try self.macroArguments()

--- a/Sources/PackageModel/Toolchain.swift
+++ b/Sources/PackageModel/Toolchain.swift
@@ -28,6 +28,12 @@ public protocol Toolchain {
     /// Path containing the macOS Swift stdlib.
     var macosSwiftStdlib: AbsolutePath { get throws }
 
+    /// An array of paths to search for headers and modules at compile time.
+    var includeSearchPaths: [AbsolutePath] { get }
+
+    /// An array of paths to search for libraries at link time.
+    var librarySearchPaths: [AbsolutePath] { get }
+
     /// Path of the `clang` compiler.
     func getClangCompiler() throws -> AbsolutePath
 

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -34,6 +34,12 @@ public final class UserToolchain: Toolchain {
     /// Path of the `swiftc` compiler.
     public let swiftCompilerPath: AbsolutePath
 
+    /// An array of paths to search for headers and modules at compile time.
+    public let includeSearchPaths: [AbsolutePath]
+
+    /// An array of paths to search for libraries at link time.
+    public let librarySearchPaths: [AbsolutePath]
+
     /// Additional flags to be passed to the build tools.
     public var extraFlags: BuildFlags
 
@@ -482,6 +488,7 @@ public final class UserToolchain: Toolchain {
         }
 
         self.triple = triple
+
         self.extraFlags = BuildFlags(
             cCompilerFlags: destination.toolset.knownTools[.cCompiler]?.extraCLIOptions ?? [],
             cxxCompilerFlags: destination.toolset.knownTools[.cxxCompiler]?.extraCLIOptions ?? [],
@@ -491,6 +498,9 @@ public final class UserToolchain: Toolchain {
                 environment: environment),
             linkerFlags: destination.toolset.knownTools[.linker]?.extraCLIOptions ?? [],
             xcbuildFlags: destination.toolset.knownTools[.xcbuild]?.extraCLIOptions ?? [])
+
+        self.includeSearchPaths = destination.pathsConfiguration.includeSearchPaths ?? []
+        self.librarySearchPaths = destination.pathsConfiguration.includeSearchPaths ?? []
 
         self.librarianPath = try UserToolchain.determineLibrarian(
             triple: triple,

--- a/Tests/BuildTests/MockBuildTestHelper.swift
+++ b/Tests/BuildTests/MockBuildTestHelper.swift
@@ -28,6 +28,8 @@ struct MockToolchain: PackageModel.Toolchain {
     let librarianPath = AbsolutePath("/fake/path/to/ar")
 #endif
     let swiftCompilerPath = AbsolutePath("/fake/path/to/swiftc")
+    let includeSearchPaths = [AbsolutePath]()
+    let librarySearchPaths = [AbsolutePath]()
     let isSwiftDevelopmentToolchain = false
     let swiftPluginServerPath: AbsolutePath? = nil
     let extraFlags = PackageModel.BuildFlags()


### PR DESCRIPTION
- Fixes a bug where includeSearchPaths and librarySearchPaths defined in
  a swift-sdk.json file were not properly respected. Updates
  UserToolchain to support these by adding matching properties and
  updates SwiftTargetBuildDescription as well as
  ClangTargetBuildDescription to pass these toolchain search paths to
  the compilers and linkers as expected.