### PR TITLE
Cache product => LLBuild target name mapping

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -125,11 +125,20 @@ extension BuildParameters {
 
     /// Computes the target triple arguments for a given resolved target.
     public func targetTripleArgs(for target: ResolvedTarget) throws -> [String] {
+        return try targetTripleArgs(targetName: target.name, macOSSupportedPlatform: target.platforms.getDerived(for: .macOS))
+    }
+
+    public func targetTripleArgs(for target: TargetInfo) throws -> [String] {
+        let macOSSupportedPlatform = target.derivedSupportedPlatforms.first(where: { $0.platform == .macOS })
+        return try targetTripleArgs(targetName: target.name, macOSSupportedPlatform: macOSSupportedPlatform)
+    }
+
+    private func targetTripleArgs(targetName: String, macOSSupportedPlatform: SupportedPlatform?) throws -> [String] {
         var args = ["-target"]
         // Compute the triple string for Darwin platform using the platform version.
         if targetTriple.isDarwin() {
-            guard let macOSSupportedPlatform = target.platforms.getDerived(for: .macOS) else {
-                throw StringError("the target \(target) doesn't support building for macOS")
+            guard let macOSSupportedPlatform = macOSSupportedPlatform else {
+                throw StringError("the target \(targetName) doesn't support building for macOS")
             }
             args += [targetTriple.tripleString(forPlatformVersion: macOSSupportedPlatform.version.versionString)]
         } else {

--- a/Sources/Build/CMakeLists.txt
+++ b/Sources/Build/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(Build
   BuildOperation.swift
   BuildPlan.swift
   LLBuildManifestBuilder.swift
+  LLBuildManifestInfo.swift
   SwiftCompilerOutputParser.swift)
 target_link_libraries(Build PUBLIC
   TSCBasic

--- a/Sources/Build/LLBuildManifestInfo.swift
+++ b/Sources/Build/LLBuildManifestInfo.swift
@@ -1,0 +1,157 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import PackageGraph
+import PackageModel
+import SPMBuildCore
+
+public enum LLBuildManifestInfo {
+    public struct Info: Codable, PackageGraphInfo {
+        let _products: [Product]
+        let _targets: [Target]
+
+        init(products: [Product], targets: [Target]) {
+            self._products = products
+            self._targets = targets
+        }
+
+        public var products: [ProductInfo] {
+            return _products
+        }
+
+        public var targets: [TargetInfo] {
+            return _targets
+        }
+
+        static func from(_ packageGraph: PackageGraph) -> Info {
+            return Info(
+                products: packageGraph.allProducts.compactMap {
+                    if let target = $0.targets.first, let package = packageGraph.package(for: target) {
+                        return try? .init($0, package)
+                    } else {
+                        return nil
+                    }
+                },
+                targets: packageGraph.allTargets.compactMap {
+                    if let package = packageGraph.package(for: $0) {
+                        return .init($0, package)
+                    } else {
+                        return nil
+                    }
+                }
+            )
+        }
+    }
+
+    public struct Product: Codable, ProductInfo {
+        private let _package: Package
+        public let name: String
+        public let type: ProductType
+        private let _targets: [Target]
+        let LLBuildTargetNameByConfig: [String: String]
+
+        private init(package: Package, name: String, type: ProductType, targets: [Target], LLBuildTargetNameByConfig: [String : String]) {
+            self._package = package
+            self.name = name
+            self.type = type
+            self._targets = targets
+            self.LLBuildTargetNameByConfig = LLBuildTargetNameByConfig
+        }
+
+        public var package: PackageInfo {
+            return _package
+        }
+
+        public var targets: [TargetInfo] {
+            return _targets
+        }
+    }
+
+    public struct Target: Codable, TargetInfo {
+        private let _package: Package
+        public let name: String
+        public let isSwiftTarget: Bool
+        public let c99name: String
+        public let sourcesDirectory: AbsolutePath?
+        public let derivedSupportedPlatforms: [SupportedPlatform]
+        public let type: PackageModel.Target.Kind
+        let LLBuildTargetNameByConfig: [String: String]
+
+        private init(package: Package, name: String, isSwiftTarget: Bool, c99name: String, sourcesDirectory: AbsolutePath?, derivedSupportedPlatforms: [SupportedPlatform], type: PackageModel.Target.Kind, LLBuildTargetNameByConfig: [String : String]) {
+            self._package = package
+            self.name = name
+            self.isSwiftTarget = isSwiftTarget
+            self.c99name = c99name
+            self.sourcesDirectory = sourcesDirectory
+            self.derivedSupportedPlatforms = derivedSupportedPlatforms
+            self.type = type
+            self.LLBuildTargetNameByConfig = LLBuildTargetNameByConfig
+        }
+
+        public var package: PackageInfo {
+            return _package
+        }
+    }
+
+    public struct Package: Codable, PackageInfo {
+        public let identity: String
+        public let isRoot: Bool
+    }
+}
+
+extension LLBuildManifestInfo.Product {
+    init(_ product: ResolvedProduct, _ package: ResolvedPackage) throws {
+        var LLBuildTargetNameByConfig = [String: String]()
+
+        // These types do not have LLBuild target names.
+        if product.type != .plugin && product.type != .library(.automatic) {
+            try BuildConfiguration.allCases.forEach {
+                LLBuildTargetNameByConfig[$0.rawValue] = try product.getLLBuildTargetName(config: $0.rawValue)
+            }
+        }
+
+        self.init(
+            package: .init(package),
+            name: product.name,
+            type: product.type,
+            targets: product.targets.map { .init($0, package) },
+            LLBuildTargetNameByConfig: LLBuildTargetNameByConfig
+        )
+    }
+}
+
+extension LLBuildManifestInfo.Target {
+    init(_ target: ResolvedTarget, _ package: ResolvedPackage) {
+        var LLBuildTargetNameByConfig = [String: String]()
+        BuildConfiguration.allCases.forEach {
+            LLBuildTargetNameByConfig[$0.rawValue] = target.getLLBuildTargetName(config: $0.rawValue)
+        }
+        
+        self.init(
+            package: .init(package),
+            name: target.name,
+            isSwiftTarget: target.underlyingTarget is SwiftTarget,
+            c99name: target.c99name,
+            sourcesDirectory: target.sources.paths.first?.parentDirectory,
+            derivedSupportedPlatforms: target.platforms.derived,
+            type: target.type,
+            LLBuildTargetNameByConfig: LLBuildTargetNameByConfig
+        )
+    }
+}
+
+extension LLBuildManifestInfo.Package {
+    init(_ package: ResolvedPackage) {
+        self.init(identity: package.identity.description, isRoot: package.manifest.packageKind.isRoot)
+    }
+}

--- a/Sources/Build/LLBuildManifestInfo.swift
+++ b/Sources/Build/LLBuildManifestInfo.swift
@@ -41,14 +41,14 @@ public enum LLBuildManifestInfo {
                     } else {
                         return nil
                     }
-                },
+                }.sorted(),
                 targets: packageGraph.allTargets.compactMap {
                     if let package = packageGraph.package(for: $0) {
                         return .init($0, package)
                     } else {
                         return nil
                     }
-                }
+                }.sorted()
             )
         }
     }
@@ -153,5 +153,33 @@ extension LLBuildManifestInfo.Target {
 extension LLBuildManifestInfo.Package {
     init(_ package: ResolvedPackage) {
         self.init(identity: package.identity.description, isRoot: package.manifest.packageKind.isRoot)
+    }
+}
+
+extension LLBuildManifestInfo.Product: Comparable {
+    public static func < (lhs: LLBuildManifestInfo.Product, rhs: LLBuildManifestInfo.Product) -> Bool {
+        if lhs.name == rhs.name {
+            return lhs.package.identity < rhs.package.identity
+        } else {
+            return lhs.name < rhs.name
+        }
+    }
+
+    public static func == (lhs: LLBuildManifestInfo.Product, rhs: LLBuildManifestInfo.Product) -> Bool {
+        return lhs.name == rhs.name && lhs.package.identity == rhs.package.identity
+    }
+}
+
+extension LLBuildManifestInfo.Target: Comparable {
+    public static func < (lhs: LLBuildManifestInfo.Target, rhs: LLBuildManifestInfo.Target) -> Bool {
+        if lhs.name == rhs.name {
+            return lhs.package.identity < rhs.package.identity
+        } else {
+            return lhs.name < rhs.name
+        }
+    }
+
+    public static func == (lhs: LLBuildManifestInfo.Target, rhs: LLBuildManifestInfo.Target) -> Bool {
+        return lhs.name == rhs.name && lhs.package.identity == rhs.package.identity
     }
 }

--- a/Sources/Commands/PackageTools/DumpCommands.swift
+++ b/Sources/Commands/PackageTools/DumpCommands.swift
@@ -66,7 +66,7 @@ struct DumpSymbolGraph: SwiftCommand {
         // Run the tool once for every library and executable target in the root package.
         let buildPlan = try buildSystem.buildPlan
         let symbolGraphDirectory = buildPlan.buildParameters.dataPath.appending("symbolgraph")
-        let targets = try buildSystem.getPackageGraph().rootPackages.flatMap{ $0.targets }.filter{ $0.type == .library || $0.type == .executable }
+        let targets = try buildSystem.getPackageGraphInfo().targets.filter{ $0.package.isRoot }.filter{ $0.type == .library || $0.type == .executable }
         for target in targets {
             print("-- Emitting symbol graph for", target.name)
             try symbolGraphExtractor.extractSymbolGraph(

--- a/Sources/Commands/Snippets/Cards/SnippetCard.swift
+++ b/Sources/Commands/Snippets/Cards/SnippetCard.swift
@@ -93,11 +93,11 @@ struct SnippetCard: Card {
 
     func runExample() throws {
         print("Building '\(snippet.path)'\n")
-        let buildSystem = try swiftTool.createBuildSystem(explicitProduct: snippet.name)
+        let buildSystem = try swiftTool.createBuildSystem(explicitBuildSystem: .native, explicitProduct: snippet.name)
         try buildSystem.build(subset: .product(snippet.name))
         let executablePath = try swiftTool.buildParameters().buildPath.appending(component: snippet.name)
-        if let exampleTarget = try buildSystem.getPackageGraph().allTargets.first(where: { $0.name == snippet.name }) {
-            try ProcessEnv.chdir(exampleTarget.sources.paths[0].parentDirectory)
+        if let exampleTarget = try buildSystem.getPackageGraphInfo().targets.first(where: { $0.name == snippet.name }) {
+            try ProcessEnv.chdir(exampleTarget.sourcesDirectory!)
         }
         try exec(path: executablePath.pathString, args: [])
     }

--- a/Sources/Commands/Utilities/APIDigester.swift
+++ b/Sources/Commands/Utilities/APIDigester.swift
@@ -316,6 +316,19 @@ extension PackageGraph {
     }
 }
 
+// FIXME: A bit unfortunate that we need to implement this on both `PackageGraph` and `PackageGraphInfo`
+extension PackageGraphInfo {
+    /// The list of modules that should be used as an input to the API digester.
+    var apiDigesterModules: [String] {
+        self.products
+            .filter { $0.package.isRoot }
+            .filter { $0.type.isLibrary }
+            .flatMap(\.targets)
+            .filter { $0.isSwiftTarget }
+            .map { $0.c99name }
+    }
+}
+
 extension SerializedDiagnostics.SourceLocation: DiagnosticLocation {
     public var description: String {
         return "\(filename):\(line):\(column)"

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -329,8 +329,8 @@ final class PluginDelegate: PluginInvocationDelegate {
         let buildSystem = try swiftTool.createBuildSystem(explicitBuildSystem: .native, cacheBuildManifest: false)
 
         // Find the target in the build operation's package graph; it's an error if we don't find it.
-        let packageGraph = try buildSystem.getPackageGraph()
-        guard let target = packageGraph.allTargets.first(where: { $0.name == targetName }) else {
+        let packageGraphInfo = try buildSystem.getPackageGraphInfo()
+        guard let target = packageGraphInfo.targets.first(where: { $0.name == targetName }) else {
             throw StringError("could not find a target named “\(targetName)”")
         }
 
@@ -361,12 +361,9 @@ final class PluginDelegate: PluginInvocationDelegate {
         symbolGraphExtractor.emitExtensionBlockSymbols = options.emitExtensionBlocks
 
         // Determine the output directory, and remove any old version if it already exists.
-        guard let package = packageGraph.package(for: target) else {
-            throw StringError("could not determine the package for target “\(target.name)”")
-        }
         let outputDir = try buildSystem.buildPlan.buildParameters.dataPath.appending(
             components: "extracted-symbols",
-            package.identity.description,
+            target.package.identity,
             target.name
         )
         try swiftTool.fileSystem.removeFileTree(outputDir)

--- a/Sources/Commands/Utilities/SymbolGraphExtract.swift
+++ b/Sources/Commands/Utilities/SymbolGraphExtract.swift
@@ -47,7 +47,7 @@ public struct SymbolGraphExtract {
     
     /// Creates a symbol graph for `target` in `outputDirectory` using the build information from `buildPlan`. The `outputDirection` determines how the output from the tool subprocess is handled, and `verbosity` specifies how much console output to ask the tool to emit.
     public func extractSymbolGraph(
-        target: ResolvedTarget,
+        target: TargetInfo,
         buildPlan: BuildPlan,
         outputRedirection: TSCBasic.Process.OutputRedirection = .none,
         outputDirectory: AbsolutePath,

--- a/Sources/SPMBuildCore/BuildSystem.swift
+++ b/Sources/SPMBuildCore/BuildSystem.swift
@@ -41,8 +41,8 @@ public protocol BuildSystem: Cancellable {
     /// The test products that this build system will build.
     var builtTestProducts: [BuiltTestProduct] { get }
 
-    /// Returns the package graph used by the build system.
-    func getPackageGraph() throws -> PackageGraph
+    /// Returns information about the package graph used by the build system.
+    func getPackageGraphInfo() throws -> PackageGraphInfo
 
     /// Builds a subset of the package graph.
     /// - Parameters:

--- a/Sources/SPMBuildCore/CMakeLists.txt
+++ b/Sources/SPMBuildCore/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(SPMBuildCore
   BuildSystemCommand.swift
   BuildSystemDelegate.swift
   BuiltTestProduct.swift
+  PackageGraphInfo.swift
   PluginContextSerializer.swift
   PluginInvocation.swift
   PluginMessages.swift

--- a/Sources/SPMBuildCore/PackageGraphInfo.swift
+++ b/Sources/SPMBuildCore/PackageGraphInfo.swift
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import PackageModel
+
+public protocol PackageGraphInfo {
+    var products: [ProductInfo] { get }
+    var targets: [TargetInfo] { get }
+}
+
+public protocol ProductInfo {
+    var package: PackageInfo { get }
+    var name: String { get }
+    var type: ProductType { get }
+    var targets: [TargetInfo] { get }
+}
+
+public protocol TargetInfo {
+    var package: PackageInfo { get }
+    var name: String { get }
+    var type: Target.Kind { get }
+
+    var isSwiftTarget: Bool { get }
+    var c99name: String { get }
+    var derivedSupportedPlatforms: [SupportedPlatform] { get }
+
+    // note: this is only used by snippet targets and only accurate for them
+    var sourcesDirectory: AbsolutePath? { get }
+}
+
+public protocol PackageInfo {
+    var identity: String { get }
+    var isRoot: Bool { get }
+}

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -276,6 +276,11 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
             try packageGraphLoader()
         }
     }
+
+    public func getPackageGraphInfo() throws -> PackageGraphInfo {
+        // any functionality requiring this is already explicitly using the native build system only.
+        fatalError("not implemented")
+    }
 }
 
 struct XCBBuildParameters: Encodable {


### PR DESCRIPTION
Currently, using the `--product`/`--target` options will lead to SwiftPM re-resolving the package graph on every invocation, just in order to determine the names of the corresponding LLBuild target. We can cache that mapping when computing the build description, so that subsequent invocations can work like invoking `swift build` without a particular product/target.

rdar://111224467
