### PR TITLE
Tests: adjust the tests for path spellings

### DIFF
--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -1197,6 +1197,9 @@ class PackageGraphTests: XCTestCase {
             "/Bar/Sources/Bar/bar.swift",
             "/Baz/Sources/Baz/baz.swift"
         )
+        let fooPkg: AbsolutePath = "/Foo"
+        let barPkg: AbsolutePath = "/Bar"
+        let bazPkg: AbsolutePath = "/Baz"
 
         let observability = ObservabilitySystem.makeForTesting()
         XCTAssertThrowsError(try loadPackageGraph(
@@ -1204,17 +1207,17 @@ class PackageGraphTests: XCTestCase {
             manifests: [
                 Manifest.createRootManifest(
                     displayName: "Foo",
-                    path: "/Foo",
+                    path: fooPkg,
                     dependencies: [
-                        .localSourceControl(path: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
-                        .localSourceControl(path: "/Baz", requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: barPkg, requirement: .upToNextMajor(from: "1.0.0")),
+                        .localSourceControl(path: bazPkg, requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Bar"]),
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "Bar",
-                    path: "/Bar",
+                    path: barPkg,
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
                     ],
@@ -1223,7 +1226,7 @@ class PackageGraphTests: XCTestCase {
                     ]),
                 Manifest.createFileSystemManifest(
                     displayName: "Baz",
-                    path: "/Baz",
+                    path: bazPkg,
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Baz"])
                     ],
@@ -1233,7 +1236,8 @@ class PackageGraphTests: XCTestCase {
             ],
             observabilityScope: observability.topScope
         )) { error in
-            XCTAssertEqual((error as? PackageGraphError)?.description, "multiple products named 'Bar' in: 'bar' (at '/Bar'), 'baz' (at '/Baz')")
+            XCTAssertEqual((error as? PackageGraphError)?.description,
+                           "multiple products named 'Bar' in: 'bar' (at '\(barPkg)'), 'baz' (at '\(bazPkg)')")
         }
     }
 
@@ -1506,7 +1510,7 @@ class PackageGraphTests: XCTestCase {
         let pinsFile = AbsolutePath("/pins")
         try fs.writeFileContents(pinsFile, string: json)
 
-        XCTAssertThrows(StringError("/pins file is corrupted or malformed; fix or delete the file to continue: duplicated entry for package \"yams\""), {
+        XCTAssertThrows(StringError("\(pinsFile) file is corrupted or malformed; fix or delete the file to continue: duplicated entry for package \"yams\""), {
             _ = try PinsStore(pinsFile: pinsFile, workingDirectory: .root, fileSystem: fs, mirrors: .init())
         })
     }


### PR DESCRIPTION
Tweak the expectations to account for the path component separator on Windows.  This improves the test coverage on Windows.