### PR TITLE
[5.9] Compute path to `swift-plugin-server` on demand

### DIFF
--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -394,7 +394,7 @@ public final class SwiftTargetBuildDescription {
         #endif
 
         // If we're using an OSS toolchain, add the required arguments bringing in the plugin server from the default toolchain if available.
-        if self.buildParameters.toolchain.isSwiftDevelopmentToolchain, driverSupport.checkSupportedFrontendFlags(flags: ["-external-plugin-path"], toolchain: self.buildParameters.toolchain, fileSystem: self.fileSystem), let pluginServer = self.buildParameters.toolchain.swiftPluginServerPath {
+        if self.buildParameters.toolchain.isSwiftDevelopmentToolchain, driverSupport.checkSupportedFrontendFlags(flags: ["-external-plugin-path"], toolchain: self.buildParameters.toolchain, fileSystem: self.fileSystem), let pluginServer = try self.buildParameters.toolchain.swiftPluginServerPath {
             let toolchainUsrPath = pluginServer.parentDirectory.parentDirectory
             let pluginPathComponents = ["lib", "swift", "host", "plugins"]
 

--- a/Sources/PackageModel/Toolchain.swift
+++ b/Sources/PackageModel/Toolchain.swift
@@ -23,7 +23,7 @@ public protocol Toolchain {
     var isSwiftDevelopmentToolchain: Bool { get }
 
     /// Path to the Swift plugin server utility.
-    var swiftPluginServerPath: AbsolutePath? { get }
+    var swiftPluginServerPath: AbsolutePath? { get throws }
 
     /// Path containing the macOS Swift stdlib.
     var macosSwiftStdlib: AbsolutePath { get throws }

--- a/Sources/PackageModel/ToolchainConfiguration.swift
+++ b/Sources/PackageModel/ToolchainConfiguration.swift
@@ -43,9 +43,6 @@ public struct ToolchainConfiguration {
     /// This is optional for example on macOS w/o Xcode.
     public var xctestPath: AbsolutePath?
 
-    /// Path to the Swift plugin server utility.
-    public var swiftPluginServerPath: AbsolutePath?
-
     /// Creates the set of manifest resources associated with a `swiftc` executable.
     ///
     /// - Parameters:
@@ -56,7 +53,6 @@ public struct ToolchainConfiguration {
     ///     - swiftPMLibrariesRootPath: Custom path for SwiftPM libraries. Computed based on the compiler path by default.
     ///     - sdkRootPath: Optional path to SDK root.
     ///     - xctestPath: Optional path to XCTest.
-    ///     - swiftPluginServerPath: Optional path to the Swift plugin server executable.
     public init(
         librarianPath: AbsolutePath,
         swiftCompilerPath: AbsolutePath,
@@ -64,8 +60,7 @@ public struct ToolchainConfiguration {
         swiftCompilerEnvironment: EnvironmentVariables = .process(),
         swiftPMLibrariesLocation: SwiftPMLibrariesLocation? = nil,
         sdkRootPath: AbsolutePath? = nil,
-        xctestPath: AbsolutePath? = nil,
-        swiftPluginServerPath: AbsolutePath? = nil
+        xctestPath: AbsolutePath? = nil
     ) {
         let swiftPMLibrariesLocation = swiftPMLibrariesLocation ?? {
             return .init(swiftCompilerPath: swiftCompilerPath)
@@ -78,7 +73,6 @@ public struct ToolchainConfiguration {
         self.swiftPMLibrariesLocation = swiftPMLibrariesLocation
         self.sdkRootPath = sdkRootPath
         self.xctestPath = xctestPath
-        self.swiftPluginServerPath = swiftPluginServerPath
     }
 }
 

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -559,13 +559,10 @@ public final class UserToolchain: Toolchain {
             environment: environment
         )
 
-        let swiftPluginServerPath: AbsolutePath?
         let xctestPath: AbsolutePath?
         if case .custom(_, let useXcrun) = searchStrategy, !useXcrun {
-            swiftPluginServerPath = nil
             xctestPath = nil
         } else {
-            swiftPluginServerPath = try Self.derivePluginServerPath(triple: triple)
             xctestPath = try Self.deriveXCTestPath(
                 destination: self.destination,
                 triple: triple,
@@ -580,8 +577,7 @@ public final class UserToolchain: Toolchain {
             swiftCompilerEnvironment: environment,
             swiftPMLibrariesLocation: swiftPMLibrariesLocation,
             sdkRootPath: self.destination.pathsConfiguration.sdkRootPath,
-            xctestPath: xctestPath,
-            swiftPluginServerPath: swiftPluginServerPath
+            xctestPath: xctestPath
         )
     }
 
@@ -655,8 +651,8 @@ public final class UserToolchain: Toolchain {
 
     private static func derivePluginServerPath(triple: Triple) throws -> AbsolutePath? {
         if triple.isDarwin() {
-            let xctestFindArgs = ["/usr/bin/xcrun", "--find", "swift-plugin-server"]
-            if let path = try? TSCBasic.Process.checkNonZeroExit(arguments: xctestFindArgs, environment: [:])
+            let pluginServerPathFindArgs = ["/usr/bin/xcrun", "--find", "swift-plugin-server"]
+            if let path = try? TSCBasic.Process.checkNonZeroExit(arguments: pluginServerPathFindArgs, environment: [:])
                 .spm_chomp() {
                 return try AbsolutePath(validating: path)
             }
@@ -787,7 +783,13 @@ public final class UserToolchain: Toolchain {
         configuration.xctestPath
     }
 
+    private let _swiftPluginServerPath = ThreadSafeBox<AbsolutePath?>()
+
     public var swiftPluginServerPath: AbsolutePath? {
-        configuration.swiftPluginServerPath
+        get throws {
+            try _swiftPluginServerPath.memoize {
+                return try Self.derivePluginServerPath(triple: self.triple)
+            }
+        }
     }
 }


### PR DESCRIPTION
This takes a significant amount of time when the selected Xcode doesn't have a `swift-plugin-server` executable:

```
/tmp/exec
❯ time /usr/bin/xcrun --find swift-plugin-server
xcrun: error: sh -c '/Users/neonacho/Downloads/Xcode.app/Contents/Developer/usr/bin/xcodebuild -sdk /Users/neonacho/Downloads/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk -find swift-plugin-server 2> /dev/null' failed with exit code 17664: (null) (errno=No such file or directory)
xcrun: error: unable to find utility "swift-plugin-server", not a developer tool or in PATH
/usr/bin/xcrun --find swift-plugin-server  0.34s user 0.17s system 32% cpu 1.579 total
```

Doing this on demand is at least gated on `self.buildParameters.toolchain.isSwiftDevelopmentToolchain` so it shouldn't happen for the primary usage scenario on macOS.

(cherry picked from commit de8e6e8e416f0ddf66ded9bf9c9abafe9517f3c3)