### PR TITLE
[5.9] Set `-user-module-version` for any version-based package

### DIFF
--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -528,6 +528,11 @@ public final class SwiftTargetBuildDescription {
             }
         }
 
+        // Pass `-user-module-version` for versioned packages that aren't pre-releases.
+        if let version = package.manifest.version, version.prereleaseIdentifiers.isEmpty, version.buildMetadataIdentifiers.isEmpty, toolsVersion >= .v5_9 {
+            args += ["-user-module-version", version.description]
+        }
+
         args += self.packageNameArgumentIfSupported(with: self.package, packageAccess: self.target.packageAccess)
         args += try self.macroArguments()
 

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -4744,4 +4744,59 @@ final class BuildPlanTests: XCTestCase {
 
         XCTAssertMatch(try result.buildProduct(for: "exe").linkArguments(), ["-sanitize=\(expectedName)"])
     }
+
+    func testPackageDependencySetsUserModuleVersion() throws {
+        let fs = InMemoryFileSystem(emptyFiles: "/Pkg/Sources/exe/main.swift", "/ExtPkg/Sources/ExtLib/best.swift")
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "Pkg",
+                    path: "/Pkg",
+                    dependencies: [
+                        .localSourceControl(path: "/ExtPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    targets: [
+                        TargetDescription(name: "exe", dependencies: [
+                            .product(name: "ExtPkg", package: "ExtPkg"),
+                        ]),
+                    ]),
+                Manifest.createLocalSourceControlManifest(
+                    displayName: "ExtPkg",
+                    path: "/ExtPkg",
+                    version: "1.0.0",
+                    toolsVersion: .v5_9,
+                    products: [
+                        ProductDescription(name: "ExtPkg", type: .library(.automatic), targets: ["ExtLib"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "ExtLib", dependencies: []),
+                    ]),
+            ],
+            observabilityScope: observability.topScope
+        )
+
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
+        let result = try BuildPlanResult(plan: BuildPlan(
+            buildParameters: mockBuildParameters(environment: BuildEnvironment(
+                platform: .linux,
+                configuration: .release
+            )),
+            graph: graph,
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        ))
+
+        switch try XCTUnwrap(result.targetMap["ExtLib"]) {
+        case .swift(let swiftTarget):
+            if #available(macOS 13, *) { // `.contains` is only available in macOS 13 or newer
+                XCTAssertTrue(try swiftTarget.compileArguments().contains(["-user-module-version", "1.0.0"]))
+            }
+        case .clang:
+            XCTFail("expected a Swift target")
+        }
+    }
 }


### PR DESCRIPTION
This would allow conditionalizing client code using ``#if canImport(:_version:)`` so that different versions of a dependency can be supported within a single codebase.

Note: this is explicitly not passing the flag if pre-releases are in use to avoid any confusion in those cases.

rdar://107077287

(cherry picked from commit 6f0a64b8d2430a9abe84713116809e45e2a2c205)