### PR TITLE
better error message when cycle is detected

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1054,7 +1054,7 @@ extension Workspace {
         let stillMissingPackages = try updatedDependencyManifests.computePackages().missing
         guard stillMissingPackages.isEmpty else {
             let missing = stillMissingPackages.map{ $0.description }
-            observabilityScope.emit(error: "exhausted attempts to resolve the dependencies graph, with '\(missing.joined(separator: "', '"))' unresolved.")
+            observabilityScope.emit(error: "exhausted attempts to resolve the dependencies graph, with '\(missing.sorted().joined(separator: "', '"))' unresolved.")
             return nil
         }
 
@@ -2646,7 +2646,7 @@ extension Workspace {
         let stillMissingPackages = try updatedDependencyManifests.computePackages().missing
         guard stillMissingPackages.isEmpty else {
             let missing = stillMissingPackages.map{ $0.description }
-            observabilityScope.emit(error: "exhausted attempts to resolve the dependencies graph, with '\(missing.joined(separator: "', '"))' unresolved.")
+            observabilityScope.emit(error: "exhausted attempts to resolve the dependencies graph, with '\(missing.sorted().joined(separator: "', '"))' unresolved.")
             return updatedDependencyManifests
         }
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -10868,7 +10868,7 @@ final class WorkspaceTests: XCTestCase {
         try workspace.checkPackageGraph(roots: ["Root1", "Root2"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
-                    diagnostic: .regex("cyclic dependency declaration found: root[1|2] -> foo -> bar -> baz -> foo"),
+                    diagnostic: .regex("cyclic dependency declaration found: root[1|2] -> *"),
                     severity: .error
                 )
                 result.check(

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -10868,11 +10868,11 @@ final class WorkspaceTests: XCTestCase {
         try workspace.checkPackageGraph(roots: ["Root1", "Root2"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
-                    diagnostic: "cyclic dependency declaration found: root1 -> foo -> bar -> baz -> foo",
+                    diagnostic: .regex("cyclic dependency declaration found: root[1|2] -> foo -> bar -> baz -> foo"),
                     severity: .error
                 )
                 result.check(
-                    diagnostic: "exhausted attempts to resolve the dependencies graph, with 'foo remoteSourceControl http://scm.com/org/foo', 'bar remoteSourceControl http://scm.com/org/bar' unresolved.",
+                    diagnostic: "exhausted attempts to resolve the dependencies graph, with 'bar remoteSourceControl http://scm.com/org/bar', 'foo remoteSourceControl http://scm.com/org/foo' unresolved.",
                     severity: .error
                 )
             }


### PR DESCRIPTION
motivation: nicer error message to users when dependencies graph has an unresolvable cycle

changes:
* check for cycle prior to loading top level manifests and produce a nicer error message
* add test
