### PR TITLE
Do not use canonical location for checkouts

### DIFF
--- a/Sources/PackageModel/PackageIdentity.swift
+++ b/Sources/PackageModel/PackageIdentity.swift
@@ -419,50 +419,71 @@ public struct CanonicalPackageLocation: Equatable, CustomStringConvertible {
 
     /// Instantiates an instance of the conforming type from a string representation.
     public init(_ string: String) {
-        var description = string.precomposedStringWithCanonicalMapping.lowercased()
-
-        // Remove the scheme component, if present.
-        let detectedScheme = description.dropSchemeComponentPrefixIfPresent()
-
-        // Remove the userinfo subcomponent (user / password), if present.
-        if case (let user, _)? = description.dropUserinfoSubcomponentPrefixIfPresent() {
-            // If a user was provided, perform tilde expansion, if applicable.
-            description.replaceFirstOccurenceIfPresent(of: "/~/", with: "/~\(user)/")
-        }
-
-        // Remove the port subcomponent, if present.
-        description.removePortComponentIfPresent()
-
-        // Remove the fragment component, if present.
-        description.removeFragmentComponentIfPresent()
-
-        // Remove the query component, if present.
-        description.removeQueryComponentIfPresent()
-
-        // Accomodate "`scp`-style" SSH URLs
-        if detectedScheme == nil || detectedScheme == "ssh" {
-            description.replaceFirstOccurenceIfPresent(of: ":", before: description.firstIndex(of: "/"), with: "/")
-        }
-
-        // Split the remaining string into path components,
-        // filtering out empty path components and removing valid percent encodings.
-        var components = description.split(omittingEmptySubsequences: true, whereSeparator: isSeparator)
-            .compactMap { $0.removingPercentEncoding ?? String($0) }
-
-        // Remove the `.git` suffix from the last path component.
-        var lastPathComponent = components.popLast() ?? ""
-        lastPathComponent.removeSuffixIfPresent(".git")
-        components.append(lastPathComponent)
-
-        description = components.joined(separator: "/")
-
-        // Prepend a leading slash for file URLs and paths
-        if detectedScheme == "file" || string.first.flatMap(isSeparator) ?? false {
-            description.insert("/", at: description.startIndex)
-        }
-
-        self.description = description
+        self.description = computeCanonicalLocation(string).description
     }
+}
+
+/// Similar to `CanonicalPackageLocation` but differentiates based on the scheme.
+public struct CanonicalPackageURL: CustomStringConvertible {
+    public let description: String
+    public let scheme: String?
+
+    public init(_ string: String) {
+        let location = computeCanonicalLocation(string)
+        self.description = location.description
+        self.scheme = location.scheme
+    }
+}
+
+private func computeCanonicalLocation(_ string: String) -> (description: String, scheme: String?) {
+    var description = string.precomposedStringWithCanonicalMapping.lowercased()
+
+    // Remove the scheme component, if present.
+    let detectedScheme = description.dropSchemeComponentPrefixIfPresent()
+    var scheme = detectedScheme
+
+    // Remove the userinfo subcomponent (user / password), if present.
+    if case (let user, _)? = description.dropUserinfoSubcomponentPrefixIfPresent() {
+        // If a user was provided, perform tilde expansion, if applicable.
+        description.replaceFirstOccurenceIfPresent(of: "/~/", with: "/~\(user)/")
+
+        if user == "git", scheme == nil {
+            scheme = "ssh"
+        }
+    }
+
+    // Remove the port subcomponent, if present.
+    description.removePortComponentIfPresent()
+
+    // Remove the fragment component, if present.
+    description.removeFragmentComponentIfPresent()
+
+    // Remove the query component, if present.
+    description.removeQueryComponentIfPresent()
+
+    // Accomodate "`scp`-style" SSH URLs
+    if detectedScheme == nil || detectedScheme == "ssh" {
+        description.replaceFirstOccurenceIfPresent(of: ":", before: description.firstIndex(of: "/"), with: "/")
+    }
+
+    // Split the remaining string into path components,
+    // filtering out empty path components and removing valid percent encodings.
+    var components = description.split(omittingEmptySubsequences: true, whereSeparator: isSeparator)
+        .compactMap { $0.removingPercentEncoding ?? String($0) }
+
+    // Remove the `.git` suffix from the last path component.
+    var lastPathComponent = components.popLast() ?? ""
+    lastPathComponent.removeSuffixIfPresent(".git")
+    components.append(lastPathComponent)
+
+    description = components.joined(separator: "/")
+
+    // Prepend a leading slash for file URLs and paths
+    if detectedScheme == "file" || string.first.flatMap(isSeparator) ?? false {
+        description.insert("/", at: description.startIndex)
+    }
+
+    return (description, scheme)
 }
 
 #if os(Windows)

--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -587,8 +587,9 @@ extension RepositorySpecifier {
 }
 
 extension RepositorySpecifier {
-    fileprivate var canonicalLocation: CanonicalPackageLocation {
-        .init(self.location.description)
+    fileprivate var canonicalLocation: String {
+        let canonicalPackageLocation: CanonicalPackageURL = .init(self.location.description)
+        return "\(canonicalPackageLocation.description)_\(canonicalPackageLocation.scheme ?? "")"
     }
 }
 

--- a/Tests/PackageModelTests/CanonicalPackageLocationTests.swift
+++ b/Tests/PackageModelTests/CanonicalPackageLocationTests.swift
@@ -324,4 +324,19 @@ final class CanonicalPackageLocationTests: XCTestCase {
             "example.com/mona/linked:list"
         )
     }
+
+    func testScheme() {
+        XCTAssertEqual(CanonicalPackageURL("https://example.com/mona/LinkedList").scheme, "https")
+        XCTAssertEqual(CanonicalPackageURL("git@example.com/mona/LinkedList").scheme, "ssh")
+        XCTAssertEqual(CanonicalPackageURL("git@example.com:mona/LinkedList.git ").scheme, "ssh")
+        XCTAssertEqual(CanonicalPackageURL("ssh://mona@example.com/~/LinkedList.git").scheme, "ssh")
+        XCTAssertEqual(CanonicalPackageURL("file:///Users/mona/LinkedList").scheme, "file")
+        XCTAssertEqual(CanonicalPackageURL("example.com:443/mona/LinkedList").scheme, nil)
+        XCTAssertEqual(CanonicalPackageURL("example.com/mona/%F0%9F%94%97List").scheme, nil)
+        XCTAssertEqual(CanonicalPackageURL("example.com/mona/LinkedList.git").scheme, nil)
+        XCTAssertEqual(CanonicalPackageURL("example.com/mona/LinkedList/").scheme, nil)
+        XCTAssertEqual(CanonicalPackageURL("example.com/mona/LinkedList#installation").scheme, nil)
+        XCTAssertEqual(CanonicalPackageURL("example.com/mona/LinkedList?utm_source=forums.swift.org").scheme, nil)
+        XCTAssertEqual(CanonicalPackageURL("user:sw0rdf1sh!@example.com:/mona/Linked:List.git").scheme, nil)
+    }
 }

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -328,8 +328,6 @@ class RepositoryManagerTests: XCTestCase {
         let variants: [RepositorySpecifier] = [
             .init(url: "https://scm.com/org/foo"),
             .init(url: "https://scm.com/org/foo.git"),
-            .init(url: "http://scm.com/org/foo"),
-            .init(url: "http://scm.com/org/foo.git")
         ]
 
         for variant in variants {


### PR DESCRIPTION
In #6780, we switched to using the canonical location of a package for the checkouts paths, but that can lead to mixing up checkouts storage when there has been a legitimate change to locations that isn't reflected in the canonical location (most prominently switching from SSH to HTTPS or vice versa). Because of that, we should undo that change.

rdar://116534183
