### PR TITLE
Package plugins can't use the UniformTypeIdentifiers module (#6731)

### DIFF
--- a/Sources/Basics/Sandbox.swift
+++ b/Sources/Basics/Sandbox.swift
@@ -120,6 +120,9 @@ fileprivate func macOSSandboxProfile(
 
     // This is needed to launch any processes.
     contents += "(allow process*)\n"
+    
+    // This is needed to use the UniformTypeIdentifiers API.
+    contents += "(allow mach-lookup (global-name \"com.apple.lsd.mapdb\"))\n"
 
     if allowNetworkConnections.filter({ $0 != .none }).isEmpty == false {
         // this is used by the system for caching purposes and will lead to log spew if not allowed


### PR DESCRIPTION
Cherry pick of #6731 and #6735 for 5.9