### PR TITLE
Fix interpreter flags for manifests using pre-release tools-version

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1951,7 +1951,7 @@ extension Workspace {
             let manifestPath = try ManifestLoader.findManifest(packagePath: packagePath, fileSystem: self.fileSystem, currentToolsVersion: self.currentToolsVersion)
             let manifestToolsVersion = try ToolsVersionParser.parse(manifestPath: manifestPath, fileSystem: self.fileSystem)
 
-            guard self.currentToolsVersion >= manifestToolsVersion, manifestToolsVersion >= ToolsVersion.minimumRequired else {
+            guard self.currentToolsVersion >= manifestToolsVersion || SwiftVersion.current.isDevelopment, manifestToolsVersion >= ToolsVersion.minimumRequired else {
                 throw StringError("invalid tools version")
             }
             return manifestLoader.interpreterFlags(for: manifestToolsVersion)

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -203,6 +203,20 @@ final class WorkspaceTests: XCTestCase {
 
                 XCTAssertEqual(ws.interpreterFlags(for: foo), [])
             }
+
+            do {
+                let ws = try createWorkspace(
+                    """
+                    // swift-tools-version:999.0
+                    import PackageDescription
+                    let package = Package(
+                        name: "foo"
+                    )
+                    """
+                )
+
+                XCTAssertMatch(ws.interpreterFlags(for: foo), [.equal("-swift-version"), .equal("5")])
+            }
         }
     }
 


### PR DESCRIPTION
`self.currentToolsVersion >= manifestToolsVersion` will always be true when using the 999.0 tools-version, so also accept a higher tools-version if we're in development mode.