### PR TITLE
tests: loosen expectations on WorkspaceTests

### DIFF
--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -242,9 +242,7 @@ final class WorkspaceTests: XCTestCase {
 
             testDiagnostics(observability.diagnostics) { result in
                 let diagnostic = result.check(
-                    diagnostic: .contains(
-                        "\(pkgDir.appending("Package.swift")):4:8: error: An error in MyPkg"
-                    ),
+                    diagnostic: .contains(":4:8: error: An error in MyPkg"),
                     severity: .error
                 )
                 XCTAssertEqual(diagnostic?.metadata?.packageIdentity, .init(path: pkgDir))


### PR DESCRIPTION
Some targets use pre-compiled manifests instead of interpretation.  Such a manifest will copy the `Package.swift` to `manifest.swift` and change the location.  As a result, the prefix expectation on the filename will fail.  Loosen the condition to accommodate the implementation.