### PR TITLE
Fix dependencies in `SWIFTPM_LLBUILD_FWK` case

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -196,10 +196,7 @@ let package = Package(
         .target(
             /** Shim for llbuild library */
             name: "SPMLLBuild",
-            dependencies: [
-                "Basics",
-                .product(name: "llbuild", package: "swift-llbuild"),
-            ],
+            dependencies: ["Basics"],
             exclude: ["CMakeLists.txt"]
         ),
 
@@ -714,7 +711,10 @@ if ProcessInfo.processInfo.environment["SWIFTPM_LLBUILD_FWK"] == nil {
             .package(name: "swift-llbuild", path: "../llbuild"),
         ]
     }
-    package.targets.first(where: { $0.name == "SPMLLBuild" })!.dependencies += [.product(name: "llbuildSwift", package: "swift-llbuild")]
+    package.targets.first(where: { $0.name == "SPMLLBuild" })!.dependencies += [
+        .product(name: "llbuildSwift", package: "swift-llbuild"),
+        .product(name: "llbuild", package: "swift-llbuild"),
+    ]
 }
 
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {


### PR DESCRIPTION
The changes in #6807 can actually break in this case, moving the new dependency to the correct place.
