### PR TITLE
[5.10] Fix backward compatibility in host triple checks

### DIFF
--- a/Sources/Basics/Triple+Basics.swift
+++ b/Sources/Basics/Triple+Basics.swift
@@ -183,6 +183,19 @@ extension Triple {
             return ".resources"
         }
     }
+
+    public func isRuntimeCompatible(with triple: Triple) -> Bool {                        
+        if
+            self.arch == triple.arch &&
+            self.vendor == triple.vendor &&
+            self.os == triple.os &&
+            self.environment == triple.environment
+        {
+            return self.osVersion >= triple.osVersion
+        } else {
+            return false
+        }
+    }
 }
 
 extension Triple: CustomStringConvertible {

--- a/Sources/PackageModel/SwiftSDKBundle.swift
+++ b/Sources/PackageModel/SwiftSDKBundle.swift
@@ -428,7 +428,9 @@ extension [SwiftSDKBundle] {
         for bundle in self {
             for (artifactID, variants) in bundle.artifacts {
                 for variant in variants {
-                    guard variant.metadata.supportedTriples.contains(hostTriple) else {
+                    guard variant.metadata.supportedTriples.contains(where: { variantTriple in
+                        hostTriple.isRuntimeCompatible(with: variantTriple)
+                    }) else {
                         continue
                     }
 

--- a/Tests/BasicsTests/TripleTests.swift
+++ b/Tests/BasicsTests/TripleTests.swift
@@ -165,4 +165,11 @@ final class TripleTests: XCTestCase {
         XCTAssertTriple("x86_64-unknown-windows-msvc", matches: (.x86_64, nil, nil, .win32, .msvc, .coff))
         XCTAssertTriple("wasm32-unknown-wasi", matches: (.wasm32, nil, nil, .wasi, nil, .wasm))
     }
+
+    func testIsRuntimeCompatibleWith() throws {
+        try XCTAssertTrue(Triple("x86_64-apple-macosx").isRuntimeCompatible(with: Triple("x86_64-apple-macosx")))
+        try XCTAssertTrue(Triple("x86_64-unknown-linux").isRuntimeCompatible(with: Triple("x86_64-unknown-linux")))
+        try XCTAssertFalse(Triple("x86_64-apple-macosx").isRuntimeCompatible(with: Triple("x86_64-apple-linux")))
+        try XCTAssertTrue(Triple("x86_64-apple-macosx14.0").isRuntimeCompatible(with: Triple("x86_64-apple-macosx13.0")))
+    }
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-package-manager/pull/6819.

When setting host triple in Swift SDKs to `arm64-apple-macosx13.0` to allow cross-compiling from an older version of macOS, this triple is not recognized as directly matching `arm64-apple-macosx14.0` on a newer version of macOS.

We should support backward compatibility with Swift SDKs that were built for older version of macOS.

Resolves rdar://113967401.

```
# Conflicts:
#	Sources/PackageModel/SwiftSDKBundle.swift
```