### PR TITLE
Update help message in `InstalledPackages.swift`

### DIFF
--- a/Sources/Commands/PackageTools/InstalledPackages.swift
+++ b/Sources/Commands/PackageTools/InstalledPackages.swift
@@ -94,7 +94,7 @@ extension SwiftPackageTool {
     struct Uninstall: SwiftCommand {
         static let configuration = CommandConfiguration(
             commandName: "experimental-uninstall",
-            abstract: "Offers the ability to uninstall executable products previously installed by `swift package experimental-uninstall`."
+            abstract: "Offers the ability to uninstall executable products previously installed by `swift package experimental-install`."
         )
 
         @OptionGroup

--- a/Sources/Commands/PackageTools/InstalledPackages.swift
+++ b/Sources/Commands/PackageTools/InstalledPackages.swift
@@ -94,7 +94,7 @@ extension SwiftPackageTool {
     struct Uninstall: SwiftCommand {
         static let configuration = CommandConfiguration(
             commandName: "experimental-uninstall",
-            abstract: "Offers the ability to uninstall executable products of installed package products"
+            abstract: "Offers the ability to uninstall executable products previously installed by `swift package experimental-uninstall`."
         )
 
         @OptionGroup


### PR DESCRIPTION
Cleaned up the help message to make it clear what executable products are uninstalled.