### PR TITLE
FileList should conform to Collection

### DIFF
--- a/Sources/PackagePlugin/PackageModel.swift
+++ b/Sources/PackagePlugin/PackageModel.swift
@@ -400,22 +400,11 @@ public struct FileList {
         self.files = files
     }
 }
-extension FileList: Sequence {
-    public struct Iterator: IteratorProtocol {
-        private var files: ArraySlice<File>
-        fileprivate init(files: ArraySlice<File>) {
-            self.files = files
-        }
-        mutating public func next() -> File? {
-            guard let nextInfo = self.files.popFirst() else {
-                return nil
-            }
-            return nextInfo
-        }
-    }
-    public func makeIterator() -> Iterator {
-        return Iterator(files: ArraySlice(self.files))
-    }
+
+extension FileList: RandomAccessCollection {
+    public var startIndex: Int { 0 }
+    public var endIndex: Int { files.endIndex }
+    public subscript(i: Int) -> File { files[i] }
 }
 
 /// Provides information about a single file in a FileList.

--- a/Sources/PackagePlugin/PackageModel.swift
+++ b/Sources/PackagePlugin/PackageModel.swift
@@ -400,7 +400,25 @@ public struct FileList {
         self.files = files
     }
 }
+extension FileList: Sequence {
+    public struct Iterator: IteratorProtocol {
+        private var files: ArraySlice<File>
+        fileprivate init(files: ArraySlice<File>) {
+            self.files = files
+        }
+        mutating public func next() -> File? {
+            guard let nextInfo = self.files.popFirst() else {
+                return nil
+            }
+            return nextInfo
+        }
+    }
+    public func makeIterator() -> Iterator {
+        return Iterator(files: ArraySlice(self.files))
+    }
+}
 
+@available(_PackageDescription, introduced: 999.0)
 extension FileList: RandomAccessCollection {
     public var startIndex: Int { 0 }
     public var endIndex: Int { files.endIndex }

--- a/Sources/PackagePlugin/PackageModel.swift
+++ b/Sources/PackagePlugin/PackageModel.swift
@@ -418,7 +418,7 @@ extension FileList: Sequence {
     }
 }
 
-@available(_PackageDescription, introduced: 999.0)
+@available(_PackageDescription, introduced: 5.10)
 extension FileList: RandomAccessCollection {
     public var startIndex: Int { 0 }
     public var endIndex: Int { files.endIndex }


### PR DESCRIPTION
It's a little perverse that I can't even ask if the `FileList` `isEmpty`—currently I'm doing `.contains(where: {_ in true})` and `RandomAccessCollection` conformance is even simpler to achieve than `Sequence` conformance.  If you really don't want to expose `RandomAccessCollection` conformance to preserve your ability to change the representation arbitrarily, at *least* make it conform to `Collection`, since it is multi-pass.
