### PR TITLE
Bring back test fixes from 5.9 branch

### DIFF
--- a/Fixtures/Miscellaneous/CXX17CompilerCrash/v5_8/Package.swift
+++ b/Fixtures/Miscellaneous/CXX17CompilerCrash/v5_8/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:999.0.0
+// swift-tools-version:5.8.0
 
 import PackageDescription
 

--- a/Fixtures/Miscellaneous/Plugins/PluginsAndSnippets/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/PluginsAndSnippets/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 999.0
+// swift-tools-version: 5.9
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
I fixed these up when we enabled development mode on the branch, but we should have these in main as well.

(cherry picked from commit ad4ffe4250a126156d563fd6024f4ec71dfe4caf)