### PR TITLE
Fix missing `from` arguments in PackageDependency's comments

### DIFF
--- a/Sources/PackageDescription/PackageDependency.swift
+++ b/Sources/PackageDescription/PackageDependency.swift
@@ -424,14 +424,14 @@ extension Package.Dependency {
     /// versions between 1.0.0 and 2.0.0
     ///
     /// ```swift
-    /// .package(url: "https://example.com/example-package.git", .upToNextMajor("1.0.0"),
+    /// .package(url: "https://example.com/example-package.git", .upToNextMajor(from: "1.0.0"),
     /// ```
     ///
     /// The following example allows the Swift Package Manager to pick
     /// versions between 1.0.0 and 1.1.0
     ///
     /// ```swift
-    /// .package(url: "https://example.com/example-package.git", .upToNextMinor("1.0.0"),
+    /// .package(url: "https://example.com/example-package.git", .upToNextMinor(from: "1.0.0"),
     /// ```
     ///
     /// - Parameters:
@@ -623,14 +623,14 @@ extension Package.Dependency {
     /// versions between 1.0.0 and 2.0.0
     ///
     /// ```swift
-    /// .package(id: "scope.name", .upToNextMajor("1.0.0"),
+    /// .package(id: "scope.name", .upToNextMajor(from: "1.0.0"),
     /// ```
     ///
     /// The following example allows the Swift Package Manager to pick
     /// versions between 1.0.0 and 1.1.0
     ///
     /// ```swift
-    /// .package(id: "scope.name", .upToNextMinor("1.0.0"),
+    /// .package(id: "scope.name", .upToNextMinor(from: "1.0.0"),
     /// ```
     ///
     /// - Parameters:


### PR DESCRIPTION
`.upToNextMajor` and `.upToNextMinor` need a `from` argument, but it was missing in the comments.

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

While I was modifying a `Package.swift` file, I noticed that the comments for `.upToNextMajor` and `.upToNextMinor` were missing the `from` argument. So, I'd like to fix that.

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
