### PR TITLE
Disable `IncrementalBuildTests` in unsupported environments

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -548,7 +548,7 @@ let package = Package(
         ),
         .testTarget(
             name: "BuildTests",
-            dependencies: ["Build", "SPMTestSupport"]
+            dependencies: ["Build", "PackageModel", "SPMTestSupport"]
         ),
         .testTarget(
             name: "WorkspaceTests",

--- a/Sources/SPMTestSupport/Toolchain.swift
+++ b/Sources/SPMTestSupport/Toolchain.swift
@@ -110,4 +110,9 @@ extension UserToolchain {
             return false
         }
     }
+
+    /// Helper function to determine whether we should run SDK-dependent tests.
+    public func supportsSDKDependentTests() -> Bool {
+        return ProcessInfo.processInfo.environment["SWIFTCI_DISABLE_SDK_DEPENDENT_TESTS"] == nil
+    }
 }

--- a/Tests/BuildTests/IncrementalBuildTests.swift
+++ b/Tests/BuildTests/IncrementalBuildTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import PackageModel
 import SPMTestSupport
 import XCTest
 
@@ -36,6 +37,7 @@ import XCTest
 final class IncrementalBuildTests: XCTestCase {
 
     func testIncrementalSingleModuleCLibraryInSources() throws {
+        try XCTSkipIf(!UserToolchain.default.supportsSDKDependentTests(), "skipping because test environment doesn't support this test")
         try fixture(name: "CFamilyTargets/CLibrarySources") { fixturePath in
             // Build it once and capture the log (this will be a full build).
             let (fullLog, _) = try executeSwiftBuild(fixturePath)
@@ -93,6 +95,7 @@ final class IncrementalBuildTests: XCTestCase {
     }
 
     func testBuildManifestCaching() throws {
+        try XCTSkipIf(!UserToolchain.default.supportsSDKDependentTests(), "skipping because test environment doesn't support this test")
         try fixture(name: "ValidLayouts/SingleModule/Library") { fixturePath in
             @discardableResult
             func build() throws -> String {
@@ -126,6 +129,7 @@ final class IncrementalBuildTests: XCTestCase {
     }
 
     func testDisableBuildManifestCaching() throws {
+        try XCTSkipIf(!UserToolchain.default.supportsSDKDependentTests(), "skipping because test environment doesn't support this test")
         try fixture(name: "ValidLayouts/SingleModule/Library") { fixturePath in
             @discardableResult
             func build() throws -> String {


### PR DESCRIPTION
This is another set of tests that requires a fully functioning SDK on macOS, so they should be skipped based on `SWIFTCI_DISABLE_SDK_DEPENDENT_TESTS`.
