### PR TITLE
[5.10] Add and fix missing `Triple` tests

### DIFF
--- a/Sources/Basics/Triple+Basics.swift
+++ b/Sources/Basics/Triple+Basics.swift
@@ -203,7 +203,11 @@ extension Triple: CustomStringConvertible {
 }
 
 extension Triple: Equatable {
-    public static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.triple == rhs.triple
+    public static func ==(lhs: Triple, rhs: Triple) -> Bool {
+      lhs.arch == rhs.arch
+        && lhs.vendor == rhs.vendor
+        && lhs.os == rhs.os
+        && lhs.environment == rhs.environment
+        && lhs.osVersion == rhs.osVersion
     }
 }

--- a/Sources/Basics/Triple+Basics.swift
+++ b/Sources/Basics/Triple+Basics.swift
@@ -189,9 +189,13 @@ extension Triple {
             self.arch == triple.arch &&
             self.vendor == triple.vendor &&
             self.os == triple.os &&
-            self.environment == triple.environment
+            self.environment == triple.environment,
+            // If either of the triples have no `osVersion` specified, we can't determine compatibility and will
+            // have to return `false`.
+            let selfOSVersion = self.osVersion,
+            let osVersion = triple.osVersion
         {
-            return self.osVersion >= triple.osVersion
+            return selfOSVersion >= osVersion
         } else {
             return false
         }

--- a/Sources/Basics/Triple+Basics.swift
+++ b/Sources/Basics/Triple+Basics.swift
@@ -184,7 +184,11 @@ extension Triple {
         }
     }
 
-    public func isRuntimeCompatible(with triple: Triple) -> Bool {                        
+    public func isRuntimeCompatible(with triple: Triple) -> Bool {    
+        guard self != triple else {
+            return true
+        }
+
         if
             self.arch == triple.arch &&
             self.vendor == triple.vendor &&

--- a/Sources/Basics/Vendor/Triple.swift
+++ b/Sources/Basics/Vendor/Triple.swift
@@ -1,12 +1,12 @@
-//===--------------- Triple.swift - Swift Target Triples ------------------===//
+//===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift.org open source project
+// This source file is part of the Swift open source project
 //
-// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Copyright (c) 2014-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
-// See https://swift.org/LICENSE.txt for license information
-// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 
@@ -72,14 +72,16 @@ public struct Triple {
 
   /// Represents a version that may be present in the target triple.
   public struct Version: Equatable, Comparable, CustomStringConvertible {
-    public static let zero = Version(0, 0, 0)
-
     public var major: Int
     public var minor: Int
     public var micro: Int
 
-    public init<S: StringProtocol>(parse string: S) {
-      let components = string.split(separator: ".", maxSplits: 3).map{ Int($0) ?? 0 }
+    public init?(parse string: some StringProtocol) {
+      guard !string.isEmpty else {
+        return nil
+      }
+
+      let components = string.split(separator: ".", maxSplits: 3).map { Int($0) ?? 0 }
       self.major = components.count > 0 ? components[0] : 0
       self.minor = components.count > 1 ? components[1] : 0
       self.micro = components.count > 2 ? components[2] : 0
@@ -162,10 +164,9 @@ public struct Triple {
 
       // Now that we've parsed everything, we construct a normalized form of the
       // triple string.
-      triple = parser.components.map({ $0.isEmpty ? "unknown" : $0 }).joined(separator: "-")
-    }
-    else {
-      triple = string
+      self.triple = parser.components.map { $0.isEmpty ? "unknown" : $0 }.joined(separator: "-")
+    } else {
+      self.triple = string
     }
 
     // Unpack the parsed data into the fields. If no environment info was found,
@@ -1569,7 +1570,9 @@ extension Triple {
   /// This accessor is semi-private; it's typically better to use `version(for:)` or
   /// `Triple.FeatureAvailability`.
   public var _macOSVersion: Version? {
-    var version = osVersion
+    guard var version = osVersion else {
+      return nil
+    }
 
     switch os {
     case .darwin:
@@ -1632,7 +1635,7 @@ extension Triple {
       // OS X.
       return Version(5, 0, 0)
     case .ios, .tvos:
-      var version = self.osVersion
+      guard var version = self.osVersion else { return nil }
       // Default to 5.0 (or 7.0 for arm64).
       if version.major == 0 {
         version.major = arch == .aarch64 ? 7 : 5

--- a/Sources/Basics/Vendor/Triple.swift
+++ b/Sources/Basics/Vendor/Triple.swift
@@ -1526,7 +1526,7 @@ extension Triple {
   /// `darwin` OS version number is not adjusted to match the equivalent
   /// `macosx` version number. It's usually better to use `version(for:)`
   /// to get Darwin versions.
-  public var osVersion: Version {
+  public var osVersion: Version? {
     var osName = self.osName[...]
 
     // Assume that the OS portion of the triple starts with the canonical name.
@@ -1623,7 +1623,7 @@ extension Triple {
   ///
   /// This accessor is semi-private; it's typically better to use `version(for:)` or
   /// `Triple.FeatureAvailability`.
-  public var _iOSVersion: Version {
+  public var _iOSVersion: Version? {
     switch os {
     case .darwin, .macosx:
       // Ignore the version from the triple.  This is only handled because the
@@ -1650,7 +1650,7 @@ extension Triple {
   ///
   /// This accessor is semi-private; it's typically better to use `version(for:)` or
   /// `Triple.FeatureAvailability`.
-  public var _watchOSVersion: Version {
+  public var _watchOSVersion: Version? {
     switch os {
     case .darwin, .macosx:
       // Ignore the version from the triple.  This is only handled because the
@@ -1659,7 +1659,7 @@ extension Triple {
       // OS X.
       return Version(2, 0, 0)
     case .watchos:
-      var version = self.osVersion
+      guard var version = self.osVersion else { return nil }
       if version.major == 0 {
         version.major = 2
       }

--- a/Tests/BasicsTests/TripleTests.swift
+++ b/Tests/BasicsTests/TripleTests.swift
@@ -164,6 +164,54 @@ final class TripleTests: XCTestCase {
         XCTAssertTriple("aarch64-unknown-linux-android", matches: (.aarch64, nil, nil, .linux, .android, .elf))
         XCTAssertTriple("x86_64-unknown-windows-msvc", matches: (.x86_64, nil, nil, .win32, .msvc, .coff))
         XCTAssertTriple("wasm32-unknown-wasi", matches: (.wasm32, nil, nil, .wasi, nil, .wasm))
+    }    
+
+    func testTriple() {
+        let linux = try? Triple("x86_64-unknown-linux-gnu")
+        XCTAssertNotNil(linux)
+        XCTAssertEqual(linux!.os, .linux)
+        XCTAssertNil(linux!.osVersion)
+        XCTAssertEqual(linux!.environment, .gnu)
+
+        let macos = try? Triple("x86_64-apple-macosx10.15")
+        XCTAssertNotNil(macos!)
+        XCTAssertEqual(macos!.osVersion, .init(parse: "10.15")!)
+        let newVersion = "10.12"
+        let tripleString = macos!.tripleString(forPlatformVersion: newVersion)
+        XCTAssertEqual(tripleString, "x86_64-apple-macosx10.12")
+        let macosNoX = try? Triple("x86_64-apple-macos12.2")
+        XCTAssertNotNil(macosNoX!)
+        XCTAssertEqual(macosNoX!.os, .macosx)
+        XCTAssertEqual(macosNoX!.osVersion, .init(parse: "12.2")!)
+
+        let android = try? Triple("aarch64-unknown-linux-android24")
+        XCTAssertNotNil(android)
+        XCTAssertEqual(android!.os, .linux)
+        XCTAssertEqual(android!.environment, .android)
+
+        let linuxWithABIVersion = try? Triple("x86_64-unknown-linux-gnu42")
+        XCTAssertEqual(linuxWithABIVersion!.environment, .gnu)
+    }
+
+    func testEquality() throws {
+        let macOSTriple = try Triple("arm64-apple-macos")
+        let macOSXTriple = try Triple("arm64-apple-macosx")
+        XCTAssertEqual(macOSTriple, macOSXTriple)
+
+        let intelMacOSTriple = try Triple("x86_64-apple-macos")
+        XCTAssertNotEqual(macOSTriple, intelMacOSTriple)
+
+        let linuxWithoutGNUABI = try Triple("x86_64-unknown-linux")
+        let linuxWithGNUABI = try Triple("x86_64-unknown-linux-gnu")
+        XCTAssertNotEqual(linuxWithoutGNUABI, linuxWithGNUABI)
+    }
+
+    func testWASI() throws {
+        let wasi = try Triple("wasm32-unknown-wasi")
+
+        // WASI dynamic libraries are only experimental,
+        // but SwiftPM requires this property not to crash.
+        _ = wasi.dynamicLibraryExtension
     }
 
     func testIsRuntimeCompatibleWith() throws {


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-package-manager/pull/6843

Vendored Swift Driver triple was not checked against a few tests that weren't brought over from TSC after `TSC.Triple` type was deprecated. We should fix those tests, especially as they verified that per-component equality for triples worked instead of the current string-based equality check.

(cherry picked from commit 8de70d36ae2b210ff1b505768526621ec4acd4d1)

```
# Conflicts:
#	Tests/BasicsTests/TripleTests.swift
```

Related to rdar://113967401
May be related to rdar://115731621