### PR TITLE
Fingerprint filename for the same Git repository is not consistent

### DIFF
--- a/Sources/PackageFingerprint/FilePackageFingerprintStorage.swift
+++ b/Sources/PackageFingerprint/FilePackageFingerprintStorage.swift
@@ -398,8 +398,21 @@ extension PackageReference: FingerprintReference {
         }
 
         let canonicalLocation = CanonicalPackageLocation(sourceControlURL.absoluteString)
-        let locationHash = String(format: "%02x", canonicalLocation.description.hashValue)
+        // Cannot use hashValue because it is not consistent across executions
+        let locationHash = String(format: "%02x", canonicalLocation.description.stableHash)
         return "\(self.identity.description)-\(locationHash).json"
+    }
+}
+
+extension String {
+    // From: https://stackoverflow.com/questions/35882103/hash-value-of-string-that-would-be-stable-across-ios-releases/43149500#43149500
+    fileprivate var stableHash: UInt64 {
+        var result = UInt64(5381)
+        let buf = [UInt8](self.utf8)
+        for b in buf {
+            result = 127 * (result & 0x00FF_FFFF_FFFF_FFFF) + UInt64(b)
+        }
+        return result
     }
 }
 

--- a/Sources/PackageFingerprint/FilePackageFingerprintStorage.swift
+++ b/Sources/PackageFingerprint/FilePackageFingerprintStorage.swift
@@ -399,20 +399,8 @@ extension PackageReference: FingerprintReference {
 
         let canonicalLocation = CanonicalPackageLocation(sourceControlURL.absoluteString)
         // Cannot use hashValue because it is not consistent across executions
-        let locationHash = String(format: "%02x", canonicalLocation.description.stableHash)
+        let locationHash = canonicalLocation.description.sha256Checksum.prefix(8)
         return "\(self.identity.description)-\(locationHash).json"
-    }
-}
-
-extension String {
-    // From: https://stackoverflow.com/questions/35882103/hash-value-of-string-that-would-be-stable-across-ios-releases/43149500#43149500
-    fileprivate var stableHash: UInt64 {
-        var result = UInt64(5381)
-        let buf = [UInt8](self.utf8)
-        for b in buf {
-            result = 127 * (result & 0x00FF_FFFF_FFFF_FFFF) + UInt64(b)
-        }
-        return result
     }
 }
 


### PR DESCRIPTION
Motivation:
The fingerprint filename for package coming from a Git repository should take the form of `{PACKAGE_NAME}-{REPOSITORY_URL_HASH}.json`. The `REPOSITORY_URL_HASH` part is to distinguish repository URLs with the same last path component (and therefore same package name). For example: https://github.com/apple/swift-nio
https://github.com/yim-lee/swift-nio

`REPOSITORY_URL_HASH` is computed by converting `hashValue` property of the URL string to hexadecimal, but turns out `hashValue` doesn't yield consistent value across program executions (because random seed is used), and as a result multiple fingerprint files get created for the same (package name, repository URL) pair.

Modification:
Generate consistent hash value to be used for fingerprint filename.

rdar://113540625
