### PR TITLE
BuildDescription: Set output path for bc files

### DIFF
--- a/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
@@ -293,6 +293,17 @@ public final class ClangTargetBuildDescription {
             // User arguments (from -Xcxx) should follow generated arguments to allow user overrides
             args += self.buildParameters.flags.cxxCompilerFlags
         }
+
+        // Enable the correct lto mode if requested.
+        switch self.buildParameters.linkTimeOptimizationMode {
+        case nil:
+            break
+        case .full:
+            args += ["-flto=full"]
+        case .thin:
+            args += ["-flto=thin"]
+        }
+
         return args
     }
 

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -470,6 +470,13 @@ public struct BuildOptions: ParsableArguments {
     )
     public var testEntryPointPath: AbsolutePath?
 
+    /// The lto mode to use if any.
+    @Option(
+        name: .customLong("experimental-lto-mode"),
+        help: .hidden
+    )
+    public var linkTimeOptimizationMode: LinkTimeOptimizationMode?
+
     // @Flag works best when there is a default value present
     // if true, false aren't enough and a third state is needed
     // nil should not be the goto. Instead create an enum
@@ -483,6 +490,14 @@ public struct BuildOptions: ParsableArguments {
         case none
         case warn
         case error
+    }
+
+    /// See `BuildParameters.LinkTimeOptimizationMode` for details.
+    public enum LinkTimeOptimizationMode: String, Codable, ExpressibleByArgument {
+        /// See `BuildParameters.LinkTimeOptimizationMode.full` for details.
+        case full
+        /// See `BuildParameters.LinkTimeOptimizationMode.thin` for details.
+        case thin
     }
 }
 

--- a/Sources/CoreCommands/SwiftTool.swift
+++ b/Sources/CoreCommands/SwiftTool.swift
@@ -703,7 +703,8 @@ public final class SwiftTool {
                 testEntryPointPath: options.build.testEntryPointPath,
                 explicitTargetDependencyImportCheckingMode: options.build.explicitTargetDependencyImportCheck.modeParameter,
                 linkerDeadStrip: options.linker.linkerDeadStrip,
-                verboseOutput: self.logLevel <= .info
+                verboseOutput: self.logLevel <= .info,
+                linkTimeOptimizationMode: options.build.linkTimeOptimizationMode?.buildParameter
             )
         })
     }()
@@ -962,6 +963,17 @@ extension BuildOptions.TargetDependencyImportCheckingMode {
             return .warn
         case .error:
             return .error
+        }
+    }
+}
+
+extension BuildOptions.LinkTimeOptimizationMode {
+    fileprivate var buildParameter: BuildParameters.LinkTimeOptimizationMode? {
+        switch self {
+        case .full:
+            return .full
+        case .thin:
+            return .thin
         }
     }
 }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -4690,4 +4690,62 @@ final class BuildPlanTests: XCTestCase {
 
         XCTAssertMatch(try result.buildProduct(for: "exe").linkArguments(), ["-sanitize=\(expectedName)"])
     }
+
+    func testBuildParameterLTOMode() throws {
+        let fileSystem = InMemoryFileSystem(emptyFiles:
+            "/Pkg/Sources/exe/main.swift",
+            "/Pkg/Sources/cLib/cLib.c",
+            "/Pkg/Sources/cLib/include/cLib.h"
+        )
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fileSystem: fileSystem,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "Pkg",
+                    path: "/Pkg",
+                    targets: [
+                        TargetDescription(name: "exe", dependencies: ["cLib"]),
+                        TargetDescription(name: "cLib", dependencies: []),
+                    ]),
+            ],
+            observabilityScope: observability.topScope
+        )
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
+        let toolchain = try UserToolchain.default
+        let buildParameters = mockBuildParameters(
+            toolchain: toolchain,
+            linkTimeOptimizationMode: .full)
+        let result = try BuildPlanResult(plan: BuildPlan(
+            buildParameters: buildParameters,
+            graph: graph,
+            fileSystem: fileSystem,
+            observabilityScope: observability.topScope))
+        result.checkProductsCount(1)
+        result.checkTargetsCount(2)
+
+        // Compile C Target
+        let cLibCompileArguments = try result.target(for: "cLib").clangTarget().basicArguments(isCXX: false)
+        let cLibCompileArgumentsPattern: [StringPattern] = ["-flto=full"]
+        XCTAssertMatch(cLibCompileArguments, cLibCompileArgumentsPattern)
+
+        // Compile Swift Target
+        let exeCompileArguments = try result.target(for: "exe").swiftTarget().compileArguments()
+        let exeCompileArgumentsPattern: [StringPattern] = ["-lto=llvm-full"]
+        XCTAssertMatch(exeCompileArguments, exeCompileArgumentsPattern)
+
+        // Assert the objects built by the Swift Target are actually bitcode
+        // files, indicated by the "bc" extension.
+        let exeCompileObjects = try result.target(for: "exe").swiftTarget().objects
+        XCTAssert(exeCompileObjects.allSatisfy { $0.extension == "bc"})
+
+        // Assert the objects getting linked contain all the bitcode objects
+        // built by the Swift Target
+        let exeProduct = try result.buildProduct(for: "exe")
+        for exeCompileObject in exeCompileObjects {
+            XCTAssertTrue(exeProduct.objects.contains(exeCompileObject))
+        }
+    }
 }

--- a/Tests/BuildTests/MockBuildTestHelper.swift
+++ b/Tests/BuildTests/MockBuildTestHelper.swift
@@ -72,7 +72,8 @@ func mockBuildParameters(
     destinationTriple: Basics.Triple = hostTriple,
     indexStoreMode: BuildParameters.IndexStoreMode = .off,
     useExplicitModuleBuild: Bool = false,
-    linkerDeadStrip: Bool = true
+    linkerDeadStrip: Bool = true,
+    linkTimeOptimizationMode: BuildParameters.LinkTimeOptimizationMode? = nil
 ) -> BuildParameters {
     return try! BuildParameters(
         dataPath: buildPath,
@@ -87,7 +88,8 @@ func mockBuildParameters(
         canRenameEntrypointFunctionName: canRenameEntrypointFunctionName,
         indexStoreMode: indexStoreMode,
         useExplicitModuleBuild: useExplicitModuleBuild,
-        linkerDeadStrip: linkerDeadStrip
+        linkerDeadStrip: linkerDeadStrip,
+        linkTimeOptimizationMode: linkTimeOptimizationMode
     )
 }
 


### PR DESCRIPTION
- Updates swift build with an `-experimental-lto-mode` option which can
  be set to either "full" or "thin" enabling the use of llvm LTO for
  both swift and c targets. Updates BuildParameters with a matching
  linkTimeOptimizationMode and updates SwiftTargetBuildDescription to
  use the proper file extension for bitcode objects as well as place
  them in the proper output location.