### PR TITLE
Workspace,Build: reduce `mtime` updates

### DIFF
--- a/Sources/Basics/FileSystem/FileSystem+Extensions.swift
+++ b/Sources/Basics/FileSystem/FileSystem+Extensions.swift
@@ -526,6 +526,10 @@ extension FileSystem {
         try writeIfChanged(path: path, bytes: .init(encodingAsUTF8: string))
     }
 
+    public func writeIfChanged(path: AbsolutePath, data: Data) throws {
+        try writeIfChanged(path: path, bytes: .init(data))
+    }
+
     /// Write bytes to the path if the given contents are different.
     public func writeIfChanged(path: AbsolutePath, bytes: ByteString) throws {
         try createDirectory(path.parentDirectory, recursive: true)

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -517,7 +517,7 @@ final class WriteAuxiliaryFileCommand: CustomLLBuildCommand {
         }
 
         do {
-            try self.context.fileSystem.writeFileContents(outputFilePath, string: getFileContents(tool: tool))
+            try self.context.fileSystem.writeIfChanged(path: outputFilePath, string: getFileContents(tool: tool))
             return true
         } catch {
             self.context.observabilityScope.emit(error: "failed to write auxiliary file '\(outputFilePath.pathString)': \(error.interpolationDescription)")

--- a/Sources/Workspace/Workspace+State.swift
+++ b/Sources/Workspace/Workspace+State.swift
@@ -135,7 +135,7 @@ fileprivate struct WorkspaceStateStorage {
             let storage = V6(dependencies: dependencies, artifacts: artifacts)
 
             let data = try self.encoder.encode(storage)
-            try self.fileSystem.writeFileContents(self.path, data: data)
+            try self.fileSystem.writeIfChanged(path: self.path, data: data)
         }
     }
 


### PR DESCRIPTION
When building a project inside of VSCode with the LSP enabled, rebuilding the project would trigger a change to the mtimes of the auxiliary files resulting in an unnecessary rebuilding of targets.  In conjunction with the changes to tools-support-core (apple/swift-tools-support-core#422), incremental builds do not trigger a cascade of rebuilds that are unnecessary.

Extracted from a patch by Ami Fischman!