### PR TITLE
Remove extra paths added to LD_LIBRARY_PATH on Linux when running tests

### DIFF
--- a/Sources/Commands/Utilities/TestingSupport.swift
+++ b/Sources/Commands/Utilities/TestingSupport.swift
@@ -157,16 +157,6 @@ enum TestingSupport {
         if let location = toolchain.xctestPath {
             env.prependPath("Path", value: location.pathString)
         }
-        #elseif os(Linux)
-        var libraryPaths = ["/usr/lib/swift/linux"]
-        if let path = env["PATH"], let firstPathEntry = path.components(separatedBy: ":").first {
-            libraryPaths.append("\(firstPathEntry)/../lib/swift/linux")
-        }
-        if let originalLibraryPaths = env["LD_LIBRARY_PATH"] {
-            libraryPaths.append(originalLibraryPaths)
-        }
-        // Pass this explicitly on Linux because XCTest started requiring it, rdar://103054033
-        env["LD_LIBRARY_PATH"] = libraryPaths.joined(separator: ":")
         #endif
         return env
         #else


### PR DESCRIPTION
These break running tests when there's already a swift on PATH that isn't the swift currently being run.

They were originally added as a workaround to (https://github.com/apple/swift-package-manager/pull/5952), but the RUNPATH looks correct (includes the library of the compiler that built the test and "$ORIGIN") and tests are working without it.
