### PR TITLE
Fix `platforms` declaration in `IntegrationTests` package

### DIFF
--- a/IntegrationTests/Package.swift
+++ b/IntegrationTests/Package.swift
@@ -4,6 +4,9 @@ import PackageDescription
 
 let package = Package(
     name: "IntegrationTests",
+    platforms: [
+        .macOS(.v10_15),
+    ],
     targets: [
         .testTarget(name: "IntegrationTests", dependencies: [
             .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),


### PR DESCRIPTION
Not sure why this is only becoming visible now, it seems like this should have been needed since https://github.com/apple/swift-tools-support-core/commit/be6f39691456b6be2a030db22df02173de56ca35