### PR TITLE
Qualify use of `fatalError` with `Swift`

### DIFF
--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -353,7 +353,8 @@ public final class SwiftTargetBuildDescription {
                     let preferredBundle = Bundle(path: mainPath)
 
                     guard let bundle = preferredBundle ?? Bundle(path: buildPath) else {
-                        fatalError("could not load resource bundle: from \\(mainPath) or \\(buildPath)")
+                        // Users can write a function called fatalError themselves, we should be resilient against that.
+                        Swift.fatalError("could not load resource bundle: from \\(mainPath) or \\(buildPath)")
                     }
 
                     return bundle


### PR DESCRIPTION
Users can write a function called `fatalError` themselves, we should be resilient against that.

resolves https://github.com/apple/swift/issues/68105
resolves #6846
