### PR TITLE
CoreCommands: support `-debug-info-format none` for Windows

### DIFF
--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -510,6 +510,8 @@ public struct BuildOptions: ParsableArguments {
         case dwarf
         /// See `BuildParameters.DebugInfoFormat.codeview` for details.
         case codeview
+        /// See `BuildParameters.DebugInfoFormat.none` for details.
+        case none
     }
 }
 

--- a/Sources/CoreCommands/SwiftTool.swift
+++ b/Sources/CoreCommands/SwiftTool.swift
@@ -988,6 +988,8 @@ extension BuildOptions.DebugInfoFormat {
             return .dwarf
         case .codeview:
             return .codeview
+        case .none:
+            return .none
         }
     }
 }

--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -62,6 +62,8 @@ public struct BuildParameters: Encodable {
         case dwarf
         /// CodeView debug information format, used on Windows.
         case codeview
+        /// No debug information to be emitted.
+        case none
     }
 
     /// Represents the debugging strategy.
@@ -320,6 +322,13 @@ public struct BuildParameters: Encodable {
                 cxxCompilerFlags: ["-g"],
                 swiftCompilerFlags: ["-g", "-debug-info-format=codeview"],
                 linkerFlags: ["-debug"]
+            ))
+        case .none:
+            var flags = flags
+            self.flags = flags.merging(BuildFlags(
+                cCompilerFlags: ["-g0"],
+                cxxCompilerFlags: ["-g0"],
+                swiftCompilerFlags: ["-gnone"]
             ))
         }
         self.pkgConfigDirectories = pkgConfigDirectories


### PR DESCRIPTION
Windows does not have a reliable way to strip the binary as stripping is not an operation that MSVC ever performs (PDBs are always externalised and have support for private and public symbols).  This allows us to have builds in release mode which do not embed debug information which would then need to be extricated.