### PR TITLE
Add experimental test output

### DIFF
--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -540,6 +540,13 @@ public final class SwiftTargetBuildDescription {
 
             // MARK: - Records
 
+            struct TestAttachment: Codable {
+                let name: String?
+                // TODO: Handle `userInfo: [AnyHashable : Any]?`
+                let uniformTypeIdentifier: String
+                let payload: Data?
+            }
+
             struct TestBundleEventRecord: Codable {
                 let bundle: TestBundle
                 let event: TestEvent
@@ -610,7 +617,7 @@ public final class SwiftTargetBuildDescription {
                 let detailedDescription: String?
                 let associatedError: TestErrorInfo?
                 let sourceCodeContext: TestSourceCodeContext
-                // TODO: Handle `var attachments: [XCTAttachment]`
+                let attachments: [TestAttachment]
             }
 
             enum TestIssueType: Codable {
@@ -633,12 +640,24 @@ public final class SwiftTargetBuildDescription {
             }
 
             struct TestSourceCodeContext: Codable, CustomStringConvertible {
-                // TODO: Handle `var callStack: [XCTSourceCodeFrame]`
+                let callStack: [TestSourceCodeFrame]
                 let location: TestLocation?
 
                 var description: String {
                     return location?.description ?? ""
                 }
+            }
+
+            struct TestSourceCodeFrame: Codable {
+                let address: UInt64
+                let symbolInfo: TestSourceCodeSymbolInfo?
+                let symbolicationError: TestErrorInfo?
+            }
+
+            struct TestSourceCodeSymbolInfo: Codable {
+                let imageName: String
+                let symbolName: String
+                let location: TestLocation?
             }
 
             struct TestSuiteRecord: Codable {
@@ -648,6 +667,16 @@ public final class SwiftTargetBuildDescription {
             // MARK: XCTest compatibility
 
             import XCTest
+
+            extension TestAttachment {
+                init(_ attachment: XCTAttachment) {
+                    self.init(
+                        name: attachment.name,
+                        uniformTypeIdentifier: attachment.uniformTypeIdentifier,
+                        payload: attachment.value(forKey: "payload") as? Data
+                    )
+                }
+            }
 
             extension TestBundle {
                 init(_ testBundle: Bundle) {
@@ -677,7 +706,8 @@ public final class SwiftTargetBuildDescription {
                         compactDescription: issue.compactDescription,
                         detailedDescription: issue.detailedDescription,
                         associatedError: issue.associatedError.map { .init($0) },
-                        sourceCodeContext: .init(issue.sourceCodeContext)
+                        sourceCodeContext: .init(issue.sourceCodeContext),
+                        attachments: issue.attachments.map { .init($0) }
                     )
                 }
             }
@@ -708,7 +738,28 @@ public final class SwiftTargetBuildDescription {
             extension TestSourceCodeContext {
                 init(_ context: XCTSourceCodeContext) {
                     self.init(
+                        callStack: context.callStack.map { .init($0) },
                         location: context.location.map { .init($0) }
+                    )
+                }
+            }
+
+            extension TestSourceCodeFrame {
+                init(_ frame: XCTSourceCodeFrame) {
+                    self.init(
+                        address: frame.address,
+                        symbolInfo: (try? frame.symbolInfo()).map { .init($0) },
+                        symbolicationError: frame.symbolicationError.map { .init($0) }
+                    )
+                }
+            }
+
+            extension TestSourceCodeSymbolInfo {
+                init(_ symbolInfo: XCTSourceCodeSymbolInfo) {
+                    self.init(
+                        imageName: symbolInfo.imageName,
+                        symbolName: symbolInfo.symbolName,
+                        location: symbolInfo.location.map { .init($0) }
                     )
                 }
             }

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -369,9 +369,10 @@ public struct BuildDescription: Codable {
         self.swiftTargetScanArgs = targetCommandLines
         self.generatedSourceTargetSet = Set(generatedSourceTargets)
         self.builtTestProducts = try plan.buildProducts.filter { $0.product.type == .test }.map { desc in
-            try BuiltTestProduct(
+            return try BuiltTestProduct(
                 productName: desc.product.name,
-                binaryPath: desc.binaryPath
+                binaryPath: desc.binaryPath,
+                packagePath: desc.package.path
             )
         }
         self.pluginDescriptions = pluginDescriptions

--- a/Sources/Build/LLBuildManifestBuilder.swift
+++ b/Sources/Build/LLBuildManifestBuilder.swift
@@ -978,6 +978,17 @@ extension LLBuildManifestBuilder {
     private func createProductCommand(_ buildProduct: ProductBuildDescription) throws {
         let cmdName = try buildProduct.product.getCommandName(config: self.buildConfig)
 
+        // Add dependency on Info.plist generation on Darwin platforms.
+        let testInputs: [AbsolutePath]
+        if buildProduct.product.type == .test, buildProduct.buildParameters.targetTriple.isDarwin(), buildProduct.buildParameters.experimentalTestOutput {
+            let testBundleInfoPlistPath = try buildProduct.binaryPath.parentDirectory.parentDirectory.appending(component: "Info.plist")
+            testInputs = [testBundleInfoPlistPath]
+
+            self.manifest.addWriteInfoPlistCommand(principalClass: "\(buildProduct.product.targets[0].c99name).SwiftPMXCTestObserver", outputPath: testBundleInfoPlistPath)
+        } else {
+            testInputs = []
+        }
+
         switch buildProduct.product.type {
         case .library(.static):
             try self.manifest.addShellCmd(
@@ -989,7 +1000,7 @@ extension LLBuildManifestBuilder {
             )
 
         default:
-            let inputs = try buildProduct.objects + buildProduct.dylibs.map{ try $0.binaryPath } + [buildProduct.linkFileListPath]
+            let inputs = try buildProduct.objects + buildProduct.dylibs.map{ try $0.binaryPath } + [buildProduct.linkFileListPath] + testInputs
 
             try self.manifest.addShellCmd(
                 name: cmdName,

--- a/Sources/Commands/CMakeLists.txt
+++ b/Sources/Commands/CMakeLists.txt
@@ -44,7 +44,8 @@ add_library(Commands
   Utilities/MultiRootSupport.swift
   Utilities/PluginDelegate.swift
   Utilities/SymbolGraphExtract.swift
-  Utilities/TestingSupport.swift)
+  Utilities/TestingSupport.swift
+  Utilities/XCTEvents.swift)
 target_link_libraries(Commands PUBLIC
   ArgumentParser
   Basics

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -199,6 +199,7 @@ final class PluginDelegate: PluginInvocationDelegate {
                 swiftTool: swiftTool,
                 enableCodeCoverage: parameters.enableCodeCoverage,
                 shouldSkipBuilding: false,
+                experimentalTestOutput: false,
                 sanitizers: swiftTool.options.build.sanitizers
             )
             for testSuite in testSuites {

--- a/Sources/Commands/Utilities/TestingSupport.swift
+++ b/Sources/Commands/Utilities/TestingSupport.swift
@@ -67,6 +67,7 @@ enum TestingSupport {
         swiftTool: SwiftTool,
         enableCodeCoverage: Bool,
         shouldSkipBuilding: Bool,
+        experimentalTestOutput: Bool,
         sanitizers: [Sanitizer]
     ) throws -> [AbsolutePath: [TestSuite]] {
         let testSuitesByProduct = try testProducts
@@ -77,6 +78,7 @@ enum TestingSupport {
                     swiftTool: swiftTool,
                     enableCodeCoverage: enableCodeCoverage,
                     shouldSkipBuilding: shouldSkipBuilding,
+                    experimentalTestOutput: experimentalTestOutput,
                     sanitizers: sanitizers
                 )
             )}
@@ -98,6 +100,7 @@ enum TestingSupport {
         swiftTool: SwiftTool,
         enableCodeCoverage: Bool,
         shouldSkipBuilding: Bool,
+        experimentalTestOutput: Bool,
         sanitizers: [Sanitizer]
     ) throws -> [TestSuite] {
         // Run the correct tool.
@@ -109,7 +112,8 @@ enum TestingSupport {
                 toolchain: try swiftTool.getTargetToolchain(),
                 buildParameters: swiftTool.buildParametersForTest(
                     enableCodeCoverage: enableCodeCoverage,
-                    shouldSkipBuilding: shouldSkipBuilding
+                    shouldSkipBuilding: shouldSkipBuilding,
+                    experimentalTestOutput: experimentalTestOutput
                 ),
                 sanitizers: sanitizers
             )
@@ -201,7 +205,8 @@ extension SwiftTool {
     func buildParametersForTest(
         enableCodeCoverage: Bool,
         enableTestability: Bool? = nil,
-        shouldSkipBuilding: Bool = false
+        shouldSkipBuilding: Bool = false,
+        experimentalTestOutput: Bool = false
     ) throws -> BuildParameters {
         var parameters = try self.buildParameters()
         parameters.enableCodeCoverage = enableCodeCoverage
@@ -209,6 +214,7 @@ extension SwiftTool {
         // but we let users override this with a flag
         parameters.enableTestability = enableTestability ?? true
         parameters.shouldSkipBuilding = shouldSkipBuilding
+        parameters.experimentalTestOutput = experimentalTestOutput
         return parameters
     }
 }

--- a/Sources/Commands/Utilities/XCTEvents.swift
+++ b/Sources/Commands/Utilities/XCTEvents.swift
@@ -62,6 +62,10 @@ struct TestCaseFailureRecord: Codable, CustomStringConvertible {
     var description: String {
         return "\(issue.sourceCodeContext.description)\(testCase) \(issue.compactDescription)"
     }
+
+    func description(with knownLocation: String) -> String {
+        return "\(issue.sourceCodeContext.description(with: knownLocation))\(testCase) \(issue.compactDescription)"
+    }
 }
 
 struct TestSuiteEventRecord: Codable {
@@ -82,8 +86,12 @@ struct TestBundle: Codable {
     let bundlePath: String
 }
 
-struct TestCase: Codable {
+struct TestCase: Codable, CustomStringConvertible {
     let name: String
+
+    var description: String {
+        return name
+    }
 }
 
 struct TestErrorInfo: Codable {
@@ -134,6 +142,16 @@ struct TestLocation: Codable, CustomStringConvertible {
     var description: String {
         return "\(file):\(line) "
     }
+
+    func description(with knownLocation: String) -> String {
+        var file = self.file
+        ["file:/", knownLocation].forEach {
+            if file.hasPrefix($0) {
+                file = String(file.dropFirst($0.count + 1))
+            }
+        }
+        return "\(file):\(line) "
+    }
 }
 
 struct TestSourceCodeContext: Codable, CustomStringConvertible {
@@ -142,6 +160,10 @@ struct TestSourceCodeContext: Codable, CustomStringConvertible {
 
     var description: String {
         return location?.description ?? ""
+    }
+
+    func description(with knownLocation: String) -> String {
+        return location?.description(with: knownLocation) ?? ""
     }
 }
 

--- a/Sources/Commands/Utilities/XCTEvents.swift
+++ b/Sources/Commands/Utilities/XCTEvents.swift
@@ -1,0 +1,217 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+struct TestEventRecord: Codable {
+    let caseFailure: TestCaseFailureRecord?
+    let suiteFailure: TestSuiteFailureRecord?
+
+    let bundleEvent: TestBundleEventRecord?
+    let suiteEvent: TestSuiteEventRecord?
+    let caseEvent: TestCaseEventRecord?
+
+    init(
+        caseFailure: TestCaseFailureRecord? = nil,
+        suiteFailure: TestSuiteFailureRecord? = nil,
+        bundleEvent: TestBundleEventRecord? = nil,
+        suiteEvent: TestSuiteEventRecord? = nil,
+        caseEvent: TestCaseEventRecord? = nil
+    ) {
+        self.caseFailure = caseFailure
+        self.suiteFailure = suiteFailure
+        self.bundleEvent = bundleEvent
+        self.suiteEvent = suiteEvent
+        self.caseEvent = caseEvent
+    }
+}
+
+// MARK: - Records
+
+struct TestBundleEventRecord: Codable {
+    let bundle: TestBundle
+    let event: TestEvent
+}
+
+struct TestCaseEventRecord: Codable {
+    let testCase: TestCase
+    let event: TestEvent
+}
+
+struct TestCaseFailureRecord: Codable, CustomStringConvertible {
+    let testCase: TestCase
+    let issue: TestIssue
+    let failureKind: TestFailureKind
+
+    var description: String {
+        return "\(issue.sourceCodeContext.description)\(testCase) \(issue.compactDescription)"
+    }
+}
+
+struct TestSuiteEventRecord: Codable {
+    let suite: TestSuiteRecord
+    let event: TestEvent
+}
+
+struct TestSuiteFailureRecord: Codable {
+    let suite: TestSuiteRecord
+    let issue: TestIssue
+    let failureKind: TestFailureKind
+}
+
+// MARK: Primitives
+
+struct TestBundle: Codable {
+    let bundleIdentifier: String?
+    let bundlePath: String
+}
+
+struct TestCase: Codable {
+    let name: String
+}
+
+struct TestErrorInfo: Codable {
+    let description: String
+    let type: String
+}
+
+enum TestEvent: Codable {
+    case start
+    case finish
+}
+
+enum TestFailureKind: Codable, Equatable {
+    case unexpected
+    case expected(failureReason: String?)
+
+    var isExpected: Bool {
+        switch self {
+        case .expected: return true
+        case .unexpected: return false
+        }
+    }
+}
+
+struct TestIssue: Codable {
+    let type: TestIssueType
+    let compactDescription: String
+    let detailedDescription: String?
+    let associatedError: TestErrorInfo?
+    let sourceCodeContext: TestSourceCodeContext
+    // TODO: Handle `var attachments: [XCTAttachment]`
+}
+
+enum TestIssueType: Codable {
+    case assertionFailure
+    case performanceRegression
+    case system
+    case thrownError
+    case uncaughtException
+    case unmatchedExpectedFailure
+    case unknown
+}
+
+struct TestLocation: Codable, CustomStringConvertible {
+    let file: String
+    let line: Int
+
+    var description: String {
+        return "\(file):\(line) "
+    }
+}
+
+struct TestSourceCodeContext: Codable, CustomStringConvertible {
+    // TODO: Handle `var callStack: [XCTSourceCodeFrame]`
+    let location: TestLocation?
+
+    var description: String {
+        return location?.description ?? ""
+    }
+}
+
+struct TestSuiteRecord: Codable {
+    let name: String
+}
+
+// MARK: XCTest compatibility
+
+#if false // This is just here for pre-flighting the code generation done in `SwiftTargetBuildDescription`.
+import XCTest
+
+extension TestBundle {
+    init(_ testBundle: Bundle) {
+        self.init(
+            bundleIdentifier: testBundle.bundleIdentifier,
+            bundlePath: testBundle.bundlePath
+        )
+    }
+}
+
+extension TestCase {
+    init(_ testCase: XCTestCase) {
+        self.init(name: testCase.name)
+    }
+}
+
+extension TestErrorInfo {
+    init(_ error: Swift.Error) {
+        self.init(description: "\(error)", type: "\(Swift.type(of: error))")
+    }
+}
+
+extension TestIssue {
+    init(_ issue: XCTIssue) {
+        self.init(
+            type: .init(issue.type),
+            compactDescription: issue.compactDescription,
+            detailedDescription: issue.detailedDescription,
+            associatedError: issue.associatedError.map { .init($0) },
+            sourceCodeContext: .init(issue.sourceCodeContext)
+        )
+    }
+}
+
+extension TestIssueType {
+    init(_ type: XCTIssue.IssueType) {
+        switch type {
+        case .assertionFailure: self = .assertionFailure
+        case .thrownError: self = .thrownError
+        case .uncaughtException: self = .uncaughtException
+        case .performanceRegression: self = .performanceRegression
+        case .system: self = .system
+        case .unmatchedExpectedFailure: self = .unmatchedExpectedFailure
+        @unknown default: self = .unknown
+        }
+    }
+}
+
+extension TestLocation {
+    init(_ location: XCTSourceCodeLocation) {
+        self.init(
+            file: location.fileURL.absoluteString,
+            line: location.lineNumber
+        )
+    }
+}
+
+extension TestSourceCodeContext {
+    init(_ context: XCTSourceCodeContext) {
+        self.init(
+            location: context.location.map { .init($0) }
+        )
+    }
+}
+
+extension TestSuiteRecord {
+    init(_ testSuite: XCTestSuite) {
+        self.init(name: testSuite.name)
+    }
+}
+#endif

--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -223,6 +223,9 @@ public struct BuildParameters: Encodable {
     /// Whether to enable the entry-point-function-name feature.
     public var canRenameEntrypointFunctionName: Bool
 
+    /// Whether or not to enable the experimental test output mode.
+    public var experimentalTestOutput: Bool
+
     /// The current build environment.
     public var buildEnvironment: BuildEnvironment {
         BuildEnvironment(platform: currentPlatform, configuration: configuration)
@@ -310,7 +313,8 @@ public struct BuildParameters: Encodable {
         verboseOutput: Bool = false,
         linkTimeOptimizationMode: LinkTimeOptimizationMode? = nil,
         debugInfoFormat: DebugInfoFormat = .dwarf,
-        shouldSkipBuilding: Bool = false
+        shouldSkipBuilding: Bool = false,
+        experimentalTestOutput: Bool = false
     ) throws {
         try self.init(
             dataPath: dataPath,
@@ -342,7 +346,8 @@ public struct BuildParameters: Encodable {
             verboseOutput: verboseOutput,
             linkTimeOptimizationMode: linkTimeOptimizationMode,
             debugInfoFormat: debugInfoFormat,
-            shouldSkipBuilding: shouldSkipBuilding
+            shouldSkipBuilding: shouldSkipBuilding,
+            experimentalTestOutput: experimentalTestOutput
         )
     }
 
@@ -376,7 +381,8 @@ public struct BuildParameters: Encodable {
         verboseOutput: Bool = false,
         linkTimeOptimizationMode: LinkTimeOptimizationMode? = nil,
         debugInfoFormat: DebugInfoFormat = .dwarf,
-        shouldSkipBuilding: Bool = false
+        shouldSkipBuilding: Bool = false,
+        experimentalTestOutput: Bool = false
     ) throws {
         let targetTriple = try targetTriple ?? .getHostTriple(usingSwiftCompiler: toolchain.swiftCompilerPath)
 
@@ -447,6 +453,7 @@ public struct BuildParameters: Encodable {
         self.linkTimeOptimizationMode = linkTimeOptimizationMode
         self.debugInfoFormat = debugInfoFormat
         self.shouldSkipBuilding = shouldSkipBuilding
+        self.experimentalTestOutput = experimentalTestOutput
     }
 
     @available(*, deprecated, renamed: "forTriple()")
@@ -534,6 +541,10 @@ public struct BuildParameters: Encodable {
 
     public var buildDescriptionPath: AbsolutePath {
         return buildPath.appending(components: "description.json")
+    }
+
+    public var testOutputPath: AbsolutePath {
+        return buildPath.appending(component: "testOutput.txt")
     }
 
     /// The debugging strategy according to the current build parameters.

--- a/Sources/SPMBuildCore/BuiltTestProduct.swift
+++ b/Sources/SPMBuildCore/BuiltTestProduct.swift
@@ -20,6 +20,9 @@ public struct BuiltTestProduct: Codable {
     /// The path of the test binary.
     public let binaryPath: AbsolutePath
 
+    /// The path to the package this product was declared in.
+    public let packagePath: AbsolutePath
+
     /// The path of the test bundle.
     public var bundlePath: AbsolutePath {
         // Go up the folder hierarchy until we find the .xctest bundle.
@@ -35,8 +38,10 @@ public struct BuiltTestProduct: Codable {
     /// - Parameters:
     ///   - productName: The test product name.
     ///   - binaryPath: The path of the test binary.
-    public init(productName: String, binaryPath: AbsolutePath) {
+    ///   - packagePath: The path to the package this product was declared in.
+    public init(productName: String, binaryPath: AbsolutePath, packagePath: AbsolutePath) {
         self.productName = productName
         self.binaryPath = binaryPath
+        self.packagePath = packagePath
     }
 }

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -55,7 +55,8 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
                     builtProducts.append(
                         BuiltTestProduct(
                             productName: product.name,
-                            binaryPath: binaryPath
+                            binaryPath: binaryPath,
+                            packagePath: package.path
                         )
                     )
                 }


### PR DESCRIPTION
Our current test output is not very readable. This adds an experimental feature for using `XCTestObservation` to print a summary after test execution is done.

rdar://113415965
