### PR TITLE
Revert "missing pinned version" change for 5.10

### DIFF
--- a/Sources/PackageGraph/PubGrub/PubGrubPackageContainer.swift
+++ b/Sources/PackageGraph/PubGrub/PubGrubPackageContainer.swift
@@ -76,16 +76,12 @@ internal final class PubGrubPackageContainer {
     /// Returns the best available version for a given term.
     func getBestAvailableVersion(for term: Term) throws -> Version? {
         assert(term.isPositive, "Expected term to be positive")
-        let versionSet = term.requirement
+        var versionSet = term.requirement
 
         // Restrict the selection to the pinned version if is allowed by the current requirements.
         if let pinnedVersion {
             if versionSet.contains(pinnedVersion) {
-                // Make sure the pinned version is still available
-                let version = try self.underlying.versionsDescending().first { pinnedVersion == $0 }
-                if version != nil {
-                    return version
-                }
+                versionSet = .exact(pinnedVersion)
             }
         }
 

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -1460,34 +1460,6 @@ final class PubgrubTests: XCTestCase {
         ])
     }
 
-    func testMissingPin() throws {
-        // This checks that we can drop pins that are no longer available but still keep the ones
-        // which fit the constraints.
-        try builder.serve("a", at: v1, with: ["a": ["b": (.versionSet(v1Range), .specific(["b"]))]])
-        try builder.serve("a", at: v1_1)
-        try builder.serve("b", at: v1)
-        try builder.serve("b", at: v1_1)
-
-        let dependencies = try builder.create(dependencies: [
-            "a": (.versionSet(v1Range), .specific(["a"])),
-        ])
-
-        // Here c is pinned to v1.1, but it is no longer available, so the resolver should fall back
-        // to v1.
-        let pinsStore = try builder.create(pinsStore: [
-            "a": (.version(v1), .specific(["a"])),
-            "b": (.version("1.2.0"), .specific(["b"])),
-        ])
-
-        let resolver = builder.create(pins: pinsStore.pins)
-        let result = resolver.solve(constraints: dependencies)
-
-        AssertResult(result, [
-            ("a", .version(v1)),
-            ("b", .version(v1_1)),
-        ])
-    }
-
     func testBranchedBasedPin() throws {
         // This test ensures that we get the SHA listed in Package.resolved for branch-based
         // dependencies.


### PR DESCRIPTION
There's an unfortunate interaction here with the resolver precomputation / `LocalPackageContainer` which leads to us rejecting versions as "not available" if they don't happen to be the currently checked out version. We need a more hollistic change to resolve this issue which is out of scope for 5.9, so we'll revert this change here.

rdar://115303494

(cherry picked from commit 87d65e3da6a128b87f105f579caa58e509962617)