### PR TITLE
Fix issues with excluding macros/plugins from dependency computation

### DIFF
--- a/Fixtures/Miscellaneous/Plugins/MySourceGenPlugin/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/MySourceGenPlugin/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 5.9
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
While fixing this, I also noticed the original issue also exists for executable targets, so this gets fixed here as well.

There's one unfortunate nuance here for test targets since using a macro/plugin is indistinguishable from needing to link it because it is being tested. We err on the side of caution here and will always link.

(sidenote: theoretically, plugins *do* distinguish between linkage and use in the package manifest, but this distinction is not carried forward into the actual model)

Partially fixes https://github.com/apple/swift/issues/67371 since the underlying project also does not declare a dependency on the macro that is being tested.
