### PR TITLE
Hide `--test-product` option

### DIFF
--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -65,7 +65,7 @@ struct SharedOptions: ParsableArguments {
 
     /// The test product to use. This is useful when there are multiple test products
     /// to choose from (usually in multiroot packages).
-    @Option(help: "Test the specified product.")
+    @Option(help: .hidden)
     var testProduct: String?
 }
 


### PR DESCRIPTION
This option is only useful when in cases where SwiftPM offers more than a single test product. Currently that requires either using XCBuild or a multi-root data file which are both hidden and experimental, so this option should be hidden, too, in order to not confuse users.

It could be interesting to investigate changing the build model so that we would always build a test product per test target and if that happens we could publicize this option again.