### PR TITLE
WIP: executable products installation PoC

### DIFF
--- a/Sources/Commands/PackageTools/Install.swift
+++ b/Sources/Commands/PackageTools/Install.swift
@@ -1,0 +1,71 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2014-2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import Basics
+import CoreCommands
+import Workspace
+
+import class PackageGraph.ResolvedProduct
+
+extension SwiftPackageTool {
+    struct Install: SwiftCommand {
+        public static let configuration = CommandConfiguration(
+            commandName: "experimental-install",
+            abstract: "Install executable package products to a local user directory.",
+            shouldDisplay: false
+        )
+
+        @OptionGroup(visibility: .hidden)
+        var globalOptions: GlobalOptions
+
+        /// Specific product to install.
+        @Option(help: "Install the specified product")
+        var product: String?
+
+        func run(_ swiftTool: CoreCommands.SwiftTool) throws {
+            let buildParameters = try swiftTool.buildParameters()
+            // FIXME: should be in release mode for installed packages
+//            buildParameters.configuration = .release
+            let buildSystem = try swiftTool.createBuildSystem(customBuildParameters: buildParameters)
+
+            if let product = self.product {
+                try buildSystem.build(subset: .product(product))
+            } else {
+                try buildSystem.build()
+            }
+
+            let products = try swiftTool.loadPackageGraph().rootPackages
+                .flatMap { $0.products }
+                .filter { $0.type == .executable }
+
+            let fs = swiftTool.fileSystem
+
+            let installedPackagesBinDirectory = try fs.getOrCreateSwiftPMInstalledPackagesDirectory()
+                .appending(component: "bin")
+            if !fs.exists(installedPackagesBinDirectory) {
+                try fs.createDirectory(installedPackagesBinDirectory, recursive: true)
+            }
+
+            for product in products {
+                let buildPath = try buildParameters.binaryPath(for: product)
+                let installedProductPath = installedPackagesBinDirectory.appending(component: product.name)
+                if fs.exists(installedProductPath) {
+                    try fs.removeFileTree(installedProductPath)
+                }
+                try fs.copy(from: buildPath, to: installedProductPath)
+
+                print("Product `\(product.name)` successfully installed to `\(installedProductPath)`.")
+            }
+        }
+    }
+}

--- a/Sources/Commands/PackageTools/SwiftPackageTool.swift
+++ b/Sources/Commands/PackageTools/SwiftPackageTool.swift
@@ -40,6 +40,7 @@ public struct SwiftPackageTool: ParsableCommand {
             Describe.self,
             Init.self,
             Format.self,
+            Install.self,
 
             APIDiff.self,
             DeprecatedAPIDiff.self,

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -111,6 +111,10 @@ public struct LocationOptions: ParsableArguments {
     @Option(name: .customLong("experimental-swift-sdks-path"), help: .hidden, completion: .directory)
     public var swiftSDKsDirectory: AbsolutePath?
 
+    /// Path to the directory containing installed Swift packages.
+    @Option(name: .customLong("experimental-installed-packages-path"), help: .hidden, completion: .directory)
+    public var installedPackagesDirectory: AbsolutePath?
+
     @Option(
         name: .customLong("pkg-config-path"),
         help:


### PR DESCRIPTION
### Motivation:

Users building executable products would likely want to install such products to a location in their `PATH` so that they could use such products in their workflows.

### Modifications:

Introduced a new `swift package experimental-install` subcommand that builds and copies executable products to `~/.swiftpm/installed-packages/bin`, which then can be added to `PATH` by the user if needed.

#### Limitations:

1. No version tracking (yet). For a proper implementation we should install to subdirectories that contain versions of corresponding packages, i.e. `~/.swiftpm/installed-packages/artifacts/swift-openapi-generator/0.1.5/bin/swift-openapi-generator` and then symlinked into `~/.swiftpm/installed-packages/bin/swift-openapi-generator`
2. Products installed via this command are fragile on Linux as they aren't linked statically and we're unlikely to achieve full static linking until `import FoundationNetworking` and `import FoundationXML` can be linked completely statically with all of their transitive dependencies.
3. We should (but currently don't) check if any libraries in the graph for these products are either system libraries or dynamically linked and bail out with an error if that's the case. While dynamic libraries potentially could be installed, I don't think that's something we should aim to implement in this prototype. I also don't think we can do much about system libraries. Since SwiftPM can't prevent users from updating or removing system libraries, packages should package such dependencies with SwiftPM to be able to install products that depend on them.
4. Not added to `CMakeLists.txt` files as Windows support is untested and will likely require a somewhat different approach.

### Result:

A barebones proof of concept implementation is available to experiment with. As it hasn't gone through Swift Evolution, it has an `experimental-` prefix and isn't displayed in `--help` output.
