### PR TITLE
Build: filter `-use-ld=lld` from `swift-symbolgraph-extract`

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -916,7 +916,11 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
         let buildPath = buildParameters.buildPath.pathString
         var arguments = ["-I", buildPath]
 
-        var extraSwiftCFlags = buildParameters.toolchain.extraFlags.swiftCompilerFlags
+        // swift-symbolgraph-extract does not support parsing `-use-ld=lld` and
+        // will silently error failing the operation.  Filter out this flag
+        // similar to how we filter out the library search path unless
+        // explicitly requested.
+        var extraSwiftCFlags = buildParameters.toolchain.extraFlags.swiftCompilerFlags.filter { !$0.starts(with: "-use-ld=") }
         if !includeLibrarySearchPaths {
             for index in extraSwiftCFlags.indices.dropLast().reversed() {
                 if extraSwiftCFlags[index] == "-L" {


### PR DESCRIPTION
This option is not parsed by the symbol graph extractor, nor does it materially make a difference to the tool.  Filter out this flag on the SPM side to ensure that we are able to properly run the tool.  This partially enables the use of `swift package dump-symbol-graph` on Windows.