### PR TITLE
do not emit "exhausted attempts to resolve the dependencies graph" when previous errors occurred

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1171,6 +1171,9 @@ extension Workspace {
 
         // Update the checkouts based on new dependency resolution.
         let packageStateChanges = self.updateDependenciesCheckouts(root: graphRoot, updateResults: updateResults, updateBranches: true, observabilityScope: observabilityScope)
+        guard !observabilityScope.errorsReported else {
+            return nil
+        }
 
         // Load the updated manifests.
         let updatedDependencyManifests = try self.loadDependencyManifests(root: graphRoot, observabilityScope: observabilityScope)
@@ -1199,7 +1202,7 @@ extension Workspace {
             observabilityScope: observabilityScope
         )
 
-        return nil
+        return packageStateChanges
     }
 
     @discardableResult


### PR DESCRIPTION
motivation: better diagnostics

changes:
* check for previous errors when updating dependencies and terminate early if core update/checkout dependencies error occurred
* return state changes so that dry run actually works