### PR TITLE
plugins: Build command plugin dependencies for the host, not the target

### DIFF
--- a/Sources/Commands/PackageTools/PluginCommand.swift
+++ b/Sources/Commands/PackageTools/PluginCommand.swift
@@ -250,7 +250,11 @@ struct PluginCommand: SwiftCommand {
             + getEnvSearchPaths(pathString: ProcessEnv.path, currentWorkingDirectory: .none)
 
         // Build or bring up-to-date any executable host-side tools on which this plugin depends. Add them and any binary dependencies to the tool-names-to-path map.
-        let buildSystem = try swiftTool.createBuildSystem(explicitBuildSystem: .native, cacheBuildManifest: false)
+        let buildSystem = try swiftTool.createBuildSystem(
+            explicitBuildSystem: .native,
+            cacheBuildManifest: false,
+            customBuildParameters: swiftTool.hostBuildParameters()
+        )
         let accessibleTools = try plugin.processAccessibleTools(
             packageGraph: packageGraph,
             fileSystem: swiftTool.fileSystem,

--- a/Sources/SPMBuildCore/Triple+Extensions.swift
+++ b/Sources/SPMBuildCore/Triple+Extensions.swift
@@ -24,6 +24,9 @@ extension Triple {
 
 extension Triple {
     public func platformBuildPathComponent(buildSystem: BuildSystemProvider.Kind) -> String {
+        // Use "apple" as the subdirectory because in theory Xcode build system
+        // can be used to build for any Apple platform and it has its own
+        // conventions for build subpaths based on platforms.
         buildSystem == .xcode ? "apple" : self.platformBuildPathComponent()
     }
 }


### PR DESCRIPTION
### Motivation:

When cross-compiling, SwiftPM plugins and their dependencies run on the host and so must be compiled for the host OS and architecture, not the cross-compiled target OS and architecture.   SwiftPM will
compile a command plugin for the host but if the plugin depends on an executable it will cross-compile the executable for the target so the plugin will not be able to run it:

    error: Error Domain=NSPOSIXErrorDomain Code=8 "Exec format error"

This problem does not affect `binaryTarget` dependencies, which are handled by a different code path which correctly selects the the binary for the host system from the archive.

### Modifications:

Command plugin dependencies are already handled specially in `PluginCommand.run`; this commit makes that special build step use the host toolchain instead of the target toolchain.

https://github.com/apple/swift-package-manager/pull/6060 handled the equivalent problem for build tool plugins.

### Result:

Executables which are are dependencies of command plugins will be built for the host OS and architecture, so the plugins will be able to run them.
