### PR TITLE
Update Swift SDK nomenclature

### DIFF
--- a/Sources/CoreCommands/SwiftTool.swift
+++ b/Sources/CoreCommands/SwiftTool.swift
@@ -736,7 +736,7 @@ public final class SwiftTool {
                 {
                     destination = matchingDestination
                 } else {
-                    return .failure(DestinationError.noDestinationsDecoded(customDestination))
+                    return .failure(SwiftSDKError.noSwiftSDKDecoded(customDestination))
                 }
             } else if let triple = options.build.customCompileTriple,
                       let targetDestination = Destination.defaultDestination(for: triple, host: hostDestination)

--- a/Sources/PackageModel/Destination.swift
+++ b/Sources/PackageModel/Destination.swift
@@ -18,8 +18,8 @@ import enum TSCBasic.ProcessEnv
 
 import struct TSCUtility.Version
 
-/// Errors related to cross-compilation destinations.
-public enum DestinationError: Swift.Error {
+/// Errors related to Swift SDKs.
+public enum SwiftSDKError: Swift.Error {
     /// A passed argument is neither a valid file system path nor a URL.
     case invalidPathOrURL(String)
 
@@ -32,26 +32,26 @@ public enum DestinationError: Swift.Error {
     /// Name of the destination bundle is not valid.
     case invalidBundleName(String)
 
-    /// No valid destinations were decoded from a destination file.
-    case noDestinationsDecoded(AbsolutePath)
+    /// No valid Swift SDKs were decoded from a metadata file.
+    case noSwiftSDKDecoded(AbsolutePath)
 
     /// Path used for storing destination configuration data is not a directory.
     case pathIsNotDirectory(AbsolutePath)
 
-    /// A destination couldn't be serialized with the latest serialization schema, potentially because it
+    /// Swift SDK metadata couldn't be serialized with the latest serialization schema, potentially because it
     /// was deserialized from an earlier incompatible schema version or initialized manually with properties
     /// required for initialization missing.
-    case unserializableDestination
+    case unserializableMetadata
 
-    /// No configuration values are available for this destination and run-time triple.
-    case destinationNotFound(artifactID: String, builtTimeTriple: Triple, runTimeTriple: Triple)
+    /// No configuration values are available for this Swift SDK and target triple.
+    case swiftSDKNotFound(artifactID: String, hostTriple: Triple, targetTriple: Triple)
 
-    /// A destination bundle with this name is already installed, can't install a new bundle with the same name.
-    case destinationBundleAlreadyInstalled(bundleName: String)
+    /// A Swift SDK bundle with this name is already installed, can't install a new bundle with the same name.
+    case swiftSDKBundleAlreadyInstalled(bundleName: String)
 
-    /// A destination with this artifact ID is already installed. Can't install a new bundle with this artifact,
+    /// A Swift SDK with this artifact ID is already installed. Can't install a new bundle with this artifact,
     /// installed artifact IDs are expected to be unique.
-    case destinationArtifactAlreadyInstalled(installedBundleName: String, newBundleName: String, artifactID: String)
+    case swiftSDKArtifactAlreadyInstalled(installedBundleName: String, newBundleName: String, artifactID: String)
 
     #if os(macOS)
     /// Quarantine attribute should be removed by the `xattr` command from an installed bundle.
@@ -59,40 +59,40 @@ public enum DestinationError: Swift.Error {
     #endif
 }
 
-extension DestinationError: CustomStringConvertible {
+extension SwiftSDKError: CustomStringConvertible {
     public var description: String {
         switch self {
         case .invalidPathOrURL(let argument):
             return "`\(argument)` is neither a valid filesystem path nor a URL."
         case .invalidSchemaVersion:
-            return "unsupported destination file schema version"
+            return "unsupported Swift SDK file schema version"
         case .invalidInstallation(let problem):
             return problem
         case .invalidBundleName(let name):
             return """
             invalid bundle name `\(name)`, unpacked Swift SDK bundles are expected to have `.artifactbundle` extension
             """
-        case .noDestinationsDecoded(let path):
-            return "no valid Swift SDKs were decoded from a destination file at path `\(path)`"
+        case .noSwiftSDKDecoded(let path):
+            return "no valid Swift SDKs were decoded from a metadata file at path `\(path)`"
         case .pathIsNotDirectory(let path):
             return "path expected to be a directory is not a directory or doesn't exist: `\(path)`"
-        case .unserializableDestination:
+        case .unserializableMetadata:
             return """
             Swift SDK configuration couldn't be serialized with the latest serialization schema, potentially because \
             it was deserialized from an earlier incompatible schema version or initialized manually with missing \
             properties required for initialization
             """
-        case .destinationNotFound(let artifactID, let buildTimeTriple, let runTimeTriple):
+        case .swiftSDKNotFound(let artifactID, let hostTriple, let targetTriple):
             return """
-            Swift SDK with ID `\(artifactID)`, build-time triple \(buildTimeTriple), and run-time triple \
-            \(runTimeTriple) is not currently installed.
+            Swift SDK with ID `\(artifactID)`, host triple \(hostTriple), and target triple \(targetTriple) is not \
+            currently installed.
             """
-        case .destinationBundleAlreadyInstalled(let bundleName):
+        case .swiftSDKBundleAlreadyInstalled(let bundleName):
             return """
             Swift SDK bundle with name `\(bundleName)` is already installed. Can't install a new bundle \
             with the same name.
             """
-        case .destinationArtifactAlreadyInstalled(let installedBundleName, let newBundleName, let artifactID):
+        case .swiftSDKArtifactAlreadyInstalled(let installedBundleName, let newBundleName, let artifactID):
             return """
             A Swift SDK with artifact ID `\(artifactID)` is already included in an installed bundle with name \
             `\(installedBundleName)`. Can't install a new bundle `\(newBundleName)` with this artifact, artifact IDs \
@@ -242,7 +242,10 @@ public struct Destination: Equatable {
         /// - Parameters:
         ///   - properties: properties of the destination for the given triple.
         ///   - destinationDirectory: directory used for converting relative paths in `properties` to absolute paths.
-        init(_ properties: SerializedDestinationV3.TripleProperties, destinationDirectory: AbsolutePath? = nil) throws {
+        fileprivate init(
+            _ properties: SerializedDestinationV3.TripleProperties,
+            destinationDirectory: AbsolutePath? = nil
+        ) throws {
             if let destinationDirectory {
                 self.init(
                     sdkRootPath: try AbsolutePath(validating: properties.sdkRootPath, relativeTo: destinationDirectory),
@@ -260,6 +263,52 @@ public struct Destination: Equatable {
                     },
                     toolsetPaths: try properties.toolsetPaths?.map {
                         try AbsolutePath(validating: $0, relativeTo: destinationDirectory)
+                    }
+                )
+            } else {
+                self.init(
+                    sdkRootPath: try AbsolutePath(validating: properties.sdkRootPath),
+                    swiftResourcesPath: try properties.swiftResourcesPath.map {
+                        try AbsolutePath(validating: $0)
+                    },
+                    swiftStaticResourcesPath: try properties.swiftStaticResourcesPath.map {
+                        try AbsolutePath(validating: $0)
+                    },
+                    includeSearchPaths: try properties.includeSearchPaths?.map {
+                        try AbsolutePath(validating: $0)
+                    },
+                    librarySearchPaths: try properties.librarySearchPaths?.map {
+                        try AbsolutePath(validating: $0)
+                    },
+                    toolsetPaths: try properties.toolsetPaths?.map {
+                        try AbsolutePath(validating: $0)
+                    }
+                )
+            }
+        }
+
+        /// Initialize paths configuration from values deserialized using v4 schema.
+        /// - Parameters:
+        ///   - properties: properties of a Swift SDK for the given triple.
+        ///   - swiftSDKDirectory: directory used for converting relative paths in `properties` to absolute paths.
+        fileprivate init(_ properties: SwiftSDKMetadataV4.TripleProperties, swiftSDKDirectory: AbsolutePath? = nil) throws {
+            if let swiftSDKDirectory {
+                self.init(
+                    sdkRootPath: try AbsolutePath(validating: properties.sdkRootPath, relativeTo: swiftSDKDirectory),
+                    swiftResourcesPath: try properties.swiftResourcesPath.map {
+                        try AbsolutePath(validating: $0, relativeTo: swiftSDKDirectory)
+                    },
+                    swiftStaticResourcesPath: try properties.swiftStaticResourcesPath.map {
+                        try AbsolutePath(validating: $0, relativeTo: swiftSDKDirectory)
+                    },
+                    includeSearchPaths: try properties.includeSearchPaths?.map {
+                        try AbsolutePath(validating: $0, relativeTo: swiftSDKDirectory)
+                    },
+                    librarySearchPaths: try properties.librarySearchPaths?.map {
+                        try AbsolutePath(validating: $0, relativeTo: swiftSDKDirectory)
+                    },
+                    toolsetPaths: try properties.toolsetPaths?.map {
+                        try AbsolutePath(validating: $0, relativeTo: swiftSDKDirectory)
                     }
                 )
             } else {
@@ -410,7 +459,7 @@ public struct Destination: Equatable {
                 environment: environment
             ).spm_chomp()
             guard !sdkPathStr.isEmpty else {
-                throw DestinationError.invalidInstallation("default SDK not found")
+                throw SwiftSDKError.invalidInstallation("default SDK not found")
             }
             sdkPath = try AbsolutePath(validating: sdkPathStr)
         }
@@ -571,12 +620,56 @@ extension Destination {
                     destinationDirectory: destinationDirectory
                 )
             }
+
+        case Version(4, 0, 0):
+            let swiftSDKs = try decoder.decode(path: path, fileSystem: fileSystem, as: SwiftSDKMetadataV4.self)
+            let swiftSDKDirectory = path.parentDirectory
+
+            return try swiftSDKs.targetTriples.map { triple, properties in
+                let triple = try Triple(triple)
+
+                let pathStrings = properties.toolsetPaths ?? []
+                let toolset = try pathStrings.reduce(into: Toolset(knownTools: [:], rootPaths: [])) {
+                    try $0.merge(
+                        with: Toolset(
+                            from: .init(validating: $1, relativeTo: swiftSDKDirectory),
+                            at: fileSystem,
+                            observabilityScope
+                        )
+                    )
+                }
+
+                return try Destination(
+                    targetTriple: triple,
+                    properties: properties,
+                    toolset: toolset,
+                    swiftSDKDirectory: swiftSDKDirectory
+                )
+            }
         default:
-            throw DestinationError.invalidSchemaVersion
+            throw SwiftSDKError.invalidSchemaVersion
         }
     }
 
-    
+    /// Initialize new Swift SDK from values deserialized using v4 schema.
+    /// - Parameters:
+    ///   - targetTriple: triple of the machine running code built with this Swift SDK.
+    ///   - properties: properties of the Swift SDK for the given triple.
+    ///   - toolset: combined toolset used by this Swift SDK.
+    ///   - swiftSDKDirectory: directory used for converting relative paths in `properties` to absolute paths.
+    init(
+        targetTriple: Triple,
+        properties: SwiftSDKMetadataV4.TripleProperties,
+        toolset: Toolset = .init(),
+        swiftSDKDirectory: AbsolutePath? = nil
+    ) throws {
+        self.init(
+            targetTriple: targetTriple,
+            toolset: toolset,
+            pathsConfiguration: try .init(properties, swiftSDKDirectory: swiftSDKDirectory)
+        )
+    }
+
     /// Initialize new destination from values deserialized using v3 schema.
     /// - Parameters:
     ///   - runTimeTriple: triple of the machine running code built with this destination.
@@ -643,7 +736,7 @@ extension Destination {
                 )
             )
         default:
-            throw DestinationError.invalidSchemaVersion
+            throw SwiftSDKError.invalidSchemaVersion
         }
     }
 
@@ -653,12 +746,12 @@ extension Destination {
     /// from different schema versions or constructed manually without providing valid values for such properties.
     var serialized: (Triple, SerializedDestinationV3.TripleProperties) {
         get throws {
-            guard let runTimeTriple = self.targetTriple, let sdkRootDir = self.pathsConfiguration.sdkRootPath else {
-                throw DestinationError.unserializableDestination
+            guard let targetTriple = self.targetTriple, let sdkRootDir = self.pathsConfiguration.sdkRootPath else {
+                throw SwiftSDKError.unserializableMetadata
             }
             
             return (
-                runTimeTriple,
+                targetTriple,
                 .init(
                     sdkRootPath: sdkRootDir.pathString,
                     swiftResourcesPath: self.pathsConfiguration.swiftResourcesPath?.pathString,
@@ -747,4 +840,30 @@ struct SerializedDestinationV3: Decodable {
 
     /// Mapping of triple strings to corresponding properties of such run-time triple.
     let runTimeTriples: [String: TripleProperties]
+}
+
+/// Represents v4 schema of `swift-sdk.json` (previously `destination.json`) files used for cross-compilation.
+struct SwiftSDKMetadataV4: Decodable {
+    struct TripleProperties: Codable {
+        /// Path relative to `swift-sdk.json` containing SDK root.
+        var sdkRootPath: String
+
+        /// Path relative to `swift-sdk.json` containing Swift resources for dynamic linking.
+        var swiftResourcesPath: String?
+
+        /// Path relative to `swift-sdk.json` containing Swift resources for static linking.
+        var swiftStaticResourcesPath: String?
+
+        /// Array of paths relative to `swift-sdk.json` containing headers.
+        var includeSearchPaths: [String]?
+
+        /// Array of paths relative to `swift-sdk.json` containing libraries.
+        var librarySearchPaths: [String]?
+
+        /// Array of paths relative to `swift-sdk.json` containing toolset files.
+        var toolsetPaths: [String]?
+    }
+
+    /// Mapping of triple strings to corresponding properties of such target triple.
+    let targetTriples: [String: TripleProperties]
 }

--- a/Sources/PackageModel/SwiftSDKBundle.swift
+++ b/Sources/PackageModel/SwiftSDKBundle.swift
@@ -171,7 +171,7 @@ public struct SwiftSDKBundle {
             {
                 bundlePath = originalBundlePath
             } else {
-                throw DestinationError.invalidPathOrURL(bundlePathOrURL)
+                throw SwiftSDKError.invalidPathOrURL(bundlePathOrURL)
             }
 
             try await installIfValid(
@@ -205,16 +205,16 @@ public struct SwiftSDKBundle {
         let regex = try RegEx(pattern: "(.+\\.artifactbundle).*")
 
         guard let bundleName = bundlePath.components.last else {
-            throw DestinationError.invalidPathOrURL(bundlePath.pathString)
+            throw SwiftSDKError.invalidPathOrURL(bundlePath.pathString)
         }
 
         guard let unpackedBundleName = regex.matchGroups(in: bundleName).first?.first else {
-            throw DestinationError.invalidBundleName(bundleName)
+            throw SwiftSDKError.invalidBundleName(bundleName)
         }
 
         let installedBundlePath = destinationsDirectory.appending(component: unpackedBundleName)
         guard !fileSystem.exists(installedBundlePath) else {
-            throw DestinationError.destinationBundleAlreadyInstalled(bundleName: unpackedBundleName)
+            throw SwiftSDKError.swiftSDKBundleAlreadyInstalled(bundleName: unpackedBundleName)
         }
 
         // If there's no archive extension on the bundle name, assuming it's not archived and returning the same path.
@@ -246,7 +246,7 @@ public struct SwiftSDKBundle {
         #if os(macOS)
         // Check the quarantine attribute on bundles downloaded manually in the browser.
         guard !fileSystem.hasAttribute(.quarantine, bundlePath) else {
-            throw DestinationError.quarantineAttributePresent(bundlePath: bundlePath)
+            throw SwiftSDKError.quarantineAttributePresent(bundlePath: bundlePath)
         }
         #endif
 
@@ -262,7 +262,7 @@ public struct SwiftSDKBundle {
             fileSystem.isDirectory(unpackedBundlePath),
             let bundleName = unpackedBundlePath.components.last
         else {
-            throw DestinationError.pathIsNotDirectory(bundlePath)
+            throw SwiftSDKError.pathIsNotDirectory(bundlePath)
         }
 
         let installedBundlePath = destinationsDirectory.appending(component: bundleName)
@@ -283,7 +283,7 @@ public struct SwiftSDKBundle {
         for installedBundle in installedBundles {
             for artifactID in installedBundle.artifacts.keys {
                 guard !newArtifactIDs.contains(artifactID) else {
-                    throw DestinationError.destinationArtifactAlreadyInstalled(
+                    throw SwiftSDKError.swiftSDKArtifactAlreadyInstalled(
                         installedBundleName: installedBundle.name,
                         newBundleName: validatedBundle.name,
                         artifactID: artifactID
@@ -296,12 +296,12 @@ public struct SwiftSDKBundle {
     }
 
     /// Parses metadata of an `.artifactbundle` and validates it as a bundle containing
-    /// cross-compilation destinations.
+    /// cross-compilation Swift SDKs.
     /// - Parameters:
     ///   - bundlePath: path to the bundle root directory.
     ///   - fileSystem: filesystem containing the bundle.
     ///   - observabilityScope: observability scope to log validation warnings.
-    /// - Returns: Validated `DestinationsBundle` containing validated `Destination` values for
+    /// - Returns: Validated `SwiftSDKBundle` containing validated `Destination` values for
     /// each artifact and its variants.
     private static func parseAndValidate(
         bundlePath: AbsolutePath,
@@ -313,7 +313,7 @@ public struct SwiftSDKBundle {
             rootPath: bundlePath
         )
 
-        return try parsedManifest.validateDestinationBundle(
+        return try parsedManifest.validateSwiftSDKBundle(
             bundlePath: bundlePath,
             fileSystem: fileSystem,
             observabilityScope: observabilityScope
@@ -322,7 +322,7 @@ public struct SwiftSDKBundle {
 }
 
 extension ArtifactsArchiveMetadata {
-    fileprivate func validateDestinationBundle(
+    fileprivate func validateSwiftSDKBundle(
         bundlePath: AbsolutePath,
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope

--- a/Sources/PackageModel/SwiftSDKConfigurationStore.swift
+++ b/Sources/PackageModel/SwiftSDKConfigurationStore.swift
@@ -18,7 +18,7 @@ import class Foundation.JSONEncoder
 /// Storage for configuration properties of Swift SDKs.
 public final class SwiftSDKConfigurationStore {
     /// Triple of the machine on which SwiftPM is running.
-    private let buildTimeTriple: Triple
+    private let hostTriple: Triple
 
     /// Path to the directory in which Swift SDKs and their configuration are stored. Usually
     /// `~/.swiftpm/swift-sdks` or a directory to which `~/.swiftpm/swift-sdks` symlinks to.
@@ -40,32 +40,32 @@ public final class SwiftSDKConfigurationStore {
     /// Encoder used for reading existing configuration from  ``SwiftSDKConfigurationStore//fileSystem``.
     private let decoder: JSONDecoder
 
-    /// Initializes a store for configuring destinations.
+    /// Initializes a store for configuring Swift SDKs.
     /// - Parameters:
-    ///   - buildTimeTriple: Triple of the machine on which SwiftPM is running.
-    ///   - destinationsDirectoryPath: Path to the directory in which destinations and their configuration are
-    ///   stored. Usually `~/.swiftpm/destinations` or a directory to which `~/.swiftpm/destinations` symlinks to.
+    ///   - hostTriple: Triple of the machine on which SwiftPM is running.
+    ///   - swiftSDKsDirectoryPath: Path to the directory in which Swift SDKs and their configuration are
+    ///   stored. Usually `~/.swiftpm/swift-sdks` or a directory to which `~/.swiftpm/swift-sdks` symlinks to.
     ///   If this directory doesn't exist, an error will be thrown.
-    ///   - fileSystem: file system on which `destinationsDirectoryPath` exists.
+    ///   - fileSystem: file system on which `swiftSDKsDirectoryPath` exists.
     ///   - observabilityScope: an observability scope on which warnings can be reported if any appear.
     public init(
-        buildTimeTriple: Triple,
-        destinationsDirectoryPath: AbsolutePath,
+        hostTimeTriple: Triple,
+        swiftSDKsDirectoryPath: AbsolutePath,
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope
     ) throws {
-        let configurationDirectoryPath = destinationsDirectoryPath.appending(component: "configuration")
+        let configurationDirectoryPath = swiftSDKsDirectoryPath.appending(component: "configuration")
 
         if fileSystem.exists(configurationDirectoryPath) {
             guard fileSystem.isDirectory(configurationDirectoryPath) else {
-                throw DestinationError.pathIsNotDirectory(configurationDirectoryPath)
+                throw SwiftSDKError.pathIsNotDirectory(configurationDirectoryPath)
             }
         } else {
             try fileSystem.createDirectory(configurationDirectoryPath)
         }
 
-        self.buildTimeTriple = buildTimeTriple
-        self.swiftSDKsDirectoryPath = destinationsDirectoryPath
+        self.hostTriple = hostTimeTriple
+        self.swiftSDKsDirectoryPath = swiftSDKsDirectoryPath
         self.configurationDirectoryPath = configurationDirectoryPath
         self.fileSystem = fileSystem
         self.observabilityScope = observabilityScope
@@ -74,24 +74,24 @@ public final class SwiftSDKConfigurationStore {
     }
 
     public func updateConfiguration(
-        destinationID: String,
+        sdkID: String,
         destination: Destination
     ) throws {
-        let (runTimeTriple, properties) = try destination.serialized
+        let (targetTriple, properties) = try destination.serialized
 
         let configurationPath = configurationDirectoryPath.appending(
-            component: "\(destinationID)_\(runTimeTriple).json"
+            component: "\(sdkID)_\(targetTriple).json"
         )
 
         try encoder.encode(path: configurationPath, fileSystem: fileSystem, properties)
     }
 
     public func readConfiguration(
-        destinationID: String,
-        runTimeTriple triple: Triple
+        sdkID: String,
+        targetTriple triple: Triple
     ) throws -> Destination? {
         let configurationPath = configurationDirectoryPath.appending(
-            component: "\(destinationID)_\(triple.tripleString).json"
+            component: "\(sdkID)_\(triple.tripleString).json"
         )
 
         let destinationBundles = try SwiftSDKBundle.getAllValidBundles(
@@ -101,8 +101,8 @@ public final class SwiftSDKConfigurationStore {
         )
 
         guard var destination = destinationBundles.selectDestination(
-            id: destinationID,
-            hostTriple: buildTimeTriple,
+            id: sdkID,
+            hostTriple: hostTriple,
             targetTriple: triple
         ) else {
             return nil
@@ -112,12 +112,12 @@ public final class SwiftSDKConfigurationStore {
             let properties = try decoder.decode(
                 path: configurationPath,
                 fileSystem: fileSystem,
-                as: SerializedDestinationV3.TripleProperties.self
+                as: SwiftSDKMetadataV4.TripleProperties.self
             )
 
             destination.pathsConfiguration.merge(
                 with: try Destination(
-                    runTimeTriple: triple,
+                    targetTriple: triple,
                     properties: properties
                 ).pathsConfiguration
             )
@@ -132,11 +132,11 @@ public final class SwiftSDKConfigurationStore {
     ///   - tripleString: run-time triple for which the properties should be reset.
     /// - Returns: `true` if custom configuration was successfully removed, `false` if no custom configuration existed.
     public func resetConfiguration(
-        destinationID: String,
-        runTimeTriple triple: Triple
+        sdkID: String,
+        targetTriple triple: Triple
     ) throws -> Bool {
         let configurationPath = configurationDirectoryPath.appending(
-            component: "\(destinationID)_\(triple.tripleString).json"
+            component: "\(sdkID)_\(triple.tripleString).json"
         )
 
         guard fileSystem.isFile(configurationPath) else {

--- a/Sources/SwiftSDKTool/Configuration/ConfigurationSubcommand.swift
+++ b/Sources/SwiftSDKTool/Configuration/ConfigurationSubcommand.swift
@@ -15,63 +15,63 @@ import Basics
 import PackageModel
 
 protocol ConfigurationSubcommand: SwiftSDKSubcommand {
-    /// An identifier of an already installed destination.
-    var destinationID: String { get }
+    /// An identifier of an already installed Swift SDK.
+    var sdkID: String { get }
 
-    /// A run-time triple of the destination specified by `destinationID` identifier string.
-    var runTimeTriple: String { get }
+    /// A target triple of the destination.
+    var targetTriple: String { get }
 
     /// Run a command related to configuration of cross-compilation destinations, passing it required configuration
     /// values.
     /// - Parameters:
-    ///   - buildTimeTriple: triple of the machine this command is running on.
-    ///   - runTimeTriple: triple of the machine on which cross-compiled code will run on.
+    ///   - hostTriple: triple of the machine this command is running on.
+    ///   - targetTriple: triple of the machine on which cross-compiled code will run on.
     ///   - destination: destination configuration fetched that matches currently set `destinationID` and
-    ///   `runTimeTriple`.
+    ///   `targetTriple`.
     ///   - configurationStore: storage for configuration properties that this command operates on.
-    ///   - destinationsDirectory: directory containing destination artifact bundles and their configuration.
+    ///   - swiftSDKsDirectory: directory containing Swift SDK artifact bundles and their configuration.
     ///   - observabilityScope: observability scope used for logging.
     func run(
-        buildTimeTriple: Triple,
-        runTimeTriple: Triple,
+        hostTriple: Triple,
+        targetTriple: Triple,
         _ destination: Destination,
         _ configurationStore: SwiftSDKConfigurationStore,
-        _ destinationsDirectory: AbsolutePath,
+        _ swiftSDKsDirectory: AbsolutePath,
         _ observabilityScope: ObservabilityScope
     ) throws
 }
 
 extension ConfigurationSubcommand {
     func run(
-        buildTimeTriple: Triple,
-        _ destinationsDirectory: AbsolutePath,
+        hostTriple: Triple,
+        _ swiftSDKsDirectory: AbsolutePath,
         _ observabilityScope: ObservabilityScope
     ) throws {
         let configurationStore = try SwiftSDKConfigurationStore(
-            buildTimeTriple: buildTimeTriple,
-            destinationsDirectoryPath: destinationsDirectory,
+            hostTimeTriple: hostTriple,
+            swiftSDKsDirectoryPath: swiftSDKsDirectory,
             fileSystem: fileSystem,
             observabilityScope: observabilityScope
         )
-        let runTimeTriple = try Triple(self.runTimeTriple)
+        let targetTriple = try Triple(self.targetTriple)
 
         guard let destination = try configurationStore.readConfiguration(
-            destinationID: destinationID,
-            runTimeTriple: runTimeTriple
+            sdkID: sdkID,
+            targetTriple: targetTriple
         ) else {
-            throw DestinationError.destinationNotFound(
-                artifactID: destinationID,
-                builtTimeTriple: buildTimeTriple,
-                runTimeTriple: runTimeTriple
+            throw SwiftSDKError.swiftSDKNotFound(
+                artifactID: sdkID,
+                hostTriple: hostTriple,
+                targetTriple: targetTriple
             )
         }
 
         try run(
-            buildTimeTriple: buildTimeTriple,
-            runTimeTriple: runTimeTriple,
+            hostTriple: hostTriple,
+            targetTriple: targetTriple,
             destination,
             configurationStore,
-            destinationsDirectory,
+            swiftSDKsDirectory,
             observabilityScope
         )
     }

--- a/Sources/SwiftSDKTool/Configuration/ResetConfiguration.swift
+++ b/Sources/SwiftSDKTool/Configuration/ResetConfiguration.swift
@@ -51,14 +51,14 @@ struct ResetConfiguration: ConfigurationSubcommand {
         identifiers.
         """
     )
-    var destinationID: String
+    var sdkID: String
 
     @Argument(help: "A run-time triple of the destination specified by `destination-id` identifier string.")
-    var runTimeTriple: String
+    var targetTriple: String
 
     func run(
-        buildTimeTriple: Triple,
-        runTimeTriple: Triple,
+        hostTriple: Triple,
+        targetTriple: Triple,
         _ destination: Destination,
         _ configurationStore: SwiftSDKConfigurationStore,
         _ destinationsDirectory: AbsolutePath,
@@ -105,27 +105,27 @@ struct ResetConfiguration: ConfigurationSubcommand {
         }
 
         if shouldResetAll {
-            if try !configurationStore.resetConfiguration(destinationID: destinationID, runTimeTriple: runTimeTriple) {
+            if try !configurationStore.resetConfiguration(sdkID: sdkID, targetTriple: targetTriple) {
                 observabilityScope.emit(
-                    warning: "No configuration for destination \(destinationID)"
+                    warning: "No configuration for destination \(sdkID)"
                 )
             } else {
                 observabilityScope.emit(
                     info: """
-                    All configuration properties of destination `\(destinationID) for run-time triple \
-                    `\(runTimeTriple)` were successfully reset.
+                    All configuration properties of destination `\(sdkID) for run-time triple \
+                    `\(targetTriple)` were successfully reset.
                     """
                 )
             }
         } else {
             var destination = destination
             destination.pathsConfiguration = configuration
-            try configurationStore.updateConfiguration(destinationID: destinationID, destination: destination)
+            try configurationStore.updateConfiguration(sdkID: sdkID, destination: destination)
 
             observabilityScope.emit(
                 info: """
-                These properties of destination `\(destinationID) for run-time triple \
-                `\(runTimeTriple)` were successfully reset: \(resetProperties.joined(separator: ", ")).
+                These properties of destination `\(sdkID) for run-time triple \
+                `\(targetTriple)` were successfully reset: \(resetProperties.joined(separator: ", ")).
                 """
             )
         }

--- a/Sources/SwiftSDKTool/Configuration/SetConfiguration.swift
+++ b/Sources/SwiftSDKTool/Configuration/SetConfiguration.swift
@@ -67,14 +67,14 @@ struct SetConfiguration: ConfigurationSubcommand {
         identifiers.
         """
     )
-    var destinationID: String
+    var sdkID: String
 
     @Argument(help: "The run-time triple of the destination to configure.")
-    var runTimeTriple: String
+    var targetTriple: String
 
     func run(
-        buildTimeTriple: Triple,
-        runTimeTriple: Triple,
+        hostTriple: Triple,
+        targetTriple: Triple,
         _ destination: Destination,
         _ configurationStore: SwiftSDKConfigurationStore,
         _ destinationsDirectory: AbsolutePath,
@@ -123,7 +123,7 @@ struct SetConfiguration: ConfigurationSubcommand {
         guard !updatedProperties.isEmpty else {
             observabilityScope.emit(
                 error: """
-                No properties of destination `\(destinationID) for run-time triple `\(runTimeTriple)` were updated \
+                No properties of destination `\(sdkID) for run-time triple `\(targetTriple)` were updated \
                 since none were specified. Pass `--help` flag to see the list of all available properties.
                 """
             )
@@ -132,12 +132,12 @@ struct SetConfiguration: ConfigurationSubcommand {
 
         var destination = destination
         destination.pathsConfiguration = configuration
-        try configurationStore.updateConfiguration(destinationID: destinationID, destination: destination)
+        try configurationStore.updateConfiguration(sdkID: sdkID, destination: destination)
 
         observabilityScope.emit(
             info: """
-            These properties of destination `\(destinationID) for run-time triple \
-            `\(runTimeTriple)` were successfully updated: \(updatedProperties.joined(separator: ", ")).
+            These properties of destination `\(sdkID) for run-time triple \
+            `\(targetTriple)` were successfully updated: \(updatedProperties.joined(separator: ", ")).
             """
         )
     }

--- a/Sources/SwiftSDKTool/Configuration/ShowConfiguration.swift
+++ b/Sources/SwiftSDKTool/Configuration/ShowConfiguration.swift
@@ -32,14 +32,14 @@ struct ShowConfiguration: ConfigurationSubcommand {
         identifiers.
         """
     )
-    var destinationID: String
+    var sdkID: String
 
     @Argument(help: "The run-time triple of the destination to configure.")
-    var runTimeTriple: String
+    var targetTriple: String
 
     func run(
-        buildTimeTriple: Triple,
-        runTimeTriple: Triple,
+        hostTriple: Triple,
+        targetTriple: Triple,
         _ destination: Destination,
         _ configurationStore: SwiftSDKConfigurationStore,
         _ destinationsDirectory: AbsolutePath,

--- a/Sources/SwiftSDKTool/InstallSwiftSDK.swift
+++ b/Sources/SwiftSDKTool/InstallSwiftSDK.swift
@@ -36,7 +36,7 @@ public struct InstallSwiftSDK: SwiftSDKSubcommand {
     public init() {}
 
     func run(
-        buildTimeTriple: Triple,
+        hostTriple: Triple,
         _ destinationsDirectory: AbsolutePath,
         _ observabilityScope: ObservabilityScope
     ) async throws {

--- a/Sources/SwiftSDKTool/ListSwiftSDKs.swift
+++ b/Sources/SwiftSDKTool/ListSwiftSDKs.swift
@@ -31,7 +31,7 @@ public struct ListSwiftSDKs: SwiftSDKSubcommand {
     public init() {}
 
     func run(
-        buildTimeTriple: Triple,
+        hostTriple: Triple,
         _ destinationsDirectory: AbsolutePath,
         _ observabilityScope: ObservabilityScope
     ) throws {

--- a/Sources/SwiftSDKTool/RemoveSwiftSDK.swift
+++ b/Sources/SwiftSDKTool/RemoveSwiftSDK.swift
@@ -32,7 +32,7 @@ public struct RemoveSwiftSDK: SwiftSDKSubcommand {
     public init() {}
 
     func run(
-        buildTimeTriple: Triple,
+        hostTriple: Triple,
         _ destinationsDirectory: AbsolutePath,
         _ observabilityScope: ObservabilityScope
     ) async throws {

--- a/Sources/SwiftSDKTool/SwiftSDKSubcommand.swift
+++ b/Sources/SwiftSDKTool/SwiftSDKSubcommand.swift
@@ -25,12 +25,12 @@ protocol SwiftSDKSubcommand: AsyncParsableCommand {
 
     /// Run a command operating on cross-compilation destinations, passing it required configuration values.
     /// - Parameters:
-    ///   - buildTimeTriple: triple of the machine this command is running on.
-    ///   - destinationsDirectory: directory containing destination artifact bundles and their configuration.
+    ///   - hostTriple: triple of the machine this command is running on.
+    ///   - swiftSDKsDirectory: directory containing Swift SDK artifact bundles and their configuration.
     ///   - observabilityScope: observability scope used for logging.
     func run(
-        buildTimeTriple: Triple,
-        _ destinationsDirectory: AbsolutePath,
+        hostTriple: Triple,
+        _ swiftSDKsDirectory: AbsolutePath,
         _ observabilityScope: ObservabilityScope
     ) async throws
 }
@@ -70,7 +70,7 @@ extension SwiftSDKSubcommand {
 
         var commandError: Error? = nil
         do {
-            try await self.run(buildTimeTriple: triple, destinationsDirectory, observabilityScope)
+            try await self.run(hostTriple: triple, destinationsDirectory, observabilityScope)
             if observabilityScope.errorsReported {
                 throw ExitCode.failure
             }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -3601,7 +3601,7 @@ final class BuildPlanTests: XCTestCase {
         func cliFlag(tool: Toolset.KnownTool) -> String { "-\(tool)-flag-from-cli" }
         func cliFlag(tool: Toolset.KnownTool) -> StringPattern { .equal(cliFlag(tool: tool)) }
 
-        let toolSet = Toolset(
+        let toolset = Toolset(
             knownTools: [
                 .cCompiler: .init(extraCLIOptions: [jsonFlag(tool: .cCompiler)]),
                 .cxxCompiler: .init(extraCLIOptions: [jsonFlag(tool: .cxxCompiler)]),
@@ -3609,14 +3609,13 @@ final class BuildPlanTests: XCTestCase {
                 .linker: .init(extraCLIOptions: [jsonFlag(tool: .linker)]),
             ],
             rootPaths: try UserToolchain.default.destination.toolset.rootPaths)
-        let runtimeTriple = try Triple("armv7em-unknown-none-macho")
+        let targetTriple = try Triple("armv7em-unknown-none-macho")
         let destination = try Destination(
-            runTimeTriple: runtimeTriple,
+            targetTriple: targetTriple,
             properties: .init(
                 sdkRootPath: "/fake/sdk",
                 swiftStaticResourcesPath: "/usr/lib/swift_static/none"),
-            toolset: toolSet,
-            destinationDirectory: nil)
+            toolset: toolset)
         let toolchain = try UserToolchain(destination: destination)
         let buildParameters = mockBuildParameters(
             toolchain: toolchain,
@@ -3625,7 +3624,7 @@ final class BuildPlanTests: XCTestCase {
                 cxxCompilerFlags: [cliFlag(tool: .cxxCompiler)],
                 swiftCompilerFlags: [cliFlag(tool: .swiftCompiler)],
                 linkerFlags: [cliFlag(tool: .linker)]),
-            destinationTriple: runtimeTriple)
+            destinationTriple: targetTriple)
         let result = try BuildPlanResult(plan: BuildPlan(
             buildParameters: buildParameters,
             graph: graph,
@@ -3749,11 +3748,11 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let runtimeTriple = try UserToolchain.default.triple
+        let targetTriple = try UserToolchain.default.triple
         let sdkIncludeSearchPath = "/usr/lib/swift_static/none/include"
         let sdkLibrarySearchPath = "/usr/lib/swift_static/none/lib"
         let destination = try Destination(
-            runTimeTriple: runtimeTriple,
+            targetTriple: targetTriple,
             properties: .init(
                 sdkRootPath: "/fake/sdk",
                 includeSearchPaths: [sdkIncludeSearchPath],

--- a/Tests/PackageModelTests/SwiftSDKBundleTests.swift
+++ b/Tests/PackageModelTests/SwiftSDKBundleTests.swift
@@ -117,7 +117,7 @@ final class SwiftSDKBundleTests: XCTestCase {
 
             XCTFail("Function expected to throw")
         } catch {
-            guard let error = error as? DestinationError else {
+            guard let error = error as? SwiftSDKError else {
                 XCTFail("Unexpected error type")
                 return
             }
@@ -141,13 +141,13 @@ final class SwiftSDKBundleTests: XCTestCase {
 
             XCTFail("Function expected to throw")
         } catch {
-            guard let error = error as? DestinationError else {
+            guard let error = error as? SwiftSDKError else {
                 XCTFail("Unexpected error type")
                 return
             }
 
             switch error {
-            case .destinationBundleAlreadyInstalled(let installedBundleName):
+            case .swiftSDKBundleAlreadyInstalled(let installedBundleName):
                 XCTAssertEqual(bundles[0].name, installedBundleName)
             default:
                 XCTFail("Unexpected error value")
@@ -165,13 +165,13 @@ final class SwiftSDKBundleTests: XCTestCase {
 
              XCTFail("Function expected to throw")
          } catch {
-            guard let error = error as? DestinationError else {
+            guard let error = error as? SwiftSDKError else {
                 XCTFail("Unexpected error type")
                 return
             }
 
             switch error {
-            case .destinationArtifactAlreadyInstalled(let installedBundleName, let newBundleName, let artifactID):
+            case .swiftSDKArtifactAlreadyInstalled(let installedBundleName, let newBundleName, let artifactID):
                 XCTAssertEqual(bundles[0].name, installedBundleName)
                 XCTAssertEqual(bundles[1].name, newBundleName)
                 XCTAssertEqual(artifactID, testArtifactID)


### PR DESCRIPTION
Introduced `SwiftSDKMetadataV4` type that uses `targetTriple` instead of `runTimeTriple`. We're keeping the previous v3 schema for better error handling in case v3 schema ended up being used in the wild during Swift 5.9 development cycle. The plan is to deprecate v3 and earlier schemas in a future change.

`buildTimeTriple` and `runTimeTriple` renamed to `hostTriple` and `targetTriple` across the codebase, "destination" renamed to "Swift SDK" where possible without a broader disruption. Full renaming of the `Destination` type to `SwiftSDK` would come in a separate change to reduce the diff for this one.
