### PR TITLE
[5.9] Resolve sandbox issues on external volumes

### DIFF
--- a/Sources/Basics/Sandbox.swift
+++ b/Sources/Basics/Sandbox.swift
@@ -44,18 +44,26 @@ public enum Sandbox {
     ///
     /// - Parameters:
     ///   - command: The command line to sandbox (including executable as first argument)
+    ///   - fileSystem: The file system instance to use.
     ///   - strictness: The basic strictness level of the standbox.
     ///   - writableDirectories: Paths under which writing should be allowed, even if they would otherwise be read-only based on the strictness or paths in `readOnlyDirectories`.
     ///   - readOnlyDirectories: Paths under which writing should be denied, even if they would have otherwise been allowed by the rules implied by the strictness level.
     public static func apply(
         command: [String],
+        fileSystem: FileSystem,
         strictness: Strictness = .default,
         writableDirectories: [AbsolutePath] = [],
         readOnlyDirectories: [AbsolutePath] = [],
         allowNetworkConnections: [SandboxNetworkPermission] = []
     ) throws -> [String] {
         #if os(macOS)
-        let profile = try macOSSandboxProfile(strictness: strictness, writableDirectories: writableDirectories, readOnlyDirectories: readOnlyDirectories, allowNetworkConnections: allowNetworkConnections)
+        let profile = try macOSSandboxProfile(
+            fileSystem: fileSystem,
+            strictness: strictness,
+            writableDirectories: writableDirectories,
+            readOnlyDirectories: readOnlyDirectories,
+            allowNetworkConnections: allowNetworkConnections
+        )
         return ["/usr/bin/sandbox-exec", "-p", profile] + command
         #else
         // rdar://40235432, rdar://75636874 tracks implementing sandboxes for other platforms.
@@ -101,6 +109,7 @@ fileprivate let threadSafeDarwinCacheDirectories: [AbsolutePath] = {
 }()
 
 fileprivate func macOSSandboxProfile(
+    fileSystem: FileSystem,
     strictness: Sandbox.Strictness,
     writableDirectories: [AbsolutePath],
     readOnlyDirectories: [AbsolutePath],
@@ -206,7 +215,8 @@ fileprivate func macOSSandboxProfile(
     // Emit rules for paths under which writing is allowed, even if they are descendants directories that are otherwise read-only.
     if writableDirectories.count > 0 {
         contents += "(allow file-write*\n"
-        for path in writableDirectories {
+        // For any explicit writable directories, also include the relevant item replacement directories so that Foundation APIs using atomic writes are not blocked by the sandbox.
+        for path in writableDirectories + Set(writableDirectories.compactMap { try? fileSystem.itemReplacementDirectories(for: $0) }.flatMap { $0}) {
             contents += "    (subpath \(try resolveSymlinks(path).quotedAsSubpathForSandboxProfile))\n"
         }
         contents += ")\n"

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -602,7 +602,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
                 // TODO: We need to also use any working directory, but that support isn't yet available on all platforms at a lower level.
                 var commandLine = [command.configuration.executable.pathString] + command.configuration.arguments
                 if !pluginConfiguration.disableSandbox {
-                    commandLine = try Sandbox.apply(command: commandLine, strictness: .writableTemporaryDirectory, writableDirectories: [pluginResult.pluginOutputDirectory])
+                    commandLine = try Sandbox.apply(command: commandLine, fileSystem: self.fileSystem, strictness: .writableTemporaryDirectory, writableDirectories: [pluginResult.pluginOutputDirectory])
                 }
                 let processResult = try TSCBasic.Process.popen(arguments: commandLine, environment: command.configuration.environment)
                 let output = try processResult.utf8Output() + processResult.utf8stderrOutput()

--- a/Sources/Build/LLBuildManifestBuilder.swift
+++ b/Sources/Build/LLBuildManifestBuilder.swift
@@ -221,6 +221,7 @@ extension LLBuildManifestBuilder {
                 if !self.disableSandboxForPluginCommands {
                     commandLine = try Sandbox.apply(
                         command: commandLine,
+                        fileSystem: self.fileSystem,
                         strictness: .writableTemporaryDirectory,
                         writableDirectories: [result.pluginOutputDirectory]
                     )

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -751,7 +751,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                             let cacheDirectories = [self.databaseCacheDir, moduleCachePath].compactMap{ $0 }
                             let strictness: Sandbox.Strictness = toolsVersion < .v5_3 ? .manifest_pre_53 : .default
                             do {
-                                cmd = try Sandbox.apply(command: cmd, strictness: strictness, writableDirectories: cacheDirectories)
+                                cmd = try Sandbox.apply(command: cmd, fileSystem: localFileSystem, strictness: strictness, writableDirectories: cacheDirectories)
                             } catch {
                                 return completion(.failure(error))
                             }

--- a/Sources/Workspace/DefaultPluginScriptRunner.swift
+++ b/Sources/Workspace/DefaultPluginScriptRunner.swift
@@ -441,6 +441,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
             do {
                 command = try Sandbox.apply(
                     command: command,
+                    fileSystem: self.fileSystem,
                     strictness: .writableTemporaryDirectory,
                     writableDirectories: writableDirectories + [self.cacheDir],
                     readOnlyDirectories: readOnlyDirectories,

--- a/Tests/BasicsTests/SandboxTests.swift
+++ b/Tests/BasicsTests/SandboxTests.swift
@@ -219,3 +219,22 @@ final class SandboxTest: XCTestCase {
          }
      }
 }
+
+extension Sandbox {
+    public static func apply(
+        command: [String],
+        strictness: Strictness = .default,
+        writableDirectories: [AbsolutePath] = [],
+        readOnlyDirectories: [AbsolutePath] = [],
+        allowNetworkConnections: [SandboxNetworkPermission] = []
+    ) throws -> [String] {
+        return try self.apply(
+            command: command,
+            fileSystem: InMemoryFileSystem(),
+            strictness: strictness,
+            writableDirectories: writableDirectories,
+            readOnlyDirectories: readOnlyDirectories,
+            allowNetworkConnections: allowNetworkConnections
+        )
+    }
+}


### PR DESCRIPTION
The sandbox profile SwiftPM generates curates the directories plugins and manifests are able to write to. Several Foundation APIs use a so-called "item replacement directory" when doing atomic operations and this happens to be a special path on the same volume when performing operations on an external volume. This lead to those operations being blocked in plugins which does not seem right since those item replacement directories are temporary directories in spirit. We now automatically allow writes for those when generating a sandbox profile.

rdar://112217177
