### PR TITLE
[5.9] PackageModel: honour `.librarian` for toolsets

### DIFF
--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -501,7 +501,7 @@ public final class UserToolchain: Toolchain {
         self.includeSearchPaths = destination.pathsConfiguration.includeSearchPaths ?? []
         self.librarySearchPaths = destination.pathsConfiguration.includeSearchPaths ?? []
 
-        self.librarianPath = try UserToolchain.determineLibrarian(
+        self.librarianPath = try destination.toolset.knownTools[.librarian]?.path ?? UserToolchain.determineLibrarian(
             triple: triple,
             binDirectories: destination.toolset.rootPaths,
             useXcrun: useXcrun,

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -3544,6 +3544,7 @@ final class BuildPlanTests: XCTestCase {
                 .cCompiler: .init(extraCLIOptions: [jsonFlag(tool: .cCompiler)]),
                 .cxxCompiler: .init(extraCLIOptions: [jsonFlag(tool: .cxxCompiler)]),
                 .swiftCompiler: .init(extraCLIOptions: [jsonFlag(tool: .swiftCompiler)]),
+                .librarian: .init(path: "/fake/toolchain/usr/bin/librarian"),
                 .linker: .init(extraCLIOptions: [jsonFlag(tool: .linker)]),
             ],
             rootPaths: try UserToolchain.default.destination.toolset.rootPaths)


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-package-manager/pull/6688.

When defining a custom toolset, a specified librarian shall be given precedence over the platform's librarian.  Use this to repair the toolset test on Windows where `ar` is unavailable.  This test used to succeed due to the leaking of the host tools.

This fixes a bug reproducible when cross-compiling projects with dependencies to any platform, including Linux.

Risk: low, only affects cross-compilation with SwiftPM, which is not widely used yet.

(cherry picked from commit 4d63d6692978a31ec9ecd1d6c3321ee446b7d577)
