### PR TITLE
improve diagnostics when running into multiple product conflicts

### DIFF
--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -86,12 +86,7 @@ final class BuildPlanTests: XCTestCase {
             ],
             observabilityScope: observability.topScope
         )) { error in
-            var diagnosed = false
-            if let realError = error as? PackageGraphError,
-               realError.description == "multiple products named 'Logging' in: 'barpkg', 'foopkg'" {
-                diagnosed = true
-            }
-            XCTAssertTrue(diagnosed)
+            XCTAssertEqual((error as? PackageGraphError)?.description, "multiple products named 'Logging' in: 'barpkg' (at '/barPkg'), 'foopkg' (at '/fooPkg')")
         }
     }
 
@@ -467,12 +462,7 @@ final class BuildPlanTests: XCTestCase {
             ],
             observabilityScope: observability.topScope
         )) { error in
-            var diagnosed = false
-            if let realError = error as? PackageGraphError,
-               realError.description == "multiple products named 'Logging' in: 'barpkg', 'foopkg'" {
-                diagnosed = true
-            }
-            XCTAssertTrue(diagnosed)
+            XCTAssertEqual((error as? PackageGraphError)?.description, "multiple products named 'Logging' in: 'barpkg' (at '/barPkg'), 'foopkg' (at '/fooPkg')")
         }
     }
 

--- a/Tests/BuildTests/ModuleAliasingBuildTests.swift
+++ b/Tests/BuildTests/ModuleAliasingBuildTests.swift
@@ -258,13 +258,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             ],
             observabilityScope: observability.topScope
         )) { error in
-            var diagnosed = false
-            if let realError = error as? PackageGraphError,
-               realError.description == "multiple products named 'Logging' in: 'barpkg', 'foopkg'"
-            {
-                diagnosed = true
-            }
-            XCTAssertTrue(diagnosed)
+            XCTAssertEqual((error as? PackageGraphError)?.description, "multiple products named 'Logging' in: 'barpkg' (at '/barPkg'), 'foopkg' (at '/fooPkg')")
         }
     }
 
@@ -324,13 +318,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             ],
             observabilityScope: observability.topScope
         )) { error in
-            var diagnosed = false
-            if let realError = error as? PackageGraphError,
-               realError.description == "multiple products named 'Logging' in: 'barpkg', 'foopkg'"
-            {
-                diagnosed = true
-            }
-            XCTAssertTrue(diagnosed)
+            XCTAssertEqual((error as? PackageGraphError)?.description, "multiple products named 'Logging' in: 'barpkg' (at '/barPkg'), 'foopkg' (at '/fooPkg')")
         }
     }
 

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -1233,12 +1233,7 @@ class PackageGraphTests: XCTestCase {
             ],
             observabilityScope: observability.topScope
         )) { error in
-            var diagnosed = false
-            if let realError = error as? PackageGraphError,
-               realError.description == "multiple products named 'Bar' in: 'bar', 'baz'" {
-                diagnosed = true
-            }
-            XCTAssertTrue(diagnosed)
+            XCTAssertEqual((error as? PackageGraphError)?.description, "multiple products named 'Bar' in: 'bar' (at '/Bar'), 'baz' (at '/Baz')")
         }
     }
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -12047,13 +12047,7 @@ final class WorkspaceTests: XCTestCase {
                     )
                 }
             }) { error in
-                var diagnosed = false
-                if let realError = error as? PackageGraphError,
-                   realError.description == "multiple products named 'FooProduct' in: 'foo', 'org.foo'"
-                {
-                    diagnosed = true
-                }
-                XCTAssertTrue(diagnosed)
+                XCTAssertEqual((error as? PackageGraphError)?.description, "multiple products named 'FooProduct' in: 'foo' (from 'https://git/org/foo'), 'org.foo'")
             }
         }
 
@@ -12174,13 +12168,7 @@ final class WorkspaceTests: XCTestCase {
                         )
                     }
                 }) { error in
-                    var diagnosed = false
-                    if let realError = error as? PackageGraphError,
-                       realError.description == "multiple products named 'FooProduct' in: 'foo', 'org.foo'"
-                    {
-                        diagnosed = true
-                    }
-                    XCTAssertTrue(diagnosed)
+                    XCTAssertEqual((error as? PackageGraphError)?.description, "multiple products named 'FooProduct' in: 'foo' (from 'https://git/org/foo'), 'org.foo'")
                 }
             } else {
                 XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
@@ -12358,13 +12346,7 @@ final class WorkspaceTests: XCTestCase {
                         )
                     }
                 }) { error in
-                    var diagnosed = false
-                    if let realError = error as? PackageGraphError,
-                       realError.description == "multiple products named 'FooProduct' in: 'foo', 'org.foo'"
-                    {
-                        diagnosed = true
-                    }
-                    XCTAssertTrue(diagnosed)
+                    XCTAssertEqual((error as? PackageGraphError)?.description, "multiple products named 'FooProduct' in: 'foo' (from 'https://git/org/foo'), 'org.foo'")
                 }
             } else {
                 XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
@@ -12517,13 +12499,7 @@ final class WorkspaceTests: XCTestCase {
                         )
                     }
                 }) { error in
-                    var diagnosed = false
-                    if let realError = error as? PackageGraphError,
-                       realError.description == "multiple products named 'FooProduct' in: 'foo', 'org.foo'"
-                    {
-                        diagnosed = true
-                    }
-                    XCTAssertTrue(diagnosed)
+                    XCTAssertEqual((error as? PackageGraphError)?.description, "multiple products named 'FooProduct' in: 'foo' (from 'https://git/org/foo'), 'org.foo'")
                 }
             } else {
                 XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
@@ -12663,13 +12639,7 @@ final class WorkspaceTests: XCTestCase {
                         )
                     }
                 }) { error in
-                    var diagnosed = false
-                    if let realError = error as? PackageGraphError,
-                       realError.description == "multiple products named 'FooProduct' in: 'foo', 'org.foo'"
-                    {
-                        diagnosed = true
-                    }
-                    XCTAssertTrue(diagnosed)
+                    XCTAssertEqual((error as? PackageGraphError)?.description, "multiple products named 'FooProduct' in: 'foo' (from 'https://git/org/foo'), 'org.foo'")
                 }
             } else {
                 XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
@@ -12830,13 +12800,7 @@ final class WorkspaceTests: XCTestCase {
                         )
                     }
                 }) { error in
-                    var diagnosed = false
-                    if let realError = error as? PackageGraphError,
-                       realError.description == "multiple products named 'FooProduct' in: 'foo', 'org.foo'"
-                    {
-                        diagnosed = true
-                    }
-                    XCTAssertTrue(diagnosed)
+                    XCTAssertEqual((error as? PackageGraphError)?.description, "multiple products named 'FooProduct' in: 'foo' (from 'https://git/org/foo'), 'org.foo'")
                 }
             } else {
                 XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
@@ -12992,13 +12956,7 @@ final class WorkspaceTests: XCTestCase {
                         )
                     }
                 }) { error in
-                    var diagnosed = false
-                    if let realError = error as? PackageGraphError,
-                       realError.description == "multiple products named 'BazProduct' in: 'baz', 'org.baz'"
-                    {
-                        diagnosed = true
-                    }
-                    XCTAssertTrue(diagnosed)
+                    XCTAssertEqual((error as? PackageGraphError)?.description, "multiple products named 'BazProduct' in: 'baz' (from 'https://git/org/baz'), 'org.baz'")
                 }
             } else {
                 XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
@@ -13183,13 +13141,7 @@ final class WorkspaceTests: XCTestCase {
                         )
                     }
                 }) { error in
-                    var diagnosed = false
-                    if let realError = error as? PackageGraphError,
-                       realError.description == "multiple products named 'BazProduct' in: 'baz', 'org.baz'"
-                    {
-                        diagnosed = true
-                    }
-                    XCTAssertTrue(diagnosed)
+                    XCTAssertEqual((error as? PackageGraphError)?.description, "multiple products named 'BazProduct' in: 'baz' (from 'https://git/org/baz'), 'org.baz'")
                 }
             } else {
                 XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
@@ -13329,13 +13281,7 @@ final class WorkspaceTests: XCTestCase {
                         )
                     }
                 }) { error in
-                    var diagnosed = false
-                    if let realError = error as? PackageGraphError,
-                       realError.description == "multiple products named 'FooProduct' in: 'foo', 'org.foo'"
-                    {
-                        diagnosed = true
-                    }
-                    XCTAssertTrue(diagnosed)
+                    XCTAssertEqual((error as? PackageGraphError)?.description, "multiple products named 'FooProduct' in: 'foo' (from 'https://git/org/foo'), 'org.foo'")
                 }
             } else {
                 XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in


### PR DESCRIPTION
motivation: diagnostics for multiple products conflicts could be fairly confusing with repeated package identities and not enough informaiton about the origin of the conflict

changes:
* use PackageIdentity to track duplicates instead of strings
* use Sets to track duplicates instead of array
* add information about the origin (url) of the conflict
* adjust tests
