### PR TITLE
CLI commands should not require workspace to update user-level registries config

### DIFF
--- a/Sources/PackageRegistryTool/PackageRegistryTool+Auth.swift
+++ b/Sources/PackageRegistryTool/PackageRegistryTool+Auth.swift
@@ -158,7 +158,8 @@ extension SwiftPackageRegistryTool {
                 throw ValidationError.unknownCredentialStore
             }
 
-            let configuration = try getRegistriesConfig(swiftTool)
+            // Auth config is in user-level registries config only
+            let configuration = try getRegistriesConfig(swiftTool, global: true)
 
             // compute and validate registry URL
             guard let registryURL = self.registryURL ?? configuration.configuration.defaultRegistry?.url else {
@@ -338,7 +339,8 @@ extension SwiftPackageRegistryTool {
         }
 
         func run(_ swiftTool: SwiftTool) throws {
-            let configuration = try getRegistriesConfig(swiftTool)
+            // Auth config is in user-level registries config only
+            let configuration = try getRegistriesConfig(swiftTool, global: true)
 
             // compute and validate registry URL
             guard let registryURL = self.registryURL ?? configuration.configuration.defaultRegistry?.url else {

--- a/Sources/PackageRegistryTool/PackageRegistryTool+Publish.swift
+++ b/Sources/PackageRegistryTool/PackageRegistryTool+Publish.swift
@@ -81,7 +81,8 @@ extension SwiftPackageRegistryTool {
         var dryRun: Bool = false
 
         func run(_ swiftTool: SwiftTool) throws {
-            let configuration = try getRegistriesConfig(swiftTool).configuration
+            // Require both local and user-level registries config
+            let configuration = try getRegistriesConfig(swiftTool, global: false).configuration
 
             // validate package location
             let packageDirectory = try self.globalOptions.locations.packageDirectory ?? swiftTool.getPackageRoot()

--- a/Sources/Workspace/Workspace+Configuration.swift
+++ b/Sources/Workspace/Workspace+Configuration.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2018-2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2018-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -605,7 +605,7 @@ extension Workspace.Configuration {
 
 extension Workspace.Configuration {
     public class Registries {
-        private let localRegistries: RegistriesStorage
+        private let localRegistries: RegistriesStorage?
         private let sharedRegistries: RegistriesStorage?
         private let fileSystem: FileSystem
 
@@ -624,14 +624,20 @@ extension Workspace.Configuration {
         /// - Parameters:
         ///   - fileSystem: The file system to use.
         ///   - localRegistriesFile: Path to the workspace registries configuration file
-        ///   - sharedRegistriesFile: Path to the shared registries configuration file, defaults to the standard location.
+        ///   - sharedRegistriesFile: Path to the shared registries configuration file,
+        ///                           defaults to the standard location.
         public init(
             fileSystem: FileSystem,
-            localRegistriesFile: AbsolutePath,
+            localRegistriesFile: AbsolutePath?,
             sharedRegistriesFile: AbsolutePath?
         ) throws {
+            // At least one of local or shared is required
+            if localRegistriesFile == nil, sharedRegistriesFile == nil {
+                throw StringError("No registries configuration provided")
+            }
+
             self.fileSystem = fileSystem
-            self.localRegistries = .init(path: localRegistriesFile, fileSystem: fileSystem)
+            self.localRegistries = localRegistriesFile.map { .init(path: $0, fileSystem: fileSystem) }
             self.sharedRegistries = sharedRegistriesFile.map { .init(path: $0, fileSystem: fileSystem) }
             try self.computeRegistries()
         }
@@ -640,7 +646,10 @@ extension Workspace.Configuration {
         public func updateLocal(with handler: (inout RegistryConfiguration) throws -> Void) throws
             -> RegistryConfiguration
         {
-            try self.localRegistries.update(with: handler)
+            guard let localRegistries else {
+                throw InternalError("local registries not configured")
+            }
+            try localRegistries.update(with: handler)
             try self.computeRegistries()
             return self.configuration
         }
@@ -667,8 +676,9 @@ extension Workspace.Configuration {
                     configuration.merge(sharedConfiguration)
                 }
 
-                let localConfiguration = try localRegistries.load()
-                configuration.merge(localConfiguration)
+                if let localConfiguration = try localRegistries?.load() {
+                    configuration.merge(localConfiguration)
+                }
 
                 self._configuration = configuration
             }
@@ -695,7 +705,9 @@ extension Workspace.Configuration {
                 let decoder = JSONDecoder.makeWithDefaults()
                 return try decoder.decode(path: self.path, fileSystem: self.fileSystem, as: RegistryConfiguration.self)
             } catch {
-                throw StringError("Failed loading registries configuration from '\(self.path)': \(error.interpolationDescription)")
+                throw StringError(
+                    "Failed loading registries configuration from '\(self.path)': \(error.interpolationDescription)"
+                )
             }
         }
 
@@ -744,7 +756,7 @@ public struct WorkspaceConfiguration {
 
     ///  Signing entity checking mode. Defaults to warn.
     public var signingEntityCheckingMode: CheckingMode
-    
+
     /// Whether to skip validating signature of signed packages downloaded from registry
     public var skipSignatureValidation: Bool
 


### PR DESCRIPTION
Motivation:
Certain `package-registry` subcommands, such as `set --global` and `login`, work with user-level `registries.json` only and therefore should not require workspace to run.

Modifications:
In those subcommands, do not read local `registries.json`.

rdar://113875867

