### PR TITLE
Refine error message with package name suggestion

### DIFF
--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -16,6 +16,7 @@ import PackageLoading
 import PackageModel
 
 import func TSCBasic.topologicalSort
+import func TSCBasic.bestMatch
 
 extension PackageGraph {
 
@@ -495,13 +496,16 @@ private func createResolvedPackages(
                         }.map {$0.targets}.flatMap{$0}.filter { t in
                             t.name != productRef.name
                         }
-
+                        
+                        // Find a product name from the available product dependencies that is most similar to the required product name.
+                        let bestMatchedProductName = bestMatch(for: productRef.name, from: Array(allTargetNames))
                         let error = PackageGraphError.productDependencyNotFound(
                             package: package.identity.description,
                             targetName: targetBuilder.target.name,
                             dependencyProductName: productRef.name,
                             dependencyPackageName: productRef.package,
-                            dependencyProductInDecl: !declProductsAsDependency.isEmpty
+                            dependencyProductInDecl: !declProductsAsDependency.isEmpty,
+                            similarProductName: bestMatchedProductName
                         )
                         packageObservabilityScope.emit(error)
                     }

--- a/Sources/PackageGraph/PackageGraph.swift
+++ b/Sources/PackageGraph/PackageGraph.swift
@@ -23,7 +23,7 @@ enum PackageGraphError: Swift.Error {
     case cycleDetected((path: [Manifest], cycle: [Manifest]))
 
     /// The product dependency not found.
-    case productDependencyNotFound(package: String, targetName: String, dependencyProductName: String, dependencyPackageName: String?, dependencyProductInDecl: Bool)
+    case productDependencyNotFound(package: String, targetName: String, dependencyProductName: String, dependencyPackageName: String?, dependencyProductInDecl: Bool, similarProductName: String?)
 
     /// The package dependency already satisfied by a different dependency package
     case dependencyAlreadySatisfiedByIdentifier(package: String, dependencyLocation: String, otherDependencyURL: String, identity: PackageIdentity)
@@ -219,11 +219,15 @@ extension PackageGraphError: CustomStringConvertible {
             (cycle.path + cycle.cycle).map({ $0.displayName }).joined(separator: " -> ") +
             " -> " + cycle.cycle[0].displayName
 
-        case .productDependencyNotFound(let package, let targetName, let dependencyProductName, let dependencyPackageName, let dependencyProductInDecl):
+        case .productDependencyNotFound(let package, let targetName, let dependencyProductName, let dependencyPackageName, let dependencyProductInDecl, let similarProductName):
             if dependencyProductInDecl {
                 return "product '\(dependencyProductName)' is declared in the same package '\(package)' and can't be used as a dependency for target '\(targetName)'."
             } else {
-                return "product '\(dependencyProductName)' required by package '\(package)' target '\(targetName)' \(dependencyPackageName.map{ "not found in package '\($0)'" } ?? "not found")."
+                var description = "product '\(dependencyProductName)' required by package '\(package)' target '\(targetName)' \(dependencyPackageName.map{ "not found in package '\($0)'" } ?? "not found")."
+                if let similarProductName {
+                    description += " Did you mean '\(similarProductName)'?"
+                }
+                return description
             }
         case .dependencyAlreadySatisfiedByIdentifier(let package, let dependencyURL, let otherDependencyURL, let identity):
             return "'\(package)' dependency on '\(dependencyURL)' conflicts with dependency on '\(otherDependencyURL)' which has the same identity '\(identity)'"


### PR DESCRIPTION
Update error message when there's a package target with a similar name as the one provided in the dependency.

### Motivation:
Partially addresses https://github.com/apple/swift-package-manager/issues/4803.

It adds a suggestion for an alternative dependency name when there's a dependency target with similar name as the one provided in the `Package.swift`.

### Modifications:
Use the existing `bestMatch(for, from)` from TSCBasic to compare the `productRef.name` and `allTargetNames`. 
However, I'm not sure how and if I can include target from system packages. 

### Result:
Error messages for package target not found may also suggest an alternative name like: 
`product 'Barx' required by package 'foo' target 'FooTarget' not found. Did you mean 'Bar'?`