### PR TITLE
[NFC] Remove unused parameter from pvt. method in `LLBuildManifestBuilder.swift`

### DIFF
--- a/Sources/Build/LLBuildManifestBuilder.swift
+++ b/Sources/Build/LLBuildManifestBuilder.swift
@@ -262,7 +262,6 @@ extension LLBuildManifestBuilder {
             try self.addSwiftCmdsViaIntegratedDriver(
                 target,
                 inputs: inputs,
-                objectNodes: objectNodes,
                 moduleNode: moduleNode
             )
         } else {
@@ -276,7 +275,6 @@ extension LLBuildManifestBuilder {
     private func addSwiftCmdsViaIntegratedDriver(
         _ target: SwiftTargetBuildDescription,
         inputs: [Node],
-        objectNodes: [Node],
         moduleNode: Node
     ) throws {
         // Use the integrated Swift driver to compute the set of frontend


### PR DESCRIPTION
Remove unused parameter from method signature

### Motivation:

Noticed this while working on https://github.com/apple/swift-package-manager/pull/5919.

It looks like it's been unused since at least 2020 (https://github.com/apple/swift-package-manager/commit/1f1e909013bd2886ac86acd8ed8d5e219a953e82)

### Modifications:

Remove unused `objectNodes` parameter from private `addSwiftCmdsViaIntegratedDriver` method

### Result:

NFC. Just minor code cleanup.
