### PR TITLE
Update Product.swift to render the api description correctly

### DIFF
--- a/Sources/PackageDescription/Product.swift
+++ b/Sources/PackageDescription/Product.swift
@@ -132,7 +132,6 @@ public class Product {
     ///     don't support both linkage types, use
     ///     ``Product/Library/LibraryType/static`` or
     ///     ``Product/Library/LibraryType/dynamic`` for this parameter.
-    ///
     ///  - targets: The targets that are bundled into a library product.
     ///
     /// - Returns: A `Product` instance.

--- a/Sources/PackageDescription/Product.swift
+++ b/Sources/PackageDescription/Product.swift
@@ -132,7 +132,7 @@ public class Product {
     ///     don't support both linkage types, use
     ///     ``Product/Library/LibraryType/static`` or
     ///     ``Product/Library/LibraryType/dynamic`` for this parameter.
-    ///  - targets: The targets that are bundled into a library product.
+    ///   - targets: The targets that are bundled into a library product.
     ///
     /// - Returns: A `Product` instance.
     public static func library(


### PR DESCRIPTION
There is an issue with the API documentation not rendering correctly due to unnecessary vertical spacing.

### Motivation:

<img width="404" alt="Screenshot 2023-09-10 at 5 09 05 PM" src="https://github.com/apple/swift-package-manager/assets/53814741/f78adf56-550d-4dfc-85c0-fe76f01cecef">

As you can see, the description for the "target" parameter is in an incorrect section.

### Modifications:

I removed the vertical spacing between the parameters' descriptions

### Result:

<img width="407" alt="Screenshot 2023-09-10 at 5 33 39 PM" src="https://github.com/apple/swift-package-manager/assets/53814741/c2f9dba5-b076-4df2-90d5-c012ea522120">
