### PR TITLE
Skip compiling plugins when skipping building

### DIFF
--- a/Fixtures/Miscellaneous/TestDiscovery/Simple/Package.swift
+++ b/Fixtures/Miscellaneous/TestDiscovery/Simple/Package.swift
@@ -1,10 +1,11 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.8
 import PackageDescription
 
 let package = Package(
     name: "Simple",
     targets: [
-        .target(name: "Simple"),
+        .target(name: "Simple", plugins: ["SimplePlugin"]),
         .testTarget(name: "SimpleTests", dependencies: ["Simple"]),
+        .plugin(name: "SimplePlugin", capability: .buildTool()),
     ]
 )

--- a/Fixtures/Miscellaneous/TestDiscovery/Simple/Plugins/SimplePlugin/plugin.swift
+++ b/Fixtures/Miscellaneous/TestDiscovery/Simple/Plugins/SimplePlugin/plugin.swift
@@ -1,0 +1,8 @@
+import PackagePlugin
+
+@main
+struct Simple: BuildToolPlugin {
+    func createBuildCommands(context: PackagePlugin.PluginContext, target: PackagePlugin.Target) async throws -> [PackagePlugin.Command] {
+        return []
+    }
+}

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -237,6 +237,9 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
 
     /// Perform a build using the given build description and subset.
     public func build(subset: BuildSubset) throws {
+        guard !buildParameters.shouldSkipBuilding else {
+            return
+        }
 
         let buildStartTime = DispatchTime.now()
 
@@ -422,7 +425,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         let buildToolPluginInvocationResults: [ResolvedTarget: [BuildToolPluginInvocationResult]]
         let prebuildCommandResults: [ResolvedTarget: [PrebuildCommandResult]]
         // Invoke any build tool plugins in the graph to generate prebuild commands and build commands.
-        if let pluginConfiguration {
+        if let pluginConfiguration, !self.buildParameters.shouldSkipBuilding {
             let buildOperationForPluginDependencies = try BuildOperation(
                 buildParameters: self.buildParameters.forTriple(self.buildParameters.hostTriple),
                 cacheBuildManifest: false,

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -198,6 +198,7 @@ final class PluginDelegate: PluginInvocationDelegate {
                 fromTestAt: testProduct.bundlePath,
                 swiftTool: swiftTool,
                 enableCodeCoverage: parameters.enableCodeCoverage,
+                shouldSkipBuilding: false,
                 sanitizers: swiftTool.options.build.sanitizers
             )
             for testSuite in testSuites {

--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -270,6 +270,8 @@ public struct BuildParameters: Encodable {
 
     public var debugInfoFormat: DebugInfoFormat
 
+    public var shouldSkipBuilding: Bool
+
     @available(*, deprecated, message: "use `init` overload with `targetTriple` parameter name instead")
     @_disfavoredOverload
     public init(
@@ -302,7 +304,8 @@ public struct BuildParameters: Encodable {
         colorizedOutput: Bool = false,
         verboseOutput: Bool = false,
         linkTimeOptimizationMode: LinkTimeOptimizationMode? = nil,
-        debugInfoFormat: DebugInfoFormat = .dwarf
+        debugInfoFormat: DebugInfoFormat = .dwarf,
+        shouldSkipBuilding: Bool = false
     ) throws {
         try self.init(
             dataPath: dataPath,
@@ -334,7 +337,8 @@ public struct BuildParameters: Encodable {
             colorizedOutput: colorizedOutput,
             verboseOutput: verboseOutput,
             linkTimeOptimizationMode: linkTimeOptimizationMode,
-            debugInfoFormat: debugInfoFormat
+            debugInfoFormat: debugInfoFormat,
+            shouldSkipBuilding: shouldSkipBuilding
         )
     }
 
@@ -368,7 +372,8 @@ public struct BuildParameters: Encodable {
         colorizedOutput: Bool = false,
         verboseOutput: Bool = false,
         linkTimeOptimizationMode: LinkTimeOptimizationMode? = nil,
-        debugInfoFormat: DebugInfoFormat = .dwarf
+        debugInfoFormat: DebugInfoFormat = .dwarf,
+        shouldSkipBuilding: Bool = false
     ) throws {
         let targetTriple = try targetTriple ?? .getHostTriple(usingSwiftCompiler: toolchain.swiftCompilerPath)
 
@@ -439,6 +444,7 @@ public struct BuildParameters: Encodable {
         self.verboseOutput = verboseOutput
         self.linkTimeOptimizationMode = linkTimeOptimizationMode
         self.debugInfoFormat = debugInfoFormat
+        self.shouldSkipBuilding = shouldSkipBuilding
     }
 
     @available(*, deprecated, renamed: "forTriple()")
@@ -487,7 +493,8 @@ public struct BuildParameters: Encodable {
             linkerDeadStrip: self.linkerDeadStrip,
             colorizedOutput: self.colorizedOutput,
             verboseOutput: self.verboseOutput,
-            linkTimeOptimizationMode: self.linkTimeOptimizationMode
+            linkTimeOptimizationMode: self.linkTimeOptimizationMode,
+            shouldSkipBuilding: self.shouldSkipBuilding
         )
     }
 

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -103,6 +103,10 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
     }
 
     public func build(subset: BuildSubset) throws {
+        guard !buildParameters.shouldSkipBuilding else {
+            return
+        }
+
         let pifBuilder = try getPIFBuilder()
         let pif = try pifBuilder.generatePIF()
         try self.fileSystem.writeIfChanged(path: buildParameters.pifManifest, string: pif)


### PR DESCRIPTION
Sink `shouldSkipBuilding` down into build parameters, so we can respect it whereever we would be trying to build, e.g. when trying to build plugins during build planning.

resolves #6683
