### PR TITLE
[5.9.0] Update swift-syntax version in macro template

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -252,8 +252,8 @@ public final class InitPackage {
             } else if packageType == .macro {
                 pkgParams.append("""
                     dependencies: [
-                        // Depend on the latest Swift 5.9 prerelease of SwiftSyntax
-                        .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.0-swift-5.9-DEVELOPMENT-SNAPSHOT-2023-04-25-b"),
+                        // Depend on the Swift 5.9 release of SwiftSyntax
+                        .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.0"),
                     ]
                 """)
             }


### PR DESCRIPTION
We need to update this before shipping 5.9.0

rdar://111618457

(cherry picked from commit da3bdae70cb21d90f8be89e18d236dabd5854364)
