### PR TITLE
Minimize dirtying of `swift build` relative to sourcekit-lsp invocations.

### DIFF
--- a/Sources/Basics/FileSystem/FileSystem+Extensions.swift
+++ b/Sources/Basics/FileSystem/FileSystem+Extensions.swift
@@ -198,6 +198,18 @@ extension FileSystem {
     public func withLock<T>(on path: AbsolutePath, type: FileLock.LockType, _ body: () throws -> T) throws -> T {
         try self.withLock(on: path.underlying, type: type, body)
     }
+
+    public func capitalizeDriveLetterIfOnWindows(_ path: String) -> String {
+        #if !os(Windows)
+        return path
+        #endif
+        guard path.count > 2,
+            path.prefix(2).last == ":",
+            let drive = path.first,
+            drive >= "a" && drive <= "z"
+        else { return path }
+        return drive.uppercased() + path.suffix(path.count - 1)
+    }
 }
 
 // MARK: - user level

--- a/Sources/Basics/FileSystem/FileSystem+Extensions.swift
+++ b/Sources/Basics/FileSystem/FileSystem+Extensions.swift
@@ -538,6 +538,11 @@ extension FileSystem {
         try writeIfChanged(path: path, bytes: .init(encodingAsUTF8: string))
     }
 
+    /// Write data to the path if the given contents are different.
+    public func writeIfChanged(path: AbsolutePath, data: Data) throws {
+        try writeIfChanged(path: path, bytes: .init(data))
+    }
+
     /// Write bytes to the path if the given contents are different.
     public func writeIfChanged(path: AbsolutePath, bytes: ByteString) throws {
         try createDirectory(path.parentDirectory, recursive: true)

--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -348,7 +348,7 @@ public final class SwiftTargetBuildDescription {
             extension Foundation.Bundle {
                 static let module: Bundle = {
                     let mainPath = \(mainPathSubstitution)
-                    let buildPath = "\(bundlePath.pathString.asSwiftStringLiteralConstant)"
+                    let buildPath = "\(self.fileSystem.capitalizeDriveLetterIfOnWindows(bundlePath.pathString.asSwiftStringLiteralConstant))"
 
                     let preferredBundle = Bundle(path: mainPath)
 

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -517,7 +517,7 @@ final class WriteAuxiliaryFileCommand: CustomLLBuildCommand {
         }
 
         do {
-            try self.context.fileSystem.writeFileContents(outputFilePath, string: getFileContents(tool: tool))
+            try self.context.fileSystem.writeIfChanged(path: outputFilePath, string: try getFileContents(tool: tool))
             return true
         } catch {
             self.context.observabilityScope.emit(error: "failed to write auxiliary file '\(outputFilePath.pathString)': \(error.interpolationDescription)")

--- a/Sources/Workspace/Workspace+State.swift
+++ b/Sources/Workspace/Workspace+State.swift
@@ -135,7 +135,7 @@ fileprivate struct WorkspaceStateStorage {
             let storage = V6(dependencies: dependencies, artifacts: artifacts)
 
             let data = try self.encoder.encode(storage)
-            try self.fileSystem.writeIfChanged(path: self.path, bytes: .init(data))
+            try self.fileSystem.writeIfChanged(path: self.path, data: data)
         }
     }
 

--- a/Sources/Workspace/Workspace+State.swift
+++ b/Sources/Workspace/Workspace+State.swift
@@ -135,7 +135,7 @@ fileprivate struct WorkspaceStateStorage {
             let storage = V6(dependencies: dependencies, artifacts: artifacts)
 
             let data = try self.encoder.encode(storage)
-            try self.fileSystem.writeFileContents(self.path, data: data)
+            try self.fileSystem.writeIfChanged(path: self.path, bytes: .init(data))
         }
     }
 
@@ -254,7 +254,7 @@ extension WorkspaceStateStorage {
                         let version = try container.decode(String.self, forKey: .version)
                         return try self.init(underlying: .registryDownload(version: TSCUtility.Version(versionString: version)))
                     case "edited":
-                        let path = try container.decode(AbsolutePath?.self, forKey: .path)
+                        let path = try container.decode(AbsolutePath.self, forKey: .path)
                         return try self.init(underlying: .edited(basedOn: basedOn.map { try .init($0) }, unmanagedPath: path))
                     case "custom":
                         let version = try container.decode(String.self, forKey: .version)
@@ -603,7 +603,7 @@ extension WorkspaceStateStorage {
                         let version = try container.decode(String.self, forKey: .version)
                         return try self.init(underlying: .registryDownload(version: TSCUtility.Version(versionString: version)))
                     case "edited":
-                        let path = try container.decode(AbsolutePath?.self, forKey: .path)
+                        let path = try container.decode(AbsolutePath.self, forKey: .path)
                         return try self.init(underlying: .edited(basedOn: basedOn.map { try .init($0) }, unmanagedPath: path))
                     case "custom":
                         let version = try container.decode(String.self, forKey: .version)
@@ -899,7 +899,7 @@ extension WorkspaceStateStorage {
                         let checkout = try container.decode(CheckoutInfo.self, forKey: .checkoutState)
                         return try self.init(underlying: .sourceControlCheckout(.init(checkout)))
                     case "edited":
-                        let path = try container.decode(AbsolutePath?.self, forKey: .path)
+                        let path = try container.decode(AbsolutePath.self, forKey: .path)
                         return try self.init(underlying: .edited(basedOn: basedOn.map { try .init($0) }, unmanagedPath: path))
                     default:
                         throw StringError("unknown dependency state \(kind)")

--- a/Sources/Workspace/Workspace+State.swift
+++ b/Sources/Workspace/Workspace+State.swift
@@ -254,7 +254,7 @@ extension WorkspaceStateStorage {
                         let version = try container.decode(String.self, forKey: .version)
                         return try self.init(underlying: .registryDownload(version: TSCUtility.Version(versionString: version)))
                     case "edited":
-                        let path = try container.decode(AbsolutePath.self, forKey: .path)
+                        let path = try container.decode(AbsolutePath?.self, forKey: .path)
                         return try self.init(underlying: .edited(basedOn: basedOn.map { try .init($0) }, unmanagedPath: path))
                     case "custom":
                         let version = try container.decode(String.self, forKey: .version)
@@ -603,7 +603,7 @@ extension WorkspaceStateStorage {
                         let version = try container.decode(String.self, forKey: .version)
                         return try self.init(underlying: .registryDownload(version: TSCUtility.Version(versionString: version)))
                     case "edited":
-                        let path = try container.decode(AbsolutePath.self, forKey: .path)
+                        let path = try container.decode(AbsolutePath?.self, forKey: .path)
                         return try self.init(underlying: .edited(basedOn: basedOn.map { try .init($0) }, unmanagedPath: path))
                     case "custom":
                         let version = try container.decode(String.self, forKey: .version)
@@ -899,7 +899,7 @@ extension WorkspaceStateStorage {
                         let checkout = try container.decode(CheckoutInfo.self, forKey: .checkoutState)
                         return try self.init(underlying: .sourceControlCheckout(.init(checkout)))
                     case "edited":
-                        let path = try container.decode(AbsolutePath.self, forKey: .path)
+                        let path = try container.decode(AbsolutePath?.self, forKey: .path)
                         return try self.init(underlying: .edited(basedOn: basedOn.map { try .init($0) }, unmanagedPath: path))
                     default:
                         throw StringError("unknown dependency state \(kind)")


### PR DESCRIPTION
### Motivation:

On Windows, building on the command line using `swift build` and also using VSCode causes `sourcekit-lsp` to modify the `.build` tree, making subsequent `swift build`s do nontrivial work instead of being null builds.
With this PR in SwiftPM that the sourcekit-lsp is built against, this extra work is no longer done 🎉 

### Modifications:

- replaced a couple of `writeFileContents` calls with `writeIfChanged` to avoid updating modification times, triggering unnecessary work in future builds.
- capitalize drive letters on Windows when writing `resource_bundle_accessor.swift` files since VSCode (and therefore vscode-swift) send lowercase drive letters to `sourcekit-lsp`, again dirtying the output tree unnecessarily. (vscode seems unlikely to change to use capital letters given e.g. https://github.com/microsoft/vscode/issues/42159#issuecomment-360791384)

### Result:
The latter build in the command-line below is near instant and does no work, as expected, instead of rebuilding a whole lot of stuff: `swift build && code . && sleep 30 && swift build`