### PR TITLE
Generate docc bundle and contents on library init

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -613,14 +613,14 @@ public final class InitPackage {
         try makeDirectories(tests)
         try writeTestFileStubs(testsPath: tests)
     }
-    
+
     private func writeLibraryDocumentation(_ path: AbsolutePath) throws {
         let docc = path.appending("\(moduleName).docc")
         guard fileSystem.exists(docc) == false else {
             return
         }
         try makeDirectories(docc)
-        
+
         let content = ####"""
         # ``\####(moduleName)``
 
@@ -636,12 +636,12 @@ public final class InitPackage {
 
         - <!--@START_MENU_TOKEN@-->``Symbol``<!--@END_MENU_TOKEN@-->
         """####
-        
+
         let mdFile = docc.appending("\(moduleName).md")
         try writePackageFile(mdFile) { stream in
             stream.write(content)
         }
-        
+
         let resources = docc.appending("Resources")
         try makeDirectories(resources)
     }

--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -595,6 +595,9 @@ public final class InitPackage {
           try writeMacroPluginSources(sources.appending("\(pkgname)Macros"))
           try writeMacroClientSources(sources.appending("\(pkgname)Client"))
         }
+        if packageType == .library {
+            try writeLibraryDocumentation(sources)
+        }
     }
 
     private func writeTests() throws {
@@ -609,6 +612,38 @@ public final class InitPackage {
         progressReporter?("Creating \(tests.relative(to: destinationPath))/")
         try makeDirectories(tests)
         try writeTestFileStubs(testsPath: tests)
+    }
+    
+    private func writeLibraryDocumentation(_ path: AbsolutePath) throws {
+        let docc = path.appending("\(moduleName).docc")
+        guard fileSystem.exists(docc) == false else {
+            return
+        }
+        try makeDirectories(docc)
+        
+        let content = ####"""
+        # ``\####(moduleName)``
+
+        <!--@START_MENU_TOKEN@-->Summary<!--@END_MENU_TOKEN@-->
+
+        ## Overview
+
+        <!--@START_MENU_TOKEN@-->Text<!--@END_MENU_TOKEN@-->
+
+        ## Topics
+
+        ### <!--@START_MENU_TOKEN@-->Group<!--@END_MENU_TOKEN@-->
+
+        - <!--@START_MENU_TOKEN@-->``Symbol``<!--@END_MENU_TOKEN@-->
+        """####
+        
+        let mdFile = docc.appending("\(moduleName).md")
+        try writePackageFile(mdFile) { stream in
+            stream.write(content)
+        }
+        
+        let resources = docc.appending("Resources")
+        try makeDirectories(resources)
     }
 
     private func writeLibraryTestsFile(_ path: AbsolutePath) throws {

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -141,7 +141,9 @@ class InitTests: XCTestCase {
                           \(testFileContents)
                           """)
             XCTAssertMatch(testFileContents, .contains("func testExample() throws"))
-
+            
+            XCTAssertEqual(try fs.getDirectoryContents(path.appending("Sources").appending("Foo.docc")), ["Foo.md", "Resources"])
+            
             // Try building it
             XCTAssertBuilds(path)
             let triple = try UserToolchain.default.targetTriple


### PR DESCRIPTION
Generate docc bundle and contents on library init.

### Motivation:
Xcode Framework template generates docc documentation bundle automatically. Which is a great way to promote documentation.
Generating new Swift package does not do this as of now. Which seems inconsistent.

### Modifications:

- Generate `%moduleName%.md` and `Resources` folder under `Sources/%moduleName%.docc`. This follows same pattern as Xcode Framework template.
- Only `library` module for now. But might be worth expanding it to all packages that generate sources.
- Update tests.

### Result:

When creating a new library package `Sources/%moduleName%.docc` with `%moduleName%.md` and `Resources` folder will be generated.

### Discussion
Not sure if this falls into category of "materially change the user facing semantics of Swift Package Manager" or not. IMHO it does not but someone might hold different opinion.
On one hand new user artifacts are generated.
On the other hand the artifacts are minor, and don't break anything.
https://www.swift.org/getting-started/#using-the-package-manager mentions `README.md` is supposed to be generated. But it is not the case as of now. So this is kinda a more modern version of `README.md`.