### PR TITLE
Revert "Fix `platforms` declaration in `IntegrationTests` package (#6873)"

### DIFF
--- a/IntegrationTests/Package.swift
+++ b/IntegrationTests/Package.swift
@@ -4,9 +4,6 @@ import PackageDescription
 
 let package = Package(
     name: "IntegrationTests",
-    platforms: [
-        .macOS(.v10_15),
-    ],
     targets: [
         .testTarget(name: "IntegrationTests", dependencies: [
             .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),


### PR DESCRIPTION
This reverts commit ab9581041386e0bd5ccc0acf4251aac378ae55b1.

This shouldn't have been necessary since the automatic raise of test deployment targets should be sufficient here.