### PR TITLE
Handle macOS CLT `--show-sdk-platform-path` issues

### DIFF
--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -195,7 +195,8 @@ public struct SwiftTestTool: SwiftCommand {
 
             // validate XCTest available on darwin based systems
             let toolchain = try swiftTool.getTargetToolchain()
-            if toolchain.targetTriple.isDarwin() && toolchain.xctestPath == nil {
+            let isHostTestingAvailable = try swiftTool.getHostToolchain().swiftSDK.supportsTesting
+            if (toolchain.targetTriple.isDarwin() && toolchain.xctestPath == nil) || !isHostTestingAvailable {
                 throw TestError.xctestNotAvailable
             }
         } catch {

--- a/Sources/CoreCommands/SwiftTool.swift
+++ b/Sources/CoreCommands/SwiftTool.swift
@@ -796,7 +796,9 @@ public final class SwiftTool {
     private lazy var _hostToolchain: Result<UserToolchain, Swift.Error> = {
         return Result(catching: {
             try UserToolchain(swiftSDK: SwiftSDK.hostSwiftSDK(
-                originalWorkingDirectory: self.originalWorkingDirectory))
+                originalWorkingDirectory: self.originalWorkingDirectory,
+                observabilityScope: self.observabilityScope
+            ))
         })
     }()
 

--- a/Sources/PackageModel/SwiftSDK.swift
+++ b/Sources/PackageModel/SwiftSDK.swift
@@ -138,6 +138,9 @@ public struct SwiftSDK: Equatable {
     /// The architectures to build for. We build for host architecture if this is empty.
     public var architectures: [String]? = nil
 
+    /// Whether or not the receiver supports testing.
+    public let supportsTesting: Bool
+
     /// Root directory path of the SDK used to compile for the target triple.
     @available(*, deprecated, message: "use `pathsConfiguration.sdkRootPath` instead")
     public var sdk: AbsolutePath? {
@@ -411,12 +414,14 @@ public struct SwiftSDK: Equatable {
         hostTriple: Triple? = nil,
         targetTriple: Triple? = nil,
         toolset: Toolset,
-        pathsConfiguration: PathsConfiguration
+        pathsConfiguration: PathsConfiguration,
+        supportsTesting: Bool = true
     ) {
         self.hostTriple = hostTriple
         self.targetTriple = targetTriple
         self.toolset = toolset
         self.pathsConfiguration = pathsConfiguration
+        self.supportsTesting = supportsTesting
     }
 
     /// Returns the bin directory for the host.
@@ -447,7 +452,8 @@ public struct SwiftSDK: Equatable {
     public static func hostSwiftSDK(
         _ binDir: AbsolutePath? = nil,
         originalWorkingDirectory: AbsolutePath? = nil,
-        environment: [String: String] = ProcessEnv.vars
+        environment: [String: String] = ProcessEnv.vars,
+        observabilityScope: ObservabilityScope? = nil
     ) throws -> SwiftSDK {
         let originalWorkingDirectory = originalWorkingDirectory ?? localFileSystem.currentWorkingDirectory
         // Select the correct binDir.
@@ -482,14 +488,23 @@ public struct SwiftSDK: Equatable {
         #endif
 
         // Compute common arguments for clang and swift.
+        let supportsTesting: Bool
         var extraCCFlags: [String] = []
         var extraSwiftCFlags: [String] = []
         #if os(macOS)
-        let sdkPaths = try SwiftSDK.sdkPlatformFrameworkPaths(environment: environment)
-        extraCCFlags += ["-F", sdkPaths.fwk.pathString]
-        extraSwiftCFlags += ["-F", sdkPaths.fwk.pathString]
-        extraSwiftCFlags += ["-I", sdkPaths.lib.pathString]
-        extraSwiftCFlags += ["-L", sdkPaths.lib.pathString]
+        do {
+            let sdkPaths = try SwiftSDK.sdkPlatformFrameworkPaths(environment: environment)
+            extraCCFlags += ["-F", sdkPaths.fwk.pathString]
+            extraSwiftCFlags += ["-F", sdkPaths.fwk.pathString]
+            extraSwiftCFlags += ["-I", sdkPaths.lib.pathString]
+            extraSwiftCFlags += ["-L", sdkPaths.lib.pathString]
+            supportsTesting = true
+        } catch {
+            supportsTesting = false
+            observabilityScope?.emit(warning: "could not determine XCTest paths: \(error)")
+        }
+        #else
+        supportsTesting = true
         #endif
 
         #if !os(Windows)
@@ -504,7 +519,8 @@ public struct SwiftSDK: Equatable {
                 ],
                 rootPaths: [binDir]
             ),
-            pathsConfiguration: .init(sdkRootPath: sdkPath)
+            pathsConfiguration: .init(sdkRootPath: sdkPath),
+            supportsTesting: supportsTesting
         )
     }
 


### PR DESCRIPTION
We have been seeing this issue for a while when using SwiftPM from the CommandLineTools package:

```
❯ /usr/bin/xcrun --sdk macosx --show-sdk-platform-path
xcrun: error: unable to lookup item 'PlatformPath' from command line tools installation
xcrun: error: unable to lookup item 'PlatformPath' in SDK '/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk'
```

This changes SwiftPM to handle this gracefully during builds (a warning gets emitted) and to fail properly when running `swift test`.

rdar://107479428
