### PR TITLE
[5.9] Swift SDKs: fix search paths handling

### DIFF
--- a/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
@@ -293,6 +293,12 @@ public final class ClangTargetBuildDescription {
             // User arguments (from -Xcxx) should follow generated arguments to allow user overrides
             args += self.buildParameters.flags.cxxCompilerFlags
         }
+
+        // Pass default include paths from the toolchain.
+        for includeSearchPath in self.buildParameters.toolchain.includeSearchPaths {
+            args += ["-I", includeSearchPath.pathString]
+        }
+
         return args
     }
 

--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -316,6 +316,11 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
         // User arguments (from -Xlinker) should follow generated arguments to allow user overrides
         args += self.buildParameters.flags.linkerFlags.asSwiftcLinkerFlags()
 
+        // Pass default library paths from the toolchain.
+        for librarySearchPath in self.buildParameters.toolchain.librarySearchPaths {
+            args += ["-L", librarySearchPath.pathString]
+        }
+
         // Add toolchain's libdir at the very end (even after the user -Xlinker arguments).
         //
         // This will allow linking to libraries shipped in the toolchain.

--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -513,6 +513,12 @@ public final class SwiftTargetBuildDescription {
         // // User arguments (from -Xcxx) should follow generated arguments to allow user overrides
         // args += self.buildParameters.flags.cxxCompilerFlags.asSwiftcCXXCompilerFlags()
 
+
+        // Pass default include paths from the toolchain.
+        for includeSearchPath in self.buildParameters.toolchain.includeSearchPaths {
+            args += ["-I", includeSearchPath.pathString]
+        }
+
         // suppress warnings if the package is remote
         if self.package.isRemote {
             args += ["-suppress-warnings"]
@@ -612,6 +618,11 @@ public final class SwiftTargetBuildDescription {
         result += try self.buildSettingsFlags()
         result += try self.macroArguments()
 
+        // Pass default include paths from the toolchain.
+        for includeSearchPath in self.buildParameters.toolchain.includeSearchPaths {
+            result += ["-I", includeSearchPath.pathString]
+        }
+
         return result
     }
 
@@ -680,6 +691,12 @@ public final class SwiftTargetBuildDescription {
         // result += self.buildParameters.toolchain.extraFlags.cxxCompilerFlags.asSwiftcCXXCompilerFlags()
         // // User arguments (from -Xcxx) should follow generated arguments to allow user overrides
         // result += self.buildParameters.flags.cxxCompilerFlags.asSwiftcCXXCompilerFlags()
+
+
+        // Pass default include paths from the toolchain.
+        for includeSearchPath in self.buildParameters.toolchain.includeSearchPaths {
+            result += ["-I", includeSearchPath.pathString]
+        }
 
         result += try self.macroArguments()
         return result

--- a/Sources/PackageModel/Toolchain.swift
+++ b/Sources/PackageModel/Toolchain.swift
@@ -28,6 +28,12 @@ public protocol Toolchain {
     /// Path containing the macOS Swift stdlib.
     var macosSwiftStdlib: AbsolutePath { get throws }
 
+    /// An array of paths to search for headers and modules at compile time.
+    var includeSearchPaths: [AbsolutePath] { get }
+
+    /// An array of paths to search for libraries at link time.
+    var librarySearchPaths: [AbsolutePath] { get }
+
     /// Path of the `clang` compiler.
     func getClangCompiler() throws -> AbsolutePath
 

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -33,6 +33,12 @@ public final class UserToolchain: Toolchain {
     /// Path of the `swiftc` compiler.
     public let swiftCompilerPath: AbsolutePath
 
+    /// An array of paths to search for headers and modules at compile time.
+    public let includeSearchPaths: [AbsolutePath]
+
+    /// An array of paths to search for libraries at link time.
+    public let librarySearchPaths: [AbsolutePath]
+
     /// Additional flags to be passed to the build tools.
     public var extraFlags: BuildFlags
 
@@ -481,6 +487,7 @@ public final class UserToolchain: Toolchain {
         }
 
         self.triple = triple
+
         self.extraFlags = BuildFlags(
             cCompilerFlags: destination.toolset.knownTools[.cCompiler]?.extraCLIOptions ?? [],
             cxxCompilerFlags: destination.toolset.knownTools[.cxxCompiler]?.extraCLIOptions ?? [],
@@ -490,6 +497,9 @@ public final class UserToolchain: Toolchain {
                 environment: environment),
             linkerFlags: destination.toolset.knownTools[.linker]?.extraCLIOptions ?? [],
             xcbuildFlags: destination.toolset.knownTools[.xcbuild]?.extraCLIOptions ?? [])
+
+        self.includeSearchPaths = destination.pathsConfiguration.includeSearchPaths ?? []
+        self.librarySearchPaths = destination.pathsConfiguration.includeSearchPaths ?? []
 
         self.librarianPath = try UserToolchain.determineLibrarian(
             triple: triple,

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -3552,10 +3552,7 @@ final class BuildPlanTests: XCTestCase {
             runTimeTriple: runtimeTriple,
             properties: .init(
                 sdkRootPath: "/fake/sdk",
-                swiftStaticResourcesPath: "/usr/lib/swift_static/none",
-                includeSearchPaths: ["/usr/lib/swift_static/none"],
-                librarySearchPaths: ["/usr/lib/swift_static/none"],
-                toolsetPaths: []),
+                swiftStaticResourcesPath: "/usr/lib/swift_static/none"),
             toolset: toolSet,
             destinationDirectory: nil)
         let toolchain = try UserToolchain(destination: destination)
@@ -3665,6 +3662,64 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertCount(0, exeLinkArguments, cliFlag(tool: .cxxCompiler))
         XCTAssertCount(1, exeLinkArguments, jsonFlag(tool: .linker))
         XCTAssertCount(1, exeLinkArguments, cliFlag(tool: .linker))
+    }
+
+    func testUserToolchainWithSDKSearchPaths() throws {
+        let fileSystem = InMemoryFileSystem(emptyFiles:
+            "/Pkg/Sources/exe/main.swift",
+            "/Pkg/Sources/cLib/cLib.c",
+            "/Pkg/Sources/cLib/include/cLib.h"
+        )
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fileSystem: fileSystem,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "Pkg",
+                    path: "/Pkg",
+                    targets: [
+                        TargetDescription(name: "exe", dependencies: ["cLib"]),
+                        TargetDescription(name: "cLib", dependencies: []),
+                    ]),
+            ],
+            observabilityScope: observability.topScope
+        )
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
+        let runtimeTriple = try UserToolchain.default.triple
+        let sdkIncludeSearchPath = "/usr/lib/swift_static/none/include"
+        let sdkLibrarySearchPath = "/usr/lib/swift_static/none/lib"
+        let destination = try Destination(
+            runTimeTriple: runtimeTriple,
+            properties: .init(
+                sdkRootPath: "/fake/sdk",
+                includeSearchPaths: [sdkIncludeSearchPath],
+                librarySearchPaths: [sdkLibrarySearchPath]))
+        let toolchain = try UserToolchain(destination: destination)
+        let buildParameters = mockBuildParameters(toolchain: toolchain)
+        let result = try BuildPlanResult(plan: BuildPlan(
+            buildParameters: buildParameters,
+            graph: graph,
+            fileSystem: fileSystem,
+            observabilityScope: observability.topScope))
+        result.checkProductsCount(1)
+        result.checkTargetsCount(2)
+
+        // Compile C Target
+        let cLibCompileArguments = try result.target(for: "cLib").clangTarget().basicArguments(isCXX: false)
+        let cLibCompileArgumentsPattern: [StringPattern] = ["-I", "\(sdkIncludeSearchPath)"]
+        XCTAssertMatch(cLibCompileArguments, cLibCompileArgumentsPattern)
+
+        // Compile Swift Target
+        let exeCompileArguments = try result.target(for: "exe").swiftTarget().compileArguments()
+        let exeCompileArgumentsPattern: [StringPattern] = ["-I", "\(sdkIncludeSearchPath)"]
+        XCTAssertMatch(exeCompileArguments, exeCompileArgumentsPattern)
+
+        // Link Product
+        let exeLinkArguments = try result.buildProduct(for: "exe").linkArguments()
+        let exeLinkArgumentsPattern: [StringPattern] = ["-L", "\(sdkIncludeSearchPath)"]
+        XCTAssertMatch(exeLinkArguments, exeLinkArgumentsPattern)
     }
 
     func testExecBuildTimeDependency() throws {

--- a/Tests/BuildTests/MockBuildTestHelper.swift
+++ b/Tests/BuildTests/MockBuildTestHelper.swift
@@ -29,6 +29,8 @@ struct MockToolchain: PackageModel.Toolchain {
     let librarianPath = AbsolutePath("/fake/path/to/ar")
 #endif
     let swiftCompilerPath = AbsolutePath("/fake/path/to/swiftc")
+    let includeSearchPaths = [AbsolutePath]()
+    let librarySearchPaths = [AbsolutePath]()
     let isSwiftDevelopmentToolchain = false
     let swiftPluginServerPath: AbsolutePath? = nil
     


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-package-manager/pull/6608.

Fixed a bug where `includeSearchPaths` and `librarySearchPaths` defined in a `swift-sdk.json` file were not properly respected. Updates `UserToolchain` to support these by adding matching properties and updates `SwiftTargetBuildDescription` as well as `ClangTargetBuildDescription` to pass these toolchain search paths to  the compilers and linkers as expected.

(cherry picked from commit 38c5c0537d6a894d4946a49996e1be6fd93358e8)

```
# Conflicts:
#	Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
#	Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
```