### PR TITLE
[5.9] Fix remaining mentions of "cross-compilation destinations"

### DIFF
--- a/Sources/SwiftSDKTool/Configuration/ConfigureSwiftSDK.swift
+++ b/Sources/SwiftSDKTool/Configuration/ConfigureSwiftSDK.swift
@@ -16,7 +16,7 @@ public struct ConfigureSwiftSDK: ParsableCommand {
     public static let configuration = CommandConfiguration(
         commandName: "configuration",
         abstract: """
-        Manages configuration options for installed cross-compilation destinations.
+        Manages configuration options for installed Swift SDKs.
         """,
         subcommands: [
             ResetConfiguration.self,

--- a/Sources/SwiftSDKTool/Configuration/ResetConfiguration.swift
+++ b/Sources/SwiftSDKTool/Configuration/ResetConfiguration.swift
@@ -21,8 +21,8 @@ struct ResetConfiguration: ConfigurationSubcommand {
     static let configuration = CommandConfiguration(
         commandName: "reset",
         abstract: """
-        Resets configuration properties currently applied to a given destination and run-time triple. If no specific \
-        property is specified, all of them are reset for the destination.
+        Resets configuration properties currently applied to a given Swift SDK and target triple. If no specific \
+        property is specified, all of them are reset for the Swift SDK.
         """
     )
 
@@ -49,13 +49,13 @@ struct ResetConfiguration: ConfigurationSubcommand {
 
     @Argument(
         help: """
-        An identifier of an already installed destination. Use the `list` subcommand to see all available \
+        An identifier of an already installed Swift SDK. Use the `list` subcommand to see all available \
         identifiers.
         """
     )
     var sdkID: String
 
-    @Argument(help: "A run-time triple of the destination specified by `destination-id` identifier string.")
+    @Argument(help: "A run-time triple of the Swift SDK specified by `sdk-id` identifier string.")
     var targetTriple: String
 
     func run(
@@ -109,12 +109,12 @@ struct ResetConfiguration: ConfigurationSubcommand {
         if shouldResetAll {
             if try !configurationStore.resetConfiguration(sdkID: sdkID, targetTriple: targetTriple) {
                 observabilityScope.emit(
-                    warning: "No configuration for destination \(sdkID)"
+                    warning: "No configuration for Swift SDK `\(sdkID)`"
                 )
             } else {
                 observabilityScope.emit(
                     info: """
-                    All configuration properties of destination `\(sdkID) for run-time triple \
+                    All configuration properties of Swift SDK `\(sdkID)` for run-time triple \
                     `\(targetTriple)` were successfully reset.
                     """
                 )
@@ -126,7 +126,7 @@ struct ResetConfiguration: ConfigurationSubcommand {
 
             observabilityScope.emit(
                 info: """
-                These properties of destination `\(sdkID) for run-time triple \
+                These properties of Swift SDK `\(sdkID)` for target triple \
                 `\(targetTriple)` were successfully reset: \(resetProperties.joined(separator: ", ")).
                 """
             )

--- a/Sources/SwiftSDKTool/Configuration/SetConfiguration.swift
+++ b/Sources/SwiftSDKTool/Configuration/SetConfiguration.swift
@@ -21,7 +21,7 @@ struct SetConfiguration: ConfigurationSubcommand {
     static let configuration = CommandConfiguration(
         commandName: "set",
         abstract: """
-        Sets configuration options for installed cross-compilation destinations.
+        Sets configuration options for installed Swift SDKs.
         """
     )
 
@@ -65,13 +65,13 @@ struct SetConfiguration: ConfigurationSubcommand {
 
     @Argument(
         help: """
-        An identifier of an already installed destination. Use the `list` subcommand to see all available \
+        An identifier of an already installed Swift SDK. Use the `list` subcommand to see all available \
         identifiers.
         """
     )
     var sdkID: String
 
-    @Argument(help: "The run-time triple of the destination to configure.")
+    @Argument(help: "The run-time triple of the Swift SDK to configure.")
     var targetTriple: String
 
     func run(
@@ -125,7 +125,7 @@ struct SetConfiguration: ConfigurationSubcommand {
         guard !updatedProperties.isEmpty else {
             observabilityScope.emit(
                 error: """
-                No properties of destination `\(sdkID) for run-time triple `\(targetTriple)` were updated \
+                No properties of Swift SDK `\(sdkID)` for target triple `\(targetTriple)` were updated \
                 since none were specified. Pass `--help` flag to see the list of all available properties.
                 """
             )
@@ -138,7 +138,7 @@ struct SetConfiguration: ConfigurationSubcommand {
 
         observabilityScope.emit(
             info: """
-            These properties of destination `\(sdkID) for run-time triple \
+            These properties of Swift SDK `\(sdkID)` for target triple \
             `\(targetTriple)` were successfully updated: \(updatedProperties.joined(separator: ", ")).
             """
         )

--- a/Sources/SwiftSDKTool/Configuration/ShowConfiguration.swift
+++ b/Sources/SwiftSDKTool/Configuration/ShowConfiguration.swift
@@ -21,7 +21,7 @@ struct ShowConfiguration: ConfigurationSubcommand {
     static let configuration = CommandConfiguration(
         commandName: "show",
         abstract: """
-        Prints all configuration properties currently applied to a given destination and run-time triple.
+        Prints all configuration properties currently applied to a given Swift SDK and target triple.
         """
     )
 
@@ -30,13 +30,13 @@ struct ShowConfiguration: ConfigurationSubcommand {
 
     @Argument(
         help: """
-        An identifier of an already installed destination. Use the `list` subcommand to see all available \
+        An identifier of an already installed Swift SDK. Use the `list` subcommand to see all available \
         identifiers.
         """
     )
     var sdkID: String
 
-    @Argument(help: "The run-time triple of the destination to configure.")
+    @Argument(help: "The target triple of the Swift SDK to configure.")
     var targetTriple: String
 
     func run(

--- a/Sources/SwiftSDKTool/ListSwiftSDKs.swift
+++ b/Sources/SwiftSDKTool/ListSwiftSDKs.swift
@@ -23,7 +23,7 @@ public struct ListSwiftSDKs: SwiftSDKSubcommand {
         commandName: "list",
         abstract:
         """
-        Print a list of IDs of available cross-compilation destinations available on the filesystem.
+        Print a list of IDs of available Swift SDKs available on the filesystem.
         """
     )
 
@@ -44,7 +44,7 @@ public struct ListSwiftSDKs: SwiftSDKSubcommand {
         )
 
         guard !validBundles.isEmpty else {
-            print("No cross-compilation destinations are currently installed.")
+            print("No Swift SDKs are currently installed.")
             return
         }
 

--- a/Sources/SwiftSDKTool/SwiftSDKSubcommand.swift
+++ b/Sources/SwiftSDKTool/SwiftSDKSubcommand.swift
@@ -51,7 +51,7 @@ extension SwiftSDKSubcommand {
         ) else {
             let expectedPath = try fileSystem.swiftSDKsDirectory
             throw StringError(
-                "Couldn't find or create a directory where cross-compilation destinations are stored: `\(expectedPath)`"
+                "Couldn't find or create a directory where Swift SDKs are stored: `\(expectedPath)`"
             )
         }
 


### PR DESCRIPTION
Cherry-pick of #6918.

Not all of the help strings were updated to use "Swift SDK" instead of "cross-compilation destination" after SE-0387 was accepted.

Risk: very low, only help strings are updated.

rdar://115680101
