### PR TITLE
Avoid host triple computation in `BuildParameters.forTriple()`

### DIFF
--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -473,10 +473,13 @@ public struct BuildParameters: Encodable {
             testEntryPointPath = nil
         }
 
+        var hostSDK = try SwiftSDK.hostSwiftSDK()
+        hostSDK.targetTriple = targetTriple
+
         return try .init(
             dataPath: self.dataPath.parentDirectory.appending(components: ["plugins", "tools"]),
             configuration: self.configuration,
-            toolchain: try UserToolchain(swiftSDK: SwiftSDK.hostSwiftSDK()),
+            toolchain: try UserToolchain(swiftSDK: hostSDK),
             hostTriple: self.hostTriple,
             targetTriple: targetTriple,
             flags: BuildFlags(),


### PR DESCRIPTION
We now the triple here, so we shouldn't have it be recomputed from scratch.
