### PR TITLE
[5.9] Improve handling of tool build flags

### DIFF
--- a/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
@@ -283,12 +283,14 @@ public final class ClangTargetBuildDescription {
             args += ["-include", resourceAccessorHeaderFile.pathString]
         }
 
-        args += buildParameters.toolchain.extraFlags.cCompilerFlags
-        // User arguments (from -Xcc and -Xcxx below) should follow generated arguments to allow user overrides
-        args += buildParameters.flags.cCompilerFlags
+        args += self.buildParameters.toolchain.extraFlags.cCompilerFlags
+        // User arguments (from -Xcc) should follow generated arguments to allow user overrides
+        args += self.buildParameters.flags.cCompilerFlags
 
         // Add extra C++ flags if this target contains C++ files.
-        if clangTarget.isCXX {
+        if isCXX {
+            args += self.buildParameters.toolchain.extraFlags.cxxCompilerFlags
+            // User arguments (from -Xcxx) should follow generated arguments to allow user overrides
             args += self.buildParameters.flags.cxxCompilerFlags
         }
         return args

--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -414,6 +414,11 @@ public final class SwiftTargetBuildDescription {
         args += try self.buildParameters.targetTripleArgs(for: self.target)
         args += ["-swift-version", self.swiftVersion.rawValue]
 
+        // pass `-v` during verbose builds.
+        if self.buildParameters.verboseOutput {
+            args += ["-v"]
+        }
+
         // Enable batch mode in debug mode.
         //
         // Technically, it should be enabled whenever WMO is off but we
@@ -496,7 +501,17 @@ public final class SwiftTargetBuildDescription {
 
         args += self.buildParameters.toolchain.extraFlags.swiftCompilerFlags
         // User arguments (from -Xswiftc) should follow generated arguments to allow user overrides
-        args += self.buildParameters.swiftCompilerFlags
+        args += self.buildParameters.flags.swiftCompilerFlags
+
+        args += self.buildParameters.toolchain.extraFlags.cCompilerFlags.asSwiftcCCompilerFlags()
+        // User arguments (from -Xcc) should follow generated arguments to allow user overrides
+        args += self.buildParameters.flags.cCompilerFlags.asSwiftcCCompilerFlags()
+
+        // TODO: Pass -Xcxx flags to swiftc (#6491)
+        // Uncomment when downstream support arrives.
+        // args += self.buildParameters.toolchain.extraFlags.cxxCompilerFlags.asSwiftcCXXCompilerFlags()
+        // // User arguments (from -Xcxx) should follow generated arguments to allow user overrides
+        // args += self.buildParameters.flags.cxxCompilerFlags.asSwiftcCXXCompilerFlags()
 
         // suppress warnings if the package is remote
         if self.package.isRemote {
@@ -611,6 +626,11 @@ public final class SwiftTargetBuildDescription {
         var result: [String] = []
         result.append(self.buildParameters.toolchain.swiftCompilerPath.pathString)
 
+        // pass `-v` during verbose builds.
+        if self.buildParameters.verboseOutput {
+            result += ["-v"]
+        }
+
         result.append("-module-name")
         result.append(self.target.c99name)
         result.append(contentsOf: packageNameArgumentIfSupported(with: self.package, packageAccess: self.target.packageAccess))
@@ -646,8 +666,21 @@ public final class SwiftTargetBuildDescription {
         result += self.buildParameters.sanitizers.compileSwiftFlags()
         result += ["-parseable-output"]
         result += try self.buildSettingsFlags()
+
         result += self.buildParameters.toolchain.extraFlags.swiftCompilerFlags
-        result += self.buildParameters.swiftCompilerFlags
+        // User arguments (from -Xswiftc) should follow generated arguments to allow user overrides
+        result += self.buildParameters.flags.swiftCompilerFlags
+
+        result += self.buildParameters.toolchain.extraFlags.cCompilerFlags.asSwiftcCCompilerFlags()
+        // User arguments (from -Xcc) should follow generated arguments to allow user overrides
+        result += self.buildParameters.flags.cCompilerFlags.asSwiftcCCompilerFlags()
+
+        // TODO: Pass -Xcxx flags to swiftc (#6491)
+        // Uncomment when downstream support arrives.
+        // result += self.buildParameters.toolchain.extraFlags.cxxCompilerFlags.asSwiftcCXXCompilerFlags()
+        // // User arguments (from -Xcxx) should follow generated arguments to allow user overrides
+        // result += self.buildParameters.flags.cxxCompilerFlags.asSwiftcCXXCompilerFlags()
+
         result += try self.macroArguments()
         return result
     }

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -48,29 +48,7 @@ extension Array where Element == String {
     func asSwiftcCCompilerFlags() -> Self {
         self.flatMap { ["-Xcc", $0] }
     }
-}
 
-extension BuildParameters {
-    /// Returns the directory to be used for module cache.
-    public var moduleCache: AbsolutePath {
-        get throws {
-            // FIXME: We use this hack to let swiftpm's functional test use shared
-            // cache so it doesn't become painfully slow.
-            if let path = ProcessEnv.vars["SWIFTPM_TESTS_MODULECACHE"] {
-                return try AbsolutePath(validating: path)
-            }
-            return buildPath.appending("ModuleCache")
-        }
-    }
-
-    /// Extra flags to pass to Swift compiler.
-    public var swiftCompilerFlags: [String] {
-        var flags = self.flags.cCompilerFlags.flatMap({ ["-Xcc", $0] })
-        flags += self.flags.swiftCompilerFlags
-        if self.verboseOutput {
-            flags.append("-v")
-        }
-        return flags
     /// Converts a set of C++ compiler flags into an equivalent set to be
     /// indirected through the Swift compiler instead.
     func asSwiftcCXXCompilerFlags() -> Self {
@@ -80,8 +58,6 @@ extension BuildParameters {
         fatalError("swiftc does support -Xcxx flags yet.")
     }
 
-    /// Extra flags to pass to linker.
-    public var linkerFlags: [String] {
     /// Converts a set of linker flags into an equivalent set to be indirected
     /// through the Swift compiler instead.
     ///
@@ -98,7 +74,6 @@ extension BuildParameters {
         let directSwiftLinkerArgs = ["-L"]
 
         var flags: [String] = []
-        var it = self.flags.linkerFlags.makeIterator()
         var it = self.makeIterator()
         while let flag = it.next() {
             if directSwiftLinkerArgs.contains(flag) {

--- a/Sources/CoreCommands/SwiftTool.swift
+++ b/Sources/CoreCommands/SwiftTool.swift
@@ -680,15 +680,13 @@ public final class SwiftTool {
             let dataPath = self.scratchDirectory.appending(
                 component: destinationTriple.platformBuildPathComponent(buildSystem: options.build.buildSystem)
             )
-            var buildFlags = options.build.buildFlags
-            buildFlags.append(destinationToolchain.extraFlags)
 
             return try BuildParameters(
                 dataPath: dataPath,
                 configuration: options.build.configuration,
                 toolchain: destinationToolchain,
                 destinationTriple: destinationTriple,
-                flags: buildFlags,
+                flags: options.build.buildFlags,
                 pkgConfigDirectories: options.locations.pkgConfigDirectories,
                 architectures: options.build.architectures,
                 workers: options.build.jobs ?? UInt32(ProcessInfo.processInfo.activeProcessorCount),

--- a/Sources/PackageModel/BuildFlags.swift
+++ b/Sources/PackageModel/BuildFlags.swift
@@ -40,20 +40,4 @@ public struct BuildFlags: Equatable, Encodable {
         self.linkerFlags = linkerFlags
         self.xcbuildFlags = xcbuildFlags
     }
-    
-    /// Appends corresponding properties of a different `BuildFlags` value into `self`.
-    /// - Parameter buildFlags: a `BuildFlags` value to merge flags from.
-    public mutating func append(_ buildFlags: BuildFlags) {
-        cCompilerFlags += buildFlags.cCompilerFlags
-        cxxCompilerFlags += buildFlags.cxxCompilerFlags
-        swiftCompilerFlags += buildFlags.swiftCompilerFlags
-        linkerFlags += buildFlags.linkerFlags
-
-        if var xcbuildFlags, let newXcbuildFlags = buildFlags.xcbuildFlags {
-            xcbuildFlags += newXcbuildFlags
-            self.xcbuildFlags = xcbuildFlags
-        } else if let xcbuildFlags = buildFlags.xcbuildFlags {
-            self.xcbuildFlags = xcbuildFlags
-        }
-    }
 }

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -481,13 +481,15 @@ public final class UserToolchain: Toolchain {
         }
 
         self.triple = triple
-        self.extraFlags = BuildFlags()
-
-        self.extraFlags.swiftCompilerFlags = try Self.deriveSwiftCFlags(
-            triple: triple,
-            destination: destination,
-            environment: environment
-        )
+        self.extraFlags = BuildFlags(
+            cCompilerFlags: destination.toolset.knownTools[.cCompiler]?.extraCLIOptions ?? [],
+            cxxCompilerFlags: destination.toolset.knownTools[.cxxCompiler]?.extraCLIOptions ?? [],
+            swiftCompilerFlags: try Self.deriveSwiftCFlags(
+                triple: triple,
+                destination: destination,
+                environment: environment),
+            linkerFlags: destination.toolset.knownTools[.linker]?.extraCLIOptions ?? [],
+            xcbuildFlags: destination.toolset.knownTools[.xcbuild]?.extraCLIOptions ?? [])
 
         self.librarianPath = try UserToolchain.determineLibrarian(
             triple: triple,
@@ -499,14 +501,8 @@ public final class UserToolchain: Toolchain {
         )
 
         if let sdkDir = destination.pathsConfiguration.sdkRootPath {
-            self.extraFlags.cCompilerFlags = [
-                triple.isDarwin() ? "-isysroot" : "--sysroot", sdkDir.pathString,
-            ] + (destination.toolset.knownTools[.cCompiler]?.extraCLIOptions ?? [])
-
-            self.extraFlags.cxxCompilerFlags = destination.toolset.knownTools[.cxxCompiler]?.extraCLIOptions ?? []
-        } else {
-            self.extraFlags.cCompilerFlags = (destination.toolset.knownTools[.cCompiler]?.extraCLIOptions ?? [])
-            self.extraFlags.cxxCompilerFlags = (destination.toolset.knownTools[.cxxCompiler]?.extraCLIOptions ?? [])
+            let sysrootFlags = [triple.isDarwin() ? "-isysroot" : "--sysroot", sdkDir.pathString]
+            self.extraFlags.cCompilerFlags.insert(contentsOf: sysrootFlags, at: 0)
         }
 
         if triple.isWindows() {

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -190,21 +190,22 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
         settings["LIBRARY_SEARCH_PATHS"] = "$(inherited) \(try buildParameters.toolchain.toolchainLibDir.pathString)"
         settings["OTHER_CFLAGS"] = (
             ["$(inherited)"]
-            + buildParameters.toolchain.extraFlags.cCompilerFlags
+            + buildParameters.toolchain.extraFlags.cCompilerFlags.map { $0.spm_shellEscaped() }
             + buildParameters.flags.cCompilerFlags.map { $0.spm_shellEscaped() }
         ).joined(separator: " ")
         settings["OTHER_CPLUSPLUSFLAGS"] = (
             ["$(inherited)"]
-            + buildParameters.toolchain.extraFlags.cxxCompilerFlags
+            + buildParameters.toolchain.extraFlags.cxxCompilerFlags.map { $0.spm_shellEscaped() }
             + buildParameters.flags.cxxCompilerFlags.map { $0.spm_shellEscaped() }
         ).joined(separator: " ")
         settings["OTHER_SWIFT_FLAGS"] = (
             ["$(inherited)"]
-            + buildParameters.toolchain.extraFlags.swiftCompilerFlags
+            + buildParameters.toolchain.extraFlags.swiftCompilerFlags.map { $0.spm_shellEscaped() }
             + buildParameters.flags.swiftCompilerFlags.map { $0.spm_shellEscaped() }
         ).joined(separator: " ")
         settings["OTHER_LDFLAGS"] = (
             ["$(inherited)"]
+            + buildParameters.toolchain.extraFlags.linkerFlags.map { $0.spm_shellEscaped() }
             + buildParameters.flags.linkerFlags.map { $0.spm_shellEscaped() }
         ).joined(separator: " ")
 

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -3505,7 +3505,166 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertMatch(try lib.basicArguments(isCXX: false), args)
 
         let exe = try result.target(for: "exe").swiftTarget().compileArguments()
-        XCTAssertMatch(exe, ["-module-cache-path", "\(buildPath.appending(components: "ModuleCache"))", .anySequence, "-swift-flag-from-json", "-Xcc", "-clang-command-line-flag", "-swift-command-line-flag"])
+        XCTAssertMatch(exe, ["-module-cache-path", "\(buildPath.appending(components: "ModuleCache"))", .anySequence, "-swift-flag-from-json", "-swift-command-line-flag", .anySequence, "-Xcc", "-clang-flag-from-json", "-Xcc", "-clang-command-line-flag"])
+    }
+
+    func testUserToolchainWithToolsetCompileFlags() throws {
+        let fileSystem = InMemoryFileSystem(emptyFiles:
+            "/Pkg/Sources/exe/main.swift",
+            "/Pkg/Sources/cLib/cLib.c",
+            "/Pkg/Sources/cLib/include/cLib.h",
+            "/Pkg/Sources/cxxLib/cxxLib.c",
+            "/Pkg/Sources/cxxLib/include/cxxLib.h"
+        )
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fileSystem: fileSystem,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "Pkg",
+                    path: "/Pkg",
+                    targets: [
+                        TargetDescription(name: "exe", dependencies: ["cLib", "cxxLib"]),
+                        TargetDescription(name: "cLib", dependencies: []),
+                        TargetDescription(name: "cxxLib", dependencies: []),
+                    ]),
+            ],
+            observabilityScope: observability.topScope
+        )
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
+        func jsonFlag(tool: Toolset.KnownTool) -> String { "-\(tool)-flag-from-json" }
+        func jsonFlag(tool: Toolset.KnownTool) -> StringPattern { .equal(jsonFlag(tool: tool)) }
+        func cliFlag(tool: Toolset.KnownTool) -> String { "-\(tool)-flag-from-cli" }
+        func cliFlag(tool: Toolset.KnownTool) -> StringPattern { .equal(cliFlag(tool: tool)) }
+
+        let toolSet = Toolset(
+            knownTools: [
+                .cCompiler: .init(extraCLIOptions: [jsonFlag(tool: .cCompiler)]),
+                .cxxCompiler: .init(extraCLIOptions: [jsonFlag(tool: .cxxCompiler)]),
+                .swiftCompiler: .init(extraCLIOptions: [jsonFlag(tool: .swiftCompiler)]),
+                .linker: .init(extraCLIOptions: [jsonFlag(tool: .linker)]),
+            ],
+            rootPaths: try UserToolchain.default.destination.toolset.rootPaths)
+        let runtimeTriple = try Triple("armv7em-unknown-none-macho")
+        let destination = try Destination(
+            runTimeTriple: runtimeTriple,
+            properties: .init(
+                sdkRootPath: "/fake/sdk",
+                swiftStaticResourcesPath: "/usr/lib/swift_static/none",
+                includeSearchPaths: ["/usr/lib/swift_static/none"],
+                librarySearchPaths: ["/usr/lib/swift_static/none"],
+                toolsetPaths: []),
+            toolset: toolSet,
+            destinationDirectory: nil)
+        let toolchain = try UserToolchain(destination: destination)
+        let buildParameters = mockBuildParameters(
+            toolchain: toolchain,
+            flags: BuildFlags(
+                cCompilerFlags: [cliFlag(tool: .cCompiler)],
+                cxxCompilerFlags: [cliFlag(tool: .cxxCompiler)],
+                swiftCompilerFlags: [cliFlag(tool: .swiftCompiler)],
+                linkerFlags: [cliFlag(tool: .linker)]),
+            destinationTriple: runtimeTriple)
+        let result = try BuildPlanResult(plan: BuildPlan(
+            buildParameters: buildParameters,
+            graph: graph,
+            fileSystem: fileSystem,
+            observabilityScope: observability.topScope))
+        result.checkProductsCount(1)
+        result.checkTargetsCount(3)
+
+        func XCTAssertCount<S>(
+            _ expectedCount: Int,
+            _ sequence: S,
+            _ element: S.Element,
+            file: StaticString = #filePath,
+            line: UInt = #line
+        ) where S: Sequence, S.Element: Equatable {
+            let actualCount = sequence.filter({ $0 == element }).count
+            guard actualCount != expectedCount else { return }
+            XCTFail(
+                """
+                Failed to find expected element '\(element)' in \
+                '\(sequence)' \(expectedCount) time(s) but found element \
+                \(actualCount) time(s).
+                """,
+                file: file,
+                line: line)
+        }
+
+        // Compile C Target
+        let cLibCompileArguments = try result.target(for: "cLib").clangTarget().basicArguments(isCXX: false)
+        let cLibCompileArgumentsPattern: [StringPattern] = [
+            jsonFlag(tool: .cCompiler), cliFlag(tool: .cCompiler),
+        ]
+        XCTAssertMatch(cLibCompileArguments, cLibCompileArgumentsPattern)
+        XCTAssertCount(0, cLibCompileArguments, jsonFlag(tool: .swiftCompiler))
+        XCTAssertCount(0, cLibCompileArguments, cliFlag(tool: .swiftCompiler))
+        XCTAssertCount(1, cLibCompileArguments, jsonFlag(tool: .cCompiler))
+        XCTAssertCount(1, cLibCompileArguments, cliFlag(tool: .cCompiler))
+        XCTAssertCount(0, cLibCompileArguments, jsonFlag(tool: .cxxCompiler))
+        XCTAssertCount(0, cLibCompileArguments, cliFlag(tool: .cxxCompiler))
+        XCTAssertCount(0, cLibCompileArguments, jsonFlag(tool: .linker))
+        XCTAssertCount(0, cLibCompileArguments, cliFlag(tool: .linker))
+
+        // Compile Cxx Target
+        let cxxLibCompileArguments = try result.target(for: "cxxLib").clangTarget().basicArguments(isCXX: true)
+        let cxxLibCompileArgumentsPattern: [StringPattern] = [
+            jsonFlag(tool: .cCompiler), cliFlag(tool: .cCompiler),
+            .anySequence,
+            jsonFlag(tool: .cxxCompiler), cliFlag(tool: .cxxCompiler)
+        ]
+        XCTAssertMatch(cxxLibCompileArguments, cxxLibCompileArgumentsPattern)
+        XCTAssertCount(0, cxxLibCompileArguments, jsonFlag(tool: .swiftCompiler))
+        XCTAssertCount(0, cxxLibCompileArguments, cliFlag(tool: .swiftCompiler))
+        XCTAssertCount(1, cxxLibCompileArguments, jsonFlag(tool: .cCompiler))
+        XCTAssertCount(1, cxxLibCompileArguments, cliFlag(tool: .cCompiler))
+        XCTAssertCount(1, cxxLibCompileArguments, jsonFlag(tool: .cxxCompiler))
+        XCTAssertCount(1, cxxLibCompileArguments, cliFlag(tool: .cxxCompiler))
+        XCTAssertCount(0, cxxLibCompileArguments, jsonFlag(tool: .linker))
+        XCTAssertCount(0, cxxLibCompileArguments, cliFlag(tool: .linker))
+
+        // Compile Swift Target
+        let exeCompileArguments = try result.target(for: "exe").swiftTarget().compileArguments()
+        let exeCompileArgumentsPattern: [StringPattern] = [
+            jsonFlag(tool: .swiftCompiler), cliFlag(tool: .swiftCompiler),
+            .anySequence,
+            "-Xcc", jsonFlag(tool: .cCompiler), "-Xcc", cliFlag(tool: .cCompiler),
+            // TODO: Pass -Xcxx flags to swiftc (#6491)
+            // Uncomment when downstream support arrives.
+            // .anySequence,
+            // "-Xcxx", jsonFlag(tool: .cxxCompiler), "-Xcxx", cliFlag(tool: .cxxCompiler),
+        ]
+        XCTAssertMatch(exeCompileArguments, exeCompileArgumentsPattern)
+        XCTAssertCount(1, exeCompileArguments, jsonFlag(tool: .swiftCompiler))
+        XCTAssertCount(1, exeCompileArguments, cliFlag(tool: .swiftCompiler))
+        XCTAssertCount(1, exeCompileArguments, jsonFlag(tool: .cCompiler))
+        XCTAssertCount(1, exeCompileArguments, cliFlag(tool: .cCompiler))
+        // TODO: Pass -Xcxx flags to swiftc (#6491)
+        // Change 0 to 1 when downstream support arrives.
+        XCTAssertCount(0, exeCompileArguments, jsonFlag(tool: .cxxCompiler))
+        XCTAssertCount(0, exeCompileArguments, cliFlag(tool: .cxxCompiler))
+        XCTAssertCount(0, exeCompileArguments, jsonFlag(tool: .linker))
+        XCTAssertCount(0, exeCompileArguments, cliFlag(tool: .linker))
+
+        // Link Product
+        let exeLinkArguments = try result.buildProduct(for: "exe").linkArguments()
+        let exeLinkArgumentsPattern: [StringPattern] = [
+            jsonFlag(tool: .swiftCompiler), cliFlag(tool: .swiftCompiler),
+            .anySequence,
+            "-Xlinker", jsonFlag(tool: .linker), "-Xlinker", cliFlag(tool: .linker),
+        ]
+        XCTAssertMatch(exeLinkArguments, exeLinkArgumentsPattern)
+        XCTAssertCount(1, exeLinkArguments, jsonFlag(tool: .swiftCompiler))
+        XCTAssertCount(1, exeLinkArguments, cliFlag(tool: .swiftCompiler))
+        XCTAssertCount(0, exeLinkArguments, jsonFlag(tool: .cCompiler))
+        XCTAssertCount(0, exeLinkArguments, cliFlag(tool: .cCompiler))
+        XCTAssertCount(0, exeLinkArguments, jsonFlag(tool: .cxxCompiler))
+        XCTAssertCount(0, exeLinkArguments, cliFlag(tool: .cxxCompiler))
+        XCTAssertCount(1, exeLinkArguments, jsonFlag(tool: .linker))
+        XCTAssertCount(1, exeLinkArguments, cliFlag(tool: .linker))
     }
 
     func testExecBuildTimeDependency() throws {

--- a/Tests/BuildTests/MockBuildTestHelper.swift
+++ b/Tests/BuildTests/MockBuildTestHelper.swift
@@ -32,11 +32,7 @@ struct MockToolchain: PackageModel.Toolchain {
     let isSwiftDevelopmentToolchain = false
     let swiftPluginServerPath: AbsolutePath? = nil
     
-    #if os(macOS)
-    let extraFlags = BuildFlags(cxxCompilerFlags: ["-lc++"])
-    #else
-    let extraFlags = BuildFlags(cxxCompilerFlags: ["-lstdc++"])
-    #endif
+    let extraFlags = PackageModel.BuildFlags()
 
     func getClangCompiler() throws -> AbsolutePath {
         return AbsolutePath(path: "/fake/path/to/clang")


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-package-manager/pull/6475.

Refactors the various compilerArguments and linkerArgument functions slightly to ensure flags from a user's sdk and cli properly propagate to the expected subcommand invocations.

Adds a fairly comprehensive test to cover the toolset and cli flag passing end result.

---

Fixes a bug where clang targets didn't respect the `isCXX` override.

Fixes a bug where cxxCompiler extraCLIFlags where not passed to clang when building cxx targets. Future work: #6491. cxxCompiler extraCLIFlags should also be passed to `swiftc` when compiling swift modules to ensure the clang importer has the same interpretation of the module as the initial compile.

Fixes a bug where linker extraCLIFlags were not passed to `swiftc` prefixed by `-Xlinker`. The previous workaround to pass these flags in swiftCompiler extraCLIFlags is no longer necessary.

Fixes a bug where a user could pass `-whole-module-optimization` or `-wmo` to swiftc when linking causing the driver to either attempt to compile the object files when using the legacy driver: rdar://27578292 or crash when using the new driver: rdar://108057797.

Fixes a bug where cCompiler extraCLIFlags were not passed to `swiftc` prefixed by `-Xcc`. The previous workaround to pass these flags in swiftCompiler extraCLIFlags is no longer necessary.

Fixes a bug where extraCLIFlags from an SDKs toolset.json files would be repeated multiple times in child process invocations. The repeated flags could cause issues with some downstream tools, such as repeated `-segaddr` flags to ld64 for the same segment.

Fixes a bug where extra toolchain flags would be added to an xcode build parameters file without escaping.

Fixes a bug where extra toolchain linker flags would not be added to an xcode build parameters file.

(cherry picked from commit 151343e96705327a9d7341be843d5e5aa7796e25)

```
# Conflicts:
#	Sources/Build/BuildPlan.swift
#	Tests/BuildTests/MockBuildTestHelper.swift
```