### PR TITLE
fix dynamic library building issue 

### DIFF
--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -343,7 +343,7 @@ public final class SwiftTargetBuildDescription {
 
         let content =
             """
-            \(self.toolsVersion < .vNext ? "import" : "@_implementationOnly import") class Foundation.Bundle
+            \(self.toolsVersion < .vNext ? "import" : "@_implementationOnly import") Foundation
 
             extension Foundation.Bundle {
                 static let module: Bundle = {


### PR DESCRIPTION
fix error: scoped imports are not yet supported in module interfaces import class Foundation.Bundle

### Motivation:

When building a dynamic library with `swift build --configuration debug -Xswiftc -emit-module-interface -Xswiftc -enable-library-evolution --disable-sandbox`, this error occurs:
```
DerivedSources/resource_bundle_accessor.swift:1:25: error: scoped imports are not yet supported in module interfaces
import class Foundation.Bundle
```

### Modifications:

Change `import class Foundation.Bundle` to `import Foundation`

### Result:

dynamic library can build success
