### PR TITLE
Partially revert #6726

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -700,11 +700,11 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
     ) {
         /* Prior to tools-version 5.9, we used to errorneously recursively traverse executable/plugin dependencies and statically include their
          targets. For compatibility reasons, we preserve that behavior for older tools-versions. */
-        let shouldExcludeExecutablesAndPlugins: Bool
+        let shouldExcludePlugins: Bool
         if let toolsVersion = self.graph.package(for: product)?.manifest.toolsVersion {
-            shouldExcludeExecutablesAndPlugins = toolsVersion >= .v5_9
+            shouldExcludePlugins = toolsVersion >= .v5_9
         } else {
-            shouldExcludeExecutablesAndPlugins = false
+            shouldExcludePlugins = false
         }
 
         // For test targets, we need to consider the first level of transitive dependencies since the first level is always test targets.
@@ -729,7 +729,6 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
             // Include all the dependencies of a target.
             case .target(let target, _):
                 let isTopLevel = topLevelDependencies.contains(target.underlyingTarget) || product.targets.contains(target)
-                let topLevelIsExecutable = isTopLevel && product.type == .executable
                 let topLevelIsMacro = isTopLevel && product.type == .macro
                 let topLevelIsPlugin = isTopLevel && product.type == .plugin
                 let topLevelIsTest = isTopLevel && product.type == .test
@@ -737,10 +736,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
                 if !topLevelIsMacro && !topLevelIsTest && target.type == .macro {
                     return []
                 }
-                if shouldExcludeExecutablesAndPlugins, !topLevelIsPlugin && !topLevelIsTest && target.type == .plugin {
-                    return []
-                }
-                if shouldExcludeExecutablesAndPlugins, !topLevelIsExecutable && topLevelIsTest && target.type == .executable {
+                if shouldExcludePlugins, !topLevelIsPlugin && !topLevelIsTest && target.type == .plugin {
                     return []
                 }
                 return target.dependencies.filter { $0.satisfies(self.buildEnvironment) }
@@ -757,7 +753,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
                 case .library(.automatic), .library(.static):
                     return productDependencies
                 case .plugin:
-                    return shouldExcludeExecutablesAndPlugins ? [] : productDependencies
+                    return shouldExcludePlugins ? [] : productDependencies
                 case .library(.dynamic), .test, .executable, .snippet, .macro:
                     return []
                 }


### PR DESCRIPTION
In #6726, I discovered that an issue I was fixing for macros and plugins could also apply to executables. That fix was incorrect and would drop legitimate linkage of transitive dependencies when testing executables. The logic here is pretty gnarly, so the most reasonable cause of action seems to be to revert that part of the change.

resolves #6940