### PR TITLE
Fix unhandled files warning in `Package.swift`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -126,7 +126,7 @@ let package = Package(
         // library; the bootstrap scripts build the deployable version.
         .target(
             name: "PackageDescription",
-            exclude: ["CMakeLists.txt"],
+            exclude: ["CMakeLists.txt", "PackageDescription.docc"],
             swiftSettings: [
                 .unsafeFlags(["-package-description-version", "999.0"]),
                 .unsafeFlags(["-enable-library-evolution"]),


### PR DESCRIPTION
`PackageDescription.docc` should be excluded from the list of target files to fix this warning:

```
[warning]: found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
swiftpm//Sources/PackageDescription/PackageDescription.docc
```
