### PR TITLE
[5.9.0] Remove <toolchain>/usr/bin/../lib/ from directories passed to linker to look up libraries for target triple

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -105,5 +105,5 @@ Valeriy Van <valeriy.van@enote.com> <valeriy.van@enote.com>
 Valeriy Van <valeriy.van@enote.com> <github@w7software.com>
 therealbnut <andrew.charles.bennett@gmail.com> <andrew.charles.bennett@gmail.com>
 therealbnut <andrew.charles.bennett@gmail.com> <635596+therealbnut@users.noreply.github.com>
-buttaface <butta@fastem.com> <butta@fastem.com>
-buttaface <butta@fastem.com> <repo@butta.fastem.com>
+finagolfin <butta@fastem.com> <butta@fastem.com>
+finagolfin <butta@fastem.com> <repo@butta.fastem.com>

--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -321,14 +321,6 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
             args += ["-L", librarySearchPath.pathString]
         }
 
-        // Add toolchain's libdir at the very end (even after the user -Xlinker arguments).
-        //
-        // This will allow linking to libraries shipped in the toolchain.
-        let toolchainLibDir = try buildParameters.toolchain.toolchainLibDir
-        if self.fileSystem.isDirectory(toolchainLibDir) {
-            args += ["-L", toolchainLibDir.pathString]
-        }
-
         // Library search path for the toolchain's copy of SwiftSyntax.
         #if BUILD_MACROS_AS_DYLIBS
         if product.type == .macro {

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -3409,11 +3409,8 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testExtraBuildFlags() throws {
-        let libpath = AbsolutePath("/fake/path/lib")
-
         let fs = InMemoryFileSystem(emptyFiles:
             "/A/Sources/exe/main.swift",
-            libpath.appending(components: "libSomething.dylib").pathString,
             "<end>"
         )
 
@@ -3444,7 +3441,7 @@ final class BuildPlanTests: XCTestCase {
         ))
 
         let exe = try result.buildProduct(for: "exe").linkArguments()
-        XCTAssertMatch(exe, [.anySequence, "-L", "/path/to/foo", "-L/path/to/foo", "-Xlinker", "-rpath=foo", "-Xlinker", "-rpath", "-Xlinker", "foo", "-L", "\(libpath)"])
+        XCTAssertMatch(exe, [.anySequence, "-L", "/path/to/foo", "-L/path/to/foo", "-Xlinker", "-rpath=foo", "-Xlinker", "-rpath", "-Xlinker", "foo"])
     }
 
     func testUserToolchainCompileFlags() throws {


### PR DESCRIPTION
Cherrypick of #6824

__Explanation:__ This host-specific toolchain directory was added years ago in #2035 to the list of library directories, but it can cause problems when cross-compiling.

__Scope:__ Right now, nothing is placed in this directory, so remove it before it can cause problems.

__Issue:__ #6767

__Risk:__ low, as nothing relies on it yet

__Testing:__ Passed all CI and I've removed it for my native Android builds of the toolchain for the last four months, without a problem.

__Reviewer:__ @neonichu