### PR TITLE
reduce redundant git operations

### DIFF
--- a/Sources/Commands/PackageTools/ArchiveSource.swift
+++ b/Sources/Commands/PackageTools/ArchiveSource.swift
@@ -66,7 +66,8 @@ extension SwiftPackageTool {
         cancellator: Cancellator?
     ) throws  {
         let gitRepositoryProvider = GitRepositoryProvider()
-        if gitRepositoryProvider.repositoryExists(at: packageDirectory) {
+        if gitRepositoryProvider.repositoryExists(at: packageDirectory) &&
+            gitRepositoryProvider.isValidDirectory(packageDirectory){
             let repository = GitRepository(path: packageDirectory, cancellator: cancellator)
             try repository.archive(to: archivePath)
         } else {

--- a/Sources/SPMTestSupport/InMemoryGitRepository.swift
+++ b/Sources/SPMTestSupport/InMemoryGitRepository.swift
@@ -451,10 +451,10 @@ public final class InMemoryGitRepositoryProvider: RepositoryProvider {
     }
 
     public func open(repository: RepositorySpecifier, at path: AbsolutePath) throws -> Repository {
-        guard let repo = fetchedMap[path] else {
-            throw InternalError("unknown repo at \(path)")
+        guard let repository = self.fetchedMap[path] else {
+            throw InternalError("unknown repository at \(path)")
         }
-        return repo
+        return repository
     }
 
     public func createWorkingCopy(

--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -205,18 +205,20 @@ public class RepositoryManager: Cancellable {
             // Update the repository if needed
             if self.fetchRequired(repository: repository, updateStrategy: updateStrategy) {
                 let start = DispatchTime.now()
-
+                
                 delegateQueue.async {
                     self.delegate?.willUpdate(package: package, repository: handle.repository)
                 }
-
+                
                 try repository.fetch()
                 let duration = start.distance(to: .now())
                 delegateQueue.async {
                     self.delegate?.didUpdate(package: package, repository: handle.repository, duration: duration)
                 }
+                return handle
+            } else if self.provider.isValidDirectory(repositoryPath) {
+                return handle
             }
-            return handle
         }
 
         // inform delegate that we are starting to fetch

--- a/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
@@ -132,7 +132,10 @@ private class MockRepositories: RepositoryProvider {
     }
 
     func open(repository: RepositorySpecifier, at path: AbsolutePath) throws -> Repository {
-        return self.repositories[repository.location]!
+        guard let repository = self.repositories[repository.location] else {
+            throw InternalError("unknown repository at \(repository.location)")
+        }
+        return repository
     }
 
     func createWorkingCopy(repository: RepositorySpecifier, sourcePath: AbsolutePath, at destinationPath: AbsolutePath, editable: Bool) throws -> WorkingCheckout {


### PR DESCRIPTION
motivation: better perforamnce

changes:
* GitRepositoryProvider caches GitRepository
* change order of perations such that when a valid revision is found we do not check for validity of git directory
* check if gitsubmodules are used instead of blindly trying to update them
