### PR TITLE
Tests: adjust PackageModelTests for Windows

### DIFF
--- a/Tests/PackageModelTests/SwiftSDKTests.swift
+++ b/Tests/PackageModelTests/SwiftSDKTests.swift
@@ -408,12 +408,13 @@ final class DestinationTests: XCTestCase {
             fileSystem: fs,
             observabilityScope: observability
         )) {
+            let toolsetDefinition: AbsolutePath = "/tools/asdf.json"
             XCTAssertEqual(
                 $0 as? StringError,
                 StringError(
                     """
-                    Couldn't parse toolset configuration at `/tools/asdf.json`: /tools/asdf.json doesn't exist in file \
-                    system
+                    Couldn't parse toolset configuration at `\(toolsetDefinition)`: \
+                    \(toolsetDefinition) doesn't exist in file system
                     """
                 )
             )
@@ -429,9 +430,10 @@ final class DestinationTests: XCTestCase {
             fileSystem: fs,
             observabilityScope: observability
         )) {
+            let toolsetDefinition: AbsolutePath = "/tools/invalidToolset.json"
             XCTAssertTrue(
                 ($0 as? StringError)?.description
-                    .hasPrefix("Couldn't parse toolset configuration at `/tools/invalidToolset.json`: ") ?? false
+                    .hasPrefix("Couldn't parse toolset configuration at `\(toolsetDefinition)`: ") ?? false
             )
         }
 
@@ -456,12 +458,13 @@ final class DestinationTests: XCTestCase {
             fileSystem: fs,
             observabilityScope: observability
         )) {
+            let toolsetDefinition: AbsolutePath = "/tools/asdf.json"
             XCTAssertEqual(
                 $0 as? StringError,
                 StringError(
                     """
-                    Couldn't parse toolset configuration at `/tools/asdf.json`: /tools/asdf.json doesn't exist in file \
-                    system
+                    Couldn't parse toolset configuration at `\(toolsetDefinition)`: \
+                    \(toolsetDefinition) doesn't exist in file system
                     """
                 )
             )
@@ -477,9 +480,10 @@ final class DestinationTests: XCTestCase {
             fileSystem: fs,
             observabilityScope: observability
         )) {
+            let toolsetDefinition: AbsolutePath = "/tools/invalidToolset.json"
             XCTAssertTrue(
                 ($0 as? StringError)?.description
-                    .hasPrefix("Couldn't parse toolset configuration at `/tools/invalidToolset.json`: ") ?? false
+                    .hasPrefix("Couldn't parse toolset configuration at `\(toolsetDefinition)`: ") ?? false
             )
         }
     }


### PR DESCRIPTION
Adjust the path spelling for the native path arc separator and escaping
for the encoding in the JSON.  Windows uses `\` as the path arc
separator which needs to be escaped for ensuring that the JSON is valid.