### PR TITLE
[5.9] Enable armv7em CPU and none OS triples

### DIFF
--- a/Sources/Basics/Triple.swift
+++ b/Sources/Basics/Triple.swift
@@ -48,6 +48,7 @@ public struct Triple: Encodable, Equatable, Sendable {
         case aarch64
         case amd64
         case armv7
+        case armv7em
         case armv6
         case armv5
         case arm
@@ -73,6 +74,8 @@ public struct Triple: Encodable, Equatable, Sendable {
         case windows
         case wasi
         case openbsd
+        // 'OS' suffix purely to avoid name clash with Optional.none
+        case noneOS = "none"
     }
 
     public enum ABI: Encodable, Equatable, RawRepresentable, Sendable {
@@ -265,6 +268,8 @@ extension Triple {
             return ".dll"
         case .wasi:
             return ".wasm"
+        case .noneOS:
+            fatalError("Cannot create dynamic libraries for os \"none\".")
         }
     }
 
@@ -278,6 +283,8 @@ extension Triple {
             return ".wasm"
         case .windows:
             return ".exe"
+        case .noneOS:
+            return ""
         }
     }
 

--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -137,12 +137,12 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
         let librarian = self.buildParameters.toolchain.librarianPath.pathString
         let triple = self.buildParameters.triple
         if triple.isWindows(), librarian.hasSuffix("link") || librarian.hasSuffix("link.exe") {
-            return [librarian, "/LIB", "/OUT:\(binaryPath.pathString)", "@\(self.linkFileListPath.pathString)"]
+            return try [librarian, "/LIB", "/OUT:\(binaryPath.pathString)", "@\(self.linkFileListPath.pathString)"]
         }
         if triple.isDarwin(), librarian.hasSuffix("libtool") {
-            return [librarian, "-static", "-o", binaryPath.pathString, "@\(self.linkFileListPath.pathString)"]
+            return try [librarian, "-static", "-o", binaryPath.pathString, "@\(self.linkFileListPath.pathString)"]
         }
-        return [librarian, "crs", binaryPath.pathString, "@\(self.linkFileListPath.pathString)"]
+        return try [librarian, "crs", binaryPath.pathString, "@\(self.linkFileListPath.pathString)"]
     }
 
     /// The arguments to link and create this product.
@@ -166,7 +166,7 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
         }
 
         args += ["-L", self.buildParameters.buildPath.pathString]
-        args += ["-o", binaryPath.pathString]
+        args += try ["-o", binaryPath.pathString]
         args += ["-module-name", self.product.name.spm_mangledToC99ExtendedIdentifier()]
         args += self.dylibs.map { "-l" + $0.product.name }
 
@@ -209,7 +209,7 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
         case .library(.dynamic):
             args += ["-emit-library"]
             if self.buildParameters.triple.isDarwin() {
-                let relativePath = "@rpath/\(buildParameters.binaryRelativePath(for: self.product).pathString)"
+                let relativePath = try "@rpath/\(buildParameters.binaryRelativePath(for: self.product).pathString)"
                 args += ["-Xlinker", "-install_name", "-Xlinker", relativePath]
             }
             args += self.deadStripArguments

--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -385,7 +385,7 @@ public final class SwiftTargetBuildDescription {
         #else
         try self.requiredMacroProducts.forEach { macro in
             if let macroTarget = macro.targets.first {
-                let executablePath = self.buildParameters.binaryPath(for: macro).pathString
+                let executablePath = try self.buildParameters.binaryPath(for: macro).pathString
                 args += ["-Xfrontend", "-load-plugin-executable", "-Xfrontend", "\(executablePath)#\(macroTarget.c99name)"]
             } else {
                 throw InternalError("macro product \(macro.name) has no targets") // earlier validation should normally catch this

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -431,7 +431,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
             ) { name, path in
                 try buildOperationForPluginDependencies.build(subset: .product(name))
                 if let builtTool = try buildOperationForPluginDependencies.buildPlan.buildProducts.first(where: { $0.product.name == name}) {
-                    return builtTool.binaryPath
+                    return try builtTool.binaryPath
                 } else {
                     return nil
                 }

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -357,8 +357,8 @@ public struct BuildDescription: Codable {
         )
         self.swiftTargetScanArgs = targetCommandLines
         self.generatedSourceTargetSet = Set(generatedSourceTargets)
-        self.builtTestProducts = plan.buildProducts.filter { $0.product.type == .test }.map { desc in
-            BuiltTestProduct(
+        self.builtTestProducts = try plan.buildProducts.filter { $0.product.type == .test }.map { desc in
+            try BuiltTestProduct(
                 productName: desc.product.name,
                 binaryPath: desc.binaryPath
             )

--- a/Sources/Build/LLBuildManifestBuilder.swift
+++ b/Sources/Build/LLBuildManifestBuilder.swift
@@ -661,7 +661,7 @@ extension LLBuildManifestBuilder {
                     guard let planProduct = plan.productMap[product] else {
                         throw InternalError("unknown product \(product)")
                     }
-                    inputs.append(file: planProduct.binaryPath)
+                    try inputs.append(file: planProduct.binaryPath)
                 }
                 return
             }
@@ -690,7 +690,7 @@ extension LLBuildManifestBuilder {
                         throw InternalError("unknown product \(product)")
                     }
                     // Establish a dependency on binary of the product.
-                    inputs.append(file: planProduct.binaryPath)
+                    try inputs.append(file: planProduct.binaryPath)
 
                 // For automatic and static libraries, and plugins, add their targets as static input.
                 case .library(.automatic), .library(.static), .plugin:
@@ -828,7 +828,7 @@ extension LLBuildManifestBuilder {
                         throw InternalError("unknown product \(product)")
                     }
                     // Establish a dependency on binary of the product.
-                    let binary = planProduct.binaryPath
+                    let binary = try planProduct.binaryPath
                     inputs.append(file: binary)
 
                 case .library(.automatic), .library(.static), .plugin:
@@ -983,7 +983,7 @@ extension LLBuildManifestBuilder {
 
         switch buildProduct.product.type {
         case .library(.static):
-            self.manifest.addShellCmd(
+            try self.manifest.addShellCmd(
                 name: cmdName,
                 description: "Archiving \(buildProduct.binaryPath.prettyPath())",
                 inputs: buildProduct.objects.map(Node.file),
@@ -992,9 +992,9 @@ extension LLBuildManifestBuilder {
             )
 
         default:
-            let inputs = buildProduct.objects + buildProduct.dylibs.map(\.binaryPath)
+            let inputs = try buildProduct.objects + buildProduct.dylibs.map{ try $0.binaryPath }
 
-            self.manifest.addShellCmd(
+            try self.manifest.addShellCmd(
                 name: cmdName,
                 description: "Linking \(buildProduct.binaryPath.prettyPath())",
                 inputs: inputs.map(Node.file),
@@ -1008,7 +1008,7 @@ extension LLBuildManifestBuilder {
         let output: Node = .virtual(targetName)
 
         self.manifest.addNode(output, toTarget: targetName)
-        self.manifest.addPhonyCmd(
+        try self.manifest.addPhonyCmd(
             name: output.name,
             inputs: [.file(buildProduct.binaryPath)],
             outputs: [output]

--- a/Sources/Commands/PackageTools/PluginCommand.swift
+++ b/Sources/Commands/PackageTools/PluginCommand.swift
@@ -259,7 +259,7 @@ struct PluginCommand: SwiftCommand {
             // Build the product referenced by the tool, and add the executable to the tool map. Product dependencies are not supported within a package, so if the tool happens to be from the same package, we instead find the executable that corresponds to the product. There is always one, because of autogeneration of implicit executables with the same name as the target if there isn't an explicit one.
             try buildSystem.build(subset: .product(name))
             if let builtTool = try buildSystem.buildPlan.buildProducts.first(where: { $0.product.name == name }) {
-                return builtTool.binaryPath
+                return try builtTool.binaryPath
             } else {
                 return nil
             }

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -129,15 +129,15 @@ final class PluginDelegate: PluginInvocationDelegate {
                 return $0.product.name == name
             }
         }
-        let builtArtifacts: [PluginInvocationBuildResult.BuiltArtifact] = builtProducts.compactMap {
+        let builtArtifacts: [PluginInvocationBuildResult.BuiltArtifact] = try builtProducts.compactMap {
             switch $0.product.type {
             case .library(let kind):
-                return .init(
+                return try .init(
                     path: $0.binaryPath.pathString,
                     kind: (kind == .dynamic) ? .dynamicLibrary : .staticLibrary
                 )
             case .executable:
-                return .init(path: $0.binaryPath.pathString, kind: .executable)
+                return try .init(path: $0.binaryPath.pathString, kind: .executable)
             default:
                 return nil
             }

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -1039,7 +1039,7 @@ public final class PackageBuilder {
 
                 // Ensure that the search path is contained within the package.
                 _ = try RelativePath(validating: value)
-                let path = try AbsolutePath(value, relativeTo: targetRoot)
+                let path = try AbsolutePath(validating: value, relativeTo: targetRoot)
                 guard path.isDescendantOfOrEqual(to: self.packagePath) else {
                     throw ModuleError.invalidHeaderSearchPath(value)
                 }

--- a/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
+++ b/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
@@ -97,7 +97,7 @@ extension Triple.OS {
     /// Returns a representation of the receiver that can be compared with platform strings declared in an XCFramework.
     fileprivate var asXCFrameworkPlatformString: String? {
         switch self {
-        case .darwin, .linux, .wasi, .windows, .openbsd:
+        case .darwin, .linux, .wasi, .windows, .openbsd, .noneOS:
             return nil // XCFrameworks do not support any of these platforms today.
         case .macOS:
             return "macos"

--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -391,10 +391,14 @@ public struct BuildParameters: Encodable {
         return buildPath.appending(binaryRelativePath(for: product))
     }
 
+    /// Returns the path to the dynamic library of a product for the current build parameters.
+    func potentialDynamicLibraryPath(for product: ResolvedProduct) throws -> RelativePath {
+        try RelativePath(validating: "\(triple.dynamicLibraryPrefix)\(product.name)\(triple.dynamicLibraryExtension)")
+    }
+
     /// Returns the path to the binary of a product for the current build parameters, relative to the build directory.
-    public func binaryRelativePath(for product: ResolvedProduct) -> RelativePath {
-        let potentialExecutablePath = RelativePath("\(product.name)\(triple.executableExtension)")
-        let potentialLibraryPath = RelativePath("\(triple.dynamicLibraryPrefix)\(product.name)\(triple.dynamicLibraryExtension)")
+    public func binaryRelativePath(for product: ResolvedProduct) throws -> RelativePath {
+        let potentialExecutablePath = try RelativePath(validating: "\(product.name)\(triple.executableExtension)")
 
         switch product.type {
         case .executable, .snippet:
@@ -402,7 +406,7 @@ public struct BuildParameters: Encodable {
         case .library(.static):
             return RelativePath("lib\(product.name)\(triple.staticLibraryExtension)")
         case .library(.dynamic):
-            return potentialLibraryPath
+            return try potentialDynamicLibraryPath(for: product)
         case .library(.automatic), .plugin:
             fatalError()
         case .test:
@@ -418,7 +422,7 @@ public struct BuildParameters: Encodable {
             }
         case .macro:
             #if BUILD_MACROS_AS_DYLIBS
-            return potentialLibraryPath
+            return try potentialDynamicLibraryPath(for: product)
             #else
             return potentialExecutablePath
             #endif

--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -387,8 +387,8 @@ public struct BuildParameters: Encodable {
     }
 
     /// Returns the path to the binary of a product for the current build parameters.
-    public func binaryPath(for product: ResolvedProduct) -> AbsolutePath {
-        return buildPath.appending(binaryRelativePath(for: product))
+    public func binaryPath(for product: ResolvedProduct) throws -> AbsolutePath {
+        return try buildPath.appending(binaryRelativePath(for: product))
     }
 
     /// Returns the path to the dynamic library of a product for the current build parameters.

--- a/Sources/SPMBuildCore/BuildSystem.swift
+++ b/Sources/SPMBuildCore/BuildSystem.swift
@@ -74,7 +74,9 @@ public protocol ProductBuildDescription {
 extension ProductBuildDescription {
     /// The path to the product binary produced.
     public var binaryPath: AbsolutePath {
-        return buildParameters.binaryPath(for: product)
+        get throws {
+            return try buildParameters.binaryPath(for: product)
+        }
     }
 }
 

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -46,14 +46,19 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
         var builtProducts: [BuiltTestProduct] = []
 
         for package in graph.rootPackages {
-            for product in package.products where product.type == .test {
-                let binaryPath = buildParameters.binaryPath(for: product)
-                builtProducts.append(
-                    BuiltTestProduct(
-                        productName: product.name,
-                        binaryPath: binaryPath
+            do {
+                for product in package.products where product.type == .test {
+                    let binaryPath = try buildParameters.binaryPath(for: product)
+                    builtProducts.append(
+                        BuiltTestProduct(
+                            productName: product.name,
+                            binaryPath: binaryPath
+                        )
                     )
-                )
+                }
+            } catch {
+                self.observabilityScope.emit(error)
+                return []
             }
         }
 

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -3030,7 +3030,7 @@ final class BuildPlanTests: XCTestCase {
             ]
         )
 
-        let executablePathExtension = appBuildDescription.binaryPath.extension
+        let executablePathExtension = try appBuildDescription.binaryPath.extension
         XCTAssertEqual(executablePathExtension, "wasm")
 
         let testBuildDescription = try result.buildProduct(for: "PkgPackageTests")
@@ -3047,7 +3047,7 @@ final class BuildPlanTests: XCTestCase {
             ]
         )
 
-        let testPathExtension = testBuildDescription.binaryPath.extension
+        let testPathExtension = try testBuildDescription.binaryPath.extension
         XCTAssertEqual(testPathExtension, "wasm")
     }
 

--- a/Tests/BuildTests/ModuleAliasingBuildTests.swift
+++ b/Tests/BuildTests/ModuleAliasingBuildTests.swift
@@ -355,7 +355,10 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "BarLogging" && $0.target.moduleAliases?["Logging"] == "BarLogging" })
         #if os(macOS)
         let dylib = try result.buildProduct(for: "Logging")
-        XCTAssertTrue(dylib.binaryPath.basename == "libLogging.dylib" && dylib.package.identity.description == "barpkg")
+        XCTAssertTrue(
+            try dylib.binaryPath.basename == "libLogging.dylib" && dylib.package.identity
+                .description == "barpkg"
+        )
         #endif
     }
 
@@ -422,7 +425,10 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "BazLogging" && $0.target.moduleAliases?["Logging"] == "BazLogging" })
         #if os(macOS)
         let staticlib = try result.buildProduct(for: "Logging")
-        XCTAssertTrue(staticlib.binaryPath.basename == "libLogging.a" && staticlib.package.identity.description == "bazpkg")
+        XCTAssertTrue(
+            try staticlib.binaryPath.basename == "libLogging.a" && staticlib.package.identity
+                .description == "bazpkg"
+        )
         #endif
     }
 
@@ -525,7 +531,10 @@ final class ModuleAliasingBuildTests: XCTestCase {
         XCTAssertTrue(result.targetMap.values.contains { $0.target.name == "B" && $0.target.moduleAliases == nil })
         #if os(macOS)
         let dylib = try result.buildProduct(for: "Logging")
-        XCTAssertTrue(dylib.binaryPath.basename == "libLogging.dylib" && dylib.package.identity.description == "xpkg")
+        XCTAssertTrue(
+            try dylib.binaryPath.basename == "libLogging.dylib" && dylib.package.identity
+                .description == "xpkg"
+        )
         #endif
     }
 


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-package-manager/pull/6438 required by https://github.com/apple/swift-package-manager/pull/6709.

Adds preliminary knowledge of `armv7em` and no OS environments to SwiftPM. Future diffs will be required to fully support these triples. This change allows a `armv7em-apple-none-macho` build via Swift SDK v3 and v4 bundles to make it further through SwiftPM.
