### PR TITLE
Tests: special case deserialisation on Windows

### DIFF
--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -4850,10 +4850,10 @@ final class BuildPlanTests: XCTestCase {
         let swiftGetVersionFilePath = try XCTUnwrap(llbuild.swiftGetVersionFiles.first?.value)
 
         let yamlContents: String = try fs.readFileContents(yaml)
-        let inputs: SerializedJSON = """
+        let inputs = """
             inputs: ["\(AbsolutePath("/Pkg/Snippets/ASnippet.swift"))","\(swiftGetVersionFilePath.escapedPathString)","\(AbsolutePath("/Pkg/.build/debug/Lib.swiftmodule"))"
         """
-        XCTAssertMatch(yamlContents, .contains(inputs.underlying))
+        XCTAssertMatch(yamlContents, .contains(inputs))
     }
 
     private func sanitizerTest(_ sanitizer: PackageModel.Sanitizer, expectedName: String) throws {


### PR DESCRIPTION
The content being compared here is the actual file content which is apparently not escaped.  This matches the expectations by explicitly converting the string form of the path rather than the default which escapes it.