### PR TITLE
Support qualifiers for ambiguous plugin commands

### DIFF
--- a/Fixtures/Miscellaneous/Plugins/AmbiguousCommands/Dependencies/A/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/AmbiguousCommands/Dependencies/A/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "A",
+    products: [
+        .plugin(
+            name: "A",
+            targets: ["A"]),
+    ],
+    targets: [
+        .plugin(
+            name: "A",
+            capability: .command(intent: .custom(
+                verb: "A",
+                description: "prints hello"
+            ))
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/Plugins/AmbiguousCommands/Dependencies/A/Plugins/A.swift
+++ b/Fixtures/Miscellaneous/Plugins/AmbiguousCommands/Dependencies/A/Plugins/A.swift
@@ -1,0 +1,9 @@
+import PackagePlugin
+
+@main
+struct A: CommandPlugin {
+    func performCommand(context: PluginContext, arguments: [String]) async throws {
+        print("Hello A!")
+    }
+}
+

--- a/Fixtures/Miscellaneous/Plugins/AmbiguousCommands/Dependencies/B/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/AmbiguousCommands/Dependencies/B/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "B",
+    products: [
+        .plugin(
+            name: "B",
+            targets: ["B"]),
+    ],
+    targets: [
+        .plugin(
+            name: "B",
+            capability: .command(intent: .custom(
+                verb: "A",
+                description: "prints hello"
+            ))
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/Plugins/AmbiguousCommands/Dependencies/B/Plugins/B.swift
+++ b/Fixtures/Miscellaneous/Plugins/AmbiguousCommands/Dependencies/B/Plugins/B.swift
@@ -1,0 +1,8 @@
+import PackagePlugin
+
+@main
+struct B: CommandPlugin {
+    func performCommand(context: PluginContext, arguments: [String]) async throws {
+        print("Hello B!")
+    }
+}

--- a/Fixtures/Miscellaneous/Plugins/AmbiguousCommands/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/AmbiguousCommands/Package.swift
@@ -1,0 +1,15 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "AmbiguousCommands",
+    dependencies: [
+        .package(path: "Dependencies/A"),
+        .package(path: "Dependencies/B"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "AmbiguousCommands"),
+    ]
+)

--- a/Fixtures/Miscellaneous/Plugins/AmbiguousCommands/Sources/main.swift
+++ b/Fixtures/Miscellaneous/Plugins/AmbiguousCommands/Sources/main.swift
@@ -1,0 +1,1 @@
+print("Hello, world!")

--- a/Sources/Commands/PackageTools/PluginCommand.swift
+++ b/Sources/Commands/PackageTools/PluginCommand.swift
@@ -396,7 +396,7 @@ extension SandboxNetworkPermission {
 extension ResolvedPackage {
     fileprivate func matching(identity: String?) -> Bool {
         if let identity {
-            return self.identity.description == identity.lowercased()
+            return self.identity == .plain(identity)
         } else {
             return true
         }

--- a/Sources/Commands/PackageTools/SwiftPackageTool.swift
+++ b/Sources/Commands/PackageTools/SwiftPackageTool.swift
@@ -126,7 +126,7 @@ extension PluginCommand.PluginOptions {
     func merged(with other: Self) -> Self {
         // validate against developer mistake
         assert(
-            Mirror(reflecting: self).children.count == 3,
+            Mirror(reflecting: self).children.count == 4,
             "Property added to PluginOptions without updating merged(with:)!"
         )
         // actual merge
@@ -136,6 +136,9 @@ extension PluginCommand.PluginOptions {
         merged.additionalAllowedWritableDirectories.append(contentsOf: other.additionalAllowedWritableDirectories)
         if other.allowNetworkConnections != .none {
             merged.allowNetworkConnections = other.allowNetworkConnections
+        }
+        if other.packageIdentity != nil {
+            merged.packageIdentity = other.packageIdentity
         }
         return merged
     }

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -1842,6 +1842,16 @@ final class PackageToolTests: CommandsTestCase {
         }
     }
 
+    func testAmbiguousCommandPlugin() throws {
+        // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
+        try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
+
+        try fixture(name: "Miscellaneous/Plugins/AmbiguousCommands") { fixturePath in
+            let (stdout, _) = try SwiftPM.Package.execute(["plugin", "--package", "A", "A"], packagePath: fixturePath)
+            XCTAssertMatch(stdout, .contains("Hello A!"))
+        }
+    }
+
     func testCommandPluginNetworkingPermissions(permissionsManifestFragment: String, permissionError: String, reason: String, remedy: [String]) throws {
         // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")


### PR DESCRIPTION
This adds a `--package` option to the plugin command which will limit the set of available plugins to those inside a package with the given identity.

The identity is not validated in any way, it will just be applied as a filter on all relevant packages. The option does apply to `--list` as well which seems a bit odd but a consequence of making listing an option rather than a command.

rdar://99887952

Previously:

```
❯ swift-package plugin B --help            
error: 2 plugins found for ‘B’
Usage: swift package <options> <subcommand>
  See 'package -help' for more information.
```

Now:

```
❯ swift-package plugin --package B B --help
Hello, World!
```