### PR TITLE
[cxx-interop] pass the C++ language standard to Clang importer in Swi…

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -874,7 +874,7 @@ public final class PackageBuilder {
         }
 
         // Create the build setting assignment table for this target.
-        let buildSettings = try self.buildSettings(for: manifestTarget, targetRoot: potentialModule.path)
+        let buildSettings = try self.buildSettings(for: manifestTarget, targetRoot: potentialModule.path, cxxLanguageStandard: self.manifest.cxxLanguageStandard)
 
         // Compute the path to public headers directory.
         let publicHeaderComponent = manifestTarget.publicHeadersPath ?? ClangTarget.defaultPublicHeadersComponent
@@ -1014,7 +1014,7 @@ public final class PackageBuilder {
     }
 
     /// Creates build setting assignment table for the given target.
-    func buildSettings(for target: TargetDescription?, targetRoot: AbsolutePath) throws -> BuildSettings
+    func buildSettings(for target: TargetDescription?, targetRoot: AbsolutePath, cxxLanguageStandard: String? = nil) throws -> BuildSettings
         .AssignmentTable
     {
         var table = BuildSettings.AssignmentTable()
@@ -1086,7 +1086,7 @@ public final class PackageBuilder {
                 }
 
                 if lang == .Cxx {
-                    values = ["-cxx-interoperability-mode=default"]
+                    values = ["-cxx-interoperability-mode=default"] + (cxxLanguageStandard.flatMap { ["-Xcc", "-std=\($0)"] } ?? [])
                 } else {
                     values = []
                 }


### PR DESCRIPTION
…ft when C++ interoperability is enabled (#6649)

Fixes https://github.com/apple/swift-package-manager/issues/6565

(cherry picked from commit cefff2b292828883fe2df768e8edfc6c520199f8)

- Explanation:
When C++ interoperability is enabled, Swift can import Clang modules that have C++. C++ targets in SPM can use languages standards like C++20, which could be incompatible with the default C++ language standard used by Swift in the Clang importer. For that reason, if the C++ language standard is specified in the package manifest, SwiftPM should pass it when C++ interoperability is enabled to the Swift compiler.
- Scope: Computing build settings for an SPM target.
- Risk: Low. Only affects C++ interoperability enabled targets.
- Testing: SwiftPM unit tests.
- PR: https://github.com/apple/swift-package-manager/pull/6649