### PR TITLE
Do not store Swift object files in subdirectories

### DIFF
--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -94,7 +94,7 @@ public final class SwiftTargetBuildDescription {
             let objectFileExtension = ltoEnabled ? "bc" : "o"
             return try relativeSources.map {
                 try AbsolutePath(
-                    validating: "\($0.pathString).\(objectFileExtension)",
+                    validating: "\($0.basename).\(objectFileExtension)",
                     relativeTo: self.tempsPath)
             }
         }


### PR DESCRIPTION
Looks like we have been using the full relative path from the target directory as basis for object file paths until now which seems odd and might also cause clashes with other files in the build directory. We should be using the basename here since duplicated basenames in the same Swift module are anyway prohibited.

resolves #6672
