### PR TITLE
Fix `AbsolutePath` not escaped in `SerializedJSON`

### DIFF
--- a/Sources/Basics/FileSystem/NativePathExtensions.swift
+++ b/Sources/Basics/FileSystem/NativePathExtensions.swift
@@ -35,6 +35,6 @@ extension DefaultStringInterpolation {
 
 extension SerializedJSON.StringInterpolation {
     public mutating func appendInterpolation(_ value: AbsolutePath) {
-        self.appendInterpolation(value._nativePathString(escaped: false))
+        self.appendInterpolation(value._nativePathString(escaped: true))
     }
 }


### PR DESCRIPTION
`SerializedJSON` type was created specifically for escaping `AbsolutePath` in testing code, but this argument was set to an incorrect `false` value passed to the `escape` function.

This only impacts testing code, which as far as I'm aware was no exposed to this bug yet.