### PR TITLE
Add PackageDescription platform constants for the 2023 Apple OS versions

### DIFF
--- a/Sources/PackageDescription/SupportedPlatforms.swift
+++ b/Sources/PackageDescription/SupportedPlatforms.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2018-2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2018-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -336,6 +336,12 @@ extension SupportedPlatform {
         /// - Since: First available in PackageDescription 5.7.
         @available(_PackageDescription, introduced: 5.7)
         public static let v13: MacOSVersion = .init(string: "13.0")
+
+        /// The value that represents macOS 14.0.
+        ///
+        /// - Since: First available in PackageDescription 5.9.
+        @available(_PackageDescription, introduced: 5.9)
+        public static let v14: MacOSVersion = .init(string: "14.0")
     }
 
     /// The supported tvOS version.
@@ -397,6 +403,12 @@ extension SupportedPlatform {
         /// - Since: First available in PackageDescription 5.7.
         @available(_PackageDescription, introduced: 5.7)
         public static let v16: TVOSVersion = .init(string: "16.0")
+
+        /// The value that represents tvOS 17.0.
+        ///
+        /// - Since: First available in PackageDescription 5.9.
+        @available(_PackageDescription, introduced: 5.9)
+        public static let v17: TVOSVersion = .init(string: "17.0")
     }
 
     /// The supported Mac Catalyst version.
@@ -434,6 +446,12 @@ extension SupportedPlatform {
         /// - Since: First available in PackageDescription 5.7.
         @available(_PackageDescription, introduced: 5.7)
         public static let v16: MacCatalystVersion = .init(string: "16.0")
+
+        /// The value that represents Mac Catalyst 17.0.
+        ///
+        /// - Since: First available in PackageDescription 5.9.
+        @available(_PackageDescription, introduced: 5.9)
+        public static let v17: MacCatalystVersion = .init(string: "17.0")
     }
 
     /// The supported iOS version.
@@ -501,6 +519,12 @@ extension SupportedPlatform {
         /// - Since: First available in PackageDescription 5.7.
         @available(_PackageDescription, introduced: 5.7)
         public static let v16: IOSVersion = .init(string: "16.0")
+
+        /// The value that represents iOS 17.0.
+        ///
+        /// - Since: First available in PackageDescription 5.9.
+        @available(_PackageDescription, introduced: 5.9)
+        public static let v17: IOSVersion = .init(string: "17.0")
     }
 
     /// The supported watchOS version.
@@ -562,6 +586,12 @@ extension SupportedPlatform {
         /// - Since: First available in PackageDescription 5.7.
         @available(_PackageDescription, introduced: 5.7)
         public static let v9: WatchOSVersion = .init(string: "9.0")
+
+        /// The value that represents watchOS 10.0.
+        ///
+        /// - Since: First available in PackageDescription 5.9.
+        @available(_PackageDescription, introduced: 5.9)
+        public static let v10: WatchOSVersion = .init(string: "10.0")
     }
 
     /// The supported DriverKit version.
@@ -599,6 +629,12 @@ extension SupportedPlatform {
         /// - Since: First available in PackageDescription 5.7.
         @available(_PackageDescription, introduced: 5.7)
         public static let v22: DriverKitVersion = .init(string: "22.0")
+
+        /// The value that represents DriverKit 23.0.
+        ///
+        /// - Since: First available in PackageDescription 5.9.
+        @available(_PackageDescription, introduced: 5.9)
+        public static let v23: DriverKitVersion = .init(string: "23.0")
     }
 
     /// A supported custom platform version.

--- a/Tests/PackageLoadingTests/PD_5_9_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_9_LoadingTests.swift
@@ -21,6 +21,34 @@ class PackageDescription5_9LoadingTests: PackageDescriptionLoadingTests {
         .v5_9
     }
 
+    func testPlatforms() throws {
+        let content =  """
+            import PackageDescription
+            let package = Package(
+               name: "Foo",
+               platforms: [
+                   .macOS(.v14), .iOS(.v17),
+                   .tvOS(.v17), .watchOS(.v10),
+                   .macCatalyst(.v17), .driverKit(.v23),
+               ]
+            )
+            """
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
+        XCTAssertNoDiagnostics(observability.diagnostics)
+        XCTAssertNoDiagnostics(validationDiagnostics)
+
+        XCTAssertEqual(manifest.platforms, [
+            PlatformDescription(name: "macos", version: "14.0"),
+            PlatformDescription(name: "ios", version: "17.0"),
+            PlatformDescription(name: "tvos", version: "17.0"),
+            PlatformDescription(name: "watchos", version: "10.0"),
+            PlatformDescription(name: "maccatalyst", version: "17.0"),
+            PlatformDescription(name: "driverkit", version: "23.0"),
+        ])
+    }
+
     func testMacroTargets() throws {
         let content = """
             import CompilerPluginSupport

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -432,12 +432,12 @@ class ManifestSourceGenerationTests: XCTestCase {
             let package = Package(
                 name: "MyPackage",
                 platforms: [
-                    .macOS(.v13),
-                    .iOS(.v16),
-                    .tvOS(.v16),
-                    .watchOS(.v9),
-                    .macCatalyst(.v16),
-                    .driverKit(.v22)
+                    .macOS(.v14),
+                    .iOS(.v17),
+                    .tvOS(.v17),
+                    .watchOS(.v10),
+                    .macCatalyst(.v17),
+                    .driverKit(.v23)
                 ],
                 targets: [
                 ]


### PR DESCRIPTION
Add PackageDescription platform constants for the 2023 Apple OS versions.

### Motivation

This is an update that happens every year at Apple's annual WWDC conference, where the Apple platforms usually have their versions incremented.  This allows packages that specify the latest tools version (in this case 5.9) to declare that they require the latest platform versions, which may be appropriate in some cases.  Note that most packages should continue supporting the oldest platform tools version that they can (based on the APIs they use), so that they will be usable to the maximum number of client packages and projects.

### Modifications

- added new platform version number constants for macOS 14, iOS 17, tvOS 17, watchOS 10, macCatalyst 17, and DriverKit 23 (which has its own version number, though it isn't a separate platform)
  - these are available when the package manifest specifies tools version 5.9
- include a unit test that checks the 5.9 tools version spelling of these new platform versions
- update a test that checks the 5.9 tools version package manifest generation

### Result

Packages that specify tools version 5.9 can use these new platform constants.  Older packages can continue to spell these new version numbers using the free-form variant of each platform enum that takes a string.

### Remarks

Note that the just-announced visionOS is purposefully excluded from this PR, as it has not yet been released and as no version number has been announced.

rdar://107794704