### PR TITLE
filter out expected signals when logging test crashing

### DIFF
--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -14,9 +14,7 @@ import ArgumentParser
 import Basics
 import CoreCommands
 import Dispatch
-import class Foundation.JSONDecoder
-import class Foundation.NSLock
-import class Foundation.ProcessInfo
+import Foundation
 import PackageGraph
 import PackageModel
 import SPMBuildCore
@@ -698,8 +696,8 @@ final class TestRunner {
             case .terminated(code: 0):
                 return true
             #if !os(Windows)
-            case .signalled(let signal):
-                testObservabilityScope.emit(error: "Exited with signal code \(signal)")
+            case .signalled(let signal) where ![SIGINT, SIGKILL, SIGTERM].contains(signal):
+                testObservabilityScope.emit(error: "Exited with unexpected signal code \(signal)")
                 return false
             #endif
             default:


### PR DESCRIPTION
motivation: nicer user experience when terminating tests

changes: filter out logging of signal used when terminating tests normally

radar/113751498

