### PR TITLE
Remove -incremental when using -whole-module-optimization

### DIFF
--- a/Sources/LLBuildManifest/Tools.swift
+++ b/Sources/LLBuildManifest/Tools.swift
@@ -316,7 +316,6 @@ public struct SwiftCompilerTool: ToolProtocol {
             }
         }
         arguments += [
-            "-incremental",
             "-emit-dependencies",
             "-emit-module",
             "-emit-module-path", moduleOutputPath.pathString,
@@ -327,6 +326,8 @@ public struct SwiftCompilerTool: ToolProtocol {
         }
         if wholeModuleOptimization {
             arguments += ["-whole-module-optimization", "-num-threads", "\(Self.numThreads)"]
+        } else {
+            arguments += ["-incremental"]
         }
         arguments += ["-c", "@\(self.fileList.pathString)"]
         arguments += ["-I", importPath.pathString]


### PR DESCRIPTION
Passing both results in noisy remarks when building from the command line like:

```
remark: Incremental compilation has been disabled: it is not compatible with whole module optimization
```

https://forums.swift.org/t/incremental-compilation-has-been-disabled-it-is-not-compatible-with-whole-module-optimization/66092