### PR TITLE
Cache `mirrorIndex` in `DependencyMirrors`

### DIFF
--- a/Sources/Commands/PackageTools/Config.swift
+++ b/Sources/Commands/PackageTools/Config.swift
@@ -80,7 +80,7 @@ extension SwiftPackageTool.Config {
             }
 
             try config.applyLocal { mirrors in
-                mirrors.set(mirror: mirror, for: original)
+                try mirrors.set(mirror: mirror, for: original)
             }
         }
     }

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -68,7 +68,7 @@ public final class MockWorkspace {
         self.packages = packages
         self.fingerprints = customFingerprints ?? MockPackageFingerprintStorage()
         self.signingEntities = customSigningEntities ?? MockPackageSigningEntityStorage()
-        self.mirrors = customMirrors ?? DependencyMirrors()
+        self.mirrors = try customMirrors ?? DependencyMirrors()
         self.identityResolver = DefaultIdentityResolver(
             locationMapper: self.mirrors.effective(for:),
             identityMapper: self.mirrors.effectiveIdentity(for:)

--- a/Tests/WorkspaceTests/MirrorsConfigurationTests.swift
+++ b/Tests/WorkspaceTests/MirrorsConfigurationTests.swift
@@ -73,7 +73,7 @@ final class MirrorsConfigurationTests: XCTestCase {
         let mirrorURL = "https://github.com/mona/swift-argument-parser.git"
 
         try config.apply{ mirrors in
-            mirrors.set(mirror: mirrorURL, for: originalURL)
+            try mirrors.set(mirror: mirrorURL, for: originalURL)
         }
         XCTAssertTrue(fs.exists(configFile))
 
@@ -96,7 +96,7 @@ final class MirrorsConfigurationTests: XCTestCase {
         let mirrorURL = "https://github.com/mona/swift-argument-parser.git"
 
         try config.apply{ mirrors in
-            mirrors.set(mirror: mirrorURL, for: originalURL)
+            try mirrors.set(mirror: mirrorURL, for: originalURL)
         }
         XCTAssertTrue(fs.exists(configFile))
 
@@ -124,7 +124,7 @@ final class MirrorsConfigurationTests: XCTestCase {
         let mirror1URL = "https://github.com/mona/swift-argument-parser.git"
 
         try config.applyShared { mirrors in
-            mirrors.set(mirror: mirror1URL, for: original1URL)
+            try mirrors.set(mirror: mirror1URL, for: original1URL)
         }
 
         XCTAssertEqual(config.mirrors.count, 1)
@@ -137,7 +137,7 @@ final class MirrorsConfigurationTests: XCTestCase {
         let mirror2URL = "https://github.com/mona/swift-nio.git"
 
         try config.applyLocal { mirrors in
-            mirrors.set(mirror: mirror2URL, for: original2URL)
+            try mirrors.set(mirror: mirror2URL, for: original2URL)
         }
 
         XCTAssertEqual(config.mirrors.count, 1)

--- a/Tests/WorkspaceTests/PinsStoreTests.swift
+++ b/Tests/WorkspaceTests/PinsStoreTests.swift
@@ -348,9 +348,9 @@ final class PinsStoreTests: XCTestCase {
         let bazURL = SourceControlURL("https://github.com/cool/baz.git")
         let bazIdentity = PackageIdentity(url: bazURL)
 
-        let mirrors = DependencyMirrors()
-        mirrors.set(mirror: fooMirroredURL.absoluteString, for: fooURL.absoluteString)
-        mirrors.set(mirror: barMirroredURL.absoluteString, for: barURL.absoluteString)
+        let mirrors = try DependencyMirrors()
+        try mirrors.set(mirror: fooMirroredURL.absoluteString, for: fooURL.absoluteString)
+        try mirrors.set(mirror: barMirroredURL.absoluteString, for: barURL.absoluteString)
 
         let fileSystem = InMemoryFileSystem()
         let pinsFile = AbsolutePath("/pins.txt")
@@ -398,11 +398,11 @@ final class PinsStoreTests: XCTestCase {
         let fooURL4 = SourceControlURL("https://github.com/old-corporate/foo.git")
         let fooMirroredURL = SourceControlURL("https://github.corporate.com/team/foo")
 
-        let mirrors = DependencyMirrors()
-        mirrors.set(mirror: fooMirroredURL.absoluteString, for: fooURL1.absoluteString)
-        mirrors.set(mirror: fooMirroredURL.absoluteString, for: fooURL2.absoluteString)
-        mirrors.set(mirror: fooMirroredURL.absoluteString, for: fooURL3.absoluteString)
-        mirrors.set(mirror: fooMirroredURL.absoluteString, for: fooURL4.absoluteString)
+        let mirrors = try DependencyMirrors()
+        try mirrors.set(mirror: fooMirroredURL.absoluteString, for: fooURL1.absoluteString)
+        try mirrors.set(mirror: fooMirroredURL.absoluteString, for: fooURL2.absoluteString)
+        try mirrors.set(mirror: fooMirroredURL.absoluteString, for: fooURL3.absoluteString)
+        try mirrors.set(mirror: fooMirroredURL.absoluteString, for: fooURL4.absoluteString)
 
         let fileSystem = InMemoryFileSystem()
         let pinsFile = AbsolutePath("/pins.txt")
@@ -445,7 +445,7 @@ final class PinsStoreTests: XCTestCase {
         let mirroredURL = URL("https://github.corporate.com/team/foo")
 
         do {
-            let mirrors = DependencyMirrors([
+            let mirrors = try DependencyMirrors([
                 URL1.absoluteString: mirroredURL.absoluteString,
                 URL2.absoluteString: mirroredURL.absoluteString,
                 URL3.absoluteString: mirroredURL.absoluteString,
@@ -458,7 +458,7 @@ final class PinsStoreTests: XCTestCase {
         }
 
         do {
-            let mirrors = DependencyMirrors([
+            let mirrors = try DependencyMirrors([
                 URL1.absoluteString: mirroredURL.absoluteString,
                 URL2.absoluteString: mirroredURL.absoluteString,
                 URL3.absoluteString: mirroredURL.absoluteString,
@@ -471,7 +471,7 @@ final class PinsStoreTests: XCTestCase {
         }
 
         do {
-            let mirrors = DependencyMirrors([
+            let mirrors = try DependencyMirrors([
                 URL1.absoluteString: mirroredURL.absoluteString,
                 URL2.absoluteString: mirroredURL.absoluteString,
                 URL3.absoluteString: mirroredURL.absoluteString,
@@ -485,7 +485,7 @@ final class PinsStoreTests: XCTestCase {
         }
 
         do {
-            let mirrors = DependencyMirrors([
+            let mirrors = try DependencyMirrors([
                 URL1.absoluteString: mirroredURL.absoluteString,
                 URL2.absoluteString: mirroredURL.absoluteString,
                 URL3.absoluteString: mirroredURL.absoluteString,
@@ -499,7 +499,7 @@ final class PinsStoreTests: XCTestCase {
         }
 
         do {
-            let mirrors = DependencyMirrors([
+            let mirrors = try DependencyMirrors([
                 URL1.absoluteString: mirroredURL.absoluteString,
                 URL2.absoluteString: mirroredURL.absoluteString,
                 URL3.absoluteString: mirroredURL.absoluteString,

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -4279,12 +4279,12 @@ final class WorkspaceTests: XCTestCase {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
-        let mirrors = DependencyMirrors()
-        mirrors.set(
+        let mirrors = try DependencyMirrors()
+        try mirrors.set(
             mirror: sandbox.appending(components: "pkgs", "BarMirror").pathString,
             for: sandbox.appending(components: "pkgs", "Bar").pathString
         )
-        mirrors.set(
+        try mirrors.set(
             mirror: sandbox.appending(components: "pkgs", "BazMirror").pathString,
             for: sandbox.appending(components: "pkgs", "Baz").pathString
         )
@@ -4371,12 +4371,12 @@ final class WorkspaceTests: XCTestCase {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
-        let mirrors = DependencyMirrors()
-        mirrors.set(
+        let mirrors = try DependencyMirrors()
+        try mirrors.set(
             mirror: sandbox.appending(components: "pkgs", "BarMirror").pathString,
             for: sandbox.appending(components: "pkgs", "Bar").pathString
         )
-        mirrors.set(
+        try mirrors.set(
             mirror: sandbox.appending(components: "pkgs", "BarMirror").pathString,
             for: sandbox.appending(components: "pkgs", "Baz").pathString
         )
@@ -4474,9 +4474,9 @@ final class WorkspaceTests: XCTestCase {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
-        let mirrors = DependencyMirrors()
-        mirrors.set(mirror: "https://scm.com/org/bar-mirror", for: "https://scm.com/org/bar")
-        mirrors.set(mirror: "https://scm.com/org/baz-mirror", for: "https://scm.com/org/baz")
+        let mirrors = try DependencyMirrors()
+        try mirrors.set(mirror: "https://scm.com/org/bar-mirror", for: "https://scm.com/org/bar")
+        try mirrors.set(mirror: "https://scm.com/org/baz-mirror", for: "https://scm.com/org/baz")
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
@@ -4563,9 +4563,9 @@ final class WorkspaceTests: XCTestCase {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
-        let mirrors = DependencyMirrors()
-        mirrors.set(mirror: "https://scm.com/org/bar-mirror", for: "https://scm.com/org/bar")
-        mirrors.set(mirror: "https://scm.com/org/bar-mirror", for: "https://scm.com/org/baz")
+        let mirrors = try DependencyMirrors()
+        try mirrors.set(mirror: "https://scm.com/org/bar-mirror", for: "https://scm.com/org/bar")
+        try mirrors.set(mirror: "https://scm.com/org/bar-mirror", for: "https://scm.com/org/baz")
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
@@ -4668,8 +4668,8 @@ final class WorkspaceTests: XCTestCase {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
-        let mirrors = DependencyMirrors()
-        mirrors.set(mirror: "org.bar-mirror", for: "https://scm.com/org/bar")
+        let mirrors = try DependencyMirrors()
+        try mirrors.set(mirror: "org.bar-mirror", for: "https://scm.com/org/bar")
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
@@ -4738,8 +4738,8 @@ final class WorkspaceTests: XCTestCase {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
-        let mirrors = DependencyMirrors()
-        mirrors.set(mirror: "https://scm.com/org/bar-mirror", for: "org.bar")
+        let mirrors = try DependencyMirrors()
+        try mirrors.set(mirror: "https://scm.com/org/bar-mirror", for: "org.bar")
 
         let workspace = try MockWorkspace(
             sandbox: sandbox,
@@ -14366,8 +14366,8 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testSigningEntityVerification_MirroredSignedCorrectly() throws {
-        let mirrors = DependencyMirrors()
-        mirrors.set(mirror: "ecorp.bar", for: "org.bar")
+        let mirrors = try DependencyMirrors()
+        try mirrors.set(mirror: "ecorp.bar", for: "org.bar")
 
         let actualMetadata = RegistryReleaseMetadata.createWithSigningEntity(.recognized(
             type: "adp",
@@ -14390,8 +14390,8 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testSigningEntityVerification_MirrorSignedIncorrectly() throws {
-        let mirrors = DependencyMirrors()
-        mirrors.set(mirror: "ecorp.bar", for: "org.bar")
+        let mirrors = try DependencyMirrors()
+        try mirrors.set(mirror: "ecorp.bar", for: "org.bar")
 
         let actualMetadata = RegistryReleaseMetadata.createWithSigningEntity(.recognized(
             type: "adp",
@@ -14422,8 +14422,8 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testSigningEntityVerification_MirroredUnsigned() throws {
-        let mirrors = DependencyMirrors()
-        mirrors.set(mirror: "ecorp.bar", for: "org.bar")
+        let mirrors = try DependencyMirrors()
+        try mirrors.set(mirror: "ecorp.bar", for: "org.bar")
 
         let expectedSigningEntity: RegistryReleaseMetadata.SigningEntity = .recognized(
             type: "adp",
@@ -14447,8 +14447,8 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testSigningEntityVerification_MirroredToSCM() throws {
-        let mirrors = DependencyMirrors()
-        mirrors.set(mirror: "https://scm.com/org/bar-mirror", for: "org.bar")
+        let mirrors = try DependencyMirrors()
+        try mirrors.set(mirror: "https://scm.com/org/bar-mirror", for: "org.bar")
 
         let expectedSigningEntity: RegistryReleaseMetadata.SigningEntity = .recognized(
             type: "adp",


### PR DESCRIPTION
This appears to be *very* expensive, so we should cache.