### PR TITLE
Read SwiftSyntax version for macro template from a configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ Package.resolved
 *.pyc
 .docc-build
 .vscode
+Utilities/InstalledSwiftPMConfiguration/config.json

--- a/Sources/Commands/PackageTools/Init.swift
+++ b/Sources/Commands/PackageTools/Init.swift
@@ -51,6 +51,7 @@ extension SwiftPackageTool {
                 name: packageName,
                 packageType: initMode,
                 destinationPath: cwd,
+                installedSwiftPMConfiguration: swiftTool.getHostToolchain().installedSwiftPMConfiguration,
                 fileSystem: swiftTool.fileSystem
             )
             initPackage.progressReporter = { message in

--- a/Sources/PackageModel/CMakeLists.txt
+++ b/Sources/PackageModel/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(PackageModel
   DependencyMapper.swift
   Diagnostics.swift
   IdentityResolver.swift
+  InstalledSwiftPMConfiguration.swift
   Manifest/Manifest.swift
   Manifest/PackageConditionDescription.swift
   Manifest/PackageDependencyDescription.swift

--- a/Sources/PackageModel/InstalledSwiftPMConfiguration.swift
+++ b/Sources/PackageModel/InstalledSwiftPMConfiguration.swift
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+public struct InstalledSwiftPMConfiguration: Codable {
+    public struct Version: Codable, CustomStringConvertible {
+        let major: Int
+        let minor: Int
+        let patch: Int
+        let prereleaseIdentifier: String?
+
+        public init(major: Int, minor: Int, patch: Int, prereleaseIdentifier: String? = nil) {
+            self.major = major
+            self.minor = minor
+            self.patch = patch
+            self.prereleaseIdentifier = prereleaseIdentifier
+        }
+
+        public var description: String {
+            return "\(major).\(minor).\(patch).\(prereleaseIdentifier.map { "-\($0)" } ?? "")"
+        }
+    }
+
+    let version: Int
+    public let swiftSyntaxVersionForMacroTemplate: Version
+
+    public static var `default`: InstalledSwiftPMConfiguration {
+        return .init(version: 0, swiftSyntaxVersionForMacroTemplate: .init(major: 509, minor: 0, patch: 0))
+    }
+}

--- a/Sources/PackageModel/Toolchain.swift
+++ b/Sources/PackageModel/Toolchain.swift
@@ -40,6 +40,9 @@ public protocol Toolchain {
     /// An array of paths to search for libraries at link time.
     var librarySearchPaths: [AbsolutePath] { get }
 
+    /// Configuration from the used toolchain.
+    var installedSwiftPMConfiguration: InstalledSwiftPMConfiguration { get }
+
     /// Path of the `clang` compiler.
     func getClangCompiler() throws -> AbsolutePath
 

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -86,6 +86,8 @@ public final class UserToolchain: Toolchain {
 
     public let isSwiftDevelopmentToolchain: Bool
 
+    public let installedSwiftPMConfiguration: InstalledSwiftPMConfiguration
+
     /// Returns the runtime library for the given sanitizer.
     public func runtimeLibrary(for sanitizer: Sanitizer) throws -> AbsolutePath {
         // FIXME: This is only for SwiftPM development time support. It is OK
@@ -479,7 +481,8 @@ public final class UserToolchain: Toolchain {
         swiftSDK: SwiftSDK,
         environment: EnvironmentVariables = .process(),
         searchStrategy: SearchStrategy = .default,
-        customLibrariesLocation: ToolchainConfiguration.SwiftPMLibrariesLocation? = nil
+        customLibrariesLocation: ToolchainConfiguration.SwiftPMLibrariesLocation? = nil,
+        customInstalledSwiftPMConfiguration: InstalledSwiftPMConfiguration? = nil
     ) throws {
         self.swiftSDK = swiftSDK
         self.environment = environment
@@ -521,6 +524,18 @@ public final class UserToolchain: Toolchain {
         #else
         self.isSwiftDevelopmentToolchain = false
         #endif
+
+        if let customInstalledSwiftPMConfiguration = customInstalledSwiftPMConfiguration {
+            self.installedSwiftPMConfiguration = customInstalledSwiftPMConfiguration
+        } else {
+            let path = self.swiftCompilerPath.parentDirectory.parentDirectory.appending(components: ["share", "pm", "config.json"])
+            if localFileSystem.exists(path) {
+                self.installedSwiftPMConfiguration = try JSONDecoder.makeWithDefaults().decode(path: path, fileSystem: localFileSystem, as: InstalledSwiftPMConfiguration.self)
+            } else {
+                // We *could* eventually make this an error, but not for a few releases.
+                self.installedSwiftPMConfiguration = InstalledSwiftPMConfiguration.default
+            }
+        }
 
         // Use the triple from Swift SDK or compute the host triple using swiftc.
         var triple = try swiftSDK.targetTriple ?? Triple.getHostTriple(usingSwiftCompiler: swiftCompilers.compile)

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -525,7 +525,7 @@ public final class UserToolchain: Toolchain {
         self.isSwiftDevelopmentToolchain = false
         #endif
 
-        if let customInstalledSwiftPMConfiguration = customInstalledSwiftPMConfiguration {
+        if let customInstalledSwiftPMConfiguration {
             self.installedSwiftPMConfiguration = customInstalledSwiftPMConfiguration
         } else {
             let path = self.swiftCompilerPath.parentDirectory.parentDirectory.appending(components: ["share", "pm", "config.json"])

--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -369,3 +369,20 @@ extension RelativePath: ExpressibleByStringInterpolation {
         try! self.init(validating: value)
     }
 }
+
+extension InitPackage {
+    public convenience init(
+        name: String,
+        packageType: PackageType,
+        destinationPath: AbsolutePath,
+        fileSystem: FileSystem
+    ) throws {
+        try self.init(
+            name: name,
+            options: InitPackageOptions(packageType: packageType),
+            destinationPath: destinationPath,
+            installedSwiftPMConfiguration: .default,
+            fileSystem: fileSystem
+        )
+    }
+}

--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -69,6 +69,9 @@ public final class InitPackage {
     /// The options for package to create.
     let options: InitPackageOptions
 
+    /// Configuration from the used toolchain.
+    let installedSwiftPMConfiguration: InstalledSwiftPMConfiguration
+
     /// The name of the package to create.
     let pkgname: String
 
@@ -85,12 +88,14 @@ public final class InitPackage {
         name: String,
         packageType: PackageType,
         destinationPath: AbsolutePath,
+        installedSwiftPMConfiguration: InstalledSwiftPMConfiguration,
         fileSystem: FileSystem
     ) throws {
         try self.init(
             name: name,
             options: InitPackageOptions(packageType: packageType),
             destinationPath: destinationPath,
+            installedSwiftPMConfiguration: installedSwiftPMConfiguration,
             fileSystem: fileSystem
         )
     }
@@ -100,12 +105,14 @@ public final class InitPackage {
         name: String,
         options: InitPackageOptions,
         destinationPath: AbsolutePath,
+        installedSwiftPMConfiguration: InstalledSwiftPMConfiguration,
         fileSystem: FileSystem
     ) throws {
         self.options = options
         self.pkgname = name
         self.moduleName = name.spm_mangledToC99ExtendedIdentifier()
         self.destinationPath = destinationPath
+        self.installedSwiftPMConfiguration = installedSwiftPMConfiguration
         self.fileSystem = fileSystem
     }
 
@@ -259,8 +266,7 @@ public final class InitPackage {
             } else if packageType == .macro {
                 pkgParams.append("""
                     dependencies: [
-                        // Depend on the Swift 5.9 release of SwiftSyntax
-                        .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.0"),
+                        .package(url: "https://github.com/apple/swift-syntax.git", from: "\(self.installedSwiftPMConfiguration.swiftSyntaxVersionForMacroTemplate.description)"),
                     ]
                 """)
             }

--- a/Tests/BuildTests/MockBuildTestHelper.swift
+++ b/Tests/BuildTests/MockBuildTestHelper.swift
@@ -33,6 +33,7 @@ struct MockToolchain: PackageModel.Toolchain {
     let isSwiftDevelopmentToolchain = false
     let swiftPluginServerPath: AbsolutePath? = nil
     let extraFlags = PackageModel.BuildFlags()
+    let installedSwiftPMConfiguration = InstalledSwiftPMConfiguration.default
 
     func getClangCompiler() throws -> AbsolutePath {
         return "/fake/path/to/clang"

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -286,6 +286,7 @@ class InitTests: XCTestCase {
                 name: "Foo",
                 options: options,
                 destinationPath: packageRoot,
+                installedSwiftPMConfiguration: .default,
                 fileSystem: localFileSystem
             )
             try initPackage.writePackageStructure()

--- a/Utilities/InstalledSwiftPMConfiguration/Package.swift
+++ b/Utilities/InstalledSwiftPMConfiguration/Package.swift
@@ -1,0 +1,12 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "InstalledSwiftPMConfiguration",
+    targets: [
+        .executableTarget(
+            name: "InstalledSwiftPMConfiguration"
+        ),
+    ]
+)

--- a/Utilities/InstalledSwiftPMConfiguration/Sources/InstalledSwiftPMConfiguration.swift
+++ b/Utilities/InstalledSwiftPMConfiguration/Sources/InstalledSwiftPMConfiguration.swift
@@ -1,0 +1,1 @@
+../../../Sources/PackageModel/InstalledSwiftPMConfiguration.swift

--- a/Utilities/InstalledSwiftPMConfiguration/Sources/exec.swift
+++ b/Utilities/InstalledSwiftPMConfiguration/Sources/exec.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+@main
+struct Exec {
+  static func main() throws {
+      let config = InstalledSwiftPMConfiguration(version: 1, swiftSyntaxVersionForMacroTemplate: .init(major: 509, minor: 0, patch: 0))
+      let data = try JSONEncoder().encode(config)
+      try data.write(to: URL(fileURLWithPath: "config.json"))
+  }
+}

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -395,6 +395,8 @@ def install(args):
     # Install swiftpm content in all of the passed prefixes.
     for prefix in args.install_prefixes:
         install_swiftpm(prefix, args)
+        config_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "config.json")
+        install_file(args, config_path, os.path.join(os.path.join(prefix, "share"), "pm"))
 
     # Install libSwiftPM if an install directory was provided.
     if args.libswiftpm_install_dir:
@@ -461,9 +463,11 @@ def install_dylib(args, library_name, install_dir, module_names):
 # Helper function that installs a single built artifact to a particular directory. The source may be either a file or a directory.
 def install_binary(args, binary, destination, destination_is_directory=True, ignored_patterns=[]):
     src = os.path.join(args.bin_dir, binary)
+    install_file(args, src, destination, destination_is_directory=destination_is_directory, ignored_patterns=ignored_patterns)
 
+def install_file(args, src, destination, destination_is_directory=True, ignored_patterns=[]):
     if destination_is_directory:
-        dest = os.path.join(destination, binary)
+        dest = os.path.join(destination, os.path.basename(src))
         mkdir_p(os.path.dirname(dest))
     else:
         dest = destination

--- a/Utilities/config.json
+++ b/Utilities/config.json
@@ -1,0 +1,1 @@
+{"version":1,"swiftSyntaxVersionForMacroTemplate":{"major":509,"minor":0,"patch":0}}


### PR DESCRIPTION
In 5.9 we're using a version that's hard-coded in the template, but that is annoying to maintain. It also seems like ideally we would be using a version that's aligned with the toolchain that's being used. This adds a new configuration file that we can ship as 'usr/share/pm/config.json' in the toolchain to configure this. There's a fallback to the 5.9 version if we can't find the config and also a way to customize it when instantiating a `UserToolchain` in case a client needs to do that.

rdar://113287350
