### PR TITLE
[NFC] LLBuildManifest: add `WriteAuxiliary.EntitlementPlist`

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/SwiftPM-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/SwiftPM-Package.xcscheme
@@ -829,6 +829,16 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "LLBuildManifestTests"
+               BuildableName = "LLBuildManifestTests"
+               BlueprintName = "LLBuildManifestTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Package.swift
+++ b/Package.swift
@@ -551,6 +551,10 @@ let package = Package(
             dependencies: ["Build", "PackageModel", "SPMTestSupport"]
         ),
         .testTarget(
+            name: "LLBuildManifestTests",
+            dependencies: ["Basics", "LLBuildManifest", "SPMTestSupport"]
+        ),
+        .testTarget(
             name: "WorkspaceTests",
             dependencies: ["Workspace", "SPMTestSupport"]
         ),

--- a/Sources/LLBuildManifest/BuildManifest.swift
+++ b/Sources/LLBuildManifest/BuildManifest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2014-2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2014-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information

--- a/Sources/LLBuildManifest/BuildManifest.swift
+++ b/Sources/LLBuildManifest/BuildManifest.swift
@@ -22,7 +22,37 @@ public protocol AuxiliaryFileType {
 }
 
 public enum WriteAuxiliary {
-    public static let fileTypes: [AuxiliaryFileType.Type] = [LinkFileList.self, SourcesFileList.self, SwiftGetVersion.self, XCTestInfoPlist.self]
+    public static let fileTypes: [AuxiliaryFileType.Type] = [
+        EntitlementPlist.self,
+        LinkFileList.self,
+        SourcesFileList.self,
+        SwiftGetVersion.self,
+        XCTestInfoPlist.self
+    ]
+
+    public struct EntitlementPlist: AuxiliaryFileType {
+        public static let name = "entitlement-plist"
+
+        public static func computeInputs(entitlement: String) -> [Node] {
+            [.virtual(Self.name), .virtual(entitlement)]
+        }
+
+        public static func getFileContents(inputs: [Node]) throws -> String {
+            guard let entitlementName = inputs.last?.extractedVirtualNodeName else {
+                throw Error.undefinedEntitlementName
+            }
+            let encoder = PropertyListEncoder()
+            encoder.outputFormat = .xml
+            let result = try encoder.encode([entitlementName: true])
+
+            let contents = String(decoding: result, as: UTF8.self)
+            return contents
+        }
+
+        private enum Error: Swift.Error {
+            case undefinedEntitlementName
+        }
+    }
 
     public struct LinkFileList: AuxiliaryFileType {
         public static let name = "link-file-list"
@@ -108,7 +138,7 @@ public enum WriteAuxiliary {
         }
 
         public static func getFileContents(inputs: [Node]) throws -> String {
-            guard let principalClass = inputs.last?.name.dropFirst().dropLast() else {
+            guard let principalClass = inputs.last?.extractedVirtualNodeName else {
                 throw Error.undefinedPrincipalClass
             }
 
@@ -203,6 +233,13 @@ public struct BuildManifest {
     ) {
         assert(commands[name] == nil, "already had a command named '\(name)'")
         let tool = CopyTool(inputs: inputs, outputs: outputs)
+        commands[name] = Command(name: name, tool: tool)
+    }
+
+    public mutating func addEntitlementPlistCommand(entitlement: String, outputPath: AbsolutePath) {
+        let inputs = WriteAuxiliary.EntitlementPlist.computeInputs(entitlement: entitlement)
+        let tool = WriteAuxiliaryFile(inputs: inputs, outputFilePath: outputPath)
+        let name = outputPath.pathString
         commands[name] = Command(name: name, tool: tool)
     }
 

--- a/Sources/LLBuildManifest/Node.swift
+++ b/Sources/LLBuildManifest/Node.swift
@@ -30,6 +30,12 @@ public struct Node: Hashable, Codable {
         self.name = name
         self.kind = kind
     }
+    
+    /// Extracts `name` property if this node was constructed as `Node//virtual`.
+    public var extractedVirtualNodeName: String {
+        precondition(kind == .virtual)
+        return String(self.name.dropFirst().dropLast())
+    }
 
     public static func virtual(_ name: String) -> Node {
         precondition(name.first != "<" && name.last != ">", "<> will be inserted automatically")

--- a/Sources/LLBuildManifest/Node.swift
+++ b/Sources/LLBuildManifest/Node.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2014-2019 Apple Inc. and the Swift project authors
+// Copyright (c) 2014-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information

--- a/Sources/LLBuildManifest/Tools.swift
+++ b/Sources/LLBuildManifest/Tools.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2014-2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2014-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information

--- a/Sources/LLBuildManifest/Tools.swift
+++ b/Sources/LLBuildManifest/Tools.swift
@@ -155,7 +155,7 @@ public struct ShellTool: ToolProtocol {
     }
 }
 
-public struct WriteAuxiliaryFile: ToolProtocol {
+public struct WriteAuxiliaryFile: Equatable, ToolProtocol {
     public static let name: String = "write-auxiliary-file"
 
     public let inputs: [Node]

--- a/Tests/LLBuildManifestTests/LLBuildManifestTests.swift
+++ b/Tests/LLBuildManifestTests/LLBuildManifestTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2014-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information

--- a/Tests/LLBuildManifestTests/LLBuildManifestTests.swift
+++ b/Tests/LLBuildManifestTests/LLBuildManifestTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2014-2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -10,14 +10,39 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Basics
-import LLBuildManifest
+import struct Basics.AbsolutePath
+import class Foundation.PropertyListDecoder
+@testable import LLBuildManifest
+import SPMTestSupport
+import class TSCBasic.InMemoryFileSystem
 import XCTest
 
-import class TSCBasic.InMemoryFileSystem
 
-// FIXME: This should be in its own test target.
+private let testEntitlement = "test-entitlement"
+
 final class LLBuildManifestTests: XCTestCase {
+    func testEntitlementsPlist() throws {
+        let FileType = WriteAuxiliary.EntitlementPlist.self
+        let inputs = FileType.computeInputs(entitlement: testEntitlement)
+        XCTAssertEqual(inputs, [.virtual(FileType.name), .virtual(testEntitlement)])
+
+        let contents = try FileType.getFileContents(inputs: inputs)
+        let decoder = PropertyListDecoder()
+        let decodedEntitlements = try decoder.decode([String: Bool].self, from: .init(contents.utf8))
+        XCTAssertEqual(decodedEntitlements, [testEntitlement: true])
+
+        var manifest = BuildManifest()
+        let outputPath = AbsolutePath("/test.plist")
+        manifest.addEntitlementPlistCommand(entitlement: testEntitlement, outputPath: outputPath)
+
+        let commandName = outputPath.pathString
+        XCTAssertEqual(manifest.commands.count, 1)
+        
+        let command = try XCTUnwrap(manifest.commands[commandName]?.tool as? WriteAuxiliaryFile)
+
+        XCTAssertEqual(command, .init(inputs: inputs, outputFilePath: outputPath))
+    }
+
     func testBasics() throws {
         var manifest = BuildManifest()
 


### PR DESCRIPTION
### Motivation:

For enabling backtraces on macOS we need to grant a certain entitlement on executables built with SwiftPM. For that we need to write out a plist file with this entitlement setting.

This new auxiliary file type allows writing an entitlements plist file during the build process.

Related to rdar://112065568.

### Modifications:

Added `WriteAuxiliary.EntitlementPlist` with a corresponding test, moved `LLBuildManifestTests` into its own test target that depends only on the `LLBuildManifest` target and few required targets such as `Basics` and test support target.

### Result:

A corresponding build step can be added to build description and build planning in a subsequent PR.
