### PR TITLE
Rename "destination" to "Swift SDK" in comments and code

### DIFF
--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -42,12 +42,12 @@ public final class UserToolchain: Toolchain {
 
     /// Path containing Swift resources for dynamic linking.
     public var swiftResourcesPath: AbsolutePath? {
-        destination.pathsConfiguration.swiftResourcesPath
+        swiftSDK.pathsConfiguration.swiftResourcesPath
     }
 
     /// Path containing Swift resources for static linking.
     public var swiftStaticResourcesPath: AbsolutePath? {
-        destination.pathsConfiguration.swiftStaticResourcesPath
+        swiftSDK.pathsConfiguration.swiftStaticResourcesPath
     }
 
     /// Additional flags to be passed to the build tools.
@@ -518,7 +518,7 @@ public final class UserToolchain: Toolchain {
         self.isSwiftDevelopmentToolchain = false
         #endif
 
-        // Use the triple from destination or compute the host triple using swiftc.
+        // Use the triple from Swift SDK or compute the host triple using swiftc.
         var triple = try swiftSDK.targetTriple ?? Triple.getHostTriple(usingSwiftCompiler: swiftCompilers.compile)
 
         // Change the triple to the specified arch if there's exactly one of them.

--- a/Sources/SwiftSDKTool/Configuration/ConfigurationSubcommand.swift
+++ b/Sources/SwiftSDKTool/Configuration/ConfigurationSubcommand.swift
@@ -18,15 +18,15 @@ protocol ConfigurationSubcommand: SwiftSDKSubcommand {
     /// An identifier of an already installed Swift SDK.
     var sdkID: String { get }
 
-    /// A target triple of the destination.
+    /// A target triple of the Swift SDK.
     var targetTriple: String { get }
 
-    /// Run a command related to configuration of cross-compilation destinations, passing it required configuration
+    /// Run a command related to configuration of Swift SDKs, passing it required configuration
     /// values.
     /// - Parameters:
     ///   - hostTriple: triple of the machine this command is running on.
     ///   - targetTriple: triple of the machine on which cross-compiled code will run on.
-    ///   - destination: destination configuration fetched that matches currently set `destinationID` and
+    ///   - swiftSDK: Swift SDK configuration fetched that matches currently set `sdkID` and
     ///   `targetTriple`.
     ///   - configurationStore: storage for configuration properties that this command operates on.
     ///   - swiftSDKsDirectory: directory containing Swift SDK artifact bundles and their configuration.
@@ -34,7 +34,7 @@ protocol ConfigurationSubcommand: SwiftSDKSubcommand {
     func run(
         hostTriple: Triple,
         targetTriple: Triple,
-        _ destination: SwiftSDK,
+        _ swiftSDK: SwiftSDK,
         _ configurationStore: SwiftSDKConfigurationStore,
         _ swiftSDKsDirectory: AbsolutePath,
         _ observabilityScope: ObservabilityScope
@@ -55,7 +55,7 @@ extension ConfigurationSubcommand {
         )
         let targetTriple = try Triple(self.targetTriple)
 
-        guard let destination = try configurationStore.readConfiguration(
+        guard let swiftSDK = try configurationStore.readConfiguration(
             sdkID: sdkID,
             targetTriple: targetTriple
         ) else {
@@ -69,7 +69,7 @@ extension ConfigurationSubcommand {
         try run(
             hostTriple: hostTriple,
             targetTriple: targetTriple,
-            destination,
+            swiftSDK,
             configurationStore,
             swiftSDKsDirectory,
             observabilityScope

--- a/Sources/SwiftSDKTool/Configuration/ResetConfiguration.swift
+++ b/Sources/SwiftSDKTool/Configuration/ResetConfiguration.swift
@@ -59,12 +59,12 @@ struct ResetConfiguration: ConfigurationSubcommand {
     func run(
         hostTriple: Triple,
         targetTriple: Triple,
-        _ destination: SwiftSDK,
+        _ swiftSDK: SwiftSDK,
         _ configurationStore: SwiftSDKConfigurationStore,
-        _ destinationsDirectory: AbsolutePath,
+        _ swiftSDKsDirectory: AbsolutePath,
         _ observabilityScope: ObservabilityScope
     ) throws {
-        var configuration = destination.pathsConfiguration
+        var configuration = swiftSDK.pathsConfiguration
         var shouldResetAll = true
         var resetProperties = [String]()
 
@@ -118,9 +118,9 @@ struct ResetConfiguration: ConfigurationSubcommand {
                 )
             }
         } else {
-            var destination = destination
-            destination.pathsConfiguration = configuration
-            try configurationStore.updateConfiguration(sdkID: sdkID, swiftSDK: destination)
+            var swiftSDK = swiftSDK
+            swiftSDK.pathsConfiguration = configuration
+            try configurationStore.updateConfiguration(sdkID: sdkID, swiftSDK: swiftSDK)
 
             observabilityScope.emit(
                 info: """

--- a/Sources/SwiftSDKTool/Configuration/SetConfiguration.swift
+++ b/Sources/SwiftSDKTool/Configuration/SetConfiguration.swift
@@ -75,12 +75,12 @@ struct SetConfiguration: ConfigurationSubcommand {
     func run(
         hostTriple: Triple,
         targetTriple: Triple,
-        _ destination: SwiftSDK,
+        _ swiftSDK: SwiftSDK,
         _ configurationStore: SwiftSDKConfigurationStore,
-        _ destinationsDirectory: AbsolutePath,
+        _ swiftSDKsDirectory: AbsolutePath,
         _ observabilityScope: ObservabilityScope
     ) throws {
-        var configuration = destination.pathsConfiguration
+        var configuration = swiftSDK.pathsConfiguration
         var updatedProperties = [String]()
 
         let currentWorkingDirectory: AbsolutePath? = fileSystem.currentWorkingDirectory
@@ -130,9 +130,9 @@ struct SetConfiguration: ConfigurationSubcommand {
             return
         }
 
-        var destination = destination
-        destination.pathsConfiguration = configuration
-        try configurationStore.updateConfiguration(sdkID: sdkID, swiftSDK: destination)
+        var swiftSDK = swiftSDK
+        swiftSDK.pathsConfiguration = configuration
+        try configurationStore.updateConfiguration(sdkID: sdkID, swiftSDK: swiftSDK)
 
         observabilityScope.emit(
             info: """

--- a/Sources/SwiftSDKTool/Configuration/ShowConfiguration.swift
+++ b/Sources/SwiftSDKTool/Configuration/ShowConfiguration.swift
@@ -40,12 +40,12 @@ struct ShowConfiguration: ConfigurationSubcommand {
     func run(
         hostTriple: Triple,
         targetTriple: Triple,
-        _ destination: SwiftSDK,
+        _ swiftSDK: SwiftSDK,
         _ configurationStore: SwiftSDKConfigurationStore,
-        _ destinationsDirectory: AbsolutePath,
+        _ swiftSDKsDirectory: AbsolutePath,
         _ observabilityScope: ObservabilityScope
     ) throws {
-        print(destination.pathsConfiguration)
+        print(swiftSDK.pathsConfiguration)
     }
 }
 

--- a/Sources/SwiftSDKTool/InstallSwiftSDK.swift
+++ b/Sources/SwiftSDKTool/InstallSwiftSDK.swift
@@ -37,14 +37,14 @@ public struct InstallSwiftSDK: SwiftSDKSubcommand {
 
     func run(
         hostTriple: Triple,
-        _ destinationsDirectory: AbsolutePath,
+        _ swiftSDKsDirectory: AbsolutePath,
         _ observabilityScope: ObservabilityScope
     ) async throws {
         let cancellator = Cancellator(observabilityScope: observabilityScope)
         cancellator.installSignalHandlers()
         try await SwiftSDKBundle.install(
             bundlePathOrURL: bundlePathOrURL,
-            swiftSDKsDirectory: destinationsDirectory,
+            swiftSDKsDirectory: swiftSDKsDirectory,
             self.fileSystem,
             UniversalArchiver(self.fileSystem, cancellator),
             observabilityScope

--- a/Sources/SwiftSDKTool/ListSwiftSDKs.swift
+++ b/Sources/SwiftSDKTool/ListSwiftSDKs.swift
@@ -32,11 +32,11 @@ public struct ListSwiftSDKs: SwiftSDKSubcommand {
 
     func run(
         hostTriple: Triple,
-        _ destinationsDirectory: AbsolutePath,
+        _ swiftSDKsDirectory: AbsolutePath,
         _ observabilityScope: ObservabilityScope
     ) throws {
         let validBundles = try SwiftSDKBundle.getAllValidBundles(
-            swiftSDKsDirectory: destinationsDirectory,
+            swiftSDKsDirectory: swiftSDKsDirectory,
             fileSystem: fileSystem,
             observabilityScope: observabilityScope
         )

--- a/Sources/SwiftSDKTool/README.md
+++ b/Sources/SwiftSDKTool/README.md
@@ -1,4 +1,4 @@
-# Cross-Compilation Destinations Tool
+# Swift SDKs Tool
 
-This module implements `swift experimental destination` command and its subcommands, which allow managing artifact
-bundles used as cross-compilation destinations.
+This module implements `swift experimental-sdk` command and its subcommands, which allow managing artifact
+bundles used as Swift SDKs, as specified in [SE-0387](https://github.com/apple/swift-evolution/blob/main/proposals/0387-cross-compilation-destinations.md).

--- a/Sources/SwiftSDKTool/RemoveSwiftSDK.swift
+++ b/Sources/SwiftSDKTool/RemoveSwiftSDK.swift
@@ -33,11 +33,10 @@ public struct RemoveSwiftSDK: SwiftSDKSubcommand {
 
     func run(
         hostTriple: Triple,
-        _ destinationsDirectory: AbsolutePath,
+        _ swiftSDKsDirectory: AbsolutePath,
         _ observabilityScope: ObservabilityScope
     ) async throws {
-        let destinationsDirectory = try self.getOrCreateDestinationsDirectory()
-        let artifactBundleDirectory = destinationsDirectory.appending(component: self.sdkIDOrBundleName)
+        let artifactBundleDirectory = swiftSDKsDirectory.appending(component: self.sdkIDOrBundleName)
 
         let removedBundleDirectory: AbsolutePath
         if fileSystem.exists(artifactBundleDirectory) {
@@ -46,7 +45,7 @@ public struct RemoveSwiftSDK: SwiftSDKSubcommand {
             removedBundleDirectory = artifactBundleDirectory
         } else {
             let bundles = try SwiftSDKBundle.getAllValidBundles(
-                swiftSDKsDirectory: destinationsDirectory,
+                swiftSDKsDirectory: swiftSDKsDirectory,
                 fileSystem: fileSystem,
                 observabilityScope: observabilityScope
             )

--- a/Sources/SwiftSDKTool/SwiftSDKSubcommand.swift
+++ b/Sources/SwiftSDKTool/SwiftSDKSubcommand.swift
@@ -18,12 +18,12 @@ import PackageModel
 
 import var TSCBasic.stdoutStream
 
-/// A protocol for functions and properties common to all destination subcommands.
+/// A protocol for functions and properties common to all Swift SDK subcommands.
 protocol SwiftSDKSubcommand: AsyncParsableCommand {
     /// Common locations options provided by ArgumentParser.
     var locations: LocationOptions { get }
 
-    /// Run a command operating on cross-compilation destinations, passing it required configuration values.
+    /// Run a command operating on Swift SDKs, passing it required configuration values.
     /// - Parameters:
     ///   - hostTriple: triple of the machine this command is running on.
     ///   - swiftSDKsDirectory: directory containing Swift SDK artifact bundles and their configuration.
@@ -39,11 +39,11 @@ extension SwiftSDKSubcommand {
     /// The file system used by default by this command.
     var fileSystem: FileSystem { localFileSystem }
 
-    /// Parses destinations directory option if provided or uses the default path for cross-compilation destinations
+    /// Parses Swift SDKs directory option if provided or uses the default path for Swift SDKs
     /// on the file system. A new directory at this path is created if one doesn't exist already.
     /// - Returns: existing or a newly created directory at the computed location.
-    func getOrCreateDestinationsDirectory() throws -> AbsolutePath {
-        guard var destinationsDirectory = try fileSystem.getSharedSwiftSDKsDirectory(
+    func getOrCreateSwiftSDKsDirectory() throws -> AbsolutePath {
+        guard var swiftSDKsDirectory = try fileSystem.getSharedSwiftSDKsDirectory(
             explicitDirectory: locations.swiftSDKsDirectory
         ) else {
             let expectedPath = try fileSystem.swiftSDKsDirectory
@@ -52,25 +52,25 @@ extension SwiftSDKSubcommand {
             )
         }
 
-        if !self.fileSystem.exists(destinationsDirectory) {
-            destinationsDirectory = try self.fileSystem.getOrCreateSwiftPMSwiftSDKsDirectory()
+        if !self.fileSystem.exists(swiftSDKsDirectory) {
+            swiftSDKsDirectory = try self.fileSystem.getOrCreateSwiftPMSwiftSDKsDirectory()
         }
 
-        return destinationsDirectory
+        return swiftSDKsDirectory
     }
 
     public func run() async throws {
         let observabilityHandler = SwiftToolObservabilityHandler(outputStream: stdoutStream, logLevel: .info)
         let observabilitySystem = ObservabilitySystem(observabilityHandler)
         let observabilityScope = observabilitySystem.topScope
-        let destinationsDirectory = try self.getOrCreateDestinationsDirectory()
+        let swiftSDKsDirectory = try self.getOrCreateSwiftSDKsDirectory()
 
         let hostToolchain = try UserToolchain(swiftSDK: SwiftSDK.hostSwiftSDK())
         let triple = try Triple.getHostTriple(usingSwiftCompiler: hostToolchain.swiftCompilerPath)
 
         var commandError: Error? = nil
         do {
-            try await self.run(hostTriple: triple, destinationsDirectory, observabilityScope)
+            try await self.run(hostTriple: triple, swiftSDKsDirectory, observabilityScope)
             if observabilityScope.errorsReported {
                 throw ExitCode.failure
             }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -4540,7 +4540,7 @@ final class BuildPlanTests: XCTestCase {
         }
     }
 
-    func testXCFrameworkBinaryTargets(platform: String, arch: String, destinationTriple: Basics.Triple) throws {
+    func testXCFrameworkBinaryTargets(platform: String, arch: String, targetTriple: Basics.Triple) throws {
         let Pkg: AbsolutePath = "/Pkg"
 
         let fs = InMemoryFileSystem(emptyFiles:
@@ -4649,7 +4649,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         let result = try BuildPlanResult(plan: BuildPlan(
-            buildParameters: mockBuildParameters(targetTriple: destinationTriple),
+            buildParameters: mockBuildParameters(targetTriple: targetTriple),
             graph: graph,
             fileSystem: fs,
             observabilityScope: observability.topScope
@@ -4695,16 +4695,19 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testXCFrameworkBinaryTargets() throws {
-        try testXCFrameworkBinaryTargets(platform: "macos", arch: "x86_64", destinationTriple: .x86_64MacOS)
+        try testXCFrameworkBinaryTargets(platform: "macos", arch: "x86_64", targetTriple: .x86_64MacOS)
 
         let arm64Triple = try Basics.Triple("arm64-apple-macosx")
-        try testXCFrameworkBinaryTargets(platform: "macos", arch: "arm64", destinationTriple: arm64Triple)
+        try testXCFrameworkBinaryTargets(platform: "macos", arch: "arm64", targetTriple: arm64Triple)
 
         let arm64eTriple = try Basics.Triple("arm64e-apple-macosx")
-        try testXCFrameworkBinaryTargets(platform: "macos", arch: "arm64e", destinationTriple: arm64eTriple)
+        try testXCFrameworkBinaryTargets(platform: "macos", arch: "arm64e", targetTriple: arm64eTriple)
     }
 
-    func testArtifactsArchiveBinaryTargets(artifactTriples:[Basics.Triple], destinationTriple: Basics.Triple) throws -> Bool {
+    func testArtifactsArchiveBinaryTargets(
+        artifactTriples: [Basics.Triple],
+        targetTriple: Basics.Triple
+    ) throws -> Bool {
         let fs = InMemoryFileSystem(emptyFiles: "/Pkg/Sources/exe/main.swift")
 
         let artifactName = "my-tool"
@@ -4758,7 +4761,7 @@ final class BuildPlanTests: XCTestCase {
 
         XCTAssertNoDiagnostics(observability.diagnostics)
         let result = try BuildPlanResult(plan: BuildPlan(
-            buildParameters: mockBuildParameters(targetTriple: destinationTriple),
+            buildParameters: mockBuildParameters(targetTriple: targetTriple),
             graph: graph,
             fileSystem: fs,
             observabilityScope: observability.topScope
@@ -4773,16 +4776,16 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testArtifactsArchiveBinaryTargets() throws {
-        XCTAssertTrue(try testArtifactsArchiveBinaryTargets(artifactTriples: [.x86_64MacOS], destinationTriple: .x86_64MacOS))
+        XCTAssertTrue(try testArtifactsArchiveBinaryTargets(artifactTriples: [.x86_64MacOS], targetTriple: .x86_64MacOS))
 
         do {
             let triples = try ["arm64-apple-macosx",  "x86_64-apple-macosx", "x86_64-unknown-linux-gnu"].map(Basics.Triple.init)
-            XCTAssertTrue(try testArtifactsArchiveBinaryTargets(artifactTriples: triples, destinationTriple: triples.first!))
+            XCTAssertTrue(try testArtifactsArchiveBinaryTargets(artifactTriples: triples, targetTriple: triples.first!))
         }
 
         do {
             let triples = try ["x86_64-unknown-linux-gnu"].map(Basics.Triple.init)
-            XCTAssertFalse(try testArtifactsArchiveBinaryTargets(artifactTriples: triples, destinationTriple: .x86_64MacOS))
+            XCTAssertFalse(try testArtifactsArchiveBinaryTargets(artifactTriples: triples, targetTriple: .x86_64MacOS))
         }
     }
 

--- a/Tests/PackageModelTests/PackageModelTests.swift
+++ b/Tests/PackageModelTests/PackageModelTests.swift
@@ -61,14 +61,14 @@ class PackageModelTests: XCTestCase {
         let sdkDir = AbsolutePath("/some/path/to/an/SDK.sdk")
         let toolchainPath = AbsolutePath("/some/path/to/a/toolchain.xctoolchain")
 
-        let destination = SwiftSDK(
+        let swiftSDK = SwiftSDK(
             targetTriple: triple,
             toolset: .init(toolchainBinDir: toolchainPath.appending(components: "usr", "bin"), buildFlags: .init()),
             pathsConfiguration: .init(sdkRootPath: sdkDir)
         )
 
         XCTAssertEqual(
-            try UserToolchain.deriveSwiftCFlags(triple: triple, swiftSDK: destination, environment: .process()),
+            try UserToolchain.deriveSwiftCFlags(triple: triple, swiftSDK: swiftSDK, environment: .process()),
             [
                 // Needed when cross‐compiling for Android. 2020‐03‐01
                 "-sdk", sdkDir.pathString,

--- a/Tests/PackageModelTests/SwiftSDKTests.swift
+++ b/Tests/PackageModelTests/SwiftSDKTests.swift
@@ -527,7 +527,7 @@ final class DestinationTests: XCTestCase {
         let system = ObservabilitySystem.makeForTesting()
 
         XCTAssertEqual(
-            bundles.selectDestination(
+            bundles.selectSwiftSDK(
                 matching: "id1",
                 hostTriple: hostTriple,
                 observabilityScope: system.topScope
@@ -538,7 +538,7 @@ final class DestinationTests: XCTestCase {
         // Expecting `nil` because no host triple is specified for this destination
         // in the fake destination bundle.
         XCTAssertNil(
-            bundles.selectDestination(
+            bundles.selectSwiftSDK(
                 matching: "id2",
                 hostTriple: hostTriple,
                 observabilityScope: system.topScope
@@ -546,7 +546,7 @@ final class DestinationTests: XCTestCase {
         )
 
         XCTAssertEqual(
-            bundles.selectDestination(
+            bundles.selectSwiftSDK(
                 matching: "id3",
                 hostTriple: hostTriple,
                 observabilityScope: system.topScope


### PR DESCRIPTION
While user-visible strings were cleaned up separately in https://github.com/apple/swift-package-manager/pull/6918, there are still uses of "destinations" left in variable/function naming and comments. Let's clean those up too.
