### PR TITLE
Fix backward compatibility in host triple checks

### DIFF
--- a/Sources/Basics/Triple+Basics.swift
+++ b/Sources/Basics/Triple+Basics.swift
@@ -114,14 +114,6 @@ extension Triple {
             )
         }
     }
-
-    public func isRuntimeCompatible(with triple: Triple) -> Bool {
-        guard self.isMacOSX, let version = self._macOSVersion, let comparedVersion = triple._macOSVersion else {
-            return self.tripleString == triple.tripleString
-        }
-
-        return version >= comparedVersion
-    }
 }
 
 extension Triple {

--- a/Sources/Basics/Triple+Basics.swift
+++ b/Sources/Basics/Triple+Basics.swift
@@ -115,7 +115,7 @@ extension Triple {
         }
     }
 
-    public func matches(_ triple: Triple) -> Bool {
+    public func isRuntimeCompatible(with triple: Triple) -> Bool {
         guard self.isMacOSX, let version = self._macOSVersion, let comparedVersion = triple._macOSVersion else {
             return self.tripleString == triple.tripleString
         }

--- a/Sources/Basics/Triple+Basics.swift
+++ b/Sources/Basics/Triple+Basics.swift
@@ -184,7 +184,8 @@ extension Triple {
         }
     }
 
-    public func isRuntimeCompatible(with triple: Triple) -> Bool {                        
+    /// Returns `true` if code compiled for `triple` can run on `self` value of ``Triple``.
+    public func isRuntimeCompatible(with triple: Triple) -> Bool {
         if
             self.arch == triple.arch &&
             self.vendor == triple.vendor &&

--- a/Sources/Basics/Triple+Basics.swift
+++ b/Sources/Basics/Triple+Basics.swift
@@ -183,6 +183,19 @@ extension Triple {
             return ".resources"
         }
     }
+
+    public func isRuntimeCompatible(with triple: Triple) -> Bool {                        
+        if
+            self.arch == triple.arch &&
+            self.vendor == triple.vendor &&
+            self.os == triple.os &&
+            self.environment == triple.environment
+        {
+            return self.osVersion >= triple.osVersion
+        } else {
+            return false
+        }
+    }
 }
 
 extension Triple: CustomStringConvertible {

--- a/Sources/Basics/Triple+Basics.swift
+++ b/Sources/Basics/Triple+Basics.swift
@@ -114,6 +114,14 @@ extension Triple {
             )
         }
     }
+
+    public func matches(_ triple: Triple) -> Bool {
+        guard self.isMacOSX, let version = self._macOSVersion, let comparedVersion = triple._macOSVersion else {
+            return self.tripleString == triple.tripleString
+        }
+
+        return version >= comparedVersion
+    }
 }
 
 extension Triple {

--- a/Sources/PackageModel/SwiftSDKBundle.swift
+++ b/Sources/PackageModel/SwiftSDKBundle.swift
@@ -428,8 +428,17 @@ extension [SwiftSDKBundle] {
         for bundle in self {
             for (artifactID, variants) in bundle.artifacts {
                 for variant in variants {
-                    guard variant.metadata.supportedTriples.contains(where: { 
-                        hostTriple.isRuntimeCompatible(with: $0) 
+                    guard variant.metadata.supportedTriples.contains(where: { variantTriple in
+                        if
+                            hostTriple.arch == variantTriple.arch &&
+                            hostTriple.vendor == variantTriple.vendor &&
+                            hostTriple.os == variantTriple.os &&
+                            hostTriple.environment == variantTriple.environment
+                        {
+                            return hostTriple.osVersion >= variantTriple.osVersion
+                        } else {
+                            return false
+                        }
                     }) else {
                         continue
                     }

--- a/Sources/PackageModel/SwiftSDKBundle.swift
+++ b/Sources/PackageModel/SwiftSDKBundle.swift
@@ -428,7 +428,9 @@ extension [SwiftSDKBundle] {
         for bundle in self {
             for (artifactID, variants) in bundle.artifacts {
                 for variant in variants {
-                    guard variant.metadata.supportedTriples.contains(where: { hostTriple.matches($0) }) else {
+                    guard variant.metadata.supportedTriples.contains(where: { 
+                        hostTriple.isRuntimeCompatible(with: $0) 
+                    }) else {
                         continue
                     }
 

--- a/Sources/PackageModel/SwiftSDKBundle.swift
+++ b/Sources/PackageModel/SwiftSDKBundle.swift
@@ -76,30 +76,30 @@ public struct SwiftSDKBundle {
     ///   - observabilityScope: observability scope to log warnings about multiple matches.
     /// - Returns: `Destination` value matching `query` either by artifact ID or target triple, `nil` if none found.
     public static func selectBundle(
-        fromBundlesAt destinationsDirectory: AbsolutePath?,
+        fromBundlesAt swiftSDKsDirectory: AbsolutePath?,
         fileSystem: FileSystem,
         matching selector: String,
         hostTriple: Triple,
         observabilityScope: ObservabilityScope
     ) throws -> SwiftSDK {
-        guard let destinationsDirectory else {
+        guard let swiftSDKsDirectory else {
             throw StringError(
                 """
-                No directory found for installed Swift SDKs, specify one
+                No directory found for installed Swift SDKs, specify one \
                 with `--experimental-swift-sdks-path` option.
                 """
             )
         }
 
         let validBundles = try SwiftSDKBundle.getAllValidBundles(
-            swiftSDKsDirectory: destinationsDirectory,
+            swiftSDKsDirectory: swiftSDKsDirectory,
             fileSystem: fileSystem,
             observabilityScope: observabilityScope
         )
 
         guard !validBundles.isEmpty else {
             throw StringError(
-                "No valid Swift SDK bundles found at \(destinationsDirectory)."
+                "No valid Swift SDK bundles found at \(swiftSDKsDirectory)."
             )
         }
 
@@ -110,8 +110,8 @@ public struct SwiftSDKBundle {
         ) else {
             throw StringError(
                 """
-                No Swift SDK found matching query `\(selector)` and host triple
-                `\(hostTriple.tripleString)`. Use `swift experimental-sdk list` command to see
+                No Swift SDK found matching query `\(selector)` and host triple \
+                `\(hostTriple.tripleString)`. Use `swift experimental-sdk list` command to see \
                 available destinations.
                 """
             )
@@ -428,7 +428,7 @@ extension [SwiftSDKBundle] {
         for bundle in self {
             for (artifactID, variants) in bundle.artifacts {
                 for variant in variants {
-                    guard variant.metadata.supportedTriples.contains(hostTriple) else {
+                    guard variant.metadata.supportedTriples.contains(where: { hostTriple.matches($0) }) else {
                         continue
                     }
 

--- a/Sources/PackageModel/SwiftSDKBundle.swift
+++ b/Sources/PackageModel/SwiftSDKBundle.swift
@@ -429,16 +429,7 @@ extension [SwiftSDKBundle] {
             for (artifactID, variants) in bundle.artifacts {
                 for variant in variants {
                     guard variant.metadata.supportedTriples.contains(where: { variantTriple in
-                        if
-                            hostTriple.arch == variantTriple.arch &&
-                            hostTriple.vendor == variantTriple.vendor &&
-                            hostTriple.os == variantTriple.os &&
-                            hostTriple.environment == variantTriple.environment
-                        {
-                            return hostTriple.osVersion >= variantTriple.osVersion
-                        } else {
-                            return false
-                        }
+                        hostTriple.isRuntimeCompatible(with: variantTriple)
                     }) else {
                         continue
                     }

--- a/Tests/BasicsTests/TripleTests.swift
+++ b/Tests/BasicsTests/TripleTests.swift
@@ -165,4 +165,11 @@ final class TripleTests: XCTestCase {
         XCTAssertTriple("x86_64-unknown-windows-msvc", matches: (.x86_64, nil, nil, .win32, .msvc, .coff))
         XCTAssertTriple("wasm32-unknown-wasi", matches: (.wasm32, nil, nil, .wasi, nil, .wasm))
     }
+
+    func testIsRuntimeCompatibleWith() throws {
+        try XCTAssertTrue(Triple("x86_64-apple-macosx").isRuntimeCompatible(with: Triple("x86_64-apple-macosx")))
+        try XCTAssertTrue(Triple("x86_64-unknown-linux").isRuntimeCompatible(with: Triple("x86_64-unknown-linux")))
+        try XCTAssertFalse(Triple("x86_64-apple-macosx").isRuntimeCompatible(with: Triple("x86_64-apple-linux")))
+        try XCTAssertTrue(Triple("x86_64-apple-macosx14.0").isRuntimeCompatible(with: Triple("x86_64-apple-macosx13.0")))
+    }
 }


### PR DESCRIPTION
When setting host triple in Swift SDKs to `arm64-apple-macosx13.0` to allow cross-compiling from an older version of macOS, this triple is not recognized as directly matching `arm64-apple-macosx14.0` on a newer version of macOS.

We should support backward compatibility with Swift SDKs that were built for older version of macOS.

Resolves rdar://113967401.