### PR TITLE
Sort `swift experimental-sdk list` stdout output

### DIFF
--- a/Sources/PackageModel/SwiftSDKBundle.swift
+++ b/Sources/PackageModel/SwiftSDKBundle.swift
@@ -487,4 +487,8 @@ extension [SwiftSDKBundle] {
 
         return matchedByID?.swiftSDK ?? matchedByTriple?.swiftSDK
     }
+
+    public var sortedArtifactIDs: [String] {
+        self.flatMap(\.artifacts.keys).sorted()
+    }
 }

--- a/Sources/SwiftSDKTool/ListSwiftSDKs.swift
+++ b/Sources/SwiftSDKTool/ListSwiftSDKs.swift
@@ -46,8 +46,8 @@ public struct ListSwiftSDKs: SwiftSDKSubcommand {
             return
         }
 
-        for bundle in validBundles {
-            bundle.artifacts.keys.forEach { print($0) }
+        for artifactID in validBundles.sortedArtifactIDs {
+            print(artifactID)
         }
     }
 }

--- a/Tests/PackageModelTests/SwiftSDKBundleTests.swift
+++ b/Tests/PackageModelTests/SwiftSDKBundleTests.swift
@@ -213,8 +213,8 @@ final class SwiftSDKBundleTests: XCTestCase {
     func testList() async throws {
         let (fileSystem, bundles, swiftSDKsDirectory) = try generateTestFileSystem(
             bundleArtifacts: [
+                .init(id: "\(testArtifactID)2", supportedTriples: [i686Triple]),
                 .init(id: "\(testArtifactID)1", supportedTriples: [arm64Triple]),
-                .init(id: "\(testArtifactID)2", supportedTriples: [i686Triple])
             ]
         )
         let system = ObservabilitySystem.makeForTesting()
@@ -236,6 +236,8 @@ final class SwiftSDKBundleTests: XCTestCase {
         )
 
         XCTAssertEqual(validBundles.count, bundles.count)
+
+        XCTAssertEqual(validBundles.sortedArtifactIDs, ["\(testArtifactID)1", "\(testArtifactID)2"])
     }
 
     func testBundleSelection() async throws {


### PR DESCRIPTION
With a lot of Swift SDKs installed it's not as easy to navigate through a long unsorted list of strings.
