### PR TITLE
Reduce XCTest minimum deployment target computation

### DIFF
--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -269,7 +269,7 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
             // back-deployed concurrency libraries.
             if useStdlibRpath, self.buildParameters.targetTriple.isMacOSX
             {
-                let macOSSupportedPlatform = self.package.platforms.getDerived(for: .macOS, usingXCTest: product.type == .test)
+                let macOSSupportedPlatform = self.package.platforms.getDerived(for: .macOS, usingXCTest: product.isLinkingXCTest)
                 if macOSSupportedPlatform.version.major < 12 {
                     let backDeployedStdlib = try buildParameters.toolchain.macosSwiftStdlib
                         .parentDirectory

--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -267,16 +267,17 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
 
             // When deploying to macOS prior to macOS 12, add an rpath to the
             // back-deployed concurrency libraries.
-            if useStdlibRpath, self.buildParameters.targetTriple.isMacOSX,
-               let macOSSupportedPlatform = self.package.platforms.getDerived(for: .macOS),
-               macOSSupportedPlatform.version.major < 12
+            if useStdlibRpath, self.buildParameters.targetTriple.isMacOSX
             {
-                let backDeployedStdlib = try buildParameters.toolchain.macosSwiftStdlib
-                    .parentDirectory
-                    .parentDirectory
-                    .appending("swift-5.5")
-                    .appending("macosx")
-                args += ["-Xlinker", "-rpath", "-Xlinker", backDeployedStdlib.pathString]
+                let macOSSupportedPlatform = self.package.platforms.getDerived(for: .macOS, usingXCTest: product.type == .test)
+                if macOSSupportedPlatform.version.major < 12 {
+                    let backDeployedStdlib = try buildParameters.toolchain.macosSwiftStdlib
+                        .parentDirectory
+                        .parentDirectory
+                        .appending("swift-5.5")
+                        .appending("macosx")
+                    args += ["-Xlinker", "-rpath", "-Xlinker", backDeployedStdlib.pathString]
+                }
             }
         }
 

--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -267,8 +267,7 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
 
             // When deploying to macOS prior to macOS 12, add an rpath to the
             // back-deployed concurrency libraries.
-            if useStdlibRpath, self.buildParameters.targetTriple.isMacOSX
-            {
+            if useStdlibRpath, self.buildParameters.targetTriple.isMacOSX {
                 let macOSSupportedPlatform = self.package.platforms.getDerived(for: .macOS, usingXCTest: product.isLinkingXCTest)
                 if macOSSupportedPlatform.version.major < 12 {
                     let backDeployedStdlib = try buildParameters.toolchain.macosSwiftStdlib

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -569,8 +569,8 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
     ) throws {
         // Supported platforms are defined at the package level.
         // This will need to become a bit complicated once we have target-level or product-level platform support.
-        let productPlatform = product.platforms.getDerived(for: .macOS, usingXCTest: product.type == .test)
-        let targetPlatform = target.platforms.getDerived(for: .macOS, usingXCTest: product.type == .test)
+        let productPlatform = product.platforms.getDerived(for: .macOS, usingXCTest: product.isLinkingXCTest)
+        let targetPlatform = target.platforms.getDerived(for: .macOS, usingXCTest: product.isLinkingXCTest)
 
         // Check if the version requirement is satisfied.
         //

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -292,7 +292,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
                     target: discoveryTarget,
                     dependencies: testProduct.targets.map { .target($0, conditions: []) },
                     defaultLocalization: .none, // safe since this is a derived target
-                    platforms: .init(declared: [], deriveXCTestPlatform: { _ in nil }) // safe since this is a derived target
+                    platforms: .init(declared: [], deriveXCTestPlatform: nil) // safe since this is a derived target
                 )
                 let discoveryTargetBuildDescription = try SwiftTargetBuildDescription(
                     package: package,
@@ -325,7 +325,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
                     target: entryPointTarget,
                     dependencies: testProduct.targets.map { .target($0, conditions: []) } + [.target(discoveryResolvedTarget, conditions: [])],
                     defaultLocalization: .none, // safe since this is a derived target
-                    platforms: .init(declared: [], deriveXCTestPlatform: { _ in nil }) // safe since this is a derived target
+                    platforms: .init(declared: [], deriveXCTestPlatform: nil) // safe since this is a derived target
                 )
                 return try SwiftTargetBuildDescription(
                     package: package,
@@ -354,7 +354,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
                             target: entryPointTarget,
                             dependencies: entryPointResolvedTarget.dependencies + [.target(discoveryTargets.resolved, conditions: [])],
                             defaultLocalization: .none, // safe since this is a derived target
-                            platforms: .init(declared: [], deriveXCTestPlatform: { _ in nil }) // safe since this is a derived target
+                            platforms: .init(declared: [], deriveXCTestPlatform: nil) // safe since this is a derived target
                         )
                         let entryPointTargetBuildDescription = try SwiftTargetBuildDescription(
                             package: package,

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -292,7 +292,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
                     target: discoveryTarget,
                     dependencies: testProduct.targets.map { .target($0, conditions: []) },
                     defaultLocalization: .none, // safe since this is a derived target
-                    platforms: .init(declared: [], deriveXCTestPlatform: nil) // safe since this is a derived target
+                    platforms: .init(declared: [], derivedXCTestPlatformProvider: .none) // safe since this is a derived target
                 )
                 let discoveryTargetBuildDescription = try SwiftTargetBuildDescription(
                     package: package,
@@ -325,7 +325,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
                     target: entryPointTarget,
                     dependencies: testProduct.targets.map { .target($0, conditions: []) } + [.target(discoveryResolvedTarget, conditions: [])],
                     defaultLocalization: .none, // safe since this is a derived target
-                    platforms: .init(declared: [], deriveXCTestPlatform: nil) // safe since this is a derived target
+                    platforms: .init(declared: [], derivedXCTestPlatformProvider: .none) // safe since this is a derived target
                 )
                 return try SwiftTargetBuildDescription(
                     package: package,
@@ -354,7 +354,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
                             target: entryPointTarget,
                             dependencies: entryPointResolvedTarget.dependencies + [.target(discoveryTargets.resolved, conditions: [])],
                             defaultLocalization: .none, // safe since this is a derived target
-                            platforms: .init(declared: [], deriveXCTestPlatform: nil) // safe since this is a derived target
+                            platforms: .init(declared: [], derivedXCTestPlatformProvider: .none) // safe since this is a derived target
                         )
                         let entryPointTargetBuildDescription = try SwiftTargetBuildDescription(
                             package: package,

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -145,7 +145,13 @@ extension PackageGraph {
             rootManifests: root.manifests,
             unsafeAllowedPackages: unsafeAllowedPackages,
             platformRegistry: customPlatformsRegistry ?? .default,
-            xcTestMinimumDeploymentTargets: customXCTestMinimumDeploymentTargets ?? MinimumDeploymentTarget.default.xcTestMinimumDeploymentTargets,
+            deriveXCTestPlatform: { declared in
+                if let customXCTestMinimumDeploymentTargets = customXCTestMinimumDeploymentTargets {
+                    return customXCTestMinimumDeploymentTargets[declared]
+                } else {
+                    return MinimumDeploymentTarget.default.computeXCTestMinimumDeploymentTarget(for: declared)
+                }
+            },
             fileSystem: fileSystem,
             observabilityScope: observabilityScope
         )
@@ -226,7 +232,7 @@ private func createResolvedPackages(
     rootManifests: [PackageIdentity: Manifest],
     unsafeAllowedPackages: Set<PackageReference>,
     platformRegistry: PlatformRegistry,
-    xcTestMinimumDeploymentTargets: [PackageModel.Platform: PlatformVersion],
+    deriveXCTestPlatform: @escaping (_ declared: PackageModel.Platform) -> PlatformVersion?,
     fileSystem: FileSystem,
     observabilityScope: ObservabilityScope
 ) throws -> [ResolvedPackage] {
@@ -349,16 +355,8 @@ private func createResolvedPackages(
 
         packageBuilder.platforms = computePlatforms(
             package: package,
-            usingXCTest: false,
             platformRegistry: platformRegistry,
-            xcTestMinimumDeploymentTargets: xcTestMinimumDeploymentTargets
-        )
-
-        let testPlatforms = computePlatforms(
-            package: package,
-            usingXCTest: true,
-            platformRegistry: platformRegistry,
-            xcTestMinimumDeploymentTargets: xcTestMinimumDeploymentTargets
+            deriveXCTestPlatform: deriveXCTestPlatform
         )
 
         // Create target builders for each target in the package.
@@ -380,7 +378,7 @@ private func createResolvedPackages(
                 }
             }
             targetBuilder.defaultLocalization = packageBuilder.defaultLocalization
-            targetBuilder.platforms = targetBuilder.target.type == .test ? testPlatforms : packageBuilder.platforms
+            targetBuilder.platforms = packageBuilder.platforms
         }
 
         // Create product builders for each product in the package. A product can only contain a target present in the same package.
@@ -734,9 +732,8 @@ private class DuplicateProductsChecker {
 
 private func computePlatforms(
     package: Package,
-    usingXCTest: Bool,
     platformRegistry: PlatformRegistry,
-    xcTestMinimumDeploymentTargets: [PackageModel.Platform: PlatformVersion]
+    deriveXCTestPlatform: @escaping (_ declared: PackageModel.Platform) -> PlatformVersion?
 ) -> SupportedPlatforms {
 
     // the supported platforms as declared in the manifest
@@ -750,67 +747,9 @@ private func computePlatforms(
         )
     }
 
-    // the derived platforms based on known minimum deployment target logic
-    var derivedPlatforms = [SupportedPlatform]()
-
-    /// Add each declared platform to the supported platforms list.
-    for platform in package.manifest.platforms {
-        let declaredPlatform = platformRegistry.platformByName[platform.platformName]
-            ?? PackageModel.Platform.custom(name: platform.platformName, oldestSupportedVersion: platform.version)
-        var version = PlatformVersion(platform.version)
-
-        if usingXCTest, let xcTestMinimumDeploymentTarget = xcTestMinimumDeploymentTargets[declaredPlatform], version < xcTestMinimumDeploymentTarget {
-            version = xcTestMinimumDeploymentTarget
-        }
-
-        // If the declared version is smaller than the oldest supported one, we raise the derived version to that.
-        if version < declaredPlatform.oldestSupportedVersion {
-            version = declaredPlatform.oldestSupportedVersion
-        }
-
-        let supportedPlatform = SupportedPlatform(
-            platform: declaredPlatform,
-            version: version,
-            options: platform.options
-        )
-
-        derivedPlatforms.append(supportedPlatform)
-    }
-
-    // Find the undeclared platforms.
-    let remainingPlatforms = Set(platformRegistry.platformByName.keys).subtracting(derivedPlatforms.map({ $0.platform.name }))
-
-    /// Start synthesizing for each undeclared platform.
-    for platformName in remainingPlatforms.sorted() {
-        let platform = platformRegistry.platformByName[platformName]!
-
-        let minimumSupportedVersion: PlatformVersion
-        if usingXCTest, let xcTestMinimumDeploymentTarget = xcTestMinimumDeploymentTargets[platform], xcTestMinimumDeploymentTarget > platform.oldestSupportedVersion {
-            minimumSupportedVersion = xcTestMinimumDeploymentTarget
-        } else {
-            minimumSupportedVersion = platform.oldestSupportedVersion
-        }
-
-        let oldestSupportedVersion: PlatformVersion
-        if platform == .macCatalyst, let iOS = derivedPlatforms.first(where: { $0.platform == .iOS }) {
-            // If there was no deployment target specified for Mac Catalyst, fall back to the iOS deployment target.
-            oldestSupportedVersion = max(minimumSupportedVersion, iOS.version)
-        } else {
-            oldestSupportedVersion = minimumSupportedVersion
-        }
-
-        let supportedPlatform = SupportedPlatform(
-            platform: platform,
-            version: oldestSupportedVersion,
-            options: []
-        )
-
-        derivedPlatforms.append(supportedPlatform)
-    }
-
     return SupportedPlatforms(
         declared: declaredPlatforms.sorted(by: { $0.platform.name < $1.platform.name }),
-        derived: derivedPlatforms.sorted(by: { $0.platform.name < $1.platform.name })
+        deriveXCTestPlatform: deriveXCTestPlatform
     )
 }
 
@@ -934,7 +873,7 @@ private final class ResolvedTargetBuilder: ResolvedBuilder<ResolvedTarget> {
     var defaultLocalization: String? = nil
 
     /// The platforms supported by this package.
-    var platforms: SupportedPlatforms = .init(declared: [], derived: [])
+    var platforms: SupportedPlatforms = .init(declared: [], deriveXCTestPlatform: { _ in nil })
 
     init(
         target: Target,
@@ -1026,7 +965,7 @@ private final class ResolvedPackageBuilder: ResolvedBuilder<ResolvedPackage> {
     var defaultLocalization: String? = nil
 
     /// The platforms supported by this package.
-    var platforms: SupportedPlatforms = .init(declared: [], derived: [])
+    var platforms: SupportedPlatforms = .init(declared: [], deriveXCTestPlatform: { _ in nil })
 
     /// If the given package's source is a registry release, this provides additional metadata and signature information.
     var registryMetadata: RegistryReleaseMetadata?

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -145,7 +145,7 @@ extension PackageGraph {
             rootManifests: root.manifests,
             unsafeAllowedPackages: unsafeAllowedPackages,
             platformRegistry: customPlatformsRegistry ?? .default,
-            deriveXCTestPlatform: { declared in
+            derivedXCTestPlatformProvider: { declared in
                 if let customXCTestMinimumDeploymentTargets {
                     return customXCTestMinimumDeploymentTargets[declared]
                 } else {
@@ -232,7 +232,7 @@ private func createResolvedPackages(
     rootManifests: [PackageIdentity: Manifest],
     unsafeAllowedPackages: Set<PackageReference>,
     platformRegistry: PlatformRegistry,
-    deriveXCTestPlatform: @escaping (_ declared: PackageModel.Platform) -> PlatformVersion?,
+    derivedXCTestPlatformProvider: @escaping (_ declared: PackageModel.Platform) -> PlatformVersion?,
     fileSystem: FileSystem,
     observabilityScope: ObservabilityScope
 ) throws -> [ResolvedPackage] {
@@ -356,7 +356,7 @@ private func createResolvedPackages(
         packageBuilder.platforms = computePlatforms(
             package: package,
             platformRegistry: platformRegistry,
-            deriveXCTestPlatform: deriveXCTestPlatform
+            derivedXCTestPlatformProvider: derivedXCTestPlatformProvider
         )
 
         // Create target builders for each target in the package.
@@ -733,7 +733,7 @@ private class DuplicateProductsChecker {
 private func computePlatforms(
     package: Package,
     platformRegistry: PlatformRegistry,
-    deriveXCTestPlatform: @escaping (_ declared: PackageModel.Platform) -> PlatformVersion?
+    derivedXCTestPlatformProvider: @escaping (_ declared: PackageModel.Platform) -> PlatformVersion?
 ) -> SupportedPlatforms {
 
     // the supported platforms as declared in the manifest
@@ -749,7 +749,7 @@ private func computePlatforms(
 
     return SupportedPlatforms(
         declared: declaredPlatforms.sorted(by: { $0.platform.name < $1.platform.name }),
-        deriveXCTestPlatform: deriveXCTestPlatform
+        derivedXCTestPlatformProvider: derivedXCTestPlatformProvider
     )
 }
 
@@ -873,7 +873,7 @@ private final class ResolvedTargetBuilder: ResolvedBuilder<ResolvedTarget> {
     var defaultLocalization: String? = nil
 
     /// The platforms supported by this package.
-    var platforms: SupportedPlatforms = .init(declared: [], deriveXCTestPlatform: nil)
+    var platforms: SupportedPlatforms = .init(declared: [], derivedXCTestPlatformProvider: .none)
 
     init(
         target: Target,
@@ -965,7 +965,7 @@ private final class ResolvedPackageBuilder: ResolvedBuilder<ResolvedPackage> {
     var defaultLocalization: String? = nil
 
     /// The platforms supported by this package.
-    var platforms: SupportedPlatforms = .init(declared: [], deriveXCTestPlatform: nil)
+    var platforms: SupportedPlatforms = .init(declared: [], derivedXCTestPlatformProvider: .none)
 
     /// If the given package's source is a registry release, this provides additional metadata and signature information.
     var registryMetadata: RegistryReleaseMetadata?

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -146,7 +146,7 @@ extension PackageGraph {
             unsafeAllowedPackages: unsafeAllowedPackages,
             platformRegistry: customPlatformsRegistry ?? .default,
             deriveXCTestPlatform: { declared in
-                if let customXCTestMinimumDeploymentTargets = customXCTestMinimumDeploymentTargets {
+                if let customXCTestMinimumDeploymentTargets {
                     return customXCTestMinimumDeploymentTargets[declared]
                 } else {
                     return MinimumDeploymentTarget.default.computeXCTestMinimumDeploymentTarget(for: declared)
@@ -873,7 +873,7 @@ private final class ResolvedTargetBuilder: ResolvedBuilder<ResolvedTarget> {
     var defaultLocalization: String? = nil
 
     /// The platforms supported by this package.
-    var platforms: SupportedPlatforms = .init(declared: [], deriveXCTestPlatform: { _ in nil })
+    var platforms: SupportedPlatforms = .init(declared: [], deriveXCTestPlatform: nil)
 
     init(
         target: Target,
@@ -965,7 +965,7 @@ private final class ResolvedPackageBuilder: ResolvedBuilder<ResolvedPackage> {
     var defaultLocalization: String? = nil
 
     /// The platforms supported by this package.
-    var platforms: SupportedPlatforms = .init(declared: [], deriveXCTestPlatform: { _ in nil })
+    var platforms: SupportedPlatforms = .init(declared: [], deriveXCTestPlatform: nil)
 
     /// If the given package's source is a registry release, this provides additional metadata and signature information.
     var registryMetadata: RegistryReleaseMetadata?

--- a/Sources/PackageGraph/ResolvedProduct.swift
+++ b/Sources/PackageGraph/ResolvedProduct.swift
@@ -70,7 +70,7 @@ public final class ResolvedProduct {
                 target: swiftTarget,
                 dependencies: targets.map { .target($0, conditions: []) },
                 defaultLocalization: .none, // safe since this is a derived product
-                platforms: .init(declared: [], deriveXCTestPlatform: { _ in nil }) // safe since this is a derived product
+                platforms: .init(declared: [], deriveXCTestPlatform: nil) // safe since this is a derived product
             )
         }
 

--- a/Sources/PackageGraph/ResolvedProduct.swift
+++ b/Sources/PackageGraph/ResolvedProduct.swift
@@ -143,3 +143,10 @@ extension ResolvedProduct: CustomStringConvertible {
         return "<ResolvedProduct: \(name)>"
     }
 }
+
+extension ResolvedProduct {
+    public var isLinkingXCTest: Bool {
+        // To retain existing behavior, we have to check both the product type, as well as the types of all of its targets.
+        return self.type == .test || self.targets.filter { $0.type == .test }.isEmpty == false
+    }
+}

--- a/Sources/PackageGraph/ResolvedProduct.swift
+++ b/Sources/PackageGraph/ResolvedProduct.swift
@@ -70,7 +70,7 @@ public final class ResolvedProduct {
                 target: swiftTarget,
                 dependencies: targets.map { .target($0, conditions: []) },
                 defaultLocalization: .none, // safe since this is a derived product
-                platforms: .init(declared: [], deriveXCTestPlatform: nil) // safe since this is a derived product
+                platforms: .init(declared: [], derivedXCTestPlatformProvider: .none) // safe since this is a derived product
             )
         }
 

--- a/Sources/PackageGraph/ResolvedProduct.swift
+++ b/Sources/PackageGraph/ResolvedProduct.swift
@@ -147,6 +147,6 @@ extension ResolvedProduct: CustomStringConvertible {
 extension ResolvedProduct {
     public var isLinkingXCTest: Bool {
         // To retain existing behavior, we have to check both the product type, as well as the types of all of its targets.
-        return self.type == .test || self.targets.filter { $0.type == .test }.isEmpty == false
+        return self.type == .test || self.targets.contains(where: { $0.type == .test })
     }
 }

--- a/Sources/PackageModel/MinimumDeploymentTarget.swift
+++ b/Sources/PackageModel/MinimumDeploymentTarget.swift
@@ -25,12 +25,8 @@ public struct MinimumDeploymentTarget {
     }
 
     public func computeXCTestMinimumDeploymentTarget(for platform: PackageModel.Platform) -> PlatformVersion {
-        if let result = xcTestMinimumDeploymentTargets[platform] {
-            return result
-        } else {
-            let result = Self.computeXCTestMinimumDeploymentTarget(for: platform)
-            xcTestMinimumDeploymentTargets[platform] = result
-            return result
+        self.xcTestMinimumDeploymentTargets.memoize(platform) {
+            return Self.computeXCTestMinimumDeploymentTarget(for: platform)
         }
     }
 

--- a/Sources/PackageModel/MinimumDeploymentTarget.swift
+++ b/Sources/PackageModel/MinimumDeploymentTarget.swift
@@ -17,15 +17,20 @@ import struct TSCBasic.ProcessResult
 
 
 public struct MinimumDeploymentTarget {
-    public let xcTestMinimumDeploymentTargets: [PackageModel.Platform:PlatformVersion]
+    public let xcTestMinimumDeploymentTargets = ThreadSafeKeyValueStore<PackageModel.Platform,PlatformVersion>()
 
     public static let `default`: MinimumDeploymentTarget = .init()
 
-    public init() {
-        xcTestMinimumDeploymentTargets = PlatformRegistry.default.knownPlatforms.reduce([PackageModel.Platform:PlatformVersion]()) {
-            var dict = $0
-            dict[$1] = Self.computeXCTestMinimumDeploymentTarget(for: $1)
-            return dict
+    private init() {
+    }
+
+    public func computeXCTestMinimumDeploymentTarget(for platform: PackageModel.Platform) -> PlatformVersion {
+        if let result = xcTestMinimumDeploymentTargets[platform] {
+            return result
+        } else {
+            let result = Self.computeXCTestMinimumDeploymentTarget(for: platform)
+            xcTestMinimumDeploymentTargets[platform] = result
+            return result
         }
     }
 

--- a/Sources/PackageModel/Platform.swift
+++ b/Sources/PackageModel/Platform.swift
@@ -54,9 +54,9 @@ public struct Platform: Equatable, Hashable, Codable {
 
 public struct SupportedPlatforms {
     public let declared: [SupportedPlatform]
-    private let deriveXCTestPlatform: (Platform) -> PlatformVersion?
+    private let deriveXCTestPlatform: ((Platform) -> PlatformVersion?)?
 
-    public init(declared: [SupportedPlatform], deriveXCTestPlatform: @escaping (_ declared: Platform) -> PlatformVersion?) {
+    public init(declared: [SupportedPlatform], deriveXCTestPlatform: ((_ declared: Platform) -> PlatformVersion?)?) {
         self.declared = declared
         self.deriveXCTestPlatform = deriveXCTestPlatform
     }
@@ -67,7 +67,7 @@ public struct SupportedPlatforms {
         if let declaredPlatform = self.declared.first(where: { $0.platform == platform }) {
             var version = declaredPlatform.version
 
-            if usingXCTest, let xcTestMinimumDeploymentTarget = deriveXCTestPlatform(platform), version < xcTestMinimumDeploymentTarget {
+            if usingXCTest, let xcTestMinimumDeploymentTarget = deriveXCTestPlatform?(platform), version < xcTestMinimumDeploymentTarget {
                 version = xcTestMinimumDeploymentTarget
             }
 
@@ -83,7 +83,7 @@ public struct SupportedPlatforms {
             )
         } else {
             let minimumSupportedVersion: PlatformVersion
-            if usingXCTest, let xcTestMinimumDeploymentTarget = deriveXCTestPlatform(platform), xcTestMinimumDeploymentTarget > platform.oldestSupportedVersion {
+            if usingXCTest, let xcTestMinimumDeploymentTarget = deriveXCTestPlatform?(platform), xcTestMinimumDeploymentTarget > platform.oldestSupportedVersion {
                 minimumSupportedVersion = xcTestMinimumDeploymentTarget
             } else {
                 minimumSupportedVersion = platform.oldestSupportedVersion

--- a/Sources/PackageModel/Platform.swift
+++ b/Sources/PackageModel/Platform.swift
@@ -54,11 +54,11 @@ public struct Platform: Equatable, Hashable, Codable {
 
 public struct SupportedPlatforms {
     public let declared: [SupportedPlatform]
-    private let deriveXCTestPlatform: ((Platform) -> PlatformVersion?)?
+    private let derivedXCTestPlatformProvider: ((Platform) -> PlatformVersion?)?
 
-    public init(declared: [SupportedPlatform], deriveXCTestPlatform: ((_ declared: Platform) -> PlatformVersion?)?) {
+    public init(declared: [SupportedPlatform], derivedXCTestPlatformProvider: ((_ declared: Platform) -> PlatformVersion?)?) {
         self.declared = declared
-        self.deriveXCTestPlatform = deriveXCTestPlatform
+        self.derivedXCTestPlatformProvider = derivedXCTestPlatformProvider
     }
 
     /// Returns the supported platform instance for the given platform.
@@ -67,7 +67,7 @@ public struct SupportedPlatforms {
         if let declaredPlatform = self.declared.first(where: { $0.platform == platform }) {
             var version = declaredPlatform.version
 
-            if usingXCTest, let xcTestMinimumDeploymentTarget = deriveXCTestPlatform?(platform), version < xcTestMinimumDeploymentTarget {
+            if usingXCTest, let xcTestMinimumDeploymentTarget = derivedXCTestPlatformProvider?(platform), version < xcTestMinimumDeploymentTarget {
                 version = xcTestMinimumDeploymentTarget
             }
 
@@ -83,7 +83,7 @@ public struct SupportedPlatforms {
             )
         } else {
             let minimumSupportedVersion: PlatformVersion
-            if usingXCTest, let xcTestMinimumDeploymentTarget = deriveXCTestPlatform?(platform), xcTestMinimumDeploymentTarget > platform.oldestSupportedVersion {
+            if usingXCTest, let xcTestMinimumDeploymentTarget = derivedXCTestPlatformProvider?(platform), xcTestMinimumDeploymentTarget > platform.oldestSupportedVersion {
                 minimumSupportedVersion = xcTestMinimumDeploymentTarget
             } else {
                 minimumSupportedVersion = platform.oldestSupportedVersion

--- a/Sources/SPMTestSupport/PackageGraphTester.swift
+++ b/Sources/SPMTestSupport/PackageGraphTester.swift
@@ -180,10 +180,14 @@ public final class ResolvedTargetResult {
 
     public func checkDerivedPlatforms(_ platforms: [String: String], file: StaticString = #file, line: UInt = #line) {
         let derived = platforms.map {
-            let platform = PlatformRegistry.default.platformByName[$0.key] ?? PackageModel.Platform.custom(name: $0.key, oldestSupportedVersion: $0.value)
-            return target.platforms.getDerived(for: platform, usingXCTest: target.type == .test)
+            let platform = PlatformRegistry.default.platformByName[$0.key] ?? PackageModel.Platform
+                .custom(name: $0.key, oldestSupportedVersion: $0.value)
+            return self.target.platforms.getDerived(for: platform, usingXCTest: self.target.type == .test)
         }
-        let targetPlatforms = Dictionary(uniqueKeysWithValues: derived.map({ ($0.platform.name, $0.version.versionString) }))
+        let targetPlatforms = Dictionary(
+            uniqueKeysWithValues: derived
+                .map { ($0.platform.name, $0.version.versionString) }
+        )
         XCTAssertEqual(platforms, targetPlatforms, file: file, line: line)
     }
 

--- a/Sources/SPMTestSupport/PackageGraphTester.swift
+++ b/Sources/SPMTestSupport/PackageGraphTester.swift
@@ -238,18 +238,16 @@ public final class ResolvedProductResult {
     }
 
     public func checkDerivedPlatforms(_ platforms: [String: String], file: StaticString = #file, line: UInt = #line) {
-        // To retain existing behavior, we have to check both the product type, as well as the types of all of its targets.
-        let usingXCTest = product.type == .test || product.targets.filter { $0.type == .test }.isEmpty == false
         let derived = platforms.map {
             let platform = PlatformRegistry.default.platformByName[$0.key] ?? PackageModel.Platform.custom(name: $0.key, oldestSupportedVersion: $0.value)
-            return product.platforms.getDerived(for: platform, usingXCTest: usingXCTest)
+            return product.platforms.getDerived(for: platform, usingXCTest: product.isLinkingXCTest)
         }
         let targetPlatforms = Dictionary(uniqueKeysWithValues: derived.map({ ($0.platform.name, $0.version.versionString) }))
         XCTAssertEqual(platforms, targetPlatforms, file: file, line: line)
     }
 
     public func checkDerivedPlatformOptions(_ platform: PackageModel.Platform, options: [String], file: StaticString = #file, line: UInt = #line) {
-        let platform = product.platforms.getDerived(for: platform, usingXCTest: product.type == .test)
+        let platform = product.platforms.getDerived(for: platform, usingXCTest: product.isLinkingXCTest)
         XCTAssertEqual(platform.options, options, file: file, line: line)
     }
 }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -1706,6 +1706,12 @@ final class BuildPlanTests: XCTestCase {
 
       #if os(macOS)
         let version = MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .macOS).versionString
+        let rpathsForBackdeployment: [String]
+        if let version = try? Version(string: version, lenient: true), version.major < 12 {
+            rpathsForBackdeployment = ["-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-5.5/macosx"]
+        } else {
+            rpathsForBackdeployment = []
+        }
         XCTAssertEqual(try result.buildProduct(for: "PkgPackageTests").linkArguments(), [
             result.plan.buildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
@@ -1713,9 +1719,9 @@ final class BuildPlanTests: XCTestCase {
             "-module-name", "PkgPackageTests",
             "-Xlinker", "-bundle",
             "-Xlinker", "-rpath", "-Xlinker", "@loader_path/../../../",
-            "@\(buildPath.appending(components: "PkgPackageTests.product", "Objects.LinkFileList"))",
-            "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-5.5/macosx",
-            "-target", "\(hostTriple.tripleString(forPlatformVersion: version))",
+            "@\(buildPath.appending(components: "PkgPackageTests.product", "Objects.LinkFileList"))"] +
+            rpathsForBackdeployment +
+            ["-target", "\(hostTriple.tripleString(forPlatformVersion: version))",
             "-Xlinker", "-add_ast_path", "-Xlinker", buildPath.appending(components: "Foo.swiftmodule").pathString,
             "-Xlinker", "-add_ast_path", "-Xlinker", buildPath.appending(components: "FooTests.swiftmodule").pathString,
             "-g",

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -943,7 +943,7 @@ final class PackageToolTests: CommandsTestCase {
             // Checks the content of checked out bar.swift.
             func checkBar(_ value: Int, file: StaticString = #file, line: UInt = #line) throws {
                 let contents: String = try localFileSystem.readFileContents(barPath.appending(components:"Sources", "bar.swift"))
-                XCTAssertTrue(contents.spm_chomp().hasSuffix("\(value)"), file: file, line: line)
+                XCTAssertTrue(contents.spm_chomp().hasSuffix("\(value)"), "got \(contents)", file: file, line: line)
             }
 
             // We should see a pin file now.

--- a/Tests/PackageGraphTests/TargetTests.swift
+++ b/Tests/PackageGraphTests/TargetTests.swift
@@ -30,7 +30,7 @@ private extension ResolvedTarget {
             ),
             dependencies: deps.map { .target($0, conditions: []) },
             defaultLocalization: nil,
-            platforms: .init(declared: [], deriveXCTestPlatform: nil)
+            platforms: .init(declared: [], derivedXCTestPlatformProvider: .none)
         )
     }
 }

--- a/Tests/PackageGraphTests/TargetTests.swift
+++ b/Tests/PackageGraphTests/TargetTests.swift
@@ -30,7 +30,7 @@ private extension ResolvedTarget {
             ),
             dependencies: deps.map { .target($0, conditions: []) },
             defaultLocalization: nil,
-            platforms: .init(declared: [], derived: [])
+            platforms: .init(declared: [], deriveXCTestPlatform: { _ in nil })
         )
     }
 }

--- a/Tests/PackageGraphTests/TargetTests.swift
+++ b/Tests/PackageGraphTests/TargetTests.swift
@@ -30,7 +30,7 @@ private extension ResolvedTarget {
             ),
             dependencies: deps.map { .target($0, conditions: []) },
             defaultLocalization: nil,
-            platforms: .init(declared: [], deriveXCTestPlatform: { _ in nil })
+            platforms: .init(declared: [], deriveXCTestPlatform: nil)
         )
     }
 }


### PR DESCRIPTION
We never need this for any platform that we're not building for and we also don't really need it for most commands. So we can just move the computation to `SwiftTool` and leave these empty for all other cases.

rdar://64596106
