### PR TITLE
Fix an XCBuild compatibility issue

### DIFF
--- a/Sources/XCBuildSupport/PIF.swift
+++ b/Sources/XCBuildSupport/PIF.swift
@@ -958,6 +958,7 @@ public enum PIF {
             case MARKETING_VERSION
             case CURRENT_PROJECT_VERSION
             case SWIFT_EMIT_MODULE_INTERFACE
+            case GENERATE_RESOURCE_ACCESSORS
         }
 
         public enum MultipleValueSetting: String, Codable {

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -464,6 +464,7 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
 
         if let resourceBundle = addResourceBundle(for: mainTarget, in: pifTarget) {
             settings[.PACKAGE_RESOURCE_BUNDLE_NAME] = resourceBundle
+            settings[.GENERATE_RESOURCE_ACCESSORS] = "YES"
         }
 
         // For targets, we use the common build settings for both the "Debug" and the "Release" configurations (all


### PR DESCRIPTION
Some newer versions of XCBuild require a new build setting for opting into generation of the resource accessor.

rdar://112991922
