### PR TITLE
[NFC] Rename `Destination` type to `SwiftSDK`

### DIFF
--- a/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
@@ -216,7 +216,7 @@ public final class ClangTargetBuildDescription {
 
         var args = [String]()
         // Only enable ARC on macOS.
-        if buildParameters.triple.isDarwin() {
+        if buildParameters.targetTriple.isDarwin() {
             args += ["-fobjc-arc"]
         }
         args += try buildParameters.targetTripleArgs(for: target)
@@ -231,7 +231,7 @@ public final class ClangTargetBuildDescription {
         // index store for Apple's clang or if explicitly asked to.
         if ProcessEnv.vars.keys.contains("SWIFTPM_ENABLE_CLANG_INDEX_STORE") {
             args += buildParameters.indexStoreArguments(for: target)
-        } else if buildParameters.triple.isDarwin(),
+        } else if buildParameters.targetTriple.isDarwin(),
                   (try? buildParameters.toolchain._isClangCompilerVendorApple()) == true
         {
             args += buildParameters.indexStoreArguments(for: target)
@@ -244,13 +244,13 @@ public final class ClangTargetBuildDescription {
             // 1. on Darwin when compiling for C++, because C++ modules are disabled on Apple-built Clang releases
             // 2. on Windows when compiling for any language, because of issues with the Windows SDK
             // 3. on Android when compiling for any language, because of issues with the Android SDK
-            enableModules = !(buildParameters.triple.isDarwin() && isCXX) && !buildParameters.triple
-                .isWindows() && !buildParameters.triple.isAndroid()
+            enableModules = !(buildParameters.targetTriple.isDarwin() && isCXX) && !buildParameters.targetTriple
+                .isWindows() && !buildParameters.targetTriple.isAndroid()
         } else {
             // For version >= 5.8, we disable them when compiling for C++ regardless of platforms, see:
             // https://github.com/llvm/llvm-project/issues/55980 for clang frontend crash when module
             // enabled for C++ on c++17 standard and above.
-            enableModules = !isCXX && !buildParameters.triple.isWindows() && !buildParameters.triple.isAndroid()
+            enableModules = !isCXX && !buildParameters.targetTriple.isWindows() && !buildParameters.targetTriple.isAndroid()
         }
 
         if enableModules {

--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -103,8 +103,8 @@ public final class SwiftTargetBuildDescription {
     /// The path to the swiftmodule file after compilation.
     var moduleOutputPath: AbsolutePath {
         // If we're an executable and we're not allowing test targets to link against us, we hide the module.
-        let allowLinkingAgainstExecutables = (buildParameters.triple.isDarwin() || self.buildParameters.triple
-            .isLinux() || self.buildParameters.triple.isWindows()) && self.toolsVersion >= .v5_5
+        let allowLinkingAgainstExecutables = (buildParameters.targetTriple.isDarwin() || self.buildParameters.targetTriple
+            .isLinux() || self.buildParameters.targetTriple.isWindows()) && self.toolsVersion >= .v5_5
         let dirPath = (target.type == .executable && !allowLinkingAgainstExecutables) ? self.tempsPath : self
             .buildParameters.buildPath
         return dirPath.appending(component: self.target.c99name + ".swiftmodule")
@@ -326,7 +326,7 @@ public final class SwiftTargetBuildDescription {
         guard let bundlePath else { return }
 
         let mainPathSubstitution: String
-        if self.buildParameters.triple.isWASI() {
+        if self.buildParameters.targetTriple.isWASI() {
             // We prefer compile-time evaluation of the bundle path here for WASI. There's no benefit in evaluating this
             // at runtime, especially as `Bundle` support in WASI Foundation is partial. We expect all resource paths to
             // evaluate to `/\(resourceBundleName)/\(resourcePath)`, which allows us to pass this path to JS APIs like
@@ -731,7 +731,7 @@ public final class SwiftTargetBuildDescription {
 
     /// Returns true if ObjC compatibility header should be emitted.
     private var shouldEmitObjCCompatibilityHeader: Bool {
-        self.buildParameters.triple.isDarwin() && self.target.type == .library
+        self.buildParameters.targetTriple.isDarwin() && self.target.type == .library
     }
 
     func writeOutputFileMap() throws -> AbsolutePath {
@@ -932,7 +932,7 @@ public final class SwiftTargetBuildDescription {
 
     private var stdlibArguments: [String] {
         if self.buildParameters.shouldLinkStaticSwiftStdlib,
-           self.buildParameters.triple.isSupportingStaticStdlib
+           self.buildParameters.targetTriple.isSupportingStaticStdlib
         {
             return ["-static-stdlib"]
         } else {

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -423,7 +423,17 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         let prebuildCommandResults: [ResolvedTarget: [PrebuildCommandResult]]
         // Invoke any build tool plugins in the graph to generate prebuild commands and build commands.
         if let pluginConfiguration {
-            let buildOperationForPluginDependencies = try BuildOperation(buildParameters: self.buildParameters.withDestination(self.buildParameters.hostTriple), cacheBuildManifest: false, packageGraphLoader: { return graph }, additionalFileRules: self.additionalFileRules, pkgConfigDirectories: self.pkgConfigDirectories, outputStream: self.outputStream, logLevel: self.logLevel, fileSystem: self.fileSystem, observabilityScope: self.observabilityScope)
+            let buildOperationForPluginDependencies = try BuildOperation(
+                buildParameters: self.buildParameters.forTriple(self.buildParameters.hostTriple),
+                cacheBuildManifest: false,
+                packageGraphLoader: { return graph },
+                additionalFileRules: self.additionalFileRules,
+                pkgConfigDirectories: self.pkgConfigDirectories,
+                outputStream: self.outputStream,
+                logLevel: self.logLevel,
+                fileSystem: self.fileSystem,
+                observabilityScope: self.observabilityScope
+            )
             buildToolPluginInvocationResults = try graph.invokeBuildToolPlugins(
                 outputDir: pluginConfiguration.workDirectory.appending("outputs"),
                 builtToolsDir: self.buildParameters.buildPath,

--- a/Sources/Commands/PackageTools/APIDiff.swift
+++ b/Sources/Commands/PackageTools/APIDiff.swift
@@ -75,7 +75,7 @@ struct APIDiff: SwiftCommand {
     var regenerateBaseline: Bool = false
 
     func run(_ swiftTool: SwiftTool) throws {
-        let apiDigesterPath = try swiftTool.getDestinationToolchain().getSwiftAPIDigester()
+        let apiDigesterPath = try swiftTool.getTargetToolchain().getSwiftAPIDigester()
         let apiDigesterTool = SwiftAPIDigester(fileSystem: swiftTool.fileSystem, tool: apiDigesterPath)
 
         let packageRoot = try globalOptions.locations.packageDirectory ?? swiftTool.getPackageRoot()

--- a/Sources/Commands/PackageTools/DumpCommands.swift
+++ b/Sources/Commands/PackageTools/DumpCommands.swift
@@ -53,7 +53,7 @@ struct DumpSymbolGraph: SwiftCommand {
         // Configure the symbol graph extractor.
         let symbolGraphExtractor = try SymbolGraphExtract(
             fileSystem: swiftTool.fileSystem,
-            tool: swiftTool.getDestinationToolchain().getSymbolGraphExtract(),
+            tool: swiftTool.getTargetToolchain().getSymbolGraphExtract(),
             observabilityScope: swiftTool.observabilityScope,
             skipSynthesizedMembers: skipSynthesizedMembers,
             minimumAccessLevel: minimumAccessLevel,

--- a/Sources/Commands/PackageTools/PluginCommand.swift
+++ b/Sources/Commands/PackageTools/PluginCommand.swift
@@ -246,7 +246,7 @@ struct PluginCommand: SwiftCommand {
             .contains { package.path.isDescendantOfOrEqual(to: $0) } ? [] : [package.path]
 
         // Use the directory containing the compiler as an additional search directory, and add the $PATH.
-        let toolSearchDirs = [try swiftTool.getDestinationToolchain().swiftCompilerPath.parentDirectory]
+        let toolSearchDirs = [try swiftTool.getTargetToolchain().swiftCompilerPath.parentDirectory]
             + getEnvSearchPaths(pathString: ProcessEnv.path, currentWorkingDirectory: .none)
 
         // Build or bring up-to-date any executable host-side tools on which this plugin depends. Add them and any binary dependencies to the tool-names-to-path map.

--- a/Sources/Commands/SwiftRunTool.swift
+++ b/Sources/Commands/SwiftRunTool.swift
@@ -144,7 +144,7 @@ public struct SwiftRunTool: SwiftCommand {
             print("Launching Swift REPL with arguments: \(arguments.joined(separator: " "))")
             try self.run(
                 fileSystem: swiftTool.fileSystem,
-                executablePath: swiftTool.getDestinationToolchain().swiftInterpreterPath,
+                executablePath: swiftTool.getTargetToolchain().swiftInterpreterPath,
                 originalWorkingDirectory: swiftTool.originalWorkingDirectory,
                 arguments: arguments
             )
@@ -168,7 +168,7 @@ public struct SwiftRunTool: SwiftCommand {
                 }
 
                 let pathRelativeToWorkingDirectory = executablePath.relative(to: swiftTool.originalWorkingDirectory)
-                let lldbPath = try swiftTool.getDestinationToolchain().getLLDB()
+                let lldbPath = try swiftTool.getTargetToolchain().getLLDB()
                 try exec(path: lldbPath.pathString, args: ["--", pathRelativeToWorkingDirectory.pathString] + options.arguments)
             } catch let error as RunError {
                 swiftTool.observabilityScope.emit(error)
@@ -180,7 +180,7 @@ public struct SwiftRunTool: SwiftCommand {
             if let executable = options.executable, try isValidSwiftFilePath(fileSystem: swiftTool.fileSystem, path: executable) {
                 swiftTool.observabilityScope.emit(.runFileDeprecation)
                 // Redirect execution to the toolchain's swift executable.
-                let swiftInterpreterPath = try swiftTool.getDestinationToolchain().swiftInterpreterPath
+                let swiftInterpreterPath = try swiftTool.getTargetToolchain().swiftInterpreterPath
                 // Prepend the script to interpret to the arguments.
                 let arguments = [executable] + options.arguments
                 try self.run(

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -168,8 +168,8 @@ public struct SwiftTestTool: SwiftCommand {
             try self.validateArguments(observabilityScope: swiftTool.observabilityScope)
 
             // validate XCTest available on darwin based systems
-            let toolchain = try swiftTool.getDestinationToolchain()
-            if toolchain.triple.isDarwin() && toolchain.xctestPath == nil {
+            let toolchain = try swiftTool.getTargetToolchain()
+            if toolchain.targetTriple.isDarwin() && toolchain.xctestPath == nil {
                 throw TestError.xctestNotAvailable
             }
         } catch {
@@ -185,7 +185,7 @@ public struct SwiftTestTool: SwiftCommand {
             let command = try List.parse()
             try command.run(swiftTool)
         } else if !self.options.shouldRunInParallel {
-            let toolchain = try swiftTool.getDestinationToolchain()
+            let toolchain = try swiftTool.getTargetToolchain()
             let testProducts = try buildTestsIfNeeded(swiftTool: swiftTool)
             let buildParameters = try swiftTool.buildParametersForTest(options: self.options)
 
@@ -261,7 +261,7 @@ public struct SwiftTestTool: SwiftCommand {
             }
 
         } else {
-            let toolchain = try swiftTool.getDestinationToolchain()
+            let toolchain = try swiftTool.getTargetToolchain()
             let testProducts = try buildTestsIfNeeded(swiftTool: swiftTool)
             let testSuites = try TestingSupport.getTestSuites(
                 in: testProducts,
@@ -349,7 +349,7 @@ public struct SwiftTestTool: SwiftCommand {
     /// Merges all profraw profiles in codecoverage directory into default.profdata file.
     private func mergeCodeCovRawDataFiles(swiftTool: SwiftTool) throws {
         // Get the llvm-prof tool.
-        let llvmProf = try swiftTool.getDestinationToolchain().getLLVMProf()
+        let llvmProf = try swiftTool.getTargetToolchain().getLLVMProf()
 
         // Get the profraw files.
         let buildParameters = try swiftTool.buildParametersForTest(options: self.options)
@@ -371,7 +371,7 @@ public struct SwiftTestTool: SwiftCommand {
     /// Exports profdata as a JSON file.
     private func exportCodeCovAsJSON(to path: AbsolutePath, testBinary: AbsolutePath, swiftTool: SwiftTool) throws {
         // Export using the llvm-cov tool.
-        let llvmCov = try swiftTool.getDestinationToolchain().getLLVMCov()
+        let llvmCov = try swiftTool.getTargetToolchain().getLLVMCov()
         let buildParameters = try swiftTool.buildParametersForTest(options: self.options)
         let args = [
             llvmCov.pathString,

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -169,7 +169,7 @@ final class PluginDelegate: PluginInvocationDelegate {
     ) throws -> PluginInvocationTestResult {
         // Build the tests. Ideally we should only build those that match the subset, but we don't have a way to know
         // which ones they are until we've built them and can examine the binaries.
-        let toolchain = try swiftTool.getDestinationToolchain()
+        let toolchain = try swiftTool.getTargetToolchain()
         var buildParameters = try swiftTool.buildParameters()
         buildParameters.enableTestability = true
         buildParameters.enableCodeCoverage = parameters.enableCodeCoverage
@@ -340,7 +340,7 @@ final class PluginDelegate: PluginInvocationDelegate {
         // Configure the symbol graph extractor.
         var symbolGraphExtractor = try SymbolGraphExtract(
             fileSystem: swiftTool.fileSystem,
-            tool: swiftTool.getDestinationToolchain().getSymbolGraphExtract(),
+            tool: swiftTool.getTargetToolchain().getSymbolGraphExtract(),
             observabilityScope: swiftTool.observabilityScope
         )
         symbolGraphExtractor.skipSynthesizedMembers = !options.includeSynthesized

--- a/Sources/Commands/Utilities/TestingSupport.swift
+++ b/Sources/Commands/Utilities/TestingSupport.swift
@@ -92,7 +92,7 @@ enum TestingSupport {
         let data: String = try withTemporaryFile { tempFile in
             let args = [try Self.xctestHelperPath(swiftTool: swiftTool).pathString, path.pathString, tempFile.path.pathString]
             var env = try Self.constructTestEnvironment(
-                toolchain: try swiftTool.getDestinationToolchain(),
+                toolchain: try swiftTool.getTargetToolchain(),
                 buildParameters: swiftTool.buildParametersForTest(
                     enableCodeCoverage: enableCodeCoverage
                 ),
@@ -100,7 +100,7 @@ enum TestingSupport {
             )
 
             // Add the sdk platform path if we have it. If this is not present, we might always end up failing.
-            let sdkPlatformFrameworksPath = try Destination.sdkPlatformFrameworkPaths()
+            let sdkPlatformFrameworksPath = try SwiftSDK.sdkPlatformFrameworkPaths()
             // appending since we prefer the user setting (if set) to the one we inject
             env.appendPath("DYLD_FRAMEWORK_PATH", value: sdkPlatformFrameworksPath.fwk.pathString)
             env.appendPath("DYLD_LIBRARY_PATH", value: sdkPlatformFrameworksPath.lib.pathString)
@@ -111,7 +111,7 @@ enum TestingSupport {
         }
         #else
         let env = try Self.constructTestEnvironment(
-            toolchain: try swiftTool.getDestinationToolchain(),
+            toolchain: try swiftTool.getTargetToolchain(),
             buildParameters: swiftTool.buildParametersForTest(
                 enableCodeCoverage: enableCodeCoverage
             ),

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -643,9 +643,9 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         // Use the same minimum deployment target as the PackageDescription library (with a fallback to the default host triple).
 #if os(macOS)
         if let version = self.toolchain.swiftPMLibrariesLocation.manifestLibraryMinimumDeploymentTarget?.versionString {
-            cmd += ["-target", "\(self.toolchain.triple.tripleString(forPlatformVersion: version))"]
+            cmd += ["-target", "\(self.toolchain.targetTriple.tripleString(forPlatformVersion: version))"]
         } else {
-            cmd += ["-target", self.toolchain.triple.tripleString]
+            cmd += ["-target", self.toolchain.targetTriple.tripleString]
         }
 #endif
 

--- a/Sources/PackageModel/CMakeLists.txt
+++ b/Sources/PackageModel/CMakeLists.txt
@@ -12,7 +12,6 @@ add_library(PackageModel
   BuildEnvironment.swift
   BuildFlags.swift
   BuildSettings.swift
-  Destination.swift
   Diagnostics.swift
   IdentityResolver.swift
   Manifest/Manifest.swift
@@ -42,6 +41,7 @@ add_library(PackageModel
   Sources.swift
   SupportedLanguageExtension.swift
   SwiftLanguageVersion.swift
+  SwiftSDK.swift
   SwiftSDKConfigurationStore.swift
   SwiftSDKBundle.swift
   Target.swift

--- a/Sources/PackageModel/SwiftSDKBundle.swift
+++ b/Sources/PackageModel/SwiftSDKBundle.swift
@@ -20,7 +20,7 @@ import struct TSCBasic.RegEx
 public struct SwiftSDKBundle {
     public struct Variant: Equatable {
         let metadata: ArtifactsArchiveMetadata.Variant
-        let swiftSDKs: [Destination]
+        let swiftSDKs: [SwiftSDK]
     }
 
     // Path to the bundle root directory.
@@ -81,7 +81,7 @@ public struct SwiftSDKBundle {
         matching selector: String,
         hostTriple: Triple,
         observabilityScope: ObservabilityScope
-    ) throws -> Destination {
+    ) throws -> SwiftSDK {
         guard let destinationsDirectory else {
             throw StringError(
                 """
@@ -363,12 +363,12 @@ extension ArtifactsArchiveMetadata {
                 }
 
                 do {
-                    let destinations = try Destination.decode(
+                    let swiftSDKs = try SwiftSDK.decode(
                         fromFile: variantConfigurationPath, fileSystem: fileSystem,
                         observabilityScope: observabilityScope
                     )
 
-                    variants.append(.init(metadata: variantMetadata, swiftSDKs: destinations))
+                    variants.append(.init(metadata: variantMetadata, swiftSDKs: swiftSDKs))
                 } catch {
                     observabilityScope.emit(
                         warning: "Couldn't parse Swift SDK artifact metadata at \(variantConfigurationPath)",
@@ -391,7 +391,7 @@ extension [SwiftSDKBundle] {
     ///   - hostTriple: triple of the machine on which the destination is building.
     ///   - targetTriple: triple of the machine for which the destination is building.
     /// - Returns: `Destination` value with a given artifact ID, `nil` if none found.
-    public func selectDestination(id: String, hostTriple: Triple, targetTriple: Triple) -> Destination? {
+    public func selectSwiftSDK(id: String, hostTriple: Triple, targetTriple: Triple) -> SwiftSDK? {
         for bundle in self {
             for (artifactID, variants) in bundle.artifacts {
                 guard artifactID == id else {
@@ -421,9 +421,9 @@ extension [SwiftSDKBundle] {
         matching selector: String,
         hostTriple: Triple,
         observabilityScope: ObservabilityScope
-    ) -> Destination? {
-        var matchedByID: (path: AbsolutePath, variant: SwiftSDKBundle.Variant, destination: Destination)?
-        var matchedByTriple: (path: AbsolutePath, variant: SwiftSDKBundle.Variant, destination: Destination)?
+    ) -> SwiftSDK? {
+        var matchedByID: (path: AbsolutePath, variant: SwiftSDKBundle.Variant, destination: SwiftSDK)?
+        var matchedByTriple: (path: AbsolutePath, variant: SwiftSDKBundle.Variant, destination: SwiftSDK)?
 
         for bundle in self {
             for (artifactID, variants) in bundle.artifacts {

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -524,7 +524,7 @@ public final class UserToolchain: Toolchain {
         self.includeSearchPaths = swiftSDK.pathsConfiguration.includeSearchPaths ?? []
         self.librarySearchPaths = swiftSDK.pathsConfiguration.includeSearchPaths ?? []
 
-        self.librarianPath = try destination.toolset.knownTools[.librarian]?.path ?? UserToolchain.determineLibrarian(
+        self.librarianPath = try swiftSDK.toolset.knownTools[.librarian]?.path ?? UserToolchain.determineLibrarian(
             triple: triple,
             binDirectories: swiftSDK.toolset.rootPaths,
             useXcrun: useXcrun,

--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -269,6 +269,7 @@ public struct BuildParameters: Encodable {
     public var debugInfoFormat: DebugInfoFormat
 
     @available(*, deprecated, message: "use `init` overload with `targetTriple` parameter name instead")
+    @_disfavoredOverload
     public init(
         dataPath: AbsolutePath,
         configuration: BuildConfiguration,

--- a/Sources/SPMTestSupport/Toolchain.swift
+++ b/Sources/SPMTestSupport/Toolchain.swift
@@ -37,11 +37,11 @@ private func resolveBinDir() throws -> AbsolutePath {
 #endif
 }
 
-extension Destination {
+extension SwiftSDK {
     public static var `default`: Self {
         get throws {
             let binDir = try resolveBinDir()
-            return try! Destination.hostDestination(binDir)
+            return try! SwiftSDK.hostSwiftSDK(binDir)
         }
     }
 }
@@ -49,7 +49,7 @@ extension Destination {
 extension UserToolchain {
     public static var `default`: Self {
         get throws {
-            return try .init(destination: Destination.default)
+            return try .init(swiftSDK: SwiftSDK.default)
         }
     }
 }

--- a/Sources/SwiftSDKTool/Configuration/ConfigurationSubcommand.swift
+++ b/Sources/SwiftSDKTool/Configuration/ConfigurationSubcommand.swift
@@ -34,7 +34,7 @@ protocol ConfigurationSubcommand: SwiftSDKSubcommand {
     func run(
         hostTriple: Triple,
         targetTriple: Triple,
-        _ destination: Destination,
+        _ destination: SwiftSDK,
         _ configurationStore: SwiftSDKConfigurationStore,
         _ swiftSDKsDirectory: AbsolutePath,
         _ observabilityScope: ObservabilityScope

--- a/Sources/SwiftSDKTool/Configuration/ResetConfiguration.swift
+++ b/Sources/SwiftSDKTool/Configuration/ResetConfiguration.swift
@@ -59,7 +59,7 @@ struct ResetConfiguration: ConfigurationSubcommand {
     func run(
         hostTriple: Triple,
         targetTriple: Triple,
-        _ destination: Destination,
+        _ destination: SwiftSDK,
         _ configurationStore: SwiftSDKConfigurationStore,
         _ destinationsDirectory: AbsolutePath,
         _ observabilityScope: ObservabilityScope
@@ -120,7 +120,7 @@ struct ResetConfiguration: ConfigurationSubcommand {
         } else {
             var destination = destination
             destination.pathsConfiguration = configuration
-            try configurationStore.updateConfiguration(sdkID: sdkID, destination: destination)
+            try configurationStore.updateConfiguration(sdkID: sdkID, swiftSDK: destination)
 
             observabilityScope.emit(
                 info: """

--- a/Sources/SwiftSDKTool/Configuration/SetConfiguration.swift
+++ b/Sources/SwiftSDKTool/Configuration/SetConfiguration.swift
@@ -75,7 +75,7 @@ struct SetConfiguration: ConfigurationSubcommand {
     func run(
         hostTriple: Triple,
         targetTriple: Triple,
-        _ destination: Destination,
+        _ destination: SwiftSDK,
         _ configurationStore: SwiftSDKConfigurationStore,
         _ destinationsDirectory: AbsolutePath,
         _ observabilityScope: ObservabilityScope
@@ -132,7 +132,7 @@ struct SetConfiguration: ConfigurationSubcommand {
 
         var destination = destination
         destination.pathsConfiguration = configuration
-        try configurationStore.updateConfiguration(sdkID: sdkID, destination: destination)
+        try configurationStore.updateConfiguration(sdkID: sdkID, swiftSDK: destination)
 
         observabilityScope.emit(
             info: """

--- a/Sources/SwiftSDKTool/Configuration/ShowConfiguration.swift
+++ b/Sources/SwiftSDKTool/Configuration/ShowConfiguration.swift
@@ -40,7 +40,7 @@ struct ShowConfiguration: ConfigurationSubcommand {
     func run(
         hostTriple: Triple,
         targetTriple: Triple,
-        _ destination: Destination,
+        _ destination: SwiftSDK,
         _ configurationStore: SwiftSDKConfigurationStore,
         _ destinationsDirectory: AbsolutePath,
         _ observabilityScope: ObservabilityScope
@@ -49,7 +49,7 @@ struct ShowConfiguration: ConfigurationSubcommand {
     }
 }
 
-extension Destination.PathsConfiguration: CustomStringConvertible {
+extension SwiftSDK.PathsConfiguration: CustomStringConvertible {
     public var description: String {
         """
         sdkRootPath: \(sdkRootPath.configurationString)

--- a/Sources/SwiftSDKTool/SwiftSDKSubcommand.swift
+++ b/Sources/SwiftSDKTool/SwiftSDKSubcommand.swift
@@ -65,7 +65,7 @@ extension SwiftSDKSubcommand {
         let observabilityScope = observabilitySystem.topScope
         let destinationsDirectory = try self.getOrCreateDestinationsDirectory()
 
-        let hostToolchain = try UserToolchain(destination: Destination.hostDestination())
+        let hostToolchain = try UserToolchain(swiftSDK: SwiftSDK.hostSwiftSDK())
         let triple = try Triple.getHostTriple(usingSwiftCompiler: hostToolchain.swiftCompilerPath)
 
         var commandError: Error? = nil

--- a/Sources/Workspace/DefaultPluginScriptRunner.swift
+++ b/Sources/Workspace/DefaultPluginScriptRunner.swift
@@ -107,7 +107,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
     }
 
     public var hostTriple: Triple {
-        return self.toolchain.triple
+        return self.toolchain.targetTriple
     }
     
     /// Starts compiling a plugin script asynchronously and when done, calls the completion handler on the callback queue with the results (including the path of the compiled plugin executable and with any emitted diagnostics, etc).  Existing compilation results that are still valid are reused, if possible.  This function itself returns immediately after starting the compile.  Note that the completion handler only receives a `.failure` result if the compiler couldn't be invoked at all; a non-zero exit code from the compiler still returns `.success` with a full compilation result that notes the error in the diagnostics (in other words, a `.failure` result only means "failure to invoke the compiler").
@@ -177,9 +177,9 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
         // Use the same minimum deployment target as the PackagePlugin library (with a fallback to the default host triple).
         #if os(macOS)
         if let version = self.toolchain.swiftPMLibrariesLocation.pluginLibraryMinimumDeploymentTarget?.versionString {
-            commandLine += ["-target", "\(self.toolchain.triple.tripleString(forPlatformVersion: version))"]
+            commandLine += ["-target", "\(self.toolchain.targetTriple.tripleString(forPlatformVersion: version))"]
         } else {
-            commandLine += ["-target", self.toolchain.triple.tripleString]
+            commandLine += ["-target", self.toolchain.targetTriple.tripleString]
         }
         #endif
 

--- a/Sources/Workspace/Workspace+BinaryArtifacts.swift
+++ b/Sources/Workspace/Workspace+BinaryArtifacts.swift
@@ -174,11 +174,11 @@ extension Workspace {
                                 guard let supportedArchive = metadata.archives
                                     .first(where: {
                                         $0.fileName.lowercased().hasSuffix(".zip") && $0.supportedTriples
-                                            .contains(self.hostToolchain.triple)
+                                            .contains(self.hostToolchain.targetTriple)
                                     })
                                 else {
                                     throw StringError(
-                                        "No supported archive was found for '\(self.hostToolchain.triple.tripleString)'"
+                                        "No supported archive was found for '\(self.hostToolchain.targetTriple.tripleString)'"
                                     )
                                 }
                                 // add relevant archive

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -629,7 +629,7 @@ public class Workspace {
         let location = try location.validatingSharedLocations(fileSystem: fileSystem, warningHandler: initializationWarningHandler)
 
         let currentToolsVersion = customToolsVersion ?? ToolsVersion.current
-        let hostToolchain = try customHostToolchain ?? UserToolchain(destination: .hostDestination())
+        let hostToolchain = try customHostToolchain ?? UserToolchain(swiftSDK: .hostSwiftSDK())
         var manifestLoader = customManifestLoader ?? ManifestLoader(
             toolchain: hostToolchain,
             cacheDir: location.sharedManifestsCacheDirectory,

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -184,7 +184,7 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
             platform: "macosx",
             sdk: "macosx",
             sdkVariant: nil,
-            targetArchitecture: buildParameters.triple.archName,
+            targetArchitecture: buildParameters.targetTriple.archName,
             supportedArchitectures: [],
             disableOnlyActiveArch: true
         )

--- a/Sources/swift-bootstrap/main.swift
+++ b/Sources/swift-bootstrap/main.swift
@@ -187,7 +187,7 @@ struct SwiftBootstrapBuildTool: ParsableCommand {
     struct Builder {
         let identityResolver: IdentityResolver
         let hostToolchain: UserToolchain
-        let destinationToolchain: UserToolchain
+        let targetToolchain: UserToolchain
         let fileSystem: FileSystem
         let observabilityScope: ObservabilityScope
         let logLevel: Basics.Diagnostic.Severity
@@ -203,8 +203,8 @@ struct SwiftBootstrapBuildTool: ParsableCommand {
             }
 
             self.identityResolver = DefaultIdentityResolver()
-            self.hostToolchain = try UserToolchain(destination: Destination.hostDestination(originalWorkingDirectory: cwd))
-            self.destinationToolchain = hostToolchain // TODO: support destinations?
+            self.hostToolchain = try UserToolchain(swiftSDK: SwiftSDK.hostSwiftSDK(originalWorkingDirectory: cwd))
+            self.targetToolchain = hostToolchain // TODO: support cross-compilation?
             self.fileSystem = fileSystem
             self.observabilityScope = observabilityScope
             self.logLevel = logLevel
@@ -250,15 +250,15 @@ struct SwiftBootstrapBuildTool: ParsableCommand {
             buildFlags.swiftCompilerFlags += Self.additionalSwiftBuildFlags
 
             let dataPath = scratchDirectory.appending(
-                component: self.destinationToolchain.triple.platformBuildPathComponent(buildSystem: buildSystem)
+                component: self.targetToolchain.targetTriple.platformBuildPathComponent(buildSystem: buildSystem)
             )
 
             let buildParameters = try BuildParameters(
                 dataPath: dataPath,
                 configuration: configuration,
-                toolchain: self.destinationToolchain,
-                hostTriple: self.hostToolchain.triple,
-                destinationTriple: self.destinationToolchain.triple,
+                toolchain: self.targetToolchain,
+                hostTriple: self.hostToolchain.targetTriple,
+                targetTriple: self.targetToolchain.targetTriple,
                 flags: buildFlags,
                 architectures: architectures,
                 useIntegratedSwiftDriver: useIntegratedSwiftDriver,

--- a/Tests/BuildTests/MockBuildTestHelper.swift
+++ b/Tests/BuildTests/MockBuildTestHelper.swift
@@ -57,7 +57,7 @@ extension Basics.Triple {
     static let wasi = try! Self("wasm32-unknown-wasi")
 }
 
-let hostTriple = try! UserToolchain.default.triple
+let hostTriple = try! UserToolchain.default.targetTriple
 #if os(macOS)
     let defaultTargetTriple: String = hostTriple.tripleString(forPlatformVersion: "10.13")
 #else
@@ -71,7 +71,7 @@ func mockBuildParameters(
     flags: PackageModel.BuildFlags = PackageModel.BuildFlags(),
     shouldLinkStaticSwiftStdlib: Bool = false,
     canRenameEntrypointFunctionName: Bool = false,
-    destinationTriple: Basics.Triple = hostTriple,
+    targetTriple: Basics.Triple = hostTriple,
     indexStoreMode: BuildParameters.IndexStoreMode = .off,
     useExplicitModuleBuild: Bool = false,
     linkerDeadStrip: Bool = true,
@@ -82,7 +82,7 @@ func mockBuildParameters(
         configuration: config,
         toolchain: toolchain,
         hostTriple: hostTriple,
-        destinationTriple: destinationTriple,
+        targetTriple: targetTriple,
         flags: flags,
         pkgConfigDirectories: [],
         workers: 3,
@@ -110,7 +110,7 @@ func mockBuildParameters(environment: BuildEnvironment) -> BuildParameters {
         fatalError("unsupported platform in tests")
     }
 
-    return mockBuildParameters(config: environment.configuration ?? .debug, destinationTriple: triple)
+    return mockBuildParameters(config: environment.configuration ?? .debug,     targetTriple: triple)
 }
 
 enum BuildError: Swift.Error {

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -121,7 +121,7 @@ final class BuildToolTests: CommandsTestCase {
     func testBinPathAndSymlink() throws {
         try fixture(name: "ValidLayouts/SingleModule/ExecutableNew") { fixturePath in
             let fullPath = try resolveSymlinks(fixturePath)
-            let targetPath = fullPath.appending(components: ".build", try UserToolchain.default.triple.platformBuildPathComponent())
+            let targetPath = fullPath.appending(components: ".build", try UserToolchain.default.targetTriple.platformBuildPathComponent())
             let xcbuildTargetPath = fullPath.appending(components: ".build", "apple")
             XCTAssertEqual(try execute(["--show-bin-path"], packagePath: fullPath).stdout,
                            "\(targetPath.appending("debug").pathString)\n")
@@ -328,7 +328,7 @@ final class BuildToolTests: CommandsTestCase {
             let defaultOutput = try execute(["-c", "debug", "-v"], packagePath: fixturePath).stdout
             
             // Look for certain things in the output from XCBuild.
-            XCTAssertMatch(defaultOutput, .contains("-target \(try UserToolchain.default.triple.tripleString(forPlatformVersion: ""))"))
+            XCTAssertMatch(defaultOutput, .contains("-target \(try UserToolchain.default.targetTriple.tripleString(forPlatformVersion: ""))"))
         }
     }
 

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -475,7 +475,7 @@ final class PackageToolTests: CommandsTestCase {
     // Returns symbol graph with or without pretty printing.
     private func symbolGraph(atPath path: AbsolutePath, withPrettyPrinting: Bool, file: StaticString = #file, line: UInt = #line) throws -> Data? {
         let tool = try SwiftTool.createSwiftToolForTest(options: GlobalOptions.parse(["--package-path", path.pathString]))
-        let symbolGraphExtractorPath = try tool.getDestinationToolchain().getSymbolGraphExtract()
+        let symbolGraphExtractorPath = try tool.getTargetToolchain().getSymbolGraphExtract()
 
         let arguments = withPrettyPrinting ? ["dump-symbol-graph", "--pretty-print"] : ["dump-symbol-graph"]
 
@@ -768,7 +768,7 @@ final class PackageToolTests: CommandsTestCase {
             _ = try SwiftPM.Package.execute(["edit", "baz", "--branch", "bugfix"], packagePath: fooPath)
 
             // Path to the executable.
-            let exec = [fooPath.appending(components: ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug", "foo").pathString]
+            let exec = [fooPath.appending(components: ".build", try UserToolchain.default.targetTriple.platformBuildPathComponent(), "debug", "foo").pathString]
 
             // We should see it now in packages directory.
             let editsPath = fooPath.appending(components: "Packages", "bar")
@@ -842,7 +842,7 @@ final class PackageToolTests: CommandsTestCase {
             // Build it.
             XCTAssertBuilds(packageRoot)
             let buildPath = packageRoot.appending(".build")
-            let binFile = buildPath.appending(components: try UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Bar")
+            let binFile = buildPath.appending(components: try UserToolchain.default.targetTriple.platformBuildPathComponent(), "debug", "Bar")
             XCTAssertFileExists(binFile)
             XCTAssert(localFileSystem.isDirectory(buildPath))
 
@@ -861,7 +861,7 @@ final class PackageToolTests: CommandsTestCase {
             // Build it.
             XCTAssertBuilds(packageRoot)
             let buildPath = packageRoot.appending(".build")
-            let binFile = buildPath.appending(components: try UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Bar")
+            let binFile = buildPath.appending(components: try UserToolchain.default.targetTriple.platformBuildPathComponent(), "debug", "Bar")
             XCTAssertFileExists(binFile)
             XCTAssert(localFileSystem.isDirectory(buildPath))
             // Clean, and check for removal of the build directory but not Packages.
@@ -931,7 +931,7 @@ final class PackageToolTests: CommandsTestCase {
             func build() throws -> String {
                 return try SwiftPM.Build.execute(packagePath: fooPath).stdout
             }
-            let exec = [fooPath.appending(components: ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug", "foo").pathString]
+            let exec = [fooPath.appending(components: ".build", try UserToolchain.default.targetTriple.platformBuildPathComponent(), "debug", "foo").pathString]
 
             // Build and check.
             _ = try build()
@@ -1687,7 +1687,7 @@ final class PackageToolTests: CommandsTestCase {
                 </dict>
                 """
             )
-            let hostTriple = try UserToolchain(destination: .hostDestination()).triple
+            let hostTriple = try UserToolchain(swiftSDK: .hostSwiftSDK()).targetTriple
             let hostTripleString = hostTriple.isDarwin() ? hostTriple.tripleString(forPlatformVersion: "") : hostTriple.tripleString
             try localFileSystem.writeFileContents(packageDir.appending(components: "Binaries", "LocalBinaryTool.artifactbundle", "info.json"), string:
                 """

--- a/Tests/FunctionalPerformanceTests/BuildPerfTests.swift
+++ b/Tests/FunctionalPerformanceTests/BuildPerfTests.swift
@@ -62,7 +62,7 @@ class BuildPerfTests: XCTestCasePerf {
     func runFullBuildTest(for name: String, app appString: String? = nil, product productString: String) throws {
         try fixture(name: name) { fixturePath in
             let app = fixturePath.appending(components: (appString ?? ""))
-            let triple = try UserToolchain.default.triple
+            let triple = try UserToolchain.default.targetTriple
             let product = app.appending(components: ".build", triple.platformBuildPathComponent(), "debug", productString)
             try self.execute(packagePath: app)
             measure {
@@ -76,7 +76,7 @@ class BuildPerfTests: XCTestCasePerf {
     func runNullBuildTest(for name: String, app appString: String? = nil, product productString: String) throws {
         try fixture(name: name) { fixturePath in
             let app = fixturePath.appending(components: (appString ?? ""))
-            let triple = try UserToolchain.default.triple
+            let triple = try UserToolchain.default.targetTriple
             let product = app.appending(components: ".build", triple.platformBuildPathComponent(), "debug", productString)
             try self.execute(packagePath: app)
             measure {

--- a/Tests/FunctionalTests/CFamilyTargetTests.swift
+++ b/Tests/FunctionalTests/CFamilyTargetTests.swift
@@ -41,7 +41,7 @@ class CFamilyTargetTestCase: XCTestCase {
     func testCLibraryWithSpaces() throws {
         try fixture(name: "CFamilyTargets/CLibraryWithSpaces") { fixturePath in
             XCTAssertBuilds(fixturePath)
-            let debugPath = fixturePath.appending(components: ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug")
+            let debugPath = fixturePath.appending(components: ".build", try UserToolchain.default.targetTriple.platformBuildPathComponent(), "debug")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Bar.c.o")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Foo.c.o")
         }
@@ -51,7 +51,7 @@ class CFamilyTargetTestCase: XCTestCase {
         try fixture(name: "DependencyResolution/External/CUsingCDep") { fixturePath in
             let packageRoot = fixturePath.appending("Bar")
             XCTAssertBuilds(packageRoot)
-            let debugPath = fixturePath.appending(components: "Bar", ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug")
+            let debugPath = fixturePath.appending(components: "Bar", ".build", try UserToolchain.default.targetTriple.platformBuildPathComponent(), "debug")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Sea.c.o")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Foo.c.o")
             let path = try SwiftPM.packagePath(for: "Foo", packageRoot: packageRoot)
@@ -62,7 +62,7 @@ class CFamilyTargetTestCase: XCTestCase {
     func testModuleMapGenerationCases() throws {
         try fixture(name: "CFamilyTargets/ModuleMapGenerationCases") { fixturePath in
             XCTAssertBuilds(fixturePath)
-            let debugPath = fixturePath.appending(components: ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug")
+            let debugPath = fixturePath.appending(components: ".build", try UserToolchain.default.targetTriple.platformBuildPathComponent(), "debug")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Jaz.c.o")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "main.swift.o")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "FlatInclude.c.o")
@@ -85,7 +85,7 @@ class CFamilyTargetTestCase: XCTestCase {
         // Try building a fixture which needs extra flags to be able to build.
         try fixture(name: "CFamilyTargets/CDynamicLookup") { fixturePath in
             XCTAssertBuilds(fixturePath, Xld: ["-undefined", "dynamic_lookup"])
-            let debugPath = fixturePath.appending(components: ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug")
+            let debugPath = fixturePath.appending(components: ".build", try UserToolchain.default.targetTriple.platformBuildPathComponent(), "debug")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Foo.c.o")
         }
     }
@@ -97,7 +97,7 @@ class CFamilyTargetTestCase: XCTestCase {
         try fixture(name: "CFamilyTargets/ObjCmacOSPackage") { fixturePath in
             // Build the package.
             XCTAssertBuilds(fixturePath)
-            XCTAssertDirectoryContainsFile(dir: fixturePath.appending(components: ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug"), filename: "HelloWorldExample.m.o")
+            XCTAssertDirectoryContainsFile(dir: fixturePath.appending(components: ".build", try UserToolchain.default.targetTriple.platformBuildPathComponent(), "debug"), filename: "HelloWorldExample.m.o")
             // Run swift-test on package.
             XCTAssertSwiftTest(fixturePath)
         }
@@ -106,7 +106,7 @@ class CFamilyTargetTestCase: XCTestCase {
     func testCanBuildRelativeHeaderSearchPaths() throws {
         try fixture(name: "CFamilyTargets/CLibraryParentSearchPath") { fixturePath in
             XCTAssertBuilds(fixturePath)
-            XCTAssertDirectoryContainsFile(dir: fixturePath.appending(components: ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug"), filename: "HeaderInclude.swiftmodule")
+            XCTAssertDirectoryContainsFile(dir: fixturePath.appending(components: ".build", try UserToolchain.default.targetTriple.platformBuildPathComponent(), "debug"), filename: "HeaderInclude.swiftmodule")
         }
     }
 }

--- a/Tests/FunctionalTests/DependencyResolutionTests.swift
+++ b/Tests/FunctionalTests/DependencyResolutionTests.swift
@@ -23,7 +23,7 @@ class DependencyResolutionTests: XCTestCase {
         try fixture(name: "DependencyResolution/Internal/Simple") { fixturePath in
             XCTAssertBuilds(fixturePath)
 
-            let output = try Process.checkNonZeroExit(args: fixturePath.appending(components: ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Foo").pathString)
+            let output = try Process.checkNonZeroExit(args: fixturePath.appending(components: ".build", UserToolchain.default.targetTriple.platformBuildPathComponent(), "debug", "Foo").pathString)
             XCTAssertEqual(output, "Foo\nBar\n")
         }
     }
@@ -38,7 +38,7 @@ class DependencyResolutionTests: XCTestCase {
         try fixture(name: "DependencyResolution/Internal/Complex") { fixturePath in
             XCTAssertBuilds(fixturePath)
 
-            let output = try Process.checkNonZeroExit(args: fixturePath.appending(components: ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Foo").pathString)
+            let output = try Process.checkNonZeroExit(args: fixturePath.appending(components: ".build", UserToolchain.default.targetTriple.platformBuildPathComponent(), "debug", "Foo").pathString)
             XCTAssertEqual(output, "meiow Baz\n")
         }
     }
@@ -54,7 +54,7 @@ class DependencyResolutionTests: XCTestCase {
 
             let packageRoot = fixturePath.appending("Bar")
             XCTAssertBuilds(packageRoot)
-            XCTAssertFileExists(fixturePath.appending(components: "Bar", ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Bar"))
+            XCTAssertFileExists(fixturePath.appending(components: "Bar", ".build", try UserToolchain.default.targetTriple.platformBuildPathComponent(), "debug", "Bar"))
             let path = try SwiftPM.packagePath(for: "Foo", packageRoot: packageRoot)
             XCTAssert(try GitRepository(path: path).getTags().contains("1.2.3"))
         }
@@ -63,7 +63,7 @@ class DependencyResolutionTests: XCTestCase {
     func testExternalComplex() throws {
         try fixture(name: "DependencyResolution/External/Complex") { fixturePath in
             XCTAssertBuilds(fixturePath.appending("app"))
-            let output = try Process.checkNonZeroExit(args: fixturePath.appending(components: "app", ".build", UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Dealer").pathString)
+            let output = try Process.checkNonZeroExit(args: fixturePath.appending(components: "app", ".build", UserToolchain.default.targetTriple.platformBuildPathComponent(), "debug", "Dealer").pathString)
             XCTAssertEqual(output, "♣︎K\n♣︎Q\n♣︎J\n♣︎10\n♣︎9\n♣︎8\n♣︎7\n♣︎6\n♣︎5\n♣︎4\n")
         }
     }

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -52,7 +52,7 @@ class MiscellaneousTestCase: XCTestCase {
 
         try fixture(name: "Miscellaneous/ExactDependencies") { fixturePath in
             XCTAssertBuilds(fixturePath.appending("app"))
-            let buildDir = fixturePath.appending(components: "app", ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug")
+            let buildDir = fixturePath.appending(components: "app", ".build", try UserToolchain.default.targetTriple.platformBuildPathComponent(), "debug")
             XCTAssertFileExists(buildDir.appending("FooExec"))
             XCTAssertFileExists(buildDir.appending("FooLib1.swiftmodule"))
             XCTAssertFileExists(buildDir.appending("FooLib2.swiftmodule"))
@@ -107,7 +107,7 @@ class MiscellaneousTestCase: XCTestCase {
     */
     func testInternalDependencyEdges() throws {
         try fixture(name: "Miscellaneous/DependencyEdges/Internal") { fixturePath in
-            let execpath = fixturePath.appending(components: ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Foo").pathString
+            let execpath = fixturePath.appending(components: ".build", try UserToolchain.default.targetTriple.platformBuildPathComponent(), "debug", "Foo").pathString
 
             XCTAssertBuilds(fixturePath)
             var output = try Process.checkNonZeroExit(args: execpath)
@@ -131,7 +131,7 @@ class MiscellaneousTestCase: XCTestCase {
     */
     func testExternalDependencyEdges1() throws {
         try fixture(name: "DependencyResolution/External/Complex") { fixturePath in
-            let execpath = fixturePath.appending(components: "app", ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Dealer").pathString
+            let execpath = fixturePath.appending(components: "app", ".build", try UserToolchain.default.targetTriple.platformBuildPathComponent(), "debug", "Dealer").pathString
 
             let packageRoot = fixturePath.appending("app")
             XCTAssertBuilds(packageRoot)
@@ -158,7 +158,7 @@ class MiscellaneousTestCase: XCTestCase {
      */
     func testExternalDependencyEdges2() throws {
         try fixture(name: "Miscellaneous/DependencyEdges/External") { fixturePath in
-            let execpath = [fixturePath.appending(components: "root", ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug", "dep2").pathString]
+            let execpath = [fixturePath.appending(components: "root", ".build", try UserToolchain.default.targetTriple.platformBuildPathComponent(), "debug", "dep2").pathString]
 
             let packageRoot = fixturePath.appending("root")
             XCTAssertBuilds(fixturePath.appending("root"))
@@ -182,7 +182,7 @@ class MiscellaneousTestCase: XCTestCase {
     func testSpaces() throws {
         try fixture(name: "Miscellaneous/Spaces Fixture") { fixturePath in
             XCTAssertBuilds(fixturePath)
-            XCTAssertFileExists(fixturePath.appending(components: ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Module_Name_1.build", "Foo.swift.o"))
+            XCTAssertFileExists(fixturePath.appending(components: ".build", try UserToolchain.default.targetTriple.platformBuildPathComponent(), "debug", "Module_Name_1.build", "Foo.swift.o"))
         }
     }
 
@@ -204,7 +204,7 @@ class MiscellaneousTestCase: XCTestCase {
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
         try fixture(name: "Miscellaneous/DistantFutureDeploymentTarget") { fixturePath in
-            let hostTriple = try UserToolchain.default.triple
+            let hostTriple = try UserToolchain.default.targetTriple
             try executeSwiftBuild(fixturePath, Xswiftc: ["-target", "\(hostTriple.archName)-apple-macosx41.0"])
         }
     }
@@ -214,7 +214,7 @@ class MiscellaneousTestCase: XCTestCase {
             let systemModule = fixturePath.appending("SystemModule")
             // Create a shared library.
             let input = systemModule.appending(components: "Sources", "SystemModule.c")
-            let triple = try UserToolchain.default.triple
+            let triple = try UserToolchain.default.targetTriple
             let output =  systemModule.appending("libSystemModule\(triple.dynamicLibraryExtension)")
             try systemQuietly(["clang", "-shared", input.pathString, "-o", output.pathString])
 

--- a/Tests/FunctionalTests/ModuleAliasingFixtureTests.swift
+++ b/Tests/FunctionalTests/ModuleAliasingFixtureTests.swift
@@ -22,7 +22,7 @@ class ModuleAliasingFixtureTests: XCTestCase {
     func testModuleDirectDeps1() throws {
         try fixture(name: "ModuleAliasing/DirectDeps1") { fixturePath in
             let pkgPath = fixturePath.appending(components: "AppPkg")
-            let buildPath = pkgPath.appending(components: ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug")
+            let buildPath = pkgPath.appending(components: ".build", try UserToolchain.default.targetTriple.platformBuildPathComponent(), "debug")
             XCTAssertBuilds(pkgPath, extraArgs: ["--vv"])
             XCTAssertFileExists(buildPath.appending(components: "App"))
             XCTAssertFileExists(buildPath.appending(components: "GameUtils.swiftmodule"))
@@ -34,7 +34,7 @@ class ModuleAliasingFixtureTests: XCTestCase {
     func testModuleDirectDeps2() throws {
         try fixture(name: "ModuleAliasing/DirectDeps2") { fixturePath in
             let pkgPath = fixturePath.appending(components: "AppPkg")
-            let buildPath = pkgPath.appending(components: ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug")
+            let buildPath = pkgPath.appending(components: ".build", try UserToolchain.default.targetTriple.platformBuildPathComponent(), "debug")
             XCTAssertBuilds(pkgPath, extraArgs: ["--vv"])
             XCTAssertFileExists(buildPath.appending(components: "App"))
             XCTAssertFileExists(buildPath.appending(components: "AUtils.swiftmodule"))

--- a/Tests/FunctionalTests/ModuleMapTests.swift
+++ b/Tests/FunctionalTests/ModuleMapTests.swift
@@ -22,7 +22,7 @@ class ModuleMapsTestCase: XCTestCase {
     private func fixture(name: String, cModuleName: String, rootpkg: String, body: @escaping (AbsolutePath, [String]) throws -> Void) throws {
         try SPMTestSupport.fixture(name: name) { fixturePath in
             let input = fixturePath.appending(components: cModuleName, "C", "foo.c")
-            let triple = try UserToolchain.default.triple
+            let triple = try UserToolchain.default.targetTriple
             let outdir = fixturePath.appending(components: rootpkg, ".build", triple.platformBuildPathComponent(), "debug")
             try makeDirectories(outdir)
             let output = outdir.appending("libfoo\(triple.dynamicLibraryExtension)")
@@ -42,7 +42,7 @@ class ModuleMapsTestCase: XCTestCase {
 
             XCTAssertBuilds(fixturePath.appending("App"), Xld: Xld)
 
-            let triple = try UserToolchain.default.triple
+            let triple = try UserToolchain.default.targetTriple
             let targetPath = fixturePath.appending(components: "App", ".build", triple.platformBuildPathComponent())
             let debugout = try Process.checkNonZeroExit(args: targetPath.appending(components: "debug", "App").pathString)
             XCTAssertEqual(debugout, "123\n")
@@ -57,7 +57,7 @@ class ModuleMapsTestCase: XCTestCase {
             XCTAssertBuilds(fixturePath.appending("packageA"), Xld: Xld)
 
             func verify(_ conf: String) throws {
-                let triple = try UserToolchain.default.triple
+                let triple = try UserToolchain.default.targetTriple
                 let out = try Process.checkNonZeroExit(args: fixturePath.appending(components: "packageA", ".build", triple.platformBuildPathComponent(), conf, "packageA").pathString)
                 XCTAssertEqual(out, """
                     calling Y.bar()

--- a/Tests/FunctionalTests/ToolsVersionTests.swift
+++ b/Tests/FunctionalTests/ToolsVersionTests.swift
@@ -93,7 +93,7 @@ class ToolsVersionTests: XCTestCase {
 
             // Build the primary package.
             _ = try SwiftPM.Build.execute(packagePath: primaryPath)
-            let exe = primaryPath.appending(components: ".build", try UserToolchain.default.triple.platformBuildPathComponent(), "debug", "Primary").pathString
+            let exe = primaryPath.appending(components: ".build", try UserToolchain.default.targetTriple.platformBuildPathComponent(), "debug", "Primary").pathString
             // v1 should get selected because v1.0.1 depends on a (way) higher set of tools.
             XCTAssertEqual(try Process.checkNonZeroExit(args: exe).spm_chomp(), "foo@1.0")
 

--- a/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
@@ -612,7 +612,7 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
             let moduleTraceFilePath = path.appending("swift-module-trace")
             var env = EnvironmentVariables.process()
             env["SWIFT_LOADED_MODULE_TRACE_FILE"] = moduleTraceFilePath.pathString
-            let toolchain = try UserToolchain(destination: Destination.default, environment: env)
+            let toolchain = try UserToolchain(swiftSDK: SwiftSDK.default, environment: env)
             let manifestLoader = ManifestLoader(
                 toolchain: toolchain,
                 serializedDiagnostics: true,

--- a/Tests/PackageModelTests/DestinationTests.swift
+++ b/Tests/PackageModelTests/DestinationTests.swift
@@ -277,21 +277,21 @@ private let invalidToolset = (
 private let sdkRootAbsolutePath = bundleRootPath.appending(sdkRootDir)
 private let toolchainBinAbsolutePath = bundleRootPath.appending(toolchainBinDir)
 
-private let parsedDestinationV2GNU = Destination(
+private let parsedDestinationV2GNU = SwiftSDK(
     hostTriple: hostTriple,
     targetTriple: linuxGNUTargetTriple,
     toolset: .init(toolchainBinDir: toolchainBinAbsolutePath, buildFlags: extraFlags),
     pathsConfiguration: .init(sdkRootPath: sdkRootAbsolutePath)
 )
 
-private let parsedDestinationV2Musl = Destination(
+private let parsedDestinationV2Musl = SwiftSDK(
     hostTriple: hostTriple,
     targetTriple: linuxMuslTargetTriple,
     toolset: .init(toolchainBinDir: toolchainBinAbsolutePath, buildFlags: extraFlags),
     pathsConfiguration: .init(sdkRootPath: sdkRootAbsolutePath)
 )
 
-private let parsedToolsetNoRootDestination = Destination(
+private let parsedToolsetNoRootDestination = SwiftSDK(
     targetTriple: linuxGNUTargetTriple,
     toolset: .init(
         knownTools: [
@@ -308,7 +308,7 @@ private let parsedToolsetNoRootDestination = Destination(
     )
 )
 
-private let parsedToolsetRootDestination = Destination(
+private let parsedToolsetRootDestination = SwiftSDK(
     targetTriple: linuxGNUTargetTriple,
     toolset: .init(
         knownTools: [
@@ -355,7 +355,7 @@ final class DestinationTests: XCTestCase {
         let system = ObservabilitySystem.makeForTesting()
         let observability = system.topScope
 
-        let destinationV1Decoded = try Destination.decode(
+        let destinationV1Decoded = try SwiftSDK.decode(
             fromFile: AbsolutePath(validating: destinationV1.path),
             fileSystem: fs,
             observabilityScope: observability
@@ -367,7 +367,7 @@ final class DestinationTests: XCTestCase {
         XCTAssertEqual(
             destinationV1Decoded,
             [
-                Destination(
+                SwiftSDK(
                     targetTriple: linuxGNUTargetTriple,
                     toolset: .init(toolchainBinDir: toolchainBinAbsolutePath, buildFlags: flagsWithoutLinkerFlags),
                     pathsConfiguration: .init(
@@ -377,7 +377,7 @@ final class DestinationTests: XCTestCase {
             ]
         )
 
-        let destinationV2Decoded = try Destination.decode(
+        let destinationV2Decoded = try SwiftSDK.decode(
             fromFile: AbsolutePath(validating: destinationV2.path),
             fileSystem: fs,
             observabilityScope: observability
@@ -385,7 +385,7 @@ final class DestinationTests: XCTestCase {
 
         XCTAssertEqual(destinationV2Decoded, [parsedDestinationV2GNU])
 
-        let toolsetNoRootDestinationV3Decoded = try Destination.decode(
+        let toolsetNoRootDestinationV3Decoded = try SwiftSDK.decode(
             fromFile: AbsolutePath(validating: toolsetNoRootDestinationV3.path),
             fileSystem: fs,
             observabilityScope: observability
@@ -393,7 +393,7 @@ final class DestinationTests: XCTestCase {
 
         XCTAssertEqual(toolsetNoRootDestinationV3Decoded, [parsedToolsetNoRootDestination])
 
-        let toolsetRootDestinationV3Decoded = try Destination.decode(
+        let toolsetRootDestinationV3Decoded = try SwiftSDK.decode(
             fromFile: AbsolutePath(validating: toolsetRootDestinationV3.path),
             fileSystem: fs,
             observabilityScope: observability
@@ -401,7 +401,7 @@ final class DestinationTests: XCTestCase {
 
         XCTAssertEqual(toolsetRootDestinationV3Decoded, [parsedToolsetRootDestination])
 
-        XCTAssertThrowsError(try Destination.decode(
+        XCTAssertThrowsError(try SwiftSDK.decode(
             fromFile: AbsolutePath(validating: missingToolsetDestinationV3.path),
             fileSystem: fs,
             observabilityScope: observability
@@ -416,13 +416,13 @@ final class DestinationTests: XCTestCase {
                 )
             )
         }
-        XCTAssertThrowsError(try Destination.decode(
+        XCTAssertThrowsError(try SwiftSDK.decode(
             fromFile: AbsolutePath(validating: invalidVersionDestinationV3.path),
             fileSystem: fs,
             observabilityScope: observability
         ))
 
-        XCTAssertThrowsError(try Destination.decode(
+        XCTAssertThrowsError(try SwiftSDK.decode(
             fromFile: AbsolutePath(validating: invalidToolsetDestinationV3.path),
             fileSystem: fs,
             observabilityScope: observability
@@ -433,7 +433,7 @@ final class DestinationTests: XCTestCase {
             )
         }
 
-        let toolsetNoRootSwiftSDKv4Decoded = try Destination.decode(
+        let toolsetNoRootSwiftSDKv4Decoded = try SwiftSDK.decode(
             fromFile: AbsolutePath(validating: toolsetNoRootSwiftSDKv4.path),
             fileSystem: fs,
             observabilityScope: observability
@@ -441,7 +441,7 @@ final class DestinationTests: XCTestCase {
 
         XCTAssertEqual(toolsetNoRootSwiftSDKv4Decoded, [parsedToolsetNoRootDestination])
 
-        let toolsetRootSwiftSDKv4Decoded = try Destination.decode(
+        let toolsetRootSwiftSDKv4Decoded = try SwiftSDK.decode(
             fromFile: AbsolutePath(validating: toolsetRootSwiftSDKv4.path),
             fileSystem: fs,
             observabilityScope: observability
@@ -449,7 +449,7 @@ final class DestinationTests: XCTestCase {
 
         XCTAssertEqual(toolsetRootSwiftSDKv4Decoded, [parsedToolsetRootDestination])
 
-        XCTAssertThrowsError(try Destination.decode(
+        XCTAssertThrowsError(try SwiftSDK.decode(
             fromFile: AbsolutePath(validating: missingToolsetSwiftSDKv4.path),
             fileSystem: fs,
             observabilityScope: observability
@@ -464,13 +464,13 @@ final class DestinationTests: XCTestCase {
                 )
             )
         }
-        XCTAssertThrowsError(try Destination.decode(
+        XCTAssertThrowsError(try SwiftSDK.decode(
             fromFile: AbsolutePath(validating: invalidVersionSwiftSDKv4.path),
             fileSystem: fs,
             observabilityScope: observability
         ))
 
-        XCTAssertThrowsError(try Destination.decode(
+        XCTAssertThrowsError(try SwiftSDK.decode(
             fromFile: AbsolutePath(validating: invalidToolsetSwiftSDKv4.path),
             fileSystem: fs,
             observabilityScope: observability

--- a/Tests/PackageModelTests/PackageModelTests.swift
+++ b/Tests/PackageModelTests/PackageModelTests.swift
@@ -61,14 +61,14 @@ class PackageModelTests: XCTestCase {
         let sdkDir = AbsolutePath("/some/path/to/an/SDK.sdk")
         let toolchainPath = AbsolutePath("/some/path/to/a/toolchain.xctoolchain")
 
-        let destination = Destination(
+        let destination = SwiftSDK(
             targetTriple: triple,
             toolset: .init(toolchainBinDir: toolchainPath.appending(components: "usr", "bin"), buildFlags: .init()),
             pathsConfiguration: .init(sdkRootPath: sdkDir)
         )
 
         XCTAssertEqual(
-            try UserToolchain.deriveSwiftCFlags(triple: triple, destination: destination, environment: .process()),
+            try UserToolchain.deriveSwiftCFlags(triple: triple, swiftSDK: destination, environment: .process()),
             [
                 // Needed when cross‐compiling for Android. 2020‐03‐01
                 "-sdk", sdkDir.pathString,

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -87,7 +87,7 @@ class InitTests: XCTestCase {
 
             XCTAssertEqual(try fs.getDirectoryContents(path.appending("Sources")), ["main.swift"])
             XCTAssertBuilds(path)
-            let triple = try UserToolchain.default.triple
+            let triple = try UserToolchain.default.targetTriple
             let binPath = path.appending(components: ".build", triple.platformBuildPathComponent(), "debug")
 #if os(Windows)
             XCTAssertFileExists(binPath.appending("Foo.exe"))
@@ -144,7 +144,7 @@ class InitTests: XCTestCase {
 
             // Try building it
             XCTAssertBuilds(path)
-            let triple = try UserToolchain.default.triple
+            let triple = try UserToolchain.default.targetTriple
             XCTAssertFileExists(path.appending(components: ".build", triple.platformBuildPathComponent(), "debug", "Foo.swiftmodule"))
         }
     }
@@ -242,7 +242,7 @@ class InitTests: XCTestCase {
 
             // Try building it.
             XCTAssertBuilds(packageRoot)
-            let triple = try UserToolchain.default.triple
+            let triple = try UserToolchain.default.targetTriple
             XCTAssertFileExists(packageRoot.appending(components: ".build", triple.platformBuildPathComponent(), "debug", "some_package.swiftmodule"))
         }
     }

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -7496,7 +7496,7 @@ final class WorkspaceTests: XCTestCase {
         let binaryArtifactsManager = try Workspace.BinaryArtifactsManager(
             fileSystem: fs,
             authorizationProvider: .none,
-            hostToolchain: UserToolchain(destination: .hostDestination()),
+            hostToolchain: UserToolchain(swiftSDK: .hostSwiftSDK()),
             checksumAlgorithm: checksumAlgorithm,
             customHTTPClient: .none,
             customArchiver: .none,
@@ -8535,7 +8535,7 @@ final class WorkspaceTests: XCTestCase {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let downloads = ThreadSafeKeyValueStore<URL, AbsolutePath>()
-        let hostToolchain = try UserToolchain(destination: .hostDestination())
+        let hostToolchain = try UserToolchain(swiftSDK: .hostSwiftSDK())
 
         let ariFiles = [
             """
@@ -8545,7 +8545,7 @@ final class WorkspaceTests: XCTestCase {
                     {
                         "fileName": "a1.zip",
                         "checksum": "a1",
-                        "supportedTriples": ["\(hostToolchain.triple.tripleString)"]
+                        "supportedTriples": ["\(hostToolchain.targetTriple.tripleString)"]
                     }
                 ]
             }
@@ -8557,7 +8557,7 @@ final class WorkspaceTests: XCTestCase {
                     {
                         "fileName": "a2/a2.zip",
                         "checksum": "a2",
-                        "supportedTriples": ["\(hostToolchain.triple.tripleString)"]
+                        "supportedTriples": ["\(hostToolchain.targetTriple.tripleString)"]
                     }
                 ]
             }
@@ -8823,7 +8823,7 @@ final class WorkspaceTests: XCTestCase {
     func testDownloadArchiveIndexFileBadChecksum() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
-        let hostToolchain = try UserToolchain(destination: .hostDestination())
+        let hostToolchain = try UserToolchain(swiftSDK: .hostSwiftSDK())
 
         let ari = """
         {
@@ -8832,7 +8832,7 @@ final class WorkspaceTests: XCTestCase {
                 {
                     "fileName": "a1.zip",
                     "checksum": "a1",
-                    "supportedTriples": ["\(hostToolchain.triple.tripleString)"]
+                    "supportedTriples": ["\(hostToolchain.targetTriple.tripleString)"]
                 }
             ]
         }
@@ -8942,7 +8942,7 @@ final class WorkspaceTests: XCTestCase {
     func testDownloadArchiveIndexFileBadArchivesChecksum() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
-        let hostToolchain = try UserToolchain(destination: .hostDestination())
+        let hostToolchain = try UserToolchain(swiftSDK: .hostSwiftSDK())
 
         let ari = """
         {
@@ -8951,7 +8951,7 @@ final class WorkspaceTests: XCTestCase {
                 {
                     "fileName": "a.zip",
                     "checksum": "a",
-                    "supportedTriples": ["\(hostToolchain.triple.tripleString)"]
+                    "supportedTriples": ["\(hostToolchain.targetTriple.tripleString)"]
                 }
             ]
         }
@@ -9052,7 +9052,7 @@ final class WorkspaceTests: XCTestCase {
     func testDownloadArchiveIndexFileArchiveNotFound() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
-        let hostToolchain = try UserToolchain(destination: .hostDestination())
+        let hostToolchain = try UserToolchain(swiftSDK: .hostSwiftSDK())
 
         let ari = """
         {
@@ -9061,7 +9061,7 @@ final class WorkspaceTests: XCTestCase {
                 {
                     "fileName": "not-found.zip",
                     "checksum": "a",
-                    "supportedTriples": ["\(hostToolchain.triple.tripleString)"]
+                    "supportedTriples": ["\(hostToolchain.targetTriple.tripleString)"]
                 }
             ]
         }
@@ -9128,10 +9128,10 @@ final class WorkspaceTests: XCTestCase {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
-        let hostToolchain = try UserToolchain(destination: .hostDestination())
+        let hostToolchain = try UserToolchain(swiftSDK: .hostSwiftSDK())
         let androidTriple = try Triple("x86_64-unknown-linux-android")
         let macTriple = try Triple("arm64-apple-macosx")
-        let notHostTriple = hostToolchain.triple == androidTriple ? macTriple : androidTriple
+        let notHostTriple = hostToolchain.targetTriple == androidTriple ? macTriple : androidTriple
 
         let ari = """
         {
@@ -9189,7 +9189,7 @@ final class WorkspaceTests: XCTestCase {
             testDiagnostics(diagnostics) { result in
                 result.check(
                     diagnostic: .contains(
-                        "failed retrieving 'https://a.com/a.artifactbundleindex': No supported archive was found for '\(hostToolchain.triple.tripleString)'"
+                        "failed retrieving 'https://a.com/a.artifactbundleindex': No supported archive was found for '\(hostToolchain.targetTriple.tripleString)'"
                     ),
                     severity: .error
                 )


### PR DESCRIPTION
### Motivation:

With the cross-compilation proposal accepted in principle, I think it's time to move over to the new nomenclature altogether.

### Modifications:

Renamed `Destination` type to `SwiftSDK`. Also renamed mentions of "destination" in declarations to "Swift SDK" and cleaned up usage of `triple` where it was actually referring to the target triple.

### Result:

Naming is consistent across the codebase. This is an NFC.
