### PR TITLE
[5.9] Add PackageDescription platform constants for the 2023 Apple OS versions

### DIFF
--- a/Sources/PackageDescription/SupportedPlatforms.swift
+++ b/Sources/PackageDescription/SupportedPlatforms.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2018-2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2018-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -336,6 +336,12 @@ extension SupportedPlatform {
         /// - Since: First available in PackageDescription 5.7.
         @available(_PackageDescription, introduced: 5.7)
         public static let v13: MacOSVersion = .init(string: "13.0")
+
+        /// The value that represents macOS 14.0.
+        ///
+        /// - Since: First available in PackageDescription 5.9.
+        @available(_PackageDescription, introduced: 5.9)
+        public static let v14: MacOSVersion = .init(string: "14.0")
     }
 
     /// The supported tvOS version.
@@ -397,6 +403,12 @@ extension SupportedPlatform {
         /// - Since: First available in PackageDescription 5.7.
         @available(_PackageDescription, introduced: 5.7)
         public static let v16: TVOSVersion = .init(string: "16.0")
+
+        /// The value that represents tvOS 17.0.
+        ///
+        /// - Since: First available in PackageDescription 5.9.
+        @available(_PackageDescription, introduced: 5.9)
+        public static let v17: TVOSVersion = .init(string: "17.0")
     }
 
     /// The supported Mac Catalyst version.
@@ -434,6 +446,12 @@ extension SupportedPlatform {
         /// - Since: First available in PackageDescription 5.7.
         @available(_PackageDescription, introduced: 5.7)
         public static let v16: MacCatalystVersion = .init(string: "16.0")
+
+        /// The value that represents Mac Catalyst 17.0.
+        ///
+        /// - Since: First available in PackageDescription 5.9.
+        @available(_PackageDescription, introduced: 5.9)
+        public static let v17: MacCatalystVersion = .init(string: "17.0")
     }
 
     /// The supported iOS version.
@@ -501,6 +519,12 @@ extension SupportedPlatform {
         /// - Since: First available in PackageDescription 5.7.
         @available(_PackageDescription, introduced: 5.7)
         public static let v16: IOSVersion = .init(string: "16.0")
+
+        /// The value that represents iOS 17.0.
+        ///
+        /// - Since: First available in PackageDescription 5.9.
+        @available(_PackageDescription, introduced: 5.9)
+        public static let v17: IOSVersion = .init(string: "17.0")
     }
 
     /// The supported watchOS version.
@@ -562,6 +586,12 @@ extension SupportedPlatform {
         /// - Since: First available in PackageDescription 5.7.
         @available(_PackageDescription, introduced: 5.7)
         public static let v9: WatchOSVersion = .init(string: "9.0")
+
+        /// The value that represents watchOS 10.0.
+        ///
+        /// - Since: First available in PackageDescription 5.9.
+        @available(_PackageDescription, introduced: 5.9)
+        public static let v10: WatchOSVersion = .init(string: "10.0")
     }
 
     /// The supported DriverKit version.
@@ -599,6 +629,12 @@ extension SupportedPlatform {
         /// - Since: First available in PackageDescription 5.7.
         @available(_PackageDescription, introduced: 5.7)
         public static let v22: DriverKitVersion = .init(string: "22.0")
+
+        /// The value that represents DriverKit 23.0.
+        ///
+        /// - Since: First available in PackageDescription 5.9.
+        @available(_PackageDescription, introduced: 5.9)
+        public static let v23: DriverKitVersion = .init(string: "23.0")
     }
 
     /// A supported custom platform version.

--- a/Tests/PackageLoadingTests/PD_5_9_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_9_LoadingTests.swift
@@ -21,6 +21,34 @@ class PackageDescription5_9LoadingTests: PackageDescriptionLoadingTests {
         .v5_9
     }
 
+    func testPlatforms() throws {
+        let content =  """
+            import PackageDescription
+            let package = Package(
+               name: "Foo",
+               platforms: [
+                   .macOS(.v14), .iOS(.v17),
+                   .tvOS(.v17), .watchOS(.v10),
+                   .macCatalyst(.v17), .driverKit(.v23),
+               ]
+            )
+            """
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let (manifest, validationDiagnostics) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
+        XCTAssertNoDiagnostics(observability.diagnostics)
+        XCTAssertNoDiagnostics(validationDiagnostics)
+
+        XCTAssertEqual(manifest.platforms, [
+            PlatformDescription(name: "macos", version: "14.0"),
+            PlatformDescription(name: "ios", version: "17.0"),
+            PlatformDescription(name: "tvos", version: "17.0"),
+            PlatformDescription(name: "watchos", version: "10.0"),
+            PlatformDescription(name: "maccatalyst", version: "17.0"),
+            PlatformDescription(name: "driverkit", version: "23.0"),
+        ])
+    }
+
     func testMacroTargets() throws {
         let content = """
             import CompilerPluginSupport

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -433,12 +433,12 @@ class ManifestSourceGenerationTests: XCTestCase {
             let package = Package(
                 name: "MyPackage",
                 platforms: [
-                    .macOS(.v13),
-                    .iOS(.v16),
-                    .tvOS(.v16),
-                    .watchOS(.v9),
-                    .macCatalyst(.v16),
-                    .driverKit(.v22)
+                    .macOS(.v14),
+                    .iOS(.v17),
+                    .tvOS(.v17),
+                    .watchOS(.v10),
+                    .macCatalyst(.v17),
+                    .driverKit(.v23)
                 ],
                 targets: [
                 ]


### PR DESCRIPTION
This is a 5.9 nomination of #6636.

* Add platform constants for each of the Apple platforms, to match those in the WWDC 2023 Xcode beta release.

* Add a package loading unit test for checking the platform versions allowed in tools version 5.9.

rdar://107794704

(cherry picked from commit 55006dce81ae70cd8f2b78479038423eeebde1e4)
