### PR TITLE
Tests: adjust SPMBuildCoreTests for Windows

### DIFF
--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -495,6 +495,8 @@ class PluginInvocationTests: XCTestCase {
                 }
                 """)
 
+            Thread.sleep(forTimeInterval: 1)
+
             // Recompile the plugin again.
             let thirdExecModTime: Date
             do {

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -495,7 +495,7 @@ class PluginInvocationTests: XCTestCase {
                 }
                 """)
 
-            // The file system on Windows does not have nanosecond granularity (nor is this is a guaranteed file 
+            // NTFS does not have nanosecond granularity (nor is this is a guaranteed file 
             // system feature on all file systems). Add a sleep before the execution to ensure that we have sufficient 
             // precision to read a difference.
             Thread.sleep(forTimeInterval: 1)

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -495,6 +495,9 @@ class PluginInvocationTests: XCTestCase {
                 }
                 """)
 
+            // The file system on Windows does not have nanosecond granularity (nor is this is a guaranteed file 
+            // system feature on all file systems). Add a sleep before the execution to ensure that we have sufficient 
+            // precision to read a difference.
             Thread.sleep(forTimeInterval: 1)
 
             // Recompile the plugin again.


### PR DESCRIPTION
The file system on Windows does not have nanosecond granularity (nor is this is a guaranteed file system feature on all file systems).  Add a sleep before the execution to ensure that we have sufficient precision to read a difference.