### PR TITLE
Fix cancellation test

### DIFF
--- a/Tests/BasicsTests/CancellatorTests.swift
+++ b/Tests/BasicsTests/CancellatorTests.swift
@@ -82,7 +82,7 @@ final class CancellatorTests: XCTestCase {
                     try process.launch()
                     let result = try process.waitUntilExit()
                     print("process finished")
-                    XCTAssertEqual(result.exitStatus, .signalled(signal: SIGINT))
+                    XCTAssertTrue([.signalled(signal: SIGINT), .signalled(signal: SIGKILL)].contains(result.exitStatus), "unexpected exit status: \(result.exitStatus)")
                 } catch {
                     XCTFail("failed launching process: \(error)")
                 }


### PR DESCRIPTION
I regularly see this test failing because it terminates with SIGKILL instead of SIGINT, but looking at the code that seems totally normal. It seems as if that just means the process didn't terminate fast enough which does not seem to indicate an issue with the cancellation to me.
