### PR TITLE
Restore `RepositorySpecifier.Location.gitURL`

### DIFF
--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -192,7 +192,7 @@ public struct GitRepositoryProvider: RepositoryProvider, Cancellable {
 
         try self.clone(
             repository,
-            repository.location.SourceControlURL,
+            repository.location.gitURL,
             path.pathString,
             ["--mirror"],
             progress: progressHandler
@@ -256,7 +256,7 @@ public struct GitRepositoryProvider: RepositoryProvider, Cancellable {
             // In destination repo remove the remote which will be pointing to the source repo.
             let clone = GitRepository(git: self.git, path: destinationPath)
             // Set the original remote to the new clone.
-            try clone.setURL(remote: origin, url: repository.location.SourceControlURL)
+            try clone.setURL(remote: origin, url: repository.location.gitURL)
             // FIXME: This is unfortunate that we have to fetch to update remote's data.
             try clone.fetch()
         } else {
@@ -1382,7 +1382,7 @@ private func gitFetchStatusFilter(_ bytes: [UInt8], progress: FetchProgress.Hand
 }
 
 extension RepositorySpecifier.Location {
-    fileprivate var SourceControlURL: String {
+    fileprivate var gitURL: String {
         switch self {
         case .path(let path):
             return path.pathString


### PR DESCRIPTION
My search/replace for `GitURL` was a bit overeager and changed this as well.
