### PR TITLE
Swift SDKs: fix `toolset.linker.path` not passed to `-ld-path`

### DIFF
--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -331,7 +331,7 @@ public final class UserToolchain: Toolchain {
         var swiftCompilerFlags = swiftSDK.toolset.knownTools[.swiftCompiler]?.extraCLIOptions ?? []
 
         if let linker = swiftSDK.toolset.knownTools[.linker]?.path {
-            swiftCompilerFlags += ["-use-ld=\(linker.pathString)"]
+            swiftCompilerFlags += ["-use-ld=\(linker._nativePathString(escaped: false))"]
         }
 
         guard let sdkDir = swiftSDK.pathsConfiguration.sdkRootPath else {

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -331,7 +331,7 @@ public final class UserToolchain: Toolchain {
         var swiftCompilerFlags = swiftSDK.toolset.knownTools[.swiftCompiler]?.extraCLIOptions ?? []
 
         if let linker = swiftSDK.toolset.knownTools[.linker]?.path {
-            swiftCompilerFlags += ["-Xclang-linker", "--ld-path=\(linker)"]
+            swiftCompilerFlags += ["--ld-path=\(linker)"]
         }
 
         guard let sdkDir = swiftSDK.pathsConfiguration.sdkRootPath else {

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -331,7 +331,7 @@ public final class UserToolchain: Toolchain {
         var swiftCompilerFlags = swiftSDK.toolset.knownTools[.swiftCompiler]?.extraCLIOptions ?? []
 
         if let linker = swiftSDK.toolset.knownTools[.linker]?.path {
-            swiftCompilerFlags += ["--ld-path=\(linker)"]
+            swiftCompilerFlags += ["-ld-path=\(linker)"]
         }
 
         guard let sdkDir = swiftSDK.pathsConfiguration.sdkRootPath else {

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -328,7 +328,11 @@ public final class UserToolchain: Toolchain {
         swiftSDK: SwiftSDK,
         environment: EnvironmentVariables
     ) throws -> [String] {
-        let swiftCompilerFlags = swiftSDK.toolset.knownTools[.swiftCompiler]?.extraCLIOptions ?? []
+        var swiftCompilerFlags = swiftSDK.toolset.knownTools[.swiftCompiler]?.extraCLIOptions ?? []
+
+        if let linker = swiftSDK.toolset.knownTools[.linker]?.path {
+            swiftCompilerFlags += ["-use-ld=\(linker.pathString)"]
+        }
 
         guard let sdkDir = swiftSDK.pathsConfiguration.sdkRootPath else {
             if triple.isWindows() {

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -331,7 +331,7 @@ public final class UserToolchain: Toolchain {
         var swiftCompilerFlags = swiftSDK.toolset.knownTools[.swiftCompiler]?.extraCLIOptions ?? []
 
         if let linker = swiftSDK.toolset.knownTools[.linker]?.path {
-            swiftCompilerFlags += ["-use-ld=\(linker._nativePathString(escaped: false))"]
+            swiftCompilerFlags += ["-Xclang-linker", "--ld-path=\(linker)"]
         }
 
         guard let sdkDir = swiftSDK.pathsConfiguration.sdkRootPath else {

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -3689,7 +3689,7 @@ final class BuildPlanTests: XCTestCase {
         let exeCompileArguments = try result.target(for: "exe").swiftTarget().compileArguments()
         let exeCompileArgumentsPattern: [StringPattern] = [
             jsonFlag(tool: .swiftCompiler),
-            "-use-ld=/fake/toolchain/usr/bin/linker",
+            "-Xclang-linker", "--ld-path=/fake/toolchain/usr/bin/linker",
             "-g", cliFlag(tool: .swiftCompiler),
             .anySequence,
             "-Xcc", jsonFlag(tool: .cCompiler), "-Xcc", "-g", "-Xcc", cliFlag(tool: .cCompiler),
@@ -3714,7 +3714,7 @@ final class BuildPlanTests: XCTestCase {
         let exeLinkArguments = try result.buildProduct(for: "exe").linkArguments()
         let exeLinkArgumentsPattern: [StringPattern] = [
             jsonFlag(tool: .swiftCompiler),
-            "-use-ld=/fake/toolchain/usr/bin/linker",
+            "-Xclang-linker", "--ld-path=/fake/toolchain/usr/bin/linker",
             "-g", cliFlag(tool: .swiftCompiler),
             .anySequence,
             "-Xlinker", jsonFlag(tool: .linker), "-Xlinker", cliFlag(tool: .linker),

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -3607,7 +3607,7 @@ final class BuildPlanTests: XCTestCase {
                 .cxxCompiler: .init(extraCLIOptions: [jsonFlag(tool: .cxxCompiler)]),
                 .swiftCompiler: .init(extraCLIOptions: [jsonFlag(tool: .swiftCompiler)]),
                 .librarian: .init(path: "/fake/toolchain/usr/bin/librarian"),
-                .linker: .init(extraCLIOptions: [jsonFlag(tool: .linker)]),
+                .linker: .init(path: "/fake/toolchain/usr/bin/linker", extraCLIOptions: [jsonFlag(tool: .linker)]),
             ],
             rootPaths: try UserToolchain.default.swiftSDK.toolset.rootPaths)
         let targetTriple = try Triple("armv7em-unknown-none-macho")
@@ -3688,7 +3688,9 @@ final class BuildPlanTests: XCTestCase {
         // Compile Swift Target
         let exeCompileArguments = try result.target(for: "exe").swiftTarget().compileArguments()
         let exeCompileArgumentsPattern: [StringPattern] = [
-            jsonFlag(tool: .swiftCompiler), "-g", cliFlag(tool: .swiftCompiler),
+            jsonFlag(tool: .swiftCompiler),
+            "-use-ld=/fake/toolchain/usr/bin/linker",
+            "-g", cliFlag(tool: .swiftCompiler),
             .anySequence,
             "-Xcc", jsonFlag(tool: .cCompiler), "-Xcc", "-g", "-Xcc", cliFlag(tool: .cCompiler),
             // TODO: Pass -Xcxx flags to swiftc (#6491)
@@ -3711,7 +3713,9 @@ final class BuildPlanTests: XCTestCase {
         // Link Product
         let exeLinkArguments = try result.buildProduct(for: "exe").linkArguments()
         let exeLinkArgumentsPattern: [StringPattern] = [
-            jsonFlag(tool: .swiftCompiler), "-g", cliFlag(tool: .swiftCompiler),
+            jsonFlag(tool: .swiftCompiler),
+            "-use-ld=/fake/toolchain/usr/bin/linker",
+            "-g", cliFlag(tool: .swiftCompiler),
             .anySequence,
             "-Xlinker", jsonFlag(tool: .linker), "-Xlinker", cliFlag(tool: .linker),
         ]

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -3689,7 +3689,7 @@ final class BuildPlanTests: XCTestCase {
         let exeCompileArguments = try result.target(for: "exe").swiftTarget().compileArguments()
         let exeCompileArgumentsPattern: [StringPattern] = [
             jsonFlag(tool: .swiftCompiler),
-            "-Xclang-linker", "--ld-path=/fake/toolchain/usr/bin/linker",
+            "--ld-path=/fake/toolchain/usr/bin/linker",
             "-g", cliFlag(tool: .swiftCompiler),
             .anySequence,
             "-Xcc", jsonFlag(tool: .cCompiler), "-Xcc", "-g", "-Xcc", cliFlag(tool: .cCompiler),
@@ -3714,7 +3714,7 @@ final class BuildPlanTests: XCTestCase {
         let exeLinkArguments = try result.buildProduct(for: "exe").linkArguments()
         let exeLinkArgumentsPattern: [StringPattern] = [
             jsonFlag(tool: .swiftCompiler),
-            "-Xclang-linker", "--ld-path=/fake/toolchain/usr/bin/linker",
+            "--ld-path=/fake/toolchain/usr/bin/linker",
             "-g", cliFlag(tool: .swiftCompiler),
             .anySequence,
             "-Xlinker", jsonFlag(tool: .linker), "-Xlinker", cliFlag(tool: .linker),

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -3689,7 +3689,7 @@ final class BuildPlanTests: XCTestCase {
         let exeCompileArguments = try result.target(for: "exe").swiftTarget().compileArguments()
         let exeCompileArgumentsPattern: [StringPattern] = [
             jsonFlag(tool: .swiftCompiler),
-            "--ld-path=/fake/toolchain/usr/bin/linker",
+            "-ld-path=/fake/toolchain/usr/bin/linker",
             "-g", cliFlag(tool: .swiftCompiler),
             .anySequence,
             "-Xcc", jsonFlag(tool: .cCompiler), "-Xcc", "-g", "-Xcc", cliFlag(tool: .cCompiler),
@@ -3714,7 +3714,7 @@ final class BuildPlanTests: XCTestCase {
         let exeLinkArguments = try result.buildProduct(for: "exe").linkArguments()
         let exeLinkArgumentsPattern: [StringPattern] = [
             jsonFlag(tool: .swiftCompiler),
-            "--ld-path=/fake/toolchain/usr/bin/linker",
+            "-ld-path=/fake/toolchain/usr/bin/linker",
             "-g", cliFlag(tool: .swiftCompiler),
             .anySequence,
             "-Xlinker", jsonFlag(tool: .linker), "-Xlinker", cliFlag(tool: .linker),


### PR DESCRIPTION
This PR implements support for the `linker.path` field in the Swift SDK toolset spec.

Depends on https://github.com/apple/swift/pull/68495 and https://github.com/apple/swift-driver/pull/1441.

### Motivation:

This field was previously parsed but not respected.

### Modifications:

Add `-ld-path=\(linker.path)` to the toolchain's Swift flags if a linker path override is supplied

### Result:

The linker path is now respected.
