### PR TITLE
Skip tests which need `-suppress-warnings` to work if it doesn't work

### DIFF
--- a/Sources/SPMTestSupport/Toolchain.swift
+++ b/Sources/SPMTestSupport/Toolchain.swift
@@ -111,6 +111,29 @@ extension UserToolchain {
         }
     }
 
+    public func supportsSuppressWarnings() -> Bool {
+        do {
+            try testWithTemporaryDirectory { tmpPath in
+                let inputPath = tmpPath.appending("best.swift")
+                try localFileSystem.writeFileContents(inputPath, string: "let foo: String? = \"bar\"\nprint(foo)\n")
+                let outputPath = tmpPath.appending("foo")
+                let serializedDiagnosticsPath = tmpPath.appending("out.dia")
+                let toolchainPath = self.swiftCompilerPath.parentDirectory.parentDirectory
+                try Process.checkNonZeroExit(arguments: ["/usr/bin/xcrun", "--toolchain", toolchainPath.pathString, "swiftc", inputPath.pathString, "-Xfrontend", "-serialize-diagnostics-path", "-Xfrontend", serializedDiagnosticsPath.pathString, "-o", outputPath.pathString, "-suppress-warnings"])
+
+                let diaFileContents = try localFileSystem.readFileContents(serializedDiagnosticsPath)
+                let diagnosticsSet = try SerializedDiagnostics(bytes: diaFileContents)
+
+                if diagnosticsSet.diagnostics.contains(where: { $0.text.contains("warning") }) {
+                    throw StringError("does not support suppressing warnings")
+                }
+            }
+            return true
+        } catch {
+            return false
+        }
+    }
+
     /// Helper function to determine whether we should run SDK-dependent tests.
     public func supportsSDKDependentTests() -> Bool {
         return ProcessInfo.processInfo.environment["SWIFTCI_DISABLE_SDK_DEPENDENT_TESTS"] == nil

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -606,6 +606,8 @@ class MiscellaneousTestCase: XCTestCase {
     }
 
     func testNoWarningFromRemoteDependencies() throws {
+        try XCTSkipIf(!UserToolchain.default.supportsSuppressWarnings(), "skipping because test environment doesn't support suppressing warnings")
+
         try fixture(name: "Miscellaneous/DependenciesWarnings") { path in
             // prepare the deps as git sources
             let dependency1Path = path.appending("dep1")
@@ -623,6 +625,8 @@ class MiscellaneousTestCase: XCTestCase {
     }
 
     func testNoWarningFromRemoteDependenciesWithWarningsAsErrors() throws {
+        try XCTSkipIf(!UserToolchain.default.supportsSuppressWarnings(), "skipping because test environment doesn't support suppressing warnings")
+
         try fixture(name: "Miscellaneous/DependenciesWarnings2") { path in
             // prepare the deps as git sources
             let dependency1Path = path.appending("dep1")


### PR DESCRIPTION
I filed an issue about this separately, but in the meantime we need a way to get to passing tests.