### PR TITLE
Use non-optional functions for `Data` conversion

### DIFF
--- a/Sources/Basics/HTTPClient/HTTPClientResponse.swift
+++ b/Sources/Basics/HTTPClient/HTTPClientResponse.swift
@@ -37,7 +37,7 @@ public struct HTTPClientResponse: Sendable {
 
 extension HTTPClientResponse {
     public static func okay(body: String? = nil) -> HTTPClientResponse {
-        .okay(body: body?.data(using: .utf8))
+        .okay(body: body.map { Data($0.utf8) })
     }
 
     public static func okay(body: Data?) -> HTTPClientResponse {
@@ -45,10 +45,10 @@ extension HTTPClientResponse {
     }
 
     public static func notFound(reason: String? = nil) -> HTTPClientResponse {
-        HTTPClientResponse(statusCode: 404, body: (reason ?? "Not Found").data(using: .utf8))
+        HTTPClientResponse(statusCode: 404, body: Data((reason ?? "Not Found").utf8))
     }
 
     public static func serverError(reason: String? = nil) -> HTTPClientResponse {
-        HTTPClientResponse(statusCode: 500, body: (reason ?? "Internal Server Error").data(using: .utf8))
+        HTTPClientResponse(statusCode: 500, body: Data((reason ?? "Internal Server Error").utf8))
     }
 }

--- a/Sources/Basics/JSONDecoder+Extensions.swift
+++ b/Sources/Basics/JSONDecoder+Extensions.swift
@@ -14,11 +14,7 @@ import Foundation
 
 extension JSONDecoder {
     public func decode<T>(_ type: T.Type, from string: String) throws -> T where T: Decodable {
-        guard let data = string.data(using: .utf8) else {
-            let context = DecodingError.Context(codingPath: [], debugDescription: "invalid UTF-8 string")
-            throw DecodingError.dataCorrupted(context)
-        }
-
+        let data = Data(string.utf8)
         return try self.decode(type, from: data)
     }
 }

--- a/Sources/Commands/PackageTools/DumpCommands.swift
+++ b/Sources/Commands/PackageTools/DumpCommands.swift
@@ -112,7 +112,7 @@ struct DumpPackage: SwiftCommand {
         encoder.userInfo[Manifest.dumpPackageKey] = true
 
         let jsonData = try encoder.encode(rootManifest)
-        let jsonString = String(data: jsonData, encoding: .utf8)!
+        let jsonString = String(decoding: jsonData, as: UTF8.self)
         print(jsonString)
     }
 }

--- a/Sources/LLBuildManifest/BuildManifest.swift
+++ b/Sources/LLBuildManifest/BuildManifest.swift
@@ -117,9 +117,7 @@ public enum WriteAuxiliary {
             encoder.outputFormat = .xml
             let result = try encoder.encode(plist)
 
-            guard let contents = String(data: result, encoding: .utf8) else {
-                throw Error.invalidPropertyListData
-            }
+            let contents = String(decoding: result, as: UTF8.self)
             return contents
         }
 
@@ -128,7 +126,6 @@ public enum WriteAuxiliary {
         }
 
         private enum Error: Swift.Error {
-            case invalidPropertyListData
             case undefinedPrincipalClass
         }
     }

--- a/Sources/PackageCollectionsSigning/PackageCollectionSigning.swift
+++ b/Sources/PackageCollectionsSigning/PackageCollectionSigning.swift
@@ -239,9 +239,7 @@ public actor PackageCollectionSigning: PackageCollectionSigner, PackageCollectio
         signedCollection: Model.SignedCollection,
         certPolicyKey: CertificatePolicyKey = .default
     ) async throws {
-        guard let signatureBytes = signedCollection.signature.signature.data(using: .utf8)?.copyBytes() else {
-            throw PackageCollectionSigningError.invalidSignature
-        }
+        let signatureBytes = Data(signedCollection.signature.signature.utf8).copyBytes()
 
         // Parse the signature
         let certChainValidate = { certChainData in

--- a/Sources/PackageCollectionsTool/SwiftPackageCollectionsTool.swift
+++ b/Sources/PackageCollectionsTool/SwiftPackageCollectionsTool.swift
@@ -380,7 +380,7 @@ private func optionalRow(_ title: String, _ contents: String?, indentationLevel:
 private extension JSONEncoder {
     func print<T>(_ value: T) throws where T: Encodable {
         let jsonData = try self.encode(value)
-        let jsonString = String(data: jsonData, encoding: .utf8)!
+        let jsonString = String(decoding: jsonData, as: UTF8.self)
         Swift.print(jsonString)
     }
 }

--- a/Sources/PackageDescription/PackageDescription.swift
+++ b/Sources/PackageDescription/PackageDescription.swift
@@ -442,7 +442,7 @@ private func manifestToJSON(_ package: Package) -> String {
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
     let data = try! encoder.encode(Output(package: .init(package), errors: errors, version: 2))
-    return String(data: data, encoding: .utf8)!
+    return String(decoding: data, as: UTF8.self)
 }
 
 var errors: [String] = []

--- a/Sources/PackageLoading/ContextModel.swift
+++ b/Sources/PackageLoading/ContextModel.swift
@@ -28,7 +28,7 @@ extension ContextModel : Codable {
     func encode() throws -> String {
         let encoder = JSONEncoder()
         let data = try encoder.encode(self)
-        return String(data: data, encoding: .utf8)!
+        return String(decoding: data, as: UTF8.self)
     }
 
     static func decode() throws -> ContextModel {
@@ -36,9 +36,7 @@ extension ContextModel : Codable {
         while let arg = args.next() {
             if arg == "-context", let json = args.next() {
                 let decoder = JSONDecoder()
-                guard let data = json.data(using: .utf8) else {
-                    throw StringError(description: "Failed decoding context json as UTF8")
-                }
+                let data = Data(json.utf8)
                 return try decoder.decode(ContextModel.self, from: data)
             }
         }

--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -86,9 +86,7 @@ public final class RegistryClient: Cancellable {
                 switch registryAuthentication.type {
                 case .basic:
                     let authorizationString = "\(user):\(password)"
-                    guard let authorizationData = authorizationString.data(using: .utf8) else {
-                        return nil
-                    }
+                    let authorizationData = Data(authorizationString.utf8)
                     return "Basic \(authorizationData.base64EncodedString())"
                 case .token: // `user` value is irrelevant in this case
                     return "Bearer \(password)"
@@ -592,9 +590,7 @@ public final class RegistryClient: Cancellable {
                                 guard let data = response.body else {
                                     throw RegistryError.invalidResponse
                                 }
-                                guard let manifestContent = String(data: data, encoding: .utf8) else {
-                                    throw RegistryError.invalidResponse
-                                }
+                                let manifestContent = String(decoding: data, as: UTF8.self)
 
                                 signatureValidation.validate(
                                     registry: registry,
@@ -830,9 +826,7 @@ public final class RegistryClient: Cancellable {
                                 guard let data = response.body else {
                                     throw RegistryError.invalidResponse
                                 }
-                                guard let manifestContent = String(data: data, encoding: .utf8) else {
-                                    throw RegistryError.invalidResponse
-                                }
+                                let manifestContent = String(decoding: data, as: UTF8.self)
 
                                 signatureValidation.validate(
                                     registry: registry,
@@ -1614,14 +1608,14 @@ public final class RegistryClient: Cancellable {
         case 400...499:
             return RegistryError.clientError(
                 code: response.statusCode,
-                details: response.body.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+                details: response.body.map { String(decoding: $0, as: UTF8.self) } ?? ""
             )
         case 501:
             return RegistryError.authenticationMethodNotSupported
         case 500...599:
             return RegistryError.serverError(
                 code: response.statusCode,
-                details: response.body.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+                details: response.body.map { String(decoding: $0, as: UTF8.self) } ?? ""
             )
         default:
             return RegistryError.invalidResponseStatus(expected: expectedStatus, actual: response.statusCode)

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -97,7 +97,7 @@ public final class PIFBuilder {
         try PIF.sign(topLevelObject.workspace)
 
         let pifData = try encoder.encode(topLevelObject)
-        return String(data: pifData, encoding: .utf8)!
+        return String(decoding: pifData, as: UTF8.self)
     }
 
     /// Constructs a `PIF.TopLevelObject` representing the package graph.

--- a/Tests/BasicsTests/AuthorizationProviderTests.swift
+++ b/Tests/BasicsTests/AuthorizationProviderTests.swift
@@ -274,7 +274,7 @@ final class AuthorizationProviderTests: XCTestCase {
         XCTAssertEqual(authentication?.password, expected.password)
         XCTAssertEqual(
             provider.httpAuthorizationHeader(for: url),
-            "Basic " + "\(expected.user):\(expected.password)".data(using: .utf8)!.base64EncodedString()
+            "Basic " + Data("\(expected.user):\(expected.password)".utf8).base64EncodedString()
         )
     }
 }

--- a/Tests/BasicsTests/HTTPClientTests.swift
+++ b/Tests/BasicsTests/HTTPClientTests.swift
@@ -40,7 +40,7 @@ final class HTTPClientTests: XCTestCase {
         let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
         let responseStatus = Int.random(in: 201 ..< 500)
         let responseHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let responseBody = UUID().uuidString.data(using: .utf8)
+        let responseBody = Data(UUID().uuidString.utf8)
 
         let httpClient = HTTPClient { request, _ in
             XCTAssertEqual(request.url, url, "url should match")
@@ -58,10 +58,10 @@ final class HTTPClientTests: XCTestCase {
     func testPost() async throws {
         let url = URL("http://test")
         let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let requestBody = UUID().uuidString.data(using: .utf8)
+        let requestBody = Data(UUID().uuidString.utf8)
         let responseStatus = Int.random(in: 201 ..< 500)
         let responseHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let responseBody = UUID().uuidString.data(using: .utf8)
+        let responseBody = Data(UUID().uuidString.utf8)
 
         let httpClient = HTTPClient { request, _ in
             XCTAssertEqual(request.url, url, "url should match")
@@ -80,10 +80,10 @@ final class HTTPClientTests: XCTestCase {
     func testPut() async throws {
         let url = URL("http://test")
         let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let requestBody = UUID().uuidString.data(using: .utf8)
+        let requestBody = Data(UUID().uuidString.utf8)
         let responseStatus = Int.random(in: 201 ..< 500)
         let responseHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let responseBody = UUID().uuidString.data(using: .utf8)
+        let responseBody = Data(UUID().uuidString.utf8)
 
         let httpClient = HTTPClient { request, _ in
             XCTAssertEqual(request.url, url, "url should match")
@@ -104,7 +104,7 @@ final class HTTPClientTests: XCTestCase {
         let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
         let responseStatus = Int.random(in: 201 ..< 500)
         let responseHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let responseBody = UUID().uuidString.data(using: .utf8)
+        let responseBody = Data(UUID().uuidString.utf8)
 
         let httpClient = HTTPClient { request, _ in
             XCTAssertEqual(request.url, url, "url should match")

--- a/Tests/BasicsTests/LegacyHTTPClientTests.swift
+++ b/Tests/BasicsTests/LegacyHTTPClientTests.swift
@@ -52,7 +52,7 @@ final class LegacyHTTPClientTests: XCTestCase {
         let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
         let responseStatus = Int.random(in: 201 ..< 500)
         let responseHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let responseBody = UUID().uuidString.data(using: .utf8)
+        let responseBody = Data(UUID().uuidString.utf8)
 
         let handler: LegacyHTTPClient.Handler = { request, _, completion in
             XCTAssertEqual(request.url, url, "url should match")
@@ -82,10 +82,10 @@ final class LegacyHTTPClientTests: XCTestCase {
     func testPost() {
         let url = URL("http://test")
         let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let requestBody = UUID().uuidString.data(using: .utf8)
+        let requestBody = Data(UUID().uuidString.utf8)
         let responseStatus = Int.random(in: 201 ..< 500)
         let responseHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let responseBody = UUID().uuidString.data(using: .utf8)
+        let responseBody = Data(UUID().uuidString.utf8)
 
         let handler: LegacyHTTPClient.Handler = { request, _, completion in
             XCTAssertEqual(request.url, url, "url should match")
@@ -116,10 +116,10 @@ final class LegacyHTTPClientTests: XCTestCase {
     func testPut() {
         let url = URL("http://test")
         let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let requestBody = UUID().uuidString.data(using: .utf8)
+        let requestBody = Data(UUID().uuidString.utf8)
         let responseStatus = Int.random(in: 201 ..< 500)
         let responseHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let responseBody = UUID().uuidString.data(using: .utf8)
+        let responseBody = Data(UUID().uuidString.utf8)
 
         let handler: LegacyHTTPClient.Handler = { request, _, completion in
             XCTAssertEqual(request.url, url, "url should match")
@@ -152,7 +152,7 @@ final class LegacyHTTPClientTests: XCTestCase {
         let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
         let responseStatus = Int.random(in: 201 ..< 500)
         let responseHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let responseBody = UUID().uuidString.data(using: .utf8)
+        let responseBody = Data(UUID().uuidString.utf8)
 
         let handler: LegacyHTTPClient.Handler = { request, _, completion in
             XCTAssertEqual(request.url, url, "url should match")

--- a/Tests/BasicsTests/URLSessionHTTPClientTests.swift
+++ b/Tests/BasicsTests/URLSessionHTTPClientTests.swift
@@ -36,7 +36,7 @@ final class URLSessionHTTPClientTest: XCTestCase {
 
         let responseStatus = 200
         let responseHeaders = [UUID().uuidString: UUID().uuidString]
-        let responseBody = UUID().uuidString.data(using: .utf8)
+        let responseBody = Data(UUID().uuidString.utf8)
 
         MockURLProtocol.onRequest("HEAD", url) { request in
             self.assertRequestHeaders(request.allHTTPHeaderFields, expected: requestHeaders)
@@ -70,7 +70,7 @@ final class URLSessionHTTPClientTest: XCTestCase {
 
         let responseStatus = 200
         let responseHeaders = [UUID().uuidString: UUID().uuidString]
-        let responseBody = UUID().uuidString.data(using: .utf8)
+        let responseBody = Data(UUID().uuidString.utf8)
 
         MockURLProtocol.onRequest("GET", url) { request in
             self.assertRequestHeaders(request.allHTTPHeaderFields, expected: requestHeaders)
@@ -101,11 +101,11 @@ final class URLSessionHTTPClientTest: XCTestCase {
 
         let url = URL("http://test")
         let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let requestBody = UUID().uuidString.data(using: .utf8)
+        let requestBody = Data(UUID().uuidString.utf8)
 
         let responseStatus = 200
         let responseHeaders = [UUID().uuidString: UUID().uuidString]
-        let responseBody = UUID().uuidString.data(using: .utf8)
+        let responseBody = Data(UUID().uuidString.utf8)
 
         MockURLProtocol.onRequest("POST", url) { request in
             // FIXME:
@@ -138,11 +138,11 @@ final class URLSessionHTTPClientTest: XCTestCase {
 
         let url = URL("http://test")
         let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let requestBody = UUID().uuidString.data(using: .utf8)
+        let requestBody = Data(UUID().uuidString.utf8)
 
         let responseStatus = 200
         let responseHeaders = [UUID().uuidString: UUID().uuidString]
-        let responseBody = UUID().uuidString.data(using: .utf8)
+        let responseBody = Data(UUID().uuidString.utf8)
 
         MockURLProtocol.onRequest("PUT", url) { request in
             XCTAssertEqual(request.httpBody, requestBody)
@@ -177,7 +177,7 @@ final class URLSessionHTTPClientTest: XCTestCase {
 
         let responseStatus = 200
         let responseHeaders = [UUID().uuidString: UUID().uuidString]
-        let responseBody = UUID().uuidString.data(using: .utf8)
+        let responseBody = Data(UUID().uuidString.utf8)
 
         MockURLProtocol.onRequest("DELETE", url) { request in
             self.assertRequestHeaders(request.allHTTPHeaderFields, expected: requestHeaders)
@@ -287,7 +287,7 @@ final class URLSessionHTTPClientTest: XCTestCase {
         #endif
         let netrcContent = "machine protected.downloader-tests.com login anonymous password qwerty"
         let netrc = try NetrcAuthorizationWrapper(underlying: NetrcParser.parse(netrcContent))
-        let authData = "anonymous:qwerty".data(using: .utf8)!
+        let authData = Data("anonymous:qwerty".utf8)
         let testAuthHeader = "Basic \(authData.base64EncodedString())"
 
         let configuration = URLSessionConfiguration.default
@@ -358,7 +358,7 @@ final class URLSessionHTTPClientTest: XCTestCase {
         #endif
         let netrcContent = "default login default password default"
         let netrc = try NetrcAuthorizationWrapper(underlying: NetrcParser.parse(netrcContent))
-        let authData = "default:default".data(using: .utf8)!
+        let authData = Data("default:default".utf8)
         let testAuthHeader = "Basic \(authData.base64EncodedString())"
 
         let configuration = URLSessionConfiguration.default
@@ -577,7 +577,7 @@ final class URLSessionHTTPClientTest: XCTestCase {
 
         let responseStatus = 200
         let responseHeaders = [UUID().uuidString: UUID().uuidString]
-        let responseBody = UUID().uuidString.data(using: .utf8)
+        let responseBody = Data(UUID().uuidString.utf8)
 
         MockURLProtocol.onRequest("HEAD", url) { request in
             self.assertRequestHeaders(request.allHTTPHeaderFields, expected: requestHeaders)
@@ -602,7 +602,7 @@ final class URLSessionHTTPClientTest: XCTestCase {
 
         let responseStatus = 200
         let responseHeaders = [UUID().uuidString: UUID().uuidString]
-        let responseBody = UUID().uuidString.data(using: .utf8)
+        let responseBody = Data(UUID().uuidString.utf8)
 
         MockURLProtocol.onRequest("GET", url) { request in
             self.assertRequestHeaders(request.allHTTPHeaderFields, expected: requestHeaders)
@@ -623,11 +623,11 @@ final class URLSessionHTTPClientTest: XCTestCase {
 
         let url = URL("http://async-post-test")
         let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let requestBody = UUID().uuidString.data(using: .utf8)
+        let requestBody = Data(UUID().uuidString.utf8)
 
         let responseStatus = 200
         let responseHeaders = [UUID().uuidString: UUID().uuidString]
-        let responseBody = UUID().uuidString.data(using: .utf8)
+        let responseBody = Data(UUID().uuidString.utf8)
 
         MockURLProtocol.onRequest("POST", url) { request in
             // FIXME:
@@ -651,11 +651,11 @@ final class URLSessionHTTPClientTest: XCTestCase {
 
         let url = URL("http://async-put-test")
         let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
-        let requestBody = UUID().uuidString.data(using: .utf8)
+        let requestBody = Data(UUID().uuidString.utf8)
 
         let responseStatus = 200
         let responseHeaders = [UUID().uuidString: UUID().uuidString]
-        let responseBody = UUID().uuidString.data(using: .utf8)
+        let responseBody = Data(UUID().uuidString.utf8)
 
         MockURLProtocol.onRequest("PUT", url) { request in
             XCTAssertEqual(request.httpBody, requestBody)
@@ -681,7 +681,7 @@ final class URLSessionHTTPClientTest: XCTestCase {
 
         let responseStatus = 200
         let responseHeaders = [UUID().uuidString: UUID().uuidString]
-        let responseBody = UUID().uuidString.data(using: .utf8)
+        let responseBody = Data(UUID().uuidString.utf8)
 
         MockURLProtocol.onRequest("DELETE", url) { request in
             self.assertRequestHeaders(request.allHTTPHeaderFields, expected: requestHeaders)
@@ -756,7 +756,7 @@ final class URLSessionHTTPClientTest: XCTestCase {
         #endif
         let netrcContent = "machine async-protected.downloader-tests.com login anonymous password qwerty"
         let netrc = try NetrcAuthorizationWrapper(underlying: NetrcParser.parse(netrcContent))
-        let authData = "anonymous:qwerty".data(using: .utf8)!
+        let authData = Data("anonymous:qwerty".utf8)
         let testAuthHeader = "Basic \(authData.base64EncodedString())"
 
         let configuration = URLSessionConfiguration.default
@@ -814,7 +814,7 @@ final class URLSessionHTTPClientTest: XCTestCase {
         #endif
         let netrcContent = "default login default password default"
         let netrc = try NetrcAuthorizationWrapper(underlying: NetrcParser.parse(netrcContent))
-        let authData = "default:default".data(using: .utf8)!
+        let authData = Data("default:default".utf8)
         let testAuthHeader = "Basic \(authData.base64EncodedString())"
 
         let configuration = URLSessionConfiguration.default

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -502,7 +502,7 @@ final class PackageToolTests: CommandsTestCase {
 
         try fixture(name: "DependencyResolution/Internal/Simple") { fixturePath in
             let compactGraphData = try XCTUnwrap(symbolGraph(atPath: fixturePath, withPrettyPrinting: false))
-            let compactJSONText = try XCTUnwrap(String(data: compactGraphData, encoding: .utf8))
+            let compactJSONText = String(decoding: compactGraphData, as: UTF8.self)
             XCTAssertEqual(compactJSONText.components(separatedBy: .newlines).count, 1)
         }
     }
@@ -513,7 +513,7 @@ final class PackageToolTests: CommandsTestCase {
 
         try fixture(name: "DependencyResolution/Internal/Simple") { fixturePath in
             let prettyGraphData = try XCTUnwrap(symbolGraph(atPath: fixturePath, withPrettyPrinting: true))
-            let prettyJSONText = try XCTUnwrap(String(data: prettyGraphData, encoding: .utf8))
+            let prettyJSONText = String(decoding: prettyGraphData, as: UTF8.self)
             XCTAssertGreaterThan(prettyJSONText.components(separatedBy: .newlines).count, 1)
         }
     }

--- a/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
+++ b/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
@@ -345,7 +345,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
 
     func testBadJSON() throws {
         let url = URL("https://www.test.com/collection.json")
-        let data = "blah".data(using: .utf8)!
+        let data = Data("blah".utf8)
 
         let handler: LegacyHTTPClient.Handler = { request, _, completion in
             XCTAssertEqual(request.url, url, "url should match")

--- a/Tests/PackageRegistryTests/RegistryClientTests.swift
+++ b/Tests/PackageRegistryTests/RegistryClientTests.swift
@@ -439,7 +439,7 @@ final class RegistryClientTests: XCTestCase {
             case (.get, manifestURL):
                 XCTAssertEqual(request.headers.get("Accept").first, "application/vnd.swift.registry.v1+swift")
 
-                let defaultManifestData = defaultManifest.data(using: .utf8)!
+                let defaultManifestData = Data(defaultManifest.utf8)
 
                 let links = """
                 <http://packages.example.com/mona/LinkedList/1.1.1/Package.swift?swift-version=4>; rel="alternate"; filename="Package@swift-4.swift"; swift-tools-version="4.0",
@@ -559,7 +559,7 @@ final class RegistryClientTests: XCTestCase {
             case (.get, manifestURL):
                 XCTAssertEqual(request.headers.get("Accept").first, "application/vnd.swift.registry.v1+swift")
 
-                let defaultManifestData = defaultManifest.data(using: .utf8)!
+                let defaultManifestData = Data(defaultManifest.utf8)
 
                 let links = """
                 <http://packages.example.com/mona/LinkedList/1.1.1/Package.swift?swift-version=4>; rel="alternate"; filename="Package@swift-4.swift"; swift-tools-version="4.0",
@@ -591,7 +591,7 @@ final class RegistryClientTests: XCTestCase {
         configuration.security = .testDefault
 
         let contentType = Fingerprint.ContentType.manifest(.none)
-        let manifestChecksum = checksumAlgorithm.hash(.init(defaultManifest.data(using: .utf8)!))
+        let manifestChecksum = checksumAlgorithm.hash(.init(Data(defaultManifest.utf8)))
             .hexadecimalRepresentation
         let fingerprintStorage = MockPackageFingerprintStorage([
             identity: [
@@ -698,7 +698,7 @@ final class RegistryClientTests: XCTestCase {
             case (.get, manifestURL):
                 XCTAssertEqual(request.headers.get("Accept").first, "application/vnd.swift.registry.v1+swift")
 
-                let defaultManifestData = defaultManifest.data(using: .utf8)!
+                let defaultManifestData = Data(defaultManifest.utf8)
 
                 let links = """
                 <http://packages.example.com/mona/LinkedList/1.1.1/Package.swift?swift-version=4>; rel="alternate"; filename="Package@swift-4.swift"; swift-tools-version="4.0",
@@ -833,7 +833,7 @@ final class RegistryClientTests: XCTestCase {
             case (.get, manifestURL):
                 XCTAssertEqual(request.headers.get("Accept").first, "application/vnd.swift.registry.v1+swift")
 
-                let defaultManifestData = defaultManifest.data(using: .utf8)!
+                let defaultManifestData = Data(defaultManifest.utf8)
 
                 let links = """
                 <http://packages.example.com/mona/LinkedList/1.1.1/Package.swift?swift-version=4>; rel="alternate"; filename="Package@swift-4.swift"; swift-tools-version="4.0",
@@ -1360,7 +1360,7 @@ final class RegistryClientTests: XCTestCase {
             case (.get, manifestURL):
                 XCTAssertEqual(request.headers.get("Accept").first, "application/vnd.swift.registry.v1+swift")
 
-                let data = manifestContent(toolsVersion: toolsVersion).data(using: .utf8)!
+                let data = Data(manifestContent(toolsVersion: toolsVersion).utf8)
 
                 completion(.success(.init(
                     statusCode: 200,
@@ -1385,9 +1385,9 @@ final class RegistryClientTests: XCTestCase {
         configuration.security = .testDefault
 
         let defaultManifestChecksum = checksumAlgorithm
-            .hash(.init(manifestContent(toolsVersion: .none).data(using: .utf8)!)).hexadecimalRepresentation
+            .hash(.init(Data(manifestContent(toolsVersion: .none).utf8))).hexadecimalRepresentation
         let versionManifestChecksum = checksumAlgorithm
-            .hash(.init(manifestContent(toolsVersion: .v5_3).data(using: .utf8)!)).hexadecimalRepresentation
+            .hash(.init(Data(manifestContent(toolsVersion: .v5_3).utf8))).hexadecimalRepresentation
         let fingerprintStorage = MockPackageFingerprintStorage([
             identity: [
                 version: [
@@ -1494,7 +1494,7 @@ final class RegistryClientTests: XCTestCase {
             case (.get, manifestURL):
                 XCTAssertEqual(request.headers.get("Accept").first, "application/vnd.swift.registry.v1+swift")
 
-                let data = manifestContent(toolsVersion: toolsVersion).data(using: .utf8)!
+                let data = Data(manifestContent(toolsVersion: toolsVersion).utf8)
 
                 completion(.success(.init(
                     statusCode: 200,
@@ -1628,7 +1628,7 @@ final class RegistryClientTests: XCTestCase {
             case (.get, manifestURL):
                 XCTAssertEqual(request.headers.get("Accept").first, "application/vnd.swift.registry.v1+swift")
 
-                let data = manifestContent(toolsVersion: toolsVersion).data(using: .utf8)!
+                let data = Data(manifestContent(toolsVersion: toolsVersion).utf8)
 
                 completion(.success(.init(
                     statusCode: 200,
@@ -3047,7 +3047,7 @@ final class RegistryClientTests: XCTestCase {
             case (.get, identifiersURL):
                 XCTAssertEqual(
                     request.headers.get("Authorization").first,
-                    "Basic \("\(user):\(password)".data(using: .utf8)!.base64EncodedString())"
+                    "Basic \(Data("\(user):\(password)".utf8).base64EncodedString())"
                 )
                 XCTAssertEqual(request.headers.get("Accept").first, "application/vnd.swift.registry.v1+json")
 
@@ -3234,7 +3234,7 @@ final class RegistryClientTests: XCTestCase {
                 XCTAssertNil(request.headers.get("X-Swift-Package-Signature-Format").first)
 
                 // TODO: implement multipart form parsing
-                let body = String(data: request.body!, encoding: .utf8)
+                let body = String(decoding: request.body!, as: UTF8.self)
                 XCTAssertMatch(body, .contains(archiveContent))
                 XCTAssertMatch(body, .contains(metadataContent))
 
@@ -3301,7 +3301,7 @@ final class RegistryClientTests: XCTestCase {
                 XCTAssertNil(request.headers.get("X-Swift-Package-Signature-Format").first)
 
                 // TODO: implement multipart form parsing
-                let body = String(data: request.body!, encoding: .utf8)
+                let body = String(decoding: request.body!, as: UTF8.self)
                 XCTAssertMatch(body, .contains(archiveContent))
                 XCTAssertMatch(body, .contains(metadataContent))
 
@@ -3371,7 +3371,7 @@ final class RegistryClientTests: XCTestCase {
                 XCTAssertEqual(request.headers.get("X-Swift-Package-Signature-Format").first, signatureFormat.rawValue)
 
                 // TODO: implement multipart form parsing
-                let body = String(data: request.body!, encoding: .utf8)
+                let body = String(decoding: request.body!, as: UTF8.self)
                 XCTAssertMatch(body, .contains(archiveContent))
                 XCTAssertMatch(body, .contains(metadataContent))
                 XCTAssertMatch(body, .contains(signature))

--- a/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
@@ -80,7 +80,7 @@ class RegistryPackageContainerTests: XCTestCase {
                                 "Content-Version": "1",
                                 "Content-Type": "text/x-swift"
                             ],
-                            body: "// swift-tools-version:\(toolsVersion)".data(using: .utf8)
+                            body: Data("// swift-tools-version:\(toolsVersion)".utf8)
                         )
                     ))
                 }
@@ -145,7 +145,7 @@ class RegistryPackageContainerTests: XCTestCase {
                                 \(self.manifestLink(packageIdentity, .v5_5)),
                                 """
                             ],
-                            body: "// swift-tools-version:\(ToolsVersion.v5_3)".data(using: .utf8)
+                            body: Data("// swift-tools-version:\(ToolsVersion.v5_3)".utf8)
                         )
                     ))
                 }
@@ -238,7 +238,7 @@ class RegistryPackageContainerTests: XCTestCase {
                                     self.manifestLink(packageIdentity, $0)
                                 }.joined(separator: ",\n")
                             ],
-                            body: "// swift-tools-version:\(requestedVersion)".data(using: .utf8)
+                            body: Data("// swift-tools-version:\(requestedVersion)".utf8)
                         )
                     ))
                 }
@@ -400,7 +400,7 @@ class RegistryPackageContainerTests: XCTestCase {
                         "Content-Version": "1",
                         "Content-Type": "text/x-swift"
                     ],
-                    body: "// swift-tools-version:\(ToolsVersion.current)".data(using: .utf8)
+                    body: Data("// swift-tools-version:\(ToolsVersion.current)".utf8)
                 )
             ))
         }
@@ -420,7 +420,7 @@ class RegistryPackageContainerTests: XCTestCase {
                         "Content-Version": "1",
                         "Content-Type": "application/zip"
                     ],
-                    body: "".data(using: .utf8)
+                    body: Data("".utf8)
                 )
             ))
         }

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -14553,7 +14553,7 @@ final class WorkspaceTests: XCTestCase {
                         "Content-Version": "1",
                         "Content-Type": "text/x-swift",
                     ],
-                    body: "// swift-tools-version:\(ToolsVersion.current)".data(using: .utf8)
+                    body: Data("// swift-tools-version:\(ToolsVersion.current)".utf8)
                 )
             ))
         }
@@ -14575,7 +14575,7 @@ final class WorkspaceTests: XCTestCase {
                         "Content-Version": "1",
                         "Content-Type": "application/zip",
                     ],
-                    body: "".data(using: .utf8)
+                    body: Data("".utf8)
                 )
             ))
         }

--- a/Tests/XCBuildSupportTests/PIFTests.swift
+++ b/Tests/XCBuildSupportTests/PIFTests.swift
@@ -231,8 +231,8 @@ class PIFTests: XCTestCase {
         let originalPIF = try encoder.encode(workspace)
         let decodedPIF = try encoder.encode(decodedWorkspace)
 
-        let originalString = String(data: originalPIF, encoding: .utf8)!
-        let decodedString = String(data: decodedPIF, encoding: .utf8)!
+        let originalString = String(decoding: originalPIF, as: UTF8.self)
+        let decodedString = String(decoding: decodedPIF, as: UTF8.self)
 
         XCTAssertEqual(originalString, decodedString)
       #endif


### PR DESCRIPTION
### Motivation:

change to Non Optional Function from Optional Function

### Result

- `String(data:encoding)?` -> `String(decoding:as)`
- `String.data(using)?` -> `Data(String.utf8)`
- remove extra Error