### PR TITLE
Set `-user-module-version` for any version-based package

### DIFF
--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -546,6 +546,11 @@ public final class SwiftTargetBuildDescription {
             }
         }
 
+        // Pass `-user-module-version` for versioned packages that aren't pre-releases.
+        if let version = package.manifest.version, version.prereleaseIdentifiers.isEmpty, version.buildMetadataIdentifiers.isEmpty, toolsVersion >= .v5_9 {
+            args += ["-user-module-version", version.description]
+        }
+
         args += self.packageNameArgumentIfSupported(with: self.package, packageAccess: self.target.packageAccess)
         args += try self.macroArguments()
 


### PR DESCRIPTION
This would allow conditionalizing client code using ``#if canImport(:_version:)`` so that different versions of a dependency can be supported within a single codebase.

Note: this is explicitly not passing the flag if pre-releases are in use to avoid any confusion in those cases.

rdar://107077287