### PR TITLE
Commands: add missing dependency on LLBuildManifest

### DIFF
--- a/Sources/Commands/CMakeLists.txt
+++ b/Sources/Commands/CMakeLists.txt
@@ -50,6 +50,7 @@ target_link_libraries(Commands PUBLIC
   Basics
   Build
   CoreCommands
+  LLBuildManifest
   PackageGraph
   SourceControl
   TSCBasic


### PR DESCRIPTION
This corrects the missing dependency which happens to work currently due to overlinking.  While trying to improve the support for static linking on Windows, this missing dependency was exposed.