### PR TITLE
[5.9] Build command plugin dependencies for the host, not the target

### DIFF
--- a/Sources/Commands/PackageTools/PluginCommand.swift
+++ b/Sources/Commands/PackageTools/PluginCommand.swift
@@ -249,7 +249,11 @@ struct PluginCommand: SwiftCommand {
             + getEnvSearchPaths(pathString: ProcessEnv.path, currentWorkingDirectory: .none)
 
         // Build or bring up-to-date any executable host-side tools on which this plugin depends. Add them and any binary dependencies to the tool-names-to-path map.
-        let buildSystem = try swiftTool.createBuildSystem(explicitBuildSystem: .native, cacheBuildManifest: false)
+        let buildSystem = try swiftTool.createBuildSystem(
+            explicitBuildSystem: .native,
+            cacheBuildManifest: false,
+            customBuildParameters: swiftTool.hostBuildParameters()
+        )
         let accessibleTools = try plugin.processAccessibleTools(
             packageGraph: packageGraph,
             fileSystem: swiftTool.fileSystem,

--- a/Sources/CoreCommands/SwiftTool.swift
+++ b/Sources/CoreCommands/SwiftTool.swift
@@ -664,6 +664,54 @@ public final class SwiftTool {
         return buildSystem
     }
 
+    private func _buildParams(toolchain: UserToolchain) throws -> BuildParameters {
+        let destinationTriple = toolchain.triple
+
+        let dataPath = self.scratchDirectory.appending(
+            component: destinationTriple.platformBuildPathComponent(buildSystem: options.build.buildSystem)
+        )
+
+        return try BuildParameters(
+            dataPath: dataPath,
+            configuration: options.build.configuration,
+            toolchain: toolchain,
+            destinationTriple: destinationTriple,
+            flags: options.build.buildFlags,
+            pkgConfigDirectories: options.locations.pkgConfigDirectories,
+            architectures: options.build.architectures,
+            workers: options.build.jobs ?? UInt32(ProcessInfo.processInfo.activeProcessorCount),
+            shouldLinkStaticSwiftStdlib: options.linker.shouldLinkStaticSwiftStdlib,
+            canRenameEntrypointFunctionName: driverSupport.checkSupportedFrontendFlags(
+                flags: ["entry-point-function-name"],
+                toolchain: toolchain,
+                fileSystem: self.fileSystem
+            ),
+            sanitizers: options.build.enabledSanitizers,
+            enableCodeCoverage: false, // set by test commands when appropriate
+            indexStoreMode: options.build.indexStoreMode.buildParameter,
+            enableParseableModuleInterfaces: options.build.shouldEnableParseableModuleInterfaces,
+            useIntegratedSwiftDriver: options.build.useIntegratedSwiftDriver,
+            useExplicitModuleBuild: options.build.useExplicitModuleBuild,
+            isXcodeBuildSystemEnabled: options.build.buildSystem == .xcode,
+            forceTestDiscovery: options.build.enableTestDiscovery, // backwards compatibility, remove with --enable-test-discovery
+            testEntryPointPath: options.build.testEntryPointPath,
+            explicitTargetDependencyImportCheckingMode: options.build.explicitTargetDependencyImportCheck.modeParameter,
+            linkerDeadStrip: options.linker.linkerDeadStrip,
+            verboseOutput: self.logLevel <= .info
+        )
+    }
+
+    /// Return the build parameters for the host toolchain.
+    public func hostBuildParameters() throws -> BuildParameters {
+        return try _hostBuildParameters.get()
+    }
+
+    private lazy var _hostBuildParameters: Result<BuildParameters, Swift.Error> = {
+        return Result(catching: {
+            try _buildParams(toolchain: self.getHostToolchain())
+        })
+    }()
+
     /// Return the build parameters.
     public func buildParameters() throws -> BuildParameters {
         return try _buildParameters.get()
@@ -671,43 +719,7 @@ public final class SwiftTool {
 
     private lazy var _buildParameters: Result<BuildParameters, Swift.Error> = {
         return Result(catching: {
-            let destinationToolchain = try self.getDestinationToolchain()
-            let destinationTriple = destinationToolchain.triple
-
-            // Use "apple" as the subdirectory because in theory Xcode build system
-            // can be used to build for any Apple platform and it has it's own
-            // conventions for build subpaths based on platforms.
-            let dataPath = self.scratchDirectory.appending(
-                component: destinationTriple.platformBuildPathComponent(buildSystem: options.build.buildSystem)
-            )
-
-            return try BuildParameters(
-                dataPath: dataPath,
-                configuration: options.build.configuration,
-                toolchain: destinationToolchain,
-                destinationTriple: destinationTriple,
-                flags: options.build.buildFlags,
-                pkgConfigDirectories: options.locations.pkgConfigDirectories,
-                architectures: options.build.architectures,
-                workers: options.build.jobs ?? UInt32(ProcessInfo.processInfo.activeProcessorCount),
-                shouldLinkStaticSwiftStdlib: options.linker.shouldLinkStaticSwiftStdlib,
-                canRenameEntrypointFunctionName: driverSupport.checkSupportedFrontendFlags(
-                    flags: ["entry-point-function-name"], toolchain: destinationToolchain, fileSystem: self.fileSystem
-                ),
-                sanitizers: options.build.enabledSanitizers,
-                enableCodeCoverage: false, // set by test commands when appropriate
-                indexStoreMode: options.build.indexStoreMode.buildParameter,
-                enableParseableModuleInterfaces: options.build.shouldEnableParseableModuleInterfaces,
-                emitSwiftModuleSeparately: options.build.emitSwiftModuleSeparately,
-                useIntegratedSwiftDriver: options.build.useIntegratedSwiftDriver,
-                useExplicitModuleBuild: options.build.useExplicitModuleBuild,
-                isXcodeBuildSystemEnabled: options.build.buildSystem == .xcode,
-                forceTestDiscovery: options.build.enableTestDiscovery, // backwards compatibility, remove with --enable-test-discovery
-                testEntryPointPath: options.build.testEntryPointPath,
-                explicitTargetDependencyImportCheckingMode: options.build.explicitTargetDependencyImportCheck.modeParameter,
-                linkerDeadStrip: options.linker.linkerDeadStrip,
-                verboseOutput: self.logLevel <= .info
-            )
+            try _buildParams(toolchain: self.getDestinationToolchain())
         })
     }()
 

--- a/Sources/SPMBuildCore/Triple+Extensions.swift
+++ b/Sources/SPMBuildCore/Triple+Extensions.swift
@@ -24,6 +24,9 @@ extension Triple {
 
 extension Triple {
     public func platformBuildPathComponent(buildSystem: BuildSystemProvider.Kind) -> String {
+        // Use "apple" as the subdirectory because in theory Xcode build system
+        // can be used to build for any Apple platform and it has its own
+        // conventions for build subpaths based on platforms.
         buildSystem == .xcode ? "apple" : self.platformBuildPathComponent()
     }
 }


### PR DESCRIPTION
When cross-compiling, SwiftPM plugins and their dependencies run on the host and so must be compiled for the host OS and architecture, not the cross-compiled target OS and architecture. SwiftPM will compile a command plugin for the host but if the plugin depends on an executable it will cross-compile the executable for the target, so the plugin will not be able to run it:

    error: Error Domain=NSPOSIXErrorDomain Code=8 "Exec format error"

Command plugin dependencies are already handled specially in PluginCommand.run; this commit makes that special build step use the host toolchain instead of the target toolchain.

https://github.com/apple/swift-package-manager/pull/6060 handled the equivalent problem for build tool plugins.

(cherry picked from commit 1daaa1c0339584e50d42f62b5a7794a2e97b5782)
```
# Conflicts:
#	Sources/CoreCommands/SwiftTool.swift
```