### PR TITLE
[5.9] Update Swift SDK nomenclature

### DIFF
--- a/Sources/CoreCommands/SwiftTool.swift
+++ b/Sources/CoreCommands/SwiftTool.swift
@@ -737,7 +737,7 @@ public final class SwiftTool {
                 {
                     destination = matchingDestination
                 } else {
-                    return .failure(DestinationError.noDestinationsDecoded(customDestination))
+                    return .failure(SwiftSDKError.noSwiftSDKDecoded(customDestination))
                 }
             } else if let triple = options.build.customCompileTriple,
                       let targetDestination = Destination.defaultDestination(for: triple, host: hostDestination)

--- a/Sources/PackageModel/SwiftSDKBundle.swift
+++ b/Sources/PackageModel/SwiftSDKBundle.swift
@@ -177,7 +177,7 @@ public struct SwiftSDKBundle {
             {
                 bundlePath = originalBundlePath
             } else {
-                throw DestinationError.invalidPathOrURL(bundlePathOrURL)
+                throw SwiftSDKError.invalidPathOrURL(bundlePathOrURL)
             }
 
             try installIfValid(
@@ -211,16 +211,16 @@ public struct SwiftSDKBundle {
         let regex = try RegEx(pattern: "(.+\\.artifactbundle).*")
 
         guard let bundleName = bundlePath.components.last else {
-            throw DestinationError.invalidPathOrURL(bundlePath.pathString)
+            throw SwiftSDKError.invalidPathOrURL(bundlePath.pathString)
         }
 
         guard let unpackedBundleName = regex.matchGroups(in: bundleName).first?.first else {
-            throw DestinationError.invalidBundleName(bundleName)
+            throw SwiftSDKError.invalidBundleName(bundleName)
         }
 
         let installedBundlePath = destinationsDirectory.appending(component: unpackedBundleName)
         guard !fileSystem.exists(installedBundlePath) else {
-            throw DestinationError.destinationBundleAlreadyInstalled(bundleName: unpackedBundleName)
+            throw SwiftSDKError.swiftSDKBundleAlreadyInstalled(bundleName: unpackedBundleName)
         }
 
         // If there's no archive extension on the bundle name, assuming it's not archived and returning the same path.
@@ -252,7 +252,7 @@ public struct SwiftSDKBundle {
         #if os(macOS)
         // Check the quarantine attribute on bundles downloaded manually in the browser.
         guard !fileSystem.hasAttribute(.quarantine, bundlePath) else {
-            throw DestinationError.quarantineAttributePresent(bundlePath: bundlePath)
+            throw SwiftSDKError.quarantineAttributePresent(bundlePath: bundlePath)
         }
         #endif
 
@@ -268,7 +268,7 @@ public struct SwiftSDKBundle {
             fileSystem.isDirectory(unpackedBundlePath),
             let bundleName = unpackedBundlePath.components.last
         else {
-            throw DestinationError.pathIsNotDirectory(bundlePath)
+            throw SwiftSDKError.pathIsNotDirectory(bundlePath)
         }
 
         let installedBundlePath = destinationsDirectory.appending(component: bundleName)
@@ -289,7 +289,7 @@ public struct SwiftSDKBundle {
         for installedBundle in installedBundles {
             for artifactID in installedBundle.artifacts.keys {
                 guard !newArtifactIDs.contains(artifactID) else {
-                    throw DestinationError.destinationArtifactAlreadyInstalled(
+                    throw SwiftSDKError.swiftSDKArtifactAlreadyInstalled(
                         installedBundleName: installedBundle.name,
                         newBundleName: validatedBundle.name,
                         artifactID: artifactID
@@ -302,12 +302,12 @@ public struct SwiftSDKBundle {
     }
 
     /// Parses metadata of an `.artifactbundle` and validates it as a bundle containing
-    /// cross-compilation destinations.
+    /// cross-compilation Swift SDKs.
     /// - Parameters:
     ///   - bundlePath: path to the bundle root directory.
     ///   - fileSystem: filesystem containing the bundle.
     ///   - observabilityScope: observability scope to log validation warnings.
-    /// - Returns: Validated `DestinationsBundle` containing validated `Destination` values for
+    /// - Returns: Validated `SwiftSDKBundle` containing validated `Destination` values for
     /// each artifact and its variants.
     private static func parseAndValidate(
         bundlePath: AbsolutePath,
@@ -319,7 +319,7 @@ public struct SwiftSDKBundle {
             rootPath: bundlePath
         )
 
-        return try parsedManifest.validateDestinationBundle(
+        return try parsedManifest.validateSwiftSDKBundle(
             bundlePath: bundlePath,
             fileSystem: fileSystem,
             observabilityScope: observabilityScope
@@ -328,7 +328,7 @@ public struct SwiftSDKBundle {
 }
 
 extension ArtifactsArchiveMetadata {
-    fileprivate func validateDestinationBundle(
+    fileprivate func validateSwiftSDKBundle(
         bundlePath: AbsolutePath,
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope

--- a/Sources/SwiftSDKTool/Configuration/ConfigurationSubcommand.swift
+++ b/Sources/SwiftSDKTool/Configuration/ConfigurationSubcommand.swift
@@ -17,63 +17,63 @@ import PackageModel
 import struct TSCBasic.AbsolutePath
 
 protocol ConfigurationSubcommand: SwiftSDKSubcommand {
-    /// An identifier of an already installed destination.
-    var destinationID: String { get }
+    /// An identifier of an already installed Swift SDK.
+    var sdkID: String { get }
 
-    /// A run-time triple of the destination specified by `destinationID` identifier string.
-    var runTimeTriple: String { get }
+    /// A target triple of the destination.
+    var targetTriple: String { get }
 
     /// Run a command related to configuration of cross-compilation destinations, passing it required configuration
     /// values.
     /// - Parameters:
-    ///   - buildTimeTriple: triple of the machine this command is running on.
-    ///   - runTimeTriple: triple of the machine on which cross-compiled code will run on.
+    ///   - hostTriple: triple of the machine this command is running on.
+    ///   - targetTriple: triple of the machine on which cross-compiled code will run on.
     ///   - destination: destination configuration fetched that matches currently set `destinationID` and
-    ///   `runTimeTriple`.
+    ///   `targetTriple`.
     ///   - configurationStore: storage for configuration properties that this command operates on.
-    ///   - destinationsDirectory: directory containing destination artifact bundles and their configuration.
+    ///   - swiftSDKsDirectory: directory containing Swift SDK artifact bundles and their configuration.
     ///   - observabilityScope: observability scope used for logging.
     func run(
-        buildTimeTriple: Triple,
-        runTimeTriple: Triple,
+        hostTriple: Triple,
+        targetTriple: Triple,
         _ destination: Destination,
         _ configurationStore: SwiftSDKConfigurationStore,
-        _ destinationsDirectory: AbsolutePath,
+        _ swiftSDKsDirectory: AbsolutePath,
         _ observabilityScope: ObservabilityScope
     ) throws
 }
 
 extension ConfigurationSubcommand {
     func run(
-        buildTimeTriple: Triple,
-        _ destinationsDirectory: AbsolutePath,
+        hostTriple: Triple,
+        _ swiftSDKsDirectory: AbsolutePath,
         _ observabilityScope: ObservabilityScope
     ) throws {
         let configurationStore = try SwiftSDKConfigurationStore(
-            buildTimeTriple: buildTimeTriple,
-            destinationsDirectoryPath: destinationsDirectory,
+            hostTimeTriple: hostTriple,
+            swiftSDKsDirectoryPath: swiftSDKsDirectory,
             fileSystem: fileSystem,
             observabilityScope: observabilityScope
         )
-        let runTimeTriple = try Triple(self.runTimeTriple)
+        let targetTriple = try Triple(self.targetTriple)
 
         guard let destination = try configurationStore.readConfiguration(
-            destinationID: destinationID,
-            runTimeTriple: runTimeTriple
+            sdkID: sdkID,
+            targetTriple: targetTriple
         ) else {
-            throw DestinationError.destinationNotFound(
-                artifactID: destinationID,
-                builtTimeTriple: buildTimeTriple,
-                runTimeTriple: runTimeTriple
+            throw SwiftSDKError.swiftSDKNotFound(
+                artifactID: sdkID,
+                hostTriple: hostTriple,
+                targetTriple: targetTriple
             )
         }
 
         try run(
-            buildTimeTriple: buildTimeTriple,
-            runTimeTriple: runTimeTriple,
+            hostTriple: hostTriple,
+            targetTriple: targetTriple,
             destination,
             configurationStore,
-            destinationsDirectory,
+            swiftSDKsDirectory,
             observabilityScope
         )
     }

--- a/Sources/SwiftSDKTool/Configuration/ResetConfiguration.swift
+++ b/Sources/SwiftSDKTool/Configuration/ResetConfiguration.swift
@@ -53,14 +53,14 @@ struct ResetConfiguration: ConfigurationSubcommand {
         identifiers.
         """
     )
-    var destinationID: String
+    var sdkID: String
 
     @Argument(help: "A run-time triple of the destination specified by `destination-id` identifier string.")
-    var runTimeTriple: String
+    var targetTriple: String
 
     func run(
-        buildTimeTriple: Triple,
-        runTimeTriple: Triple,
+        hostTriple: Triple,
+        targetTriple: Triple,
         _ destination: Destination,
         _ configurationStore: SwiftSDKConfigurationStore,
         _ destinationsDirectory: AbsolutePath,
@@ -107,27 +107,27 @@ struct ResetConfiguration: ConfigurationSubcommand {
         }
 
         if shouldResetAll {
-            if try !configurationStore.resetConfiguration(destinationID: destinationID, runTimeTriple: runTimeTriple) {
+            if try !configurationStore.resetConfiguration(sdkID: sdkID, targetTriple: targetTriple) {
                 observabilityScope.emit(
-                    warning: "No configuration for destination \(destinationID)"
+                    warning: "No configuration for destination \(sdkID)"
                 )
             } else {
                 observabilityScope.emit(
                     info: """
-                    All configuration properties of destination `\(destinationID) for run-time triple \
-                    `\(runTimeTriple)` were successfully reset.
+                    All configuration properties of destination `\(sdkID) for run-time triple \
+                    `\(targetTriple)` were successfully reset.
                     """
                 )
             }
         } else {
             var destination = destination
             destination.pathsConfiguration = configuration
-            try configurationStore.updateConfiguration(destinationID: destinationID, destination: destination)
+            try configurationStore.updateConfiguration(sdkID: sdkID, destination: destination)
 
             observabilityScope.emit(
                 info: """
-                These properties of destination `\(destinationID) for run-time triple \
-                `\(runTimeTriple)` were successfully reset: \(resetProperties.joined(separator: ", ")).
+                These properties of destination `\(sdkID) for run-time triple \
+                `\(targetTriple)` were successfully reset: \(resetProperties.joined(separator: ", ")).
                 """
             )
         }

--- a/Sources/SwiftSDKTool/Configuration/SetConfiguration.swift
+++ b/Sources/SwiftSDKTool/Configuration/SetConfiguration.swift
@@ -69,14 +69,14 @@ struct SetConfiguration: ConfigurationSubcommand {
         identifiers.
         """
     )
-    var destinationID: String
+    var sdkID: String
 
     @Argument(help: "The run-time triple of the destination to configure.")
-    var runTimeTriple: String
+    var targetTriple: String
 
     func run(
-        buildTimeTriple: Triple,
-        runTimeTriple: Triple,
+        hostTriple: Triple,
+        targetTriple: Triple,
         _ destination: Destination,
         _ configurationStore: SwiftSDKConfigurationStore,
         _ destinationsDirectory: AbsolutePath,
@@ -125,7 +125,7 @@ struct SetConfiguration: ConfigurationSubcommand {
         guard !updatedProperties.isEmpty else {
             observabilityScope.emit(
                 error: """
-                No properties of destination `\(destinationID) for run-time triple `\(runTimeTriple)` were updated \
+                No properties of destination `\(sdkID) for run-time triple `\(targetTriple)` were updated \
                 since none were specified. Pass `--help` flag to see the list of all available properties.
                 """
             )
@@ -134,12 +134,12 @@ struct SetConfiguration: ConfigurationSubcommand {
 
         var destination = destination
         destination.pathsConfiguration = configuration
-        try configurationStore.updateConfiguration(destinationID: destinationID, destination: destination)
+        try configurationStore.updateConfiguration(sdkID: sdkID, destination: destination)
 
         observabilityScope.emit(
             info: """
-            These properties of destination `\(destinationID) for run-time triple \
-            `\(runTimeTriple)` were successfully updated: \(updatedProperties.joined(separator: ", ")).
+            These properties of destination `\(sdkID) for run-time triple \
+            `\(targetTriple)` were successfully updated: \(updatedProperties.joined(separator: ", ")).
             """
         )
     }

--- a/Sources/SwiftSDKTool/Configuration/ShowConfiguration.swift
+++ b/Sources/SwiftSDKTool/Configuration/ShowConfiguration.swift
@@ -34,14 +34,14 @@ struct ShowConfiguration: ConfigurationSubcommand {
         identifiers.
         """
     )
-    var destinationID: String
+    var sdkID: String
 
     @Argument(help: "The run-time triple of the destination to configure.")
-    var runTimeTriple: String
+    var targetTriple: String
 
     func run(
-        buildTimeTriple: Triple,
-        runTimeTriple: Triple,
+        hostTriple: Triple,
+        targetTriple: Triple,
         _ destination: Destination,
         _ configurationStore: SwiftSDKConfigurationStore,
         _ destinationsDirectory: AbsolutePath,

--- a/Sources/SwiftSDKTool/InstallSwiftSDK.swift
+++ b/Sources/SwiftSDKTool/InstallSwiftSDK.swift
@@ -39,7 +39,7 @@ public struct InstallSwiftSDK: SwiftSDKSubcommand {
     public init() {}
 
     func run(
-        buildTimeTriple: Triple,
+        hostTriple: Triple,
         _ destinationsDirectory: AbsolutePath,
         _ observabilityScope: ObservabilityScope
     ) throws {

--- a/Sources/SwiftSDKTool/ListSwiftSDKs.swift
+++ b/Sources/SwiftSDKTool/ListSwiftSDKs.swift
@@ -33,7 +33,7 @@ public struct ListSwiftSDKs: SwiftSDKSubcommand {
     public init() {}
 
     func run(
-        buildTimeTriple: Triple,
+        hostTriple: Triple,
         _ destinationsDirectory: AbsolutePath,
         _ observabilityScope: ObservabilityScope
     ) throws {

--- a/Sources/SwiftSDKTool/RemoveSwiftSDK.swift
+++ b/Sources/SwiftSDKTool/RemoveSwiftSDK.swift
@@ -34,7 +34,7 @@ public struct RemoveSwiftSDK: SwiftSDKSubcommand {
     public init() {}
 
     func run(
-        buildTimeTriple: Triple,
+        hostTriple: Triple,
         _ destinationsDirectory: AbsolutePath,
         _ observabilityScope: ObservabilityScope
     ) throws {

--- a/Sources/SwiftSDKTool/RemoveSwiftSDK.swift
+++ b/Sources/SwiftSDKTool/RemoveSwiftSDK.swift
@@ -38,8 +38,8 @@ public struct RemoveSwiftSDK: SwiftSDKSubcommand {
         _ destinationsDirectory: AbsolutePath,
         _ observabilityScope: ObservabilityScope
     ) throws {
-        let destinationsDirectory = try self.getOrCreateDestinationsDirectory()
-        let artifactBundleDirectory = destinationsDirectory.appending(component: self.sdkIDOrBundleName)
+        let swiftSDKsDirectory = try self.getOrCreateSwiftSDKsDirectory()
+        let artifactBundleDirectory = swiftSDKsDirectory.appending(component: self.sdkIDOrBundleName)
 
         let removedBundleDirectory: AbsolutePath
         if fileSystem.exists(artifactBundleDirectory) {
@@ -48,7 +48,7 @@ public struct RemoveSwiftSDK: SwiftSDKSubcommand {
             removedBundleDirectory = artifactBundleDirectory
         } else {
             let bundles = try SwiftSDKBundle.getAllValidBundles(
-                swiftSDKsDirectory: destinationsDirectory,
+                swiftSDKsDirectory: swiftSDKsDirectory,
                 fileSystem: fileSystem,
                 observabilityScope: observabilityScope
             )

--- a/Sources/SwiftSDKTool/SwiftSDKSubcommand.swift
+++ b/Sources/SwiftSDKTool/SwiftSDKSubcommand.swift
@@ -28,12 +28,12 @@ protocol SwiftSDKSubcommand: ParsableCommand {
 
     /// Run a command operating on cross-compilation destinations, passing it required configuration values.
     /// - Parameters:
-    ///   - buildTimeTriple: triple of the machine this command is running on.
-    ///   - destinationsDirectory: directory containing destination artifact bundles and their configuration.
+    ///   - hostTriple: triple of the machine this command is running on.
+    ///   - swiftSDKsDirectory: directory containing Swift SDK artifact bundles and their configuration.
     ///   - observabilityScope: observability scope used for logging.
     func run(
-        buildTimeTriple: Triple,
-        _ destinationsDirectory: AbsolutePath,
+        hostTriple: Triple,
+        _ swiftSDKsDirectory: AbsolutePath,
         _ observabilityScope: ObservabilityScope
     ) throws
 }

--- a/Sources/SwiftSDKTool/SwiftSDKSubcommand.swift
+++ b/Sources/SwiftSDKTool/SwiftSDKSubcommand.swift
@@ -45,7 +45,7 @@ extension SwiftSDKSubcommand {
     /// Parses destinations directory option if provided or uses the default path for cross-compilation destinations
     /// on the file system. A new directory at this path is created if one doesn't exist already.
     /// - Returns: existing or a newly created directory at the computed location.
-    func getOrCreateDestinationsDirectory() throws -> AbsolutePath {
+    func getOrCreateSwiftSDKsDirectory() throws -> AbsolutePath {
         guard var destinationsDirectory = try fileSystem.getSharedSwiftSDKsDirectory(
             explicitDirectory: locations.swiftSDKsDirectory
         ) else {
@@ -66,14 +66,14 @@ extension SwiftSDKSubcommand {
         let observabilityHandler = SwiftToolObservabilityHandler(outputStream: stdoutStream, logLevel: .info)
         let observabilitySystem = ObservabilitySystem(observabilityHandler)
         let observabilityScope = observabilitySystem.topScope
-        let destinationsDirectory = try self.getOrCreateDestinationsDirectory()
+        let swiftSDKsDirectory = try self.getOrCreateSwiftSDKsDirectory()
 
         let hostToolchain = try UserToolchain(destination: Destination.hostDestination())
         let triple = try Triple.getHostTriple(usingSwiftCompiler: hostToolchain.swiftCompilerPath)
 
         var commandError: Error? = nil
         do {
-            try self.run(buildTimeTriple: triple, destinationsDirectory, observabilityScope)
+            try self.run(hostTriple: triple, swiftSDKsDirectory, observabilityScope)
             if observabilityScope.errorsReported {
                 throw ExitCode.failure
             }

--- a/Tests/PackageModelTests/DestinationTests.swift
+++ b/Tests/PackageModelTests/DestinationTests.swift
@@ -136,6 +136,81 @@ private let invalidToolsetDestinationV3 = (
     """#)
 )
 
+private let toolsetNoRootSwiftSDKv4 = (
+    path: "\(bundleRootPath)/toolsetNoRootSwiftSDKv4.json",
+    json: #"""
+    {
+        "targetTriples": {
+            "\#(linuxGNUTargetTriple.tripleString)": {
+                "sdkRootPath": "\#(sdkRootDir)",
+                "toolsetPaths": ["/tools/otherToolsNoRoot.json"]
+            }
+        },
+        "schemaVersion": "4.0"
+    }
+    """#
+)
+
+private let toolsetRootSwiftSDKv4 = (
+    path: "\(bundleRootPath)/toolsetRootSwiftSDKv4.json",
+    json: #"""
+    {
+        "targetTriples": {
+            "\#(linuxGNUTargetTriple.tripleString)": {
+                "sdkRootPath": "\#(sdkRootDir)",
+                "toolsetPaths": ["/tools/someToolsWithRoot.json", "/tools/otherToolsNoRoot.json"]
+            }
+        },
+        "schemaVersion": "4.0"
+    }
+    """#
+)
+
+private let missingToolsetSwiftSDKv4 = (
+    path: "\(bundleRootPath)/missingToolsetSwiftSDKv4.json",
+    json: #"""
+    {
+        "targetTriples": {
+            "\#(linuxGNUTargetTriple.tripleString)": {
+                "sdkRootPath": "\#(sdkRootDir)",
+                "toolsetPaths": ["/tools/asdf.json"]
+            }
+        },
+        "schemaVersion": "4.0"
+    }
+    """#
+)
+
+private let invalidVersionSwiftSDKv4 = (
+    path: "\(bundleRootPath)/invalidVersionSwiftSDKv4.json",
+    json: #"""
+    {
+        "targetTriples": {
+            "\#(linuxGNUTargetTriple.tripleString)": {
+                "sdkRootPath": "\#(sdkRootDir)",
+                "toolsetPaths": ["/tools/someToolsWithRoot.json"]
+            }
+        },
+        "schemaVersion": "42.9"
+    }
+    """#
+)
+
+private let invalidToolsetSwiftSDKv4 = (
+    path: "\(bundleRootPath)/invalidToolsetSwiftSDKv4.json",
+    json: #"""
+    {
+        "targetTriples": {
+            "\#(linuxGNUTargetTriple.tripleString)": {
+                "sdkRootPath": "\#(sdkRootDir)",
+                "toolsetPaths": ["/tools/invalidToolset.json"]
+            }
+        },
+        "schemaVersion": "4.0"
+    }
+    """#
+)
+
 private let usrBinTools = Dictionary(uniqueKeysWithValues: Toolset.KnownTool.allCases.map {
     ($0, try! AbsolutePath(validating: "/usr/bin/\($0.rawValue)"))
 })
@@ -215,7 +290,7 @@ private let parsedDestinationV2Musl = Destination(
     pathsConfiguration: .init(sdkRootPath: sdkRootAbsolutePath)
 )
 
-private let parsedToolsetNoRootDestinationV3 = Destination(
+private let parsedToolsetNoRootDestination = Destination(
     targetTriple: linuxGNUTargetTriple,
     toolset: .init(
         knownTools: [
@@ -232,7 +307,7 @@ private let parsedToolsetNoRootDestinationV3 = Destination(
     )
 )
 
-private let parsedToolsetRootDestinationV3 = Destination(
+private let parsedToolsetRootDestination = Destination(
     targetTriple: linuxGNUTargetTriple,
     toolset: .init(
         knownTools: [
@@ -264,6 +339,11 @@ final class DestinationTests: XCTestCase {
             missingToolsetDestinationV3,
             invalidVersionDestinationV3,
             invalidToolsetDestinationV3,
+            toolsetNoRootSwiftSDKv4,
+            toolsetRootSwiftSDKv4,
+            missingToolsetSwiftSDKv4,
+            invalidVersionSwiftSDKv4,
+            invalidToolsetSwiftSDKv4,
             otherToolsNoRoot,
             someToolsWithRoot,
             invalidToolset,
@@ -310,7 +390,7 @@ final class DestinationTests: XCTestCase {
             observabilityScope: observability
         )
 
-        XCTAssertEqual(toolsetNoRootDestinationV3Decoded, [parsedToolsetNoRootDestinationV3])
+        XCTAssertEqual(toolsetNoRootDestinationV3Decoded, [parsedToolsetNoRootDestination])
 
         let toolsetRootDestinationV3Decoded = try Destination.decode(
             fromFile: toolsetRootDestinationV3.path,
@@ -318,7 +398,7 @@ final class DestinationTests: XCTestCase {
             observabilityScope: observability
         )
 
-        XCTAssertEqual(toolsetRootDestinationV3Decoded, [parsedToolsetRootDestinationV3])
+        XCTAssertEqual(toolsetRootDestinationV3Decoded, [parsedToolsetRootDestination])
 
         XCTAssertThrowsError(try Destination.decode(
             fromFile: missingToolsetDestinationV3.path,
@@ -343,6 +423,54 @@ final class DestinationTests: XCTestCase {
 
         XCTAssertThrowsError(try Destination.decode(
             fromFile: invalidToolsetDestinationV3.path,
+            fileSystem: fs,
+            observabilityScope: observability
+        )) {
+            XCTAssertTrue(
+                ($0 as? StringError)?.description
+                    .hasPrefix("Couldn't parse toolset configuration at `/tools/invalidToolset.json`: ") ?? false
+            )
+        }
+
+        let toolsetNoRootSwiftSDKv4Decoded = try Destination.decode(
+            fromFile: AbsolutePath(validating: toolsetNoRootSwiftSDKv4.path),
+            fileSystem: fs,
+            observabilityScope: observability
+        )
+
+        XCTAssertEqual(toolsetNoRootSwiftSDKv4Decoded, [parsedToolsetNoRootDestination])
+
+        let toolsetRootSwiftSDKv4Decoded = try Destination.decode(
+            fromFile: AbsolutePath(validating: toolsetRootSwiftSDKv4.path),
+            fileSystem: fs,
+            observabilityScope: observability
+        )
+
+        XCTAssertEqual(toolsetRootSwiftSDKv4Decoded, [parsedToolsetRootDestination])
+
+        XCTAssertThrowsError(try Destination.decode(
+            fromFile: AbsolutePath(validating: missingToolsetSwiftSDKv4.path),
+            fileSystem: fs,
+            observabilityScope: observability
+        )) {
+            XCTAssertEqual(
+                $0 as? StringError,
+                StringError(
+                    """
+                    Couldn't parse toolset configuration at `/tools/asdf.json`: /tools/asdf.json doesn't exist in file \
+                    system
+                    """
+                )
+            )
+        }
+        XCTAssertThrowsError(try Destination.decode(
+            fromFile: AbsolutePath(validating: invalidVersionSwiftSDKv4.path),
+            fileSystem: fs,
+            observabilityScope: observability
+        ))
+
+        XCTAssertThrowsError(try Destination.decode(
+            fromFile: AbsolutePath(validating: invalidToolsetSwiftSDKv4.path),
             fileSystem: fs,
             observabilityScope: observability
         )) {

--- a/Tests/PackageModelTests/DestinationTests.swift
+++ b/Tests/PackageModelTests/DestinationTests.swift
@@ -137,8 +137,8 @@ private let invalidToolsetDestinationV3 = (
 )
 
 private let toolsetNoRootSwiftSDKv4 = (
-    path: "\(bundleRootPath)/toolsetNoRootSwiftSDKv4.json",
-    json: #"""
+    path: try! AbsolutePath(validating: "\(bundleRootPath)/toolsetNoRootSwiftSDKv4.json"),
+    json: ByteString(encodingAsUTF8: #"""
     {
         "targetTriples": {
             "\#(linuxGNUTargetTriple.tripleString)": {
@@ -148,12 +148,12 @@ private let toolsetNoRootSwiftSDKv4 = (
         },
         "schemaVersion": "4.0"
     }
-    """#
+    """#)
 )
 
 private let toolsetRootSwiftSDKv4 = (
-    path: "\(bundleRootPath)/toolsetRootSwiftSDKv4.json",
-    json: #"""
+    path: try! AbsolutePath(validating: "\(bundleRootPath)/toolsetRootSwiftSDKv4.json"),
+    json: ByteString(encodingAsUTF8: #"""
     {
         "targetTriples": {
             "\#(linuxGNUTargetTriple.tripleString)": {
@@ -163,12 +163,12 @@ private let toolsetRootSwiftSDKv4 = (
         },
         "schemaVersion": "4.0"
     }
-    """#
+    """#)
 )
 
 private let missingToolsetSwiftSDKv4 = (
-    path: "\(bundleRootPath)/missingToolsetSwiftSDKv4.json",
-    json: #"""
+    path: try! AbsolutePath(validating: "\(bundleRootPath)/missingToolsetSwiftSDKv4.json"),
+    json: ByteString(encodingAsUTF8: #"""
     {
         "targetTriples": {
             "\#(linuxGNUTargetTriple.tripleString)": {
@@ -178,12 +178,12 @@ private let missingToolsetSwiftSDKv4 = (
         },
         "schemaVersion": "4.0"
     }
-    """#
+    """#)
 )
 
 private let invalidVersionSwiftSDKv4 = (
-    path: "\(bundleRootPath)/invalidVersionSwiftSDKv4.json",
-    json: #"""
+    path: try! AbsolutePath(validating: "\(bundleRootPath)/invalidVersionSwiftSDKv4.json"),
+    json: ByteString(encodingAsUTF8: #"""
     {
         "targetTriples": {
             "\#(linuxGNUTargetTriple.tripleString)": {
@@ -193,12 +193,12 @@ private let invalidVersionSwiftSDKv4 = (
         },
         "schemaVersion": "42.9"
     }
-    """#
+    """#)
 )
 
 private let invalidToolsetSwiftSDKv4 = (
-    path: "\(bundleRootPath)/invalidToolsetSwiftSDKv4.json",
-    json: #"""
+    path: try! AbsolutePath(validating: "\(bundleRootPath)/invalidToolsetSwiftSDKv4.json"),
+    json: ByteString(encodingAsUTF8: #"""
     {
         "targetTriples": {
             "\#(linuxGNUTargetTriple.tripleString)": {
@@ -208,7 +208,7 @@ private let invalidToolsetSwiftSDKv4 = (
         },
         "schemaVersion": "4.0"
     }
-    """#
+    """#)
 )
 
 private let usrBinTools = Dictionary(uniqueKeysWithValues: Toolset.KnownTool.allCases.map {
@@ -331,7 +331,7 @@ final class DestinationTests: XCTestCase {
         try fs.createDirectory(.init(validating: "/tools"))
         try fs.createDirectory(.init(validating: "/tmp"))
         try fs.createDirectory(.init(validating: "\(bundleRootPath)"))
-        for testFile in [
+        let arr: [(path: AbsolutePath, json: ByteString)] = [
             destinationV1,
             destinationV2,
             toolsetNoRootDestinationV3,
@@ -347,7 +347,8 @@ final class DestinationTests: XCTestCase {
             otherToolsNoRoot,
             someToolsWithRoot,
             invalidToolset,
-        ] {
+        ]
+        for testFile in arr {
             try fs.writeFileContents(testFile.path, bytes: testFile.json)
         }
 
@@ -433,7 +434,7 @@ final class DestinationTests: XCTestCase {
         }
 
         let toolsetNoRootSwiftSDKv4Decoded = try Destination.decode(
-            fromFile: AbsolutePath(validating: toolsetNoRootSwiftSDKv4.path),
+            fromFile: toolsetNoRootSwiftSDKv4.path,
             fileSystem: fs,
             observabilityScope: observability
         )
@@ -441,7 +442,7 @@ final class DestinationTests: XCTestCase {
         XCTAssertEqual(toolsetNoRootSwiftSDKv4Decoded, [parsedToolsetNoRootDestination])
 
         let toolsetRootSwiftSDKv4Decoded = try Destination.decode(
-            fromFile: AbsolutePath(validating: toolsetRootSwiftSDKv4.path),
+            fromFile: toolsetRootSwiftSDKv4.path,
             fileSystem: fs,
             observabilityScope: observability
         )
@@ -449,7 +450,7 @@ final class DestinationTests: XCTestCase {
         XCTAssertEqual(toolsetRootSwiftSDKv4Decoded, [parsedToolsetRootDestination])
 
         XCTAssertThrowsError(try Destination.decode(
-            fromFile: AbsolutePath(validating: missingToolsetSwiftSDKv4.path),
+            fromFile: missingToolsetSwiftSDKv4.path,
             fileSystem: fs,
             observabilityScope: observability
         )) {
@@ -464,13 +465,13 @@ final class DestinationTests: XCTestCase {
             )
         }
         XCTAssertThrowsError(try Destination.decode(
-            fromFile: AbsolutePath(validating: invalidVersionSwiftSDKv4.path),
+            fromFile: invalidVersionSwiftSDKv4.path,
             fileSystem: fs,
             observabilityScope: observability
         ))
 
         XCTAssertThrowsError(try Destination.decode(
-            fromFile: AbsolutePath(validating: invalidToolsetSwiftSDKv4.path),
+            fromFile: invalidToolsetSwiftSDKv4.path,
             fileSystem: fs,
             observabilityScope: observability
         )) {

--- a/Tests/PackageModelTests/SwiftSDKBundleTests.swift
+++ b/Tests/PackageModelTests/SwiftSDKBundleTests.swift
@@ -118,7 +118,7 @@ final class SwiftSDKBundleTests: XCTestCase {
 
             XCTFail("Function expected to throw")
         } catch {
-            guard let error = error as? DestinationError else {
+            guard let error = error as? SwiftSDKError else {
                 XCTFail("Unexpected error type")
                 return
             }
@@ -142,13 +142,13 @@ final class SwiftSDKBundleTests: XCTestCase {
 
             XCTFail("Function expected to throw")
         } catch {
-            guard let error = error as? DestinationError else {
+            guard let error = error as? SwiftSDKError else {
                 XCTFail("Unexpected error type")
                 return
             }
 
             switch error {
-            case .destinationBundleAlreadyInstalled(let installedBundleName):
+            case .swiftSDKBundleAlreadyInstalled(let installedBundleName):
                 XCTAssertEqual(bundles[0].name, installedBundleName)
             default:
                 XCTFail("Unexpected error value")
@@ -166,13 +166,13 @@ final class SwiftSDKBundleTests: XCTestCase {
 
              XCTFail("Function expected to throw")
          } catch {
-            guard let error = error as? DestinationError else {
+            guard let error = error as? SwiftSDKError else {
                 XCTFail("Unexpected error type")
                 return
             }
 
             switch error {
-            case .destinationArtifactAlreadyInstalled(let installedBundleName, let newBundleName, let artifactID):
+            case .swiftSDKArtifactAlreadyInstalled(let installedBundleName, let newBundleName, let artifactID):
                 XCTAssertEqual(bundles[0].name, installedBundleName)
                 XCTAssertEqual(bundles[1].name, newBundleName)
                 XCTAssertEqual(artifactID, testArtifactID)


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-package-manager/pull/6678

Introduced `SwiftSDKMetadataV4` type that uses `targetTriple` instead of `runTimeTriple`. We're keeping the previous v3 schema for better error handling in case v3 schema ended up being used in the wild during Swift 5.9 development cycle. The plan is to deprecate v3 and earlier schemas in a future change.

`buildTimeTriple` and `runTimeTriple` renamed to `hostTriple` and `targetTriple` across the codebase, destinations renamed to Swift SDKs where possible without a broader disruption. Full renaming of the `Destination` type to `SwiftSDK` would come in a separate change to reduce the diff for this one.
