### PR TITLE
Do not process code coverage when tests failed

### DIFF
--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -296,7 +296,7 @@ public struct SwiftTestTool: SwiftCommand {
                 swiftTool.executionStatus = .failure
             }
 
-            if self.options.enableCodeCoverage {
+            if self.options.enableCodeCoverage, ranSuccessfully {
                 try processCodeCoverage(testProducts, swiftTool: swiftTool)
             }
 
@@ -355,7 +355,7 @@ public struct SwiftTestTool: SwiftCommand {
             }
 
             // process code Coverage if request
-            if self.options.enableCodeCoverage {
+            if self.options.enableCodeCoverage, runner.ranSuccessfully {
                 try processCodeCoverage(testProducts, swiftTool: swiftTool)
             }
 


### PR DESCRIPTION
This can currently lead to bogus output like

```
error: terminated(1): /Users/neonacho/Downloads/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/llvm-profdata merge -sparse -o /Users/neonacho/Desktop/lunch7/.build/arm64-apple-macosx/debug/codecov/default.profdata output:
    error: no input files specified. See llvm-profdata merge -help
```

I would also think even if it succeeded, it could result in incorrect data.

rdar://115436056
