### PR TITLE
[5.9] Remove extra paths added to LD_LIBRARY_PATH on Linux when running tests

### DIFF
--- a/Sources/Commands/Utilities/TestingSupport.swift
+++ b/Sources/Commands/Utilities/TestingSupport.swift
@@ -141,16 +141,6 @@ enum TestingSupport {
         if let location = toolchain.xctestPath {
             env.prependPath("Path", value: location.pathString)
         }
-        #elseif os(Linux)
-        var libraryPaths = ["/usr/lib/swift/linux"]
-        if let path = env["PATH"], let firstPathEntry = path.components(separatedBy: ":").first {
-            libraryPaths.append("\(firstPathEntry)/../lib/swift/linux")
-        }
-        if let originalLibraryPaths = env["LD_LIBRARY_PATH"] {
-            libraryPaths.append(originalLibraryPaths)
-        }
-        // Pass this explicitly on Linux because XCTest started requiring it, rdar://103054033
-        env["LD_LIBRARY_PATH"] = libraryPaths.joined(separator: ":")
         #endif
         return env
         #else


### PR DESCRIPTION
* **Explanation**: Removes an old workaround that breaks running tests when there's already a swift on PATH that isn't the swift currently being run.
* **Scope**: `swift test` on Linux platforms
* **Risk**: Low, our tests would fail if this was still needed.
* **Testing**: Toolchain build and test on all Linux platforms.
* **Original PR**:  https://github.com/apple/swift-package-manager/pull/6684