### PR TITLE
[5.9] fix `apple` and `darwin` triples disambiguation

### DIFF
--- a/Sources/Basics/Triple.swift
+++ b/Sources/Basics/Triple.swift
@@ -162,12 +162,23 @@ public struct Triple: Encodable, Equatable, Sendable {
         return nil
     }
 
+    public func isApple() -> Bool {
+        vendor == .apple
+    }
+
     public func isAndroid() -> Bool {
         os == .linux && abi == .android
     }
 
     public func isDarwin() -> Bool {
-        vendor == .apple || os == .macOS || os == .darwin
+        switch (vendor, os) {
+        case (.apple, .noneOS):
+            return false
+        case (.apple, _), (_, .macOS), (_, .darwin):
+            return true
+        default:
+            return false
+        }
     }
 
     public func isLinux() -> Bool {

--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -113,7 +113,7 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
         case .debug:
             return []
         case .release:
-            if self.buildParameters.triple.isDarwin() {
+            if self.buildParameters.triple.isApple() {
                 return ["-Xlinker", "-dead_strip"]
             } else if self.buildParameters.triple.isWindows() {
                 return ["-Xlinker", "/OPT:REF"]
@@ -139,7 +139,7 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
         if triple.isWindows(), librarian.hasSuffix("link") || librarian.hasSuffix("link.exe") {
             return try [librarian, "/LIB", "/OUT:\(binaryPath.pathString)", "@\(self.linkFileListPath.pathString)"]
         }
-        if triple.isDarwin(), librarian.hasSuffix("libtool") {
+        if triple.isApple(), librarian.hasSuffix("libtool") {
             return try [librarian, "-static", "-o", binaryPath.pathString, "@\(self.linkFileListPath.pathString)"]
         }
         return try [librarian, "crs", binaryPath.pathString, "@\(self.linkFileListPath.pathString)"]

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -138,7 +138,7 @@ extension BuildParameters {
     /// Computes the linker flags to use in order to rename a module-named main function to 'main' for the target platform, or nil if the linker doesn't support it for the platform.
     func linkerFlagsForRenamingMainFunction(of target: ResolvedTarget) -> [String]? {
         let args: [String]
-        if self.triple.isDarwin() {
+        if self.triple.isApple() {
             args = ["-alias", "_\(target.c99name)_main", "_main"]
         }
         else if self.triple.isLinux() {

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -137,9 +137,9 @@ public final class UserToolchain: Toolchain {
     ) throws
         -> AbsolutePath
     {
-        let variable: String = triple.isDarwin() ? "LIBTOOL" : "AR"
+        let variable: String = triple.isApple() ? "LIBTOOL" : "AR"
         let tool: String = {
-            if triple.isDarwin() { return "libtool" }
+            if triple.isApple() { return "libtool" }
             if triple.isWindows() {
                 if let librarian: AbsolutePath =
                     UserToolchain.lookup(

--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -380,7 +380,7 @@ public struct BuildParameters: Encodable {
             return nil
         }
 
-        if triple.isDarwin() {
+        if triple.isApple() {
             return .swiftAST
         }
         return .modulewrap

--- a/Tests/BasicsTests/TripleTests.swift
+++ b/Tests/BasicsTests/TripleTests.swift
@@ -14,6 +14,69 @@ import Basics
 import XCTest
 
 final class TripleTests: XCTestCase {
+    func testIsAppleIsDarwin() {
+        func XCTAssertTriple(
+            _ triple: String,
+            isApple: Bool,
+            isDarwin: Bool,
+            file: StaticString = #filePath,
+            line: UInt = #line
+        ) {
+            guard let triple = try? Triple(triple) else {
+                XCTFail(
+                    "Unknown triple '\(triple)'.",
+                    file: file,
+                    line: line)
+                return
+            }
+            XCTAssert(
+                isApple == triple.isApple(),
+                """
+                Expected triple '\(triple.tripleString)' \
+                \(isApple ? "" : " not") to be an Apple triple.
+                """,
+                file: file,
+                line: line)
+            XCTAssert(
+                isDarwin == triple.isDarwin(),
+                """
+                Expected triple '\(triple.tripleString)' \
+                \(isDarwin ? "" : " not") to be a Darwin triple.
+                """,
+                file: file,
+                line: line)
+        }
+
+        XCTAssertTriple("x86_64-pc-linux-gnu", isApple: false, isDarwin: false)
+        XCTAssertTriple("x86_64-pc-linux-musl", isApple: false, isDarwin: false)
+        XCTAssertTriple("powerpc-bgp-linux", isApple: false, isDarwin: false)
+        XCTAssertTriple("arm-none-none-eabi", isApple: false, isDarwin: false)
+        XCTAssertTriple("arm-none-linux-musleabi", isApple: false, isDarwin: false)
+        XCTAssertTriple("wasm32-unknown-wasi", isApple: false, isDarwin: false)
+        XCTAssertTriple("riscv64-unknown-linux", isApple: false, isDarwin: false)
+        XCTAssertTriple("mips-mti-linux-gnu", isApple: false, isDarwin: false)
+        XCTAssertTriple("mipsel-img-linux-gnu", isApple: false, isDarwin: false)
+        XCTAssertTriple("mips64-mti-linux-gnu", isApple: false, isDarwin: false)
+        XCTAssertTriple("mips64el-img-linux-gnu", isApple: false, isDarwin: false)
+        XCTAssertTriple("mips64el-img-linux-gnuabin32", isApple: false, isDarwin: false)
+        XCTAssertTriple("mips64-unknown-linux-gnuabi64", isApple: false, isDarwin: false)
+        XCTAssertTriple("mips64-unknown-linux-gnuabin32", isApple: false, isDarwin: false)
+        XCTAssertTriple("mipsel-unknown-linux-gnu", isApple: false, isDarwin: false)
+        XCTAssertTriple("mips-unknown-linux-gnu", isApple: false, isDarwin: false)
+        XCTAssertTriple("arm-oe-linux-gnueabi", isApple: false, isDarwin: false)
+        XCTAssertTriple("aarch64-oe-linux", isApple: false, isDarwin: false)
+        XCTAssertTriple("armv7em-unknown-none-macho", isApple: false, isDarwin: false)
+        XCTAssertTriple("armv7em-apple-none-macho", isApple: true, isDarwin: false)
+        XCTAssertTriple("armv7em-apple-none", isApple: true, isDarwin: false)
+        XCTAssertTriple("aarch64-apple-macosx", isApple: true, isDarwin: true)
+        XCTAssertTriple("x86_64-apple-macosx", isApple: true, isDarwin: true)
+        XCTAssertTriple("x86_64-apple-macosx10.15", isApple: true, isDarwin: true)
+        XCTAssertTriple("x86_64h-apple-darwin", isApple: true, isDarwin: true)
+        XCTAssertTriple("i686-pc-windows-msvc", isApple: false, isDarwin: false)
+        XCTAssertTriple("i686-pc-windows-gnu", isApple: false, isDarwin: false)
+        XCTAssertTriple("i686-pc-windows-cygnus", isApple: false, isDarwin: false)
+    }
+
     func testDescription() throws {
         let triple = try Triple("x86_64-pc-linux-gnu")
         XCTAssertEqual("foo \(triple) bar", "foo x86_64-pc-linux-gnu bar")


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-package-manager/pull/6478.

Fixes a bug where all triples with vendor `apple` are considered to be OS variants of `darwin`. This change special cases `apple-none` to not match `Triple.isDarwin()`, but all other "apple-*" triples will still be considered to be a variant `darwin`.

Fixes some fallout of making the above change to check for the newly added `Triple.isApple()` instead of `Triple.isDarwin()` to allow the triple `apple-none` to opt into behaviors like dead stripping, using libtool, etc.

As a result of these changes SwiftPM no longer appends a macOS version number to the `armv7em-apple-none-macho` triple (e.g. `armv7em-apple-none-macho10.13`) removing the work around of passing `-target armv7em-apple-none-macho` as CLI options or via a `toolset.json`.

Additionally SwiftPM no longer passes unexpected `-rpath` args to the linker when building a static binary for `armv7em-apple-none-macho`.

```
# Conflicts:
#	Tests/BasicsTests/TripleTests.swift
```