### PR TITLE
Improve macros test template

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -641,14 +641,19 @@ public final class InitPackage {
                 import SwiftSyntaxMacros
                 import SwiftSyntaxMacrosTestSupport
                 import XCTest
+
+                // Macro implementations build for the host, so the corresponding module is not available when cross-compiling. Cross-compiled tests may still make use of the macro itself in end-to-end tests.
+                #if canImport(\##(moduleName)Macros)
                 import \##(moduleName)Macros
 
                 let testMacros: [String: Macro.Type] = [
                     "stringify": StringifyMacro.self,
                 ]
+                #endif
 
                 final class \##(moduleName)Tests: XCTestCase {
-                    func testMacro() {
+                    func testMacro() throws {
+                        #if canImport(\##(moduleName)Macros)
                         assertMacroExpansion(
                             """
                             #stringify(a + b)
@@ -658,9 +663,13 @@ public final class InitPackage {
                             """,
                             macros: testMacros
                         )
+                        #else
+                        throw XCTSkip("macros are only supported when running tests for the host platform")
+                        #endif
                     }
 
-                    func testMacroWithStringLiteral() {
+                    func testMacroWithStringLiteral() throws {
+                        #if canImport(\##(moduleName)Macros)
                         assertMacroExpansion(
                             #"""
                             #stringify("Hello, \(name)")
@@ -670,6 +679,9 @@ public final class InitPackage {
                             """#,
                             macros: testMacros
                         )
+                        #else
+                        throw XCTSkip("macros are only supported when running tests for the host platform")
+                        #endif
                     }
                 }
 


### PR DESCRIPTION
The testable module for a macro will only build for the host platform which currently causes somewhat confusing issues if e.g. one is running tests for iOS in Xcode. This change will allow us to skip the tests if they are being run in an unsupported configuration.

rdar://110541100
