### PR TITLE
[5.9] Add `visionOS` as a platform alongside `iOS`, `tvOS`, `watchOS`, and the others

### DIFF
--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -480,6 +480,8 @@ extension PackageModel.Platform {
             self = PackageModel.Platform.tvOS
         case let name where name.contains("watchos"):
             self = PackageModel.Platform.watchOS
+        case let name where name.contains("visionos"):
+            self = PackageModel.Platform.visionOS
         case let name where name.contains("driverkit"):
             self = PackageModel.Platform.driverKit
         case let name where name.contains("linux"):

--- a/Sources/PackageDescription/PackageDescription.docc/Curation/SupportedPlatforms.md
+++ b/Sources/PackageDescription/PackageDescription.docc/Curation/SupportedPlatforms.md
@@ -23,6 +23,13 @@
 - <doc:/documentation/PackageDescription/Platform/watchOS>
 - ``WatchOSVersion``
 
+### Supporting visionOS
+
+- ``visionOS(_:)-3ip0z``
+- ``visionOS(_:)-6ur2u``
+- <doc:/documentation/PackageDescription/Platform/visionOS>
+- ``VisionOSVersion``
+
 ### Supporting tvOS
 
 - ``tvOS(_:)-6931l``

--- a/Sources/PackageDescription/SupportedPlatforms.swift
+++ b/Sources/PackageDescription/SupportedPlatforms.swift
@@ -45,6 +45,9 @@ public struct Platform: Equatable {
     /// The watchOS platform.
     public static let watchOS: Platform = Platform(name: "watchos")
 
+    /// The visionOS platform.
+    public static let visionOS: Platform = Platform(name: "visionos")
+
     /// The DriverKit platform
     public static let driverKit: Platform = Platform(name: "driverkit")
 
@@ -222,6 +225,33 @@ public struct SupportedPlatform: Equatable {
     /// - Returns: A `SupportedPlatform` instance.
     public static func watchOS(_ versionString: String) -> SupportedPlatform {
         return SupportedPlatform(platform: .watchOS, version: SupportedPlatform.WatchOSVersion(string: versionString).version)
+    }
+
+    /// Configure the minimum deployment target version for the visionOS
+    /// platform.
+    ///
+    /// - Since: First available in PackageDescription 5.9
+    ///
+    /// - Parameter version: The minimum deployment target that the package supports.
+    /// - Returns: A `SupportedPlatform` instance.
+    @available(_PackageDescription, introduced: 5.9)
+    public static func visionOS(_ version: SupportedPlatform.VisionOSVersion) -> SupportedPlatform {
+        return SupportedPlatform(platform: .visionOS, version: version.version)
+    }
+
+    /// Configure the minimum deployment target version for the visionOS
+    /// platform using a custom version string.
+    ///
+    /// The version string must be a series of two or three dot-separated integers, such as `1.0` or `1.0.0`.
+    ///
+    /// - Since: First available in PackageDescription 5.9
+    ///
+    /// - Parameter versionString: The minimum deployment target as a string
+    ///     representation of two or three dot-separated integers, such as `1.0.0`.
+    /// - Returns: A `SupportedPlatform` instance.
+    @available(_PackageDescription, introduced: 5.9)
+    public static func visionOS(_ versionString: String) -> SupportedPlatform {
+        return SupportedPlatform(platform: .visionOS, version: SupportedPlatform.VisionOSVersion(string: versionString).version)
     }
 
     /// Configures the minimum deployment target version for the DriverKit platform.
@@ -592,6 +622,25 @@ extension SupportedPlatform {
         /// - Since: First available in PackageDescription 5.9.
         @available(_PackageDescription, introduced: 5.9)
         public static let v10: WatchOSVersion = .init(string: "10.0")
+    }
+
+    /// The supported visionOS version.
+    public struct VisionOSVersion: AppleOSVersion {
+        fileprivate static let name = "visionOS"
+        fileprivate static let minimumMajorVersion = 1
+
+        /// The underlying version representation.
+        let version: String
+
+        fileprivate init(uncheckedVersion version: String) {
+            self.version = version
+        }
+
+        /// The value that represents visionOS 1.0.
+        ///
+        /// - Since: First available in PackageDescription 5.9.
+        @available(_PackageDescription, introduced: 5.9)
+        public static let v1: VisionOSVersion = .init(string: "1.0")
     }
 
     /// The supported DriverKit version.

--- a/Sources/PackageModel/ManifestSourceGeneration.swift
+++ b/Sources/PackageModel/ManifestSourceGeneration.swift
@@ -142,6 +142,8 @@ fileprivate extension SourceCodeFragment {
             self.init(enum: "tvOS", string: platform.version)
         case "watchos":
             self.init(enum: "watchOS", string: platform.version)
+        case "visionos":
+            self.init(enum: "visionOS", string: platform.version)
         case "driverkit":
             self.init(enum: "driverKit", string: platform.version)
         default:
@@ -367,6 +369,7 @@ fileprivate extension SourceCodeFragment {
             case "ios": return SourceCodeFragment(enum: "iOS")
             case "tvos": return SourceCodeFragment(enum: "tvOS")
             case "watchos": return SourceCodeFragment(enum: "watchOS")
+            case "visionos": return SourceCodeFragment(enum: "visionOS")
             case "driverkit": return SourceCodeFragment(enum: "driverKit")
             default: return SourceCodeFragment(enum: platformName)
             }

--- a/Sources/PackageModel/MinimumDeploymentTarget.swift
+++ b/Sources/PackageModel/MinimumDeploymentTarget.swift
@@ -81,6 +81,8 @@ private extension PackageModel.Platform {
             return ("appletvos", "TVOS")
         case .watchOS:
             return ("watchos", "WATCHOS")
+        case .visionOS:
+            return ("xros", "XROS")
         case .driverKit:
             return nil // DriverKit does not support XCTest.
         default:

--- a/Sources/PackageModel/Platform.swift
+++ b/Sources/PackageModel/Platform.swift
@@ -38,6 +38,7 @@ public struct Platform: Equatable, Hashable, Codable {
     public static let iOS: Platform = Platform(name: "ios", oldestSupportedVersion: "11.0")
     public static let tvOS: Platform = Platform(name: "tvos", oldestSupportedVersion: "11.0")
     public static let watchOS: Platform = Platform(name: "watchos", oldestSupportedVersion: "4.0")
+    public static let visionOS: Platform = Platform(name: "visionos", oldestSupportedVersion: "1.0")
     public static let driverKit: Platform = Platform(name: "driverkit", oldestSupportedVersion: "19.0")
     public static let linux: Platform = Platform(name: "linux", oldestSupportedVersion: .unknown)
     public static let android: Platform = Platform(name: "android", oldestSupportedVersion: .unknown)

--- a/Sources/PackageModel/PlatformRegistry.swift
+++ b/Sources/PackageModel/PlatformRegistry.swift
@@ -31,6 +31,6 @@ public final class PlatformRegistry {
 
     /// The static list of known platforms.
     private static var _knownPlatforms: [Platform] {
-        return [.macOS, .macCatalyst, .iOS, .tvOS, .watchOS, .linux, .windows, .android, .wasi, .driverKit, .openbsd]
+        return [.macOS, .macCatalyst, .iOS, .tvOS, .watchOS, .visionOS, .linux, .windows, .android, .wasi, .driverKit, .openbsd]
     }
 }

--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -781,6 +781,8 @@ extension PackageModel.Platform {
             return "tvOS"
         case .watchOS:
             return "watchOS"
+        case .visionOS:
+            return "visionOS"
         case .driverKit:
             return "DriverKit"
         default:
@@ -816,6 +818,8 @@ extension SupportedPlatform {
             return (9...14).contains(version.major)
         case .watchOS:
             return (2...7).contains(version.major)
+        case .visionOS:
+            return (1...1).contains(version.major)
         case .driverKit:
             return (19...20).contains(version.major)
 

--- a/Sources/XCBuildSupport/PIF.swift
+++ b/Sources/XCBuildSupport/PIF.swift
@@ -953,6 +953,7 @@ public enum PIF {
             case USE_HEADERMAP
             case USES_SWIFTPM_UNSAFE_FLAGS
             case WATCHOS_DEPLOYMENT_TARGET
+            case XROS_DEPLOYMENT_TARGET
             case MARKETING_VERSION
             case CURRENT_PROJECT_VERSION
             case SWIFT_EMIT_MODULE_INTERFACE

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -273,6 +273,7 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         settings[.IPHONEOS_DEPLOYMENT_TARGET, for: .macCatalyst] = package.platforms.deploymentTarget(for: .macCatalyst)
         settings[.TVOS_DEPLOYMENT_TARGET] = package.platforms.deploymentTarget(for: .tvOS)
         settings[.WATCHOS_DEPLOYMENT_TARGET] = package.platforms.deploymentTarget(for: .watchOS)
+        settings[.XROS_DEPLOYMENT_TARGET] = package.platforms.deploymentTarget(for: .visionOS)
         settings[.DRIVERKIT_DEPLOYMENT_TARGET] = package.platforms.deploymentTarget(for: .driverKit)
         settings[.DYLIB_INSTALL_NAME_BASE] = "@rpath"
         settings[.USE_HEADERMAP] = "NO"
@@ -430,6 +431,7 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
             settings[.IPHONEOS_DEPLOYMENT_TARGET] = mainTarget.platforms.deploymentTarget(for: .iOS)
             settings[.TVOS_DEPLOYMENT_TARGET] = mainTarget.platforms.deploymentTarget(for: .tvOS)
             settings[.WATCHOS_DEPLOYMENT_TARGET] = mainTarget.platforms.deploymentTarget(for: .watchOS)
+            settings[.XROS_DEPLOYMENT_TARGET] = mainTarget.platforms.deploymentTarget(for: .visionOS)
         }
 
         if product.type == .executable {

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -2153,6 +2153,7 @@ class PackageGraphTests: XCTestCase {
             "tvos": "11.0",
             "driverkit": "19.0",
             "watchos": "4.0",
+            "visionos": "1.0",
             "android": "0.0",
             "windows": "0.0",
             "wasi": "0.0",
@@ -2164,6 +2165,7 @@ class PackageGraphTests: XCTestCase {
             PackageModel.Platform.iOS: PlatformVersion("11.0"),
             PackageModel.Platform.tvOS: PlatformVersion("10.0"),
             PackageModel.Platform.watchOS: PlatformVersion("4.0"),
+            PackageModel.Platform.visionOS: PlatformVersion("1.0"),
         ]
 
         let expectedPlatformsForTests = customXCTestMinimumDeploymentTargets.reduce(into: [Platform : PlatformVersion]()) { partialResult, entry in
@@ -2402,6 +2404,7 @@ class PackageGraphTests: XCTestCase {
             "tvos": "11.0",
             "driverkit": "19.0",
             "watchos": "4.0",
+            "visionos": "1.0",
             "android": "0.0",
             "windows": "0.0",
             "wasi": "0.0",

--- a/Tests/PackageLoadingTests/PD_5_9_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_9_LoadingTests.swift
@@ -28,7 +28,7 @@ class PackageDescription5_9LoadingTests: PackageDescriptionLoadingTests {
                name: "Foo",
                platforms: [
                    .macOS(.v14), .iOS(.v17),
-                   .tvOS(.v17), .watchOS(.v10),
+                   .tvOS(.v17), .watchOS(.v10), .visionOS(.v1),
                    .macCatalyst(.v17), .driverKit(.v23),
                ]
             )
@@ -44,6 +44,7 @@ class PackageDescription5_9LoadingTests: PackageDescriptionLoadingTests {
             PlatformDescription(name: "ios", version: "17.0"),
             PlatformDescription(name: "tvos", version: "17.0"),
             PlatformDescription(name: "watchos", version: "10.0"),
+            PlatformDescription(name: "visionos", version: "1.0"),
             PlatformDescription(name: "maccatalyst", version: "17.0"),
             PlatformDescription(name: "driverkit", version: "23.0"),
         ])

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -437,6 +437,7 @@ class ManifestSourceGenerationTests: XCTestCase {
                     .iOS(.v17),
                     .tvOS(.v17),
                     .watchOS(.v10),
+                    .visionOS(.v1),
                     .macCatalyst(.v17),
                     .driverKit(.v23)
                 ],
@@ -461,8 +462,8 @@ class ManifestSourceGenerationTests: XCTestCase {
                         name: "MyExe",
                         dependencies: [
                             .target(name: "MyLib", condition: .when(platforms: [
-                                .macOS, .macCatalyst, .iOS, .tvOS, .watchOS, .driverKit,
-                                .linux, .windows, .android, .wasi, .openbsd
+                                .macOS, .macCatalyst, .iOS, .tvOS, .watchOS, .visionOS,
+                                .driverKit, .linux, .windows, .android, .wasi, .openbsd
                             ]))
                         ]
                     ),

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -204,6 +204,7 @@ class PIFBuilderTests: XCTestCase {
                         XCTAssertEqual(settings[.TVOS_DEPLOYMENT_TARGET], "11.0")
                         XCTAssertEqual(settings[.USE_HEADERMAP], "NO")
                         XCTAssertEqual(settings[.WATCHOS_DEPLOYMENT_TARGET], "4.0")
+                        XCTAssertEqual(settings[.XROS_DEPLOYMENT_TARGET], "1.0")
 
                         let frameworksSearchPaths = ["$(inherited)", "$(PLATFORM_DIR)/Developer/Library/Frameworks"]
                         for platform in [PIF.BuildSettings.Platform.macOS, .iOS, .tvOS] {
@@ -249,6 +250,7 @@ class PIFBuilderTests: XCTestCase {
                         XCTAssertEqual(settings[.TVOS_DEPLOYMENT_TARGET], "11.0")
                         XCTAssertEqual(settings[.USE_HEADERMAP], "NO")
                         XCTAssertEqual(settings[.WATCHOS_DEPLOYMENT_TARGET], "4.0")
+                        XCTAssertEqual(settings[.XROS_DEPLOYMENT_TARGET], "1.0")
 
                         let frameworksSearchPaths = ["$(inherited)", "$(PLATFORM_DIR)/Developer/Library/Frameworks"]
                         for platform in [PIF.BuildSettings.Platform.macOS, .iOS, .tvOS] {
@@ -306,6 +308,7 @@ class PIFBuilderTests: XCTestCase {
                         XCTAssertEqual(settings[.TVOS_DEPLOYMENT_TARGET], "11.0")
                         XCTAssertEqual(settings[.USE_HEADERMAP], "NO")
                         XCTAssertEqual(settings[.WATCHOS_DEPLOYMENT_TARGET], "6.0")
+                        XCTAssertEqual(settings[.XROS_DEPLOYMENT_TARGET], "1.0")
 
                         let frameworksSearchPaths = ["$(inherited)", "$(PLATFORM_DIR)/Developer/Library/Frameworks"]
                         for platform in [PIF.BuildSettings.Platform.macOS, .iOS, .tvOS] {
@@ -351,6 +354,7 @@ class PIFBuilderTests: XCTestCase {
                         XCTAssertEqual(settings[.TVOS_DEPLOYMENT_TARGET], "11.0")
                         XCTAssertEqual(settings[.USE_HEADERMAP], "NO")
                         XCTAssertEqual(settings[.WATCHOS_DEPLOYMENT_TARGET], "6.0")
+                        XCTAssertEqual(settings[.XROS_DEPLOYMENT_TARGET], "1.0")
 
                         let frameworksSearchPaths = ["$(inherited)", "$(PLATFORM_DIR)/Developer/Library/Frameworks"]
                         for platform in [PIF.BuildSettings.Platform.macOS, .iOS, .tvOS] {
@@ -836,6 +840,7 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.IPHONEOS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .iOS).versionString)
                             XCTAssertEqual(settings[.TVOS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .tvOS).versionString)
                             XCTAssertEqual(settings[.MACOSX_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .macOS).versionString)
+                            XCTAssertEqual(settings[.XROS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .visionOS).versionString)
                         }
                     }
 
@@ -868,6 +873,7 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.IPHONEOS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .iOS).versionString)
                             XCTAssertEqual(settings[.TVOS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .tvOS).versionString)
                             XCTAssertEqual(settings[.MACOSX_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .macOS).versionString)
+                            XCTAssertEqual(settings[.XROS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .visionOS).versionString)
                         }
                     }
 
@@ -914,6 +920,7 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.IPHONEOS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .iOS).versionString)
                             XCTAssertEqual(settings[.TVOS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .tvOS).versionString)
                             XCTAssertEqual(settings[.MACOSX_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .macOS).versionString)
+                            XCTAssertEqual(settings[.XROS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .visionOS).versionString)
                         }
                     }
 
@@ -949,6 +956,7 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.IPHONEOS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .iOS).versionString)
                             XCTAssertEqual(settings[.TVOS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .tvOS).versionString)
                             XCTAssertEqual(settings[.MACOSX_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .macOS).versionString)
+                            XCTAssertEqual(settings[.XROS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .visionOS).versionString)
                         }
                     }
 


### PR DESCRIPTION
This is a 5.9 nomination of a cherry-pick of #6662.