### PR TITLE
Revert "Swift SDKs: fix `toolset.linker.path` not passed to `-ld-path` (#6719)"

### DIFF
--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -347,11 +347,7 @@ public final class UserToolchain: Toolchain {
         swiftSDK: SwiftSDK,
         environment: EnvironmentVariables
     ) throws -> [String] {
-        var swiftCompilerFlags = swiftSDK.toolset.knownTools[.swiftCompiler]?.extraCLIOptions ?? []
-
-        if let linker = swiftSDK.toolset.knownTools[.linker]?.path {
-            swiftCompilerFlags += ["-ld-path=\(linker)"]
-        }
+        let swiftCompilerFlags = swiftSDK.toolset.knownTools[.swiftCompiler]?.extraCLIOptions ?? []
 
         guard let sdkDir = swiftSDK.pathsConfiguration.sdkRootPath else {
             if triple.isWindows() {

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -3700,7 +3700,7 @@ final class BuildPlanTests: XCTestCase {
                 .cxxCompiler: .init(extraCLIOptions: [jsonFlag(tool: .cxxCompiler)]),
                 .swiftCompiler: .init(extraCLIOptions: [jsonFlag(tool: .swiftCompiler)]),
                 .librarian: .init(path: "/fake/toolchain/usr/bin/librarian"),
-                .linker: .init(path: "/fake/toolchain/usr/bin/linker", extraCLIOptions: [jsonFlag(tool: .linker)]),
+                .linker: .init(extraCLIOptions: [jsonFlag(tool: .linker)]),
             ],
             rootPaths: try UserToolchain.default.swiftSDK.toolset.rootPaths)
         let targetTriple = try Triple("armv7em-unknown-none-macho")
@@ -3781,9 +3781,7 @@ final class BuildPlanTests: XCTestCase {
         // Compile Swift Target
         let exeCompileArguments = try result.target(for: "exe").swiftTarget().compileArguments()
         let exeCompileArgumentsPattern: [StringPattern] = [
-            jsonFlag(tool: .swiftCompiler),
-            "-ld-path=/fake/toolchain/usr/bin/linker",
-            "-g", cliFlag(tool: .swiftCompiler),
+            jsonFlag(tool: .swiftCompiler), "-g", cliFlag(tool: .swiftCompiler),
             .anySequence,
             "-Xcc", jsonFlag(tool: .cCompiler), "-Xcc", "-g", "-Xcc", cliFlag(tool: .cCompiler),
             // TODO: Pass -Xcxx flags to swiftc (#6491)
@@ -3806,9 +3804,7 @@ final class BuildPlanTests: XCTestCase {
         // Link Product
         let exeLinkArguments = try result.buildProduct(for: "exe").linkArguments()
         let exeLinkArgumentsPattern: [StringPattern] = [
-            jsonFlag(tool: .swiftCompiler),
-            "-ld-path=/fake/toolchain/usr/bin/linker",
-            "-g", cliFlag(tool: .swiftCompiler),
+            jsonFlag(tool: .swiftCompiler), "-g", cliFlag(tool: .swiftCompiler),
             .anySequence,
             "-Xlinker", jsonFlag(tool: .linker), "-Xlinker", cliFlag(tool: .linker),
         ]


### PR DESCRIPTION
This reverts commit d328002c7a255efb79618f7775ee561a6448b469.

This broke existing Swift SDKs:

```
ld.lld: error: unable to find library -ld-path=/Users/neonacho/Library/org.swift.swiftpm/swift-sdks/5.8-RELEASE_rhel_ubi9_aarch64.artifactbundle/5.8-RELEASE_rhel_ubi9_aarch64/aarch64-unknown-linux-gnu/swift.xctoolchain/usr/bin/ld.lld
```
