### PR TITLE
[5.9] Reduce XCTest minimum deployment target computation

### DIFF
--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -274,16 +274,16 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
 
             // When deploying to macOS prior to macOS 12, add an rpath to the
             // back-deployed concurrency libraries.
-            if useStdlibRpath, self.buildParameters.triple.isDarwin(),
-               let macOSSupportedPlatform = self.package.platforms.getDerived(for: .macOS),
-               macOSSupportedPlatform.version.major < 12
-            {
-                let backDeployedStdlib = try buildParameters.toolchain.macosSwiftStdlib
-                    .parentDirectory
-                    .parentDirectory
-                    .appending("swift-5.5")
-                    .appending("macosx")
-                args += ["-Xlinker", "-rpath", "-Xlinker", backDeployedStdlib.pathString]
+            if useStdlibRpath, self.buildParameters.triple.isDarwin() {
+                let macOSSupportedPlatform = self.package.platforms.getDerived(for: .macOS, usingXCTest: product.isLinkingXCTest)
+                if macOSSupportedPlatform.version.major < 12 {
+                    let backDeployedStdlib = try buildParameters.toolchain.macosSwiftStdlib
+                        .parentDirectory
+                        .parentDirectory
+                        .appending("swift-5.5")
+                        .appending("macosx")
+                    args += ["-Xlinker", "-rpath", "-Xlinker", backDeployedStdlib.pathString]
+                }
             }
         }
 

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -144,7 +144,13 @@ extension PackageGraph {
             rootManifests: root.manifests,
             unsafeAllowedPackages: unsafeAllowedPackages,
             platformRegistry: customPlatformsRegistry ?? .default,
-            xcTestMinimumDeploymentTargets: customXCTestMinimumDeploymentTargets ?? MinimumDeploymentTarget.default.xcTestMinimumDeploymentTargets,
+            derivedXCTestPlatformProvider: { declared in
+                if let customXCTestMinimumDeploymentTargets {
+                    return customXCTestMinimumDeploymentTargets[declared]
+                } else {
+                    return MinimumDeploymentTarget.default.computeXCTestMinimumDeploymentTarget(for: declared)
+                }
+            },
             fileSystem: fileSystem,
             observabilityScope: observabilityScope
         )
@@ -225,7 +231,7 @@ private func createResolvedPackages(
     rootManifests: [PackageIdentity: Manifest],
     unsafeAllowedPackages: Set<PackageReference>,
     platformRegistry: PlatformRegistry,
-    xcTestMinimumDeploymentTargets: [PackageModel.Platform: PlatformVersion],
+    derivedXCTestPlatformProvider: @escaping (_ declared: PackageModel.Platform) -> PlatformVersion?,
     fileSystem: FileSystem,
     observabilityScope: ObservabilityScope
 ) throws -> [ResolvedPackage] {
@@ -348,16 +354,8 @@ private func createResolvedPackages(
 
         packageBuilder.platforms = computePlatforms(
             package: package,
-            usingXCTest: false,
             platformRegistry: platformRegistry,
-            xcTestMinimumDeploymentTargets: xcTestMinimumDeploymentTargets
-        )
-
-        let testPlatforms = computePlatforms(
-            package: package,
-            usingXCTest: true,
-            platformRegistry: platformRegistry,
-            xcTestMinimumDeploymentTargets: xcTestMinimumDeploymentTargets
+            derivedXCTestPlatformProvider: derivedXCTestPlatformProvider
         )
 
         // Create target builders for each target in the package.
@@ -379,7 +377,7 @@ private func createResolvedPackages(
                 }
             }
             targetBuilder.defaultLocalization = packageBuilder.defaultLocalization
-            targetBuilder.platforms = targetBuilder.target.type == .test ? testPlatforms : packageBuilder.platforms
+            targetBuilder.platforms = packageBuilder.platforms
         }
 
         // Create product builders for each product in the package. A product can only contain a target present in the same package.
@@ -686,9 +684,8 @@ private class DuplicateProductsChecker {
 
 private func computePlatforms(
     package: Package,
-    usingXCTest: Bool,
     platformRegistry: PlatformRegistry,
-    xcTestMinimumDeploymentTargets: [PackageModel.Platform: PlatformVersion]
+    derivedXCTestPlatformProvider: @escaping (_ declared: PackageModel.Platform) -> PlatformVersion?
 ) -> SupportedPlatforms {
 
     // the supported platforms as declared in the manifest
@@ -702,67 +699,9 @@ private func computePlatforms(
         )
     }
 
-    // the derived platforms based on known minimum deployment target logic
-    var derivedPlatforms = [SupportedPlatform]()
-
-    /// Add each declared platform to the supported platforms list.
-    for platform in package.manifest.platforms {
-        let declaredPlatform = platformRegistry.platformByName[platform.platformName]
-            ?? PackageModel.Platform.custom(name: platform.platformName, oldestSupportedVersion: platform.version)
-        var version = PlatformVersion(platform.version)
-
-        if usingXCTest, let xcTestMinimumDeploymentTarget = xcTestMinimumDeploymentTargets[declaredPlatform], version < xcTestMinimumDeploymentTarget {
-            version = xcTestMinimumDeploymentTarget
-        }
-
-        // If the declared version is smaller than the oldest supported one, we raise the derived version to that.
-        if version < declaredPlatform.oldestSupportedVersion {
-            version = declaredPlatform.oldestSupportedVersion
-        }
-
-        let supportedPlatform = SupportedPlatform(
-            platform: declaredPlatform,
-            version: version,
-            options: platform.options
-        )
-
-        derivedPlatforms.append(supportedPlatform)
-    }
-
-    // Find the undeclared platforms.
-    let remainingPlatforms = Set(platformRegistry.platformByName.keys).subtracting(derivedPlatforms.map({ $0.platform.name }))
-
-    /// Start synthesizing for each undeclared platform.
-    for platformName in remainingPlatforms.sorted() {
-        let platform = platformRegistry.platformByName[platformName]!
-
-        let minimumSupportedVersion: PlatformVersion
-        if usingXCTest, let xcTestMinimumDeploymentTarget = xcTestMinimumDeploymentTargets[platform], xcTestMinimumDeploymentTarget > platform.oldestSupportedVersion {
-            minimumSupportedVersion = xcTestMinimumDeploymentTarget
-        } else {
-            minimumSupportedVersion = platform.oldestSupportedVersion
-        }
-
-        let oldestSupportedVersion: PlatformVersion
-        if platform == .macCatalyst, let iOS = derivedPlatforms.first(where: { $0.platform == .iOS }) {
-            // If there was no deployment target specified for Mac Catalyst, fall back to the iOS deployment target.
-            oldestSupportedVersion = max(minimumSupportedVersion, iOS.version)
-        } else {
-            oldestSupportedVersion = minimumSupportedVersion
-        }
-
-        let supportedPlatform = SupportedPlatform(
-            platform: platform,
-            version: oldestSupportedVersion,
-            options: []
-        )
-
-        derivedPlatforms.append(supportedPlatform)
-    }
-
     return SupportedPlatforms(
         declared: declaredPlatforms.sorted(by: { $0.platform.name < $1.platform.name }),
-        derived: derivedPlatforms.sorted(by: { $0.platform.name < $1.platform.name })
+        derivedXCTestPlatformProvider: derivedXCTestPlatformProvider
     )
 }
 
@@ -886,7 +825,7 @@ private final class ResolvedTargetBuilder: ResolvedBuilder<ResolvedTarget> {
     var defaultLocalization: String? = nil
 
     /// The platforms supported by this package.
-    var platforms: SupportedPlatforms = .init(declared: [], derived: [])
+    var platforms: SupportedPlatforms = .init(declared: [], derivedXCTestPlatformProvider: .none)
 
     init(
         target: Target,
@@ -978,7 +917,7 @@ private final class ResolvedPackageBuilder: ResolvedBuilder<ResolvedPackage> {
     var defaultLocalization: String? = nil
 
     /// The platforms supported by this package.
-    var platforms: SupportedPlatforms = .init(declared: [], derived: [])
+    var platforms: SupportedPlatforms = .init(declared: [], derivedXCTestPlatformProvider: .none)
 
     /// If the given package's source is a registry release, this provides additional metadata and signature information.
     var registryMetadata: RegistryReleaseMetadata?

--- a/Sources/PackageModel/MinimumDeploymentTarget.swift
+++ b/Sources/PackageModel/MinimumDeploymentTarget.swift
@@ -10,18 +10,20 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Basics
 import TSCBasic
 
 public struct MinimumDeploymentTarget {
-    public let xcTestMinimumDeploymentTargets: [PackageModel.Platform:PlatformVersion]
+    public let xcTestMinimumDeploymentTargets = ThreadSafeKeyValueStore<PackageModel.Platform,PlatformVersion>()
 
     public static let `default`: MinimumDeploymentTarget = .init()
 
-    public init() {
-        xcTestMinimumDeploymentTargets = PlatformRegistry.default.knownPlatforms.reduce([PackageModel.Platform:PlatformVersion]()) {
-            var dict = $0
-            dict[$1] = Self.computeXCTestMinimumDeploymentTarget(for: $1)
-            return dict
+    private init() {
+    }
+
+    public func computeXCTestMinimumDeploymentTarget(for platform: PackageModel.Platform) -> PlatformVersion {
+        self.xcTestMinimumDeploymentTargets.memoize(platform) {
+            return Self.computeXCTestMinimumDeploymentTarget(for: platform)
         }
     }
 

--- a/Sources/PackageModel/Platform.swift
+++ b/Sources/PackageModel/Platform.swift
@@ -50,16 +50,56 @@ public struct Platform: Equatable, Hashable, Codable {
 
 public struct SupportedPlatforms {
     public let declared: [SupportedPlatform]
-    public let derived: [SupportedPlatform]
+    private let derivedXCTestPlatformProvider: ((Platform) -> PlatformVersion?)?
 
-    public init(declared: [SupportedPlatform], derived: [SupportedPlatform]) {
+    public init(declared: [SupportedPlatform], derivedXCTestPlatformProvider: ((_ declared: Platform) -> PlatformVersion?)?) {
         self.declared = declared
-        self.derived = derived
+        self.derivedXCTestPlatformProvider = derivedXCTestPlatformProvider
     }
 
     /// Returns the supported platform instance for the given platform.
-    public func getDerived(for platform: Platform) -> SupportedPlatform? {
-        return self.derived.first(where: { $0.platform == platform })
+    public func getDerived(for platform: Platform, usingXCTest: Bool) -> SupportedPlatform {
+        // derived platform based on known minimum deployment target logic
+        if let declaredPlatform = self.declared.first(where: { $0.platform == platform }) {
+            var version = declaredPlatform.version
+
+            if usingXCTest, let xcTestMinimumDeploymentTarget = derivedXCTestPlatformProvider?(platform), version < xcTestMinimumDeploymentTarget {
+                version = xcTestMinimumDeploymentTarget
+            }
+
+            // If the declared version is smaller than the oldest supported one, we raise the derived version to that.
+            if version < platform.oldestSupportedVersion {
+                version = platform.oldestSupportedVersion
+            }
+
+            return SupportedPlatform(
+                platform: declaredPlatform.platform,
+                version: version,
+                options: declaredPlatform.options
+            )
+        } else {
+            let minimumSupportedVersion: PlatformVersion
+            if usingXCTest, let xcTestMinimumDeploymentTarget = derivedXCTestPlatformProvider?(platform), xcTestMinimumDeploymentTarget > platform.oldestSupportedVersion {
+                minimumSupportedVersion = xcTestMinimumDeploymentTarget
+            } else {
+                minimumSupportedVersion = platform.oldestSupportedVersion
+            }
+
+            let oldestSupportedVersion: PlatformVersion
+            if platform == .macCatalyst {
+                let iOS = getDerived(for: .iOS, usingXCTest: usingXCTest)
+                // If there was no deployment target specified for Mac Catalyst, fall back to the iOS deployment target.
+                oldestSupportedVersion = max(minimumSupportedVersion, iOS.version)
+            } else {
+                oldestSupportedVersion = minimumSupportedVersion
+            }
+
+            return SupportedPlatform(
+                platform: platform,
+                version: oldestSupportedVersion,
+                options: []
+            )
+        }
     }
 }
 

--- a/Sources/SPMTestSupport/PackageGraphTester.swift
+++ b/Sources/SPMTestSupport/PackageGraphTester.swift
@@ -179,13 +179,21 @@ public final class ResolvedTargetResult {
     }
 
     public func checkDerivedPlatforms(_ platforms: [String: String], file: StaticString = #file, line: UInt = #line) {
-        let targetPlatforms = Dictionary(uniqueKeysWithValues: target.platforms.derived.map({ ($0.platform.name, $0.version.versionString) }))
+        let derived = platforms.map {
+            let platform = PlatformRegistry.default.platformByName[$0.key] ?? PackageModel.Platform
+                .custom(name: $0.key, oldestSupportedVersion: $0.value)
+            return self.target.platforms.getDerived(for: platform, usingXCTest: self.target.type == .test)
+        }
+        let targetPlatforms = Dictionary(
+            uniqueKeysWithValues: derived
+                .map { ($0.platform.name, $0.version.versionString) }
+        )
         XCTAssertEqual(platforms, targetPlatforms, file: file, line: line)
     }
 
     public func checkDerivedPlatformOptions(_ platform: PackageModel.Platform, options: [String], file: StaticString = #file, line: UInt = #line) {
-        let platform = target.platforms.getDerived(for: platform)
-        XCTAssertEqual(platform?.options, options, file: file, line: line)
+        let platform = target.platforms.getDerived(for: platform, usingXCTest: target.type == .test)
+        XCTAssertEqual(platform.options, options, file: file, line: line)
     }
 }
 
@@ -230,13 +238,17 @@ public final class ResolvedProductResult {
     }
 
     public func checkDerivedPlatforms(_ platforms: [String: String], file: StaticString = #file, line: UInt = #line) {
-        let targetPlatforms = Dictionary(uniqueKeysWithValues: product.platforms.derived.map({ ($0.platform.name, $0.version.versionString) }))
+        let derived = platforms.map {
+            let platform = PlatformRegistry.default.platformByName[$0.key] ?? PackageModel.Platform.custom(name: $0.key, oldestSupportedVersion: $0.value)
+            return product.platforms.getDerived(for: platform, usingXCTest: product.isLinkingXCTest)
+        }
+        let targetPlatforms = Dictionary(uniqueKeysWithValues: derived.map({ ($0.platform.name, $0.version.versionString) }))
         XCTAssertEqual(platforms, targetPlatforms, file: file, line: line)
     }
 
     public func checkDerivedPlatformOptions(_ platform: PackageModel.Platform, options: [String], file: StaticString = #file, line: UInt = #line) {
-        let platform = product.platforms.getDerived(for: platform)
-        XCTAssertEqual(platform?.options, options, file: file, line: line)
+        let platform = product.platforms.getDerived(for: platform, usingXCTest: product.isLinkingXCTest)
+        XCTAssertEqual(platform.options, options, file: file, line: line)
     }
 }
 

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -940,7 +940,7 @@ final class PackageToolTests: CommandsTestCase {
             // Checks the content of checked out bar.swift.
             func checkBar(_ value: Int, file: StaticString = #file, line: UInt = #line) throws {
                 let contents: String = try localFileSystem.readFileContents(barPath.appending(components:"Sources", "bar.swift"))
-                XCTAssertTrue(contents.spm_chomp().hasSuffix("\(value)"), file: file, line: line)
+                XCTAssertTrue(contents.spm_chomp().hasSuffix("\(value)"), "got \(contents)", file: file, line: line)
             }
 
             // We should see a pin file now.

--- a/Tests/PackageGraphTests/TargetTests.swift
+++ b/Tests/PackageGraphTests/TargetTests.swift
@@ -31,7 +31,7 @@ private extension ResolvedTarget {
             ),
             dependencies: deps.map { .target($0, conditions: []) },
             defaultLocalization: nil,
-            platforms: .init(declared: [], derived: [])
+            platforms: .init(declared: [], derivedXCTestPlatformProvider: .none)
         )
     }
 }


### PR DESCRIPTION
We never need this for any platform that we're not building for and we also don't really need it for most commands. So we can just move the computation to SwiftTool and leave these empty for all other cases.

rdar://64596106

(cherry picked from commit 019a6fb4b396a1cb5cb64ef8c0ba02cd580fc14a)