### PR TITLE
[NFC] Build/Commands: fix `triple` property deprecation warnings

### DIFF
--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -216,7 +216,8 @@ final class TestEntryPointCommand: CustomLLBuildCommand, TestBuildCommand {
         }
 
         let testObservabilitySetup: String
-        if self.context.buildParameters.experimentalTestOutput, self.context.buildParameters.triple.supportsTestSummary {
+        if self.context.buildParameters.experimentalTestOutput
+            && self.context.buildParameters.targetTriple.supportsTestSummary {
             testObservabilitySetup = "_ = SwiftPMXCTestObserver()\n"
         } else {
             testObservabilitySetup = ""

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -208,7 +208,7 @@ public struct SwiftTestTool: SwiftCommand {
         let buildParameters = try swiftTool.buildParametersForTest(options: self.options, sharedOptions: self.sharedOptions)
 
         // Remove test output from prior runs and validate priors.
-        if self.options.enableExperimentalTestOutput, buildParameters.triple.supportsTestSummary {
+        if self.options.enableExperimentalTestOutput && buildParameters.targetTriple.supportsTestSummary {
             _ = try? localFileSystem.removeFileTree(buildParameters.testOutputPath)
         }
 


### PR DESCRIPTION
As `triple` was deprecated with the recommendation to use explicit `targetTriple` property instead, we should update all of our code to get rid of the remaining deprecation warnings.
