### PR TITLE
Only pass `-framework` on platforms that support frameworks

### DIFF
--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -343,10 +343,12 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
         flags += libraries.map { "-l" + $0 }
 
         // Linked frameworks.
-        let frameworks = OrderedSet(staticTargets.reduce([]) {
-            $0 + buildParameters.createScope(for: $1).evaluate(.LINK_FRAMEWORKS)
-        })
-        flags += frameworks.flatMap { ["-framework", $0] }
+        if self.buildParameters.targetTriple.supportsFrameworks {
+            let frameworks = OrderedSet(staticTargets.reduce([]) {
+                $0 + buildParameters.createScope(for: $1).evaluate(.LINK_FRAMEWORKS)
+            })
+            flags += frameworks.flatMap { ["-framework", $0] }
+        }
 
         // Other linker flags.
         for target in self.staticTargets {
@@ -361,5 +363,11 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
 extension SortedArray where Element == AbsolutePath {
     public static func +=<S: Sequence>(lhs: inout SortedArray, rhs: S) where S.Iterator.Element == AbsolutePath {
         lhs.insert(contentsOf: rhs)
+    }
+}
+
+extension Triple {
+    var supportsFrameworks: Bool {
+        return self.isDarwin()
     }
 }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -3450,7 +3450,7 @@ final class BuildPlanTests: XCTestCase {
             XCTAssertMatch(exe, [.anySequence, "-DFOO", "-g", "-Xcc", "-g", .end])
 
             let linkExe = try result.buildProduct(for: "exe").linkArguments()
-            XCTAssertMatch(linkExe, [.anySequence, "-lsqlite3", "-llibz", "-framework", "best", "-Ilfoo", "-L", "lbar", "-g", .end])
+            XCTAssertMatch(linkExe, [.anySequence, "-lsqlite3", "-llibz", "-Ilfoo", "-L", "lbar", "-g", .end])
         }
 
         do {


### PR DESCRIPTION
It doesn't make sense to pass `-framework` on platforms that don't support them and might lead to confusing errors, e.g. some linkers will interpret it as `-f` with an option.

rdar://74600880
