### PR TITLE
[5.9] Preserve port when computing the login URL

### DIFF
--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -75,7 +75,7 @@ public final class RegistryClient: Cancellable {
 
         if let authorizationProvider {
             self.authorizationProvider = { url in
-                guard let registryAuthentication = configuration.authentication(for: url) else {
+                guard let registryAuthentication = try? configuration.authentication(for: url) else {
                     return .none
                 }
                 guard let (user, password) = authorizationProvider.authentication(for: url) else {

--- a/Sources/PackageRegistryTool/PackageRegistryTool+Auth.swift
+++ b/Sources/PackageRegistryTool/PackageRegistryTool+Auth.swift
@@ -89,6 +89,20 @@ private func readpassword(_ prompt: String) throws -> String {
 
 extension SwiftPackageRegistryTool {
     struct Login: SwiftCommand {
+
+        static func loginURL(from registryURL: URL, loginAPIPath: String?) throws -> URL {
+            // Login URL must be HTTPS
+            var loginURLComponents = URLComponents(url: registryURL, resolvingAgainstBaseURL: true)
+            loginURLComponents?.scheme = "https"
+            loginURLComponents?.path = loginAPIPath ?? "/login"
+
+            guard let loginURL = loginURLComponents?.url else {
+                throw ValidationError.invalidURL(registryURL)
+            }
+
+            return loginURL
+        }
+
         static let configuration = CommandConfiguration(
             abstract: "Log in to a registry"
         )
@@ -151,10 +165,6 @@ extension SwiftPackageRegistryTool {
             }
 
             try registryURL.validateRegistryURL()
-
-            guard let host = registryURL.host?.lowercased() else {
-                throw ValidationError.invalidURL(registryURL)
-            }
 
             let authenticationType: RegistryConfiguration.AuthenticationType
             let storeUsername: String
@@ -225,15 +235,12 @@ extension SwiftPackageRegistryTool {
                 loginAPIPath = registryURL.path
             }
 
-            // Login URL must be HTTPS
-            guard let loginURL = URL(string: "https://\(host)\(loginAPIPath ?? "/login")") else {
-                throw ValidationError.invalidURL(registryURL)
-            }
+            let loginURL = try Self.loginURL(from: registryURL, loginAPIPath: loginAPIPath)
+
 
             // Build a RegistryConfiguration with the given authentication settings
             var registryConfiguration = configuration.configuration
-            registryConfiguration
-                .registryAuthentication[host] = .init(type: authenticationType, loginAPIPath: loginAPIPath)
+            try registryConfiguration.add(authentication: .init(type: authenticationType, loginAPIPath: loginAPIPath), for: registryURL)
 
             // Build a RegistryClient to test login credentials (fingerprints don't matter in this case)
             let registryClient = RegistryClient(
@@ -306,7 +313,7 @@ extension SwiftPackageRegistryTool {
 
             // Update user-level registry configuration file
             let update: (inout RegistryConfiguration) throws -> Void = { configuration in
-                configuration.registryAuthentication[host] = .init(type: authenticationType, loginAPIPath: loginAPIPath)
+                try configuration.add(authentication: .init(type: authenticationType, loginAPIPath: loginAPIPath), for: registryURL)
             }
             try configuration.updateShared(with: update)
 
@@ -339,10 +346,6 @@ extension SwiftPackageRegistryTool {
 
             try registryURL.validateRegistryURL()
 
-            guard let host = registryURL.host?.lowercased() else {
-                throw ValidationError.invalidURL(registryURL)
-            }
-
             // We need to be able to read/write credentials
             guard let authorizationProvider = try swiftTool.getRegistryAuthorizationProvider() else {
                 throw ValidationError.unknownCredentialStore
@@ -361,7 +364,7 @@ extension SwiftPackageRegistryTool {
 
             // Update user-level registry configuration file
             let update: (inout RegistryConfiguration) throws -> Void = { configuration in
-                configuration.registryAuthentication.removeValue(forKey: host)
+                configuration.removeAuthentication(for: registryURL)
             }
             try configuration.updateShared(with: update)
 

--- a/Tests/CommandsTests/PackageRegistryToolTests.swift
+++ b/Tests/CommandsTests/PackageRegistryToolTests.swift
@@ -947,6 +947,23 @@ final class PackageRegistryToolTests: CommandsTestCase {
         }
     }
 
+    func testCreateLoginURL() {
+        let registryURL = URL(string: "https://packages.example.com")!
+
+        XCTAssertEqual(try SwiftPackageRegistryTool.Login.loginURL(from: registryURL, loginAPIPath: nil).absoluteString, "https://packages.example.com/login")
+
+        XCTAssertEqual(try SwiftPackageRegistryTool.Login.loginURL(from: registryURL, loginAPIPath: "/secret-sign-in").absoluteString, "https://packages.example.com/secret-sign-in")
+
+    }
+
+    func testCreateLoginURLMaintainsPort() {
+        let registryURL = URL(string: "https://packages.example.com:8081")!
+
+        XCTAssertEqual(try SwiftPackageRegistryTool.Login.loginURL(from: registryURL, loginAPIPath: nil).absoluteString, "https://packages.example.com:8081/login")
+
+        XCTAssertEqual(try SwiftPackageRegistryTool.Login.loginURL(from: registryURL, loginAPIPath: "/secret-sign-in").absoluteString, "https://packages.example.com:8081/secret-sign-in")
+    }
+
     private func testRoots(callback: (Result<[[UInt8]], Error>) -> Void) {
         do {
             try fixture(name: "Signing", createGitRepo: false) { fixturePath in

--- a/Tests/PackageRegistryTests/RegistryConfigurationTests.swift
+++ b/Tests/PackageRegistryTests/RegistryConfigurationTests.swift
@@ -372,10 +372,10 @@ final class RegistryConfigurationTests: XCTestCase {
 
     func testGetAuthenticationConfigurationByRegistryURL() throws {
         var configuration = RegistryConfiguration()
-        configuration.registryAuthentication[defaultRegistryBaseURL.host!] = .init(type: .token)
+        try configuration.add(authentication: .init(type: .token), for: defaultRegistryBaseURL)
 
-        XCTAssertEqual(configuration.authentication(for: defaultRegistryBaseURL)?.type, .token)
-        XCTAssertNil(configuration.authentication(for: customRegistryBaseURL))
+        XCTAssertEqual(try configuration.authentication(for: defaultRegistryBaseURL)?.type, .token)
+        XCTAssertNil(try configuration.authentication(for: customRegistryBaseURL))
     }
 
     func testGetSigning_noOverrides() throws {


### PR DESCRIPTION
(Same as #6711 but for 5.9.)

When using a registry URL that contains a port, ensure the port is preserved when computing the login URL.

### Motivation:

Currently if you run the following
```
swift package-registry set https://packages.example.com:8081
swift package-registry login --token XYZ
```

You might get something like 
```
Error: Unable to connect to server: https://packages.example.com
```

That's because the login url is built like this and ignores the port: `URL(string: "https://\(host)\(loginAPIPath ?? "/login")")`

### Modifications:

- Use `URLComponents` to build the login URL (which maintains the port)
- Update RegistryConfiguration to compute the storage key

### Result:

SPM can use registry URLs with ports.