### PR TITLE
Fix `swift package plugin --list`

### DIFF
--- a/Sources/Commands/PackageTools/PluginCommand.swift
+++ b/Sources/Commands/PackageTools/PluginCommand.swift
@@ -82,7 +82,7 @@ struct PluginCommand: SwiftCommand {
             let packageGraph = try swiftTool.loadPackageGraph()
             let allPlugins = PluginCommand.availableCommandPlugins(in: packageGraph)
             for plugin in allPlugins.sorted(by: { $0.name < $1.name }) {
-                guard case .command(let intent, _) = plugin.capability else { return }
+                guard case .command(let intent, _) = plugin.capability else { continue }
                 var line = "‘\(intent.invocationVerb)’ (plugin ‘\(plugin.name)’"
                 if let package = packageGraph.packages
                     .first(where: { $0.targets.contains(where: { $0.name == plugin.name }) })


### PR DESCRIPTION
Printing the list needs to continue beyond the first non-command plugin.

resolves #6804
