### PR TITLE
[WIP] Specify registry specific credentials file in registries.json

### DIFF
--- a/Sources/Basics/CMakeLists.txt
+++ b/Sources/Basics/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This source file is part of the Swift open source project
 #
-# Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See http://swift.org/LICENSE.txt for license information
@@ -54,6 +54,7 @@ add_library(Basics
   SendableTimeInterval.swift
   Serialization/SerializedJSON.swift
   String+Extensions.swift
+  Swiftpmrc.swift
   SwiftVersion.swift
   SQLiteBackedCache.swift
   Triple+Basics.swift

--- a/Sources/Basics/Swiftpmrc.swift
+++ b/Sources/Basics/Swiftpmrc.swift
@@ -1,0 +1,146 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// A `swiftpmrc` file is similar to a `netrc` file but in JSON format instead.
+/// For example:
+///
+/// ````
+/// {
+///   "machines": [
+///     {
+///       "name": "example.com",
+///       "login": "jappleseed",
+///       "password": "top-secret"
+///     },
+///     {
+///       "name": "example.com:8080",
+///       "password": "secret-token"
+///     }
+///   ],
+///   "version": 1
+/// }
+/// ````
+///
+/// Both `login` and `password` are required for basic authentication.
+/// Only `password` is required for token authentication.
+///
+/// Machine name should include port if non-standard ports are used.
+public struct Swiftpmrc {
+    /// Representation of `machine` connection settings
+    public let machines: [Machine]
+
+    /// Returns authorization information.
+    ///
+    /// - Parameters:
+    ///   - url: The url to retrieve authorization information for.
+    public func authorization(for url: URL) -> Authorization? {
+        guard let index = machines.firstIndex(where: { $0.name == url.machineName }) else {
+            return .none
+        }
+        let machine = self.machines[index]
+        return Authorization(
+            login: machine.login,
+            password: machine.password
+        )
+    }
+
+    private func machineName(for url: URL) throws -> String? {
+        guard let host = url.host?.lowercased() else {
+            return .none
+        }
+        return [host, url.port?.description].compactMap { $0 }.joined(separator: ":")
+    }
+
+    /// Representation of connection settings
+    public struct Machine: Equatable, Decodable {
+        public let name: String
+        // `login` is not required in some authentication methods (e.g., token)
+        public let login: String?
+        public let password: String
+    }
+
+    /// Representation of authorization information
+    public struct Authorization: Equatable {
+        public let login: String?
+        public let password: String
+    }
+}
+
+extension URL {
+    fileprivate var machineName: String? {
+        guard let host = self.host?.lowercased() else {
+            return .none
+        }
+        return [host, self.port?.description].compactMap { $0 }.joined(separator: ":")
+    }
+}
+
+// MARK: - swiftpmrc parsing
+
+extension Swiftpmrc {
+    /// Parse a `swiftpmrc` file at the give location.
+    ///
+    /// - Parameters:
+    ///   - fileSystem: The file system to use.
+    ///   - path: The file to parse.
+    public static func parse(fileSystem: FileSystem, path: AbsolutePath) throws -> Swiftpmrc {
+        guard fileSystem.exists(path) else {
+            throw SwiftpmrcError.fileNotFound(path)
+        }
+        guard fileSystem.isReadable(path) else {
+            throw SwiftpmrcError.unreadableFile(path)
+        }
+        let content: Data = try fileSystem.readFileContents(path)
+        return try Self.parse(content)
+    }
+
+    /// Parse `swiftpmrc` contents.
+    ///
+    /// - Parameters:
+    ///   - content: The content to parse.
+    public static func parse(_ content: Data) throws -> Swiftpmrc {
+        let decoder = JSONDecoder()
+        let schemaVersion = try decoder.decode(SchemaVersion.self, from: content)
+        switch schemaVersion.version {
+        case .some(1):
+            let container = try decoder.decode(Container.V1.self, from: content)
+            guard !container.machines.isEmpty else {
+                throw SwiftpmrcError.machineNotFound
+            }
+            return Swiftpmrc(machines: container.machines)
+        default:
+            throw SwiftpmrcError.unsupportedVersion(schemaVersion.version)
+        }
+    }
+}
+
+extension Swiftpmrc {
+    struct SchemaVersion: Codable {
+        let version: Int?
+    }
+
+    enum Container {
+        struct V1: Decodable {
+            let version: Int?
+            let machines: [Swiftpmrc.Machine]
+        }
+    }
+}
+
+public enum SwiftpmrcError: Error, Equatable {
+    case fileNotFound(AbsolutePath)
+    case unreadableFile(AbsolutePath)
+    case machineNotFound
+    case unsupportedVersion(Int?)
+}

--- a/Sources/PackageRegistry/RegistryConfiguration.swift
+++ b/Sources/PackageRegistry/RegistryConfiguration.swift
@@ -116,10 +116,16 @@ public struct RegistryConfiguration: Hashable {
 extension RegistryConfiguration {
     public struct Authentication: Hashable, Codable {
         public var type: AuthenticationType
+        public var swiftpmrcPath: AbsolutePath?
         public var loginAPIPath: String?
 
-        public init(type: AuthenticationType, loginAPIPath: String? = nil) {
+        public init(
+            type: AuthenticationType,
+            swiftpmrcPath: AbsolutePath? = nil,
+            loginAPIPath: String? = nil
+        ) {
             self.type = type
+            self.swiftpmrcPath = swiftpmrcPath
             self.loginAPIPath = loginAPIPath
         }
     }

--- a/Tests/BasicsTests/SwiftpmrcTests.swift
+++ b/Tests/BasicsTests/SwiftpmrcTests.swift
@@ -1,0 +1,99 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import XCTest
+
+class SwiftpmrcTests: XCTestCase {
+    func testParse() throws {
+        let content = """
+        {
+          "machines": [
+            {
+              "name": "example.com",
+              "login": "anonymous",
+              "password": "qwerty"
+            },
+            {
+              "name": "example.com:8080",
+              "password": "secret-token"
+            }
+          ],
+          "version": 1
+        }
+        """
+
+        let swiftpmrc = try Swiftpmrc.parse(content.data(using: .utf8)!)
+        XCTAssertEqual(swiftpmrc.machines.count, 2)
+
+        let basic = swiftpmrc.machines[0]
+        XCTAssertEqual(basic.name, "example.com")
+        XCTAssertEqual(basic.login, "anonymous")
+        XCTAssertEqual(basic.password, "qwerty")
+
+        let token = swiftpmrc.machines[1]
+        XCTAssertEqual(token.name, "example.com:8080")
+        XCTAssertNil(token.login)
+        XCTAssertEqual(token.password, "secret-token")
+
+        let authorizationBasic = swiftpmrc.authorization(for: "http://example.com/resource.zip")
+        XCTAssertEqual(authorizationBasic?.login, "anonymous")
+        XCTAssertEqual(authorizationBasic?.password, "qwerty")
+
+        let authorizationToken = swiftpmrc.authorization(for: "http://example.com:8080/resource.zip")
+        XCTAssertNil(authorizationToken?.login)
+        XCTAssertEqual(authorizationToken?.password, "secret-token")
+
+        XCTAssertNil(swiftpmrc.authorization(for: "http://example2.com/resource.zip"))
+        XCTAssertNil(swiftpmrc.authorization(for: "http://www.example.com/resource.zip"))
+    }
+
+    func testUnsupportedVersion() throws {
+        let content = """
+        {
+          "machines": [
+            {
+              "name": "example.com",
+              "login": "anonymous",
+              "password": "qwerty"
+            }
+          ],
+          "version": 0
+        }
+        """
+
+        XCTAssertThrowsError(
+            try Swiftpmrc.parse(content.data(using: .utf8)!)
+        ) { error in
+            guard case SwiftpmrcError.unsupportedVersion = error else {
+                return XCTFail("expected SwiftpmrcError.unsupportedVersion, got \(error)")
+            }
+        }
+    }
+
+    func testEmptyMachines() throws {
+        let content = """
+        {
+          "machines": [],
+          "version": 1
+        }
+        """
+
+        XCTAssertThrowsError(
+            try Swiftpmrc.parse(content.data(using: .utf8)!)
+        ) { error in
+            guard case SwiftpmrcError.machineNotFound = error else {
+                return XCTFail("expected SwiftpmrcError.machineNotFound, got \(error)")
+            }
+        }
+    }
+}

--- a/Tests/PackageRegistryTests/RegistryConfigurationTests.swift
+++ b/Tests/PackageRegistryTests/RegistryConfigurationTests.swift
@@ -144,6 +144,10 @@ final class RegistryConfigurationTests: XCTestCase {
                 "packages.example.com": {
                     "type": "basic",
                     "loginAPIPath": "/v1/login"
+                },
+                "other.packages.example.com": {
+                    "type": "token",
+                    "swiftpmrcPath": "/me/.swiftpmrc"
                 }
             },
             "security": {
@@ -199,7 +203,14 @@ final class RegistryConfigurationTests: XCTestCase {
         XCTAssertEqual(configuration.scopedRegistries["foo"]?.url, customRegistryBaseURL)
         XCTAssertEqual(configuration.scopedRegistries["bar"]?.url, customRegistryBaseURL)
         XCTAssertEqual(configuration.registryAuthentication["packages.example.com"]?.type, .basic)
+        XCTAssertNil(configuration.registryAuthentication["packages.example.com"]?.swiftpmrcPath)
         XCTAssertEqual(configuration.registryAuthentication["packages.example.com"]?.loginAPIPath, "/v1/login")
+        XCTAssertEqual(configuration.registryAuthentication["other.packages.example.com"]?.type, .token)
+        XCTAssertEqual(
+            configuration.registryAuthentication["other.packages.example.com"]?.swiftpmrcPath,
+            "/me/.swiftpmrc"
+        )
+        XCTAssertNil(configuration.registryAuthentication["other.packages.example.com"]?.loginAPIPath)
         XCTAssertEqual(configuration.security?.default.signing?.onUnsigned, .error)
         XCTAssertEqual(configuration.security?.default.signing?.onUntrustedCertificate, .error)
         XCTAssertEqual(


### PR DESCRIPTION
Motivation:
Current supported credential stores (namely Keychain and netrc file) are intended for long-lasting credentials (weeks/months vs. minutes/hours). For registries that use short-lived access tokens, frequent updates are made to the credential store. Using netrc file then becomes challenging, because SwiftPM doesn't do in-place edit of an existing entry but always appends to the end of file and uses the last match. The netrc file would become bloated very quickly.

https://github.com/apple/swift-package-manager/issues/6865 rdar://114607754

Modifications:

- Add new `swiftpmrc` format which is similar to `netrc` but it's in JSON.

```
        {
          "machines": [
            {
              "name": "example.com",
              "login": "anonymous",
              "password": "qwerty"
            },
            {
              "name": "example.com:8080",
              "password": "secret-token"
            }
          ],
          "version": 1
        }
```

 - Add option `swiftpmrcPath` to `authentication` block in `registries.json`. Short-lived tokens can be written to a `swiftpmrc` file and overwritten as needed without worrying that it's shared across apps like `netrc` does.
 - Update `RegistryClient` to read from `swiftpmrc` file if specified
 - Update `package-registry login` subcommand to support `--swiftpmrc-file` option

