### PR TITLE
Fix to call `didFinishCommand`

### DIFF
--- a/Sources/XCBuildSupport/XCBuildDelegate.swift
+++ b/Sources/XCBuildSupport/XCBuildDelegate.swift
@@ -81,7 +81,7 @@ extension XCBuildDelegate: XCBuildOutputParserDelegate {
             }
         case .taskComplete(let info):
             queue.async {
-                self.buildSystem.delegate?.buildSystem(self.buildSystem, didStartCommand: BuildSystemCommand(name: "\(info.taskID)", description: info.result.rawValue))
+                self.buildSystem.delegate?.buildSystem(self.buildSystem, didFinishCommand: BuildSystemCommand(name: "\(info.taskID)", description: info.result.rawValue))
             }
         case .buildDiagnostic(let info):
             queue.async {


### PR DESCRIPTION
When `XCBuildDelegate` receives a `taskComplete` message, it calls `buildSystem(:didStartCommand:)` of `BuildSystemDelegate`. 
However, it should probably call `buildSystem(:didFinishCommand:)`.

Since there doesn't seem to be any concrete type conforming to `BuildSystemDelegate`, this change doesn't appear to have any impact on the behavior of existing code.