### PR TITLE
Fix XCTest deployment target computation in `BuildPlan`

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -570,7 +570,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
         // Supported platforms are defined at the package level.
         // This will need to become a bit complicated once we have target-level or product-level platform support.
         let productPlatform = product.platforms.getDerived(for: .macOS, usingXCTest: product.isLinkingXCTest)
-        let targetPlatform = target.platforms.getDerived(for: .macOS, usingXCTest: product.isLinkingXCTest)
+        let targetPlatform = target.platforms.getDerived(for: .macOS, usingXCTest: target.type == .test)
 
         // Check if the version requirement is satisfied.
         //


### PR DESCRIPTION
This fixes an issue introduced in #6849 and noticed in the cherry-pick to 5.9 in #6886.
