### PR TITLE
[5.9] Write link file list as a build command

### DIFF
--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -339,18 +339,6 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
         return self.stripInvalidArguments(args)
     }
 
-    /// Writes link filelist to the filesystem.
-    func writeLinkFilelist(_ fs: FileSystem) throws {
-        let stream = BufferedOutputByteStream()
-
-        for object in self.objects {
-            stream <<< object.pathString.spm_shellEscaped() <<< "\n"
-        }
-
-        try fs.createDirectory(self.linkFileListPath.parentDirectory, recursive: true)
-        try fs.writeFileContents(self.linkFileListPath, bytes: stream.bytes)
-    }
-
     /// Returns the build flags from the declared build settings.
     private func buildSettingsFlags() -> [String] {
         var flags: [String] = []

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -694,6 +694,7 @@ extension BuildDescription {
         let testDiscoveryCommands = llbuild.manifest.getCmdToolMap(kind: TestDiscoveryTool.self)
         let testEntryPointCommands = llbuild.manifest.getCmdToolMap(kind: TestEntryPointTool.self)
         let copyCommands = llbuild.manifest.getCmdToolMap(kind: CopyTool.self)
+        let writeCommands = llbuild.manifest.getCmdToolMap(kind: WriteAuxiliaryFile.self)
 
         // Create the build description.
         let buildDescription = try BuildDescription(
@@ -703,6 +704,7 @@ extension BuildDescription {
             testDiscoveryCommands: testDiscoveryCommands,
             testEntryPointCommands: testEntryPointCommands,
             copyCommands: copyCommands,
+            writeCommands: writeCommands,
             pluginDescriptions: plan.pluginDescriptions
         )
         try fileSystem.createDirectory(

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -694,12 +694,6 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
         }
         buildProduct.libraryBinaryPaths = dependencies.libraryBinaryPaths
 
-        // Write the link filelist file.
-        //
-        // FIXME: We should write this as a custom llbuild task once we adopt it
-        // as a library.
-        try buildProduct.writeLinkFilelist(fileSystem)
-
         buildProduct.availableTools = dependencies.availableTools
     }
 

--- a/Sources/Build/LLBuildManifestBuilder.swift
+++ b/Sources/Build/LLBuildManifestBuilder.swift
@@ -986,13 +986,13 @@ extension LLBuildManifestBuilder {
             try self.manifest.addShellCmd(
                 name: cmdName,
                 description: "Archiving \(buildProduct.binaryPath.prettyPath())",
-                inputs: buildProduct.objects.map(Node.file),
+                inputs: (buildProduct.objects + [buildProduct.linkFileListPath]).map(Node.file),
                 outputs: [.file(buildProduct.binaryPath)],
                 arguments: try buildProduct.archiveArguments()
             )
 
         default:
-            let inputs = try buildProduct.objects + buildProduct.dylibs.map{ try $0.binaryPath }
+            let inputs = try buildProduct.objects + buildProduct.dylibs.map{ try $0.binaryPath } + [buildProduct.linkFileListPath]
 
             try self.manifest.addShellCmd(
                 name: cmdName,
@@ -1020,6 +1020,8 @@ extension LLBuildManifestBuilder {
             }
             self.addNode(output, toTarget: .test)
         }
+
+        self.manifest.addWriteLinkFileListCommand(objects: Array(buildProduct.objects), linkFileListPath: buildProduct.linkFileListPath)
     }
 }
 

--- a/Sources/LLBuildManifest/Tools.swift
+++ b/Sources/LLBuildManifest/Tools.swift
@@ -151,6 +151,26 @@ public struct ShellTool: ToolProtocol {
     }
 }
 
+public struct WriteAuxiliaryFile: ToolProtocol {
+    public static let name: String = "write-auxiliary-file"
+
+    public let inputs: [Node]
+    private let outputFilePath: AbsolutePath
+
+    public init(inputs: [Node], outputFilePath: AbsolutePath) {
+        self.inputs = inputs
+        self.outputFilePath = outputFilePath
+    }
+
+    public var outputs: [Node] {
+        return [.file(outputFilePath)]
+    }
+
+    public func write(to stream: ManifestToolStream) {
+        stream["description"] = "Write auxiliary file \(outputFilePath.pathString)"
+    }
+}
+
 public struct ClangTool: ToolProtocol {
     public static let name: String = "clang"
 

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -868,9 +868,11 @@ final class BuildPlanTests: XCTestCase {
 
             let buildPath: AbsolutePath = plan.buildParameters.dataPath.appending(components: "release")
 
-            let linkedFileList: String = try fs.readFileContents("/path/to/build/release/exe.product/Objects.LinkFileList")
-            XCTAssertMatch(linkedFileList, .contains("PkgLib"))
-            XCTAssertNoMatch(linkedFileList, .contains("ExtLib"))
+            let result = try BuildPlanResult(plan: plan)
+            let buildProduct = try result.buildProduct(for: "exe")
+            let objectDirectoryNames = buildProduct.objects.map { $0.parentDirectory.basename }
+            XCTAssertTrue(objectDirectoryNames.contains("PkgLib.build"))
+            XCTAssertFalse(objectDirectoryNames.contains("ExtLib.build"))
 
             let yaml = try fs.tempDirectory.appending(components: UUID().uuidString, "release.yaml")
             try fs.createDirectory(yaml.parentDirectory, recursive: true)
@@ -894,9 +896,11 @@ final class BuildPlanTests: XCTestCase {
                 observabilityScope: observability.topScope
             )
 
-            let linkedFileList: String = try fs.readFileContents("/path/to/build/debug/exe.product/Objects.LinkFileList")
-            XCTAssertNoMatch(linkedFileList, .contains("PkgLib"))
-            XCTAssertNoMatch(linkedFileList, .contains("ExtLib"))
+            let result = try BuildPlanResult(plan: plan)
+            let buildProduct = try result.buildProduct(for: "exe")
+            let objectDirectoryNames = buildProduct.objects.map { $0.parentDirectory.basename }
+            XCTAssertFalse(objectDirectoryNames.contains("PkgLib.build"))
+            XCTAssertFalse(objectDirectoryNames.contains("ExtLib.build"))
 
             let yaml = try fs.tempDirectory.appending(components: UUID().uuidString, "debug.yaml")
             try fs.createDirectory(yaml.parentDirectory, recursive: true)
@@ -1263,13 +1267,12 @@ final class BuildPlanTests: XCTestCase {
         ])
       #endif
 
-      let linkedFileList: String = try fs.readFileContents(buildPath.appending(components: "exe.product", "Objects.LinkFileList"))
-      XCTAssertEqual(linkedFileList, """
-          \(buildPath.appending(components: "exe.build", "main.c.o"))
-          \(buildPath.appending(components: "extlib.build", "extlib.c.o"))
-          \(buildPath.appending(components: "lib.build", "lib.c.o"))
-
-          """)
+        let buildProduct = try XCTUnwrap(result.productMap["exe"])
+        XCTAssertEqual(Array(buildProduct.objects), [
+            buildPath.appending(components: "exe.build", "main.c.o"),
+            buildPath.appending(components: "extlib.build", "extlib.c.o"),
+            buildPath.appending(components: "lib.build", "lib.c.o")
+        ])
     }
 
     func testClangConditionalDependency() throws {
@@ -4065,75 +4068,75 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testArchiving() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-            "/Package/Sources/rary/rary.swift"
-        )
+            let fs: FileSystem = InMemoryFileSystem(emptyFiles:
+                "/Package/Sources/rary/rary.swift"
+            )
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let graph = try loadPackageGraph(
-            fileSystem: fs,
-            manifests: [
-                Manifest.createRootManifest(
-                    displayName: "Package",
-                    path: .init(path: "/Package"),
-                    products: [
-                        ProductDescription(name: "rary", type: .library(.static), targets: ["rary"]),
-                    ],
-                    targets: [
-                        TargetDescription(name: "rary", dependencies: []),
-                    ]
-                ),
-            ],
-            observabilityScope: observability.topScope
-        )
-        XCTAssertNoDiagnostics(observability.diagnostics)
+            let observability = ObservabilitySystem.makeForTesting()
+            let graph = try loadPackageGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Package",
+                        path: "/Package",
+                        products: [
+                            ProductDescription(name: "rary", type: .library(.static), targets: ["rary"]),
+                        ],
+                        targets: [
+                            TargetDescription(name: "rary", dependencies: []),
+                        ]
+                    ),
+                ],
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let result = try BuildPlanResult(plan: BuildPlan(
-            buildParameters: mockBuildParameters(),
-            graph: graph,
-            fileSystem: fs,
-            observabilityScope: observability.topScope
-        ))
+            let result = try BuildPlanResult(plan: BuildPlan(
+                buildParameters: mockBuildParameters(),
+                graph: graph,
+                fileSystem: fs,
+                observabilityScope: observability.topScope
+            ))
 
-        let buildPath: AbsolutePath = result.plan.buildParameters.dataPath.appending(components: "debug")
+            let buildPath = result.plan.buildParameters.dataPath.appending(components: "debug")
 
-        let yaml = try fs.tempDirectory.appending(components: UUID().uuidString, "debug.yaml")
-        try fs.createDirectory(yaml.parentDirectory, recursive: true)
+            let yaml = try fs.tempDirectory.appending(components: UUID().uuidString, "debug.yaml")
+            try fs.createDirectory(yaml.parentDirectory, recursive: true)
 
-        let llbuild = LLBuildManifestBuilder(result.plan, fileSystem: fs, observabilityScope: observability.topScope)
-        try llbuild.generateManifest(at: yaml)
+            let llbuild = LLBuildManifestBuilder(result.plan, fileSystem: fs, observabilityScope: observability.topScope)
+            try llbuild.generateManifest(at: yaml)
 
-        let contents: String = try fs.readFileContents(yaml)
+            let contents: String = try fs.readFileContents(yaml)
 
-        if result.plan.buildParameters.triple.isWindows() {
-            XCTAssertMatch(contents, .contains("""
-              "C.rary-debug.a":
-                tool: shell
-                inputs: ["\(buildPath.appending(components: "rary.build", "rary.swift.o").escapedPathString())","\(buildPath.appending(components: "rary.build", "rary.swiftmodule.o").escapedPathString())"]
-                outputs: ["\(buildPath.appending(components: "library.a").escapedPathString())"]
-                description: "Archiving \(buildPath.appending(components: "library.a").escapedPathString())"
-                args: ["\(result.plan.buildParameters.toolchain.librarianPath.escapedPathString())","/LIB","/OUT:\(buildPath.appending(components: "library.a").escapedPathString())","@\(buildPath.appending(components: "rary.product", "Objects.LinkFileList").escapedPathString())"]
-            """))
-        } else if result.plan.buildParameters.triple.isDarwin() {
-            XCTAssertMatch(contents, .contains("""
-              "C.rary-debug.a":
-                tool: shell
-                inputs: ["\(buildPath.appending(components: "rary.build", "rary.swift.o").escapedPathString())"]
-                outputs: ["\(buildPath.appending(components: "library.a").escapedPathString())"]
-                description: "Archiving \(buildPath.appending(components: "library.a").escapedPathString())"
-                args: ["\(result.plan.buildParameters.toolchain.librarianPath.escapedPathString())","-static","-o","\(buildPath.appending(components: "library.a").escapedPathString())","@\(buildPath.appending(components: "rary.product", "Objects.LinkFileList").escapedPathString())"]
-            """))
-        } else {    // assume Unix `ar` is the librarian
-            XCTAssertMatch(contents, .contains("""
-              "C.rary-debug.a":
-                tool: shell
-                inputs: ["\(buildPath.appending(components: "rary.build", "rary.swift.o").escapedPathString())","\(buildPath.appending(components: "rary.build", "rary.swiftmodule.o").escapedPathString())"]
-                outputs: ["\(buildPath.appending(components: "library.a").escapedPathString())"]
-                description: "Archiving \(buildPath.appending(components: "library.a").escapedPathString())"
-                args: ["\(result.plan.buildParameters.toolchain.librarianPath.escapedPathString())","crs","\(buildPath.appending(components: "library.a").escapedPathString())","@\(buildPath.appending(components: "rary.product", "Objects.LinkFileList").escapedPathString())"]
-            """))
+            if result.plan.buildParameters.triple.isWindows() {
+                XCTAssertMatch(contents, .contains("""
+                  "C.rary-debug.a":
+                    tool: shell
+                    inputs: ["\(buildPath.appending(components: "rary.build", "rary.swift.o").escapedPathString())","\(buildPath.appending(components: "rary.build", "rary.swiftmodule.o").escapedPathString())","\(buildPath.appending(components: "rary.product", "Objects.LinkFileList").escapedPathString())"]
+                    outputs: ["\(buildPath.appending(components: "library.a").escapedPathString())"]
+                    description: "Archiving \(buildPath.appending(components: "library.a").escapedPathString())"
+                    args: ["\(result.plan.buildParameters.toolchain.librarianPath.escapedPathString())","/LIB","/OUT:\(buildPath.appending(components: "library.a").escapedPathString())","@\(buildPath.appending(components: "rary.product", "Objects.LinkFileList").escapedPathString())"]
+                """))
+            } else if result.plan.buildParameters.triple.isDarwin() {
+                XCTAssertMatch(contents, .contains("""
+                  "C.rary-debug.a":
+                    tool: shell
+                    inputs: ["\(buildPath.appending(components: "rary.build", "rary.swift.o").escapedPathString())","\(buildPath.appending(components: "rary.product", "Objects.LinkFileList").escapedPathString())"]
+                    outputs: ["\(buildPath.appending(components: "library.a").escapedPathString())"]
+                    description: "Archiving \(buildPath.appending(components: "library.a").escapedPathString())"
+                    args: ["\(result.plan.buildParameters.toolchain.librarianPath.escapedPathString())","-static","-o","\(buildPath.appending(components: "library.a").escapedPathString())","@\(buildPath.appending(components: "rary.product", "Objects.LinkFileList").escapedPathString())"]
+                """))
+            } else {    // assume Unix `ar` is the librarian
+                XCTAssertMatch(contents, .contains("""
+                  "C.rary-debug.a":
+                    tool: shell
+                    inputs: ["\(buildPath.appending(components: "rary.build", "rary.swift.o").escapedPathString())","\(buildPath.appending(components: "rary.build", "rary.swiftmodule.o").escapedPathString())","\(buildPath.appending(components: "rary.product", "Objects.LinkFileList").escapedPathString())"]
+                    outputs: ["\(buildPath.appending(components: "library.a").escapedPathString())"]
+                    description: "Archiving \(buildPath.appending(components: "library.a").escapedPathString())"
+                    args: ["\(result.plan.buildParameters.toolchain.librarianPath.escapedPathString())","crs","\(buildPath.appending(components: "library.a").escapedPathString())","@\(buildPath.appending(components: "rary.product", "Objects.LinkFileList").escapedPathString())"]
+                """))
+            }
         }
-    }
 
     func testSwiftBundleAccessor() throws {
         // This has a Swift and ObjC target in the same package.


### PR DESCRIPTION
This moves the generation of link file lists into the build system instead of doing it ad-hoc outside of the build. For this, we have a new `WriteAuxiliaryFile` tool and associated command that should be usable for any kind of writing of auxiliary files during the build.

Note that this change opted to not touch the existing infrastructure for in-process tools, so any inputs that are needed for the file generation will need to be flattened into a generic array of input nodes. The different types of file generation are keyed off a virtual node at the start of that array.

(cherry picked from commit ee7f064d7796533deb5ce4fe2094b72cfd510faf)
