### PR TITLE
canonicalize repository lcoation for storage path calculation

### DIFF
--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -569,9 +569,16 @@ extension RepositorySpecifier {
     /// This identifier is suitable for use in a file system path, and
     /// unique for each repository.
     private var fileSystemIdentifier: String {
+        // canonicalize across similar locations (mainly for URLs)
         // Use first 8 chars of a stable hash.
-        let suffix = self.location.description .sha256Checksum.prefix(8)
+        let suffix = self.canonicalLocation.description.sha256Checksum.prefix(8)
         return "\(self.basename)-\(suffix)"
+    }
+}
+
+extension RepositorySpecifier {
+    fileprivate var canonicalLocation: CanonicalPackageLocation {
+        .init(self.location.description)
     }
 }
 

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -332,6 +332,19 @@ class RepositoryManagerTests: XCTestCase {
         }
     }
 
+    func testCanonicalLocation() throws {
+        let variants: [RepositorySpecifier] = [
+            .init(url: "https://scm.com/org/foo"),
+            .init(url: "https://scm.com/org/foo.git"),
+            .init(url: "http://scm.com/org/foo"),
+            .init(url: "http://scm.com/org/foo.git")
+        ]
+
+        for variant in variants {
+            XCTAssertEqual(try variant.storagePath(), try variants[0].storagePath())
+        }
+    }
+
     func testConcurrency() throws {
         let fs = localFileSystem
         let observability = ObservabilitySystem.makeForTesting()

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -3808,7 +3808,7 @@ final class WorkspaceTests: XCTestCase {
                     products: [
                         MockProduct(name: "Foo", targets: ["Foo"]),
                     ],
-                    versions: ["1.0.0"],
+                    versions: ["1.0.0", "1.1.0"],
                     revisionProvider: { version in version } // stable revisions
                 ),
                 MockPackage(
@@ -3820,7 +3820,7 @@ final class WorkspaceTests: XCTestCase {
                     products: [
                         MockProduct(name: "Bar", targets: ["Bar"]),
                     ],
-                    versions: ["1.0.0"],
+                    versions: ["1.0.0", "1.1.0"],
                     revisionProvider: { version in version } // stable revisions
                 ),
                 MockPackage(


### PR DESCRIPTION
motivation: there is some built-in non-determinism where the graph resolution races and sometime one location variant wins in the location -> identity mapping, this can lead to looking up a different storage path since that does not use the normalized form of the location

changes:
* normalize (canonicalize) the repository location when computing the storage path
* add and adjust tests

rdar://112134161
