### PR TITLE
[5.9] Avoid host triple computation in `BuildParameters.forTriple()`

### DIFF
--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -305,10 +305,13 @@ public struct BuildParameters: Encodable {
             testEntryPointPath = nil
         }
 
+        var hostDestination = try Destination.hostDestination()
+        hostDestination.targetTriple = destinationTriple
+
         return try .init(
             dataPath: self.dataPath.parentDirectory.appending(components: ["plugins", "tools"]),
             configuration: self.configuration,
-            toolchain: try UserToolchain(destination: Destination.hostDestination()),
+            toolchain: try UserToolchain(destination: hostDestination),
             hostTriple: self.hostTriple,
             destinationTriple: destinationTriple,
             flags: BuildFlags(),


### PR DESCRIPTION
We know the triple here, so we shouldn't have to recompute from scratch.

(cherry picked from commit 389edb717478e7fc7963eccdc338463321407e75)
