### PR TITLE
Package-level `moduleAliases` should be internal

### DIFF
--- a/Sources/PackageDescription/PackageDependency.swift
+++ b/Sources/PackageDescription/PackageDependency.swift
@@ -85,8 +85,7 @@ extension Package {
 
         /// Module aliases for targets in this dependency. The key is an original target name and
         /// the value is a new unique name mapped to the name of the .swiftmodule binary.
-        @available(_PackageDescription, introduced: 5.7)
-        public var moduleAliases: [String: String]?
+        internal var moduleAliases: [String: String]?
 
         /// The dependency requirement of the package dependency.
         @available(_PackageDescription, deprecated: 5.6, message: "use kind instead")


### PR DESCRIPTION
These were public for implementation reasons, likely because of how the old serialization code worked which I refactored in 5.9

fixes #6911
