### PR TITLE
Implement `swift-get-version` in SwiftPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -666,6 +666,13 @@ if ProcessInfo.processInfo.environment["SWIFTCI_DISABLE_SDK_DEPENDENT_TESTS"] ==
             ]
         ),
 
+        .executableTarget(
+            name: "dummy-swiftc",
+            dependencies: [
+                "Basics",
+            ]
+        ),
+
         .testTarget(
             name: "CommandsTests",
             dependencies: [
@@ -681,6 +688,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_DISABLE_SDK_DEPENDENT_TESTS"] ==
                 "SourceControl",
                 "SPMTestSupport",
                 "Workspace",
+                "dummy-swiftc",
             ]
         ),
     ])

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -473,9 +473,11 @@ public final class BuildExecutionContext {
 final class WriteAuxiliaryFileCommand: CustomLLBuildCommand {
     override func getSignature(_ command: SPMLLBuild.Command) -> [UInt8] {
         guard let buildDescription = self.context.buildDescription else {
+            self.context.observabilityScope.emit(error: "unknown build description")
             return []
         }
-        guard let tool = buildDescription.copyCommands[command.name] else {
+        guard let tool = buildDescription.writeCommands[command.name] else {
+            self.context.observabilityScope.emit(error: "command \(command.name) not registered")
             return []
         }
 

--- a/Sources/LLBuildManifest/ManifestWriter.swift
+++ b/Sources/LLBuildManifest/ManifestWriter.swift
@@ -72,6 +72,10 @@ public struct ManifestWriter {
             manifestToolWriter["inputs"] = tool.inputs
             manifestToolWriter["outputs"] = tool.outputs
 
+            if tool.alwaysOutOfDate {
+                manifestToolWriter["always-out-of-date"] = "true"
+            }
+
             tool.write(to: manifestToolWriter)
 
             stream.send("\n")

--- a/Sources/LLBuildManifest/Tools.swift
+++ b/Sources/LLBuildManifest/Tools.swift
@@ -17,6 +17,9 @@ public protocol ToolProtocol: Codable {
     /// The name of the tool.
     static var name: String { get }
 
+    /// Whether or not the tool should run on every build instead of using dependency tracking.
+    var alwaysOutOfDate: Bool { get }
+
     /// The list of inputs to declare.
     var inputs: [Node] { get }
 
@@ -28,6 +31,8 @@ public protocol ToolProtocol: Codable {
 }
 
 extension ToolProtocol {
+    public var alwaysOutOfDate: Bool { return false }
+
     public func write(to stream: ManifestToolStream) {}
 }
 
@@ -155,10 +160,12 @@ public struct WriteAuxiliaryFile: ToolProtocol {
 
     public let inputs: [Node]
     private let outputFilePath: AbsolutePath
+    public let alwaysOutOfDate: Bool
 
-    public init(inputs: [Node], outputFilePath: AbsolutePath) {
+    public init(inputs: [Node], outputFilePath: AbsolutePath, alwaysOutOfDate: Bool = false) {
         self.inputs = inputs
         self.outputFilePath = outputFilePath
+        self.alwaysOutOfDate = alwaysOutOfDate
     }
 
     public var outputs: [Node] {

--- a/Sources/SPMTestSupport/SwiftPMProduct.swift
+++ b/Sources/SPMTestSupport/SwiftPMProduct.swift
@@ -46,14 +46,18 @@ extension SwiftPM {
 
     /// Path to currently built binary.
     public var path: AbsolutePath {
+        return Self.testBinaryPath(for: self.executableName)
+    }
+
+    public static func testBinaryPath(for executableName: RelativePath) -> AbsolutePath {
         #if canImport(Darwin)
         for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
-            return try! AbsolutePath(AbsolutePath(validating: bundle.bundlePath).parentDirectory, self.executableName)
+            return try! AbsolutePath(AbsolutePath(validating: bundle.bundlePath).parentDirectory, executableName)
         }
         fatalError()
         #else
         return try! AbsolutePath(validating: CommandLine.arguments.first!, relativeTo: localFileSystem.currentWorkingDirectory!)
-            .parentDirectory.appending(self.executableName)
+            .parentDirectory.appending(executableName)
         #endif
     }
 }

--- a/Sources/dummy-swiftc/main.swift
+++ b/Sources/dummy-swiftc/main.swift
@@ -1,0 +1,27 @@
+// This program can be used as `swiftc` in order to influence `-version` output
+
+import Foundation
+
+import class TSCBasic.Process
+
+let info = ProcessInfo.processInfo
+let env = info.environment
+
+if info.arguments.last == "-version" {
+    if let customSwiftVersion = env["CUSTOM_SWIFT_VERSION"] {
+        print(customSwiftVersion)
+    } else {
+        print("999.0")
+    }
+} else {
+    let swiftPath: String
+    if let swiftOriginalPath = env["SWIFT_ORIGINAL_PATH"] {
+        swiftPath = swiftOriginalPath
+    } else {
+        swiftPath = "/usr/bin/swiftc"
+    }
+
+    let result = try Process.popen(arguments: [swiftPath] + info.arguments.dropFirst())
+    print(try result.utf8Output())
+    print(try result.utf8stderrOutput())
+}

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -867,8 +867,9 @@ final class BuildPlanTests: XCTestCase {
             let llbuild = LLBuildManifestBuilder(plan, fileSystem: fs, observabilityScope: observability.topScope)
             try llbuild.generateManifest(at: yaml)
             let contents: String = try fs.readFileContents(yaml)
+            let swiftGetVersionFilePath = try XCTUnwrap(llbuild.swiftGetVersionFiles.first?.value)
             XCTAssertMatch(contents, .contains("""
-                    inputs: ["\(Pkg.appending(components: "Sources", "exe", "main.swift").escapedPathString())","\(buildPath.appending(components: "PkgLib.swiftmodule").escapedPathString())","\(buildPath.appending(components: "exe.build", "sources").escapedPathString())"]
+                    inputs: ["\(Pkg.appending(components: "Sources", "exe", "main.swift").escapedPathString())","\(swiftGetVersionFilePath.escapedPathString())","\(buildPath.appending(components: "PkgLib.swiftmodule").escapedPathString())","\(buildPath.appending(components: "exe.build", "sources").escapedPathString())"]
                 """))
 
         }
@@ -896,8 +897,9 @@ final class BuildPlanTests: XCTestCase {
             try llbuild.generateManifest(at: yaml)
             let contents: String = try fs.readFileContents(yaml)
             let buildPath = plan.buildParameters.dataPath.appending(components: "debug")
+            let swiftGetVersionFilePath = try XCTUnwrap(llbuild.swiftGetVersionFiles.first?.value)
             XCTAssertMatch(contents, .contains("""
-                    inputs: ["\(Pkg.appending(components: "Sources", "exe", "main.swift").escapedPathString())","\(buildPath.appending(components: "exe.build", "sources").escapedPathString())"]
+                    inputs: ["\(Pkg.appending(components: "Sources", "exe", "main.swift").escapedPathString())","\(swiftGetVersionFilePath.escapedPathString())","\(buildPath.appending(components: "exe.build", "sources").escapedPathString())"]
                 """))
         }
     }
@@ -3894,6 +3896,7 @@ final class BuildPlanTests: XCTestCase {
         let llbuild = LLBuildManifestBuilder(plan, fileSystem: fs, observabilityScope: observability.topScope)
         try llbuild.generateManifest(at: yaml)
         let contents: String = try fs.readFileContents(yaml)
+        let swiftGetVersionFilePath = try XCTUnwrap(llbuild.swiftGetVersionFiles.first?.value)
 
 #if os(Windows)
         let suffix = ".exe"
@@ -3901,7 +3904,7 @@ final class BuildPlanTests: XCTestCase {
         let suffix = ""
 #endif
         XCTAssertMatch(contents, .contains("""
-                inputs: ["\(PkgA.appending(components: "Sources", "swiftlib", "lib.swift").escapedPathString())","\(buildPath.appending(components: "exe\(suffix)").escapedPathString())","\(buildPath.appending(components: "swiftlib.build", "sources").escapedPathString())"]
+                inputs: ["\(PkgA.appending(components: "Sources", "swiftlib", "lib.swift").escapedPathString())","\(swiftGetVersionFilePath.escapedPathString())","\(buildPath.appending(components: "exe\(suffix)").escapedPathString())","\(buildPath.appending(components: "swiftlib.build", "sources").escapedPathString())"]
                 outputs: ["\(buildPath.appending(components: "swiftlib.build", "lib.swift.o").escapedPathString())","\(buildPath.escapedPathString())
             """))
     }
@@ -4804,10 +4807,11 @@ final class BuildPlanTests: XCTestCase {
         let yaml = buildPath.appending("release.yaml")
         let llbuild = LLBuildManifestBuilder(plan, fileSystem: fs, observabilityScope: observability.topScope)
         try llbuild.generateManifest(at: yaml)
+        let swiftGetVersionFilePath = try XCTUnwrap(llbuild.swiftGetVersionFiles.first?.value)
 
         let yamlContents: String = try fs.readFileContents(yaml)
         let inputs: SerializedJSON = """
-            inputs: ["\(AbsolutePath("/Pkg/Snippets/ASnippet.swift"))","\(AbsolutePath("/Pkg/.build/debug/Lib.swiftmodule"))"
+            inputs: ["\(AbsolutePath("/Pkg/Snippets/ASnippet.swift"))","\(swiftGetVersionFilePath.escapedPathString())","\(AbsolutePath("/Pkg/.build/debug/Lib.swiftmodule"))"
         """
         XCTAssertMatch(yamlContents, .contains(inputs.underlying))
     }

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -400,4 +400,53 @@ final class BuildToolTests: CommandsTestCase {
             }
         }
     }
+
+    func testSwiftGetVersion() throws {
+        try fixture(name: "Miscellaneous/Simple") { fixturePath in
+            func findSwiftGetVersionFile() throws -> AbsolutePath {
+                let buildArenaPath = fixturePath.appending(components: ".build", "debug")
+                let files = try localFileSystem.getDirectoryContents(buildArenaPath)
+                let filename = try XCTUnwrap(files.first { $0.hasPrefix("swift-version") })
+                return buildArenaPath.appending(component: filename)
+            }
+
+            let dummySwiftcPath = SwiftPM.testBinaryPath(for: "dummy-swiftc")
+            let swiftCompilerPath = try UserToolchain.default.swiftCompilerPath
+
+            var environment = [
+                "SWIFT_EXEC": dummySwiftcPath.pathString,
+                // Environment variables used by `dummy-swiftc.sh`
+                "SWIFT_ORIGINAL_PATH": swiftCompilerPath.pathString,
+                "CUSTOM_SWIFT_VERSION": "1.0",
+            ]
+
+            // Build with a swiftc that returns version 1.0, we expect a successful build which compiles our one source file.
+            do {
+                let result = try execute(["--verbose"], environment: environment, packagePath: fixturePath)
+                XCTAssertTrue(result.stdout.contains("\(dummySwiftcPath.pathString) -module-name"), "compilation task missing from build result: \(result.stdout)")
+                XCTAssertTrue(result.stdout.contains("Build complete!"), "unexpected build result: \(result.stdout)")
+                let swiftGetVersionFilePath = try findSwiftGetVersionFile()
+                XCTAssertEqual(try String(contentsOfFile: swiftGetVersionFilePath.pathString).spm_chomp(), "1.0")
+            }
+
+            // Build again with that same version, we do not expect any compilation tasks.
+            do {
+                let result = try execute(["--verbose"], environment: environment, packagePath: fixturePath)
+                XCTAssertFalse(result.stdout.contains("\(dummySwiftcPath.pathString) -module-name"), "compilation task present in build result: \(result.stdout)")
+                XCTAssertTrue(result.stdout.contains("Build complete!"), "unexpected build result: \(result.stdout)")
+                let swiftGetVersionFilePath = try findSwiftGetVersionFile()
+                XCTAssertEqual(try String(contentsOfFile: swiftGetVersionFilePath.pathString).spm_chomp(), "1.0")
+            }
+
+            // Build again with a swiftc that returns version 2.0, we expect compilation happening once more.
+            do {
+                environment["CUSTOM_SWIFT_VERSION"] = "2.0"
+                let result = try execute(["--verbose"], environment: environment, packagePath: fixturePath)
+                XCTAssertTrue(result.stdout.contains("\(dummySwiftcPath.pathString) -module-name"), "compilation task missing from build result: \(result.stdout)")
+                XCTAssertTrue(result.stdout.contains("Build complete!"), "unexpected build result: \(result.stdout)")
+                let swiftGetVersionFilePath = try findSwiftGetVersionFile()
+                XCTAssertEqual(try String(contentsOfFile: swiftGetVersionFilePath.pathString).spm_chomp(), "2.0")
+            }
+        }
+    }
 }


### PR DESCRIPTION
The changes in #6585 meant that we are no longer using LLBuild's built-in tracking of Swift compiler versions. We are lacking the infrastructure to really use that for the same purpose since we are now running the Swift compiler as a shell-tool, so this is adding a poor man's version of that.

We have a task that writes the output of `swift -version` for a particular Swift compiler path to the build directory and all Swift tasks that are using that compiler depend on that file as an input. This should give us the desired behavior of the tasks re-running if the Swift version changes.

rdar://114047018
