### PR TITLE
Package plugins can't use the UniformTypeIdentifiers module

### DIFF
--- a/Sources/Basics/Sandbox.swift
+++ b/Sources/Basics/Sandbox.swift
@@ -125,6 +125,9 @@ fileprivate func macOSSandboxProfile(
 
     // This is needed to launch any processes.
     contents += "(allow process*)\n"
+    
+    // This is needed to use the UniformTypeIdentifiers API.
+    contents += "(allow mach-lookup (global-name \"com.apple.lsd.mapdb\"))\n"
 
     if allowNetworkConnections.filter({ $0 != .none }).isEmpty == false {
         // this is used by the system for caching purposes and will lead to log spew if not allowed

--- a/Tests/BasicsTests/SandboxTests.swift
+++ b/Tests/BasicsTests/SandboxTests.swift
@@ -28,6 +28,29 @@ final class SandboxTest: XCTestCase {
             XCTAssertNoThrow(try TSCBasic.Process.checkNonZeroExit(arguments: command))
         }
     }
+    
+    func testUniformTypeIdentifiers() throws {
+        #if !os(macOS)
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
+
+        let testProgram = """
+        import Foundation
+
+        let file = URL(fileURLWithPath:"\(#file)", isDirectory:false)
+        guard let resourceValues = try? file.resourceValues(forKeys: [.contentTypeKey]) else {
+            fputs("Failed to get content type/type identifier for '\(#file)'", stderr)
+            exit(EXIT_FAILURE)
+        }
+        """
+        let command = try Sandbox.apply(command: ["swift", "-"], strictness: .writableTemporaryDirectory)
+        let process = Process(arguments: command)
+        let stdin = try process.launch()
+        stdin.write(sequence: testProgram.utf8)
+        try stdin.close()
+        let processResult = try process.waitUntilExit()
+        XCTAssertEqual(processResult.exitStatus, .terminated(code: 0), (try? processResult.utf8stderrOutput()) ?? "")
+    }
 
     func testNetworkNotAllowed() throws {
         #if !os(macOS)


### PR DESCRIPTION
Add the com.apple.lsd.mapdb Mach service to the macOS sandbox

### Motivation:

Swift package plugins can't use the Uniform Type Identifier API, such as to get a file's type identifier, because they don't have the right entitlement which is normally provided by the App Sandbox.

### Modifications:

Allow looking up the com.apple.lsd.mapdb Mach service in the macOS sandbox.

### Result:

Swift package plugins are able to use the Uniform Type Identifier APIs.
