### PR TITLE
[5.9] Fix another XCBuild compatibility issue

### DIFF
--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -677,6 +677,7 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
 
         if let resourceBundle = addResourceBundle(for: target, in: pifTarget) {
             settings[.PACKAGE_RESOURCE_BUNDLE_NAME] = resourceBundle
+            settings[.GENERATE_RESOURCE_ACCESSORS] = "YES"
             impartedSettings[.EMBED_PACKAGE_RESOURCE_BUNDLE_NAMES, default: ["$(inherited)"]].append(resourceBundle)
         }
 


### PR DESCRIPTION
Similar to #6752, there was another case where we needed the new setting.

rdar://113157040

(cherry picked from commit 2dceb21867508dd7cf30c87f02faae7c61b0f1f9)