### PR TITLE
Support custom platforms in conditionals

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -1153,7 +1153,13 @@ public final class PackageBuilder {
             conditions.append(condition)
         }
 
-        if let platforms = condition?.platformNames.compactMap({ platformRegistry.platformByName[$0] }),
+        if let platforms = condition?.platformNames.map({
+            if let platform = platformRegistry.platformByName[$0] {
+                return platform
+            } else {
+                return PackageModel.Platform.custom(name: $0, oldestSupportedVersion: .unknown)
+            }
+        }),
            !platforms.isEmpty
         {
             let condition = PlatformsCondition(platforms: platforms)

--- a/Sources/PackageModel/BuildSettings.swift
+++ b/Sources/PackageModel/BuildSettings.swift
@@ -39,7 +39,7 @@ public enum BuildSettings {
     }
 
     /// An individual build setting assignment.
-    public struct Assignment: Codable {
+    public struct Assignment: Codable, Equatable, Hashable {
         /// The assignment value.
         public var values: [String]
 

--- a/Sources/PackageModel/Manifest/PackageConditionDescription.swift
+++ b/Sources/PackageModel/Manifest/PackageConditionDescription.swift
@@ -28,7 +28,7 @@ public protocol PackageConditionProtocol: Codable {
 }
 
 /// Wrapper for package condition so it can be conformed to Codable.
-struct PackageConditionWrapper: Codable {
+struct PackageConditionWrapper: Codable, Equatable, Hashable {
     var platform: PlatformsCondition?
     var config: ConfigurationCondition?
 
@@ -55,7 +55,7 @@ struct PackageConditionWrapper: Codable {
 }
 
 /// Platforms condition implies that an assignment is valid on these platforms.
-public struct PlatformsCondition: PackageConditionProtocol {
+public struct PlatformsCondition: PackageConditionProtocol, Equatable, Hashable {
     public let platforms: [Platform]
 
     public init(platforms: [Platform]) {
@@ -70,7 +70,7 @@ public struct PlatformsCondition: PackageConditionProtocol {
 
 /// A configuration condition implies that an assignment is valid on
 /// a particular build configuration.
-public struct ConfigurationCondition: PackageConditionProtocol {
+public struct ConfigurationCondition: PackageConditionProtocol, Equatable, Hashable {
     public let configuration: BuildConfiguration
 
     public init(configuration: BuildConfiguration) {

--- a/Sources/PackageModel/Platform.swift
+++ b/Sources/PackageModel/Platform.swift
@@ -33,6 +33,10 @@ public struct Platform: Equatable, Hashable, Codable {
         return Platform(name: name, oldestSupportedVersion: PlatformVersion(oldestSupportedVersion))
     }
 
+    public static func custom(name: String, oldestSupportedVersion: PlatformVersion) -> Platform {
+        return Platform(name: name, oldestSupportedVersion: oldestSupportedVersion)
+    }
+
     public static let macOS: Platform = Platform(name: "macos", oldestSupportedVersion: "10.13")
     public static let macCatalyst: Platform = Platform(name: "maccatalyst", oldestSupportedVersion: "13.0")
     public static let iOS: Platform = Platform(name: "ios", oldestSupportedVersion: "11.0")


### PR DESCRIPTION
In #3742, support for custom platforms was added and I think everyone understood it as supporting custom deployment targets, but it actually also added API for custom platform conditionals. Those never actually worked, though, because any platform that the platform registry doesn't know about was dropped when going from `TargetDescription` to `Target`. This fixes it and adds a unit test.

See also https://github.com/RevenueCat/purchases-ios/issues/2998

rdar://113709387