### PR TITLE
Compute path to `swift-plugin-server` on demand

### DIFF
--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -887,7 +887,7 @@ public final class SwiftTargetBuildDescription {
         #endif
 
         // If we're using an OSS toolchain, add the required arguments bringing in the plugin server from the default toolchain if available.
-        if self.buildParameters.toolchain.isSwiftDevelopmentToolchain, driverSupport.checkSupportedFrontendFlags(flags: ["-external-plugin-path"], toolchain: self.buildParameters.toolchain, fileSystem: self.fileSystem), let pluginServer = self.buildParameters.toolchain.swiftPluginServerPath {
+        if self.buildParameters.toolchain.isSwiftDevelopmentToolchain, driverSupport.checkSupportedFrontendFlags(flags: ["-external-plugin-path"], toolchain: self.buildParameters.toolchain, fileSystem: self.fileSystem), let pluginServer = try self.buildParameters.toolchain.swiftPluginServerPath {
             let toolchainUsrPath = pluginServer.parentDirectory.parentDirectory
             let pluginPathComponents = ["lib", "swift", "host", "plugins"]
 

--- a/Sources/PackageModel/Toolchain.swift
+++ b/Sources/PackageModel/Toolchain.swift
@@ -29,7 +29,7 @@ public protocol Toolchain {
     var isSwiftDevelopmentToolchain: Bool { get }
 
     /// Path to the Swift plugin server utility.
-    var swiftPluginServerPath: AbsolutePath? { get }
+    var swiftPluginServerPath: AbsolutePath? { get throws }
 
     /// Path containing the macOS Swift stdlib.
     var macosSwiftStdlib: AbsolutePath { get throws }

--- a/Sources/PackageModel/ToolchainConfiguration.swift
+++ b/Sources/PackageModel/ToolchainConfiguration.swift
@@ -42,9 +42,6 @@ public struct ToolchainConfiguration {
     /// This is optional for example on macOS w/o Xcode.
     public var xctestPath: AbsolutePath?
 
-    /// Path to the Swift plugin server utility.
-    public var swiftPluginServerPath: AbsolutePath?
-
     /// Creates the set of manifest resources associated with a `swiftc` executable.
     ///
     /// - Parameters:
@@ -55,7 +52,6 @@ public struct ToolchainConfiguration {
     ///     - swiftPMLibrariesRootPath: Custom path for SwiftPM libraries. Computed based on the compiler path by default.
     ///     - sdkRootPath: Optional path to SDK root.
     ///     - xctestPath: Optional path to XCTest.
-    ///     - swiftPluginServerPath: Optional path to the Swift plugin server executable.
     public init(
         librarianPath: AbsolutePath,
         swiftCompilerPath: AbsolutePath,
@@ -63,8 +59,7 @@ public struct ToolchainConfiguration {
         swiftCompilerEnvironment: EnvironmentVariables = .process(),
         swiftPMLibrariesLocation: SwiftPMLibrariesLocation? = nil,
         sdkRootPath: AbsolutePath? = nil,
-        xctestPath: AbsolutePath? = nil,
-        swiftPluginServerPath: AbsolutePath? = nil
+        xctestPath: AbsolutePath? = nil
     ) {
         let swiftPMLibrariesLocation = swiftPMLibrariesLocation ?? {
             return .init(swiftCompilerPath: swiftCompilerPath)
@@ -77,7 +72,6 @@ public struct ToolchainConfiguration {
         self.swiftPMLibrariesLocation = swiftPMLibrariesLocation
         self.sdkRootPath = sdkRootPath
         self.xctestPath = xctestPath
-        self.swiftPluginServerPath = swiftPluginServerPath
     }
 }
 


### PR DESCRIPTION
This takes a significant amount of time when the selected Xcode doesn't have a `swift-plugin-server` executable:

```
/tmp/exec
❯ time /usr/bin/xcrun --find swift-plugin-server
xcrun: error: sh -c '/Users/neonacho/Downloads/Xcode.app/Contents/Developer/usr/bin/xcodebuild -sdk /Users/neonacho/Downloads/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk -find swift-plugin-server 2> /dev/null' failed with exit code 17664: (null) (errno=No such file or directory)
xcrun: error: unable to find utility "swift-plugin-server", not a developer tool or in PATH
/usr/bin/xcrun --find swift-plugin-server  0.34s user 0.17s system 32% cpu 1.579 total
```

Doing this on demand is at least gated on `self.buildParameters.toolchain.isSwiftDevelopmentToolchain` so it shouldn't happen for the primary usage scenario on macOS.
