### PR TITLE
Opt in to explicit target dependencies

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -805,6 +805,9 @@ def get_swiftpm_flags(args):
     for modifier in ["-Xswiftc", "-Xbuild-tools-swiftc"]:
         build_flags.extend([modifier, "-module-cache-path", modifier, local_module_cache_path])
 
+    # Enforce explicit target dependencies
+    build_flags.extend(["--explicit-target-dependency-import-check", "error"])
+
     return build_flags
 
 if __name__ == '__main__':


### PR DESCRIPTION
We may want to make `--explicit-target-dependency-import-check` the default at some point, so it would be good to get some more testing in practice. We can opt in SwiftPM's CI itself as a starting point.
