### PR TITLE
Change PackageCollectionSigning API from callback-based to async/await

### DIFF
--- a/Sources/PackageCollectionsSigning/CertificatePolicy.swift
+++ b/Sources/PackageCollectionsSigning/CertificatePolicy.swift
@@ -53,66 +53,58 @@ protocol CertificatePolicy {
     /// Validates the given certificate chain.
     ///
     /// - Parameters:
-    ///   - certChainPaths: Paths to each certificate in the chain. The certificate being verified must be the first
-    ///                     element of the array, with its issuer the next element and so on, and the root CA
-    ///                     certificate is last.
+    ///   - certChain: The certificate being verified must be the first element of the array, with its issuer the next
+    ///                element and so on, and the root CA certificate is last.
     ///   - validationTime: Overrides the timestamp used for checking certificate expiry (e.g., for testing).
     ///                     By default the current time is used.
-    ///   - callback: The callback to invoke when the result is available.
-    func validate(certChain: [Certificate], validationTime: Date, callback: @escaping (Result<Void, Error>) -> Void)
+    func validate(certChain: [Certificate], validationTime: Date) async throws
 }
 
 extension CertificatePolicy {
     /// Validates the given certificate chain.
     ///
     /// - Parameters:
-    ///   - certChainPaths: Paths to each certificate in the chain. The certificate being verified must be the first
-    ///                     element of the array, with its issuer the next element and so on, and the root CA
-    ///                     certificate is last.
-    ///   - callback: The callback to invoke when the result is available.
-    func validate(certChain: [Certificate], callback: @escaping (Result<Void, Error>) -> Void) {
-        self.validate(certChain: certChain, validationTime: Date(), callback: callback)
+    ///   - certChain: The certificate being verified must be the first element of the array, with its issuer the next
+    ///                element and so on, and the root CA certificate is last.
+    func validate(certChain: [Certificate]) async throws {
+        try await self.validate(certChain: certChain, validationTime: Date())
     }
 
     func verify(
         certChain: [Certificate],
         trustedRoots: [Certificate]?,
         @PolicyBuilder policies: () -> some VerifierPolicy,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        callback: @escaping (Result<Void, Error>) -> Void
-    ) {
-        let wrappedCallback: (Result<Void, Error>) -> Void = { result in callbackQueue.async { callback(result) } }
-
+        observabilityScope: ObservabilityScope
+    ) async throws {
         guard !certChain.isEmpty else {
-            return wrappedCallback(.failure(CertificatePolicyError.emptyCertChain))
+            throw CertificatePolicyError.emptyCertChain
         }
+
         let policies = policies()
-        Task {
-            var trustStore = CertificateStores.defaultTrustRoots
-            if let trustedRoots {
-                trustStore.append(contentsOf: trustedRoots)
-            }
 
-            guard !trustStore.isEmpty else {
-                return wrappedCallback(.failure(CertificatePolicyError.noTrustedRootCertsConfigured))
-            }
+        var trustStore = CertificateStores.defaultTrustRoots
+        if let trustedRoots {
+            trustStore.append(contentsOf: trustedRoots)
+        }
 
-            var verifier = Verifier(rootCertificates: CertificateStore(trustStore)) {
-                policies
-            }
-            let result = await verifier.validate(
-                leafCertificate: certChain[0],
-                intermediates: CertificateStore(certChain)
-            )
+        guard !trustStore.isEmpty else {
+            throw CertificatePolicyError.noTrustedRootCertsConfigured
+        }
 
-            switch result {
-            case .validCertificate:
-                wrappedCallback(.success(()))
-            case .couldNotValidate(let failures):
-                observabilityScope.emit(error: "Failed to validate certificate chain \(certChain): \(failures)")
-                wrappedCallback(.failure(CertificatePolicyError.invalidCertChain))
-            }
+        var verifier = Verifier(rootCertificates: CertificateStore(trustStore)) {
+            policies
+        }
+        let result = await verifier.validate(
+            leafCertificate: certChain[0],
+            intermediates: CertificateStore(certChain)
+        )
+
+        switch result {
+        case .validCertificate:
+            return
+        case .couldNotValidate(let failures):
+            observabilityScope.emit(error: "Failed to validate certificate chain \(certChain): \(failures)")
+            throw CertificatePolicyError.invalidCertChain
         }
     }
 }
@@ -136,7 +128,6 @@ struct DefaultCertificatePolicy: CertificatePolicy {
     let expectedSubjectUserID: String?
     let expectedSubjectOrganizationalUnit: String?
 
-    private let callbackQueue: DispatchQueue
     private let httpClient: HTTPClient
     private let observabilityScope: ObservabilityScope
 
@@ -150,14 +141,12 @@ struct DefaultCertificatePolicy: CertificatePolicy {
     ///                                 user configured and dynamic, while this is configured by SwiftPM and static.
     ///   - expectedSubjectUserID: The subject user ID that must match if specified.
     ///   - expectedSubjectOrganizationalUnit: The subject organizational unit name that must match if specified.
-    ///   - callbackQueue: The `DispatchQueue` to use for callbacks.
     init(
         trustedRootCertsDir: URL?,
         additionalTrustedRootCerts: [Certificate]?,
         expectedSubjectUserID: String? = nil,
         expectedSubjectOrganizationalUnit: String? = nil,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue
+        observabilityScope: ObservabilityScope
     ) {
         var trustedRoots = [Certificate]()
         if let trustedRootCertsDir {
@@ -170,19 +159,16 @@ struct DefaultCertificatePolicy: CertificatePolicy {
         self.trustedRoots = trustedRoots
         self.expectedSubjectUserID = expectedSubjectUserID
         self.expectedSubjectOrganizationalUnit = expectedSubjectOrganizationalUnit
-        self.callbackQueue = callbackQueue
         self.httpClient = HTTPClient.makeDefault()
         self.observabilityScope = observabilityScope
     }
 
-    func validate(certChain: [Certificate], validationTime: Date, callback: @escaping (Result<Void, Error>) -> Void) {
-        let wrappedCallback: (Result<Void, Error>) -> Void = { result in self.callbackQueue.async { callback(result) } }
-
+    func validate(certChain: [Certificate], validationTime: Date) async throws {
         guard !certChain.isEmpty else {
-            return wrappedCallback(.failure(CertificatePolicyError.emptyCertChain))
+            throw CertificatePolicyError.emptyCertChain
         }
 
-        self.verify(
+        try await self.verify(
             certChain: certChain,
             trustedRoots: self.trustedRoots,
             policies: {
@@ -202,9 +188,7 @@ struct DefaultCertificatePolicy: CertificatePolicy {
                     validationTime: validationTime
                 )
             },
-            observabilityScope: self.observabilityScope,
-            callbackQueue: self.callbackQueue,
-            callback: callback
+            observabilityScope: self.observabilityScope
         )
     }
 }
@@ -218,7 +202,6 @@ struct ADPSwiftPackageCollectionCertificatePolicy: CertificatePolicy {
     let expectedSubjectUserID: String?
     let expectedSubjectOrganizationalUnit: String?
 
-    private let callbackQueue: DispatchQueue
     private let httpClient: HTTPClient
     private let observabilityScope: ObservabilityScope
 
@@ -232,14 +215,12 @@ struct ADPSwiftPackageCollectionCertificatePolicy: CertificatePolicy {
     ///                                 user configured and dynamic, while this is configured by SwiftPM and static.
     ///   - expectedSubjectUserID: The subject user ID that must match if specified.
     ///   - expectedSubjectOrganizationalUnit: The subject organizational unit name that must match if specified.
-    ///   - callbackQueue: The `DispatchQueue` to use for callbacks.
     init(
         trustedRootCertsDir: URL?,
         additionalTrustedRootCerts: [Certificate]?,
         expectedSubjectUserID: String? = nil,
         expectedSubjectOrganizationalUnit: String? = nil,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue
+        observabilityScope: ObservabilityScope
     ) {
         var trustedRoots = [Certificate]()
         if let trustedRootCertsDir {
@@ -252,19 +233,16 @@ struct ADPSwiftPackageCollectionCertificatePolicy: CertificatePolicy {
         self.trustedRoots = trustedRoots
         self.expectedSubjectUserID = expectedSubjectUserID
         self.expectedSubjectOrganizationalUnit = expectedSubjectOrganizationalUnit
-        self.callbackQueue = callbackQueue
         self.httpClient = HTTPClient.makeDefault()
         self.observabilityScope = observabilityScope
     }
 
-    func validate(certChain: [Certificate], validationTime: Date, callback: @escaping (Result<Void, Error>) -> Void) {
-        let wrappedCallback: (Result<Void, Error>) -> Void = { result in self.callbackQueue.async { callback(result) } }
-
+    func validate(certChain: [Certificate], validationTime: Date) async throws {
         guard !certChain.isEmpty else {
-            return wrappedCallback(.failure(CertificatePolicyError.emptyCertChain))
+            throw CertificatePolicyError.emptyCertChain
         }
 
-        self.verify(
+        try await self.verify(
             certChain: certChain,
             trustedRoots: self.trustedRoots,
             policies: {
@@ -286,9 +264,7 @@ struct ADPSwiftPackageCollectionCertificatePolicy: CertificatePolicy {
                     validationTime: validationTime
                 )
             },
-            observabilityScope: self.observabilityScope,
-            callbackQueue: self.callbackQueue,
-            callback: callback
+            observabilityScope: self.observabilityScope
         )
     }
 }
@@ -302,7 +278,6 @@ struct ADPAppleDistributionCertificatePolicy: CertificatePolicy {
     let expectedSubjectUserID: String?
     let expectedSubjectOrganizationalUnit: String?
 
-    private let callbackQueue: DispatchQueue
     private let httpClient: HTTPClient
     private let observabilityScope: ObservabilityScope
 
@@ -316,14 +291,12 @@ struct ADPAppleDistributionCertificatePolicy: CertificatePolicy {
     ///                                 user configured and dynamic, while this is configured by SwiftPM and static.
     ///   - expectedSubjectUserID: The subject user ID that must match if specified.
     ///   - expectedSubjectOrganizationalUnit: The subject organizational unit name that must match if specified.
-    ///   - callbackQueue: The `DispatchQueue` to use for callbacks.
     init(
         trustedRootCertsDir: URL?,
         additionalTrustedRootCerts: [Certificate]?,
         expectedSubjectUserID: String? = nil,
         expectedSubjectOrganizationalUnit: String? = nil,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue
+        observabilityScope: ObservabilityScope
     ) {
         var trustedRoots = [Certificate]()
         if let trustedRootCertsDir {
@@ -336,19 +309,16 @@ struct ADPAppleDistributionCertificatePolicy: CertificatePolicy {
         self.trustedRoots = trustedRoots
         self.expectedSubjectUserID = expectedSubjectUserID
         self.expectedSubjectOrganizationalUnit = expectedSubjectOrganizationalUnit
-        self.callbackQueue = callbackQueue
         self.httpClient = HTTPClient.makeDefault()
         self.observabilityScope = observabilityScope
     }
 
-    func validate(certChain: [Certificate], validationTime: Date, callback: @escaping (Result<Void, Error>) -> Void) {
-        let wrappedCallback: (Result<Void, Error>) -> Void = { result in self.callbackQueue.async { callback(result) } }
-
+    func validate(certChain: [Certificate], validationTime: Date) async throws {
         guard !certChain.isEmpty else {
-            return wrappedCallback(.failure(CertificatePolicyError.emptyCertChain))
+            throw CertificatePolicyError.emptyCertChain
         }
 
-        self.verify(
+        try await self.verify(
             certChain: certChain,
             trustedRoots: self.trustedRoots,
             policies: {
@@ -370,9 +340,7 @@ struct ADPAppleDistributionCertificatePolicy: CertificatePolicy {
                     validationTime: validationTime
                 )
             },
-            observabilityScope: self.observabilityScope,
-            callbackQueue: self.callbackQueue,
-            callback: callback
+            observabilityScope: self.observabilityScope
         )
     }
 }

--- a/Tests/PackageCollectionsSigningTests/CertificatePolicyTests.swift
+++ b/Tests/PackageCollectionsSigningTests/CertificatePolicyTests.swift
@@ -13,93 +13,373 @@
 import Basics
 @testable import PackageCollectionsSigning
 import SPMTestSupport
+import SwiftASN1
 import X509
 import XCTest
 
 class CertificatePolicyTests: XCTestCase {
-    func test_RSA_validate_happyCase() throws {
+    func test_RSA_validate_happyCase() async throws {
         let certChain = try temp_await { callback in self.readTestRSACertChain(callback: callback) }
         let policy = TestCertificatePolicy(trustedRoots: certChain.suffix(1))
-        XCTAssertNoThrow(try temp_await { callback in policy.validate(
+
+        try await policy.validate(
             certChain: certChain,
-            validationTime: TestCertificatePolicy.testCertValidDate,
-            callback: callback
-        ) })
+            validationTime: TestCertificatePolicy.testCertValidDate
+        )
     }
 
-    func test_EC_validate_happyCase() throws {
+    func test_EC_validate_happyCase() async throws {
         let certChain = try temp_await { callback in self.readTestECCertChain(callback: callback) }
         let policy = TestCertificatePolicy(trustedRoots: certChain.suffix(1))
-        XCTAssertNoThrow(try temp_await { callback in policy.validate(
+
+        try await policy.validate(
             certChain: certChain,
-            validationTime: TestCertificatePolicy.testCertValidDate,
-            callback: callback
-        ) })
+            validationTime: TestCertificatePolicy.testCertValidDate
+        )
     }
 
-    func test_validate_untrustedRoot() throws {
+    func test_validate_untrustedRoot() async throws {
         let certChain = try temp_await { callback in self.readTestRSACertChain(callback: callback) }
         // Test root is not trusted
         let policy = TestCertificatePolicy(trustedRoots: nil)
-        XCTAssertThrowsError(try temp_await { callback in policy.validate(
-            certChain: certChain,
-            validationTime: TestCertificatePolicy.testCertValidDate,
-            callback: callback
-        ) }) { error in
+
+        do {
+            try await policy.validate(
+                certChain: certChain,
+                validationTime: TestCertificatePolicy.testCertValidDate
+            )
+            XCTFail("Expected error")
+        } catch {
             guard CertificatePolicyError.invalidCertChain == error as? CertificatePolicyError else {
                 return XCTFail("Expected CertificatePolicyError.invalidCertChain")
             }
         }
     }
 
-    func test_validate_expiredCert() throws {
+    func test_validate_expiredCert() async throws {
         let certChain = try temp_await { callback in self.readTestRSACertChain(callback: callback) }
-        // Test root is not trusted
         let policy = TestCertificatePolicy(trustedRoots: certChain.suffix(1))
 
         // Use verify date outside of cert's validity period
-        XCTAssertThrowsError(try temp_await { callback in policy.validate(
-            certChain: certChain,
-            validationTime: TestCertificatePolicy.testCertInvalidDate,
-            callback: callback
-        ) }) { error in
+        do {
+            try await policy.validate(
+                certChain: certChain,
+                validationTime: TestCertificatePolicy.testCertInvalidDate
+            )
+            XCTFail("Expected error")
+        } catch {
             guard CertificatePolicyError.invalidCertChain == error as? CertificatePolicyError else {
                 return XCTFail("Expected CertificatePolicyError.invalidCertChain")
             }
         }
     }
 
-    func test_validate_revoked() throws {
+    func test_validate_revoked() async throws {
         #if ENABLE_REAL_CERT_TEST
         #else
         try XCTSkipIf(true)
         #endif
 
-        try fixture(name: "Signing", createGitRepo: false) { fixturePath in
-            let certPath = fixturePath.appending(components: "Certificates", "development-revoked.cer")
-            let certificate = try Certificate(derEncoded: try localFileSystem.readFileContents(certPath).contents)
-
-            let intermediateCAPath = fixturePath.appending(components: "Certificates", "AppleWWDRCAG3.cer")
-            let intermediateCA = try Certificate(
-                derEncoded: try localFileSystem.readFileContents(intermediateCAPath).contents
+        let certChain = try temp_await { callback in
+            self.readTestCertChain(
+                paths: { fixturePath in
+                    [
+                        fixturePath.appending(components: "Certificates", "development-revoked.cer"),
+                        fixturePath.appending(components: "Certificates", "AppleWWDRCAG3.cer"),
+                        fixturePath.appending(components: "Certificates", "AppleIncRoot.cer"),
+                    ]
+                },
+                callback: callback
             )
+        }
 
-            let rootCAPath = fixturePath.appending(components: "Certificates", "AppleIncRoot.cer")
-            let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath).contents)
+        // Apple root certs are in SwiftPM's default trust store
+        let policy = DefaultCertificatePolicy(
+            trustedRootCertsDir: nil,
+            additionalTrustedRootCerts: nil,
+            observabilityScope: ObservabilitySystem.NOOP
+        )
 
-            let certChain = [certificate, intermediateCA, rootCA]
+        do {
+            try await policy.validate(certChain: certChain)
+            XCTFail("Expected error")
+        } catch {
+            guard CertificatePolicyError.invalidCertChain == error as? CertificatePolicyError else {
+                return XCTFail("Expected CertificatePolicyError.invalidCertChain")
+            }
+        }
+    }
 
+    func test_validate_defaultPolicy() async throws {
+        #if ENABLE_REAL_CERT_TEST
+        #else
+        try XCTSkipIf(true)
+        #endif
+
+        let certChain = try temp_await { callback in
+            self.readTestCertChain(
+                paths: { fixturePath in
+                    [
+                        fixturePath.appending(components: "Certificates", "development.cer"),
+                        fixturePath.appending(components: "Certificates", "AppleWWDRCAG3.cer"),
+                        fixturePath.appending(components: "Certificates", "AppleIncRoot.cer"),
+                    ]
+                },
+                callback: callback
+            )
+        }
+
+        do {
             // Apple root certs are in SwiftPM's default trust store
             let policy = DefaultCertificatePolicy(
                 trustedRootCertsDir: nil,
                 additionalTrustedRootCerts: nil,
-                observabilityScope: ObservabilitySystem.NOOP,
-                callbackQueue: callbackQueue
+                observabilityScope: ObservabilitySystem.NOOP
+            )
+            try await policy.validate(certChain: certChain)
+        }
+
+        do {
+            // What if `additionalTrustedRootCerts` has a cert that's already in the default trust store?
+            let rootCA = certChain.last!
+            let policy = DefaultCertificatePolicy(
+                trustedRootCertsDir: nil,
+                additionalTrustedRootCerts: [rootCA],
+                observabilityScope: ObservabilitySystem.NOOP
+            )
+            try await policy.validate(certChain: certChain)
+        }
+
+        do {
+            // What if the same cert is in both `trustedRootCertsDir` and `additionalTrustedRootCerts`?
+            try await withTemporaryDirectory { tmp in
+                let rootCA = certChain.last!
+
+                var serializer = DER.Serializer()
+                try rootCA.serialize(into: &serializer)
+                let rootCABytes = serializer.serializedBytes
+                try localFileSystem.writeFileContents(
+                    tmp.appending(components: "AppleIncRoot.cer"),
+                    bytes: .init(rootCABytes)
+                )
+
+                let policy = DefaultCertificatePolicy(
+                    trustedRootCertsDir: tmp.asURL,
+                    additionalTrustedRootCerts: [rootCA],
+                    observabilityScope: ObservabilitySystem.NOOP
+                )
+                try await policy.validate(certChain: certChain)
+            }
+        }
+    }
+
+    func test_validate_appleSwiftPackageCollectionPolicy_rsa() async throws {
+        #if ENABLE_REAL_CERT_TEST
+        #else
+        try XCTSkipIf(true)
+        #endif
+
+        let certChain = try temp_await { callback in
+            self.readTestCertChain(
+                paths: { fixturePath in
+                    [
+                        fixturePath.appending(components: "Certificates", "swift_package_collection.cer"),
+                        fixturePath.appending(components: "Certificates", "AppleWWDRCAG3.cer"),
+                        fixturePath.appending(components: "Certificates", "AppleIncRoot.cer"),
+                    ]
+                },
+                callback: callback
+            )
+        }
+
+        do {
+            // Apple root certs are in SwiftPM's default trust store
+            let policy = ADPSwiftPackageCollectionCertificatePolicy(
+                trustedRootCertsDir: nil,
+                additionalTrustedRootCerts: nil,
+                observabilityScope: ObservabilitySystem.NOOP
+            )
+            try await policy.validate(certChain: certChain)
+        }
+
+        do {
+            // What if `additionalTrustedRootCerts` has a cert that's already in the default trust store?
+            let rootCA = certChain.last!
+            let policy = ADPSwiftPackageCollectionCertificatePolicy(
+                trustedRootCertsDir: nil,
+                additionalTrustedRootCerts: [rootCA],
+                observabilityScope: ObservabilitySystem.NOOP
+            )
+            try await policy.validate(certChain: certChain)
+        }
+
+        do {
+            // What if the same cert is in both `trustedRootCertsDir` and `additionalTrustedRootCerts`?
+            try await withTemporaryDirectory { tmp in
+                let rootCA = certChain.last!
+
+                var serializer = DER.Serializer()
+                try rootCA.serialize(into: &serializer)
+                let rootCABytes = serializer.serializedBytes
+                try localFileSystem.writeFileContents(
+                    tmp.appending(components: "AppleIncRoot.cer"),
+                    bytes: .init(rootCABytes)
+                )
+
+                let policy = ADPSwiftPackageCollectionCertificatePolicy(
+                    trustedRootCertsDir: tmp.asURL,
+                    additionalTrustedRootCerts: [rootCA],
+                    observabilityScope: ObservabilitySystem.NOOP
+                )
+                try await policy.validate(certChain: certChain)
+            }
+        }
+    }
+
+    func test_validate_appleSwiftPackageCollectionPolicy_ec() async throws {
+        #if ENABLE_REAL_CERT_TEST
+        #else
+        try XCTSkipIf(true)
+        #endif
+
+        let certChain = try temp_await { callback in
+            self.readTestCertChain(
+                paths: { fixturePath in
+                    [
+                        fixturePath.appending(components: "Certificates", "swift_package.cer"),
+                        fixturePath.appending(components: "Certificates", "AppleWWDRCAG6.cer"),
+                        fixturePath.appending(components: "Certificates", "AppleRootCAG3.cer"),
+                    ]
+                },
+                callback: callback
+            )
+        }
+
+        do {
+            // Apple root certs are in SwiftPM's default trust store
+            let policy = ADPSwiftPackageCollectionCertificatePolicy(
+                trustedRootCertsDir: nil,
+                additionalTrustedRootCerts: nil,
+                observabilityScope: ObservabilitySystem.NOOP
+            )
+            try await policy.validate(certChain: certChain)
+        }
+
+        do {
+            // What if `additionalTrustedRootCerts` has a cert that's already in the default trust store?
+            let rootCA = certChain.last!
+            let policy = ADPSwiftPackageCollectionCertificatePolicy(
+                trustedRootCertsDir: nil,
+                additionalTrustedRootCerts: [rootCA],
+                observabilityScope: ObservabilitySystem.NOOP
+            )
+            try await policy.validate(certChain: certChain)
+        }
+
+        do {
+            // What if the same cert is in both `trustedRootCertsDir` and `additionalTrustedRootCerts`?
+            try await withTemporaryDirectory { tmp in
+                let rootCA = certChain.last!
+
+                var serializer = DER.Serializer()
+                try rootCA.serialize(into: &serializer)
+                let rootCABytes = serializer.serializedBytes
+                try localFileSystem.writeFileContents(
+                    tmp.appending(components: "AppleIncRoot.cer"),
+                    bytes: .init(rootCABytes)
+                )
+
+                let policy = ADPSwiftPackageCollectionCertificatePolicy(
+                    trustedRootCertsDir: tmp.asURL,
+                    additionalTrustedRootCerts: [rootCA],
+                    observabilityScope: ObservabilitySystem.NOOP
+                )
+                try await policy.validate(certChain: certChain)
+            }
+        }
+    }
+
+    func test_validate_defaultPolicy_user() async throws {
+        #if ENABLE_REAL_CERT_TEST
+        #else
+        try XCTSkipIf(true)
+        #endif
+
+        let certChain = try temp_await { callback in
+            self.readTestCertChain(
+                paths: { fixturePath in
+                    [
+                        fixturePath.appending(components: "Certificates", "development.cer"),
+                        fixturePath.appending(components: "Certificates", "AppleWWDRCAG3.cer"),
+                        fixturePath.appending(components: "Certificates", "AppleIncRoot.cer"),
+                    ]
+                },
+                callback: callback
+            )
+        }
+
+        do {
+            // Apple root certs are in SwiftPM's default trust store
+            // Subject user ID matches
+            let policy = DefaultCertificatePolicy(
+                trustedRootCertsDir: nil,
+                additionalTrustedRootCerts: nil,
+                expectedSubjectUserID: expectedSubjectUserID,
+                expectedSubjectOrganizationalUnit: nil,
+                observabilityScope: ObservabilitySystem.NOOP
+            )
+            try await policy.validate(certChain: certChain)
+        }
+
+        do {
+            // Apple root certs are in SwiftPM's default trust store
+            // Subject user ID does not match
+            let policy = DefaultCertificatePolicy(
+                trustedRootCertsDir: nil,
+                additionalTrustedRootCerts: nil,
+                expectedSubjectUserID: "\(expectedSubjectUserID)-2",
+                expectedSubjectOrganizationalUnit: nil,
+                observabilityScope: ObservabilitySystem.NOOP
             )
 
-            XCTAssertThrowsError(try temp_await { callback in
-                policy.validate(certChain: certChain, callback: callback)
-            }) { error in
+            do {
+                try await policy.validate(certChain: certChain)
+                XCTFail("Expected error")
+            } catch {
+                guard CertificatePolicyError.invalidCertChain == error as? CertificatePolicyError else {
+                    return XCTFail("Expected CertificatePolicyError.invalidCertChain")
+                }
+            }
+        }
+
+        do {
+            // Apple root certs are in SwiftPM's default trust store
+            // Subject organizational unit matches
+            let policy = DefaultCertificatePolicy(
+                trustedRootCertsDir: nil,
+                additionalTrustedRootCerts: nil,
+                expectedSubjectUserID: nil,
+                expectedSubjectOrganizationalUnit: expectedSubjectOrgUnit,
+                observabilityScope: ObservabilitySystem.NOOP
+            )
+            try await policy.validate(certChain: certChain)
+        }
+
+        do {
+            // Apple root certs are in SwiftPM's default trust store
+            // Subject organizational unit does not match
+            let policy = DefaultCertificatePolicy(
+                trustedRootCertsDir: nil,
+                additionalTrustedRootCerts: nil,
+                expectedSubjectUserID: nil,
+                expectedSubjectOrganizationalUnit: "\(expectedSubjectOrgUnit)-2",
+                observabilityScope: ObservabilitySystem.NOOP
+            )
+
+            do {
+                try await policy.validate(certChain: certChain)
+                XCTFail("Expected error")
+            } catch {
                 guard CertificatePolicyError.invalidCertChain == error as? CertificatePolicyError else {
                     return XCTFail("Expected CertificatePolicyError.invalidCertChain")
                 }
@@ -107,698 +387,219 @@ class CertificatePolicyTests: XCTestCase {
         }
     }
 
-    func test_validate_defaultPolicy() throws {
+    func test_validate_appleSwiftPackageCollectionPolicy_rsa_user() async throws {
         #if ENABLE_REAL_CERT_TEST
         #else
         try XCTSkipIf(true)
         #endif
 
-        try fixture(name: "Signing", createGitRepo: false) { fixturePath in
-            let certPath = fixturePath.appending(components: "Certificates", "development.cer")
-            let certificate = try Certificate(derEncoded: try localFileSystem.readFileContents(certPath).contents)
+        let certChain = try temp_await { callback in
+            self.readTestCertChain(
+                paths: { fixturePath in
+                    [
+                        fixturePath.appending(components: "Certificates", "swift_package_collection.cer"),
+                        fixturePath.appending(components: "Certificates", "AppleWWDRCAG3.cer"),
+                        fixturePath.appending(components: "Certificates", "AppleIncRoot.cer"),
+                    ]
+                },
+                callback: callback
+            )
+        }
 
-            let intermediateCAPath = fixturePath.appending(components: "Certificates", "AppleWWDRCAG3.cer")
-            let intermediateCA = try Certificate(
-                derEncoded: try localFileSystem.readFileContents(intermediateCAPath).contents
+        do {
+            // Apple root certs are in SwiftPM's default trust store
+            // Subject user ID matches
+            let policy = ADPSwiftPackageCollectionCertificatePolicy(
+                trustedRootCertsDir: nil,
+                additionalTrustedRootCerts: nil,
+                expectedSubjectUserID: expectedSubjectUserID,
+                expectedSubjectOrganizationalUnit: nil,
+                observabilityScope: ObservabilitySystem.NOOP
+            )
+            try await policy.validate(certChain: certChain)
+        }
+
+        do {
+            // Apple root certs are in SwiftPM's default trust store
+            // Subject user ID does not match
+            let policy = ADPSwiftPackageCollectionCertificatePolicy(
+                trustedRootCertsDir: nil,
+                additionalTrustedRootCerts: nil,
+                expectedSubjectUserID: "\(expectedSubjectUserID)-2",
+                expectedSubjectOrganizationalUnit: nil,
+                observabilityScope: ObservabilitySystem.NOOP
             )
 
-            let rootCAPath = fixturePath.appending(components: "Certificates", "AppleIncRoot.cer")
-            let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath).contents)
-
-            let certChain = [certificate, intermediateCA, rootCA]
-
             do {
-                // Apple root certs are in SwiftPM's default trust store
-                let policy = DefaultCertificatePolicy(
-                    trustedRootCertsDir: nil,
-                    additionalTrustedRootCerts: nil,
-                    observabilityScope: ObservabilitySystem.NOOP,
-                    callbackQueue: callbackQueue
-                )
-                XCTAssertNoThrow(try temp_await { callback in
-                    policy.validate(certChain: certChain, callback: callback)
-                })
+                try await policy.validate(certChain: certChain)
+                XCTFail("Expected error")
+            } catch {
+                guard CertificatePolicyError.invalidCertChain == error as? CertificatePolicyError else {
+                    return XCTFail("Expected CertificatePolicyError.invalidCertChain")
+                }
             }
+        }
+
+        do {
+            // Apple root certs are in SwiftPM's default trust store
+            // Subject organizational unit matches
+            let policy = ADPSwiftPackageCollectionCertificatePolicy(
+                trustedRootCertsDir: nil,
+                additionalTrustedRootCerts: nil,
+                expectedSubjectUserID: nil,
+                expectedSubjectOrganizationalUnit: expectedSubjectOrgUnit,
+                observabilityScope: ObservabilitySystem.NOOP
+            )
+            try await policy.validate(certChain: certChain)
+        }
+
+        do {
+            // Apple root certs are in SwiftPM's default trust store
+            // Subject organizational unit does not match
+            let policy = ADPSwiftPackageCollectionCertificatePolicy(
+                trustedRootCertsDir: nil,
+                additionalTrustedRootCerts: nil,
+                expectedSubjectUserID: nil,
+                expectedSubjectOrganizationalUnit: "\(expectedSubjectOrgUnit)-2",
+                observabilityScope: ObservabilitySystem.NOOP
+            )
 
             do {
-                // What if `additionalTrustedRootCerts` has a cert that's already in the default trust store?
-                let policy = DefaultCertificatePolicy(
-                    trustedRootCertsDir: nil,
-                    additionalTrustedRootCerts: [rootCA],
-                    observabilityScope: ObservabilitySystem.NOOP,
-                    callbackQueue: callbackQueue
-                )
-                XCTAssertNoThrow(try temp_await { callback in
-                    policy.validate(certChain: certChain, callback: callback)
-                })
-            }
-
-            do {
-                // What if the same cert is in both `trustedRootCertsDir` and `additionalTrustedRootCerts`?
-                try withTemporaryDirectory { tmp in
-                    try localFileSystem.copy(from: rootCAPath, to: tmp.appending(components: "AppleIncRoot.cer"))
-
-                    let policy = DefaultCertificatePolicy(
-                        trustedRootCertsDir: tmp.asURL,
-                        additionalTrustedRootCerts: [rootCA],
-                        observabilityScope: ObservabilitySystem.NOOP,
-                        callbackQueue: callbackQueue
-                    )
-                    XCTAssertNoThrow(try temp_await { callback in
-                        policy.validate(certChain: certChain, callback: callback)
-                    })
+                try await policy.validate(certChain: certChain)
+                XCTFail("Expected error")
+            } catch {
+                guard CertificatePolicyError.invalidCertChain == error as? CertificatePolicyError else {
+                    return XCTFail("Expected CertificatePolicyError.invalidCertChain")
                 }
             }
         }
     }
 
-    func test_validate_appleSwiftPackageCollectionPolicy_rsa() throws {
+    func test_validate_appleSwiftPackageCollectionPolicy_ec_user() async throws {
         #if ENABLE_REAL_CERT_TEST
         #else
         try XCTSkipIf(true)
         #endif
 
-        try fixture(name: "Signing", createGitRepo: false) { fixturePath in
-            let certPath = fixturePath.appending(components: "Certificates", "swift_package_collection.cer")
-            let certificate = try Certificate(derEncoded: try localFileSystem.readFileContents(certPath).contents)
+        let certChain = try temp_await { callback in
+            self.readTestCertChain(
+                paths: { fixturePath in
+                    [
+                        fixturePath.appending(components: "Certificates", "swift_package.cer"),
+                        fixturePath.appending(components: "Certificates", "AppleWWDRCAG6.cer"),
+                        fixturePath.appending(components: "Certificates", "AppleRootCAG3.cer"),
+                    ]
+                },
+                callback: callback
+            )
+        }
 
-            let intermediateCAPath = fixturePath.appending(components: "Certificates", "AppleWWDRCAG3.cer")
-            let intermediateCA = try Certificate(
-                derEncoded: try localFileSystem.readFileContents(intermediateCAPath).contents
+        do {
+            // Apple root certs are in SwiftPM's default trust store
+            // Subject user ID matches
+            let policy = ADPSwiftPackageCollectionCertificatePolicy(
+                trustedRootCertsDir: nil,
+                additionalTrustedRootCerts: nil,
+                expectedSubjectUserID: expectedSubjectUserID,
+                expectedSubjectOrganizationalUnit: nil,
+                observabilityScope: ObservabilitySystem.NOOP
+            )
+            try await policy.validate(certChain: certChain)
+        }
+
+        do {
+            // Apple root certs are in SwiftPM's default trust store
+            // Subject user ID does not match
+            let policy = ADPSwiftPackageCollectionCertificatePolicy(
+                trustedRootCertsDir: nil,
+                additionalTrustedRootCerts: nil,
+                expectedSubjectUserID: "\(expectedSubjectUserID)-2",
+                expectedSubjectOrganizationalUnit: nil,
+                observabilityScope: ObservabilitySystem.NOOP
             )
 
-            let rootCAPath = fixturePath.appending(components: "Certificates", "AppleIncRoot.cer")
-            let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath).contents)
-
-            let certChain = [certificate, intermediateCA, rootCA]
-
             do {
-                // Apple root certs are in SwiftPM's default trust store
-                let policy = ADPSwiftPackageCollectionCertificatePolicy(
-                    trustedRootCertsDir: nil,
-                    additionalTrustedRootCerts: nil,
-                    observabilityScope: ObservabilitySystem.NOOP,
-                    callbackQueue: callbackQueue
-                )
-                XCTAssertNoThrow(try temp_await { callback in
-                    policy.validate(certChain: certChain, callback: callback)
-                })
-            }
-
-            do {
-                // What if `additionalTrustedRootCerts` has a cert that's already in the default trust store?
-                let policy = ADPSwiftPackageCollectionCertificatePolicy(
-                    trustedRootCertsDir: nil,
-                    additionalTrustedRootCerts: [rootCA],
-                    observabilityScope: ObservabilitySystem.NOOP,
-                    callbackQueue: callbackQueue
-                )
-                XCTAssertNoThrow(try temp_await { callback in
-                    policy.validate(certChain: certChain, callback: callback)
-                })
-            }
-
-            do {
-                // What if the same cert is in both `trustedRootCertsDir` and `additionalTrustedRootCerts`?
-                try withTemporaryDirectory { tmp in
-                    try localFileSystem.copy(from: rootCAPath, to: tmp.appending(components: "AppleIncRoot.cer"))
-
-                    let policy = ADPSwiftPackageCollectionCertificatePolicy(
-                        trustedRootCertsDir: tmp.asURL,
-                        additionalTrustedRootCerts: [rootCA],
-                        observabilityScope: ObservabilitySystem.NOOP,
-                        callbackQueue: callbackQueue
-                    )
-                    XCTAssertNoThrow(try temp_await { callback in
-                        policy.validate(certChain: certChain, callback: callback)
-                    })
+                try await policy.validate(certChain: certChain)
+                XCTFail("Expected error")
+            } catch {
+                guard CertificatePolicyError.invalidCertChain == error as? CertificatePolicyError else {
+                    return XCTFail("Expected CertificatePolicyError.invalidCertChain")
                 }
             }
         }
-    }
 
-    func test_validate_appleSwiftPackageCollectionPolicy_ec() throws {
-        #if ENABLE_REAL_CERT_TEST
-        #else
-        try XCTSkipIf(true)
-        #endif
-
-        try fixture(name: "Signing", createGitRepo: false) { fixturePath in
-            let certPath = fixturePath.appending(components: "Certificates", "swift_package.cer")
-            let certificate = try Certificate(derEncoded: try localFileSystem.readFileContents(certPath).contents)
-
-            let intermediateCAPath = fixturePath.appending(components: "Certificates", "AppleWWDRCAG6.cer")
-            let intermediateCA = try Certificate(
-                derEncoded: try localFileSystem.readFileContents(intermediateCAPath).contents
+        do {
+            // Apple root certs are in SwiftPM's default trust store
+            // Subject organizational unit matches
+            let policy = ADPSwiftPackageCollectionCertificatePolicy(
+                trustedRootCertsDir: nil,
+                additionalTrustedRootCerts: nil,
+                expectedSubjectUserID: nil,
+                expectedSubjectOrganizationalUnit: expectedSubjectOrgUnit,
+                observabilityScope: ObservabilitySystem.NOOP
             )
-
-            let rootCAPath = fixturePath.appending(components: "Certificates", "AppleRootCAG3.cer")
-            let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath).contents)
-
-            let certChain = [certificate, intermediateCA, rootCA]
-
-            do {
-                // Apple root certs are in SwiftPM's default trust store
-                let policy = ADPSwiftPackageCollectionCertificatePolicy(
-                    trustedRootCertsDir: nil,
-                    additionalTrustedRootCerts: nil,
-                    observabilityScope: ObservabilitySystem.NOOP,
-                    callbackQueue: callbackQueue
-                )
-                XCTAssertNoThrow(try temp_await { callback in
-                    policy.validate(certChain: certChain, callback: callback)
-                })
-            }
-
-            do {
-                // What if `additionalTrustedRootCerts` has a cert that's already in the default trust store?
-                let policy = ADPSwiftPackageCollectionCertificatePolicy(
-                    trustedRootCertsDir: nil,
-                    additionalTrustedRootCerts: [rootCA],
-                    observabilityScope: ObservabilitySystem.NOOP,
-                    callbackQueue: callbackQueue
-                )
-                XCTAssertNoThrow(try temp_await { callback in
-                    policy.validate(certChain: certChain, callback: callback)
-                })
-            }
-
-            do {
-                // What if the same cert is in both `trustedRootCertsDir` and `additionalTrustedRootCerts`?
-                try withTemporaryDirectory { tmp in
-                    try localFileSystem.copy(from: rootCAPath, to: tmp.appending(components: "AppleIncRoot.cer"))
-
-                    let policy = ADPSwiftPackageCollectionCertificatePolicy(
-                        trustedRootCertsDir: tmp.asURL,
-                        additionalTrustedRootCerts: [rootCA],
-                        observabilityScope: ObservabilitySystem.NOOP,
-                        callbackQueue: callbackQueue
-                    )
-                    XCTAssertNoThrow(try temp_await { callback in
-                        policy.validate(certChain: certChain, callback: callback)
-                    })
-                }
-            }
+            try await policy.validate(certChain: certChain)
         }
-    }
 
-    func test_validate_appleDistributionPolicy() throws {
-        #if ENABLE_REAL_CERT_TEST
-        #else
-        try XCTSkipIf(true)
-        #endif
-
-        try fixture(name: "Signing", createGitRepo: false) { fixturePath in
-            let certPath = fixturePath.appending(components: "Certificates", "distribution.cer")
-            let certificate = try Certificate(derEncoded: try localFileSystem.readFileContents(certPath).contents)
-
-            let intermediateCAPath = fixturePath.appending(components: "Certificates", "AppleWWDRCAG3.cer")
-            let intermediateCA = try Certificate(
-                derEncoded: try localFileSystem.readFileContents(intermediateCAPath).contents
+        do {
+            // Apple root certs are in SwiftPM's default trust store
+            // Subject organizational unit does not match
+            let policy = ADPSwiftPackageCollectionCertificatePolicy(
+                trustedRootCertsDir: nil,
+                additionalTrustedRootCerts: nil,
+                expectedSubjectUserID: nil,
+                expectedSubjectOrganizationalUnit: "\(expectedSubjectOrgUnit)-2",
+                observabilityScope: ObservabilitySystem.NOOP
             )
 
-            let rootCAPath = fixturePath.appending(components: "Certificates", "AppleIncRoot.cer")
-            let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath).contents)
-
-            let certChain = [certificate, intermediateCA, rootCA]
-
             do {
-                // Apple root certs are in SwiftPM's default trust store
-                let policy = ADPAppleDistributionCertificatePolicy(
-                    trustedRootCertsDir: nil,
-                    additionalTrustedRootCerts: nil,
-                    observabilityScope: ObservabilitySystem.NOOP,
-                    callbackQueue: callbackQueue
-                )
-                XCTAssertNoThrow(try temp_await { callback in
-                    policy.validate(certChain: certChain, callback: callback)
-                })
-            }
-
-            do {
-                // What if `additionalTrustedRootCerts` has a cert that's already in the default trust store?
-                let policy = ADPAppleDistributionCertificatePolicy(
-                    trustedRootCertsDir: nil,
-                    additionalTrustedRootCerts: [rootCA],
-                    observabilityScope: ObservabilitySystem.NOOP,
-                    callbackQueue: callbackQueue
-                )
-                XCTAssertNoThrow(try temp_await { callback in
-                    policy.validate(certChain: certChain, callback: callback)
-                })
-            }
-
-            do {
-                // What if the same cert is in both `trustedRootCertsDir` and `additionalTrustedRootCerts`?
-                try withTemporaryDirectory { tmp in
-                    try localFileSystem.copy(from: rootCAPath, to: tmp.appending(components: "AppleIncRoot.cer"))
-
-                    let policy = ADPAppleDistributionCertificatePolicy(
-                        trustedRootCertsDir: tmp.asURL,
-                        additionalTrustedRootCerts: [rootCA],
-                        observabilityScope: ObservabilitySystem.NOOP,
-                        callbackQueue: callbackQueue
-                    )
-                    XCTAssertNoThrow(try temp_await { callback in
-                        policy.validate(certChain: certChain, callback: callback)
-                    })
-                }
-            }
-        }
-    }
-
-    func test_validate_defaultPolicy_user() throws {
-        #if ENABLE_REAL_CERT_TEST
-        #else
-        try XCTSkipIf(true)
-        #endif
-
-        try fixture(name: "Signing", createGitRepo: false) { fixturePath in
-            let certPath = fixturePath.appending(components: "Certificates", "development.cer")
-            let certificate = try Certificate(derEncoded: try localFileSystem.readFileContents(certPath).contents)
-
-            let intermediateCAPath = fixturePath.appending(components: "Certificates", "AppleWWDRCAG3.cer")
-            let intermediateCA = try Certificate(
-                derEncoded: try localFileSystem.readFileContents(intermediateCAPath).contents
-            )
-
-            let rootCAPath = fixturePath.appending(components: "Certificates", "AppleIncRoot.cer")
-            let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath).contents)
-
-            let certChain = [certificate, intermediateCA, rootCA]
-
-            do {
-                // Apple root certs are in SwiftPM's default trust store
-                // Subject user ID matches
-                let policy = DefaultCertificatePolicy(
-                    trustedRootCertsDir: nil,
-                    additionalTrustedRootCerts: nil,
-                    expectedSubjectUserID: expectedSubjectUserID,
-                    expectedSubjectOrganizationalUnit: nil,
-                    observabilityScope: ObservabilitySystem.NOOP,
-                    callbackQueue: callbackQueue
-                )
-
-                XCTAssertNoThrow(try temp_await { callback in
-                    policy.validate(certChain: certChain, callback: callback)
-                })
-            }
-
-            do {
-                // Apple root certs are in SwiftPM's default trust store
-                // Subject user ID does not match
-                let policy = DefaultCertificatePolicy(
-                    trustedRootCertsDir: nil,
-                    additionalTrustedRootCerts: nil,
-                    expectedSubjectUserID: "\(expectedSubjectUserID)-2",
-                    expectedSubjectOrganizationalUnit: nil,
-                    observabilityScope: ObservabilitySystem.NOOP,
-                    callbackQueue: callbackQueue
-                )
-
-                XCTAssertThrowsError(try temp_await { callback in
-                    policy.validate(certChain: certChain, callback: callback)
-                }) { error in
-                    guard CertificatePolicyError.invalidCertChain == error as? CertificatePolicyError else {
-                        return XCTFail("Expected CertificatePolicyError.invalidCertChain")
-                    }
-                }
-            }
-
-            do {
-                // Apple root certs are in SwiftPM's default trust store
-                // Subject organizational unit matches
-                let policy = DefaultCertificatePolicy(
-                    trustedRootCertsDir: nil,
-                    additionalTrustedRootCerts: nil,
-                    expectedSubjectUserID: nil,
-                    expectedSubjectOrganizationalUnit: expectedSubjectOrgUnit,
-                    observabilityScope: ObservabilitySystem.NOOP,
-                    callbackQueue: callbackQueue
-                )
-
-                XCTAssertNoThrow(try temp_await { callback in
-                    policy.validate(certChain: certChain, callback: callback)
-                })
-            }
-
-            do {
-                // Apple root certs are in SwiftPM's default trust store
-                // Subject organizational unit does not match
-                let policy = DefaultCertificatePolicy(
-                    trustedRootCertsDir: nil,
-                    additionalTrustedRootCerts: nil,
-                    expectedSubjectUserID: nil,
-                    expectedSubjectOrganizationalUnit: "\(expectedSubjectOrgUnit)-2",
-                    observabilityScope: ObservabilitySystem.NOOP,
-                    callbackQueue: callbackQueue
-                )
-
-                XCTAssertThrowsError(try temp_await { callback in
-                    policy.validate(certChain: certChain, callback: callback)
-                }) { error in
-                    guard CertificatePolicyError.invalidCertChain == error as? CertificatePolicyError else {
-                        return XCTFail("Expected CertificatePolicyError.invalidCertChain")
-                    }
-                }
-            }
-        }
-    }
-
-    func test_validate_appleSwiftPackageCollectionPolicy_rsa_user() throws {
-        #if ENABLE_REAL_CERT_TEST
-        #else
-        try XCTSkipIf(true)
-        #endif
-
-        try fixture(name: "Signing", createGitRepo: false) { fixturePath in
-            let certPath = fixturePath.appending(components: "Certificates", "swift_package_collection.cer")
-            let certificate = try Certificate(derEncoded: try localFileSystem.readFileContents(certPath).contents)
-
-            let intermediateCAPath = fixturePath.appending(components: "Certificates", "AppleWWDRCAG3.cer")
-            let intermediateCA = try Certificate(
-                derEncoded: try localFileSystem.readFileContents(intermediateCAPath).contents
-            )
-
-            let rootCAPath = fixturePath.appending(components: "Certificates", "AppleIncRoot.cer")
-            let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath).contents)
-
-            let certChain = [certificate, intermediateCA, rootCA]
-
-            do {
-                // Apple root certs are in SwiftPM's default trust store
-                // Subject user ID matches
-                let policy = ADPSwiftPackageCollectionCertificatePolicy(
-                    trustedRootCertsDir: nil,
-                    additionalTrustedRootCerts: nil,
-                    expectedSubjectUserID: expectedSubjectUserID,
-                    expectedSubjectOrganizationalUnit: nil,
-                    observabilityScope: ObservabilitySystem.NOOP,
-                    callbackQueue: callbackQueue
-                )
-
-                XCTAssertNoThrow(try temp_await { callback in
-                    policy.validate(certChain: certChain, callback: callback)
-                })
-            }
-
-            do {
-                // Apple root certs are in SwiftPM's default trust store
-                // Subject user ID does not match
-                let policy = ADPSwiftPackageCollectionCertificatePolicy(
-                    trustedRootCertsDir: nil,
-                    additionalTrustedRootCerts: nil,
-                    expectedSubjectUserID: "\(expectedSubjectUserID)-2",
-                    expectedSubjectOrganizationalUnit: nil,
-                    observabilityScope: ObservabilitySystem.NOOP,
-                    callbackQueue: callbackQueue
-                )
-
-                XCTAssertThrowsError(try temp_await { callback in
-                    policy.validate(certChain: certChain, callback: callback)
-                }) { error in
-                    guard CertificatePolicyError.invalidCertChain == error as? CertificatePolicyError else {
-                        return XCTFail("Expected CertificatePolicyError.invalidCertChain")
-                    }
-                }
-            }
-
-            do {
-                // Apple root certs are in SwiftPM's default trust store
-                // Subject organizational unit matches
-                let policy = ADPSwiftPackageCollectionCertificatePolicy(
-                    trustedRootCertsDir: nil,
-                    additionalTrustedRootCerts: nil,
-                    expectedSubjectUserID: nil,
-                    expectedSubjectOrganizationalUnit: expectedSubjectOrgUnit,
-                    observabilityScope: ObservabilitySystem.NOOP,
-                    callbackQueue: callbackQueue
-                )
-
-                XCTAssertNoThrow(try temp_await { callback in
-                    policy.validate(certChain: certChain, callback: callback)
-                })
-            }
-
-            do {
-                // Apple root certs are in SwiftPM's default trust store
-                // Subject organizational unit does not match
-                let policy = ADPSwiftPackageCollectionCertificatePolicy(
-                    trustedRootCertsDir: nil,
-                    additionalTrustedRootCerts: nil,
-                    expectedSubjectUserID: nil,
-                    expectedSubjectOrganizationalUnit: "\(expectedSubjectOrgUnit)-2",
-                    observabilityScope: ObservabilitySystem.NOOP,
-                    callbackQueue: callbackQueue
-                )
-
-                XCTAssertThrowsError(try temp_await { callback in
-                    policy.validate(certChain: certChain, callback: callback)
-                }) { error in
-                    guard CertificatePolicyError.invalidCertChain == error as? CertificatePolicyError else {
-                        return XCTFail("Expected CertificatePolicyError.invalidCertChain")
-                    }
-                }
-            }
-        }
-    }
-
-    func test_validate_appleSwiftPackageCollectionPolicy_ec_user() throws {
-        #if ENABLE_REAL_CERT_TEST
-        #else
-        try XCTSkipIf(true)
-        #endif
-
-        try fixture(name: "Signing", createGitRepo: false) { fixturePath in
-            let certPath = fixturePath.appending(components: "Certificates", "swift_package.cer")
-            let certificate = try Certificate(derEncoded: try localFileSystem.readFileContents(certPath).contents)
-
-            let intermediateCAPath = fixturePath.appending(components: "Certificates", "AppleWWDRCAG6.cer")
-            let intermediateCA = try Certificate(
-                derEncoded: try localFileSystem.readFileContents(intermediateCAPath).contents
-            )
-
-            let rootCAPath = fixturePath.appending(components: "Certificates", "AppleRootCAG3.cer")
-            let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath).contents)
-
-            let certChain = [certificate, intermediateCA, rootCA]
-
-            do {
-                // Apple root certs are in SwiftPM's default trust store
-                // Subject user ID matches
-                let policy = ADPSwiftPackageCollectionCertificatePolicy(
-                    trustedRootCertsDir: nil,
-                    additionalTrustedRootCerts: nil,
-                    expectedSubjectUserID: expectedSubjectUserID,
-                    expectedSubjectOrganizationalUnit: nil,
-                    observabilityScope: ObservabilitySystem.NOOP,
-                    callbackQueue: callbackQueue
-                )
-
-                XCTAssertNoThrow(try temp_await { callback in
-                    policy.validate(certChain: certChain, callback: callback)
-                })
-            }
-
-            do {
-                // Apple root certs are in SwiftPM's default trust store
-                // Subject user ID does not match
-                let policy = ADPSwiftPackageCollectionCertificatePolicy(
-                    trustedRootCertsDir: nil,
-                    additionalTrustedRootCerts: nil,
-                    expectedSubjectUserID: "\(expectedSubjectUserID)-2",
-                    expectedSubjectOrganizationalUnit: nil,
-                    observabilityScope: ObservabilitySystem.NOOP,
-                    callbackQueue: callbackQueue
-                )
-
-                XCTAssertThrowsError(try temp_await { callback in
-                    policy.validate(certChain: certChain, callback: callback)
-                }) { error in
-                    guard CertificatePolicyError.invalidCertChain == error as? CertificatePolicyError else {
-                        return XCTFail("Expected CertificatePolicyError.invalidCertChain")
-                    }
-                }
-            }
-
-            do {
-                // Apple root certs are in SwiftPM's default trust store
-                // Subject organizational unit matches
-                let policy = ADPSwiftPackageCollectionCertificatePolicy(
-                    trustedRootCertsDir: nil,
-                    additionalTrustedRootCerts: nil,
-                    expectedSubjectUserID: nil,
-                    expectedSubjectOrganizationalUnit: expectedSubjectOrgUnit,
-                    observabilityScope: ObservabilitySystem.NOOP,
-                    callbackQueue: callbackQueue
-                )
-
-                XCTAssertNoThrow(try temp_await { callback in
-                    policy.validate(certChain: certChain, callback: callback)
-                })
-            }
-
-            do {
-                // Apple root certs are in SwiftPM's default trust store
-                // Subject organizational unit does not match
-                let policy = ADPSwiftPackageCollectionCertificatePolicy(
-                    trustedRootCertsDir: nil,
-                    additionalTrustedRootCerts: nil,
-                    expectedSubjectUserID: nil,
-                    expectedSubjectOrganizationalUnit: "\(expectedSubjectOrgUnit)-2",
-                    observabilityScope: ObservabilitySystem.NOOP,
-                    callbackQueue: callbackQueue
-                )
-
-                XCTAssertThrowsError(try temp_await { callback in
-                    policy.validate(certChain: certChain, callback: callback)
-                }) { error in
-                    guard CertificatePolicyError.invalidCertChain == error as? CertificatePolicyError else {
-                        return XCTFail("Expected CertificatePolicyError.invalidCertChain")
-                    }
-                }
-            }
-        }
-    }
-
-    func test_validate_appleDistributionPolicy_user() throws {
-        #if ENABLE_REAL_CERT_TEST
-        #else
-        try XCTSkipIf(true)
-        #endif
-
-        try fixture(name: "Signing", createGitRepo: false) { fixturePath in
-            let certPath = fixturePath.appending(components: "Certificates", "distribution.cer")
-            let certificate = try Certificate(derEncoded: try localFileSystem.readFileContents(certPath).contents)
-
-            let intermediateCAPath = fixturePath.appending(components: "Certificates", "AppleWWDRCAG3.cer")
-            let intermediateCA = try Certificate(
-                derEncoded: try localFileSystem.readFileContents(intermediateCAPath).contents
-            )
-
-            let rootCAPath = fixturePath.appending(components: "Certificates", "AppleIncRoot.cer")
-            let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath).contents)
-
-            let certChain = [certificate, intermediateCA, rootCA]
-
-            do {
-                // Apple root certs are in SwiftPM's default trust store
-                // Subject user ID matches
-                let policy = ADPAppleDistributionCertificatePolicy(
-                    trustedRootCertsDir: nil,
-                    additionalTrustedRootCerts: nil,
-                    expectedSubjectUserID: expectedSubjectUserID,
-                    expectedSubjectOrganizationalUnit: nil,
-                    observabilityScope: ObservabilitySystem.NOOP,
-                    callbackQueue: callbackQueue
-                )
-
-                XCTAssertNoThrow(try temp_await { callback in
-                    policy.validate(certChain: certChain, callback: callback)
-                })
-            }
-
-            do {
-                // Apple root certs are in SwiftPM's default trust store
-                // Subject user ID does not match
-                let policy = ADPAppleDistributionCertificatePolicy(
-                    trustedRootCertsDir: nil,
-                    additionalTrustedRootCerts: nil,
-                    expectedSubjectUserID: "\(expectedSubjectUserID)-2",
-                    expectedSubjectOrganizationalUnit: nil,
-                    observabilityScope: ObservabilitySystem.NOOP,
-                    callbackQueue: callbackQueue
-                )
-
-                XCTAssertThrowsError(try temp_await { callback in
-                    policy.validate(certChain: certChain, callback: callback)
-                }) { error in
-                    guard CertificatePolicyError.invalidCertChain == error as? CertificatePolicyError else {
-                        return XCTFail("Expected CertificatePolicyError.invalidCertChain")
-                    }
-                }
-            }
-
-            do {
-                // Apple root certs are in SwiftPM's default trust store
-                // Subject organizational unit matches
-                let policy = ADPAppleDistributionCertificatePolicy(
-                    trustedRootCertsDir: nil,
-                    additionalTrustedRootCerts: nil,
-                    expectedSubjectUserID: nil,
-                    expectedSubjectOrganizationalUnit: expectedSubjectOrgUnit,
-                    observabilityScope: ObservabilitySystem.NOOP,
-                    callbackQueue: callbackQueue
-                )
-
-                XCTAssertNoThrow(try temp_await { callback in
-                    policy.validate(certChain: certChain, callback: callback)
-                })
-            }
-
-            do {
-                // Apple root certs are in SwiftPM's default trust store
-                // Subject organizational unit does not match
-                let policy = ADPAppleDistributionCertificatePolicy(
-                    trustedRootCertsDir: nil,
-                    additionalTrustedRootCerts: nil,
-                    expectedSubjectUserID: nil,
-                    expectedSubjectOrganizationalUnit: "\(expectedSubjectOrgUnit)-2",
-                    observabilityScope: ObservabilitySystem.NOOP,
-                    callbackQueue: callbackQueue
-                )
-
-                XCTAssertThrowsError(try temp_await { callback in
-                    policy.validate(certChain: certChain, callback: callback)
-                }) { error in
-                    guard CertificatePolicyError.invalidCertChain == error as? CertificatePolicyError else {
-                        return XCTFail("Expected CertificatePolicyError.invalidCertChain")
-                    }
+                try await policy.validate(certChain: certChain)
+                XCTFail("Expected error")
+            } catch {
+                guard CertificatePolicyError.invalidCertChain == error as? CertificatePolicyError else {
+                    return XCTFail("Expected CertificatePolicyError.invalidCertChain")
                 }
             }
         }
     }
 
     private func readTestRSACertChain(callback: (Result<[Certificate], Error>) -> Void) {
-        do {
-            try fixture(name: "Signing", createGitRepo: false) { fixturePath in
-                let certPath = fixturePath.appending(components: "Certificates", "Test_rsa.cer")
-                let leaf = try Certificate(derEncoded: try localFileSystem.readFileContents(certPath).contents)
-
-                let intermediateCAPath = fixturePath.appending(components: "Certificates", "TestIntermediateCA.cer")
-                let intermediateCA = try Certificate(
-                    derEncoded: try localFileSystem
-                        .readFileContents(intermediateCAPath).contents
-                )
-
-                let rootCAPath = fixturePath.appending(components: "Certificates", "TestRootCA.cer")
-                let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath).contents)
-
-                let certChain = [leaf, intermediateCA, rootCA]
-                callback(.success(certChain))
-            }
-        } catch {
-            callback(.failure(error))
-        }
+        self.readTestCertChain(
+            paths: { fixturePath in
+                [
+                    fixturePath.appending(components: "Certificates", "Test_rsa.cer"),
+                    fixturePath.appending(components: "Certificates", "TestIntermediateCA.cer"),
+                    fixturePath.appending(components: "Certificates", "TestRootCA.cer"),
+                ]
+            },
+            callback: callback
+        )
     }
 
     private func readTestECCertChain(callback: (Result<[Certificate], Error>) -> Void) {
+        self.readTestCertChain(
+            paths: { fixturePath in
+                [
+                    fixturePath.appending(components: "Certificates", "Test_ec.cer"),
+                    fixturePath.appending(components: "Certificates", "TestIntermediateCA.cer"),
+                    fixturePath.appending(components: "Certificates", "TestRootCA.cer"),
+                ]
+            },
+            callback: callback
+        )
+    }
+
+    private func readTestCertChain(
+        paths: (AbsolutePath) -> [AbsolutePath],
+        callback: (Result<[Certificate], Error>) -> Void
+    ) {
         do {
             try fixture(name: "Signing", createGitRepo: false) { fixturePath in
-                let certPath = fixturePath.appending(components: "Certificates", "Test_ec.cer")
-                let leaf = try Certificate(derEncoded: try localFileSystem.readFileContents(certPath).contents)
-
-                let intermediateCAPath = fixturePath.appending(components: "Certificates", "TestIntermediateCA.cer")
-                let intermediateCA = try Certificate(
-                    derEncoded: try localFileSystem
-                        .readFileContents(intermediateCAPath).contents
-                )
-
-                let rootCAPath = fixturePath.appending(components: "Certificates", "TestRootCA.cer")
-                let rootCA = try Certificate(derEncoded: try localFileSystem.readFileContents(rootCAPath).contents)
-
-                let certChain = [leaf, intermediateCA, rootCA]
-                callback(.success(certChain))
+                let certPaths = paths(fixturePath)
+                let certificates = try certPaths.map { certPath in
+                    try Certificate(derEncoded: try localFileSystem.readFileContents(certPath).contents)
+                }
+                callback(.success(certificates))
             }
         } catch {
             callback(.failure(error))

--- a/Tests/PackageCollectionsSigningTests/Utilities.swift
+++ b/Tests/PackageCollectionsSigningTests/Utilities.swift
@@ -20,8 +20,6 @@ import X509
 let expectedSubjectUserID = ProcessInfo.processInfo.environment["REAL_CERT_USER_ID"] ?? "<USER ID>"
 let expectedSubjectOrgUnit = ProcessInfo.processInfo.environment["REAL_CERT_ORG_UNIT"] ?? "<ORG UNIT>"
 
-let callbackQueue = DispatchQueue(label: "org.swift.swiftpm.PackageCollectionsSigningTests", attributes: .concurrent)
-
 // MARK: - CertificatePolicy for test certs
 
 struct TestCertificatePolicy: CertificatePolicy {
@@ -53,10 +51,9 @@ struct TestCertificatePolicy: CertificatePolicy {
 
     func validate(
         certChain: [Certificate],
-        validationTime: Date,
-        callback: @escaping (Result<Void, Error>) -> Void
-    ) {
-        self.verify(
+        validationTime: Date
+    ) async throws {
+        try await self.verify(
             certChain: certChain,
             trustedRoots: self.trustedRoots,
             policies: {
@@ -66,9 +63,7 @@ struct TestCertificatePolicy: CertificatePolicy {
                 RFC5280Policy(validationTime: validationTime)
                 // Doesn't require OCSP
             },
-            observabilityScope: ObservabilitySystem.NOOP,
-            callbackQueue: callbackQueue,
-            callback: callback
+            observabilityScope: ObservabilitySystem.NOOP
         )
     }
 }

--- a/Tests/PackageCollectionsTests/Utility.swift
+++ b/Tests/PackageCollectionsTests/Utility.swift
@@ -203,17 +203,18 @@ struct MockCollectionSignatureValidator: PackageCollectionSignatureValidator {
         self.hasTrustedRootCerts = hasTrustedRootCerts
     }
 
-    func validate(signedCollection: PackageCollectionModel.V1.SignedCollection,
-                  certPolicyKey: CertificatePolicyKey,
-                  callback: @escaping (Result<Void, Error>) -> Void) {
+    func validate(
+        signedCollection: PackageCollectionModel.V1.SignedCollection,
+        certPolicyKey: CertificatePolicyKey
+    ) async throws {
         guard self.hasTrustedRootCerts else {
-            return callback(.failure(PackageCollectionSigningError.noTrustedRootCertsConfigured))
+            throw PackageCollectionSigningError.noTrustedRootCertsConfigured
         }
 
         if self.collections.contains(signedCollection.collection.name) || self.certPolicyKeys.contains(certPolicyKey) {
-            callback(.success(()))
+            return
         } else {
-            callback(.failure(PackageCollectionSigningError.invalidSignature))
+            throw PackageCollectionSigningError.invalidSignature
         }
     }
 }


### PR DESCRIPTION
Motivation:
Package collection signing crashes with code 139 on Linux (Ubuntu Jammy). Adding a signed collection also fails.

Modifications:
- Change `PackageCollectionSigning` API from callback-based to async/await
- Certificate validation is async/await instead of callback-based
- Change `PackageCollectionSigning` to actor since accessing `self.observabilityScope` also causes crash
