### PR TITLE
[NFC] SwiftPMProduct.swift: fix use of deprecated initializer

### DIFF
--- a/Sources/SPMTestSupport/SwiftPMProduct.swift
+++ b/Sources/SPMTestSupport/SwiftPMProduct.swift
@@ -55,7 +55,7 @@ extension SwiftPM {
         }
         fatalError()
         #else
-        return try! AbsolutePath(CommandLine.arguments.first!, relativeTo: localFileSystem.currentWorkingDirectory!)
+        return try! AbsolutePath(validating: CommandLine.arguments.first!, relativeTo: localFileSystem.currentWorkingDirectory!)
             .parentDirectory.appending(self.executableName)
         #endif
     }


### PR DESCRIPTION
Fixes a warning produced during compilation of this file:

```
swiftpm/Sources/SPMTestSupport/SwiftPMProduct.swift:58:16: warning: no calls to throwing functions occur within 'try' expression
        return try! AbsolutePath(CommandLine.arguments.first!, relativeTo: localFileSystem.currentWorkingDirectory!)
```
