### PR TITLE
add performance probes for manifest loading

### DIFF
--- a/Sources/Commands/ToolWorkspaceDelegate.swift
+++ b/Sources/Commands/ToolWorkspaceDelegate.swift
@@ -210,7 +210,7 @@ class ToolWorkspaceDelegate: WorkspaceDelegate {
     }
 
     public func didUpdateDependencies(duration: DispatchTimeInterval) {
-        self.observabilityScope.emit(debug: "Dependencies updated (\(duration.descriptionInSeconds))")
+        self.observabilityScope.emit(debug: "Dependencies updated in (\(duration.descriptionInSeconds))")
         os_signpost(.end, name: SignpostName.updatingDependencies)
     }
 
@@ -220,7 +220,7 @@ class ToolWorkspaceDelegate: WorkspaceDelegate {
     }
 
     public func didResolveDependencies(duration: DispatchTimeInterval) {
-        self.observabilityScope.emit(debug: "Dependencies resolved (\(duration.descriptionInSeconds))")
+        self.observabilityScope.emit(debug: "Dependencies resolved in (\(duration.descriptionInSeconds))")
         os_signpost(.end, name: SignpostName.resolvingDependencies)
     }
 
@@ -230,18 +230,30 @@ class ToolWorkspaceDelegate: WorkspaceDelegate {
     }
 
     func didLoadGraph(duration: DispatchTimeInterval) {
-        self.observabilityScope.emit(debug: "Graph loaded (\(duration.descriptionInSeconds))")
+        self.observabilityScope.emit(debug: "Graph loaded in (\(duration.descriptionInSeconds))")
         os_signpost(.end, name: SignpostName.loadingGraph)
     }
 
-    // noop
+    func didCompileManifest(packageIdentity: PackageIdentity, packageLocation: String, duration: DispatchTimeInterval) {
+        self.observabilityScope.emit(debug: "Compiled manifest for '\(packageIdentity)' (from '\(packageLocation)') in \(duration.descriptionInSeconds)")
+    }
 
-    func willLoadManifest(packageIdentity: PackageIdentity, packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind) {}
-    func didLoadManifest(packageIdentity: PackageIdentity, packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind, manifest: Manifest?, diagnostics: [Basics.Diagnostic], duration: DispatchTimeInterval) {}
+    func didEvaluateManifest(packageIdentity: PackageIdentity, packageLocation: String, duration: DispatchTimeInterval) {
+        self.observabilityScope.emit(debug: "Evaluated manifest for '\(packageIdentity)' (from '\(packageLocation)') in \(duration.descriptionInSeconds)")
+    }
+
+    func didLoadManifest(packageIdentity: PackageIdentity, packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind, manifest: Manifest?, diagnostics: [Basics.Diagnostic], duration: DispatchTimeInterval) {
+        self.observabilityScope.emit(debug: "Loaded manifest for '\(packageIdentity)' (from '\(url)') in \(duration.descriptionInSeconds)")
+    }
+
+    // noop
     func willCheckOut(package: PackageIdentity, repository url: String, revision: String, at path: AbsolutePath) {}
     func didCreateWorkingCopy(package: PackageIdentity, repository url: String, at path: AbsolutePath, duration: DispatchTimeInterval) {}
     func resolvedFileChanged() {}
     func didDownloadAllBinaryArtifacts() {}
+    func willCompileManifest(packageIdentity: PackageIdentity, packageLocation: String) {}
+    func willEvaluateManifest(packageIdentity: PackageIdentity, packageLocation: String) {}
+    func willLoadManifest(packageIdentity: PackageIdentity, packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind) {}
 }
 
 public extension _SwiftCommand {

--- a/Sources/CoreCommands/SwiftTool.swift
+++ b/Sources/CoreCommands/SwiftTool.swift
@@ -428,7 +428,7 @@ public final class SwiftTool {
                     // TODO: should supportsAvailability be a flag as well?
                     .init(url: $0, supportsAvailability: true)
                 },
-                restrictImports: .none
+                manifestImportRestrictions: .none
             ),
             cancellator: self.cancellator,
             initializationWarningHandler: { self.observabilityScope.emit(warning: $0) },
@@ -833,7 +833,7 @@ public final class SwiftTool {
                 isManifestSandboxEnabled: !self.shouldDisableSandbox,
                 cacheDir: cachePath,
                 extraManifestFlags: extraManifestFlags,
-                restrictImports: nil
+                importRestrictions: .none
             )
         })
     }()

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -295,7 +295,7 @@ public final class MockWorkspace {
                 skipSignatureValidation: false,
                 sourceControlToRegistryDependencyTransformation: self.sourceControlToRegistryDependencyTransformation,
                 defaultRegistry: self.defaultRegistry,
-                restrictImports: .none
+                manifestImportRestrictions: .none
             ),
             customFingerprints: self.fingerprints,
             customMirrors: self.mirrors,
@@ -930,6 +930,22 @@ public final class MockWorkspaceDelegate: WorkspaceDelegate {
     }
 
     public func didLoadGraph(duration: DispatchTimeInterval) {
+        // noop
+    }
+
+    public func willCompileManifest(packageIdentity: PackageIdentity, packageLocation: String) {
+        // noop
+    }
+
+    public func didCompileManifest(packageIdentity: PackageIdentity, packageLocation: String, duration: DispatchTimeInterval) {
+        // noop
+    }
+
+    public func willEvaluateManifest(packageIdentity: PackageIdentity, packageLocation: String) {
+        // noop
+    }
+
+    public func didEvaluateManifest(packageIdentity: PackageIdentity, packageLocation: String, duration: DispatchTimeInterval) {
         // noop
     }
 

--- a/Sources/Workspace/Workspace+Configuration.swift
+++ b/Sources/Workspace/Workspace+Configuration.swift
@@ -773,7 +773,7 @@ public struct WorkspaceConfiguration {
     public var createREPLProduct: Bool
 
     /// Whether or not there should be import restrictions applied when loading manifests
-    public var restrictImports: (startingToolsVersion: ToolsVersion, allowedImports: [String])?
+    public var manifestImportRestrictions: (startingToolsVersion: ToolsVersion, allowedImports: [String])?
 
     public init(
         skipDependenciesUpdates: Bool,
@@ -787,7 +787,7 @@ public struct WorkspaceConfiguration {
         skipSignatureValidation: Bool,
         sourceControlToRegistryDependencyTransformation: SourceControlToRegistryDependencyTransformation,
         defaultRegistry: Registry?,
-        restrictImports: (startingToolsVersion: ToolsVersion, allowedImports: [String])?
+        manifestImportRestrictions: (startingToolsVersion: ToolsVersion, allowedImports: [String])?
     ) {
         self.skipDependenciesUpdates = skipDependenciesUpdates
         self.prefetchBasedOnResolvedFile = prefetchBasedOnResolvedFile
@@ -800,7 +800,7 @@ public struct WorkspaceConfiguration {
         self.skipSignatureValidation = skipSignatureValidation
         self.sourceControlToRegistryDependencyTransformation = sourceControlToRegistryDependencyTransformation
         self.defaultRegistry = defaultRegistry
-        self.restrictImports = restrictImports
+        self.manifestImportRestrictions = manifestImportRestrictions
     }
 
     /// Default instance of WorkspaceConfiguration
@@ -817,7 +817,7 @@ public struct WorkspaceConfiguration {
             skipSignatureValidation: false,
             sourceControlToRegistryDependencyTransformation: .disabled,
             defaultRegistry: .none,
-            restrictImports: .none
+            manifestImportRestrictions: .none
         )
     }
 

--- a/Tests/PackageLoadingTests/PDLoadingTests.swift
+++ b/Tests/PackageLoadingTests/PDLoadingTests.swift
@@ -21,12 +21,37 @@ import class TSCBasic.InMemoryFileSystem
 class PackageDescriptionLoadingTests: XCTestCase, ManifestLoaderDelegate {
     lazy var manifestLoader = ManifestLoader(toolchain: try! UserToolchain.default, delegate: self)
     var parsedManifest = ThreadSafeBox<AbsolutePath>()
-    
-    public func willLoad(manifest: AbsolutePath) {
+
+    func willLoad(packageIdentity: PackageModel.PackageIdentity, packageLocation: String, manifestPath: AbsolutePath) {
+        // noop
     }
-    
-    public func willParse(manifest: AbsolutePath) {
-        parsedManifest.put(manifest)
+
+    func didLoad(packageIdentity: PackageIdentity, packageLocation: String, manifestPath: AbsolutePath, duration: DispatchTimeInterval) {
+        // noop
+    }
+
+    func willParse(packageIdentity: PackageIdentity, packageLocation: String) {
+        // noop
+    }
+
+    func didParse(packageIdentity: PackageIdentity, packageLocation: String, duration: DispatchTimeInterval) {
+        // noop
+    }
+
+    func willCompile(packageIdentity: PackageIdentity, packageLocation: String, manifestPath: AbsolutePath) {
+        // noop
+    }
+
+    func didCompile(packageIdentity: PackageIdentity, packageLocation: String, manifestPath: AbsolutePath, duration: DispatchTimeInterval) {
+        // noop
+    }
+
+    func willEvaluate(packageIdentity: PackageIdentity, packageLocation: String, manifestPath: AbsolutePath) {
+        // noop
+    }
+
+    func didEvaluate(packageIdentity: PackageModel.PackageIdentity, packageLocation: String, manifestPath: AbsolutePath, duration: DispatchTimeInterval) {
+        parsedManifest.put(manifestPath)
     }
 
     var toolsVersion: ToolsVersion {

--- a/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
@@ -23,6 +23,8 @@ import enum TSCBasic.PathValidationError
 
 import func TSCTestSupport.withCustomEnv
 
+import struct TSCUtility.Version
+
 class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
     override var toolsVersion: ToolsVersion {
         .v4_2
@@ -988,15 +990,40 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             }
         }
 
-        func willLoad(manifest: AbsolutePath) {
-            self.loaded.append(manifest)
+        func willLoad(packageIdentity: PackageModel.PackageIdentity, packageLocation: String, manifestPath: AbsolutePath) {
+            // noop
+        }
+
+        func didLoad(packageIdentity: PackageIdentity, packageLocation: String, manifestPath: AbsolutePath, duration: DispatchTimeInterval) {
+            self.loaded.append(manifestPath)
             self.loadingGroup.leave()
         }
 
-        func willParse(manifest: AbsolutePath) {
-            self.parsed.append(manifest)
+        func willParse(packageIdentity: PackageIdentity, packageLocation: String) {
+            // noop
+        }
+
+        func didParse(packageIdentity: PackageIdentity, packageLocation: String, duration: DispatchTimeInterval) {
+            // noop
+        }
+
+        func willCompile(packageIdentity: PackageIdentity, packageLocation: String, manifestPath: AbsolutePath) {
+            // noop
+        }
+
+        func didCompile(packageIdentity: PackageIdentity, packageLocation: String, manifestPath: AbsolutePath, duration: DispatchTimeInterval) {
+            // noop
+        }
+
+        func willEvaluate(packageIdentity: PackageIdentity, packageLocation: String, manifestPath: AbsolutePath) {
+            // noop
+        }
+
+        func didEvaluate(packageIdentity: PackageIdentity, packageLocation: String, manifestPath: AbsolutePath, duration: DispatchTimeInterval) {
+            self.parsed.append(manifestPath)
             self.parsingGroup.leave()
         }
+
 
         func clear() {
             self.loaded.clear()

--- a/Tests/PackageLoadingTests/PD_5_7_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_7_LoadingTests.swift
@@ -180,7 +180,7 @@ class PackageDescription5_7LoadingTests: PackageDescriptionLoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        let manifestLoader = ManifestLoader(toolchain: try UserToolchain.default, restrictImports: (.v5_7, []))
+        let manifestLoader = ManifestLoader(toolchain: try UserToolchain.default, importRestrictions: (.v5_7, []))
         XCTAssertThrowsError(try loadAndValidateManifest(content, customManifestLoader: manifestLoader, observabilityScope: observability.topScope)) { error in
             if case ManifestParseError.importsRestrictedModules(let modules) = error {
                 XCTAssertEqual(modules.sorted(), ["BestModule", "Foundation"])


### PR DESCRIPTION
motivation: better visibility for performance data

changes:
* expand manifest loader delegate
* wire up the manifest loader delegate to the workspace one
* output performance info
* use weak reference over unowned in delegates since we do not control their lifetime
* rename configuraiton argument to make it more expressive