### PR TITLE
WIP: Make multiple test products the default

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -315,7 +315,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
                 let entryPointSources = Sources(paths: [entryPointMainFile], root: entryPointDerivedDir)
 
                 let entryPointTarget = SwiftTarget(
-                    name: testProduct.name,
+                    name: testProduct.name + String(testProduct.name.hash, radix: 16, uppercase: true),
                     type: .library,
                     dependencies: testProduct.underlyingProduct.targets.map { .target($0, conditions: []) } + [.target(discoveryTarget, conditions: [])],
                     packageAccess: true, // test target is allowed access to package decls

--- a/Sources/CoreCommands/SwiftTool.swift
+++ b/Sources/CoreCommands/SwiftTool.swift
@@ -55,7 +55,7 @@ public struct ToolWorkspaceConfiguration {
 
     public init(
         shouldInstallSignalHandlers: Bool = true,
-        wantsMultipleTestProducts: Bool = false,
+        wantsMultipleTestProducts: Bool = true,
         wantsREPLProduct: Bool = false
     ) {
         self.shouldInstallSignalHandlers = shouldInstallSignalHandlers

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -28,7 +28,7 @@ extension PackageGraph {
         requiredDependencies: [PackageReference] = [],
         unsafeAllowedPackages: Set<PackageReference> = [],
         binaryArtifacts: [PackageIdentity: [String: BinaryArtifact]],
-        shouldCreateMultipleTestProducts: Bool = false,
+        shouldCreateMultipleTestProducts: Bool = true,
         createREPLProduct: Bool = false,
         customPlatformsRegistry: PlatformRegistry? = .none,
         customXCTestMinimumDeploymentTargets: [PackageModel.Platform: PlatformVersion]? = .none,

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -332,7 +332,7 @@ public final class PackageBuilder {
         path: AbsolutePath,
         additionalFileRules: [FileRuleDescription],
         binaryArtifacts: [String: BinaryArtifact],
-        shouldCreateMultipleTestProducts: Bool = false,
+        shouldCreateMultipleTestProducts: Bool = true,
         testEntryPointPath: AbsolutePath? = nil,
         warnAboutImplicitExecutableTargets: Bool = true,
         createREPLProduct: Bool = false,

--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -251,7 +251,7 @@ public func loadPackageGraph(
     manifests: [Manifest],
     binaryArtifacts: [PackageIdentity: [String: BinaryArtifact]] = [:],
     explicitProduct: String? = .none,
-    shouldCreateMultipleTestProducts: Bool = false,
+    shouldCreateMultipleTestProducts: Bool = true,
     createREPLProduct: Bool = false,
     useXCBuildFileRules: Bool = false,
     customXCTestMinimumDeploymentTargets: [PackageModel.Platform: PlatformVersion]? = .none,

--- a/Sources/Workspace/Workspace+Configuration.swift
+++ b/Sources/Workspace/Workspace+Configuration.swift
@@ -808,7 +808,7 @@ public struct WorkspaceConfiguration {
         .init(
             skipDependenciesUpdates: false,
             prefetchBasedOnResolvedFile: true,
-            shouldCreateMultipleTestProducts: false,
+            shouldCreateMultipleTestProducts: true,
             createREPLProduct: false,
             additionalFileRules: [],
             sharedDependenciesCacheEnabled: true,

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -948,12 +948,11 @@ final class BuildPlanTests: XCTestCase {
             observabilityScope: observability.topScope
         ))
 
-        XCTAssertEqual(Set(result.productMap.keys), ["APackageTests"])
+        XCTAssertEqual(Set(result.productMap.keys), ["ATargetTests"])
       #if os(macOS)
         XCTAssertEqual(Set(result.targetMap.keys), ["ATarget", "BTarget", "ATargetTests"])
       #else
         XCTAssertEqual(Set(result.targetMap.keys), [
-            "APackageTests",
             "APackageDiscoveredTests",
             "ATarget",
             "ATargetTests",
@@ -1712,14 +1711,14 @@ final class BuildPlanTests: XCTestCase {
         } else {
             rpathsForBackdeployment = []
         }
-        XCTAssertEqual(try result.buildProduct(for: "PkgPackageTests").linkArguments(), [
+        XCTAssertEqual(try result.buildProduct(for: "FooTests").linkArguments(), [
             result.plan.buildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
-            "-o", buildPath.appending(components: "PkgPackageTests.xctest", "Contents", "MacOS", "PkgPackageTests").pathString,
-            "-module-name", "PkgPackageTests",
+            "-o", buildPath.appending(components: "FooTests.xctest", "Contents", "MacOS", "FooTests").pathString,
+            "-module-name", "FooTests",
             "-Xlinker", "-bundle",
             "-Xlinker", "-rpath", "-Xlinker", "@loader_path/../../../",
-            "@\(buildPath.appending(components: "PkgPackageTests.product", "Objects.LinkFileList"))"] +
+            "@\(buildPath.appending(components: "FooTests.product", "Objects.LinkFileList"))"] +
             rpathsForBackdeployment +
             ["-target", "\(hostTriple.tripleString(forPlatformVersion: version))",
             "-Xlinker", "-add_ast_path", "-Xlinker", buildPath.appending(components: "Foo.swiftmodule").pathString,
@@ -3090,16 +3089,16 @@ final class BuildPlanTests: XCTestCase {
         let executablePathExtension = try appBuildDescription.binaryPath.extension
         XCTAssertEqual(executablePathExtension, "wasm")
 
-        let testBuildDescription = try result.buildProduct(for: "PkgPackageTests")
+        let testBuildDescription = try result.buildProduct(for: "test")
         XCTAssertEqual(
             try testBuildDescription.linkArguments(),
             [
                 result.plan.buildParameters.toolchain.swiftCompilerPath.pathString,
                 "-L", buildPath.pathString,
-                "-o", buildPath.appending(components: "PkgPackageTests.wasm").pathString,
-                "-module-name", "PkgPackageTests",
+                "-o", buildPath.appending(components: "test.wasm").pathString,
+                "-module-name", "test",
                 "-emit-executable",
-                "@\(buildPath.appending(components: "PkgPackageTests.product", "Objects.LinkFileList"))",
+                "@\(buildPath.appending(components: "test.product", "Objects.LinkFileList"))",
                 "-target", "wasm32-unknown-wasi",
                 "-g",
             ]

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -401,7 +401,7 @@ class MiscellaneousTestCase: XCTestCase {
                 // in "swift test" build output goes to stderr
                 XCTAssertMatch(stderr, .contains("Linking TestableExe1"))
                 XCTAssertMatch(stderr, .contains("Linking TestableExe2"))
-                XCTAssertMatch(stderr, .contains("Linking TestableExePackageTests"))
+                XCTAssertMatch(stderr, .contains("Linking TestableExeTests"))
                 XCTAssertMatch(stderr, .contains("Build complete!"))
                 // in "swift test" test output goes to stdout
                 XCTAssertMatch(stdout, .contains("Executed 1 test"))


### PR DESCRIPTION
This would enable `--test-product` to work in general and may have other benefits.