### PR TITLE
Keychain credentials - better support for protocol and port

### DIFF
--- a/Sources/Basics/AuthorizationProvider.swift
+++ b/Sources/Basics/AuthorizationProvider.swift
@@ -54,15 +54,6 @@ extension AuthorizationProvider {
     }
 }
 
-extension URL {
-    fileprivate var authenticationID: String? {
-        guard let host = host?.lowercased() else {
-            return nil
-        }
-        return host.isEmpty ? nil : host
-    }
-}
-
 // MARK: - netrc
 
 public class NetrcAuthorizationProvider: AuthorizationProvider, AuthorizationWriter {
@@ -86,7 +77,7 @@ public class NetrcAuthorizationProvider: AuthorizationProvider, AuthorizationWri
         persist: Bool = true,
         callback: @escaping (Result<Void, Error>) -> Void
     ) {
-        guard let machine = url.authenticationID else {
+        guard let machine = Self.machine(for: url) else {
             return callback(.failure(AuthorizationProviderError.invalidURLHost))
         }
 
@@ -135,14 +126,14 @@ public class NetrcAuthorizationProvider: AuthorizationProvider, AuthorizationWri
     }
 
     public func authentication(for url: URL) -> (user: String, password: String)? {
-        if let machine = url.authenticationID, let cached = self.cache[machine] {
+        if let machine = Self.machine(for: url), let cached = self.cache[machine] {
             return cached
         }
         return self.machine(for: url).map { (user: $0.login, password: $0.password) }
     }
 
     private func machine(for url: URL) -> Basics.Netrc.Machine? {
-        if let machine = url.authenticationID,
+        if let machine = Self.machine(for: url),
            let existing = self.machines.first(where: { $0.name.lowercased() == machine })
         {
             return existing
@@ -170,6 +161,13 @@ public class NetrcAuthorizationProvider: AuthorizationProvider, AuthorizationWri
             return .none
         }
     }
+
+    private static func machine(for url: URL) -> String? {
+        guard let host = url.host?.lowercased() else {
+            return nil
+        }
+        return host.isEmpty ? nil : host
+    }
 }
 
 // MARK: - Keychain
@@ -191,26 +189,25 @@ public class KeychainAuthorizationProvider: AuthorizationProvider, Authorization
         persist: Bool = true,
         callback: @escaping (Result<Void, Error>) -> Void
     ) {
-        guard let server = url.authenticationID else {
+        guard let protocolHostPort = ProtocolHostPort(from: url) else {
             return callback(.failure(AuthorizationProviderError.invalidURLHost))
         }
 
         self.observabilityScope
-            .emit(debug: "Add/update credentials for server '\(server)' [\(url.absoluteString)] in keychain")
+            .emit(debug: "Add/update credentials for '\(protocolHostPort)' [\(url.absoluteString)] in keychain")
 
         if !persist {
-            self.cache[server] = (user, password)
+            self.cache[protocolHostPort.description] = (user, password)
             return callback(.success(()))
         }
 
         guard let passwordData = password.data(using: .utf8) else {
             return callback(.failure(AuthorizationProviderError.cannotEncodePassword))
         }
-        let `protocol` = self.protocol(for: url)
 
         do {
-            if !(try self.update(server: server, protocol: `protocol`, account: user, password: passwordData)) {
-                try self.create(server: server, protocol: `protocol`, account: user, password: passwordData)
+            if !(try self.update(protocolHostPort: protocolHostPort, account: user, password: passwordData)) {
+                try self.create(protocolHostPort: protocolHostPort, account: user, password: passwordData)
             }
             callback(.success(()))
         } catch {
@@ -219,17 +216,15 @@ public class KeychainAuthorizationProvider: AuthorizationProvider, Authorization
     }
 
     public func remove(for url: URL, callback: @escaping (Result<Void, Error>) -> Void) {
-        guard let server = url.authenticationID else {
+        guard let protocolHostPort = ProtocolHostPort(from: url) else {
             return callback(.failure(AuthorizationProviderError.invalidURLHost))
         }
 
         self.observabilityScope
-            .emit(debug: "Remove credentials for server '\(server)' [\(url.absoluteString)] from keychain")
-
-        let `protocol` = self.protocol(for: url)
+            .emit(debug: "Remove credentials for '\(protocolHostPort)' [\(url.absoluteString)] from keychain")
 
         do {
-            try self.delete(server: server, protocol: `protocol`)
+            try self.delete(protocolHostPort: protocolHostPort)
             callback(.success(()))
         } catch {
             callback(.failure(error))
@@ -237,37 +232,37 @@ public class KeychainAuthorizationProvider: AuthorizationProvider, Authorization
     }
 
     public func authentication(for url: URL) -> (user: String, password: String)? {
-        guard let server = url.authenticationID else {
+        guard let protocolHostPort = ProtocolHostPort(from: url) else {
             return nil
         }
 
-        if let cached = self.cache[server] {
+        if let cached = self.cache[protocolHostPort.description] {
             return cached
         }
 
         self.observabilityScope
-            .emit(debug: "Search credentials for server '\(server)' [\(url.absoluteString)] in keychain")
+            .emit(debug: "Search credentials for '\(protocolHostPort)' [\(url.absoluteString)] in keychain")
 
         do {
             guard let existingItem = try self
-                .search(server: server, protocol: self.protocol(for: url)) as? [String: Any],
+                .search(protocolHostPort: protocolHostPort) as? [String: Any],
                 let passwordData = existingItem[kSecValueData as String] as? Data,
                 let password = String(data: passwordData, encoding: String.Encoding.utf8),
                 let account = existingItem[kSecAttrAccount as String] as? String
             else {
                 throw AuthorizationProviderError
-                    .other("Failed to extract credentials for server \(server) from keychain")
+                    .other("Failed to extract credentials for '\(protocolHostPort)' from keychain")
             }
             return (user: account, password: password)
         } catch {
             switch error {
             case AuthorizationProviderError.notFound:
-                self.observabilityScope.emit(debug: "No credentials found for server \(server) in keychain")
+                self.observabilityScope.emit(debug: "No credentials found for '\(protocolHostPort)' in keychain")
             case AuthorizationProviderError.other(let detail):
                 self.observabilityScope.emit(error: detail)
             default:
                 self.observabilityScope.emit(
-                    error: "Failed to find credentials for server \(server) in keychain",
+                    error: "Failed to find credentials for '\(protocolHostPort)' in keychain",
                     underlyingError: error
                 )
             }
@@ -275,24 +270,33 @@ public class KeychainAuthorizationProvider: AuthorizationProvider, Authorization
         }
     }
 
-    private func create(server: String, protocol: CFString, account: String, password: Data) throws {
-        let query: [String: Any] = [kSecClass as String: kSecClassInternetPassword,
-                                    kSecAttrServer as String: server,
-                                    kSecAttrProtocol as String: `protocol`,
+    private func create(protocolHostPort: ProtocolHostPort, account: String, password: Data) throws {
+        var query: [String: Any] = [kSecClass as String: kSecClassInternetPassword,
+                                    kSecAttrProtocol as String: protocolHostPort.protocolCFString,
+                                    kSecAttrServer as String: protocolHostPort.server,
                                     kSecAttrAccount as String: account,
                                     kSecValueData as String: password]
+
+        if let port = protocolHostPort.port {
+            query[kSecAttrPort as String] = port
+        }
 
         let status = SecItemAdd(query as CFDictionary, nil)
         guard status == errSecSuccess else {
             throw AuthorizationProviderError
-                .other("Failed to save credentials for server \(server) to keychain: status \(status)")
+                .other("Failed to save credentials for '\(protocolHostPort)' to keychain: status \(status)")
         }
     }
 
-    private func update(server: String, protocol: CFString, account: String, password: Data) throws -> Bool {
-        let query: [String: Any] = [kSecClass as String: kSecClassInternetPassword,
-                                    kSecAttrServer as String: server,
-                                    kSecAttrProtocol as String: `protocol`]
+    private func update(protocolHostPort: ProtocolHostPort, account: String, password: Data) throws -> Bool {
+        var query: [String: Any] = [kSecClass as String: kSecClassInternetPassword,
+                                    kSecAttrProtocol as String: protocolHostPort.protocolCFString,
+                                    kSecAttrServer as String: protocolHostPort.server]
+
+        if let port = protocolHostPort.port {
+            query[kSecAttrPort as String] = port
+        }
+
         let attributes: [String: Any] = [kSecAttrAccount as String: account,
                                          kSecValueData as String: password]
 
@@ -302,29 +306,38 @@ public class KeychainAuthorizationProvider: AuthorizationProvider, Authorization
         }
         guard status == errSecSuccess else {
             throw AuthorizationProviderError
-                .other("Failed to update credentials for server \(server) in keychain: status \(status)")
+                .other("Failed to update credentials for '\(protocolHostPort)' in keychain: status \(status)")
         }
         return true
     }
 
-    private func delete(server: String, protocol: CFString) throws {
-        let query: [String: Any] = [kSecClass as String: kSecClassInternetPassword,
-                                    kSecAttrServer as String: server,
-                                    kSecAttrProtocol as String: `protocol`]
+    private func delete(protocolHostPort: ProtocolHostPort) throws {
+        var query: [String: Any] = [kSecClass as String: kSecClassInternetPassword,
+                                    kSecAttrProtocol as String: protocolHostPort.protocolCFString,
+                                    kSecAttrServer as String: protocolHostPort.server]
+
+        if let port = protocolHostPort.port {
+            query[kSecAttrPort as String] = port
+        }
+
         let status = SecItemDelete(query as CFDictionary)
         guard status == errSecSuccess else {
             throw AuthorizationProviderError
-                .other("Failed to delete credentials for server \(server) from keychain: status \(status)")
+                .other("Failed to delete credentials for '\(protocolHostPort)' from keychain: status \(status)")
         }
     }
 
-    private func search(server: String, protocol: CFString) throws -> CFTypeRef? {
-        let query: [String: Any] = [kSecClass as String: kSecClassInternetPassword,
-                                    kSecAttrServer as String: server,
-                                    kSecAttrProtocol as String: `protocol`,
+    private func search(protocolHostPort: ProtocolHostPort) throws -> CFTypeRef? {
+        var query: [String: Any] = [kSecClass as String: kSecClassInternetPassword,
+                                    kSecAttrProtocol as String: protocolHostPort.protocolCFString,
+                                    kSecAttrServer as String: protocolHostPort.server,
                                     kSecMatchLimit as String: kSecMatchLimitOne,
                                     kSecReturnAttributes as String: true,
                                     kSecReturnData as String: true]
+
+        if let port = protocolHostPort.port {
+            query[kSecAttrPort as String] = port
+        }
 
         var item: CFTypeRef?
         // Search keychain for server's username and password, if any.
@@ -334,21 +347,47 @@ public class KeychainAuthorizationProvider: AuthorizationProvider, Authorization
         }
         guard status == errSecSuccess else {
             throw AuthorizationProviderError
-                .other("Failed to find credentials for server \(server) in keychain: status \(status)")
+                .other("Failed to find credentials for '\(protocolHostPort)' in keychain: status \(status)")
         }
 
         return item
     }
 
-    private func `protocol`(for url: URL) -> CFString {
-        // See
-        // https://developer.apple.com/documentation/security/keychain_services/keychain_items/item_attribute_keys_and_values?language=swift
-        // for a list of possible values for the `kSecAttrProtocol` attribute.
-        switch url.scheme?.lowercased() {
-        case "https":
-            return kSecAttrProtocolHTTPS
-        default:
-            return kSecAttrProtocolHTTPS
+    struct ProtocolHostPort: Hashable, CustomStringConvertible {
+        let `protocol`: String?
+        let host: String
+        let port: Int?
+
+        var server: String {
+            self.host
+        }
+
+        var protocolCFString: CFString {
+            // See
+            // https://developer.apple.com/documentation/security/keychain_services/keychain_items/item_attribute_keys_and_values?language=swift
+            // for a list of possible values for the `kSecAttrProtocol` attribute.
+            switch self.protocol {
+            case "https":
+                return kSecAttrProtocolHTTPS
+            case "http":
+                return kSecAttrProtocolHTTP
+            default:
+                return kSecAttrProtocolHTTPS
+            }
+        }
+
+        init?(from url: URL) {
+            guard let host = url.host?.lowercased(), !host.isEmpty else {
+                return nil
+            }
+
+            self.protocol = url.scheme?.lowercased()
+            self.host = host
+            self.port = url.port
+        }
+
+        var description: String {
+            "\(self.protocol.map { "\($0)://" } ?? "")\(self.host)\(self.port.map { ":\($0)" } ?? "")"
         }
     }
 }

--- a/Tests/BasicsTests/AuthorizationProviderTests.swift
+++ b/Tests/BasicsTests/AuthorizationProviderTests.swift
@@ -69,7 +69,7 @@ final class AuthorizationProviderTests: XCTestCase {
         }
     }
 
-    func testProtocolHostPort() {
+    func testProtocolHostPort() throws {
         #if !canImport(Security)
         try XCTSkipIf(true)
         #else

--- a/Tests/BasicsTests/AuthorizationProviderTests.swift
+++ b/Tests/BasicsTests/AuthorizationProviderTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -39,27 +39,93 @@ final class AuthorizationProviderTests: XCTestCase {
             let otherPassword = UUID().uuidString
 
             // Add
-            XCTAssertNoThrow(try temp_await { callback in provider.addOrUpdate(for: url, user: user, password: password, callback: callback) })
-            XCTAssertNoThrow(try temp_await { callback in provider.addOrUpdate(for: otherURL, user: user, password: otherPassword, callback: callback) })
+            XCTAssertNoThrow(try temp_await { callback in
+                provider.addOrUpdate(for: url, user: user, password: password, callback: callback)
+            })
+            XCTAssertNoThrow(try temp_await { callback in
+                provider.addOrUpdate(for: otherURL, user: user, password: otherPassword, callback: callback)
+            })
 
             self.assertAuthentication(provider, for: url, expected: (user, password))
 
             // Update - the new password is appended to the end of file
             let newPassword = UUID().uuidString
-            XCTAssertNoThrow(try temp_await { callback in provider.addOrUpdate(for: url, user: user, password: newPassword, callback: callback) })
+            XCTAssertNoThrow(try temp_await { callback in
+                provider.addOrUpdate(for: url, user: user, password: newPassword, callback: callback)
+            })
 
             // .netrc file now contains two entries for `url`: one with `password` and the other with `newPassword`.
             // `NetrcAuthorizationProvider` returns the first entry it finds.
             self.assertAuthentication(provider, for: url, expected: (user, password))
 
             // Make sure the new entry is saved
-            XCTAssertNotNil(provider.machines.first(where: { $0.name == url.host!.lowercased() && $0.login == user && $0.password == newPassword }))
+            XCTAssertNotNil(
+                provider.machines
+                    .first(where: { $0.name == url.host!.lowercased() && $0.login == user && $0.password == newPassword
+                    })
+            )
 
             self.assertAuthentication(provider, for: otherURL, expected: (user, otherPassword))
         }
     }
 
-    func testKeychain() throws {
+    func testProtocolHostPort() {
+        #if !canImport(Security)
+        try XCTSkipIf(true)
+        #else
+        do {
+            let url = URL("http://localhost")
+            let parsed = KeychainAuthorizationProvider.ProtocolHostPort(from: url)
+            XCTAssertNotNil(parsed)
+            XCTAssertEqual(parsed?.protocol, "http")
+            XCTAssertEqual(parsed?.host, "localhost")
+            XCTAssertNil(parsed?.port)
+            XCTAssertEqual(parsed?.protocolCFString, kSecAttrProtocolHTTP)
+            XCTAssertEqual(parsed?.description, "http://localhost")
+        }
+
+        do {
+            let url = URL("http://localhost:8080")
+            let parsed = KeychainAuthorizationProvider.ProtocolHostPort(from: url)
+            XCTAssertNotNil(parsed)
+            XCTAssertEqual(parsed?.protocol, "http")
+            XCTAssertEqual(parsed?.host, "localhost")
+            XCTAssertEqual(parsed?.port, 8080)
+            XCTAssertEqual(parsed?.protocolCFString, kSecAttrProtocolHTTP)
+            XCTAssertEqual(parsed?.description, "http://localhost:8080")
+        }
+
+        do {
+            let url = URL("https://localhost")
+            let parsed = KeychainAuthorizationProvider.ProtocolHostPort(from: url)
+            XCTAssertNotNil(parsed)
+            XCTAssertEqual(parsed?.protocol, "https")
+            XCTAssertEqual(parsed?.host, "localhost")
+            XCTAssertNil(parsed?.port)
+            XCTAssertEqual(parsed?.protocolCFString, kSecAttrProtocolHTTPS)
+            XCTAssertEqual(parsed?.description, "https://localhost")
+        }
+
+        do {
+            let url = URL("https://localhost:8080")
+            let parsed = KeychainAuthorizationProvider.ProtocolHostPort(from: url)
+            XCTAssertNotNil(parsed)
+            XCTAssertEqual(parsed?.protocol, "https")
+            XCTAssertEqual(parsed?.host, "localhost")
+            XCTAssertEqual(parsed?.port, 8080)
+            XCTAssertEqual(parsed?.protocolCFString, kSecAttrProtocolHTTPS)
+            XCTAssertEqual(parsed?.description, "https://localhost:8080")
+        }
+
+        do {
+            let url = URL("https://:8080")
+            let parsed = KeychainAuthorizationProvider.ProtocolHostPort(from: url)
+            XCTAssertNil(parsed)
+        }
+        #endif
+    }
+
+    func testKeychain_protocol() throws {
         #if !canImport(Security) || !ENABLE_KEYCHAIN_TEST
         try XCTSkipIf(true)
         #else
@@ -67,30 +133,93 @@ final class AuthorizationProviderTests: XCTestCase {
 
         let user = UUID().uuidString
 
-        let url = URL("http://\(UUID().uuidString)")
-        let password = UUID().uuidString
+        let httpURL = URL("http://\(UUID().uuidString)")
+        let httpPassword = UUID().uuidString
 
-        let otherURL = URL("https://\(UUID().uuidString)")
-        let otherPassword = UUID().uuidString
+        let httpsURL = URL("https://\(UUID().uuidString)")
+        let httpsPassword = UUID().uuidString
 
         // Add
-        XCTAssertNoThrow(try temp_await { callback in provider.addOrUpdate(for: url, user: user, password: password, callback: callback) })
-        XCTAssertNoThrow(try temp_await { callback in provider.addOrUpdate(for: otherURL, user: user, password: otherPassword, callback: callback) })
+        XCTAssertNoThrow(try temp_await { callback in
+            provider.addOrUpdate(for: httpURL, user: user, password: httpPassword, callback: callback)
+        })
+        XCTAssertNoThrow(try temp_await { callback in
+            provider.addOrUpdate(for: httpsURL, user: user, password: httpsPassword, callback: callback)
+        })
 
-        self.assertAuthentication(provider, for: url, expected: (user, password))
+        self.assertAuthentication(provider, for: httpURL, expected: (user, httpPassword))
+        self.assertAuthentication(provider, for: httpsURL, expected: (user, httpsPassword))
 
         // Update
-        let newPassword = UUID().uuidString
-        XCTAssertNoThrow(try temp_await { callback in provider.addOrUpdate(for: url, user: user, password: newPassword, callback: callback) })
+        let newHTTPPassword = UUID().uuidString
+        XCTAssertNoThrow(try temp_await { callback in
+            provider.addOrUpdate(for: httpURL, user: user, password: newHTTPPassword, callback: callback)
+        })
+        let newHTTPSPassword = UUID().uuidString
+        XCTAssertNoThrow(try temp_await { callback in
+            provider.addOrUpdate(for: httpsURL, user: user, password: newHTTPSPassword, callback: callback)
+        })
 
         // Existing password is updated
-        self.assertAuthentication(provider, for: url, expected: (user, newPassword))
-        self.assertAuthentication(provider, for: otherURL, expected: (user, otherPassword))
+        self.assertAuthentication(provider, for: httpURL, expected: (user, newHTTPPassword))
+        self.assertAuthentication(provider, for: httpsURL, expected: (user, newHTTPSPassword))
 
         // Delete
-        XCTAssertNoThrow(try temp_await { callback in provider.remove(for: url, callback: callback) })
-        XCTAssertNil(provider.authentication(for: url))
-        self.assertAuthentication(provider, for: otherURL, expected: (user, otherPassword))
+        XCTAssertNoThrow(try temp_await { callback in provider.remove(for: httpURL, callback: callback) })
+        XCTAssertNil(provider.authentication(for: httpURL))
+        self.assertAuthentication(provider, for: httpsURL, expected: (user, newHTTPSPassword))
+
+        XCTAssertNoThrow(try temp_await { callback in provider.remove(for: httpsURL, callback: callback) })
+        XCTAssertNil(provider.authentication(for: httpsURL))
+        #endif
+    }
+
+    func testKeychain_port() throws {
+        #if !canImport(Security) || !ENABLE_KEYCHAIN_TEST
+        try XCTSkipIf(true)
+        #else
+        let provider = KeychainAuthorizationProvider(observabilityScope: ObservabilitySystem.NOOP)
+
+        let user = UUID().uuidString
+
+        let noPortURL = URL("http://\(UUID().uuidString)")
+        let noPortPassword = UUID().uuidString
+
+        let portURL = URL("http://\(UUID().uuidString):8971")
+        let portPassword = UUID().uuidString
+
+        // Add
+        XCTAssertNoThrow(try temp_await { callback in
+            provider.addOrUpdate(for: noPortURL, user: user, password: noPortPassword, callback: callback)
+        })
+        XCTAssertNoThrow(try temp_await { callback in
+            provider.addOrUpdate(for: portURL, user: user, password: portPassword, callback: callback)
+        })
+
+        self.assertAuthentication(provider, for: noPortURL, expected: (user, noPortPassword))
+        self.assertAuthentication(provider, for: portURL, expected: (user, portPassword))
+
+        // Update
+        let newPortPassword = UUID().uuidString
+        XCTAssertNoThrow(try temp_await { callback in
+            provider.addOrUpdate(for: portURL, user: user, password: newPortPassword, callback: callback)
+        })
+        let newNoPortPassword = UUID().uuidString
+        XCTAssertNoThrow(try temp_await { callback in
+            provider.addOrUpdate(for: noPortURL, user: user, password: newNoPortPassword, callback: callback)
+        })
+
+        // Existing password is updated
+        self.assertAuthentication(provider, for: portURL, expected: (user, newPortPassword))
+        self.assertAuthentication(provider, for: noPortURL, expected: (user, newNoPortPassword))
+
+        // Delete
+        XCTAssertNoThrow(try temp_await { callback in provider.remove(for: noPortURL, callback: callback) })
+        XCTAssertNil(provider.authentication(for: noPortURL))
+        self.assertAuthentication(provider, for: portURL, expected: (user, newPortPassword))
+
+        XCTAssertNoThrow(try temp_await { callback in provider.remove(for: portURL, callback: callback) })
+        XCTAssertNil(provider.authentication(for: portURL))
         #endif
     }
 
@@ -105,29 +234,48 @@ final class AuthorizationProviderTests: XCTestCase {
 
         do {
             // providerOne's password is returned first
-            let provider = CompositeAuthorizationProvider(providerOne, providerTwo, observabilityScope: ObservabilitySystem.NOOP)
+            let provider = CompositeAuthorizationProvider(
+                providerOne,
+                providerTwo,
+                observabilityScope: ObservabilitySystem.NOOP
+            )
             self.assertAuthentication(provider, for: url, expected: (user, passwordOne))
         }
 
         do {
             // providerTwo's password is returned first
-            let provider = CompositeAuthorizationProvider(providerTwo, providerOne, observabilityScope: ObservabilitySystem.NOOP)
+            let provider = CompositeAuthorizationProvider(
+                providerTwo,
+                providerOne,
+                observabilityScope: ObservabilitySystem.NOOP
+            )
             self.assertAuthentication(provider, for: url, expected: (user, passwordTwo))
         }
 
         do {
             // Neither has password
             let unknownURL = URL("http://\(UUID().uuidString)")
-            let provider = CompositeAuthorizationProvider(providerOne, providerTwo, observabilityScope: ObservabilitySystem.NOOP)
+            let provider = CompositeAuthorizationProvider(
+                providerOne,
+                providerTwo,
+                observabilityScope: ObservabilitySystem.NOOP
+            )
             XCTAssertNil(provider.authentication(for: unknownURL))
         }
     }
 
-    private func assertAuthentication(_ provider: AuthorizationProvider, for url: URL, expected: (user: String, password: String)) {
+    private func assertAuthentication(
+        _ provider: AuthorizationProvider,
+        for url: URL,
+        expected: (user: String, password: String)
+    ) {
         let authentication = provider.authentication(for: url)
         XCTAssertEqual(authentication?.user, expected.user)
         XCTAssertEqual(authentication?.password, expected.password)
-        XCTAssertEqual(provider.httpAuthorizationHeader(for: url), "Basic " + "\(expected.user):\(expected.password)".data(using: .utf8)!.base64EncodedString())
+        XCTAssertEqual(
+            provider.httpAuthorizationHeader(for: url),
+            "Basic " + "\(expected.user):\(expected.password)".data(using: .utf8)!.base64EncodedString()
+        )
     }
 }
 
@@ -135,6 +283,6 @@ private struct TestProvider: AuthorizationProvider {
     let map: [URL: (user: String, password: String)]
 
     func authentication(for url: URL) -> (user: String, password: String)? {
-        return self.map[url]
+        self.map[url]
     }
 }


### PR DESCRIPTION
Motivation:
`KeychainAuthorizationProvider` supports HTTPS only and no port. Credentials for URLs that include port or HTTP URLs stored in Keychain are not found.

Changes:
- Support HTTP
- Use URL port as search criteria
