### PR TITLE
load => loadUnaligned

### DIFF
--- a/Sources/PackagePlugin/Plugin.swift
+++ b/Sources/PackagePlugin/Plugin.swift
@@ -303,7 +303,7 @@ internal struct MessageConnection<TX,RX> where TX: Encodable, RX: Decodable {
         }
         
         // Decode the count.
-        let count = header.withUnsafeBytes{ $0.load(as: UInt64.self).littleEndian }
+        let count = header.withUnsafeBytes{ $0.loadUnaligned(as: UInt64.self).littleEndian }
         guard count >= 2 else {
             throw PluginMessageError.invalidPayloadSize
         }

--- a/Sources/Workspace/DefaultPluginScriptRunner.swift
+++ b/Sources/Workspace/DefaultPluginScriptRunner.swift
@@ -664,7 +664,7 @@ fileprivate extension FileHandle {
         guard header.count == 8 else {
             throw PluginMessageError.truncatedHeader
         }
-        let length = header.withUnsafeBytes{ $0.load(as: UInt64.self).littleEndian }
+        let length = header.withUnsafeBytes{ $0.loadUnaligned(as: UInt64.self).littleEndian }
         guard length >= 2 else {
             throw PluginMessageError.invalidPayloadSize
         }


### PR DESCRIPTION
This is the potential source of a crash on x86_64 using the rebranch branch of Swift.

rdar://115675736
