### PR TITLE
Add "Creating a Macro Package" to `Usage.md`

### DIFF
--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -83,7 +83,7 @@ SwiftPM can generate boilerplate for custom macros:
 This creates a package with a `.macro` type target with its required dependencies
 on [swift-syntax](https://github.com/apple/swift-syntax), a library `.target` 
 containing the macro's code, and an `.executableTarget` and `.testTarget` for 
-running the macro. The sample macro, StringifyMacro, is documented in the Swift 
+running the macro. The sample macro, `StringifyMacro`, is documented in the Swift 
 Evolution proposal for [Expression Macros](https://github.com/apple/swift-evolution/blob/main/proposals/0382-expression-macros.md)
 and the WWDC [Write Swift macros](https://developer.apple.com/videos/play/wwdc2023/10166) 
 video. See further documentation on macros in [The Swift Programming Language](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/macros/) book.

--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -84,7 +84,7 @@ This creates a package with a `.macro` type target with its required dependencie
 on [swift-syntax](https://github.com/apple/swift-syntax), a `.library` target 
 containing the macro's code, and an `.executableTarget` and `.testTarget` for 
 running the macro. The sample macro, StringifyMacro, is documented in the Swift 
-Evolution proposal for [Freestanding Declaration Macros]](https://github.com/apple/swift-evolution/blob/main/proposals/0382-expression-macros.md)
+Evolution proposal for [Expression Macros](https://github.com/apple/swift-evolution/blob/main/proposals/0382-expression-macros.md)
 and the WWDC [Write Swift macros](https://developer.apple.com/videos/play/wwdc2023/10166) 
 video.
 

--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -86,7 +86,7 @@ containing the macro's code, and an `.executableTarget` and `.testTarget` for
 running the macro. The sample macro, StringifyMacro, is documented in the Swift 
 Evolution proposal for [Expression Macros](https://github.com/apple/swift-evolution/blob/main/proposals/0382-expression-macros.md)
 and the WWDC [Write Swift macros](https://developer.apple.com/videos/play/wwdc2023/10166) 
-video.
+video. See further documentation on macros in [The Swift Programming Language](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/macros/) book.
 
 ## Defining Dependencies
 

--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -7,6 +7,7 @@
   * [Creating a Package](#creating-a-package)
     * [Creating a Library Package](#creating-a-library-package)
     * [Creating an Executable Package](#creating-an-executable-package)
+    * [Creating a Macro Package](#creating-a-macro-package)
   * [Defining Dependencies](#defining-dependencies)
   * [Publishing a Package](#publishing-a-package)
   * [Requiring System Libraries](#requiring-system-libraries)
@@ -67,6 +68,25 @@ This creates the directory structure needed for executable targets. Any target
 can be turned into a executable target if there is a `main.swift` file present in
 its sources. The complete reference for layout is
 [here](PackageDescription.md#target).
+
+### Creating a Macro Package
+
+SwiftPM can generate boilerplate for custom macros:
+
+    $ mkdir MyMacro
+    $ cd MyMacro
+    $ swift package init --type macro
+    $ swift build
+    $ swift run
+    The value 42 was produced by the code "a + b"
+
+This creates a package with a `.macro` type target with its required dependencies
+on [swift-syntax](https://github.com/apple/swift-syntax), a `.library` target 
+containing the macro's code, and an `.executableTarget` and `.testTarget` for 
+running the macro. The sample macro, StringifyMacro, is documented in the Swift 
+Evolution proposal for [Freestanding Declaration Macros]](https://github.com/apple/swift-evolution/blob/main/proposals/0382-expression-macros.md)
+and the WWDC [Write Swift macros](https://developer.apple.com/videos/play/wwdc2023/10166) 
+video.
 
 ## Defining Dependencies
 

--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -81,7 +81,7 @@ SwiftPM can generate boilerplate for custom macros:
     The value 42 was produced by the code "a + b"
 
 This creates a package with a `.macro` type target with its required dependencies
-on [swift-syntax](https://github.com/apple/swift-syntax), a `.library` target 
+on [swift-syntax](https://github.com/apple/swift-syntax), a library `.target` 
 containing the macro's code, and an `.executableTarget` and `.testTarget` for 
 running the macro. The sample macro, StringifyMacro, is documented in the Swift 
 Evolution proposal for [Expression Macros](https://github.com/apple/swift-evolution/blob/main/proposals/0382-expression-macros.md)


### PR DESCRIPTION
Add a section containing and describing `swift package init --type macro`.

### Motivation:

I was looking for the documentation and it wasn't there.

### Modifications:

Added the section by copying the Library Package and Executable Package sections' format, showing the command line input and output, describing the output of [InitPackage.swift](https://github.com/apple/swift-package-manager/blob/main/Sources/Workspace/InitPackage.swift) and linking to documentation for the sample macro.

### Result:

Only one file is changed, which is documentation, so no change in behaviour of Swift Package Manager.
