### PR TITLE
Filter superfluous diagnostics

### DIFF
--- a/Sources/SPMTestSupport/Observability.swift
+++ b/Sources/SPMTestSupport/Observability.swift
@@ -72,6 +72,14 @@ public struct TestingObservability {
 
         // TODO: do something useful with scope
         func handleDiagnostic(scope: ObservabilityScope, diagnostic: Basics.Diagnostic) {
+            // Filter superfluous diagnostics.
+            guard !diagnostic.message.hasPrefix("<unknown>:0: warning: annotation implies no releases") else {
+                return
+            }
+            guard !diagnostic.message.hasPrefix("<unknown>:0: note: add explicit") else {
+                return
+            }
+
             if self.verbose {
                 print(diagnostic.description)
             }

--- a/Sources/SPMTestSupport/Toolchain.swift
+++ b/Sources/SPMTestSupport/Toolchain.swift
@@ -134,6 +134,22 @@ extension UserToolchain {
         }
     }
 
+    // This builds a trivial program with `-warnings-as-errors`, if it fails, the compiler in use generates warnings by default and is not suitable for testing warnings as errors behaviors.
+    public func supportsWarningsAsErrors() -> Bool {
+        do {
+            try testWithTemporaryDirectory { tmpPath in
+                let inputPath = tmpPath.appending("best.swift")
+                try localFileSystem.writeFileContents(inputPath, string: "print(\"hello\")")
+                let outputPath = tmpPath.appending("foo")
+                let toolchainPath = self.swiftCompilerPath.parentDirectory.parentDirectory
+                try Process.checkNonZeroExit(arguments: ["/usr/bin/xcrun", "--toolchain", toolchainPath.pathString, "swiftc", inputPath.pathString, "-o", outputPath.pathString, "-warnings-as-errors"])
+            }
+            return true
+        } catch {
+            return false
+        }
+    }
+
     /// Helper function to determine whether we should run SDK-dependent tests.
     public func supportsSDKDependentTests() -> Bool {
         return ProcessInfo.processInfo.environment["SWIFTCI_DISABLE_SDK_DEPENDENT_TESTS"] == nil

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -2159,7 +2159,10 @@ final class PackageToolTests: CommandsTestCase {
             do {
                 let (stdout, stderr) = try SwiftPM.Package.execute(["plugin", "MyPlugin", "--foo", "--help", "--version", "--verbose"], packagePath: packageDir)
                 XCTAssertMatch(stdout, .contains("success"))
-                XCTAssertEqual(stderr, "")
+                let filteredStderr = stderr.components(separatedBy: "\n").filter {
+                    !$0.contains("annotation implies no releases") && !$0.contains("note: add explicit")
+                }.joined(separator: "\n")
+                XCTAssertEqual(filteredStderr, "")
             }
 
             // Check default command arguments

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -667,7 +667,7 @@ class MiscellaneousTestCase: XCTestCase {
     func testRootPackageWithConditionals() throws {
         try fixture(name: "Miscellaneous/RootPackageWithConditionals") { path in
             let (_, stderr) = try SwiftPM.Build.execute(packagePath: path)
-            let errors = stderr.components(separatedBy: .newlines).filter { !$0.contains("[logging] misuse") && !$0.isEmpty }
+            let errors = stderr.components(separatedBy: .newlines).filter { !$0.contains("[logging] misuse") && !$0.contains("annotation implies no releases") && !$0.contains("note: add explicit") && !$0.isEmpty }
             XCTAssertEqual(errors, [], "unexpected errors: \(errors)")
         }
     }

--- a/Tests/FunctionalTests/ResourcesTests.swift
+++ b/Tests/FunctionalTests/ResourcesTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import PackageModel
 import SPMTestSupport
 import XCTest
 
@@ -114,6 +115,8 @@ class ResourcesTests: XCTestCase {
     }
 
     func testSwiftResourceAccessorDoesNotCauseInconsistentImportWarning() throws {
+        try XCTSkipIf(!UserToolchain.default.supportsWarningsAsErrors(), "skipping because test environment doesn't support warnings as errors")
+
         try fixture(name: "Resources/FoundationlessClient/UtilsWithFoundationPkg") { fixturePath in
             XCTAssertBuilds(
                 fixturePath,


### PR DESCRIPTION
A bit similar to #6930, we need to filter some superfluous diagnostics to get passing tests in certain configurations.