### PR TITLE
PackageModel: honour `.librarian` for toolsets

### DIFF
--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -502,7 +502,7 @@ public final class UserToolchain: Toolchain {
         self.includeSearchPaths = destination.pathsConfiguration.includeSearchPaths ?? []
         self.librarySearchPaths = destination.pathsConfiguration.includeSearchPaths ?? []
 
-        self.librarianPath = try UserToolchain.determineLibrarian(
+        self.librarianPath = try destination.toolset.knownTools[.librarian]?.path ?? UserToolchain.determineLibrarian(
             triple: triple,
             binDirectories: destination.toolset.rootPaths,
             useXcrun: useXcrun,

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -3606,6 +3606,7 @@ final class BuildPlanTests: XCTestCase {
                 .cCompiler: .init(extraCLIOptions: [jsonFlag(tool: .cCompiler)]),
                 .cxxCompiler: .init(extraCLIOptions: [jsonFlag(tool: .cxxCompiler)]),
                 .swiftCompiler: .init(extraCLIOptions: [jsonFlag(tool: .swiftCompiler)]),
+                .librarian: .init(path: "/fake/toolchain/usr/bin/librarian"),
                 .linker: .init(extraCLIOptions: [jsonFlag(tool: .linker)]),
             ],
             rootPaths: try UserToolchain.default.destination.toolset.rootPaths)


### PR DESCRIPTION
When defining a custom toolset, a specified librarian shall be given precedence over the platform's librarian.  Use this to repair the toolset test on Windows where `ar` is unavailable.  This test used to succeed due to the leaking of the host tools.