### PR TITLE
Support String Catalogs in Packages when using XCBuild

### DIFF
--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -649,6 +649,15 @@ public struct FileRuleDescription {
         )
     }()
 
+    /// File types related to the string catalog.
+    public static let stringCatalog: FileRuleDescription = {
+        .init(
+            rule: .processResource(localization: .none),
+            toolsVersion: .v5_9,
+            fileTypes: ["xcstrings"]
+        )
+    }()
+
     /// File types related to the CoreData.
     public static let coredata: FileRuleDescription = {
         .init(
@@ -689,6 +698,7 @@ public struct FileRuleDescription {
     public static let xcbuildFileTypes: [FileRuleDescription] = [
         xib,
         assetCatalog,
+        stringCatalog,
         coredata,
         metal,
     ]

--- a/Sources/XCBuildSupport/PIF.swift
+++ b/Sources/XCBuildSupport/PIF.swift
@@ -1215,6 +1215,8 @@ extension PIF.FileReference {
 
         case "xcassets":
             return "folder.assetcatalog"
+        case "xcstrings":
+            return "text.json.xcstrings"
         case "storyboard":
             return "file.storyboard"
         case "xib":

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -2859,16 +2859,19 @@ class PackageBuilderTests: XCTestCase {
         }
     }
 
-    func testXcodeResources() throws {
+    func testXcodeResources5_4AndEarlier() throws {
+        // In SwiftTools 5.4 and earlier, supported xcbuild file types are supported by default.
+        // Of course, modern file types such as xcstrings won't be supported here because those require a newer Swift tools version in general.
+        
         let root: AbsolutePath = "/Foo"
-        let Foo = root.appending(components: "Sources", "Foo")
+        let foo = root.appending(components: "Sources", "Foo")
 
         let fs = InMemoryFileSystem(emptyFiles:
-            Foo.appending(components: "foo.swift").pathString,
-            Foo.appending(components: "Foo.xcassets").pathString,
-            Foo.appending(components: "Foo.xib").pathString,
-            Foo.appending(components: "Foo.xcdatamodel").pathString,
-            Foo.appending(components: "Foo.metal").pathString
+            foo.appending(components: "foo.swift").pathString,
+            foo.appending(components: "Foo.xcassets").pathString,
+            foo.appending(components: "Foo.xib").pathString,
+            foo.appending(components: "Foo.xcdatamodel").pathString,
+            foo.appending(components: "Foo.metal").pathString
         )
 
         let manifest = Manifest.createRootManifest(
@@ -2883,10 +2886,47 @@ class PackageBuilderTests: XCTestCase {
             result.checkModule("Foo") { result in
                 result.checkSources(sources: ["foo.swift"])
                 result.checkResources(resources: [
-                    Foo.appending(components: "Foo.xib").pathString,
-                    Foo.appending(components: "Foo.xcdatamodel").pathString,
-                    Foo.appending(components: "Foo.xcassets").pathString,
-                    Foo.appending(components: "Foo.metal").pathString
+                    foo.appending(components: "Foo.xib").pathString,
+                    foo.appending(components: "Foo.xcdatamodel").pathString,
+                    foo.appending(components: "Foo.xcassets").pathString,
+                    foo.appending(components: "Foo.metal").pathString
+                ])
+            }
+        }
+    }
+    
+    func testXcodeResources5_5AndLater() throws {
+        // In SwiftTools 5.5 and later, xcbuild file types are only supported when explicitly passed via additionalFileRules.
+        
+        let root: AbsolutePath = "/Foo"
+        let foo = root.appending(components: "Sources", "Foo")
+
+        let fs = InMemoryFileSystem(emptyFiles:
+            foo.appending(components: "foo.swift").pathString,
+            foo.appending(components: "Foo.xcassets").pathString,
+            foo.appending(components: "Foo.xcstrings").pathString,
+            foo.appending(components: "Foo.xib").pathString,
+            foo.appending(components: "Foo.xcdatamodel").pathString,
+            foo.appending(components: "Foo.metal").pathString
+        )
+
+        let manifest = Manifest.createRootManifest(
+            displayName: "Foo",
+            toolsVersion: .v5_9,
+            targets: [
+                try TargetDescription(name: "Foo"),
+            ]
+        )
+
+        PackageBuilderTester(manifest, path: root, supportXCBuildTypes: true, in: fs) { result, diagnostics in
+            result.checkModule("Foo") { result in
+                result.checkSources(sources: ["foo.swift"])
+                result.checkResources(resources: [
+                    foo.appending(components: "Foo.xib").pathString,
+                    foo.appending(components: "Foo.xcdatamodel").pathString,
+                    foo.appending(components: "Foo.xcassets").pathString,
+                    foo.appending(components: "Foo.xcstrings").pathString,
+                    foo.appending(components: "Foo.metal").pathString
                 ])
             }
         }
@@ -2958,6 +2998,7 @@ final class PackageBuilderTester {
         binaryArtifacts: [String: BinaryArtifact] = [:],
         shouldCreateMultipleTestProducts: Bool = false,
         createREPLProduct: Bool = false,
+        supportXCBuildTypes: Bool = false,
         in fs: FileSystem,
         file: StaticString = #file,
         line: UInt = #line,
@@ -2972,7 +3013,7 @@ final class PackageBuilderTester {
                 manifest: manifest,
                 productFilter: .everything,
                 path: path,
-                additionalFileRules: [],
+                additionalFileRules: supportXCBuildTypes ? FileRuleDescription.xcbuildFileTypes : FileRuleDescription.swiftpmFileTypes,
                 binaryArtifacts: binaryArtifacts,
                 shouldCreateMultipleTestProducts: shouldCreateMultipleTestProducts,
                 warnAboutImplicitExecutableTargets: true,


### PR DESCRIPTION
Support building String Catalogs when using XCBuild as the underlying build system (in Swift 5.9 tools).

### Motivation:

Xcode 15 introduced String Catalogs, which are also supported in Swift Packages when building with Xcode.

### Modifications:

Teach `FileRuleDescription` about the String Catalog file type, similar to other xcbuild-only file types such as Asset Catalogs.

### Result:

Packages using swift-tools-version 5.9 and later will be able to build String Catalogs without any manual processing rules in the Package manifest.
