### PR TITLE
PackagePlugin: avoid warnings on Windows by overloading functions

### DIFF
--- a/Sources/PackagePlugin/Plugin.swift
+++ b/Sources/PackagePlugin/Plugin.swift
@@ -13,6 +13,19 @@
 @_implementationOnly import Foundation
 #if os(Windows)
 @_implementationOnly import ucrt
+
+internal func dup(_ fd: CInt) -> CInt {
+    return _dup(fd)
+}
+internal func dup2(_ fd1: CInt, _ fd2: CInt) -> CInt {
+    return _dup2(fd1, fd2)
+}
+internal func close(_ fd: CInt) -> CInt {
+    return _close(fd)
+}
+internal func fileno(_ fh: UnsafeMutablePointer<FILE>?) -> CInt {
+    return _fileno(fh)
+}
 #endif
 
 //


### PR DESCRIPTION
The Windows builds spew warnings about deprecated functions.  Use an overload for the name to avoid the warning and prefer the alternate spellings.