### PR TITLE
Disable the bootstrap checking for explicit target dependencies and remove wrong llbuild dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -721,7 +721,6 @@ if ProcessInfo.processInfo.environment["SWIFTPM_LLBUILD_FWK"] == nil {
     }
     package.targets.first(where: { $0.name == "SPMLLBuild" })!.dependencies += [
         .product(name: "llbuildSwift", package: "swift-llbuild"),
-        .product(name: "llbuild", package: "swift-llbuild"),
     ]
 }
 

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -805,8 +805,9 @@ def get_swiftpm_flags(args):
     for modifier in ["-Xswiftc", "-Xbuild-tools-swiftc"]:
         build_flags.extend([modifier, "-module-cache-path", modifier, local_module_cache_path])
 
+    # Disabled, enable this again when it works
     # Enforce explicit target dependencies
-    build_flags.extend(["--explicit-target-dependency-import-check", "error"])
+    # build_flags.extend(["--explicit-target-dependency-import-check", "error"])
 
     return build_flags
 


### PR DESCRIPTION
This is currently flagging wrong dependencies, enable it again once it works.

@neonichu, reverting for now as you suggested.