### PR TITLE
Rely on resolved revision for branch dependencies

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -2603,8 +2603,8 @@ extension Workspace {
                     return .never
                 } else {
                     switch pin.state {
-                    case .branch:
-                        return .always
+                    case .branch(_, let revision):
+                        return .ifNeeded(revision: revision)
                     case .revision(let revision):
                         return .ifNeeded(revision: revision)
                     case .version(_, let .some(revision)):


### PR DESCRIPTION
We should rely on the resolved file being accurate for branch dependencies as well since we will not update the revision outside of `swift package update` anyway.
