### PR TITLE
Do not use product identifier based lookup for older tools-versions

### DIFF
--- a/Tests/BuildTests/ModuleAliasingBuildTests.swift
+++ b/Tests/BuildTests/ModuleAliasingBuildTests.swift
@@ -161,6 +161,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                 Manifest.createRootManifest(
                     displayName: "thisPkg",
                     path: "/thisPkg",
+                    toolsVersion: .v5_9,
                     dependencies: [
                         .localSourceControl(path: "/fooPkg", requirement: .upToNextMajor(from: "1.0.0")),
                         .localSourceControl(path: "/barPkg", requirement: .upToNextMajor(from: "2.0.0")),
@@ -176,7 +177,8 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                 name: "Logging",
                                 package: "barPkg",
                                 moduleAliases: ["Logging": "BarLogging"]
-                            )]
+                            )],
+                            type: .executable
                         ),
                     ]
                 ),
@@ -357,6 +359,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                 Manifest.createRootManifest(
                     displayName: "thisPkg",
                     path: "/thisPkg",
+                    toolsVersion: .v5_9,
                     dependencies: [
                         .localSourceControl(path: "/fooPkg", requirement: .upToNextMajor(from: "1.0.0")),
                         .localSourceControl(path: "/barPkg", requirement: .upToNextMajor(from: "2.0.0")),
@@ -372,7 +375,8 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                 name: "Logging",
                                 package: "barPkg",
                                 moduleAliases: ["Logging": "BarLogging"]
-                            )]
+                            )],
+                            type: .executable
                         ),
                     ]
                 ),
@@ -439,6 +443,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                 Manifest.createRootManifest(
                     displayName: "thisPkg",
                     path: "/thisPkg",
+                    toolsVersion: .v5_9,
                     dependencies: [
                         .localSourceControl(path: "/fooPkg", requirement: .upToNextMajor(from: "1.0.0")),
                         .localSourceControl(path: "/bazPkg", requirement: .upToNextMajor(from: "2.0.0")),
@@ -454,7 +459,8 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                 name: "Logging",
                                 package: "bazPkg",
                                 moduleAliases: ["Logging": "BazLogging"]
-                            )]
+                            )],
+                            type: .executable
                         ),
                     ]
                 ),
@@ -654,6 +660,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                 Manifest.createRootManifest(
                     displayName: "thisPkg",
                     path: "/thisPkg",
+                    toolsVersion: .v5_9,
                     dependencies: [
                         .localSourceControl(path: "/fooPkg", requirement: .upToNextMajor(from: "1.0.0")),
                         .localSourceControl(path: "/barPkg", requirement: .upToNextMajor(from: "2.0.0")),
@@ -671,7 +678,8 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                                name: "Logging",
                                                package: "barPkg",
                                                moduleAliases: ["Logging": "BarLogging"]
-                                           )]
+                                           )],
+                            type: .executable
                         ),
                         TargetDescription(name: "Logging", dependencies: []),
                     ]
@@ -3498,6 +3506,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                 Manifest.createRootManifest(
                     displayName: "xpkg",
                     path: "/xPkg",
+                    toolsVersion: .v5_9,
                     dependencies: [
                         .localSourceControl(path: "/yPkg", requirement: .upToNextMajor(from: "1.0.0")),
                         .localSourceControl(path: "/zPkg", requirement: .upToNextMajor(from: "1.0.0")),
@@ -3545,6 +3554,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                 Manifest.createRootManifest(
                     displayName: "apkg",
                     path: "/aPkg",
+                    toolsVersion: .v5_9,
                     dependencies: [
                         .localSourceControl(path: "/bPkg", requirement: .upToNextMajor(from: "1.0.0")),
                         .localSourceControl(path: "/cPkg", requirement: .upToNextMajor(from: "1.0.0")),
@@ -3572,6 +3582,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                 Manifest.createRootManifest(
                     displayName: "appPkg",
                     path: "/appPkg",
+                    toolsVersion: .v5_9,
                     dependencies: [
                         .localSourceControl(path: "/xPkg", requirement: .upToNextMajor(from: "1.0.0")),
                         .localSourceControl(path: "/aPkg", requirement: .upToNextMajor(from: "1.0.0")),
@@ -3590,7 +3601,8 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                     package: "apkg",
                                     moduleAliases: ["Utils": "AUtils"]
                                 ),
-                            ]
+                            ],
+                            type: .executable
                         ),
                     ]
                 ),
@@ -3665,6 +3677,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                 Manifest.createRootManifest(
                     displayName: "xpkg",
                     path: "/xPkg",
+                    toolsVersion: .v5_9,
                     dependencies: [
                         .localSourceControl(path: "/yPkg", requirement: .upToNextMajor(from: "1.0.0")),
                         .localSourceControl(path: "/zPkg", requirement: .upToNextMajor(from: "1.0.0")),
@@ -3703,6 +3716,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                 Manifest.createRootManifest(
                     displayName: "appPkg",
                     path: "/appPkg",
+                    toolsVersion: .v5_9,
                     dependencies: [
                         .localSourceControl(path: "/xPkg", requirement: .upToNextMajor(from: "1.0.0")),
                         .localSourceControl(path: "/aPkg", requirement: .upToNextMajor(from: "1.0.0")),
@@ -3720,7 +3734,8 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                     package: "apkg",
                                     moduleAliases: ["Utils": "AUtils"]
                                 ),
-                            ]
+                            ],
+                            type: .executable
                         ),
                     ]
                 ),
@@ -3790,6 +3805,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                 Manifest.createRootManifest(
                     displayName: "xpkg",
                     path: "/xPkg",
+                    toolsVersion: .v5_9,
                     dependencies: [
                         .localSourceControl(path: "/yPkg", requirement: .upToNextMajor(from: "1.0.0")),
                         .localSourceControl(path: "/zPkg", requirement: .upToNextMajor(from: "1.0.0")),
@@ -3827,6 +3843,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                 Manifest.createRootManifest(
                     displayName: "appPkg",
                     path: "/appPkg",
+                    toolsVersion: .v5_9,
                     dependencies: [
                         .localSourceControl(path: "/xPkg", requirement: .upToNextMajor(from: "1.0.0")),
                         .localSourceControl(path: "/aPkg", requirement: .upToNextMajor(from: "1.0.0")),
@@ -3845,7 +3862,8 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                     package: "apkg",
                                     moduleAliases: ["Utils": "AUtils"]
                                 ),
-                            ]
+                            ],
+                            type: .executable
                         ),
                     ]
                 ),
@@ -4074,6 +4092,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                 Manifest.createFileSystemManifest(
                     displayName: "xpkg",
                     path: "/xPkg",
+                    toolsVersion: .v5_9,
                     dependencies: [
                         .localSourceControl(path: "/yPkg", requirement: .upToNextMajor(from: "1.0.0")),
                         .localSourceControl(path: "/zPkg", requirement: .upToNextMajor(from: "1.0.0")),
@@ -4111,6 +4130,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                 Manifest.createFileSystemManifest(
                     displayName: "apkg",
                     path: "/aPkg",
+                    toolsVersion: .v5_9,
                     dependencies: [
                         .localSourceControl(path: "/bPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
@@ -4135,6 +4155,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                 Manifest.createRootManifest(
                     displayName: "appPkg",
                     path: "/appPkg",
+                    toolsVersion: .v5_9,
                     dependencies: [
                         .localSourceControl(path: "/aPkg", requirement: .upToNextMajor(from: "1.0.0")),
                         .localSourceControl(path: "/xPkg", requirement: .upToNextMajor(from: "1.0.0")),
@@ -4154,7 +4175,8 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                 name: "X",
                                 package: "xpkg",
                                 moduleAliases: ["FooUtils": "XFUtils"]
-                            )]
+                            )],
+                            type: .executable
                         ),
                     ]
                 ),
@@ -4236,6 +4258,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                 Manifest.createFileSystemManifest(
                     displayName: "xpkg",
                     path: "/xPkg",
+                    toolsVersion: .v5_9,
                     dependencies: [
                         .localSourceControl(path: "/yPkg", requirement: .upToNextMajor(from: "1.0.0")),
                         .localSourceControl(path: "/zPkg", requirement: .upToNextMajor(from: "1.0.0")),
@@ -4274,6 +4297,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                 Manifest.createFileSystemManifest(
                     displayName: "apkg",
                     path: "/aPkg",
+                    toolsVersion: .v5_9,
                     dependencies: [
                         .localSourceControl(path: "/bPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
@@ -4298,6 +4322,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
                 Manifest.createRootManifest(
                     displayName: "appPkg",
                     path: "/appPkg",
+                    toolsVersion: .v5_9,
                     dependencies: [
                         .localSourceControl(path: "/aPkg", requirement: .upToNextMajor(from: "1.0.0")),
                         .localSourceControl(path: "/xPkg", requirement: .upToNextMajor(from: "1.0.0")),
@@ -4320,7 +4345,8 @@ final class ModuleAliasingBuildTests: XCTestCase {
                                     "ZUtils": "XUtils",
                                     "FooUtils": "XFooUtils",
                                 ]
-                            )]
+                            )],
+                            type: .executable
                         ),
                     ]
                 ),
@@ -4528,5 +4554,142 @@ final class ModuleAliasingBuildTests: XCTestCase {
             result.targetMap.values
                 .contains { $0.target.name == "ZUtils" || $0.target.moduleAliases?["Utils"] == "ZUtils" }
         )
+    }
+
+    func testProductAliasingDoesNotBreakPackagesWithOlderToolsVersions() throws {
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/Lunch/Sources/MyTarget/file.swift",
+            "/Some/Sources/Some/file.swift",
+            "/Other/Sources/Other/file.swift"
+        )
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "lunch",
+                    path: "/Lunch",
+                    dependencies: [
+                        .fileSystem(path: "/Some"),
+                        .fileSystem(path: "/Other"),
+                    ],
+                    targets: [
+                        TargetDescription(
+                            name: "MyTarget",
+                            dependencies: [
+                                .byName(name: "SomeProduct", condition: nil),
+                                .product(name: "Other", package: nil, moduleAliases: ["Other": "Other2"], condition: nil),
+                            ]
+                        )
+                    ]
+                ),
+                Manifest.createFileSystemManifest(
+                    displayName: "Some",
+                    path: "/Some",
+                    products: [
+                        ProductDescription(
+                            name: "SomeProduct",
+                            type: .library(.automatic),
+                            targets: ["Some"]
+                        )
+                    ],
+                    targets: [
+                        TargetDescription(name: "Some"),
+                    ]
+                ),
+                Manifest.createFileSystemManifest(
+                    displayName: "Other",
+                    path: "/Other",
+                    products: [
+                        ProductDescription(
+                            name: "Other",
+                            type: .library(.automatic),
+                            targets: ["Other"]
+                        )
+                    ],
+                    targets: [
+                        TargetDescription(name: "Other"),
+                    ]
+                )
+            ],
+            observabilityScope: observability.topScope
+        )
+        XCTAssertNoDiagnostics(observability.diagnostics)
+        let result = try BuildPlanResult(plan: try BuildPlan(
+            buildParameters: mockBuildParameters(shouldLinkStaticSwiftStdlib: true),
+            graph: graph,
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        ))
+        result.checkTargetsCount(3)
+    }
+
+    func testProductAliasingWarnsIfPackageWithOlderToolsVersionIsPossibleCauseOfConflict() throws {
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/Lunch/Sources/MyTarget/file.swift",
+            "/Some/Sources/Some/file.swift",
+            "/Other/Sources/Some/file.swift"
+        )
+        let observability = ObservabilitySystem.makeForTesting()
+        do {
+            _ = try loadPackageGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "lunch",
+                        path: "/Lunch",
+                        dependencies: [
+                            .fileSystem(path: "/Some"),
+                            .fileSystem(path: "/Other"),
+                        ],
+                        targets: [
+                            TargetDescription(
+                                name: "MyTarget",
+                                dependencies: [
+                                    .byName(name: "SomeProduct", condition: nil),
+                                    .product(name: "Some", package: nil, moduleAliases: ["Some": "Some2"], condition: nil),
+                                ]
+                            )
+                        ]
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Some",
+                        path: "/Some",
+                        products: [
+                            ProductDescription(
+                                name: "SomeProduct",
+                                type: .library(.automatic),
+                                targets: ["Some"]
+                            )
+                        ],
+                        targets: [
+                            TargetDescription(name: "Some"),
+                        ]
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Some",
+                        path: "/Other",
+                        products: [
+                            ProductDescription(
+                                name: "SomeProduct",
+                                type: .library(.automatic),
+                                targets: ["Some"]
+                            )
+                        ],
+                        targets: [
+                            TargetDescription(name: "Some"),
+                        ]
+                    )
+                ],
+                observabilityScope: observability.topScope
+            )
+
+            XCTFail("unexpectedly resolved the package graph successfully")
+        } catch {
+            XCTAssertEqual(error.interpolationDescription, "multiple products named 'SomeProduct' in: 'other' (at '/Other'), 'some' (at '/Some')")
+        }
+        XCTAssertEqual(observability.diagnostics.map { $0.description }.sorted(), ["[warning]: product aliasing requires tools-version 5.2 or later, so it is not supported by \'other\'", "[warning]: product aliasing requires tools-version 5.2 or later, so it is not supported by \'some\'"])
     }
 }


### PR DESCRIPTION
When we introduced module aliasing, we tried to paper over the fact that there are no product aliases by changing the lookup under certain conditions. It looks like one of these conditions is "one package in the graph uses aliasing" which breaks if the graph contains any packages with pre-5.2 tools-versions because they lack the information to do a identity based lookup.

This changes opts packages with older tools-versions out of the identity based lookup. This implies that it is not possible to use aliasing in certain situations, but that seems preferrable to not being to use aliasing at all in affected package graphs.

rdar://113506853
