### PR TITLE
Preserve environment in `tripleString(forPlatformVersion:)`

### DIFF
--- a/Sources/Basics/Triple+Basics.swift
+++ b/Sources/Basics/Triple+Basics.swift
@@ -64,13 +64,11 @@ extension Triple {
     /// This is currently meant for Apple platforms only.
     public func tripleString(forPlatformVersion version: String) -> String {
         precondition(isDarwin())
-        // This function did not handle triples with a specific environments and
-        // object formats previously to using SwiftDriver.Triple and still does
-        // not.
         return """
             \(self.archName)-\
             \(self.vendorName)-\
-            \(self.osNameUnversioned)\(version)
+            \(self.osNameUnversioned)\(version)\
+            \(self.environmentName.isEmpty ? "" : "-\(self.environmentName)")
             """
     }
 

--- a/Tests/BasicsTests/TripleTests.swift
+++ b/Tests/BasicsTests/TripleTests.swift
@@ -122,6 +122,12 @@ final class TripleTests: XCTestCase {
 
         XCTAssertTriple("mips-apple-darwin19", forPlatformVersion: "", is: "mips-apple-darwin")
         XCTAssertTriple("mips-apple-darwin19", forPlatformVersion: "22", is: "mips-apple-darwin22")
+
+        XCTAssertTriple("arm64-apple-ios-simulator", forPlatformVersion: "", is: "arm64-apple-ios-simulator")
+        XCTAssertTriple("arm64-apple-ios-simulator", forPlatformVersion: "13.0", is: "arm64-apple-ios13.0-simulator")
+
+        XCTAssertTriple("arm64-apple-ios12-simulator", forPlatformVersion: "", is: "arm64-apple-ios-simulator")
+        XCTAssertTriple("arm64-apple-ios12-simulator", forPlatformVersion: "13.0", is: "arm64-apple-ios13.0-simulator")
     }
 
     func testKnownTripleParsing() {


### PR DESCRIPTION
Preserve the `environmentName` part of triples when altering the OS version with `Triple.tripleString(forPlatformVersion:)`

### Motivation:

Building for the iOS simulator (and presumably anything other triple with a fourth component) would fail because we would generate the wrong swiftc/clang `-target`, incorrectly excluding the `Triple.environmentName`.

### Modifications:

- Modify `tripleString(forPlatformVersion:)` to include `self.environmentName` if it is non-empty.

### Result:

You can now build for the iOS simulator with
```shell
swift build --triple arm64-apple-ios-simulator --sdk "$(xcrun --sdk iphonesimulator --show-sdk-path)"
```

or if you also pull #6828, just
```shell
swift build --triple arm64-apple-ios-simulator
```