### PR TITLE
Add test fixture for experimental-lto-mode

### DIFF
--- a/Fixtures/Miscellaneous/LTO/SwiftAndCTargets/.gitignore
+++ b/Fixtures/Miscellaneous/LTO/SwiftAndCTargets/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Fixtures/Miscellaneous/LTO/SwiftAndCTargets/Package.swift
+++ b/Fixtures/Miscellaneous/LTO/SwiftAndCTargets/Package.swift
@@ -1,0 +1,12 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "SwiftAndCTargets",
+    targets: [
+        .target(name: "cLib"),
+        .executableTarget(name: "exe", dependencies: ["cLib", "swiftLib"]),
+        .target(name: "swiftLib"),
+    ]
+)

--- a/Fixtures/Miscellaneous/LTO/SwiftAndCTargets/Sources/cLib/cLib.c
+++ b/Fixtures/Miscellaneous/LTO/SwiftAndCTargets/Sources/cLib/cLib.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+#include "include/cLib.h"
+
+void cPrint(int value) {
+    printf("c value: %i\n", value);
+}

--- a/Fixtures/Miscellaneous/LTO/SwiftAndCTargets/Sources/cLib/include/cLib.h
+++ b/Fixtures/Miscellaneous/LTO/SwiftAndCTargets/Sources/cLib/include/cLib.h
@@ -1,0 +1,3 @@
+#pragma once
+
+extern void cPrint(int);

--- a/Fixtures/Miscellaneous/LTO/SwiftAndCTargets/Sources/exe/main.swift
+++ b/Fixtures/Miscellaneous/LTO/SwiftAndCTargets/Sources/exe/main.swift
@@ -1,0 +1,5 @@
+import swiftLib
+import cLib
+
+cPrint(1)
+swiftPrint(value: 2)

--- a/Fixtures/Miscellaneous/LTO/SwiftAndCTargets/Sources/swiftLib/swiftLib.swift
+++ b/Fixtures/Miscellaneous/LTO/SwiftAndCTargets/Sources/swiftLib/swiftLib.swift
@@ -1,0 +1,3 @@
+public func swiftPrint(value: Int) {
+  print("swift value: \(value)")
+}

--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -331,6 +331,16 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
         // User arguments (from -Xlinker) should follow generated arguments to allow user overrides
         args += self.buildParameters.flags.linkerFlags.asSwiftcLinkerFlags()
 
+        // Enable the correct lto mode if requested.
+        switch self.buildParameters.linkingParameters.linkTimeOptimizationMode {
+        case nil:
+            break
+        case .full:
+            args += ["-lto=llvm-full"]
+        case .thin:
+            args += ["-lto=llvm-thin"]
+        }
+
         // Pass default library paths from the toolchain.
         for librarySearchPath in self.buildParameters.toolchain.librarySearchPaths {
             args += ["-L", librarySearchPath.pathString]

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -347,17 +347,13 @@ class MiscellaneousTestCase: XCTestCase {
         // - https://github.com/apple/swift/pull/61766
         // - https://github.com/apple/swift-package-manager/pull/5842#issuecomment-1301632685
         try fixture(name: "Miscellaneous/LTO/SwiftAndCTargets") { fixturePath in
-            do {
-                let output = try executeSwiftBuild(
-                  fixturePath,
-                  extraArgs: ["--experimental-lto-mode=full", "--verbose"])
-                // FIXME: On macOS dsymutil cannot find temporary .o files? (#6890)
-                // Ensure warnings like the following are not present in build output
-                // warning: (arm64) /var/folders/ym/6l_0x8vj0b70sz_4h9d70p440000gn/T/main-e120de.o unable to open object file: No such file or directory
-                // XCTAssertNoMatch(output.stdout, .contains("unable to open object file"))
-            } catch {
-                XCTFail("\(error)")
-            }
+            let output = try executeSwiftBuild(
+                fixturePath,
+                extraArgs: ["--experimental-lto-mode=full", "--verbose"])
+            // FIXME: On macOS dsymutil cannot find temporary .o files? (#6890)
+            // Ensure warnings like the following are not present in build output
+            // warning: (arm64) /var/folders/ym/6l_0x8vj0b70sz_4h9d70p440000gn/T/main-e120de.o unable to open object file: No such file or directory
+            // XCTAssertNoMatch(output.stdout, .contains("unable to open object file"))
         }
         #endif
     }

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -342,7 +342,7 @@ class MiscellaneousTestCase: XCTestCase {
             do {
                 let output = try executeSwiftBuild(
                   fixturePath,
-                  extraArgs: ["--experimental-lto-mode=full"])
+                  extraArgs: ["--experimental-lto-mode=full", "--verbose"])
                 // FIXME: On macOS dsymutil cannot find temporary .o files? (#6890)
                 // Ensure warnings like the following are not present in build output
                 // warning: (arm64) /var/folders/ym/6l_0x8vj0b70sz_4h9d70p440000gn/T/main-e120de.o unable to open object file: No such file or directory

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -337,6 +337,22 @@ class MiscellaneousTestCase: XCTestCase {
         }
     }
 
+    func testLTO() throws {
+        try fixture(name: "Miscellaneous/LTO/SwiftAndCTargets") { fixturePath in
+            do {
+                let output = try executeSwiftBuild(
+                  fixturePath,
+                  extraArgs: ["--experimental-lto-mode=full"])
+                // FIXME: On macOS dsymutil cannot find temporary .o files? (#6890)
+                // Ensure warnings like the following are not present in build output
+                // warning: (arm64) /var/folders/ym/6l_0x8vj0b70sz_4h9d70p440000gn/T/main-e120de.o unable to open object file: No such file or directory
+                // XCTAssertNoMatch(output.stdout, .contains("unable to open object file"))
+            } catch {
+                XCTFail("\(error)")
+            }
+        }
+    }
+
     func testUnicode() throws {
         #if !os(Linux) && !os(Android) // TODO: - Linux has trouble with this and needs investigation.
         try fixture(name: "Miscellaneous/Unicode") { fixturePath in

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -338,6 +338,14 @@ class MiscellaneousTestCase: XCTestCase {
     }
 
     func testLTO() throws {
+        #if os(macOS)
+        // FIXME: this test requires swift-driver to be installed
+        // Currently swift-ci does not build/install swift-driver before running
+        // swift-package-manager tests which results in this test failing.
+        // See the following additional discussion:
+        // - https://github.com/apple/swift/pull/69696
+        // - https://github.com/apple/swift/pull/61766
+        // - https://github.com/apple/swift-package-manager/pull/5842#issuecomment-1301632685
         try fixture(name: "Miscellaneous/LTO/SwiftAndCTargets") { fixturePath in
             do {
                 let output = try executeSwiftBuild(
@@ -351,6 +359,7 @@ class MiscellaneousTestCase: XCTestCase {
                 XCTFail("\(error)")
             }
         }
+        #endif
     }
 
     func testUnicode() throws {


### PR DESCRIPTION
Adds a test covering experimental lto mode and fixes a bug where the
lto mode was not passed to the linker.

Fixes #6888