### PR TITLE
only update local checkout if necessary

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -3754,7 +3754,7 @@ extension Workspace {
                 // only update if necessary
                 if !workingCopy.exists(revision: revision) {
                     // The fetch operation may update contents of the checkout, 
-                    // so we need do mutable-immutable dance.
+                    // so we need to do mutable-immutable dance.
                     try self.fileSystem.chmod(.userWritable, path: checkoutPath, options: [.recursive, .onlyFiles])
                     try workingCopy.fetch()
                     try? self.fileSystem.chmod(.userUnWritable, path: checkoutPath, options: [.recursive, .onlyFiles])

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -3751,10 +3751,14 @@ extension Workspace {
                     break fetch
                 }
 
-                // we need do mutable-immutable dance.
-                try self.fileSystem.chmod(.userWritable, path: checkoutPath, options: [.recursive, .onlyFiles])
-                try workingCopy.fetch()
-                try? self.fileSystem.chmod(.userUnWritable, path: checkoutPath, options: [.recursive, .onlyFiles])
+                // only update if necessary
+                if !workingCopy.exists(revision: revision) {
+                    // The fetch operation may update contents of the checkout, 
+                    // so we need do mutable-immutable dance.
+                    try self.fileSystem.chmod(.userWritable, path: checkoutPath, options: [.recursive, .onlyFiles])
+                    try workingCopy.fetch()
+                    try? self.fileSystem.chmod(.userUnWritable, path: checkoutPath, options: [.recursive, .onlyFiles])
+                }
 
                 return checkoutPath
             }


### PR DESCRIPTION
motivation: reduce redundant git operations

changes:
* before updating a local checkout, confirm the action is nevessary
* update test to check for revision and not tag

