### PR TITLE
Diagnose invalid module alias

### DIFF
--- a/Sources/PackageGraph/ModuleAliasTracker.swift
+++ b/Sources/PackageGraph/ModuleAliasTracker.swift
@@ -284,7 +284,7 @@ class ModuleAliasTracker {
         for aliasList in aliasMap.values {
             for productAlias in aliasList {
                 if !appliedAliases.contains(productAlias.name) {
-                    observabilityScope.emit(warning: "module alias for target '\(productAlias.name)', declared in '\(productAlias.consumingPackage)', does not match any recursive target dependency of '\(productAlias.productName)' from '\(productAlias.originPackage)'")
+                    observabilityScope.emit(warning: "module alias for target '\(productAlias.name)', declared in package '\(productAlias.consumingPackage)', does not match any recursive target dependency of product '\(productAlias.productName)' from package '\(productAlias.originPackage)'")
                 }
             }
         }

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -799,6 +799,10 @@ private func resolveModuleAliases(packageBuilders: [ResolvedPackageBuilder],
                                                      observabilityScope: observabilityScope)
         }
     }
+
+    // Emit diagnostics for any module aliases that did not end up being applied.
+    aliasTracker.diagnoseUnappliedAliases(observabilityScope: observabilityScope)
+
     return true
 }
 


### PR DESCRIPTION
Declaring a module alias for a target that isn't a recursive dependency of the product the alias is being defined for doesn't actually work, instead it gets silently skipped. This adds a diagnostic for this case.

I don't know if this scenario *should* work, but it doesn't in practice, so even if it is supposed to, a diagnostic seems better than nothing.

Separately, it seems problematic that the `duplicateModule` diagnostic contains a completely context-free suggestion to use module aliases. This leads to the very confusing outcome that it is being suggested in this particular case which cannot be resolved using a module alias.

rdar://114200576
