### PR TITLE
Improve handling of broken JSON responses from XCTest helpers

### DIFF
--- a/Sources/Commands/Utilities/TestingSupport.swift
+++ b/Sources/Commands/Utilities/TestingSupport.swift
@@ -101,9 +101,10 @@ enum TestingSupport {
         sanitizers: [Sanitizer]
     ) throws -> [TestSuite] {
         // Run the correct tool.
+        var args = [String]()
         #if os(macOS)
         let data: String = try withTemporaryFile { tempFile in
-            let args = [try Self.xctestHelperPath(swiftTool: swiftTool).pathString, path.pathString, tempFile.path.pathString]
+            args = [try Self.xctestHelperPath(swiftTool: swiftTool).pathString, path.pathString, tempFile.path.pathString]
             var env = try Self.constructTestEnvironment(
                 toolchain: try swiftTool.getTargetToolchain(),
                 buildParameters: swiftTool.buildParametersForTest(
@@ -132,11 +133,11 @@ enum TestingSupport {
             ),
             sanitizers: sanitizers
         )
-        let args = [path.description, "--dump-tests-json"]
+        args = [path.description, "--dump-tests-json"]
         let data = try Process.checkNonZeroExit(arguments: args, environment: env)
         #endif
         // Parse json and return TestSuites.
-        return try TestSuite.parse(jsonString: data)
+        return try TestSuite.parse(jsonString: data, context: args.joined(separator: " "))
     }
 
     /// Creates the environment needed to test related tools.


### PR DESCRIPTION
We should include as much context as possible here to allow users to debug issues like that. One well-known way to run into this is that on non-Darwin, we just execute test executables with `--dump-tests-json` and parse all of their `stdout` as JSON, so if the executable has any output of its own for whatever reason, there would be just a very non-descript `malformed` error emitted to the console.
