### PR TITLE
[5.9] Fix testable executables once more

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -799,7 +799,9 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
                     if product.targets.contains(target) {
                         staticTargets.append(target)
                     } else if product.type == .test && (target.underlyingTarget as? SwiftTarget)?.supportsTestableExecutablesFeature == true {
-                        if let toolsVersion = graph.package(for: product)?.manifest.toolsVersion, toolsVersion >= .v5_5 {
+                        // Only "top-level" targets should really be considered here, not transitive ones.
+                        let isTopLevel = topLevelDependencies.contains(target.underlyingTarget) || product.targets.contains(target)
+                        if let toolsVersion = graph.package(for: product)?.manifest.toolsVersion, toolsVersion >= .v5_5, isTopLevel {
                             staticTargets.append(target)
                         }
                     }


### PR DESCRIPTION
A previous problem here was fixed in #6723, this new fix is attempting to resolve issues where macros are used transitively by a product that a test is depending on. It seems to me that those transitively available macros should not be statically linked into tests and in fact doing so can cause various issues such as linker errors on non-Darwin platforms.

It does feel like eventually we need to get away from `computeDependencies(of:)` being a computation on the entire package graph and instead let each package produce separate products which we can then just use transitively, but that is a much bigger change to SwiftPM's build system.

rdar://115071012

(cherry picked from commit 00a64dfb4924a2e167d8e91c390b8563bf3d9e79)