### PR TITLE
PackageLoading,Basics: properly handle cross-root manifests

### DIFF
--- a/Sources/Basics/FileSystem/NativePathExtensions.swift
+++ b/Sources/Basics/FileSystem/NativePathExtensions.swift
@@ -14,6 +14,8 @@ import Foundation
 import struct TSCBasic.AbsolutePath
 
 extension AbsolutePath {
+    /// Returns the File System Representation of the `AbsolutePath`'s
+    /// `pathString` property converted into a `URL`.
     public func _nativePathString(escaped: Bool) -> String {
         return URL(fileURLWithPath: self.pathString).withUnsafeFileSystemRepresentation {
             let repr = String(cString: $0!)


### PR DESCRIPTION
The path representation uses a relative path (`/relative/paths`) as an absolute path due to limitations of Unix systems.  If the source is located in one root and the manifest is built into another root, the path remains a relative path which will fail to match the VFS entry as the relative path is made absolute by normalizing the path to the current drive as per Windows rules.  This then results in the VFS entry not being honoured and the path fails to be found.  More aggressively perform the path normalization when loading the manifest to resolve this issue.