### PR TITLE
Remove fallback in `dummy-swiftc`

### DIFF
--- a/Sources/dummy-swiftc/main.swift
+++ b/Sources/dummy-swiftc/main.swift
@@ -18,7 +18,7 @@ if info.arguments.last == "-version" {
     if let swiftOriginalPath = env["SWIFT_ORIGINAL_PATH"] {
         swiftPath = swiftOriginalPath
     } else {
-        swiftPath = "/usr/bin/swiftc"
+        fatalError("need `SWIFT_ORIGINAL_PATH` in the environment")
     }
 
     let result = try Process.popen(arguments: [swiftPath] + info.arguments.dropFirst())


### PR DESCRIPTION
This fallback was a leftover from earlier development, but should be removed now since it isn't very portable as-is and isn't needed for the currently existing tests.