### PR TITLE
`withLock` should be marked as having a discardable result

### DIFF
--- a/Sources/Basics/Concurrency/NSLock+Extensions.swift
+++ b/Sources/Basics/Concurrency/NSLock+Extensions.swift
@@ -14,7 +14,7 @@ import class Foundation.NSLock
 
 extension NSLock {
     /// Execute the given block while holding the lock.
-    public func withLock<T>(_ body: () throws -> T) rethrows -> T {
+    @discardableResult public func withLock<T>(_ body: () throws -> T) rethrows -> T {
         lock()
         defer { unlock() }
         return try body()


### PR DESCRIPTION
I noticed this through warnings, but I think this also generally makes sense since there isn't a requirement to consume the result here.
