### PR TITLE
Add availability to source module APIs

### DIFF
--- a/Sources/PackagePlugin/PackageModel.swift
+++ b/Sources/PackagePlugin/PackageModel.swift
@@ -43,12 +43,6 @@ public struct Package {
     public let targets: [Target]
 }
 
-public extension Package {
-    var sourceModules: [SourceModuleTarget] {
-        return targets.compactMap { $0.sourceModule }
-    }
-}
-
 /// Represents the origin of a package as it appears in the graph.
 public enum PackageOrigin {
     /// A root package (unversioned).
@@ -111,12 +105,6 @@ public protocol Product {
     /// example, an executable product must have one and only one target that
     /// defines the main entry point for an executable).
     var targets: [Target] { get }
-}
-
-public extension Product {
-    var sourceModules: [SourceModuleTarget] {
-        return targets.compactMap { $0.sourceModule }
-    }
 }
 
 /// Represents an executable product defined in a package.
@@ -400,13 +388,6 @@ public struct SystemLibraryTarget: Target {
   
     /// Flags from `pkg-config` to pass to the platform linker.
     public let linkerFlags: [String]
-}
-
-public extension Target {
-    /// Convenience accessor which casts the receiver to`SourceModuleTarget` if possible.
-    var sourceModule: SourceModuleTarget? {
-        return self as? SourceModuleTarget
-    }
 }
 
 /// Provides information about a list of files. The order is not defined

--- a/Sources/PackagePlugin/Utilities.swift
+++ b/Sources/PackagePlugin/Utilities.swift
@@ -32,6 +32,18 @@ extension Package {
             return product
         }
     }
+
+    @available(_PackageDescription, introduced: 5.9)
+    public var sourceModules: [SourceModuleTarget] {
+        return targets.compactMap { $0.sourceModule }
+    }
+}
+
+extension Product {
+    @available(_PackageDescription, introduced: 5.9)
+    public var sourceModules: [SourceModuleTarget] {
+        return targets.compactMap { $0.sourceModule }
+    }
 }
 
 extension Target {
@@ -54,6 +66,12 @@ extension Target {
             }
         }
         return self.dependencies.flatMap{ dependencyClosure(for: $0) }
+    }
+
+    /// Convenience accessor which casts the receiver to`SourceModuleTarget` if possible.
+    @available(_PackageDescription, introduced: 5.9)
+    public var sourceModule: SourceModuleTarget? {
+        return self as? SourceModuleTarget
     }
 }
 

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -1427,7 +1427,7 @@ final class PackageToolTests: CommandsTestCase {
             let packageDir = tmpPath.appending(components: "MyPackage")
             try localFileSystem.writeFileContents(packageDir.appending("Package.swift"), string:
                 """
-                // swift-tools-version: 5.5
+                // swift-tools-version: 5.9
                 import PackageDescription
                 let package = Package(
                     name: "MyPackage",
@@ -1635,7 +1635,7 @@ final class PackageToolTests: CommandsTestCase {
             let packageDir = tmpPath.appending(components: "MyPackage")
             try localFileSystem.writeFileContents(packageDir.appending(components: "Package.swift"), string:
                 """
-                // swift-tools-version: 5.6
+                // swift-tools-version: 5.9
                 import PackageDescription
                 let package = Package(
                     name: "MyPackage",
@@ -2539,7 +2539,7 @@ final class PackageToolTests: CommandsTestCase {
             let packageDir = tmpPath.appending(components: "MyPackage")
             try localFileSystem.createDirectory(packageDir, recursive: true)
             try localFileSystem.writeFileContents(packageDir.appending("Package.swift"), string: """
-                // swift-tools-version: 5.6
+                // swift-tools-version: 5.9
                 import PackageDescription
                 let package = Package(
                     name: "MyPackage",


### PR DESCRIPTION
These were missing availability and also are more suited for the `Utilities.swift` file.

resolves #6733
