### PR TITLE
[nfc] cleanup use of pins

### DIFF
--- a/Sources/Commands/PackageTools/Update.swift
+++ b/Sources/Commands/PackageTools/Update.swift
@@ -67,7 +67,7 @@ extension SwiftPackageTool {
             
             var report = "\(changes.count) dependenc\(changes.count == 1 ? "y has" : "ies have") changed\(changes.count > 0 ? ":" : ".")"
             for (package, change) in changes {
-                let currentVersion = pins.pinsMap[package.identity]?.state.description ?? ""
+                let currentVersion = pins.pins[package.identity]?.state.description ?? ""
                 switch change {
                 case let .added(state):
                     report += "\n"

--- a/Sources/PackageGraph/PinsStore.swift
+++ b/Sources/PackageGraph/PinsStore.swift
@@ -19,7 +19,7 @@ import enum TSCBasic.JSON
 import struct TSCUtility.Version
 
 public final class PinsStore {
-    public typealias PinsMap = [PackageIdentity: PinsStore.Pin]
+    public typealias Pins = [PackageIdentity: PinsStore.Pin]
 
     public struct Pin: Equatable {
         /// The package reference of the pinned dependency.
@@ -58,13 +58,8 @@ public final class PinsStore {
     private let _pins: ThreadSafeKeyValueStore<PackageIdentity, PinsStore.Pin>
 
     /// The current pins.
-
-    public var pinsMap: PinsMap {
+    public var pins: Pins {
         self._pins.get()
-    }
-
-    public var pins: AnySequence<Pin> {
-        AnySequence<Pin>(self.pinsMap.values)
     }
 
     /// Create a new pins store.
@@ -157,7 +152,7 @@ private struct PinsStorage {
         self.fileSystem = fileSystem
     }
 
-    func load(mirrors: DependencyMirrors) throws -> PinsStore.PinsMap {
+    func load(mirrors: DependencyMirrors) throws -> PinsStore.Pins {
         if !self.fileSystem.exists(self.path) {
             return [:]
         }
@@ -190,7 +185,7 @@ private struct PinsStorage {
     }
 
     func save(
-        pins: PinsStore.PinsMap,
+        pins: PinsStore.Pins,
         mirrors: DependencyMirrors,
         removeIfEmpty: Bool,
         toolsVersion: ToolsVersion
@@ -254,7 +249,7 @@ private struct PinsStorage {
         let version: Int
         let object: Container
 
-        init(pins: PinsStore.PinsMap, mirrors: DependencyMirrors) throws {
+        init(pins: PinsStore.Pins, mirrors: DependencyMirrors) throws {
             self.version = Self.version
             self.object = try .init(
                 pins: pins.values
@@ -356,7 +351,7 @@ private struct PinsStorage {
         let version: Int
         let pins: [Pin]
 
-        init(pins: PinsStore.PinsMap, mirrors: DependencyMirrors) throws {
+        init(pins: PinsStore.Pins, mirrors: DependencyMirrors) throws {
             self.version = Self.version
             self.pins = try pins.values
                 .sorted(by: { $0.packageRef.identity < $1.packageRef.identity })

--- a/Sources/PackageGraph/PubGrub/ContainerProvider.swift
+++ b/Sources/PackageGraph/PubGrub/ContainerProvider.swift
@@ -25,7 +25,7 @@ final class ContainerProvider {
     private let skipUpdate: Bool
 
     /// Reference to the pins store.
-    private let pinsMap: PinsStore.PinsMap
+    private let pins: PinsStore.Pins
 
     /// Observability scope to emit diagnostics with
     private let observabilityScope: ObservabilityScope
@@ -39,12 +39,12 @@ final class ContainerProvider {
     init(
         provider underlying: PackageContainerProvider,
         skipUpdate: Bool,
-        pinsMap: PinsStore.PinsMap,
+        pins: PinsStore.Pins,
         observabilityScope: ObservabilityScope
     ) {
         self.underlying = underlying
         self.skipUpdate = skipUpdate
-        self.pinsMap = pinsMap
+        self.pins = pins
         self.observabilityScope = observabilityScope
     }
 
@@ -84,7 +84,7 @@ final class ContainerProvider {
                 on: .sharedConcurrent
             ) { result in
                 let result = result.tryMap { container -> PubGrubPackageContainer in
-                    let pubGrubContainer = PubGrubPackageContainer(underlying: container, pinsMap: self.pinsMap)
+                    let pubGrubContainer = PubGrubPackageContainer(underlying: container, pins: self.pins)
                     // only cache positive results
                     self.containersCache[package] = pubGrubContainer
                     return pubGrubContainer
@@ -115,7 +115,7 @@ final class ContainerProvider {
                     defer { self.prefetches[identifier]?.leave() }
                     // only cache positive results
                     if case .success(let container) = result {
-                        self.containersCache[identifier] = PubGrubPackageContainer(underlying: container, pinsMap: self.pinsMap)
+                        self.containersCache[identifier] = PubGrubPackageContainer(underlying: container, pins: self.pins)
                     }
                 }
             }

--- a/Sources/PackageGraph/PubGrub/PubGrubDependencyResolver.swift
+++ b/Sources/PackageGraph/PubGrub/PubGrubDependencyResolver.swift
@@ -101,7 +101,7 @@ public struct PubGrubDependencyResolver {
     }
 
     /// Reference to the pins store, if provided.
-    private let pinsMap: PinsStore.PinsMap
+    private let pins: PinsStore.Pins
 
     /// The container provider used to load package containers.
     private let provider: ContainerProvider
@@ -120,20 +120,20 @@ public struct PubGrubDependencyResolver {
 
     public init(
         provider: PackageContainerProvider,
-        pinsMap: PinsStore.PinsMap = [:],
+        pins: PinsStore.Pins = [:],
         skipDependenciesUpdates: Bool = false,
         prefetchBasedOnResolvedFile: Bool = false,
         observabilityScope: ObservabilityScope,
         delegate: DependencyResolverDelegate? = nil
     ) {
         self.packageContainerProvider = provider
-        self.pinsMap = pinsMap
+        self.pins = pins
         self.skipDependenciesUpdates = skipDependenciesUpdates
         self.prefetchBasedOnResolvedFile = prefetchBasedOnResolvedFile
         self.provider = ContainerProvider(
             provider: self.packageContainerProvider,
             skipUpdate: self.skipDependenciesUpdates,
-            pinsMap: self.pinsMap,
+            pins: self.pins,
             observabilityScope: observabilityScope
         )
         self.delegate = delegate
@@ -189,7 +189,7 @@ public struct PubGrubDependencyResolver {
             // We avoid prefetching packages that are overridden since
             // otherwise we'll end up creating a repository container
             // for them.
-            let pins = self.pinsMap.values
+            let pins = self.pins.values
                 .map(\.packageRef)
                 .filter { !inputs.overriddenPackages.keys.contains($0) }
             self.provider.prefetch(containers: pins)
@@ -362,7 +362,7 @@ public struct PubGrubDependencyResolver {
             // latest commit on that branch. Note that if this revision-based dependency is
             // already a commit, then its pin entry doesn't matter in practice.
             let revisionForDependencies: String
-            if case .branch(revision, let pinRevision) = pinsMap[package.identity]?.state {
+            if case .branch(revision, let pinRevision) = self.pins[package.identity]?.state {
                 revisionForDependencies = pinRevision
 
                 // Mark the package as overridden with the pinned revision and record the branch as well.

--- a/Sources/PackageGraph/PubGrub/PubGrubPackageContainer.swift
+++ b/Sources/PackageGraph/PubGrub/PubGrubPackageContainer.swift
@@ -23,11 +23,11 @@ internal final class PubGrubPackageContainer {
     let underlying: PackageContainer
 
     /// Reference to the pins map.
-    private let pinsMap: PinsStore.PinsMap
+    private let pins: PinsStore.Pins
 
-    init(underlying: PackageContainer, pinsMap: PinsStore.PinsMap) {
+    init(underlying: PackageContainer, pins: PinsStore.Pins) {
         self.underlying = underlying
-        self.pinsMap = pinsMap
+        self.pins = pins
     }
 
     var package: PackageReference {
@@ -36,7 +36,7 @@ internal final class PubGrubPackageContainer {
 
     /// Returns the pinned version for this package, if any.
     var pinnedVersion: Version? {
-        switch self.pinsMap[self.underlying.package.identity]?.state {
+        switch self.pins[self.underlying.package.identity]?.state {
         case .version(let version, _):
             return version
         default:

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -758,11 +758,11 @@ public final class MockWorkspace {
         }
 
         public func check(notPresent name: String, file: StaticString = #file, line: UInt = #line) {
-            XCTAssertFalse(self.store.pinsMap.keys.contains(where: { $0.description == name }), "Unexpectedly found \(name) in Package.resolved", file: file, line: line)
+            XCTAssertFalse(self.store.pins.keys.contains(where: { $0.description == name }), "Unexpectedly found \(name) in Package.resolved", file: file, line: line)
         }
 
         public func check(dependency package: String, at state: State, file: StaticString = #file, line: UInt = #line) {
-            guard let pin = store.pinsMap.first(where: { $0.key.description == package })?.value else {
+            guard let pin = store.pins.first(where: { $0.key.description == package })?.value else {
                 XCTFail("Pin for \(package) not found", file: file, line: line)
                 return
             }
@@ -789,7 +789,7 @@ public final class MockWorkspace {
         }
 
         public func check(dependency package: String, url: String, file: StaticString = #file, line: UInt = #line) {
-            guard let pin = store.pinsMap.first(where: { $0.key.description == package })?.value else {
+            guard let pin = store.pins.first(where: { $0.key.description == package })?.value else {
                 XCTFail("Pin for \(package) not found", file: file, line: line)
                 return
             }

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -905,7 +905,7 @@ final class PackageToolTests: CommandsTestCase {
                 let pinsStore = try PinsStore(pinsFile: pinsFile, workingDirectory: fixturePath, fileSystem: localFileSystem, mirrors: .init())
                 let state = PinsStore.PinState.branch(name: "YOLO", revision: yoloRevision.identifier)
                 let identity = PackageIdentity(path: barPath)
-                XCTAssertEqual(pinsStore.pinsMap[identity]?.state, state)
+                XCTAssertEqual(pinsStore.pins[identity]?.state, state)
             }
 
             // Try to pin bar at a revision.
@@ -914,7 +914,7 @@ final class PackageToolTests: CommandsTestCase {
                 let pinsStore = try PinsStore(pinsFile: pinsFile, workingDirectory: fixturePath, fileSystem: localFileSystem, mirrors: .init())
                 let state = PinsStore.PinState.revision(yoloRevision.identifier)
                 let identity = PackageIdentity(path: barPath)
-                XCTAssertEqual(pinsStore.pinsMap[identity]?.state, state)
+                XCTAssertEqual(pinsStore.pins[identity]?.state, state)
             }
 
             // Try to pin bar at a bad revision.
@@ -956,7 +956,7 @@ final class PackageToolTests: CommandsTestCase {
                 XCTAssertEqual(pinsStore.pins.map{$0}.count, 2)
                 for pkg in ["bar", "baz"] {
                     let path = try SwiftPM.packagePath(for: pkg, packageRoot: fooPath)
-                    let pin = pinsStore.pinsMap[PackageIdentity(path: path)]!
+                    let pin = pinsStore.pins[PackageIdentity(path: path)]!
                     XCTAssertEqual(pin.packageRef.identity, PackageIdentity(path: path))
                     guard case .localSourceControl(let path) = pin.packageRef.kind, path.pathString.hasSuffix(pkg) else {
                         return XCTFail("invalid pin location \(path)")
@@ -980,7 +980,7 @@ final class PackageToolTests: CommandsTestCase {
                 try execute("resolve", "bar")
                 let pinsStore = try PinsStore(pinsFile: pinsFile, workingDirectory: fixturePath, fileSystem: localFileSystem, mirrors: .init())
                 let identity = PackageIdentity(path: barPath)
-                switch pinsStore.pinsMap[identity]?.state {
+                switch pinsStore.pins[identity]?.state {
                 case .version(let version, revision: _):
                     XCTAssertEqual(version, "1.2.3")
                 default:
@@ -1009,7 +1009,7 @@ final class PackageToolTests: CommandsTestCase {
                 try execute("resolve", "bar", "--version", "1.2.3")
                 let pinsStore = try PinsStore(pinsFile: pinsFile, workingDirectory: fixturePath, fileSystem: localFileSystem, mirrors: .init())
                 let identity = PackageIdentity(path: barPath)
-                switch pinsStore.pinsMap[identity]?.state {
+                switch pinsStore.pins[identity]?.state {
                 case .version(let version, revision: _):
                     XCTAssertEqual(version, "1.2.3")
                 default:

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -1416,7 +1416,7 @@ final class PubgrubTests: XCTestCase {
             "b": (.version(v1), .specific(["b"])),
         ])
 
-        let resolver = builder.create(pinsMap: pinsStore.pinsMap)
+        let resolver = builder.create(pins: pinsStore.pins)
         let result = try resolver.solve(root: rootNode, constraints: dependencies)
 
         // Since a was pinned, we shouldn't have computed bounds for its incomaptibilities.
@@ -1450,7 +1450,7 @@ final class PubgrubTests: XCTestCase {
             "b": (.version(v1), .specific(["b"])),
         ])
 
-        let resolver = builder.create(pinsMap: pinsStore.pinsMap)
+        let resolver = builder.create(pins: pinsStore.pins)
         let result = resolver.solve(constraints: dependencies)
 
         AssertResult(result, [
@@ -1479,7 +1479,7 @@ final class PubgrubTests: XCTestCase {
             "b": (.version("1.2.0"), .specific(["b"])),
         ])
 
-        let resolver = builder.create(pinsMap: pinsStore.pinsMap)
+        let resolver = builder.create(pins: pinsStore.pins)
         let result = resolver.solve(constraints: dependencies)
 
         AssertResult(result, [
@@ -1504,7 +1504,7 @@ final class PubgrubTests: XCTestCase {
             "b": (.branch(name: "master", revision: "master-sha-2"), .specific(["b"])),
         ])
 
-        let resolver = builder.create(pinsMap: pinsStore.pinsMap)
+        let resolver = builder.create(pins: pinsStore.pins)
         let result = resolver.solve(constraints: dependencies)
 
         AssertResult(result, [
@@ -1644,7 +1644,7 @@ final class PubgrubTests: XCTestCase {
                         versionRequirement: .exact(Version(1, 0, 0))
                     )]
                 ]),
-            pinsMap: PinsStore.PinsMap()
+            pins: PinsStore.Pins()
         )
         let rootLocation = AbsolutePath("/Root")
         let otherLocation = AbsolutePath("/Other")
@@ -2864,7 +2864,7 @@ final class PubGrubBacktrackTests: XCTestCase {
 
         let observability = ObservabilitySystem.makeForTesting()
 
-        let resolver = builder.create(pinsMap: [:], delegate: ObservabilityDependencyResolverDelegate(observabilityScope: observability.topScope))
+        let resolver = builder.create(pins: [:], delegate: ObservabilityDependencyResolverDelegate(observabilityScope: observability.topScope))
         let dependencies = try builder.create(dependencies: [
             "a": (.versionSet(.range("1.0.0"..<"4.0.0")), .specific(["a"])),
             "c": (.versionSet(.range("1.0.0"..<"4.0.0")), .specific(["c"])),
@@ -3258,13 +3258,13 @@ class DependencyGraphBuilder {
     }
 
 
-    func create(pinsMap: PinsStore.PinsMap = [:], delegate: DependencyResolverDelegate? = .none) -> PubGrubDependencyResolver {
+    func create(pins: PinsStore.Pins = [:], delegate: DependencyResolverDelegate? = .none) -> PubGrubDependencyResolver {
         defer {
             self.containers = [:]
             self.references = [:]
         }
         let provider = MockProvider(containers: Array(self.containers.values))
-        return PubGrubDependencyResolver(provider :provider, pinsMap: pinsMap, observabilityScope: ObservabilitySystem.NOOP, delegate: delegate)
+        return PubGrubDependencyResolver(provider :provider, pins: pins, observabilityScope: ObservabilitySystem.NOOP, delegate: delegate)
     }
 }
 

--- a/Tests/WorkspaceTests/PinsStoreTests.swift
+++ b/Tests/WorkspaceTests/PinsStoreTests.swift
@@ -57,8 +57,8 @@ final class PinsStoreTests: XCTestCase {
             // Test basics on the store.
             for s in [store, store2] {
                 XCTAssert(s.pins.map{$0}.count == 1)
-                XCTAssertEqual(s.pinsMap[bar], nil)
-                let fooPin = s.pinsMap[foo]!
+                XCTAssertEqual(s.pins[bar], nil)
+                let fooPin = s.pins[foo]!
                 XCTAssertEqual(fooPin.packageRef, fooRef)
                 XCTAssertEqual(fooPin.state, .version(v1, revision: revision))
                 XCTAssertEqual(fooPin.state.description, v1.description)
@@ -93,7 +93,7 @@ final class PinsStoreTests: XCTestCase {
             try store.saveState(toolsVersion: ToolsVersion.current)
             store = try PinsStore(pinsFile: pinsFile, workingDirectory: .root, fileSystem: fs, mirrors: .init())
 
-            let pin = store.pinsMap[identity]!
+            let pin = store.pins[identity]!
             XCTAssertEqual(pin.state, .version("1.2.3", revision: revision))
             XCTAssertEqual(pin.state.description, "1.2.3")
         }
@@ -113,7 +113,7 @@ final class PinsStoreTests: XCTestCase {
             try store.saveState(toolsVersion: ToolsVersion.current)
             store = try PinsStore(pinsFile: pinsFile, workingDirectory: .root, fileSystem: fs, mirrors: .init())
 
-            let pin = store.pinsMap[identity]!
+            let pin = store.pins[identity]!
             XCTAssertEqual(pin.state, .branch(name: "develop", revision: revision))
             XCTAssertEqual(pin.state.description, "develop")
         }
@@ -133,7 +133,7 @@ final class PinsStoreTests: XCTestCase {
             try store.saveState(toolsVersion: ToolsVersion.current)
             store = try PinsStore(pinsFile: pinsFile, workingDirectory: .root, fileSystem: fs, mirrors: .init())
 
-            let pin = store.pinsMap[identity]!
+            let pin = store.pins[identity]!
             XCTAssertEqual(pin.state, .revision(revision))
             XCTAssertEqual(pin.state.description, revision)
         }
@@ -151,7 +151,7 @@ final class PinsStoreTests: XCTestCase {
             try store.saveState(toolsVersion: ToolsVersion.current)
             store = try PinsStore(pinsFile: pinsFile, workingDirectory: .root, fileSystem: fs, mirrors: .init())
 
-            let pin = store.pinsMap[identity]!
+            let pin = store.pins[identity]!
             XCTAssertEqual(pin.state, .version("1.2.3", revision: .none))
             XCTAssertEqual(pin.state.description, "1.2.3")
         }
@@ -192,7 +192,7 @@ final class PinsStoreTests: XCTestCase {
         )
 
         let store = try PinsStore(pinsFile: pinsFile, workingDirectory: .root, fileSystem: fs, mirrors: .init())
-        XCTAssertEqual(store.pinsMap.keys.map { $0.description }.sorted(), ["clang_c", "commandant"])
+        XCTAssertEqual(store.pins.keys.map { $0.description }.sorted(), ["clang_c", "commandant"])
     }
 
     func testLoadingSchema2() throws {
@@ -236,7 +236,7 @@ final class PinsStoreTests: XCTestCase {
         )
 
         let store = try PinsStore(pinsFile: pinsFile, workingDirectory: .root, fileSystem: fs, mirrors: .init())
-        XCTAssertEqual(store.pinsMap.keys.map { $0.description }.sorted(), ["clang_c", "commandant", "scope.package"])
+        XCTAssertEqual(store.pins.keys.map { $0.description }.sorted(), ["clang_c", "commandant", "scope.package"])
     }
 
     func testLoadingUnknownSchemaVersion() throws {
@@ -316,11 +316,11 @@ final class PinsStoreTests: XCTestCase {
         store.pin(packageRef: .remoteSourceControl(identity: bazIdentity, url: bazURL),
                   state: .version(v1, revision: "baz-revision"))
 
-        XCTAssert(store.pinsMap.count == 3)
-        XCTAssertEqual(store.pinsMap[fooIdentity]!.packageRef.kind, .remoteSourceControl(fooMirroredURL))
-        XCTAssertEqual(store.pinsMap[barIdentity]!.packageRef.kind, .remoteSourceControl(barMirroredURL))
-        XCTAssertNil(store.pinsMap[barMirroredIdentity])
-        XCTAssertEqual(store.pinsMap[bazIdentity]!.packageRef.kind, .remoteSourceControl(bazURL))
+        XCTAssert(store.pins.count == 3)
+        XCTAssertEqual(store.pins[fooIdentity]!.packageRef.kind, .remoteSourceControl(fooMirroredURL))
+        XCTAssertEqual(store.pins[barIdentity]!.packageRef.kind, .remoteSourceControl(barMirroredURL))
+        XCTAssertNil(store.pins[barMirroredIdentity])
+        XCTAssertEqual(store.pins[bazIdentity]!.packageRef.kind, .remoteSourceControl(bazURL))
 
         try store.saveState(toolsVersion: ToolsVersion.current)
         XCTAssert(fileSystem.exists(pinsFile))
@@ -331,15 +331,15 @@ final class PinsStoreTests: XCTestCase {
 
         // Load the store again from disk, with no mirrors
         let store2 = try PinsStore(pinsFile: pinsFile, workingDirectory: .root, fileSystem: fileSystem, mirrors: .init())
-        XCTAssert(store2.pinsMap.count == 3)
-        XCTAssertEqual(store2.pinsMap[fooIdentity]!.packageRef.kind, .remoteSourceControl(fooURL))
-        XCTAssertEqual(store2.pinsMap[barIdentity]!.packageRef.kind, .remoteSourceControl(barURL))
-        XCTAssertEqual(store2.pinsMap[bazIdentity]!.packageRef.kind, .remoteSourceControl(bazURL))
+        XCTAssert(store2.pins.count == 3)
+        XCTAssertEqual(store2.pins[fooIdentity]!.packageRef.kind, .remoteSourceControl(fooURL))
+        XCTAssertEqual(store2.pins[barIdentity]!.packageRef.kind, .remoteSourceControl(barURL))
+        XCTAssertEqual(store2.pins[bazIdentity]!.packageRef.kind, .remoteSourceControl(bazURL))
 
         // Load the store again from disk, with mirrors
         let store3 = try PinsStore(pinsFile: pinsFile, workingDirectory: .root, fileSystem: fileSystem, mirrors: mirrors)
-        XCTAssert(store3.pinsMap.count == 3)
-        XCTAssertEqual(store3.pinsMap, store.pinsMap)
+        XCTAssert(store3.pins.count == 3)
+        XCTAssertEqual(store3.pins, store.pins)
     }
 
     func testPinsWithMirrorsDeterminism() throws {
@@ -365,8 +365,8 @@ final class PinsStoreTests: XCTestCase {
             state: .version(v1, revision: "revision")
         )
 
-        XCTAssert(store1.pinsMap.count == 1)
-        XCTAssertEqual(store1.pinsMap[fooIdentity]!.packageRef.kind, .remoteSourceControl(fooMirroredURL))
+        XCTAssert(store1.pins.count == 1)
+        XCTAssertEqual(store1.pins[fooIdentity]!.packageRef.kind, .remoteSourceControl(fooMirroredURL))
 
         try store1.saveState(toolsVersion: ToolsVersion.current)
         XCTAssert(fileSystem.exists(pinsFile))
@@ -380,13 +380,13 @@ final class PinsStoreTests: XCTestCase {
 
         // Load the store again from disk, with no mirrors
         let store2 = try PinsStore(pinsFile: pinsFile, workingDirectory: .root, fileSystem: fileSystem, mirrors: .init())
-        XCTAssert(store2.pinsMap.count == 1)
-        XCTAssertEqual(store2.pinsMap[fooIdentity]!.packageRef.kind, .remoteSourceControl(fooURL1))
+        XCTAssert(store2.pins.count == 1)
+        XCTAssertEqual(store2.pins[fooIdentity]!.packageRef.kind, .remoteSourceControl(fooURL1))
 
         // Load the store again from disk, with mirrors
         let store3 = try PinsStore(pinsFile: pinsFile, workingDirectory: .root, fileSystem: fileSystem, mirrors: mirrors)
-        XCTAssert(store3.pinsMap.count == 1)
-        XCTAssertEqual(store3.pinsMap, store1.pinsMap)
+        XCTAssert(store3.pins.count == 1)
+        XCTAssertEqual(store3.pins, store1.pins)
     }
 
     func testMirrorsDeterminism() throws {

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -3872,8 +3872,8 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
-            XCTAssertEqual(result.store.pinsMap[.plain("foo")]?.packageRef.locationString, "https://localhost/org/foo")
-            XCTAssertEqual(result.store.pinsMap[.plain("bar")]?.packageRef.locationString, "https://localhost/org/bar")
+            XCTAssertEqual(result.store.pins[.plain("foo")]?.packageRef.locationString, "https://localhost/org/foo")
+            XCTAssertEqual(result.store.pins[.plain("bar")]?.packageRef.locationString, "https://localhost/org/bar")
         }
 
         // case 2: set state with slightly different URLs that are canonically the same
@@ -3908,8 +3908,8 @@ final class WorkspaceTests: XCTestCase {
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
             // URLs should be stable since URLs are canonically the same and we kept the resolved file between the two iterations
-            XCTAssertEqual(result.store.pinsMap[.plain("foo")]?.packageRef.locationString, "https://localhost/org/foo")
-            XCTAssertEqual(result.store.pinsMap[.plain("bar")]?.packageRef.locationString, "https://localhost/org/bar")
+            XCTAssertEqual(result.store.pins[.plain("foo")]?.packageRef.locationString, "https://localhost/org/foo")
+            XCTAssertEqual(result.store.pins[.plain("bar")]?.packageRef.locationString, "https://localhost/org/bar")
         }
 
         // case 2: set state with slightly different URLs that are canonically the same but request different versions
@@ -3943,9 +3943,9 @@ final class WorkspaceTests: XCTestCase {
             result.check(dependency: "foo", at: .checkout(.version("1.1.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.1.0")))
             // URLs should reflect the actual dependencies since the new version forces rewrite of the resolved file
-            XCTAssertEqual(result.store.pinsMap[.plain("foo")]?.packageRef.locationString, "https://localhost/ORG/FOO")
+            XCTAssertEqual(result.store.pins[.plain("foo")]?.packageRef.locationString, "https://localhost/ORG/FOO")
             XCTAssertEqual(
-                result.store.pinsMap[.plain("bar")]?.packageRef.locationString,
+                result.store.pins[.plain("bar")]?.packageRef.locationString,
                 "https://localhost/org/bar.git"
             )
         }
@@ -3983,11 +3983,11 @@ final class WorkspaceTests: XCTestCase {
             result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
             // URLs should reflect the actual dependencies since we deleted the resolved file
             XCTAssertEqual(
-                result.store.pinsMap[.plain("foo")]?.packageRef.locationString,
+                result.store.pins[.plain("foo")]?.packageRef.locationString,
                 "https://localhost/org/foo.git"
             )
             XCTAssertEqual(
-                result.store.pinsMap[.plain("bar")]?.packageRef.locationString,
+                result.store.pins[.plain("bar")]?.packageRef.locationString,
                 "https://localhost/org/bar.git"
             )
         }
@@ -4641,7 +4641,7 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
-            XCTAssertEqual(result.store.pinsMap[.plain("foo")]?.packageRef.locationString, "https://scm.com/org/foo")
+            XCTAssertEqual(result.store.pins[.plain("foo")]?.packageRef.locationString, "https://scm.com/org/foo")
         }
 
         // reset state
@@ -4668,7 +4668,7 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.1.0")))
-            XCTAssertEqual(result.store.pinsMap[.plain("foo")]?.packageRef.locationString, "https://scm.com/other/foo")
+            XCTAssertEqual(result.store.pins[.plain("foo")]?.packageRef.locationString, "https://scm.com/other/foo")
         }
     }
 
@@ -4736,7 +4736,7 @@ final class WorkspaceTests: XCTestCase {
         do {
             let ws = try workspace.getOrCreateWorkspace()
             let pinsStore = try ws.pinsStore.load()
-            let fooPin = pinsStore.pins.first(where: { $0.packageRef.identity.description == "foo" })!
+            let fooPin = pinsStore.pins.values.first(where: { $0.packageRef.identity.description == "foo" })!
 
             let fooRepo = workspace.repositoryProvider
                 .specifierMap[RepositorySpecifier(path: try AbsolutePath(


### PR DESCRIPTION
motivaiton: nicer code

changes:
* remove uneccesary PinsStore::pins API
* rename PinsStore::pinsMap tp PinsStore::pins
* adjust call sites
