### PR TITLE
[NFC] Fix deprecation in `IntegrationTests/SwiftPMTests.swift`

### DIFF
--- a/IntegrationTests/Tests/IntegrationTests/SwiftPMTests.swift
+++ b/IntegrationTests/Tests/IntegrationTests/SwiftPMTests.swift
@@ -63,7 +63,7 @@ final class SwiftPMTests: XCTestCase {
                 try localFileSystem.removeFileTree(packagePath.appending(components: "Sources", entry))
             }
             try localFileSystem.writeFileContents(AbsolutePath(validating: "Sources/main.m", relativeTo: packagePath)) {
-                $0 <<< "int main() {}"
+                $0.send("int main() {}")
             }
             let archs = ["x86_64", "arm64"]
 


### PR DESCRIPTION
`<<<` operator is deprecated and should be replaced with `.send(_: String)`