### PR TITLE
Use Swift Concurrency in `SwiftcImportScanner`

### DIFF
--- a/Sources/Basics/ImportScanning.swift
+++ b/Sources/Basics/ImportScanning.swift
@@ -23,11 +23,7 @@ private struct Imports: Decodable {
 }
 
 public protocol ImportScanner {
-    func scanImports(
-        _ filePathToScan: AbsolutePath,
-        callbackQueue: DispatchQueue,
-        completion: @escaping (Result<[String], Error>) -> Void
-    )
+    func scanImports(_ filePathToScan: AbsolutePath) async throws -> [String]
 }
 
 public struct SwiftcImportScanner: ImportScanner {
@@ -45,32 +41,15 @@ public struct SwiftcImportScanner: ImportScanner {
         self.swiftCompilerPath = swiftCompilerPath
     }
 
-    public func scanImports(
-        _ filePathToScan: AbsolutePath,
-        callbackQueue: DispatchQueue,
-        completion: @escaping (Result<[String], Error>) -> Void
-    ) {
+    public func scanImports(_ filePathToScan: AbsolutePath) async throws -> [String] {
         let cmd = [swiftCompilerPath.pathString,
                    filePathToScan.pathString,
                    "-scan-dependencies", "-Xfrontend", "-import-prescan"] + self.swiftCompilerFlags
 
-        TSCBasic.Process
-            .popen(arguments: cmd, environment: self.swiftCompilerEnvironment, queue: callbackQueue) { result in
-                dispatchPrecondition(condition: .onQueue(callbackQueue))
+        let result = try await TSCBasic.Process.popen(arguments: cmd, environment: self.swiftCompilerEnvironment)
 
-                do {
-                    let stdout = try result.get().utf8Output()
-                    let imports = try JSONDecoder.makeWithDefaults().decode(Imports.self, from: stdout).imports
-                        .filter { !defaultImports.contains($0) }
-
-                    callbackQueue.async {
-                        completion(.success(imports))
-                    }
-                } catch {
-                    callbackQueue.async {
-                        completion(.failure(error))
-                    }
-                }
-            }
+        let stdout = try result.utf8Output()
+        return try JSONDecoder.makeWithDefaults().decode(Imports.self, from: stdout).imports
+            .filter { !defaultImports.contains($0) }
     }
 }

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import _Concurrency
 import Basics
 import Dispatch
 @_implementationOnly import Foundation
@@ -658,23 +659,19 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 
             // we must not block the calling thread (for concurrency control) so nesting this in a queue
             self.evaluationQueue.addOperation {
-                do {
-                    // park the evaluation thread based on the max concurrency allowed
-                    self.concurrencySemaphore.wait()
+                // park the evaluation thread based on the max concurrency allowed
+                self.concurrencySemaphore.wait()
 
-                    let importScanner = SwiftcImportScanner(swiftCompilerEnvironment: self.toolchain.swiftCompilerEnvironment,
-                                                            swiftCompilerFlags: self.extraManifestFlags,
-                                                            swiftCompilerPath: self.toolchain.swiftCompilerPathForManifests)
+                let importScanner = SwiftcImportScanner(swiftCompilerEnvironment: self.toolchain.swiftCompilerEnvironment,
+                                                        swiftCompilerFlags: self.extraManifestFlags,
+                                                        swiftCompilerPath: self.toolchain.swiftCompilerPathForManifests)
 
-                    importScanner.scanImports(manifestPath, callbackQueue: callbackQueue) { result in
-                        do {
-                            let imports = try result.get().filter { !allowedImports.contains($0) }
-                            guard imports.isEmpty else {
-                                throw ManifestParseError.importsRestrictedModules(imports)
-                            }
-                        } catch {
-                            completion(.failure(error))
-                        }
+                Task {
+                    let result = try await importScanner.scanImports(manifestPath)
+                    let imports = result.filter { !allowedImports.contains($0) }
+                    guard imports.isEmpty else {
+                        completion(.failure(ManifestParseError.importsRestrictedModules(imports)))
+                        return
                     }
                 }
             }

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -916,11 +916,11 @@ class PluginInvocationTests: XCTestCase {
         }
     }
 
-    func testScanImportsInPluginTargets() throws {
+    func testScanImportsInPluginTargets() async throws {
         // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
 
-        try testWithTemporaryDirectory { tmpPath in
+        try await testWithTemporaryDirectory { tmpPath in
             // Create a sample package with a library target and a plugin.
             let packageDir = tmpPath.appending(components: "MyPackage")
             try localFileSystem.createDirectory(packageDir, recursive: true)
@@ -1058,39 +1058,35 @@ class PluginInvocationTests: XCTestCase {
             XCTAssert(rootManifests.count == 1, "\(rootManifests)")
 
             let graph = try workspace.loadPackageGraph(rootInput: rootInput, observabilityScope: observability.topScope)
-            workspace.loadPluginImports(packageGraph: graph) { (result: Result<[PackageIdentity : [String : [String]]], Error>) in
+            let dict = try await workspace.loadPluginImports(packageGraph: graph)
 
-                var count = 0
-                if let dict = try? result.get() {
-                    for (pkg, entry) in dict {
-                        if pkg.description == "mypackage" {
-                            XCTAssertNotNil(entry["XPlugin"])
-                            let XPluginPossibleImports1 = ["PackagePlugin", "XcodeProjectPlugin"]
-                            let XPluginPossibleImports2 = ["PackagePlugin", "XcodeProjectPlugin", "_SwiftConcurrencyShims"]
-                            XCTAssertTrue(entry["XPlugin"] == XPluginPossibleImports1 ||
-                                          entry["XPlugin"] == XPluginPossibleImports2)
+            var count = 0
+            for (pkg, entry) in dict {
+                if pkg.description == "mypackage" {
+                    XCTAssertNotNil(entry["XPlugin"])
+                    let XPluginPossibleImports1 = ["PackagePlugin", "XcodeProjectPlugin"]
+                    let XPluginPossibleImports2 = ["PackagePlugin", "XcodeProjectPlugin", "_SwiftConcurrencyShims"]
+                    XCTAssertTrue(entry["XPlugin"] == XPluginPossibleImports1 ||
+                                  entry["XPlugin"] == XPluginPossibleImports2)
 
-                            let YPluginPossibleImports1 = ["PackagePlugin", "Foundation"]
-                            let YPluginPossibleImports2 = ["PackagePlugin", "Foundation", "_SwiftConcurrencyShims"]
-                            XCTAssertTrue(entry["YPlugin"] == YPluginPossibleImports1 ||
-                                          entry["YPlugin"] == YPluginPossibleImports2)
-                            count += 1
-                        } else if pkg.description == "otherpackage" {
-                            XCTAssertNotNil(dict[pkg]?["QPlugin"])
+                    let YPluginPossibleImports1 = ["PackagePlugin", "Foundation"]
+                    let YPluginPossibleImports2 = ["PackagePlugin", "Foundation", "_SwiftConcurrencyShims"]
+                    XCTAssertTrue(entry["YPlugin"] == YPluginPossibleImports1 ||
+                                  entry["YPlugin"] == YPluginPossibleImports2)
+                    count += 1
+                } else if pkg.description == "otherpackage" {
+                    XCTAssertNotNil(dict[pkg]?["QPlugin"])
 
-                            let possibleImports1 = ["PackagePlugin", "XcodeProjectPlugin", "ModuleFoundViaExtraSearchPaths"]
-                            let possibleImports2 = ["PackagePlugin", "XcodeProjectPlugin", "ModuleFoundViaExtraSearchPaths", "_SwiftConcurrencyShims"]
-                            XCTAssertTrue(entry["QPlugin"] == possibleImports1 ||
-                                          entry["QPlugin"] == possibleImports2)
-                            count += 1
-                        }
-                    }
-                } else {
-                    XCTFail("Scanned import list should not be empty")
+                    let possibleImports1 = ["PackagePlugin", "XcodeProjectPlugin", "ModuleFoundViaExtraSearchPaths"]
+                    let possibleImports2 = ["PackagePlugin", "XcodeProjectPlugin", "ModuleFoundViaExtraSearchPaths", "_SwiftConcurrencyShims"]
+                    XCTAssertTrue(entry["QPlugin"] == possibleImports1 ||
+                                  entry["QPlugin"] == possibleImports2)
+                    count += 1
                 }
-
-                XCTAssertEqual(count, 2)
             }
+
+
+            XCTAssertEqual(count, 2)
         }
     }
 


### PR DESCRIPTION
This allows `Workspace.loadPluginImports` to be implemented in a non-blocking way without any uses of `temp_await`.

Also a dependency of https://github.com/apple/swift-package-manager/pull/6624.
