### PR TITLE
Resolve sandbox issues on external volumes

### DIFF
--- a/Sources/Basics/FileSystem/FileSystem+Extensions.swift
+++ b/Sources/Basics/FileSystem/FileSystem+Extensions.swift
@@ -198,6 +198,12 @@ extension FileSystem {
     public func withLock<T>(on path: AbsolutePath, type: FileLock.LockType, _ body: () throws -> T) throws -> T {
         try self.withLock(on: path.underlying, type: type, body)
     }
+
+    /// Returns any known item replacement directories for a given path. These may be used by platform-specific
+    /// libraries to handle atomic file system operations, such as deletion.
+    func itemReplacementDirectories(for path: AbsolutePath) throws -> [AbsolutePath] {
+        return try self.itemReplacementDirectories(for: path.underlying).compactMap { AbsolutePath($0) }
+    }
 }
 
 // MARK: - user level

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -620,7 +620,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
                 // TODO: We need to also use any working directory, but that support isn't yet available on all platforms at a lower level.
                 var commandLine = [command.configuration.executable.pathString] + command.configuration.arguments
                 if !pluginConfiguration.disableSandbox {
-                    commandLine = try Sandbox.apply(command: commandLine, strictness: .writableTemporaryDirectory, writableDirectories: [pluginResult.pluginOutputDirectory])
+                    commandLine = try Sandbox.apply(command: commandLine, fileSystem: self.fileSystem, strictness: .writableTemporaryDirectory, writableDirectories: [pluginResult.pluginOutputDirectory])
                 }
                 let processResult = try Process.popen(arguments: commandLine, environment: command.configuration.environment)
                 let output = try processResult.utf8Output() + processResult.utf8stderrOutput()

--- a/Sources/Build/LLBuildManifestBuilder.swift
+++ b/Sources/Build/LLBuildManifestBuilder.swift
@@ -224,6 +224,7 @@ extension LLBuildManifestBuilder {
                 if !self.disableSandboxForPluginCommands {
                     commandLine = try Sandbox.apply(
                         command: commandLine,
+                        fileSystem: self.fileSystem,
                         strictness: .writableTemporaryDirectory,
                         writableDirectories: [result.pluginOutputDirectory]
                     )

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -775,7 +775,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                             let cacheDirectories = [self.databaseCacheDir, moduleCachePath].compactMap{ $0 }
                             let strictness: Sandbox.Strictness = toolsVersion < .v5_3 ? .manifest_pre_53 : .default
                             do {
-                                cmd = try Sandbox.apply(command: cmd, strictness: strictness, writableDirectories: cacheDirectories)
+                                cmd = try Sandbox.apply(command: cmd, fileSystem: localFileSystem, strictness: strictness, writableDirectories: cacheDirectories)
                             } catch {
                                 return completion(.failure(error))
                             }

--- a/Sources/Workspace/DefaultPluginScriptRunner.swift
+++ b/Sources/Workspace/DefaultPluginScriptRunner.swift
@@ -445,6 +445,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
             do {
                 command = try Sandbox.apply(
                     command: command,
+                    fileSystem: self.fileSystem,
                     strictness: .writableTemporaryDirectory,
                     writableDirectories: writableDirectories + [self.cacheDir],
                     readOnlyDirectories: readOnlyDirectories,

--- a/Tests/BasicsTests/SandboxTests.swift
+++ b/Tests/BasicsTests/SandboxTests.swift
@@ -18,6 +18,7 @@ import XCTest
 import Darwin
 #endif
 
+import class TSCBasic.InMemoryFileSystem
 import class TSCBasic.Process
 import struct TSCBasic.ProcessResult
 
@@ -220,4 +221,23 @@ final class SandboxTest: XCTestCase {
              XCTAssertNoThrow(try TSCBasic.Process.checkNonZeroExit(arguments: allowedCommand))
          }
      }
+}
+
+extension Sandbox {
+    public static func apply(
+        command: [String],
+        strictness: Strictness = .default,
+        writableDirectories: [AbsolutePath] = [],
+        readOnlyDirectories: [AbsolutePath] = [],
+        allowNetworkConnections: [SandboxNetworkPermission] = []
+    ) throws -> [String] {
+        return try self.apply(
+            command: command,
+            fileSystem: InMemoryFileSystem(),
+            strictness: strictness,
+            writableDirectories: writableDirectories,
+            readOnlyDirectories: readOnlyDirectories,
+            allowNetworkConnections: allowNetworkConnections
+        )
+    }
 }


### PR DESCRIPTION
The sandbox profile SwiftPM generates curates the directories plugins and manifests are able to write to. Several Foundation APIs use a so-called "item replacement directory" when doing atomic operations and this happens to be a special path on the same volume when performing operations on an external volume. This lead to those operations being blocked in plugins which does not seem right since those item replacement directories are temporary directories in spirit. We now automatically allow writes for those when generating a sandbox profile.

rdar://112217177
