### PR TITLE
[docs] Requiring System Libraries with .systemLibrary targets

### DIFF
--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -140,16 +140,16 @@ print(options)
 ```
 
 To `import Clibgit`, the package manager requires that the libgit2 library has
-been installed by a system packager (eg. `apt`, `brew`, `yum`, etc.). The
+been installed by a system packager (eg. `apt`, `brew`, `yum`, `nuget`, etc.). The
 following files from the libgit2 system-package are of interest:
 
     /usr/local/lib/libgit2.dylib      # .so on Linux
     /usr/local/include/git2.h
 
-**Note:** the system library may be located elsewhere on your system, such as
-`/usr/`, or `/opt/homebrew/` if you're using Homebrew on an Apple Silicon Mac.
-If you're not sure where `Clibgit` is in your system, you can run this command
-to look it up:
+**Note:** the system library may be located elsewhere on your system, such as:
+- `/usr/`, or `/opt/homebrew/` if you're using Homebrew on an Apple Silicon Mac.
+- `C:\vcpkg\installed\x64-windows\include` on Windows, if you're using `vcpkg`.
+On most Unix-like systems, you can use `pkg-config` to lookup where a library is installed:
 
     example$ pkg-config --cflags libgit2
     -I/usr/local/libgit2/1.6.4/include
@@ -199,7 +199,7 @@ add a `module.modulemap` and the header file to it:
 The header file should look like this:
 
 ```c
-# git2.h
+// git2.h
 #pragma once
 #include <git2.h>
 ```

--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -120,8 +120,8 @@ You can link against system libraries using the package manager. To do so, you'l
 need to add a special `target` of type `.systemLibrary`, and a `module.modulemap`
 for each system library you're using.
 
-Let's see an example of using [libgit2](https://libgit2.github.com) from an
-executable.
+Let's see an example of adding [libgit2](https://libgit2.github.com) as a
+dependency to an executable target.
 
 Create a directory called `example`, and initialize it as a package that
 builds an executable:
@@ -147,7 +147,7 @@ following files from the libgit2 system-package are of interest:
     /usr/local/include/git2.h
 
 **Note:** the system library may be located elsewhere on your system, such as
-`/usr/`, or `/opt/homebrew/` if you're using Homebrew on an Apple silicon Mac.
+`/usr/`, or `/opt/homebrew/` if you're using Homebrew on an Apple Silicon Mac.
 If you're not sure where `Clibgit` is in your system, you can run this command
 to look it up:
 
@@ -187,7 +187,7 @@ when building your app instead:
 
     example$ swift build -Xlinker -L/usr/local/lib/
 
-Next, we'll create a directory `Sources/Clibgit` in your `example` projcet, and
+Next, create a directory `Sources/Clibgit` in your `example` project, and
 add a `module.modulemap` to it:
 
     module Clibgit [system] {
@@ -256,7 +256,7 @@ executable:
     git_repository_init_options(version: 0, flags: 0, mode: 0, workdir_path: nil, description: nil, template_path: nil, initial_head: nil, origin_url: nil)
     example$
 
-### Requiring a System Library Without pkg-config
+### Requiring a System Library Without `pkg-config`
 
 Let’s see another example of using [IJG’s JPEG library](http://www.ijg.org)
 from an executable, which has some caveats.
@@ -277,7 +277,7 @@ let jpegData = jpeg_common_struct()
 print(jpegData)
 ```
 
-Install JPEG library using a system packager, e.g, `$ brew install jpeg`.
+Install JPEG library, on macOS you can use Homebrew package manager: `brew install jpeg`.
 `jpeg` is a keg-only formula, meaning it won't be linked to `/usr/local/lib`,
 and you'll have to link it manually at build time.
 

--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -226,7 +226,7 @@ let package = Package(
         .executableTarget(
             name: "example",
 
-            // example executable requires "Clibgit" target as it's dependency.
+            // example executable requires "Clibgit" target as its dependency.
             // It's a systemLibrary target defined below.
             dependencies: ["Clibgit"],
             path: "Sources"
@@ -277,7 +277,7 @@ let jpegData = jpeg_common_struct()
 print(jpegData)
 ```
 
-Install JPEG library, on macOS you can use Homebrew package manager: `brew install jpeg`.
+Install the JPEG library, on macOS you can use Homebrew package manager: `brew install jpeg`.
 `jpeg` is a keg-only formula, meaning it won't be linked to `/usr/local/lib`,
 and you'll have to link it manually at build time.
 

--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -188,16 +188,25 @@ when building your app instead:
     example$ swift build -Xlinker -L/usr/local/lib/
 
 Next, create a directory `Sources/Clibgit` in your `example` project, and
-add a `module.modulemap` to it:
+add a `module.modulemap` and the header file to it:
 
     module Clibgit [system] {
-      header "/usr/local/include/git2.h"
+      header "git2.h"
       link "git2"
       export *
     }
 
-**Note:** The include path in the module map must be an absolute path, more on
-that below.
+The header file should look like this:
+
+```c
+# git2.h
+#pragma once
+#include <git2.h>
+```
+
+**Note:** Alternatively, you can provide an absolute path to `git2.h` provided
+by the library in the `modile.modulemap`. However, doing so might break
+cross-platform compatibility of your project.
 
 > The convention we hope the community will adopt is to prefix such modules
 > with `C` and to camelcase the modules as per Swift module name conventions.
@@ -210,6 +219,7 @@ The `example` directory structure should look like this now:
     ├── Package.swift
     └── Sources
         ├── Clibgit
+        │   ├── git2.h
         │   └── module.modulemap
         └── main.swift
 

--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -281,7 +281,7 @@ Install the JPEG library, on macOS you can use Homebrew package manager: `brew i
 `jpeg` is a keg-only formula, meaning it won't be linked to `/usr/local/lib`,
 and you'll have to link it manually at build time.
 
-Just like in the previous example, `mkdir Sources/CJPEG`, and add the
+Just like in the previous example, run `mkdir Sources/CJPEG` and add the
 following `module.modulemap`:
 
     module CJPEG [system] {

--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -181,9 +181,11 @@ let package = Package(
 
 ```
 
-**Note:** If you don't want to use the `pkgConfig` parameter you can pass the
-path of a directory containing the library using the `-L` flag in command line
-when building your app instead:
+**Note:** For Windows-only packages `pkgConfig` should be omitted as
+`pkg-config` is not expected to be available. If you don't want to use the
+`pkgConfig` parameter you can pass the path of a directory containing the
+library using the `-L` flag in the command line when building your package
+instead.
 
     example$ swift build -Xlinker -L/usr/local/lib/
 


### PR DESCRIPTION
Updates the [usage documentation](Documentation/Usage.md) around requiring system libraries.

### Motivation:

I was getting started with Swift package manager, and looking to get a bit more experience using it — and stumbled on #6121, thought I'd play around and try to clean it up. Fixes #6121.

The existing documentation on `main` worked, but following it emitted a build-time warning about wrapping system libraries in a target, instead of it's own package.

## Modifications

I've tried to make things work without warnings, tested the `.systemLibrary` approach, and documented my steps.

- [x] `clibgit` example
- [x] `cjpeg` example

### Result:

No functional changes to the package manager behavior — just the documentation change. After the change, one should be able to follow the docs step by step, and it should work without any build warnings.
