### PR TITLE
Improve handling of non-macOS Darwin triples (reprise)

### DIFF
--- a/Sources/Basics/Triple+Basics.swift
+++ b/Sources/Basics/Triple+Basics.swift
@@ -178,7 +178,7 @@ extension Triple {
     /// The file extension for Foundation-style bundle.
     public var nsbundleExtension: String {
         switch os {
-        case .darwin, .macosx:
+        case _ where isDarwin():
             return ".bundle"
         default:
             // See: https://github.com/apple/swift-corelibs-foundation/blob/master/Docs/FHS%20Bundles.md

--- a/Sources/Basics/Triple+Basics.swift
+++ b/Sources/Basics/Triple+Basics.swift
@@ -136,7 +136,7 @@ extension Triple {
         }
 
         switch os {
-        case .darwin, .macosx:
+        case _ where isDarwin():
             return ".dylib"
         case .linux, .openbsd:
             return ".so"
@@ -155,7 +155,7 @@ extension Triple {
         }
 
         switch os {
-        case .darwin, .macosx:
+        case _ where isDarwin():
             return ""
         case .linux, .openbsd:
             return ""

--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -267,7 +267,7 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
 
             // When deploying to macOS prior to macOS 12, add an rpath to the
             // back-deployed concurrency libraries.
-            if useStdlibRpath, self.buildParameters.targetTriple.isDarwin(),
+            if useStdlibRpath, self.buildParameters.targetTriple.isMacOSX,
                let macOSSupportedPlatform = self.package.platforms.getDerived(for: .macOS),
                macOSSupportedPlatform.version.major < 12
             {

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -127,9 +127,10 @@ extension BuildParameters {
     public func targetTripleArgs(for target: ResolvedTarget) throws -> [String] {
         var args = ["-target"]
         // Compute the triple string for Darwin platform using the platform version.
-        if let darwinPlatform = targetTriple.darwinPlatform {
-            guard let supportedPlatform = target.platforms.getDerived(for: darwinPlatform.packagePlatform) else {
-                throw StringError("the target \(target) doesn't support building for the \(darwinPlatform.platformDisplayName) platform")
+        if targetTriple.isDarwin() {
+            let platform = buildEnvironment.platform
+            guard let supportedPlatform = target.platforms.getDerived(for: platform) else {
+                throw StringError("the target \(target) doesn't support building for the \(platform.name) platform")
             }
             args += [targetTriple.tripleString(forPlatformVersion: supportedPlatform.version.versionString)]
         } else {
@@ -1100,23 +1101,6 @@ func generateResourceInfoPlist(
 extension Basics.Triple {
     var isSupportingStaticStdlib: Bool {
         isLinux() || arch == .wasm32
-    }
-}
-
-extension Basics.DarwinPlatform {
-    var packagePlatform: PackageModel.Platform {
-        switch self {
-        case .macOS:
-            return .macOS
-        case .iOS(.catalyst):
-            return .macCatalyst
-        case .iOS(.device), .iOS(.simulator):
-            return .iOS
-        case .tvOS:
-            return .tvOS
-        case .watchOS:
-            return .watchOS
-        }
     }
 }
 

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -127,11 +127,11 @@ extension BuildParameters {
     public func targetTripleArgs(for target: ResolvedTarget) throws -> [String] {
         var args = ["-target"]
         // Compute the triple string for Darwin platform using the platform version.
-        if targetTriple.isDarwin() {
-            guard let macOSSupportedPlatform = target.platforms.getDerived(for: .macOS) else {
-                throw StringError("the target \(target) doesn't support building for macOS")
+        if let darwinPlatform = targetTriple.darwinPlatform {
+            guard let supportedPlatform = target.platforms.getDerived(for: darwinPlatform.packagePlatform) else {
+                throw StringError("the target \(target) doesn't support building for the \(darwinPlatform.platformDisplayName) platform")
             }
-            args += [targetTriple.tripleString(forPlatformVersion: macOSSupportedPlatform.version.versionString)]
+            args += [targetTriple.tripleString(forPlatformVersion: supportedPlatform.version.versionString)]
         } else {
             args += [targetTriple.tripleString]
         }
@@ -1100,6 +1100,23 @@ func generateResourceInfoPlist(
 extension Basics.Triple {
     var isSupportingStaticStdlib: Bool {
         isLinux() || arch == .wasm32
+    }
+}
+
+extension Basics.DarwinPlatform {
+    var packagePlatform: PackageModel.Platform {
+        switch self {
+        case .macOS:
+            return .macOS
+        case .iOS(.catalyst):
+            return .macCatalyst
+        case .iOS(.device), .iOS(.simulator):
+            return .iOS
+        case .tvOS:
+            return .tvOS
+        case .watchOS:
+            return .watchOS
+        }
     }
 }
 

--- a/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
+++ b/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
@@ -124,4 +124,3 @@ extension Triple.Environment {
         }
     }
 }
-

--- a/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
+++ b/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
@@ -124,3 +124,4 @@ extension Triple.Environment {
         }
     }
 }
+

--- a/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
+++ b/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
@@ -41,10 +41,10 @@ extension BinaryTarget {
         // At the moment we return at most a single library.
         let metadata = try XCFrameworkMetadata.parse(fileSystem: fileSystem, rootPath: self.artifactPath)
         // Filter the libraries that are relevant to the triple.
-        // FIXME: this filter needs to become more sophisticated
         guard let library = metadata.libraries.first(where: {
             $0.platform == triple.os?.asXCFrameworkPlatformString &&
-                $0.architectures.contains(triple.archName)
+            $0.variant == triple.environment?.asXCFrameworkPlatformVariantString &&
+            $0.architectures.contains(triple.archName)
         }) else {
             return []
         }
@@ -100,8 +100,27 @@ extension Triple.OS {
             return nil // XCFrameworks do not support any of these platforms today.
         case .macosx:
             return "macos"
+        case .ios:
+            return "ios"
+        case .tvos:
+            return "tvos"
+        case .watchos:
+            return "watchos"
         default:
             return nil // XCFrameworks do not support any of these platforms today.
+        }
+    }
+}
+
+extension Triple.Environment {
+    fileprivate var asXCFrameworkPlatformVariantString: String? {
+        switch self {
+        case .simulator:
+            return "simulator"
+        case .macabi:
+            return "maccatalyst"
+        default:
+            return nil // XCFrameworks do not support any of these platform variants today.
         }
     }
 }

--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -236,7 +236,18 @@ public struct BuildParameters: Encodable {
     /// The current platform we're building for.
     var currentPlatform: PackageModel.Platform {
         if self.targetTriple.isDarwin() {
-            return .macOS
+            switch self.targetTriple.darwinPlatform {
+            case .iOS(.catalyst):
+                return .macCatalyst
+            case .iOS(.device), .iOS(.simulator):
+                return .iOS
+            case .tvOS:
+                return .tvOS
+            case .watchOS:
+                return .watchOS
+            case .macOS, nil:
+                return .macOS
+            }
         } else if self.targetTriple.isAndroid() {
             return .android
         } else if self.targetTriple.isWASI() {

--- a/Sources/SPMBuildCore/XCFrameworkMetadata.swift
+++ b/Sources/SPMBuildCore/XCFrameworkMetadata.swift
@@ -25,19 +25,22 @@ public struct XCFrameworkMetadata: Equatable {
         public let headersPath: String?
         public let platform: String
         public let architectures: [String]
+        public let variant: String?
 
         public init(
             libraryIdentifier: String,
             libraryPath: String,
             headersPath: String?,
             platform: String,
-            architectures: [String]
+            architectures: [String],
+            variant: String?
         ) {
             self.libraryIdentifier = libraryIdentifier
             self.libraryPath = libraryPath
             self.headersPath = headersPath
             self.platform = platform
             self.architectures = architectures
+            self.variant = variant
         }
     }
 
@@ -78,6 +81,7 @@ extension XCFrameworkMetadata.Library: Decodable {
         case headersPath = "HeadersPath"
         case platform = "SupportedPlatform"
         case architectures = "SupportedArchitectures"
+        case variant = "SupportedPlatformVariant"
     }
 }
 

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -3270,7 +3270,7 @@ final class BuildPlanTests: XCTestCase {
       #endif
     }
 
-    func testCrossPlatforms() throws {
+    func testPlatformsCustomTriple() throws {
         let fileSystem = InMemoryFileSystem(emptyFiles:
             "/A/Sources/ATarget/foo.swift",
             "/B/Sources/BTarget/foo.swift"

--- a/Tests/SPMBuildCoreTests/XCFrameworkMetadataTests.swift
+++ b/Tests/SPMBuildCoreTests/XCFrameworkMetadataTests.swift
@@ -37,6 +37,21 @@ final class XCFrameworkMetadataTests: XCTestCase {
                         <key>SupportedPlatform</key>
                         <string>macos</string>
                     </dict>
+                    <dict>
+                        <key>LibraryIdentifier</key>
+                        <string>ios-arm64_x86_64-simulator</string>
+                        <key>LibraryPath</key>
+                        <string>MyFramework.framework</string>
+                        <key>SupportedArchitectures</key>
+                        <array>
+                            <string>arm64</string>
+                            <string>x86_64</string>
+                        </array>
+                        <key>SupportedPlatform</key>
+                        <string>ios</string>
+                        <key>SupportedPlatformVariant</key>
+                        <string>simulator</string>
+                    </dict>
                 </array>
                 <key>CFBundlePackageType</key>
                 <string>XFWK</string>
@@ -55,7 +70,16 @@ final class XCFrameworkMetadataTests: XCTestCase {
                                libraryPath: "MyFramework.framework",
                                headersPath: nil,
                                platform: "macos",
-                               architectures: ["x86_64"]
+                               architectures: ["x86_64"],
+                               variant: nil
+                           ),
+                           XCFrameworkMetadata.Library(
+                               libraryIdentifier: "ios-arm64_x86_64-simulator",
+                               libraryPath: "MyFramework.framework",
+                               headersPath: nil,
+                               platform: "ios",
+                               architectures: ["arm64", "x86_64"],
+                               variant: "simulator"
                            ),
                        ]))
     }
@@ -102,7 +126,8 @@ final class XCFrameworkMetadataTests: XCTestCase {
                                    libraryPath: "MyLibrary.a",
                                    headersPath: "Headers",
                                    platform: "macos",
-                                   architectures: ["x86_64"]
+                                   architectures: ["x86_64"],
+                                   variant: nil
                                ),
                            ]))
     }


### PR DESCRIPTION
This PR improves the way that iOS and other non-macOS Darwin triples are handled. Somewhat based on #6572, accounting for the changes since then.

### Motivation:

We can't assume that darwin == macOS anymore, necessitating a few changes to handle the other OSes.

### Modifications:

- Teach Basics about the file extensions for non-macOS Darwin libraries (.dylib) and executables (none)
- Update the target triple based on the supported platform version for all Darwin platforms, not just macOS (e.g. `.iOS(.v16)` now implies `arm64-apple-ios16`)
- Handle xcframeworks for triples other than {arm64,x86_64}-apple-macosx

### Result:

iOS/tvOS/watchOS libraries and (xc)frameworks are now better supported.