### PR TITLE
[5.9] Handle macOS CLT `--show-sdk-platform-path` issues

### DIFF
--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -166,7 +166,8 @@ public struct SwiftTestTool: SwiftCommand {
 
             // validate XCTest available on darwin based systems
             let toolchain = try swiftTool.getDestinationToolchain()
-            if toolchain.triple.isDarwin() && toolchain.xctestPath == nil {
+            let isHostTestingAvailable = try swiftTool.getHostToolchain().destination.supportsTesting
+            if toolchain.triple.isDarwin() && toolchain.xctestPath == nil || !isHostTestingAvailable {
                 throw TestError.xctestNotAvailable
             }
         } catch {

--- a/Sources/CoreCommands/SwiftTool.swift
+++ b/Sources/CoreCommands/SwiftTool.swift
@@ -792,7 +792,7 @@ public final class SwiftTool {
     private lazy var _hostToolchain: Result<UserToolchain, Swift.Error> = {
         return Result(catching: {
             try UserToolchain(destination: Destination.hostDestination(
-                originalWorkingDirectory: self.originalWorkingDirectory))
+                originalWorkingDirectory: self.originalWorkingDirectory, observabilityScope: self.observabilityScope))
         })
     }()
 


### PR DESCRIPTION
We have been seeing this issue for a while when using SwiftPM from the CommandLineTools package:

```
❯ /usr/bin/xcrun --sdk macosx --show-sdk-platform-path
xcrun: error: unable to lookup item 'PlatformPath' from command line tools installation
xcrun: error: unable to lookup item 'PlatformPath' in SDK '/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk'
```

This changes SwiftPM to handle this gracefully during builds (a warning gets emitted) and to fail properly when running `swift test`.

rdar://107479428

(cherry picked from commit 3ab568e1a27ec01c4515caf9475e4460d4f8c15b)
