### PR TITLE
[5.9] SwiftTestTool: run `fflush` after `print`

### DIFF
--- a/Fixtures/Miscellaneous/HangingTest/.gitignore
+++ b/Fixtures/Miscellaneous/HangingTest/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Fixtures/Miscellaneous/HangingTest/Package.swift
+++ b/Fixtures/Miscellaneous/HangingTest/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "HangingTest",
+    products: [
+        .library(
+            name: "HangingTest",
+            targets: ["HangingTest"]),
+    ],
+    targets: [
+        .target(
+            name: "HangingTest"),
+        .testTarget(
+            name: "HangingTestTests",
+            dependencies: ["HangingTest"]),
+    ]
+)

--- a/Fixtures/Miscellaneous/HangingTest/Tests/HangingTestTests/HangingTestTests.swift
+++ b/Fixtures/Miscellaneous/HangingTest/Tests/HangingTestTests/HangingTestTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class aaaaTests: XCTestCase {
     func testExample() throws {
         while true {
-            Thread.sleep(for: 1)
+            Thread.sleep(forTimeInterval: 1)
         }
     }
 }

--- a/Fixtures/Miscellaneous/HangingTest/Tests/HangingTestTests/HangingTestTests.swift
+++ b/Fixtures/Miscellaneous/HangingTest/Tests/HangingTestTests/HangingTestTests.swift
@@ -1,15 +1,10 @@
-#if os(Windows)
-import CRT
-#elseif canImport(Darwin)
-import Darwin
-#elseif canImport(Glibc)
-import Glibc
-#endif
+import Foundation
+import XCTest
 
 final class aaaaTests: XCTestCase {
     func testExample() throws {
         while true {
-            sleep(1)
+            Thread.sleep(for: 1)
         }
     }
 }

--- a/Fixtures/Miscellaneous/HangingTest/Tests/HangingTestTests/HangingTestTests.swift
+++ b/Fixtures/Miscellaneous/HangingTest/Tests/HangingTestTests/HangingTestTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+import Darwin
+
+final class aaaaTests: XCTestCase {
+    func testExample() throws {
+        while true {
+            sleep(1)
+        }
+    }
+}

--- a/Fixtures/Miscellaneous/HangingTest/Tests/HangingTestTests/HangingTestTests.swift
+++ b/Fixtures/Miscellaneous/HangingTest/Tests/HangingTestTests/HangingTestTests.swift
@@ -1,5 +1,10 @@
-import XCTest
+#if os(Windows)
+import CRT
+#elseif canImport(Darwin)
 import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
 
 final class aaaaTests: XCTestCase {
     func testExample() throws {

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -27,6 +27,14 @@ import class TSCUtility.NinjaProgressAnimation
 import class TSCUtility.PercentProgressAnimation
 import protocol TSCUtility.ProgressAnimationProtocol
 
+#if canImport(Darwin)
+import func Darwin.fflush
+import let Darwin.stdout
+#elseif canImport(Glibc)
+import func Glibc.fflush
+import let Glibc.stdout
+#endif
+
 private enum TestError: Swift.Error {
     case invalidListTestJSONData
     case testsExecutableNotFound

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -30,7 +30,7 @@ import protocol TSCUtility.ProgressAnimationProtocol
 #if os(Windows)
 import func CRT.fflush
 import let CRT.stdout
-#if canImport(Darwin)
+#elseif canImport(Darwin)
 import func Darwin.fflush
 import let Darwin.stdout
 #elseif canImport(Glibc)

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -27,6 +27,9 @@ import class TSCUtility.NinjaProgressAnimation
 import class TSCUtility.PercentProgressAnimation
 import protocol TSCUtility.ProgressAnimationProtocol
 
+#if os(Windows)
+import func CRT.fflush
+import let CRT.stdout
 #if canImport(Darwin)
 import func Darwin.fflush
 import let Darwin.stdout

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -252,6 +252,7 @@ public struct SwiftTestTool: SwiftCommand {
                 // command's result output goes on stdout
                 // ie "swift test" should output to stdout
                 print($0)
+                fflush(stdout)
             })
             if !ranSuccessfully {
                 swiftTool.executionStatus = .failure

--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -319,9 +319,9 @@ final class TestToolTests: CommandsTestCase {
     func testOutputLineBuffering() async throws {
         try fixture(name: "Miscellaneous/HangingTest") { fixturePath in
             // Pre-build tests so that `swift test` command takes as little time as possible to start the hanging test.
-            _ = try SwiftPM.Build.execute(["--build-tests"], packagePath: fixturePath)
+            _ = try SwiftPMProduct.SwiftBuild.execute(["--build-tests"], packagePath: fixturePath)
 
-            let completeArgs = [SwiftPM.Test.path.pathString, "--package-path", fixturePath.pathString]
+            let completeArgs = [SwiftPMProduct.SwiftTest.path.pathString, "--package-path", fixturePath.pathString]
 
             var output = [UInt8]()
             let outputRedirection = TSCBasic.Process.OutputRedirection.stream(

--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -340,7 +340,7 @@ final class TestToolTests: CommandsTestCase {
             try process.launch()
 
             // This time interval should be enough for the test to start and get its output into the pipe.
-            Thread.sleep(forTimeInterval: 2)
+            Thread.sleep(forTimeInterval: 5)
 
             process.signal(9)
 

--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -340,7 +340,7 @@ final class TestToolTests: CommandsTestCase {
             try process.launch()
 
             // This time interval should be enough for the test to start and get its output into the pipe.
-            Thread.sleep(forTimeInterval: 5)
+            Thread.sleep(forTimeInterval: 10)
 
             process.signal(9)
 

--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -16,6 +16,8 @@ import SPMTestSupport
 import TSCBasic
 import XCTest
 
+import class TSCBasic.Process
+
 final class TestToolTests: CommandsTestCase {
     
     private func execute(_ args: [String], packagePath: AbsolutePath? = nil) throws -> (stdout: String, stderr: String) {
@@ -311,6 +313,38 @@ final class TestToolTests: CommandsTestCase {
                 XCTAssertMatch(stdout, .contains("SimpleTests.SimpleTests/test_Example2"))
                 XCTAssertMatch(stdout, .contains("SimpleTests.SimpleTests/testThrowing"))
             }
+        }
+    }
+
+    func testOutputLineBuffering() async throws {
+        try fixture(name: "Miscellaneous/HangingTest") { fixturePath in
+            _ = try SwiftPM.Build.execute(["--build-tests"], packagePath: fixturePath)
+
+            let completeArgs = [SwiftPM.Test.path.pathString, "--package-path", fixturePath.pathString]
+
+            var output = [UInt8]()
+            let outputRedirection = TSCBasic.Process.OutputRedirection.stream(
+                stdout: {
+                    output.append(contentsOf: $0)
+                },
+                stderr: {
+                    output.append(contentsOf: $0)
+                }
+            )
+
+            let process = TSCBasic.Process(
+                arguments: completeArgs,
+                outputRedirection: outputRedirection
+            )
+            try process.launch()
+
+            // This time interval should be enough for the test to start and get its output into the pipe.
+            Thread.sleep(forTimeInterval: 2)
+
+            process.signal(9)
+
+            let outputString = String(bytes: output, encoding: .utf8)
+            XCTAssertMatch(outputString, .and(.contains("Test Suite"), .contains(" started at ")))
         }
     }
 }

--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -318,6 +318,7 @@ final class TestToolTests: CommandsTestCase {
 
     func testOutputLineBuffering() async throws {
         try fixture(name: "Miscellaneous/HangingTest") { fixturePath in
+            // Pre-build tests so that `swift test` command takes as little time as possible to start the hanging test.
             _ = try SwiftPM.Build.execute(["--build-tests"], packagePath: fixturePath)
 
             let completeArgs = [SwiftPM.Test.path.pathString, "--package-path", fixturePath.pathString]


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-package-manager/pull/6612.

This makes sure that the output of `swift test` is line-buffered, which is crucial when a test crashes or hangs. `swift test` should be able to output information about tests it's currently running with its output piped (e.g. on CI) through line-size buffers.

Resolves https://github.com/apple/swift-package-manager/issues/6592.
