### PR TITLE
Modified some functions to computed properties for API style

### DIFF
--- a/Sources/Basics/Cancellator.swift
+++ b/Sources/Basics/Cancellator.swift
@@ -151,7 +151,7 @@ public final class Cancellator: Cancellable {
 
         let deadline = deadline ?? .now() + .seconds(30)
         // deadline for individual handlers set slightly before overall deadline
-        let delta: DispatchTimeInterval = .nanoseconds(abs(deadline.distance(to: .now()).nanoseconds() ?? 0) / 5)
+        let delta: DispatchTimeInterval = .nanoseconds(abs(deadline.distance(to: .now()).nanoseconds ?? 0) / 5)
         let handlersDeadline = deadline - delta
 
         let cancellationHandlers = self.registry.get()

--- a/Sources/Basics/DispatchTimeInterval+Extensions.swift
+++ b/Sources/Basics/DispatchTimeInterval+Extensions.swift
@@ -14,7 +14,7 @@ import Dispatch
 import struct Foundation.TimeInterval
 
 extension DispatchTimeInterval {
-    public func timeInterval() -> TimeInterval? {
+    public var timeInterval: TimeInterval? {
         switch self {
         case .seconds(let value):
             return Double(value)
@@ -29,7 +29,7 @@ extension DispatchTimeInterval {
         }
     }
 
-    public func nanoseconds() -> Int? {
+    public var nanoseconds: Int? {
         switch self {
         case .seconds(let value):
             return value.multipliedReportingOverflow(by: 1_000_000_000).partialValue
@@ -44,7 +44,7 @@ extension DispatchTimeInterval {
         }
     }
 
-    public func milliseconds() -> Int? {
+    public var milliseconds: Int? {
         switch self {
         case .seconds(let value):
             return value.multipliedReportingOverflow(by: 1000).partialValue
@@ -59,7 +59,7 @@ extension DispatchTimeInterval {
         }
     }
 
-    public func seconds() -> Int? {
+    public var seconds: Int? {
         switch self {
         case .seconds(let value):
             return value

--- a/Sources/Basics/HTTPClient/HTTPClient.swift
+++ b/Sources/Basics/HTTPClient/HTTPClient.swift
@@ -126,7 +126,7 @@ public actor HTTPClient {
             response: response,
             request: request,
             requestNumber: requestNumber
-        ), let retryDelayInNanoseconds = retryDelay.nanoseconds() {
+        ), let retryDelayInNanoseconds = retryDelay.nanoseconds {
             observabilityScope?.emit(warning: "\(request.url) failed, retrying in \(retryDelay)")
             try await Task.sleep(nanoseconds: UInt64(retryDelayInNanoseconds))
 
@@ -158,7 +158,7 @@ public actor HTTPClient {
                 return nil
             }
             let exponential = Int(min(pow(2.0, Double(requestNumber)), Double(Int.max)))
-            let delayMilli = exponential.multipliedReportingOverflow(by: delay.milliseconds() ?? 0).partialValue
+            let delayMilli = exponential.multipliedReportingOverflow(by: delay.milliseconds ?? 0).partialValue
             let jitterMilli = Int.random(in: 1 ... 10)
             return .milliseconds(delayMilli + jitterMilli)
         }
@@ -195,7 +195,7 @@ public actor HTTPClient {
         switch strategy {
         case .hostErrors(let maxErrors, let age):
             if let host = request.url.host, let errors = self.hostsErrors[host] {
-                if errors.numberOfErrors >= maxErrors, let age = age.timeInterval() {
+                if errors.numberOfErrors >= maxErrors, let age = age.timeInterval {
                     return Date().timeIntervalSince(errors.lastError) <= age
                 } else if errors.numberOfErrors >= maxErrors {
                     // reset aged errors

--- a/Sources/Basics/HTTPClient/LegacyHTTPClient.swift
+++ b/Sources/Basics/HTTPClient/LegacyHTTPClient.swift
@@ -259,7 +259,7 @@ public final class LegacyHTTPClient: Cancellable {
                 return .none
             }
             let exponential = Int(min(pow(2.0, Double(requestNumber)), Double(Int.max)))
-            let delayMilli = exponential.multipliedReportingOverflow(by: delay.milliseconds() ?? 0).partialValue
+            let delayMilli = exponential.multipliedReportingOverflow(by: delay.milliseconds ?? 0).partialValue
             let jitterMilli = Int.random(in: 1 ... 10)
             return .milliseconds(delayMilli + jitterMilli)
         }
@@ -292,7 +292,7 @@ public final class LegacyHTTPClient: Cancellable {
         switch strategy {
         case .hostErrors(let maxErrors, let age):
             if let host = request.url.host, let errors = (Self.hostsErrorsLock.withLock { Self.hostsErrors[host] }) {
-                if errors.count >= maxErrors, let lastError = errors.last, let age = age.timeInterval() {
+                if errors.count >= maxErrors, let lastError = errors.last, let age = age.timeInterval {
                     return Date().timeIntervalSince(lastError) <= age
                 } else if errors.count >= maxErrors {
                     // reset aged errors

--- a/Sources/Basics/HTTPClient/URLSessionHTTPClient.swift
+++ b/Sources/Basics/HTTPClient/URLSessionHTTPClient.swift
@@ -343,7 +343,7 @@ extension URLRequest {
             self.addValue(header.value, forHTTPHeaderField: header.name)
         }
         self.httpBody = request.body
-        if let interval = request.options.timeout?.timeInterval() {
+        if let interval = request.options.timeout?.timeInterval {
             self.timeoutInterval = interval
         }
     }
@@ -355,7 +355,7 @@ extension URLRequest {
             self.addValue(header.value, forHTTPHeaderField: header.name)
         }
         self.httpBody = request.body
-        if let interval = request.options.timeout?.timeInterval() {
+        if let interval = request.options.timeout?.timeInterval {
             self.timeoutInterval = interval
         }
     }

--- a/Sources/Basics/Triple+Basics.swift
+++ b/Sources/Basics/Triple+Basics.swift
@@ -24,15 +24,15 @@ extension Triple {
 }
 
 extension Triple {
-    public func isApple() -> Bool {
+    public var isApple: Bool {
         vendor == .apple
     }
 
-    public func isAndroid() -> Bool {
+    public var isAndroid: Bool {
         os == .linux && environment == .android
     }
 
-    public func isDarwin() -> Bool {
+    public var isDarwin: Bool {
         switch (vendor, os) {
         case (.apple, .noneOS):
             return false
@@ -43,19 +43,19 @@ extension Triple {
         }
     }
 
-    public func isLinux() -> Bool {
+    public var isLinux: Bool {
         os == .linux
     }
 
-    public func isWindows() -> Bool {
+    public var isWindows: Bool {
         os == .win32
     }
 
-    public func isWASI() -> Bool {
+    public var isWASI: Bool {
         os == .wasi
     }
 
-    public func isOpenBSD() -> Bool {
+    public var isOpenBSD: Bool {
         os == .openbsd
     }
 
@@ -63,7 +63,7 @@ extension Triple {
     ///
     /// This is currently meant for Apple platforms only.
     public func tripleString(forPlatformVersion version: String) -> String {
-        precondition(isDarwin())
+        precondition(isDarwin)
         return """
             \(self.archName)-\
             \(self.vendorName)-\
@@ -134,7 +134,7 @@ extension Triple {
         }
 
         switch os {
-        case _ where isDarwin():
+        case _ where isDarwin:
             return ".dylib"
         case .linux, .openbsd:
             return ".so"
@@ -153,7 +153,7 @@ extension Triple {
         }
 
         switch os {
-        case _ where isDarwin():
+        case _ where isDarwin:
             return ""
         case .linux, .openbsd:
             return ""
@@ -176,7 +176,7 @@ extension Triple {
     /// The file extension for Foundation-style bundle.
     public var nsbundleExtension: String {
         switch os {
-        case _ where isDarwin():
+        case _ where isDarwin:
             return ".bundle"
         default:
             // See: https://github.com/apple/swift-corelibs-foundation/blob/master/Docs/FHS%20Bundles.md

--- a/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
@@ -216,7 +216,7 @@ public final class ClangTargetBuildDescription {
 
         var args = [String]()
         // Only enable ARC on macOS.
-        if buildParameters.targetTriple.isDarwin() {
+        if buildParameters.targetTriple.isDarwin {
             args += ["-fobjc-arc"]
         }
         args += try buildParameters.targetTripleArgs(for: target)
@@ -231,7 +231,7 @@ public final class ClangTargetBuildDescription {
         // index store for Apple's clang or if explicitly asked to.
         if ProcessEnv.vars.keys.contains("SWIFTPM_ENABLE_CLANG_INDEX_STORE") {
             args += buildParameters.indexStoreArguments(for: target)
-        } else if buildParameters.targetTriple.isDarwin(),
+        } else if buildParameters.targetTriple.isDarwin,
                   (try? buildParameters.toolchain._isClangCompilerVendorApple()) == true
         {
             args += buildParameters.indexStoreArguments(for: target)
@@ -244,13 +244,13 @@ public final class ClangTargetBuildDescription {
             // 1. on Darwin when compiling for C++, because C++ modules are disabled on Apple-built Clang releases
             // 2. on Windows when compiling for any language, because of issues with the Windows SDK
             // 3. on Android when compiling for any language, because of issues with the Android SDK
-            enableModules = !(buildParameters.targetTriple.isDarwin() && isCXX) && !buildParameters.targetTriple
-                .isWindows() && !buildParameters.targetTriple.isAndroid()
+            enableModules = !(buildParameters.targetTriple.isDarwin && isCXX) && !buildParameters.targetTriple
+                .isWindows && !buildParameters.targetTriple.isAndroid
         } else {
             // For version >= 5.8, we disable them when compiling for C++ regardless of platforms, see:
             // https://github.com/llvm/llvm-project/issues/55980 for clang frontend crash when module
             // enabled for C++ on c++17 standard and above.
-            enableModules = !isCXX && !buildParameters.targetTriple.isWindows() && !buildParameters.targetTriple.isAndroid()
+            enableModules = !isCXX && !buildParameters.targetTriple.isWindows && !buildParameters.targetTriple.isAndroid
         }
 
         if enableModules {

--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -115,9 +115,9 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
         case .debug:
             return []
         case .release:
-            if self.buildParameters.targetTriple.isApple() {
+            if self.buildParameters.targetTriple.isApple {
                 return ["-Xlinker", "-dead_strip"]
-            } else if self.buildParameters.targetTriple.isWindows() {
+            } else if self.buildParameters.targetTriple.isWindows {
                 return ["-Xlinker", "/OPT:REF"]
             } else if self.buildParameters.targetTriple.arch == .wasm32 {
                 // FIXME: wasm-ld strips data segments referenced through __start/__stop symbols
@@ -138,10 +138,10 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
     public func archiveArguments() throws -> [String] {
         let librarian = self.buildParameters.toolchain.librarianPath.pathString
         let triple = self.buildParameters.targetTriple
-        if triple.isWindows(), librarian.hasSuffix("link") || librarian.hasSuffix("link.exe") {
+        if triple.isWindows, librarian.hasSuffix("link") || librarian.hasSuffix("link.exe") {
             return try [librarian, "/LIB", "/OUT:\(binaryPath.pathString)", "@\(self.linkFileListPath.pathString)"]
         }
-        if triple.isApple(), librarian.hasSuffix("libtool") {
+        if triple.isApple, librarian.hasSuffix("libtool") {
             return try [librarian, "-static", "-o", binaryPath.pathString, "@\(self.linkFileListPath.pathString)"]
         }
         return try [librarian, "crs", binaryPath.pathString, "@\(self.linkFileListPath.pathString)"]
@@ -207,7 +207,7 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
             args += self.deadStripArguments
         case .library(.dynamic):
             args += ["-emit-library"]
-            if self.buildParameters.targetTriple.isDarwin() {
+            if self.buildParameters.targetTriple.isDarwin {
                 let relativePath = try "@rpath/\(buildParameters.binaryRelativePath(for: self.product).pathString)"
                 args += ["-Xlinker", "-install_name", "-Xlinker", relativePath]
             }
@@ -216,7 +216,7 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
             // Link the Swift stdlib statically, if requested.
             // TODO: unify this logic with SwiftTargetBuildDescription.stdlibArguments
             if self.buildParameters.shouldLinkStaticSwiftStdlib {
-                if self.buildParameters.targetTriple.isDarwin() {
+                if self.buildParameters.targetTriple.isDarwin {
                     self.observabilityScope.emit(.swiftBackDeployError)
                 } else if self.buildParameters.targetTriple.isSupportingStaticStdlib {
                     args += ["-static-stdlib"]
@@ -258,9 +258,9 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
 
         // Set rpath such that dynamic libraries are looked up
         // adjacent to the product.
-        if self.buildParameters.targetTriple.isLinux() {
+        if self.buildParameters.targetTriple.isLinux {
             args += ["-Xlinker", "-rpath=$ORIGIN"]
-        } else if self.buildParameters.targetTriple.isDarwin() {
+        } else if self.buildParameters.targetTriple.isDarwin {
             let rpath = self.product.type == .test ? "@loader_path/../../../" : "@loader_path"
             args += ["-Xlinker", "-rpath", "-Xlinker", rpath]
         }
@@ -373,6 +373,6 @@ extension SortedArray where Element == AbsolutePath {
 
 extension Triple {
     var supportsFrameworks: Bool {
-        return self.isDarwin()
+        self.isDarwin
     }
 }

--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -103,8 +103,8 @@ public final class SwiftTargetBuildDescription {
     /// The path to the swiftmodule file after compilation.
     var moduleOutputPath: AbsolutePath {
         // If we're an executable and we're not allowing test targets to link against us, we hide the module.
-        let allowLinkingAgainstExecutables = (buildParameters.targetTriple.isDarwin() || self.buildParameters.targetTriple
-            .isLinux() || self.buildParameters.targetTriple.isWindows()) && self.toolsVersion >= .v5_5
+        let allowLinkingAgainstExecutables = (buildParameters.targetTriple.isDarwin || self.buildParameters.targetTriple
+            .isLinux || self.buildParameters.targetTriple.isWindows) && self.toolsVersion >= .v5_5
         let dirPath = (target.type == .executable && !allowLinkingAgainstExecutables) ? self.tempsPath : self
             .buildParameters.buildPath
         return dirPath.appending(component: self.target.c99name + ".swiftmodule")
@@ -312,7 +312,7 @@ public final class SwiftTargetBuildDescription {
             return
         }
 
-        guard buildParameters.targetTriple.isDarwin(), buildParameters.experimentalTestOutput else {
+        guard buildParameters.targetTriple.isDarwin, buildParameters.experimentalTestOutput else {
             return
         }
 
@@ -809,7 +809,7 @@ public final class SwiftTargetBuildDescription {
         guard let bundlePath else { return }
 
         let mainPathSubstitution: String
-        if self.buildParameters.targetTriple.isWASI() {
+        if self.buildParameters.targetTriple.isWASI {
             // We prefer compile-time evaluation of the bundle path here for WASI. There's no benefit in evaluating this
             // at runtime, especially as `Bundle` support in WASI Foundation is partial. We expect all resource paths to
             // evaluate to `/\(resourceBundleName)/\(resourcePath)`, which allows us to pass this path to JS APIs like
@@ -1083,7 +1083,7 @@ public final class SwiftTargetBuildDescription {
 
     /// Returns true if ObjC compatibility header should be emitted.
     private var shouldEmitObjCCompatibilityHeader: Bool {
-        self.buildParameters.targetTriple.isDarwin() && self.target.type == .library
+        self.buildParameters.targetTriple.isDarwin && self.target.type == .library
     }
 
     func writeOutputFileMap() throws -> AbsolutePath {

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -127,7 +127,7 @@ extension BuildParameters {
     public func targetTripleArgs(for target: ResolvedTarget) throws -> [String] {
         var args = ["-target"]
         // Compute the triple string for Darwin platform using the platform version.
-        if targetTriple.isDarwin() {
+        if targetTriple.isDarwin {
             let platform = buildEnvironment.platform
             let supportedPlatform = target.platforms.getDerived(for: platform, usingXCTest: target.type == .test)
             args += [targetTriple.tripleString(forPlatformVersion: supportedPlatform.version.versionString)]
@@ -140,10 +140,10 @@ extension BuildParameters {
     /// Computes the linker flags to use in order to rename a module-named main function to 'main' for the target platform, or nil if the linker doesn't support it for the platform.
     func linkerFlagsForRenamingMainFunction(of target: ResolvedTarget) -> [String]? {
         let args: [String]
-        if self.targetTriple.isApple() {
+        if self.targetTriple.isApple {
             args = ["-alias", "_\(target.c99name)_main", "_main"]
         }
-        else if self.targetTriple.isLinux() {
+        else if self.targetTriple.isLinux {
             args = ["--defsym", "main=\(target.c99name)_main"]
         }
         else {
@@ -458,7 +458,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
                 switch dependency {
                 case .target: break
                 case .product(let product, _):
-                    if buildParameters.targetTriple.isDarwin() {
+                    if buildParameters.targetTriple.isDarwin {
                         try BuildPlan.validateDeploymentVersionOfProductDependency(
                             product: product,
                             forTarget: target,
@@ -635,9 +635,9 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
         // Note: This will come from build settings in future.
         for target in dependencies.staticTargets {
             if case let target as ClangTarget = target.underlyingTarget, target.isCXX {
-                if buildParameters.targetTriple.isDarwin() {
+                if buildParameters.targetTriple.isDarwin {
                     buildProduct.additionalFlags += ["-lc++"]
-                } else if buildParameters.targetTriple.isWindows() {
+                } else if buildParameters.targetTriple.isWindows {
                     // Don't link any C++ library.
                 } else {
                     buildProduct.additionalFlags += ["-lstdc++"]
@@ -1132,7 +1132,7 @@ func generateResourceInfoPlist(
 
 extension Basics.Triple {
     var isSupportingStaticStdlib: Bool {
-        isLinux() || arch == .wasm32
+        isLinux || arch == .wasm32
     }
 }
 

--- a/Sources/Build/LLBuildManifestBuilder.swift
+++ b/Sources/Build/LLBuildManifestBuilder.swift
@@ -978,7 +978,7 @@ extension LLBuildManifestBuilder {
 
         // Add dependency on Info.plist generation on Darwin platforms.
         let testInputs: [AbsolutePath]
-        if buildProduct.product.type == .test, buildProduct.buildParameters.targetTriple.isDarwin(), buildProduct.buildParameters.experimentalTestOutput {
+        if buildProduct.product.type == .test, buildProduct.buildParameters.targetTriple.isDarwin, buildProduct.buildParameters.experimentalTestOutput {
             let testBundleInfoPlistPath = try buildProduct.binaryPath.parentDirectory.parentDirectory.appending(component: "Info.plist")
             testInputs = [testBundleInfoPlistPath]
 

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -191,7 +191,7 @@ public struct SwiftTestTool: SwiftCommand {
 
             // validate XCTest available on darwin based systems
             let toolchain = try swiftTool.getTargetToolchain()
-            if toolchain.targetTriple.isDarwin() && toolchain.xctestPath == nil {
+            if toolchain.targetTriple.isDarwin && toolchain.xctestPath == nil {
                 throw TestError.xctestNotAvailable
             }
         } catch {
@@ -203,7 +203,7 @@ public struct SwiftTestTool: SwiftCommand {
 
         // Remove test output from prior runs and validate priors.
         if self.options.enableExperimentalTestOutput {
-            if !buildParameters.targetTriple.isDarwin() {
+            if !buildParameters.targetTriple.isDarwin {
                 swiftTool.observabilityScope.emit(error: "The experimental test output feature is only available on Darwin.")
                 throw ExitCode.failure
             }
@@ -1092,7 +1092,7 @@ final class XUnitGenerator {
 
         // Get the failure count.
         let failures = results.filter({ !$0.success }).count
-        let duration = results.compactMap({ $0.duration.timeInterval() }).reduce(0.0, +)
+        let duration = results.compactMap({ $0.duration.timeInterval }).reduce(0.0, +)
 
         // We need better output reporting from XCTest.
         content +=
@@ -1106,7 +1106,7 @@ final class XUnitGenerator {
         // FIXME: This is very minimal right now. We should allow including test output etc.
         for result in results {
             let test = result.unitTest
-            let duration = result.duration.timeInterval() ?? 0.0
+            let duration = result.duration.timeInterval ?? 0.0
             content +=
                 """
                 <testcase classname="\(test.testCase)" name="\(test.name)" time="\(duration)">

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -232,7 +232,7 @@ final class PluginDelegate: PluginInvocationDelegate {
                         // Run the test — for now we run the sequentially so we can capture accurate timing results.
                         let startTime = DispatchTime.now()
                         let success = testRunner.test(outputHandler: { _ in }) // this drops the tests output
-                        let duration = Double(startTime.distance(to: .now()).milliseconds() ?? 0) / 1000.0
+                        let duration = Double(startTime.distance(to: .now()).milliseconds ?? 0) / 1000.0
                         numFailedTests += success ? 0 : 1
                         testResults.append(
                             .init(name: testName, result: success ? .succeeded : .failed, duration: duration)

--- a/Sources/PackageModel/SwiftSDK.swift
+++ b/Sources/PackageModel/SwiftSDK.swift
@@ -547,7 +547,7 @@ public struct SwiftSDK: Equatable {
     /// Returns a default destination of a given target environment
     @available(*, deprecated, renamed: "defaultSwiftSDK")
     public static func defaultDestination(for triple: Triple, host: SwiftSDK) -> SwiftSDK? {
-        if triple.isWASI() {
+        if triple.isWASI {
             let wasiSysroot = host.toolset.rootPaths.first?
                 .parentDirectory // usr
                 .appending(components: "share", "wasi-sysroot")
@@ -562,7 +562,7 @@ public struct SwiftSDK: Equatable {
 
     /// Returns a default Swift SDK of a given target environment.
     public static func defaultSwiftSDK(for targetTriple: Triple, hostSDK: SwiftSDK) -> SwiftSDK? {
-        if targetTriple.isWASI() {
+        if targetTriple.isWASI {
             let wasiSysroot = hostSDK.toolset.rootPaths.first?
                 .parentDirectory // usr
                 .appending(components: "share", "wasi-sysroot")

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -161,10 +161,10 @@ public final class UserToolchain: Toolchain {
     ) throws
         -> AbsolutePath
     {
-        let variable: String = triple.isApple() ? "LIBTOOL" : "AR"
+        let variable: String = triple.isApple ? "LIBTOOL" : "AR"
         let tool: String = {
-            if triple.isApple() { return "libtool" }
-            if triple.isWindows() {
+            if triple.isApple { return "libtool" }
+            if triple.isWindows {
                 if let librarian: AbsolutePath =
                     UserToolchain.lookup(
                         variable: "AR",
@@ -198,7 +198,7 @@ public final class UserToolchain: Toolchain {
         if let librarian = try? UserToolchain.getTool(tool, binDirectories: binDirectories) {
             return librarian
         }
-        if triple.isApple() || triple.isWindows() {
+        if triple.isApple || triple.isWindows {
             return try UserToolchain.findTool(tool, envSearchPaths: searchPaths, useXcrun: useXcrun)
         } else {
             if let librarian = try? UserToolchain.findTool(tool, envSearchPaths: searchPaths, useXcrun: false) {
@@ -350,7 +350,7 @@ public final class UserToolchain: Toolchain {
         let swiftCompilerFlags = swiftSDK.toolset.knownTools[.swiftCompiler]?.extraCLIOptions ?? []
 
         guard let sdkDir = swiftSDK.pathsConfiguration.sdkRootPath else {
-            if triple.isWindows() {
+            if triple.isWindows {
                 // Windows uses a variable named SDKROOT to determine the root of
                 // the SDK.  This is not the same value as the SDKROOT parameter
                 // in Xcode, however, the value represents a similar concept.
@@ -443,7 +443,7 @@ public final class UserToolchain: Toolchain {
         }
 
         return (
-            triple.isDarwin() || triple.isAndroid() || triple.isWASI() || triple.isWindows()
+            triple.isDarwin || triple.isAndroid || triple.isWASI || triple.isWindows
                 ? ["-sdk", sdkDir.pathString]
                 : []
         ) + swiftCompilerFlags
@@ -553,11 +553,11 @@ public final class UserToolchain: Toolchain {
         )
 
         if let sdkDir = swiftSDK.pathsConfiguration.sdkRootPath {
-            let sysrootFlags = [triple.isDarwin() ? "-isysroot" : "--sysroot", sdkDir.pathString]
+            let sysrootFlags = [triple.isDarwin ? "-isysroot" : "--sysroot", sdkDir.pathString]
             self.extraFlags.cCompilerFlags.insert(contentsOf: sysrootFlags, at: 0)
         }
 
-        if triple.isWindows() {
+        if triple.isWindows {
             if let SDKROOT = environment["SDKROOT"], let root = try? AbsolutePath(validating: SDKROOT) {
                 if let settings = WindowsSDKSettings(
                     reading: root.appending("SDKSettings.plist"),
@@ -696,7 +696,7 @@ public final class UserToolchain: Toolchain {
     }
 
     private static func derivePluginServerPath(triple: Triple) throws -> AbsolutePath? {
-        if triple.isDarwin() {
+        if triple.isDarwin {
             let xctestFindArgs = ["/usr/bin/xcrun", "--find", "swift-plugin-server"]
             if let path = try? TSCBasic.Process.checkNonZeroExit(arguments: xctestFindArgs, environment: [:])
                 .spm_chomp() {
@@ -712,7 +712,7 @@ public final class UserToolchain: Toolchain {
         triple: Triple,
         environment: EnvironmentVariables
     ) throws -> AbsolutePath? {
-        if triple.isDarwin() {
+        if triple.isDarwin {
             // XCTest is optional on macOS, for example when Xcode is not installed
             let xctestFindArgs = ["/usr/bin/xcrun", "--sdk", "macosx", "--find", "xctest"]
             if let path = try? TSCBasic.Process.checkNonZeroExit(arguments: xctestFindArgs, environment: environment)
@@ -720,7 +720,7 @@ public final class UserToolchain: Toolchain {
             {
                 return try AbsolutePath(validating: path)
             }
-        } else if triple.isWindows() {
+        } else if triple.isWindows {
             let sdkRoot: AbsolutePath
 
             if let sdkDir = swiftSDK.pathsConfiguration.sdkRootPath {

--- a/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
+++ b/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
@@ -58,7 +58,7 @@ extension BinaryTarget {
 
     public func parseArtifactArchives(for triple: Triple, fileSystem: FileSystem) throws -> [ExecutableInfo] {
         // The host triple might contain a version which we don't want to take into account here.
-        let versionLessTriple = try triple.withoutVersion()
+        let versionLessTriple = try triple.withoutVersion
         // We return at most a single variant of each artifact.
         let metadata = try ArtifactsArchiveMetadata.parse(fileSystem: fileSystem, rootPath: self.artifactPath)
         // Currently we filter out everything except executables.
@@ -70,7 +70,7 @@ extension BinaryTarget {
             // ExecutableInfo; empty if non matching triples found.
             try entry.value.variants.map {
                 let filteredSupportedTriples = try $0.supportedTriples
-                    .filter { try $0.withoutVersion() == versionLessTriple }
+                    .filter { try $0.withoutVersion == versionLessTriple }
                 return ExecutableInfo(
                     name: entry.key,
                     executablePath: self.artifactPath.appending($0.path),
@@ -82,12 +82,14 @@ extension BinaryTarget {
 }
 
 extension Triple {
-    func withoutVersion() throws -> Triple {
-        if isDarwin() {
-            let stringWithoutVersion = tripleString(forPlatformVersion: "")
-            return try Triple(stringWithoutVersion)
-        } else {
-            return self
+    var withoutVersion: Triple {
+        get throws {
+            if isDarwin {
+                let stringWithoutVersion = tripleString(forPlatformVersion: "")
+                return try Triple(stringWithoutVersion)
+            } else {
+                return self
+            }
         }
     }
 }

--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -233,7 +233,7 @@ public struct BuildParameters: Encodable {
 
     /// The current platform we're building for.
     var currentPlatform: PackageModel.Platform {
-        if self.targetTriple.isDarwin() {
+        if self.targetTriple.isDarwin {
             switch self.targetTriple.darwinPlatform {
             case .iOS(.catalyst):
                 return .macCatalyst
@@ -246,13 +246,13 @@ public struct BuildParameters: Encodable {
             case .macOS, nil:
                 return .macOS
             }
-        } else if self.targetTriple.isAndroid() {
+        } else if self.targetTriple.isAndroid {
             return .android
-        } else if self.targetTriple.isWASI() {
+        } else if self.targetTriple.isWASI {
             return .wasi
-        } else if self.targetTriple.isWindows() {
+        } else if self.targetTriple.isWindows {
             return .windows
-        } else if self.targetTriple.isOpenBSD() {
+        } else if self.targetTriple.isOpenBSD {
             return .openbsd
         } else {
             return .linux
@@ -395,14 +395,14 @@ public struct BuildParameters: Encodable {
         case .dwarf:
             var flags = flags
             // DWARF requires lld as link.exe expects CodeView debug info.
-            self.flags = flags.merging(targetTriple.isWindows() ? BuildFlags(
+            self.flags = flags.merging(targetTriple.isWindows ? BuildFlags(
                 cCompilerFlags: ["-gdwarf"],
                 cxxCompilerFlags: ["-gdwarf"],
                 swiftCompilerFlags: ["-g", "-use-ld=lld"],
                 linkerFlags: ["-debug:dwarf"]
             ) : BuildFlags(cCompilerFlags: ["-g"], cxxCompilerFlags: ["-g"], swiftCompilerFlags: ["-g"]))
         case .codeview:
-            if !targetTriple.isWindows() {
+            if !targetTriple.isWindows {
                 throw StringError("CodeView debug information is currently not supported on \(targetTriple.osName)")
             }
             var flags = flags
@@ -442,7 +442,7 @@ public struct BuildParameters: Encodable {
         // when building and testing in release mode, one can use the '--disable-testable-imports' flag
         // to disable testability in `swift test`, but that requires that the tests do not use the testable imports feature
         self.enableTestability = enableTestability ?? (.debug == configuration)
-        self.testProductStyle = targetTriple.isDarwin() ? .loadableBundle : .entryPointExecutable(
+        self.testProductStyle = targetTriple.isDarwin ? .loadableBundle : .entryPointExecutable(
             explicitlyEnabledDiscovery: forceTestDiscovery,
             explicitlySpecifiedPath: testEntryPointPath
         )
@@ -553,7 +553,7 @@ public struct BuildParameters: Encodable {
             return nil
         }
 
-        if targetTriple.isApple() {
+        if targetTriple.isApple {
             return .swiftAST
         }
         return .modulewrap
@@ -583,12 +583,12 @@ public struct BuildParameters: Encodable {
         case .library(.automatic), .plugin:
             fatalError()
         case .test:
-            guard !targetTriple.isWASI() else {
+            guard !targetTriple.isWASI else {
                 return try RelativePath(validating: "\(product.name).wasm")
             }
 
             let base = "\(product.name).xctest"
-            if targetTriple.isDarwin() {
+            if targetTriple.isDarwin {
                 return try RelativePath(validating: "\(base)/Contents/MacOS/\(product.name)")
             } else {
                 return try RelativePath(validating: base)

--- a/Sources/SPMBuildCore/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/PluginInvocation.swift
@@ -544,7 +544,7 @@ public extension PluginTarget {
             if let target = executableOrBinaryTarget as? BinaryTarget {
                 // TODO: Memoize this result for the host triple
                 let execInfos = try target.parseArtifactArchives(for: hostTriple, fileSystem: fileSystem)
-                return try execInfos.map{ .vendedTool(name: $0.name, path: $0.executablePath, supportedTriples: try $0.supportedTriples.map{ try $0.withoutVersion().tripleString }) }
+                return try execInfos.map{ .vendedTool(name: $0.name, path: $0.executablePath, supportedTriples: try $0.supportedTriples.map{ try $0.withoutVersion.tripleString }) }
             }
             // For an executable target we create a `builtTool`.
             else if executableOrBinaryTarget.type == .executable {

--- a/Sources/SPMBuildCore/Triple+Extensions.swift
+++ b/Sources/SPMBuildCore/Triple+Extensions.swift
@@ -14,11 +14,7 @@ import struct Basics.Triple
 
 extension Triple {
     public var platformBuildPathComponent: String {
-        if isDarwin() {
-            return self.tripleString(forPlatformVersion: "")
-        }
-
-        return self.tripleString
+        return isDarwin ? self.tripleString(forPlatformVersion: "") : self.tripleString
     }
 }
 

--- a/Tests/BasicsTests/DispatchTimeTests.swift
+++ b/Tests/BasicsTests/DispatchTimeTests.swift
@@ -19,10 +19,10 @@ final class DispatchTimeTests: XCTestCase {
         let future: DispatchTime = point + .seconds(10)
 
         let diff1: DispatchTimeInterval = point.distance(to: future)
-        XCTAssertEqual(diff1.seconds(), 10)
+        XCTAssertEqual(diff1.seconds, 10)
 
         let diff2: DispatchTimeInterval = future.distance(to: point)
-        XCTAssertEqual(diff2.seconds(), -10)
+        XCTAssertEqual(diff2.seconds, -10)
     }
 
     func testDifferenceNegative() {
@@ -30,9 +30,9 @@ final class DispatchTimeTests: XCTestCase {
         let past: DispatchTime = point - .seconds(10)
 
         let diff1: DispatchTimeInterval = point.distance(to: past)
-        XCTAssertEqual(diff1.seconds(), -10)
+        XCTAssertEqual(diff1.seconds, -10)
 
         let diff2: DispatchTimeInterval = past.distance(to: point)
-        XCTAssertEqual(diff2.seconds(), 10)
+        XCTAssertEqual(diff2.seconds, 10)
     }
 }

--- a/Tests/BasicsTests/HTTPClientTests.swift
+++ b/Tests/BasicsTests/HTTPClientTests.swift
@@ -233,7 +233,7 @@ final class HTTPClientTests: XCTestCase {
 
         let httpClient = HTTPClient { _, _ in
             let count = await counter.value!
-            let expectedDelta = pow(2.0, Double(count - 1)) * delay.timeInterval()!
+            let expectedDelta = pow(2.0, Double(count - 1)) * delay.timeInterval!
             let delta = await lastCall.value.flatMap { Date().timeIntervalSince($0) } ?? 0
             XCTAssertEqual(delta, expectedDelta, accuracy: 0.1)
 
@@ -332,7 +332,7 @@ final class HTTPClientTests: XCTestCase {
         for index in (0 ..< total) {
             // age it
             let sleepInterval = SendableTimeInterval.milliseconds(ageInMilliseconds)
-            try await Task.sleep(nanoseconds: UInt64(sleepInterval.nanoseconds()!))
+            try await Task.sleep(nanoseconds: UInt64(sleepInterval.nanoseconds!))
             let response = try await httpClient.get("\(host)/\(index)/okay")
             count.increment()
             XCTAssertEqual(response.statusCode, 200, "expected status code to match")

--- a/Tests/BasicsTests/LegacyHTTPClientTests.swift
+++ b/Tests/BasicsTests/LegacyHTTPClientTests.swift
@@ -357,7 +357,7 @@ final class LegacyHTTPClientTests: XCTestCase {
         let delay = SendableTimeInterval.milliseconds(100)
 
         let brokenHandler: LegacyHTTPClient.Handler = { _, _, completion in
-            let expectedDelta = pow(2.0, Double(count.get(default: 0) - 1)) * delay.timeInterval()!
+            let expectedDelta = pow(2.0, Double(count.get(default: 0) - 1)) * delay.timeInterval!
             let delta = lastCall.get().flatMap { Date().timeIntervalSince($0) } ?? 0
             XCTAssertEqual(delta, expectedDelta, accuracy: 0.1)
 
@@ -382,7 +382,7 @@ final class LegacyHTTPClientTests: XCTestCase {
             promise.fulfill()
         }
 
-        let timeout = Double(Int(pow(2.0, Double(maxAttempts))) * delay.milliseconds()!) / 1000
+        let timeout = Double(Int(pow(2.0, Double(maxAttempts))) * delay.milliseconds!) / 1000
         wait(for: [promise], timeout: 1.0 + timeout)
     }
 

--- a/Tests/BasicsTests/TripleTests.swift
+++ b/Tests/BasicsTests/TripleTests.swift
@@ -30,7 +30,7 @@ final class TripleTests: XCTestCase {
                 return
             }
             XCTAssert(
-                isApple == triple.isApple(),
+                isApple == triple.isApple,
                 """
                 Expected triple '\(triple.tripleString)' \
                 \(isApple ? "" : " not") to be an Apple triple.
@@ -38,7 +38,7 @@ final class TripleTests: XCTestCase {
                 file: file,
                 line: line)
             XCTAssert(
-                isDarwin == triple.isDarwin(),
+                isDarwin == triple.isDarwin,
                 """
                 Expected triple '\(triple.tripleString)' \
                 \(isDarwin ? "" : " not") to be a Darwin triple.

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -1183,7 +1183,7 @@ final class BuildPlanTests: XCTestCase {
         args += ["-fmodules-cache-path=\(buildPath.appending(components: "ModuleCache"))"]
 #endif
 
-        args += [hostTriple.isWindows() ? "-gdwarf" : "-g"]
+        args += [hostTriple.isWindows ? "-gdwarf" : "-g"]
 
         XCTAssertEqual(try ext.basicArguments(isCXX: false), args)
         XCTAssertEqual(try ext.objects, [buildPath.appending(components: "extlib.build", "extlib.c.o")])
@@ -1213,7 +1213,7 @@ final class BuildPlanTests: XCTestCase {
 #if !os(Windows)    // FIXME(5473) - modules flags on Windows dropped
         args += ["-fmodules-cache-path=\(buildPath.appending(components: "ModuleCache"))"]
 #endif
-        args += [hostTriple.isWindows() ? "-gdwarf" : "-g"]
+        args += [hostTriple.isWindows ? "-gdwarf" : "-g"]
         XCTAssertEqual(try exe.basicArguments(isCXX: false), args)
         XCTAssertEqual(try exe.objects, [buildPath.appending(components: "exe.build", "main.c.o")])
         XCTAssertEqual(exe.moduleMap, nil)
@@ -1508,7 +1508,7 @@ final class BuildPlanTests: XCTestCase {
 #if !os(Windows)    // FIXME(5473) - modules flags on Windows dropped
         args += ["-fmodules-cache-path=\(buildPath.appending(components: "ModuleCache"))"]
 #endif
-        args += [hostTriple.isWindows() ? "-gdwarf" : "-g"]
+        args += [hostTriple.isWindows ? "-gdwarf" : "-g"]
         XCTAssertEqual(try lib.basicArguments(isCXX: false), args)
         XCTAssertEqual(try lib.objects, [buildPath.appending(components: "lib.build", "lib.c.o")])
         XCTAssertEqual(lib.moduleMap, buildPath.appending(components: "lib.build", "module.modulemap"))
@@ -2492,7 +2492,7 @@ final class BuildPlanTests: XCTestCase {
 
         let exe = try result.target(for: "exe").clangTarget()
         
-        var expectedExeBasicArgs = triple.isDarwin() ? ["-fobjc-arc"] : []
+        var expectedExeBasicArgs = triple.isDarwin ? ["-fobjc-arc"] : []
         expectedExeBasicArgs += ["-target", defaultTargetTriple]
         expectedExeBasicArgs += ["-O0", "-DSWIFT_PACKAGE=1", "-DDEBUG=1", "-fblocks"]
 #if !os(Windows)    // FIXME(5473) - modules flags on Windows dropped
@@ -2503,17 +2503,17 @@ final class BuildPlanTests: XCTestCase {
         expectedExeBasicArgs += ["-fmodules-cache-path=\(buildPath.appending(components: "ModuleCache"))"]
 #endif
 
-        expectedExeBasicArgs += [triple.isWindows() ? "-gdwarf" : "-g"]
+        expectedExeBasicArgs += [triple.isWindows ? "-gdwarf" : "-g"]
         XCTAssertEqual(try exe.basicArguments(isCXX: false), expectedExeBasicArgs)
         XCTAssertEqual(try exe.objects, [buildPath.appending(components: "exe.build", "main.c.o")])
         XCTAssertEqual(exe.moduleMap, nil)
 
         let lib = try result.target(for: "lib").clangTarget()
         
-        var expectedLibBasicArgs = triple.isDarwin() ? ["-fobjc-arc"] : []
+        var expectedLibBasicArgs = triple.isDarwin ? ["-fobjc-arc"] : []
         expectedLibBasicArgs += ["-target", defaultTargetTriple]
         expectedLibBasicArgs += ["-O0", "-DSWIFT_PACKAGE=1", "-DDEBUG=1", "-fblocks"]
-        let shouldHaveModules = !(triple.isDarwin() || triple.isWindows() || triple.isAndroid())
+        let shouldHaveModules = !(triple.isDarwin || triple.isWindows || triple.isAndroid)
         if shouldHaveModules {
             expectedLibBasicArgs += ["-fmodules", "-fmodule-name=lib"]
         }
@@ -2522,8 +2522,8 @@ final class BuildPlanTests: XCTestCase {
             expectedLibBasicArgs += ["-fmodules-cache-path=\(buildPath.appending(components: "ModuleCache"))"]
         }
         expectedLibBasicArgs += [
-            triple.isWindows() ? "-gdwarf" : "-g",
-            triple.isWindows() ? "-gdwarf" : "-g",
+            triple.isWindows ? "-gdwarf" : "-g",
+            triple.isWindows ? "-gdwarf" : "-g",
         ]
         XCTAssertEqual(try lib.basicArguments(isCXX: true), expectedLibBasicArgs)
 
@@ -4263,7 +4263,7 @@ final class BuildPlanTests: XCTestCase {
 
             let contents: String = try fs.readFileContents(yaml)
 
-            if result.plan.buildParameters.targetTriple.isWindows() {
+            if result.plan.buildParameters.targetTriple.isWindows {
                 XCTAssertMatch(contents, .contains("""
                   "C.rary-debug.a":
                     tool: shell
@@ -4272,7 +4272,7 @@ final class BuildPlanTests: XCTestCase {
                     description: "Archiving \(buildPath.appending(components: "library.a").escapedPathString)"
                     args: ["\(result.plan.buildParameters.toolchain.librarianPath.escapedPathString)","/LIB","/OUT:\(buildPath.appending(components: "library.a").escapedPathString)","@\(buildPath.appending(components: "rary.product", "Objects.LinkFileList").escapedPathString)"]
                 """))
-            } else if result.plan.buildParameters.targetTriple.isDarwin() {
+            } else if result.plan.buildParameters.targetTriple.isDarwin {
                 XCTAssertMatch(contents, .contains("""
                   "C.rary-debug.a":
                     tool: shell

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -1688,7 +1688,7 @@ final class PackageToolTests: CommandsTestCase {
                 """
             )
             let hostTriple = try UserToolchain(swiftSDK: .hostSwiftSDK()).targetTriple
-            let hostTripleString = hostTriple.isDarwin() ? hostTriple.tripleString(forPlatformVersion: "") : hostTriple.tripleString
+            let hostTripleString = hostTriple.isDarwin ? hostTriple.tripleString(forPlatformVersion: "") : hostTriple.tripleString
             try localFileSystem.writeFileContents(packageDir.appending(components: "Binaries", "LocalBinaryTool.artifactbundle", "info.json"), string:
                 """
                 {   "schemaVersion": "1.0",

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -1271,7 +1271,7 @@ class PluginInvocationTests: XCTestCase {
         throw XCTSkip("platform versions are only available if the host is macOS")
         #else
         let hostTriple = try UserToolchain.default.targetTriple
-        let artifactSupportedTriples = try [Triple("\(hostTriple.withoutVersion().tripleString)20.0")]
+        let artifactSupportedTriples = try [Triple("\(hostTriple.withoutVersion.tripleString)20.0")]
 
         try checkParseArtifactsPlatformCompatibility(artifactSupportedTriples: artifactSupportedTriples, hostTriple: hostTriple) { result in
             result.forEach {


### PR DESCRIPTION
I modified some functions to computed properties for better API design.

### Motivation:

These methods returns a state or a simple value rather than performing an action such as `isDarwin()`, `isApple()` or `withoutVersion`
I modified some methods to the computed properties for better API design.
However, these changes depend on your style.

### Modifications:

**DispatchTimeInterval**

| As-is | To-be |
| --- | --- |
| timeInterval() | timeInterval |
| nanoseconds() | nanoseconds |
| milliseconds() | milliseconds |
| seconds() | seconds |

**Tripple extensions**
| As-is | To-be |
| --- | --- |
| isApple() | isApple |
| isAndroid() | isAndroid |
| isDarwin() | isDarwin |
| isLinux() | isLinux |
| isWindows() | isWindows |
| isWASI() | isWASI |
| isOpenBSD() | isOpenBSD |
| withoutVersion() | withoutVersion |
