### PR TITLE
Build: correct a typo in an error message

### DIFF
--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -1082,7 +1082,7 @@ extension Basics.Diagnostic {
 
     fileprivate static func multipleProducers(output: BuildKey, commands: [SPMLLBuild.Command]) -> Self {
         let producers = commands.map(\.description).joined(separator: ", ")
-        return .error("couldn't build \(output.key) because of missing producers: \(producers)")
+        return .error("couldn't build \(output.key) because of multiple producers: \(producers)")
     }
 
     fileprivate static func commandError(command: SPMLLBuild.Command, message: String) -> Self {


### PR DESCRIPTION
This appears to be a copy-pasta induced error message error where `multiple` was being reported as `missing`.