### PR TITLE
WIP: Switch to integrated driver

### DIFF
--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -425,11 +425,6 @@ public struct BuildOptions: ParsableArguments {
     @Option(name: .shortAndLong, help: "The number of jobs to spawn in parallel during the build process")
     public var jobs: UInt32?
 
-    /// Whether to use the integrated Swift driver rather than shelling out
-    /// to a separate process.
-    @Flag()
-    public var useIntegratedSwiftDriver: Bool = false
-
     /// A flag that indicates this build should check whether targets only import
     /// their explicitly-declared dependencies
     @Option()

--- a/Sources/CoreCommands/SwiftTool.swift
+++ b/Sources/CoreCommands/SwiftTool.swift
@@ -348,10 +348,6 @@ public final class SwiftTool {
             observabilityScope.emit(.unsupportedFlag("--multiroot-data-file"))
         }
 
-        if options.build.useExplicitModuleBuild && !options.build.useIntegratedSwiftDriver {
-            observabilityScope.emit(error: "'--experimental-explicit-module-build' option requires '--use-integrated-swift-driver'")
-        }
-
         if !options.build.architectures.isEmpty && options.build.customCompileTriple != nil {
             observabilityScope.emit(.mutuallyExclusiveArgumentsError(arguments: ["--arch", "--triple"]))
         }
@@ -697,7 +693,6 @@ public final class SwiftTool {
                 enableCodeCoverage: false, // set by test commands when appropriate
                 indexStoreMode: options.build.indexStoreMode.buildParameter,
                 enableParseableModuleInterfaces: options.build.shouldEnableParseableModuleInterfaces,
-                useIntegratedSwiftDriver: options.build.useIntegratedSwiftDriver,
                 useExplicitModuleBuild: options.build.useExplicitModuleBuild,
                 isXcodeBuildSystemEnabled: options.build.buildSystem == .xcode,
                 forceTestDiscovery: options.build.enableTestDiscovery, // backwards compatibility, remove with --enable-test-discovery

--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -208,7 +208,7 @@ public struct BuildParameters: Encodable {
 
     /// Whether to use the integrated Swift driver rather than shelling out
     /// to a separate process.
-    public var useIntegratedSwiftDriver: Bool
+    public let useIntegratedSwiftDriver = true
 
     /// Whether to use the explicit module build flow (with the integrated driver).
     public var useExplicitModuleBuild: Bool
@@ -287,7 +287,6 @@ public struct BuildParameters: Encodable {
         enableCodeCoverage: Bool = false,
         indexStoreMode: IndexStoreMode = .auto,
         enableParseableModuleInterfaces: Bool = false,
-        useIntegratedSwiftDriver: Bool = false,
         useExplicitModuleBuild: Bool = false,
         isXcodeBuildSystemEnabled: Bool = false,
         enableTestability: Bool? = nil,
@@ -319,7 +318,6 @@ public struct BuildParameters: Encodable {
             enableCodeCoverage: enableCodeCoverage,
             indexStoreMode: indexStoreMode,
             enableParseableModuleInterfaces: enableParseableModuleInterfaces,
-            useIntegratedSwiftDriver: useIntegratedSwiftDriver,
             useExplicitModuleBuild: useExplicitModuleBuild,
             isXcodeBuildSystemEnabled: isXcodeBuildSystemEnabled,
             enableTestability: enableTestability,
@@ -353,7 +351,6 @@ public struct BuildParameters: Encodable {
         enableCodeCoverage: Bool = false,
         indexStoreMode: IndexStoreMode = .auto,
         enableParseableModuleInterfaces: Bool = false,
-        useIntegratedSwiftDriver: Bool = false,
         useExplicitModuleBuild: Bool = false,
         isXcodeBuildSystemEnabled: Bool = false,
         enableTestability: Bool? = nil,
@@ -414,7 +411,6 @@ public struct BuildParameters: Encodable {
         self.enableCodeCoverage = enableCodeCoverage
         self.indexStoreMode = indexStoreMode
         self.enableParseableModuleInterfaces = enableParseableModuleInterfaces
-        self.useIntegratedSwiftDriver = useIntegratedSwiftDriver
         self.useExplicitModuleBuild = useExplicitModuleBuild
         self.isXcodeBuildSystemEnabled = isXcodeBuildSystemEnabled
         // decide on testability based on debug/release config
@@ -473,7 +469,6 @@ public struct BuildParameters: Encodable {
             enableCodeCoverage: self.enableCodeCoverage,
             indexStoreMode: self.indexStoreMode,
             enableParseableModuleInterfaces: self.enableParseableModuleInterfaces,
-            useIntegratedSwiftDriver: self.useIntegratedSwiftDriver,
             useExplicitModuleBuild: self.useExplicitModuleBuild,
             isXcodeBuildSystemEnabled: self.isXcodeBuildSystemEnabled,
             enableTestability: self.enableTestability,

--- a/Sources/swift-bootstrap/main.swift
+++ b/Sources/swift-bootstrap/main.swift
@@ -261,7 +261,6 @@ struct SwiftBootstrapBuildTool: ParsableCommand {
                 targetTriple: self.targetToolchain.targetTriple,
                 flags: buildFlags,
                 architectures: architectures,
-                useIntegratedSwiftDriver: useIntegratedSwiftDriver,
                 isXcodeBuildSystemEnabled: buildSystem == .xcode,
                 verboseOutput: logLevel <= .info
             )


### PR DESCRIPTION
Since we eventually want to do this, it makes sense to figure out what needs to happen to make it actionable.

First issue I have been running into is that the driver tries to shell out using the provided swiftc, this seems incompatible with doing build planning in a testing environment.
